### PR TITLE
Thread safety analysis: Fix a bug in handling temporary constructors

### DIFF
--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -1702,6 +1702,8 @@ struct TestScopedLockable {
 
   bool getBool();
 
+  bool lock2Bool(MutexLock);
+
   void foo1() {
     MutexLock mulock(&mu1);
     a = 5;
@@ -1716,6 +1718,12 @@ struct TestScopedLockable {
 
   void temporary() {
     MutexLock{&mu1}, a = 5;
+  }
+
+  void temporary_cfg(int x) {
+    // test the case where a pair of temporary Ctor and Dtor is in different CFG blocks
+    lock2Bool(MutexLock{&mu1}) || x;
+    MutexLock{&mu1};  // no-warn
   }
 
   void lifetime_extension() {


### PR DESCRIPTION
The commit 54bfd04846156dbd5e0a6b88f539c3d4569a455f introduces general handling of constructor and destructor calls.  Consider a pair of TEMPORARY constructor and destructor calls of a "SCOPED_CAPABILITY" object.  At the constructor call, a resource representing the object itself is added to the state.  But since it is a temporary object, the analyzer may not be able to find an AST part to identify the resource (As opposed to the normal case of using `VarDecl` as an identifier). Later at the destructor call, the resource needs to be removed from the state.  Since the resource cannot be identified by anything other than itself, the analyzer maintains a map from constructor calls to their created resources so that the analyzer could get the proper resource for removal at the destructor call via look up the map.  The issue is that the map lives within a CFG block.  That means in case the pair of temporary constructor and destructor calls are not in one CFG block, the analyzer is not able to remove the proper resource at the destructor call.  Although the two calls stay in one CFG block usually, they separate in the following example:

```
if (f(MutexLock{lock}) || x) { // <-- the temporary Ctor and Dtor of MutexLock are in different CFG blocks

}
```

The fix is simple. It extends the life of the map to that of the entire CFG.