### PR TITLE
[RISCV] Remove SiFive7PipeV and replace it with SiFive7VCQ

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -208,20 +208,26 @@ def SiFive7Model : SchedMachineModel {
 // Pipe A can handle memory, integer alu and vector operations.
 // Pipe B can handle integer alu, control flow, integer multiply and divide,
 // and floating point computation.
-// Pipe V can handle the V extension.
+// The V pipeline is modeled by the VCQ, VA, VL, and VS resources.
 let SchedModel = SiFive7Model in {
 let BufferSize = 0 in {
 def SiFive7PipeA       : ProcResource<1>;
 def SiFive7PipeB       : ProcResource<1>;
 def SiFive7IDiv        : ProcResource<1>; // Int Division
 def SiFive7FDiv        : ProcResource<1>; // FP Division/Sqrt
-def SiFive7PipeV       : ProcResource<1>;
-}
-
-let BufferSize = 1 in {
-def SiFive7VA          : ProcResource<1> { let Super = SiFive7PipeV; } // Arithmetic sequencer
-def SiFive7VL          : ProcResource<1> { let Super = SiFive7PipeV; } // Load sequencer
-def SiFive7VS          : ProcResource<1> { let Super = SiFive7PipeV; } // Store sequencer
+def SiFive7VA          : ProcResource<1>; // Arithmetic sequencer
+def SiFive7VL          : ProcResource<1>; // Load sequencer
+def SiFive7VS          : ProcResource<1>; // Store sequencer
+// The VCQ accepts instructions from the the A Pipe and holds them until the
+// vector unit is ready to dequeue them. The unit dequeues up to one instruction
+// per cycle, in order, as soon as the sequencer for that type of instruction is
+// avaliable. This resource is meant to be used for 1 cycle by all vector
+// instructions, to model that only one vector instruction may be dequed at a
+// time. The actual dequeueing into the sequencer is modeled by the VA, VL, and
+// VS sequencer resources below. Each of them will only accept a single
+// instruction at a time and remain busy for the number of cycles associated
+// with that instruction.
+def SiFive7VCQ         : ProcResource<1>; // Vector Command Queue
 }
 
 def SiFive7PipeAB : ProcResGroup<[SiFive7PipeA, SiFive7PipeB]>;
@@ -433,21 +439,21 @@ def : WriteRes<WriteVSETVL, [SiFive7PipeA]>;
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVLDE",    [SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDFF",   [SiFive7VL], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVLDE",    [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDFF",   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
   }
-  let Latency = 1, ReleaseAtCycles = [Cycles] in
-  defm "" : LMULWriteResMX<"WriteVSTE",    [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+  defm "" : LMULWriteResMX<"WriteVSTE",    [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
 }
 
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetMaskLoadStoreCycles<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in
-  defm "" : LMULWriteResMX<"WriteVLDM",    [SiFive7VL], mx, IsWorstCase>;
-  let Latency = 1, ReleaseAtCycles = [Cycles] in
-  defm "" : LMULWriteResMX<"WriteVSTM",    [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+  defm "" : LMULWriteResMX<"WriteVLDM",    [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+  defm "" : LMULWriteResMX<"WriteVSTM",    [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
 }
 
 // Strided loads and stores operate at one element per cycle and should be
@@ -466,17 +472,17 @@ foreach mx = SchedMxList in {
   defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 8>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS8",  VLDSX0Pred, [SiFive7VL],
-                                       4, [VLDSX0Cycles], !add(3, Cycles),
-                                       [Cycles], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX8", [SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX8", [SiFive7VL], mx, IsWorstCase>;
+  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS8",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
+                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVLDUX8", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDOX8", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
   }
-  let Latency = 1, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVSTS8",  [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX8", [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX8", [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVSTS8",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTUX8", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTOX8", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
   }
 }
 // TODO: The MxLists need to be filtered by EEW. We only need to support
@@ -486,72 +492,72 @@ foreach mx = ["MF4", "MF2", "M1", "M2", "M4", "M8"] in {
   defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 16>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS16",  VLDSX0Pred, [SiFive7VL],
-                                       4, [VLDSX0Cycles], !add(3, Cycles),
-                                       [Cycles], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX16", [SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX16", [SiFive7VL], mx, IsWorstCase>;
+  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS16",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
+                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVLDUX16", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDOX16", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
   }
-  let Latency = 1, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVSTS16",  [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX16", [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX16", [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVSTS16",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTUX16", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTOX16", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
   }
 }
 foreach mx = ["MF2", "M1", "M2", "M4", "M8"] in {
   defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 32>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS32",  VLDSX0Pred, [SiFive7VL],
-                                       4, [VLDSX0Cycles], !add(3, Cycles),
-                                       [Cycles], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX32", [SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX32", [SiFive7VL], mx, IsWorstCase>;
+  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS32",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
+                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVLDUX32", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDOX32", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
   }
-  let Latency = 1, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVSTS32",  [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX32", [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX32", [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVSTS32",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTUX32", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTOX32", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
   }
 }
 foreach mx = ["M1", "M2", "M4", "M8"] in {
   defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 64>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS64",  VLDSX0Pred, [SiFive7VL],
-                                       4, [VLDSX0Cycles], !add(3, Cycles),
-                                       [Cycles], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX64", [SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX64", [SiFive7VL], mx, IsWorstCase>;
+  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS64",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
+                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVLDUX64", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDOX64", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
   }
-  let Latency = 1, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVSTS64",  [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX64", [SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX64", [SiFive7VS], mx, IsWorstCase>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVSTS64",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTUX64", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSTOX64", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
   }
 }
 
 // VLD*R is LMUL aware
