### PR TITLE
[OpenMP][NFC] Encapsulate profiling logic

### DIFF
--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -708,6 +708,7 @@ variables is defined below.
 
     * ``LIBOMPTARGET_DEBUG=<Num>``
     * ``LIBOMPTARGET_PROFILE=<Filename>``
+    * ``LIBOMPTARGET_PROFILE_GRANULARITY=<Num> (default 500, in us)``
     * ``LIBOMPTARGET_MEMORY_MANAGER_THRESHOLD=<Num>``
     * ``LIBOMPTARGET_INFO=<Num>``
     * ``LIBOMPTARGET_HEAP_SIZE=<Num>``
@@ -748,6 +749,12 @@ for time trace output. Note that this will turn ``libomp`` into a C++ library.
 .. _`Speedscope App`: https://www.speedscope.app/
 
 .. _`LLVM Support Library`: https://llvm.org/docs/SupportLibrary.html
+
+LIBOMPTARGET_PROFILE_GRANULARITY
+""""""""""""""""""""""""""""""""
+
+``LIBOMPTARGET_PROFILE_GRANULARITY`` allows to change the time profile
+granularity measured in `us`. Default is 500 (`us`).
 
 LIBOMPTARGET_MEMORY_MANAGER_THRESHOLD
 """""""""""""""""""""""""""""""""""""

--- a/openmp/libomptarget/include/Shared/Profile.h
+++ b/openmp/libomptarget/include/Shared/Profile.h
@@ -10,7 +10,69 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef OMPTARGET_SHARED_PROFILE_H
+#define OMPTARGET_SHARED_PROFILE_H
+
+#include "Shared/Debug.h"
+#include "Shared/EnvironmentVar.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/TimeProfiler.h"
+
+/// Class that holds the singleton profiler and allows to start/end events.
+class Profiler {
+
+  Profiler() {
+    if (!ProfileTraceFile.isPresent())
+      return;
+
+    // TODO: Add an alias without LIBOMPTARGET
+    // Flag to modify the profile granularity (in us).
+    Int32Envar ProfileGranularity =
+        Int32Envar("LIBOMPTARGET_PROFILE_GRANULARITY", 500);
+
+    llvm::timeTraceProfilerInitialize(ProfileGranularity /* us */,
+                                      "libomptarget");
+  }
+
+  ~Profiler() {
+    if (!ProfileTraceFile.isPresent())
+      return;
+
+    if (auto Err = llvm::timeTraceProfilerWrite(ProfileTraceFile.get(), "-"))
+      REPORT("Error writing out the time trace: %s\n",
+             llvm::toString(std::move(Err)).c_str());
+
+    llvm::timeTraceProfilerCleanup();
+  }
+
+  // TODO: Add an alias without LIBOMPTARGET
+  /// Flag to enable profiling which also specifies the file profile information
+  /// is stored in.
+  StringEnvar ProfileTraceFile = StringEnvar("LIBOMPTARGET_PROFILE");
+
+public:
+  static Profiler &get() {
+    static Profiler P;
+    return P;
+  }
+
+  /// Manually begin a time section, with the given \p Name and \p Detail.
+  /// Profiler copies the string data, so the pointers can be given into
+  /// temporaries. Time sections can be hierarchical; every Begin must have a
+  /// matching End pair but they can nest.
+  void beginSection(llvm::StringRef Name, llvm::StringRef Detail) {
+    llvm::timeTraceProfilerBegin(Name, Detail);
+  }
+  void beginSection(llvm::StringRef Name,
+                    llvm::function_ref<std::string()> Detail) {
+    llvm::timeTraceProfilerBegin(Name, Detail);
+  }
+
+  /// Manually end the last time section.
+  void endSection() { llvm::timeTraceProfilerEnd(); }
+};
 
 /// Time spend in the current scope, assigned to the function name.
 #define TIMESCOPE() llvm::TimeTraceScope TimeScope(__FUNCTION__)
@@ -34,3 +96,5 @@
   std::string ProfileLocation = SI.getProfileLocation();                       \
   std::string RTM = RegionTypeMsg;                                             \
   llvm::TimeTraceScope TimeScope(__FUNCTION__, ProfileLocation + RTM)
+
+#endif // OMPTARGET_SHARED_PROFILE_H

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -41,8 +41,6 @@ static const char *RTLNames[] = {
     /* AMDGPU target        */ "libomptarget.rtl.amdgpu",
 };
 
-static char *ProfileTraceFile = nullptr;
-
 #ifdef OMPT_SUPPORT
 extern void ompt::connectLibrary();
 #endif
@@ -64,16 +62,12 @@ __attribute__((constructor(101))) void init() {
 
   PM = new PluginManager(UseEventsForAtomicTransfers);
 
-  ProfileTraceFile = getenv("LIBOMPTARGET_PROFILE");
-  // TODO: add a configuration option for time granularity
-  if (ProfileTraceFile)
-    timeTraceProfilerInitialize(500 /* us */, "libomptarget");
-
 #ifdef OMPT_SUPPORT
   // Initialize OMPT first
   ompt::connectLibrary();
 #endif
 
+  Profiler::get();
   PM->RTLs.loadRTLs();
   PM->registerDelayedLibraries();
 }
@@ -81,14 +75,6 @@ __attribute__((constructor(101))) void init() {
 __attribute__((destructor(101))) void deinit() {
   DP("Deinit target library!\n");
   delete PM;
-
-  if (ProfileTraceFile) {
-    // TODO: add env var for file output
-    if (auto E = timeTraceProfilerWrite(ProfileTraceFile, "-"))
-      fprintf(stderr, "Error writing out the time trace\n");
-
-    timeTraceProfilerCleanup();
-  }
 }
 
 void PluginAdaptorManagerTy::loadRTLs() {


### PR DESCRIPTION
This simply puts the profiling logic into the `Profiler` class and allows non-RAII profiling via `beginSection` and `endSection`.