### PR TITLE
[lldb] Simplify pipe2(2) handling on FreeBSD

### DIFF
--- a/lldb/source/Host/posix/PipePosix.cpp
+++ b/lldb/source/Host/posix/PipePosix.cpp
@@ -31,8 +31,8 @@ enum PIPES { READ, WRITE }; // Constants 0 and 1 for READ and WRITE
 
 // pipe2 is supported by a limited set of platforms
 // TODO: Add more platforms that support pipe2.
-#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD__ >= 10) ||       \
-    defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) ||       \
+    defined(__OpenBSD__)
 #define PIPE2_SUPPORTED 1
 #else
 #define PIPE2_SUPPORTED 0


### PR DESCRIPTION
FreeBSD 10.x and 11.x support has been dropped leaving 12.x as the minimum version. This FreeBSD check can be simplified.

https://github.com/llvm/llvm-project/commit/812dad536ed50abe94d6e2b2519f351791c24c59