### PR TITLE
[Clang] Remove NetBSD/i386 workaround for FP eval method with older versions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1239,6 +1239,11 @@ AIX Support
   This access sequence is not used for TLS variables larger than 32KB, and is
   currently only supported on 64-bit mode.
 
+NetBSD Support
+^^^^^^^^^^^^^^
+
+- Removed support for building NetBSD/i386 6.x or older binaries.
+
 WebAssembly Support
 ^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -513,15 +513,6 @@ class LLVM_LIBRARY_VISIBILITY NetBSDI386TargetInfo
 public:
   NetBSDI386TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : NetBSDTargetInfo<X86_32TargetInfo>(Triple, Opts) {}
-
-  LangOptions::FPEvalMethodKind getFPEvalMethod() const override {
-    VersionTuple OsVersion = getTriple().getOSVersion();
-    // New NetBSD uses the default rounding mode.
-    if (OsVersion >= VersionTuple(6, 99, 26) || OsVersion.getMajor() == 0)
-      return X86_32TargetInfo::getFPEvalMethod();
-    // NetBSD before 6.99.26 defaults to "double" rounding.
-    return LangOptions::FPEvalMethodKind::FEM_Double;
-  }
 };
 
 class LLVM_LIBRARY_VISIBILITY OpenBSDI386TargetInfo


### PR DESCRIPTION
NetBSD 6.x is long EoL. Make 7.x the minimum and even that is EoL.