### PR TITLE
[clang-fuzzer] Remove GCC 4.x pre GCC 4.9 workaround to silence warning

### DIFF
--- a/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
+++ b/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
@@ -185,23 +185,7 @@ static void CreateAndRunJITFunc(const std::string &IR, CodeGenOptLevel OLvl) {
   EE->finalizeObject();
   EE->runStaticConstructorsDestructors(false);
 
-#if defined(__GNUC__) && !defined(__clang) &&                                  \
-    ((__GNUC__ == 4) && (__GNUC_MINOR__ < 9))
-// Silence
-//
-//   warning: ISO C++ forbids casting between pointer-to-function and
-//   pointer-to-object [-Wpedantic]
-//
-// Since C++11 this casting is conditionally supported and GCC versions
-// starting from 4.9.0 don't warn about the cast.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
   LLVMFunc f = reinterpret_cast<LLVMFunc>(EE->getPointerToFunction(EntryFunc));
-#if defined(__GNUC__) && !defined(__clang) &&                                  \
-    ((__GNUC__ == 4) && (__GNUC_MINOR__ < 9))
-#pragma GCC diagnostic pop
-#endif
 
   // Figure out if we are running the optimized func or the unoptimized func
   RunFuncOnInputs(f, (OLvl == CodeGenOptLevel::None) ? UnoptArrays : OptArrays);


### PR DESCRIPTION
The minimum GCC version was bumped up from 4.8 to 5.1 and then even newer
awhile ago so garbage collect the pre 4.9 workaround.

https://reviews.llvm.org/D66188