### PR TITLE
[mlir] Fix the link of libcuda.so in MLIRGPUTransforms to not use fully qualified path

### DIFF
--- a/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -135,11 +135,15 @@ if(MLIR_ENABLE_CUDA_RUNNER)
     ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
   )
 
+  # Add link path for the cuda driver library.
   find_library(CUDA_DRIVER_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} REQUIRED)
+  get_filename_component(CUDA_DRIVER_LIBRARY_PATH "${CUDA_DRIVER_LIBRARY}" DIRECTORY)
+  target_link_directories(MLIRGPUTransforms PRIVATE ${CUDA_DRIVER_LIBRARY_PATH})
+
   target_link_libraries(MLIRGPUTransforms
     PRIVATE
     MLIRNVVMToLLVMIRTranslation
-    ${CUDA_DRIVER_LIBRARY}
+    cuda
   )
 
 endif()


### PR DESCRIPTION
At the moment we find libcuda.so in a path like:

  /usr/local/cuda/targets/x86_64-linux/lib/stubs/libcuda.so

and directly add this to `target_link_libraries`. The problem is that our installed MLIR package will include the full path to the library, and a user downstream when including our cmake installed package will inherit this full path.

We're changing this to instead

 -L /usr/local/cuda/targets/x86_64-linux/lib/stubs/ -lcuda