### PR TITLE
[libc] Exclude Fuchsia from float128 detection

### DIFF
--- a/libc/src/__support/macros/properties/float.h
+++ b/libc/src/__support/macros/properties/float.h
@@ -62,7 +62,8 @@ using float16 = _Float16;
 #define LIBC_COMPILER_HAS_C23_FLOAT128
 #endif
 #if (defined(LIBC_COMPILER_CLANG_VER) && (LIBC_COMPILER_CLANG_VER >= 500)) &&  \
-    (defined(LIBC_TARGET_ARCH_IS_X86_64))
+    (defined(LIBC_TARGET_ARCH_IS_X86_64) &&                                    \
+     !defined(LIBC_TARGET_OS_IS_FUCHSIA))
 #define LIBC_COMPILER_HAS_FLOAT128_EXTENSION
 #endif
 

--- a/libc/src/__support/macros/properties/os.h
+++ b/libc/src/__support/macros/properties/os.h
@@ -37,7 +37,7 @@
 #endif
 #endif
 
-#if (defined(__Fuchsia__))
+#if defined(__Fuchsia__)
 #define LIBC_TARGET_OS_IS_FUCHSIA
 #endif
 

--- a/libc/src/__support/macros/properties/os.h
+++ b/libc/src/__support/macros/properties/os.h
@@ -37,4 +37,8 @@
 #endif
 #endif
 
+#if (defined(__Fuchsia__))
+#define LIBC_TARGET_OS_IS_FUCHSIA
+#endif
+
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_OS_H


### PR DESCRIPTION
Following from https://github.com/llvm/llvm-project/pull/73372:

Fuchsia targets currently don't support `float128`. Add detection for `LIBC_TARGET_OS_IS_FUCHSIA`, and exclude this OS from setting `LIBC_COMPILER_HAS_FLOAT128_EXTENSION`.