-let Latency = 4, ReleaseAtCycles = [2] in
-  def : WriteRes<WriteVLD1R,  [SiFive7VL]>;
-let Latency = 4, ReleaseAtCycles = [4] in
-  def : WriteRes<WriteVLD2R,  [SiFive7VL]>;
-let Latency = 4, ReleaseAtCycles = [8] in
-  def : WriteRes<WriteVLD4R,  [SiFive7VL]>;
-let Latency = 4, ReleaseAtCycles = [16] in
-  def : WriteRes<WriteVLD8R,  [SiFive7VL]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+  def : WriteRes<WriteVLD1R,  [SiFive7VCQ, SiFive7VL]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+  def : WriteRes<WriteVLD2R,  [SiFive7VCQ, SiFive7VL]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+  def : WriteRes<WriteVLD4R,  [SiFive7VCQ, SiFive7VL]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+  def : WriteRes<WriteVLD8R,  [SiFive7VCQ, SiFive7VL]>;
 // VST*R is LMUL aware
-let Latency = 1, ReleaseAtCycles = [2] in
-  def : WriteRes<WriteVST1R,   [SiFive7VS]>;
-let Latency = 1, ReleaseAtCycles = [4] in
-  def : WriteRes<WriteVST2R,   [SiFive7VS]>;
-let Latency = 1, ReleaseAtCycles = [8] in
-  def : WriteRes<WriteVST4R,   [SiFive7VS]>;
-let Latency = 1, ReleaseAtCycles = [16] in
-  def : WriteRes<WriteVST8R,   [SiFive7VS]>;
+let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+  def : WriteRes<WriteVST1R,   [SiFive7VCQ, SiFive7VS]>;
+let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+  def : WriteRes<WriteVST2R,   [SiFive7VCQ, SiFive7VS]>;
+let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+  def : WriteRes<WriteVST4R,   [SiFive7VCQ, SiFive7VS]>;
+let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+  def : WriteRes<WriteVST8R,   [SiFive7VCQ, SiFive7VS]>;
 
 // Segmented Loads and Stores
 // Unit-stride segmented loads and stores are effectively converted into strided
@@ -564,22 +570,22 @@ foreach mx = SchedMxList in {
     defvar Cycles = SiFive7GetCyclesSegmentedSeg2<mx>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
     // Does not chain so set latency high
-    let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-      defm "" : LMULWriteResMX<"WriteVLSEG2e" # eew,   [SiFive7VL], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLSEGFF2e" # eew, [SiFive7VL], mx, IsWorstCase>;
+    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm "" : LMULWriteResMX<"WriteVLSEG2e" # eew,   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVLSEGFF2e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
     }
-    let Latency = 1, ReleaseAtCycles = [Cycles] in
-    defm "" : LMULWriteResMX<"WriteVSSEG2e" # eew,   [SiFive7VS], mx, IsWorstCase>;
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm "" : LMULWriteResMX<"WriteVSSEG2e" # eew,   [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
     foreach nf=3-8 in {
       defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf>.c;
       defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
       // Does not chain so set latency high
-      let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-        defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,   [SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew, [SiFive7VL], mx, IsWorstCase>;
+      let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
       }
-      let Latency = 1, ReleaseAtCycles = [Cycles] in
-      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,   [SiFive7VS], mx, IsWorstCase>;
+      let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,   [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
     }
   }
 }
