### PR TITLE
[test] Fix expected line number in `TestRunner.py`

### DIFF
--- a/llvm/utils/lit/tests/unit/TestRunner.py
+++ b/llvm/utils/lit/tests/unit/TestRunner.py
@@ -132,7 +132,7 @@ class TestIntegratedTestKeywordParser(unittest.TestCase):
         value = cmd_parser.getValue()
         self.assertEqual(len(value), 2)  # there are only two run lines
         self.assertEqual(value[0].command.strip(), "%dbg(MY_RUN: at line 4)  baz")
-        self.assertEqual(value[1].command.strip(), "%dbg(MY_RUN: at line 7)  foo  bar")
+        self.assertEqual(value[1].command.strip(), "%dbg(MY_RUN: at line 12)  foo  bar")
 
     def test_boolean(self):
         parsers = self.make_parsers()


### PR DESCRIPTION
My #73541 added lines to `llvm/utils/lit/tests/Inputs/testrunner-custom-parsers/test.txt` so what was previously on line 7 is now on line 12.

Before:
https://github.com/llvm/llvm-project/blob/28412d1800e391c5ba8e7607bb15c74b106d581b/llvm/utils/lit/tests/Inputs/testrunner-custom-parsers/test.txt#L7-L8

After:
https://github.com/llvm/llvm-project/blob/6fb7c2d713587a061cd281eda917746750559380/llvm/utils/lit/tests/Inputs/testrunner-custom-parsers/test.txt#L12-L13

This didn't show up in the PR checks, but caused a buildbot failure after merging, https://lab.llvm.org/buildbot/#/builders/139/builds/54597 :

```
# | ======================================================================
# | FAIL: test_commands (__main__.TestIntegratedTestKeywordParser)
# | ----------------------------------------------------------------------
# | Traceback (most recent call last):
# |   File "/home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/utils/lit/tests/unit/TestRunner.py", line 135, in test_commands
# |     self.assertEqual(value[1].command.strip(), "%dbg(MY_RUN: at line 7)  foo  bar")
# | AssertionError: '%dbg(MY_RUN: at line 12)  foo  bar' != '%dbg(MY_RUN: at line 7)  foo  bar'
# | - %dbg(MY_RUN: at line 12)  foo  bar
# | ?                      ^^
# | + %dbg(MY_RUN: at line 7)  foo  bar
# | ?                      ^
```

Apologies for the build break :scream_cat: