### PR TITLE
[NFC][lldb] Implement DiagnosticManager::Consume

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -118,6 +118,15 @@ public:
       m_diagnostics.push_back(std::move(diagnostic));
   }
 
+  /// Moves over the contents of a second diagnostic manager over. Leaves other
+  /// diagnostic manager in an empty state.
+  void Consume(DiagnosticManager &&other) {
+    std::move(other.m_diagnostics.begin(), other.m_diagnostics.end(),
+              std::back_inserter(m_diagnostics));
+    m_fixed_expression = std::move(other.m_fixed_expression);
+    other.Clear();
+  }
+
   size_t Printf(DiagnosticSeverity severity, const char *format, ...)
       __attribute__((format(printf, 3, 4)));
   void PutString(DiagnosticSeverity severity, llvm::StringRef str);


### PR DESCRIPTION
In some situations it may be useful to have a separate DiagnosticManager instance, and then later of move the contents of that instance back to the "main" DiagnosticManager. For example, when silently retrying some operation with different parameters, depending on whether the retry succeeded or failed, LLDB may want to present a different set of diagnostics to the user (the ones generated on the first try vs the retry). Implement DiagnosticManager::Consume to allow for this use case.