@@ -589,15 +595,15 @@ foreach mx = SchedMxList in {
       defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf>.c;
       defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
       // Does not chain so set latency high
-      let Latency = !add(3, Cycles), ReleaseAtCycles = [Cycles] in {
-        defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,  [SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew, [SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew, [SiFive7VL], mx, IsWorstCase>;
+      let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,  [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
       }
-      let Latency = 1, ReleaseAtCycles = [Cycles] in {
-        defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,  [SiFive7VS], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew, [SiFive7VS], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew, [SiFive7VS], mx, IsWorstCase>;
+      let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
       }
     }
   }
@@ -607,41 +613,41 @@ foreach mx = SchedMxList in {
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVIALUV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIALUX",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIALUI",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUX",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUI",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVShiftV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVShiftX",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVShiftI",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMinMaxV",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMinMaxX",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulX",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulAddV",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulAddX",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeI",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovX",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovI",     [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVIALUV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIALUX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIALUI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVICALUV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVICALUX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVICALUI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVShiftV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVShiftX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVShiftI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMinMaxV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMinMaxX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMulV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMulX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMulAddV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMulAddX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMergeV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMergeX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMergeI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMovV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMovX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIMovI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
   // Mask results can't chain.
-  let Latency = !add(Cycles, 3), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVICmpV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICmpX",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICmpI",     [SiFive7VA], mx, IsWorstCase>;
+  let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVICmpV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVICmpX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVICmpI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVExtV",      [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVExtV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxList in {
@@ -649,9 +655,9 @@ foreach mx = SchedMxList in {
     defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
                          !div(SiFive7GetCyclesOnePerElement<mx, sew>.c, 4));
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = Cycles, ReleaseAtCycles = [Cycles] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivV", [SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivX", [SiFive7VA], mx, sew, IsWorstCase>;
+    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
+      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivX", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
     }
   }
 }
@@ -660,24 +666,24 @@ foreach mx = SchedMxList in {
 foreach mx = SchedMxListW in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVIWALUV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWALUX",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWALUI",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulX",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulAddV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulAddX", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVIWALUV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWALUX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWALUI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWMulV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWMulX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWMulAddV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIWMulAddX", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 // Narrowing
 foreach mx = SchedMxListW in {
   defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVNShiftV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNShiftX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNShiftI",   [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVNShiftV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVNShiftX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVNShiftI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
@@ -685,27 +691,27 @@ foreach mx = SchedMxListW in {
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVSALUV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSALUX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSALUI",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVAALUV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVAALUX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSMulV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSMulX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftX", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftI", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVSALUV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSALUX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSALUI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVAALUV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVAALUX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSMulV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSMulX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSShiftV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSShiftX", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVSShiftI", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 // Narrowing
 foreach mx = SchedMxListW in {
   defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVNClipV",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNClipX",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNClipI",  [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVNClipV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVNClipX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVNClipI",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
@@ -713,30 +719,30 @@ foreach mx = SchedMxListW in {
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFALUV",      [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFALUF",      [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMulV",      [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMulF",      [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMulAddV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMulAddF",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFRecpV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFCvtIToFV",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFCvtFToIV",  [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFALUV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFALUF",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMulV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMulF",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMulAddV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMulAddF",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFRecpV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFCvtIToFV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFCvtFToIV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFSgnjV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFSgnjF",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMinMaxV",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMinMaxF",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFClassV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMergeV",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMovV",      [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFSgnjV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFSgnjF",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMinMaxV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMinMaxF",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFClassV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMergeV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFMovV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
   // Mask results can't chain.
-  let Latency = !add(Cycles, 3), ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFCmpV",      [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFCmpF",      [SiFive7VA], mx, IsWorstCase>;
+  let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFCmpV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFCmpF",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxListF in {
@@ -744,10 +750,10 @@ foreach mx = SchedMxListF in {
     defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
                          !div(SiFive7GetCyclesOnePerElement<mx, sew>.c, 4));
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
-    let Latency = Cycles, ReleaseAtCycles = [Cycles] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFSqrtV", [SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivV",  [SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivF",  [SiFive7VA], mx, sew, IsWorstCase>;
+    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFSqrtV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivV",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivF",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
     }
   }
 }
@@ -756,38 +762,38 @@ foreach mx = SchedMxListF in {
 foreach mx = SchedMxListW in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFWCvtIToFV", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFWCvtIToFV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxListFW in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListFW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFWALUV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWMulV",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWMulAddV",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWCvtFToIV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWCvtFToFV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWMulAddF",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWMulF",     [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFWALUF",     [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFWALUV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWMulV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWMulAddV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWCvtFToIV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWCvtFToFV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWMulAddF",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWMulF",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFWALUF",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 // Narrowing
 foreach mx = SchedMxListW in {
   defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFNCvtFToIV", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFNCvtFToIV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxListFW in {
   defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListFW>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVFNCvtIToFV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFNCvtFToFV", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVFNCvtIToFV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFNCvtFToFV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
@@ -796,10 +802,10 @@ foreach mx = SchedMxList in {
   foreach sew = SchedSEWSet<mx>.val in {
     defvar Cycles = SiFive7GetReductionCycles<mx, sew>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = Cycles, ReleaseAtCycles = [Cycles] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedV_From", [SiFive7VA],
+    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedV_From", [SiFive7VCQ, SiFive7VA],
                                      mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedMinMaxV_From", [SiFive7VA],
+      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedMinMaxV_From", [SiFive7VCQ, SiFive7VA],
                                      mx, sew, IsWorstCase>;
     }
   }
@@ -809,8 +815,8 @@ foreach mx = SchedMxListWRed in {
   foreach sew = SchedSEWSet<mx, 0, 1>.val in {
     defvar Cycles = SiFive7GetReductionCycles<mx, sew>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListWRed>.c;
-    let Latency = Cycles, ReleaseAtCycles = [Cycles] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVIWRedV_From", [SiFive7VA],
+    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm "" : LMULSEWWriteResMXSEW<"WriteVIWRedV_From", [SiFive7VCQ, SiFive7VA],
                                    mx, sew, IsWorstCase>;
   }
 }
@@ -819,15 +825,15 @@ foreach mx = SchedMxListF in {
   foreach sew = SchedSEWSet<mx, 1>.val in {
     defvar RedCycles = SiFive7GetReductionCycles<mx, sew>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
-    let Latency = RedCycles, ReleaseAtCycles = [RedCycles] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedV_From", [SiFive7VA],
+    let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in {
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedV_From", [SiFive7VCQ, SiFive7VA],
                                      mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedMinMaxV_From", [SiFive7VA],
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedMinMaxV_From", [SiFive7VCQ, SiFive7VA],
                                      mx, sew, IsWorstCase>;
     }
     defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew>.c;
-    let Latency = OrdRedCycles, ReleaseAtCycles = [OrdRedCycles] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFRedOV_From", [SiFive7VA],
+    let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
+    defm "" : LMULSEWWriteResMXSEW<"WriteVFRedOV_From", [SiFive7VCQ, SiFive7VA],
                                    mx, sew, IsWorstCase>;
   }
 }
@@ -836,12 +842,12 @@ foreach mx = SchedMxListFWRed in {
   foreach sew = SchedSEWSet<mx, 1, 1>.val in {
     defvar RedCycles = SiFive7GetReductionCycles<mx, sew>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFWRed, 1>.c;
-    let Latency = RedCycles, ReleaseAtCycles = [RedCycles] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedV_From", [SiFive7VA],
+    let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in
+    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedV_From", [SiFive7VCQ, SiFive7VA],
                                    mx, sew, IsWorstCase>;
     defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew>.c;
-    let Latency = OrdRedCycles, ReleaseAtCycles = [OrdRedCycles] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedOV_From", [SiFive7VA],
+    let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
+    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedOV_From", [SiFive7VCQ, SiFive7VA],
                                    mx, sew, IsWorstCase>;
   }
 }
@@ -850,35 +856,35 @@ foreach mx = SchedMxListFWRed in {
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesVMask<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVMALUV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMPopV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMFFSV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMSFSV", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVMALUV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMPopV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMFFSV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMSFSV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVMIotV", [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMIdxV", [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVMIotV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMIdxV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
 // 16. Vector Permutation Instructions
-let Latency = 4, ReleaseAtCycles = [1] in {
-  def : WriteRes<WriteVIMovVX, [SiFive7VA]>;
-  def : WriteRes<WriteVIMovXV, [SiFive7VA]>;
-  def : WriteRes<WriteVFMovVF, [SiFive7VA]>;
-  def : WriteRes<WriteVFMovFV, [SiFive7VA]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 1)] in {
+  def : WriteRes<WriteVIMovVX, [SiFive7VCQ, SiFive7VA]>;
+  def : WriteRes<WriteVIMovXV, [SiFive7VCQ, SiFive7VA]>;
+  def : WriteRes<WriteVFMovVF, [SiFive7VCQ, SiFive7VA]>;
+  def : WriteRes<WriteVFMovFV, [SiFive7VCQ, SiFive7VA]>;
 }
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVRGatherVX",    [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVRGatherVI",    [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVRGatherVX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVRGatherVI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
@@ -886,9 +892,9 @@ foreach mx = SchedMxList in {
   foreach sew = SchedSEWSet<mx>.val in {
     defvar Cycles = SiFive7GetCyclesOnePerElement<mx, sew>.c;
     defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = !add(Cycles, 3), ReleaseAtCycles = [Cycles] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVRGatherVV", [SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVCompressV", [SiFive7VA], mx, sew, IsWorstCase>;
+    let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm "" : LMULSEWWriteResMXSEW<"WriteVRGatherVV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
+      defm "" : LMULSEWWriteResMXSEW<"WriteVCompressV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
     }
   }
 }
@@ -896,23 +902,23 @@ foreach mx = SchedMxList in {
 foreach mx = SchedMxList in {
   defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
   defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, ReleaseAtCycles = [Cycles] in {
-    defm "" : LMULWriteResMX<"WriteVISlideX",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVISlideI",   [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVISlide1X",  [SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFSlide1F",  [SiFive7VA], mx, IsWorstCase>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+    defm "" : LMULWriteResMX<"WriteVISlideX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVISlideI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVISlide1X",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVFSlide1F",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
   }
 }
 
 // VMov*V is LMUL Aware
-let Latency = 4, ReleaseAtCycles = [2] in
-  def : WriteRes<WriteVMov1V,     [SiFive7VA]>;
-let Latency = 4, ReleaseAtCycles = [4] in
-  def : WriteRes<WriteVMov2V,     [SiFive7VA]>;
-let Latency = 4, ReleaseAtCycles = [8] in
-  def : WriteRes<WriteVMov4V,     [SiFive7VA]>;
-let Latency = 4, ReleaseAtCycles = [16] in
-  def : WriteRes<WriteVMov8V,     [SiFive7VA]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+  def : WriteRes<WriteVMov1V,     [SiFive7VCQ, SiFive7VA]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+  def : WriteRes<WriteVMov2V,     [SiFive7VCQ, SiFive7VA]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+  def : WriteRes<WriteVMov4V,     [SiFive7VCQ, SiFive7VA]>;
+let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+  def : WriteRes<WriteVMov8V,     [SiFive7VCQ, SiFive7VA]>;
 
 // Others
 def : WriteRes<WriteCSR, [SiFive7PipeB]>;

--- a/llvm/lib/Target/RISCV/RISCVScheduleV.td
+++ b/llvm/lib/Target/RISCV/RISCVScheduleV.td
@@ -69,19 +69,23 @@ multiclass LMULSEWWriteResMXSEW<string name, list<ProcResourceKind> resources,
 // is created similiarly if IsWorstCase is true.
 multiclass LMULWriteResMXVariant<string name, SchedPredicateBase Pred,
                                  list<ProcResourceKind> resources,
-                                 int predLat, list<int> predCycles,
-                                 int noPredLat, list<int> noPredCycles,
+                                 int predLat, list<int> predAcquireCycles,
+                                 list<int> predReleaseCycles, int noPredLat,
+                                 list<int> noPredAcquireCycles,
+                                 list<int> noPredReleaseCycles,
                                  string mx, bit IsWorstCase> {
   defvar nameMX = name # "_" # mx;
 
   // Define the different behaviors
-  def NAME # nameMX # "_Pred" : SchedWriteRes<resources> {
+  def nameMX # "_Pred" : SchedWriteRes<resources>{
     let Latency = predLat;
-    let ReleaseAtCycles = predCycles;
+    let AcquireAtCycles = predAcquireCycles;
+    let ReleaseAtCycles = predReleaseCycles;
   }
-  def NAME # nameMX # "_NoPred" : SchedWriteRes<resources> {
+  def nameMX # "_NoPred" : SchedWriteRes<resources> {
     let Latency = noPredLat;
-    let ReleaseAtCycles = noPredCycles;
+    let AcquireAtCycles = noPredAcquireCycles;
+    let ReleaseAtCycles = noPredReleaseCycles;
   }
 
   // Tie behavior to predicate

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
@@ -32,8 +32,8 @@ fdiv.s f1, f2, f3
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
@@ -70,8 +70,8 @@ c.jr a0
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
@@ -218,8 +218,8 @@ jr a0
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/reductions.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/reductions.s
@@ -223,13 +223,13 @@ vfredmin.vs  v4, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      206
-# CHECK-NEXT: Total Cycles:      8644
+# CHECK-NEXT: Total Cycles:      8746
 # CHECK-NEXT: Total uOps:        206
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 8640.0
+# CHECK-NEXT: Block RThroughput: 8743.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -241,431 +241,431 @@ vfredmin.vs  v4, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    47.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    48.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    49.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    50.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    53.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    54.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    42.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    43.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    44.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    45.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    57.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    36.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    37.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    37.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    38.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    39.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    40.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    43.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    44.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    51.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    52.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    32.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    33.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    34.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    35.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    38.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    39.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    47.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    48.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    49.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    50.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    53.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    54.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    42.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    43.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    44.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    45.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    57.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    36.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    37.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    37.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    38.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    39.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    40.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    43.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    44.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    51.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    52.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    32.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    33.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    34.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    35.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    38.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    39.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    47.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    48.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    49.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    50.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    53.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    54.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    42.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    43.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    44.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    45.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    57.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    36.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    37.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    37.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    38.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    39.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    40.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    43.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    44.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    51.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    52.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      96    96.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      96    97.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      192   192.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      192   193.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      384   384.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      384   385.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      768   768.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      768   769.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1536   1536.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      1536   1537.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      96    96.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      96    97.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      192   192.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      192   193.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      384   384.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      384   385.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      768   768.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      768   769.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    42.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    43.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    44.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    45.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    57.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    36.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    37.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    37.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    38.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    39.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    40.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    43.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    44.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    51.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    52.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    41.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    42.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    42.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    43.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    44.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    45.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    48.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    49.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    57.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    36.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    37.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    37.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    38.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    39.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    40.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    43.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    44.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    51.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    52.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    32.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    33.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    34.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    35.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    38.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    39.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    46.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    47.00                       vfredmin.vs	v4, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     103.00  -     8640.00 8640.00  -    -
+# CHECK-NEXT:  -      -     103.00  -     8743.00 103.00  -     -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  47.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  49.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     53.00  53.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  42.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  44.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     36.00  36.00   -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  37.00   -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  39.00   -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  43.00   -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     51.00  51.00   -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     32.00  32.00   -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     34.00  34.00   -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  38.00   -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  47.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  49.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     53.00  53.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  42.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  44.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     36.00  36.00   -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  37.00   -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  39.00   -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  43.00   -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     51.00  51.00   -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     32.00  32.00   -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     34.00  34.00   -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  38.00   -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  47.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  49.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     53.00  53.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  42.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  44.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     36.00  36.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  37.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  39.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  43.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     51.00  51.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  61.00   -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     96.00  96.00   -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     97.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     192.00 192.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     193.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     384.00 384.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     385.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     768.00 768.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     769.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1536.00 1536.00  -    -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1537.00 1.00   -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     96.00  96.00   -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     97.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     192.00 192.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     193.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     384.00 384.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     385.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     768.00 768.00  -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     769.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  42.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  44.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     36.00  36.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  37.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  39.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  43.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     51.00  51.00   -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     41.00  41.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  42.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  44.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  48.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     36.00  36.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  37.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  39.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  43.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     51.00  51.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     32.00  32.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     34.00  34.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  38.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     46.00  46.00   -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vfredmin.vs	v4, v8, v12

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-x0.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-x0.s
@@ -37,13 +37,13 @@ vle64.v v1, (a1)
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      26
-# CHECK-NEXT: Total Cycles:      3523
+# CHECK-NEXT: Total Cycles:      3546
 # CHECK-NEXT: Total uOps:        26
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 3517.0
+# CHECK-NEXT: Block RThroughput: 3541.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -55,71 +55,71 @@ vle64.v v1, (a1)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      515   512.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  1      515   512.00  *                   vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a1)
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a1)
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a1)
-# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a1)
+# CHECK-NEXT:  1      515   513.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      515   513.00  *                   vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a1)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a1)
+# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a1)
+# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a1)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      515   512.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   128.00  *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  1      515   512.00  *                   vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  1      131   128.00  *                   vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a1)
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a1)
-# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a1)
-# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a1)
+# CHECK-NEXT:  1      515   513.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   129.00  *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      515   513.00  *                   vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  1      131   129.00  *                   vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a1)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a1)
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a1)
+# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a1)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     3517.00  -    3517.00  -
+# CHECK-NEXT:  -      -     2.00    -      -     24.00  3541.00  -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     512.00  -     512.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     256.00  -     256.00  -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     64.00   -     64.00   -     vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     512.00  -     512.00  -     vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     256.00  -     256.00  -     vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     64.00   -     64.00   -     vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle32.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle64.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   513.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   513.00  -     vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a1)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     512.00  -     512.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     256.00  -     256.00  -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     128.00  -     128.00  -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -     512.00  -     512.00  -     vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     256.00  -     256.00  -     vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     128.00  -     128.00  -     vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle32.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle64.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   513.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   513.00  -     vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a1)

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/vector-integer-arithmetic.s
@@ -755,13 +755,13 @@ vmv.v.v v4, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      707
-# CHECK-NEXT: Total Cycles:      11753
+# CHECK-NEXT: Total Cycles:      11962
 # CHECK-NEXT: Total uOps:        707
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.06
 # CHECK-NEXT: IPC:               0.06
-# CHECK-NEXT: Block RThroughput: 11175.0
+# CHECK-NEXT: Block RThroughput: 11549.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -773,1433 +773,1433 @@ vmv.v.v v4, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsub.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsub.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vadd.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vadd.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vsub.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwsubu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwsubu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vsub.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwaddu.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwaddu.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vadd.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwsubu.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vsub.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwsubu.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwadd.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwadd.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwsub.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwsub.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     9.00                        vadd.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     17.00                       vsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwsubu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwsubu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwsub.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      8     2.00                        vwsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      8     2.00                        vwaddu.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwaddu.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwsubu.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwsubu.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwadd.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwadd.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwsub.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwsub.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     1.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     1.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vzext.vf4	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vsext.vf8	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     4.00                        vsext.vf8	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     8.00                        vsext.vf8	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     16.00                       vsext.vf8	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadc.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadc.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadc.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmadc.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmadc.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmadc.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmadc.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmadc.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmadc.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsbc.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsbc.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmsbc.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmsbc.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmsbc.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsbc.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     3.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     5.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     9.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     17.00                       vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vand.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vand.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vand.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vor.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vor.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vor.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vxor.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vxor.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmadc.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vxor.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vmadc.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmsbc.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmsbc.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vand.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vand.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vand.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vor.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vor.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vor.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vxor.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vxor.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vxor.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vand.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vand.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vand.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vor.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsll.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vand.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vand.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vsra.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vxor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsra.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vxor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsra.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vxor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsll.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vand.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vand.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vand.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     3.00                        vor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsra.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vxor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vsra.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vxor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vsra.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     17.00                       vxor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vsll.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vand.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vand.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vand.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vsll.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vsll.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vsll.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vsrl.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vsrl.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vsra.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vsra.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vsra.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vsll.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vsll.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  1      4     9.00                        vsll.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vsra.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vsra.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vsra.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vsll.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsra.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vnsrl.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      8     16.00                       vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmseq.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmseq.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     3.00                        vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      5     2.00                        vmsne.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     5.00                        vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      7     4.00                        vmsne.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     9.00                        vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      11    8.00                        vmsne.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      19    16.00                       vmsltu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     17.00                       vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmsltu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     2.00                        vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmslt.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     3.00                        vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      5     2.00                        vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     5.00                        vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      7     4.00                        vmsleu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     9.00                        vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      11    8.00                        vmsleu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      19    16.00                       vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     17.00                       vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmsle.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     3.00                        vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      5     2.00                        vmsle.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     5.00                        vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      7     4.00                        vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     9.00                        vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      11    8.00                        vmsgtu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     17.00                       vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      19    16.00                       vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      5     2.00                        vmsgt.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     5.00                        vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      7     4.00                        vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     9.00                        vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      11    8.00                        vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     17.00                       vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      19    16.00                       vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     17.00                       vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vminu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmin.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vmseq.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      5     3.00                        vmsne.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      7     5.00                        vmsne.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      11    9.00                        vmsne.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmax.vv	v4, v8, v12
+# CHECK-NEXT:  1      19    17.00                       vmsltu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmax.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmsltu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vmslt.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      5     3.00                        vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      7     5.00                        vmsleu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      11    9.00                        vmsleu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      19    17.00                       vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmsle.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      5     3.00                        vmsle.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      7     5.00                        vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      11    9.00                        vmsgtu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      19    17.00                       vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      5     3.00                        vmsgt.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      7     5.00                        vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      11    9.00                        vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      19    17.00                       vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vminu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmin.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmin.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmax.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmax.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vminu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vminu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmin.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmin.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmul.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vmin.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vmax.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmax.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vminu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vminu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmin.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmax.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmax.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vminu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmin.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmulhsu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmulhsu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmul.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vdivu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      60    60.00                       vdivu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      120   120.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      480   480.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      960   960.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1920   1920.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vmulhsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmulhsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      60    60.00                       vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      120   120.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     3.00                        vmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     5.00                        vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      480   480.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     9.00                        vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      960   960.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     17.00                       vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   112.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vmulhsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      224   224.00                      vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vmulhsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      448   448.00                      vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     9.00                        vmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     17.00                       vmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     3.00                        vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      228   228.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     5.00                        vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      456   456.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     9.00                        vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      912   912.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     17.00                       vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      30    31.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      60    61.00                       vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      120   121.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      240   241.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      480   481.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      960   961.00                      vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      1920   1921.00                      vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      30    31.00                       vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      60    61.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      120   121.00                      vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      480   481.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      960   961.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      56    57.00                       vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      112   113.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      224   225.00                      vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      448   449.00                      vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      896   897.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      228   229.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      456   457.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      912   913.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vwmulu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmulu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmulsu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     3.00                        vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     5.00                        vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     9.00                        vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     2.00                        vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vnmsub.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vnmsub.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmaccu.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmaccu.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     3.00                        vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  1      4     5.00                        vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     9.00                        vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     17.00                       vnmsub.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  1      4     2.00                        vnmsub.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     2.00                        vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      4     3.00                        vmacc.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     5.00                        vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  1      4     9.00                        vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     17.00                       vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     1.00                        vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  1      4     2.00                        vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vwmaccu.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     4.00                        vwmaccu.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     8.00                        vwmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      8     2.00                        vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      8     2.00                        vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      8     3.00                        vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      8     5.00                        vwmaccsu.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      8     9.00                        vwmaccus.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      8     2.00                        vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      8     2.00                        vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      8     3.00                        vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      8     5.00                        vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      8     2.00                        vwmaccus.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      8     3.00                        vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      8     5.00                        vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      8     9.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmerge.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmerge.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmerge.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmerge.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.v	v4, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     3.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     5.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     9.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     17.00                       vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     333.00  -     11175.00 11175.00  -   -
+# CHECK-NEXT:  -      -     333.00  -     11549.00 374.00  -    -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vadd.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadd.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwsubu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsubu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwsubu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwsubu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwaddu.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwaddu.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwsubu.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwsubu.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwsubu.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwsubu.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwadd.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwadd.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwadd.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwadd.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwsub.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwsub.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwsub.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwsub.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadc.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadc.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsbc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsbc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmsbc.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsbc.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vxor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vxor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vxor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vxor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vxor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vxor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vand.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vand.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vand.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vand.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vxor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vxor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vxor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vxor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vxor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vxor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vand.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vand.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vand.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vand.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsrl.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsrl.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsra.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsra.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsra.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsra.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsra.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsra.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsll.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsll.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsll.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsll.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsrl.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsrl.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsra.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsra.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsra.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsra.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsra.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsra.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsll.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsll.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsll.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsll.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmsne.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsne.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmsne.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsne.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmsne.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsne.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmsltu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsltu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsltu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsltu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmslt.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmslt.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmslt.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmsleu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsleu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmsleu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsleu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsleu.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsle.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsle.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmsle.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsle.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsle.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmsgtu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsgtu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsgtu.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmsgt.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsgt.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsgt.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmin.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmin.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmin.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmax.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmax.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmax.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmax.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vminu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vminu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmin.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmin.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmin.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmax.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmax.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmax.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmax.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vminu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vminu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vminu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmin.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmin.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmin.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulhsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     30.00  30.00   -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     60.00  60.00   -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     120.00 120.00  -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     480.00 480.00  -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     960.00 960.00  -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1920.00 1920.00  -    -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     30.00  30.00   -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     60.00  60.00   -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     120.00 120.00  -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     480.00 480.00  -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     960.00 960.00  -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     112.00 112.00  -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     224.00 224.00  -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     225.00 1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     448.00 448.00  -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     449.00 1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     896.00 896.00  -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     228.00 228.00  -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     229.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     456.00 456.00  -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     457.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     912.00 912.00  -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnmsub.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsub.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsub.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsub.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00   4.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12

--- a/llvm/test/tools/llvm-mca/RISCV/different-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/different-lmul-instruments.s
@@ -16,7 +16,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 18.0
+# CHECK-NEXT: Block RThroughput: 20.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -28,30 +28,30 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     18.00  18.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/different-sew-instruments.s
@@ -11,13 +11,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      358
+# CHECK-NEXT: Total Cycles:      359
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 354.0
+# CHECK-NEXT: Block RThroughput: 356.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -29,30 +29,30 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     354.00 354.00  -      -
+# CHECK-NEXT:  -      -     2.00    -     356.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/disable-im.s
+++ b/llvm/test/tools/llvm-mca/RISCV/disable-im.s
@@ -13,13 +13,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      6
-# CHECK-NEXT: Total Cycles:      40
+# CHECK-NEXT: Total Cycles:      42
 # CHECK-NEXT: Total uOps:        6
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.15
-# CHECK-NEXT: IPC:               0.15
-# CHECK-NEXT: Block RThroughput: 48.0
+# CHECK-NEXT: uOps Per Cycle:    0.14
+# CHECK-NEXT: IPC:               0.14
+# CHECK-NEXT: Block RThroughput: 51.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -31,45 +31,45 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     48.00  48.00   -      -
+# CHECK-NEXT:  -      -     3.00    -     51.00  3.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
-# CHECK-NEXT: Index     0123456789          0123456789
+# CHECK-NEXT: Index     0123456789          0123456789          01
 
-# CHECK:      [0,0]     DeeE .    .    .    .    .    .    .   .   vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .    .    .   .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .    .    .   .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,3]     .    .    .    .   DeeeE .    .    .   .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,4]     .    .    .    .    DeeE .    .    .   .   vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT: [0,5]     .    .    .    .    .    .    .    DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeE .    .    .    .    .    .    .    ..   vsetvli	zero, a0, e8, m2, tu, mu
+# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .    .    .    ..   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .    .    .    ..   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,3]     .    .    .    .    DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,4]     .    .    .    .    .DeeE.    .    .    ..   vsetvli	zero, a0, e8, m8, tu, mu
+# CHECK-NEXT: [0,5]     .    .    .    .    .    .    .    . DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/fractional-lmul-data.s
@@ -11,13 +11,13 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      90
+# CHECK-NEXT: Total Cycles:      91
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.04
 # CHECK-NEXT: IPC:               0.04
-# CHECK-NEXT: Block RThroughput: 86.0
+# CHECK-NEXT: Block RThroughput: 88.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -29,27 +29,27 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      56    57.00                       vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      30    31.00                       vdiv.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     86.00  86.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     88.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     56.00  56.00   -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     30.00  30.00   -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdiv.vv	v12, v12, v12

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-at-start.s
@@ -13,7 +13,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 2.0
+# CHECK-NEXT: Block RThroughput: 3.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -25,26 +25,26 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2.00   2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-middle.s
@@ -8,13 +8,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      21
+# CHECK-NEXT: Total Cycles:      22
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.14
 # CHECK-NEXT: IPC:               0.14
-# CHECK-NEXT: Block RThroughput: 17.0
+# CHECK-NEXT: Block RThroughput: 19.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -25,37 +25,37 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     17.00  17.00   -      -
+# CHECK-NEXT:  -      -     1.00    -     19.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          0
+# CHECK-NEXT: Index     0123456789          01
 
-# CHECK:      [0,0]     DeeeE.    .    .    .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,1]     .DeeE.    .    .    .   vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT: [0,2]     .    .    .    .DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,1]     .DeeE.    .    .    ..   vsetvli	zero, a0, e8, mf8, tu, mu
+# CHECK-NEXT: [0,2]     .    .    .    . DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-region.s
@@ -17,7 +17,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 2.0
+# CHECK-NEXT: Block RThroughput: 3.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -29,26 +29,26 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2.00   2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-straddles-region.s
@@ -18,7 +18,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 2.0
+# CHECK-NEXT: Block RThroughput: 3.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -30,26 +30,26 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2.00   2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/multiple-same-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/multiple-same-lmul-instruments.s
@@ -15,13 +15,13 @@ vsub.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      8
-# CHECK-NEXT: Total Cycles:      28
+# CHECK-NEXT: Total Cycles:      29
 # CHECK-NEXT: Total uOps:        8
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.29
-# CHECK-NEXT: IPC:               0.29
-# CHECK-NEXT: Block RThroughput: 22.0
+# CHECK-NEXT: uOps Per Cycle:    0.28
+# CHECK-NEXT: IPC:               0.28
+# CHECK-NEXT: Block RThroughput: 27.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -33,51 +33,51 @@ vsub.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
-# CHECK-NEXT:  1      4     2.00                        vsub.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vsub.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00                        vadd.vv	v12, v12, v12
-# CHECK-NEXT:  1      4     8.00                        vsub.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     9.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     9.00                        vsub.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     22.00  22.00   -      -
+# CHECK-NEXT:  -      -     3.00    -     27.00  5.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vsub.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vadd.vv	v12, v12, v12
-# CHECK-NEXT:  -      -      -      -     8.00   8.00    -      -     vsub.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsub.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          01234567
+# CHECK-NEXT: Index     0123456789          012345678
 
-# CHECK:      [0,0]     DeeE .    .    .    .    . .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    . .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    . .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,3]     .    . DeeeE   .    .    . .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,4]     .    .    .DeeeE    .    . .   vsub.vv	v12, v12, v12
-# CHECK-NEXT: [0,5]     .    .    . DeeE    .    . .   vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT: [0,6]     .    .    .    DeeeE.    . .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,7]     .    .    .    .    .  DeeeE   vsub.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeE .    .    .    .    .  .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .  .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .  .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,3]     .    . DeeeE   .    .    .  .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,4]     .    .    .DeeeE    .    .  .   vsub.vv	v12, v12, v12
+# CHECK-NEXT: [0,5]     .    .    . DeeE    .    .  .   vsetvli	zero, a0, e8, m4, tu, mu
+# CHECK-NEXT: [0,6]     .    .    .    DeeeE.    .  .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,7]     .    .    .    .    .   DeeeE   vsub.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/multiple-same-sew-instruments.s
@@ -16,13 +16,13 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      8
-# CHECK-NEXT: Total Cycles:      570
+# CHECK-NEXT: Total Cycles:      574
 # CHECK-NEXT: Total uOps:        8
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 566.0
+# CHECK-NEXT: Block RThroughput: 571.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -34,38 +34,38 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      114   114.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   112.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      112   112.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      112   113.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      112   113.00                      vdivu.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     566.00 566.00  -      -
+# CHECK-NEXT:  -      -     3.00    -     571.00 5.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     112.00 112.00  -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     112.00 112.00  -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdivu.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/needs-sew-but-only-lmul.s
@@ -10,13 +10,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      484
+# CHECK-NEXT: Total Cycles:      485
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 480.0
+# CHECK-NEXT: Block RThroughput: 482.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -28,28 +28,28 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     480.00 480.00  -      -
+# CHECK-NEXT:  -      -     1.00    -     482.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/no-vsetvli-to-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/no-vsetvli-to-start.s
@@ -7,13 +7,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      21
+# CHECK-NEXT: Total Cycles:      22
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.14
 # CHECK-NEXT: IPC:               0.14
-# CHECK-NEXT: Block RThroughput: 18.0
+# CHECK-NEXT: Block RThroughput: 20.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -24,37 +24,37 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     18.00  18.00   -      -
+# CHECK-NEXT:  -      -     1.00    -     20.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          0
+# CHECK-NEXT: Index     0123456789          01
 
-# CHECK:      [0,0]     DeeeE.    .    .    .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,1]     .DeeE.    .    .    .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,2]     .    .    .    .DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,1]     .DeeE.    .    .    ..   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,2]     .    .    .    . DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-at-start.s
@@ -14,7 +14,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 240.0
+# CHECK-NEXT: Block RThroughput: 241.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,26 +26,26 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     240.00 240.00  -      -
+# CHECK-NEXT:  -      -     1.00    -     241.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-middle.s
@@ -13,13 +13,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      2833
+# CHECK-NEXT: Total Cycles:      2834
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 2832.0
+# CHECK-NEXT: Block RThroughput: 2834.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -30,29 +30,29 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      1920   1920.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1920   1921.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      912   912.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      912   913.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2832.00 2832.00  -    -
+# CHECK-NEXT:  -      -     1.00    -     2834.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     1920.00 1920.00  -    -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     912.00 912.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-region.s
@@ -18,7 +18,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 114.0
+# CHECK-NEXT: Block RThroughput: 115.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -30,26 +30,26 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     114.00 114.00  -      -
+# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-straddles-region.s
@@ -19,7 +19,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 114.0
+# CHECK-NEXT: Block RThroughput: 115.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -31,26 +31,26 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     114.00 114.00  -      -
+# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     114.00 114.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/vle-vse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vle-vse.s
@@ -413,13 +413,13 @@ vsm.v    v1, (a0)
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      400
-# CHECK-NEXT: Total Cycles:      1084
+# CHECK-NEXT: Total Cycles:      1133
 # CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.37
-# CHECK-NEXT: IPC:               0.37
-# CHECK-NEXT: Block RThroughput: 848.0
+# CHECK-NEXT: uOps Per Cycle:    0.35
+# CHECK-NEXT: IPC:               0.35
+# CHECK-NEXT: Block RThroughput: 524.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -431,819 +431,819 @@ vsm.v    v1, (a0)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     9.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      4     17.00   *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      1     9.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
+# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     200.00  -     848.00  -     424.00 424.00
+# CHECK-NEXT:  -      -     200.00  -      -     200.00 524.00 524.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -     1.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -     4.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -     8.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -     16.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     1.00    -      -     1.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     4.00    -      -     4.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     8.00    -      -     8.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00   -      -     16.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -     2.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00    -      -     2.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)

--- a/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-instrument.s
@@ -14,7 +14,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 18.0
+# CHECK-NEXT: Block RThroughput: 20.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,30 +26,30 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     18.00  18.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1140
+# CHECK-NEXT: Total Cycles:      1141
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1136.0
+# CHECK-NEXT: Block RThroughput: 1138.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,30 +26,30 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      896   897.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1136.00 1136.00  -    -
+# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     896.00 896.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-instrument.s
@@ -14,7 +14,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 18.0
+# CHECK-NEXT: Block RThroughput: 20.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,30 +26,30 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     18.00  18.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   2.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     16.00  16.00   -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1140
+# CHECK-NEXT: Total Cycles:      1141
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1136.0
+# CHECK-NEXT: Block RThroughput: 1138.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,30 +26,30 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      896   897.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv
 # CHECK-NEXT: [1]   - SiFive7IDiv
 # CHECK-NEXT: [2]   - SiFive7PipeA
 # CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7PipeV
-# CHECK-NEXT: [5]   - SiFive7VA
+# CHECK-NEXT: [4]   - SiFive7VA
+# CHECK-NEXT: [5]   - SiFive7VCQ
 # CHECK-NEXT: [6]   - SiFive7VL
 # CHECK-NEXT: [7]   - SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1136.00 1136.00  -    -
+# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     240.00 240.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     896.00 896.00  -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123


### PR DESCRIPTION
The Arithmetic, Load, and Store sequencers can accept instructions in parallel. The PipeV blocked that from happening since it became busy if any of the sequencers were busy. This change allows the sequencers to accept instructions in parallel.

The VCQ accepts instructions from the the A Pipe and holds them until the vector unit is ready to dequeue them. The unit dequeues up to one instruction per cycle, in order, as soon as the sequencer for that type of instruction is avaliable. This resource is meant to be used for 1 cycle by all vector instructions, to model that only one vector instruction may be dequed at a time. The actual dequeueing into the sequencer is modeled by the VA, VL, and VS sequencer resources below. Each of them will only accept a single instruction at a time and remain busy for the number of cycles associated with that instruction.