### PR TITLE
[PowerPC] Fix the register class for the instruction paddi.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrP10.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrP10.td
@@ -615,7 +615,7 @@ def RCCp {
 let Predicates = [PrefixInstrs] in {
   let Interpretation64Bit = 1, isCodeGenOnly = 1 in {
     defm PADDI8 :
-      MLS_DForm_R_SI34_RTA5_p<14, (outs g8rc:$RT), (ins g8rc:$RA, s34imm:$SI),
+      MLS_DForm_R_SI34_RTA5_p<14, (outs g8rc:$RT), (ins g8rc_nox0:$RA, s34imm:$SI),
                               (ins immZero:$RA, s34imm_pcrel:$SI),
                               "paddi $RT, $RA, $SI", IIC_LdStLFD>;
     let isReMaterializable = 1, isAsCheapAsAMove = 1, isMoveImm = 1 in {
@@ -625,7 +625,7 @@ let Predicates = [PrefixInstrs] in {
     }
   }
   defm PADDI :
-    MLS_DForm_R_SI34_RTA5_p<14, (outs gprc:$RT), (ins gprc:$RA, s34imm:$SI),
+    MLS_DForm_R_SI34_RTA5_p<14, (outs gprc:$RT), (ins gprc_nor0:$RA, s34imm:$SI),
                             (ins immZero:$RA, s34imm_pcrel:$SI),
                             "paddi $RT, $RA, $SI", IIC_LdStLFD>;
   let isReMaterializable = 1, isAsCheapAsAMove = 1, isMoveImm = 1 in {

--- a/llvm/test/MC/PowerPC/ppc64-encoding-full-names.s
+++ b/llvm/test/MC/PowerPC/ppc64-encoding-full-names.s
@@ -1,0 +1,24 @@
+# RUN: llvm-mc -triple powerpc64-unknown-linux-gnu --show-encoding -ppc-asm-full-reg-names %s | \
+# RUN:   FileCheck -check-prefix=CHECK-BE %s
+# RUN: llvm-mc -triple powerpc64le-unknown-linux-gnu --show-encoding -ppc-asm-full-reg-names %s | \
+# RUN:   FileCheck -check-prefix=CHECK-LE %s
+
+# CHECK-BE: addi r1, r2, 700                   # encoding: [0x38,0x22,0x02,0xbc]
+# CHECK-LE: addi r1, r2, 700                   # encoding: [0xbc,0x02,0x22,0x38]
+            addi 1, 2, 700
+
+# CHECK-BE: li r1, 700                         # encoding: [0x38,0x20,0x02,0xbc]
+# CHECK-LE: li r1, 700                         # encoding: [0xbc,0x02,0x20,0x38]
+            addi 1, 0, 700
+
+# CHECK-BE: paddi r1, r2, 6400000, 0           # encoding: [0x06,0x00,0x00,0x61,
+# CHECK-BE-SAME:                                            0x38,0x22,0xa8,0x00]
+# CHECK-LE: paddi r1, r2, 6400000, 0           # encoding: [0x61,0x00,0x00,0x06,
+# CHECK-LE-SAME:                                            0x00,0xa8,0x22,0x38]
+            paddi 1, 2, 6400000, 0
+
+# CHECK-BE: paddi r1, 0, 6400000, 0            # encoding: [0x06,0x00,0x00,0x61,
+# CHECK-BE-SAME:                                            0x38,0x20,0xa8,0x00]
+# CHECK-LE: paddi r1, 0, 6400000, 0            # encoding: [0x61,0x00,0x00,0x06,
+# CHECK-LE-SAME:                                            0x00,0xa8,0x20,0x38]
+            paddi 1, 0, 6400000, 0


### PR DESCRIPTION
The register class for the PADDI definition is incorrect as register zero for RA is treated as an actual zero.