### PR TITLE
[OpenMP][NFC] Extract OffloadPolicy into a helper class

### DIFF
--- a/openmp/libomptarget/include/OffloadPolicy.h
+++ b/openmp/libomptarget/include/OffloadPolicy.h
@@ -1,0 +1,63 @@
+//===-- OffloadPolicy.h - Configuration of offload behavior -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Configuration for offload behavior, e.g., if offload is disabled, can be
+// disabled, is mandatory, etc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OMPTARGET_OFFLOAD_POLICY_H
+#define OMPTARGET_OFFLOAD_POLICY_H
+
+#include "PluginManager.h"
+
+enum kmp_target_offload_kind_t {
+  tgt_disabled = 0,
+  tgt_default = 1,
+  tgt_mandatory = 2
+};
+
+extern "C" int __kmpc_get_target_offload(void) __attribute__((weak));
+
+class OffloadPolicy {
+
+  OffloadPolicy(PluginManager &PM) {
+    // TODO: Check for OpenMP.
+    switch ((kmp_target_offload_kind_t)__kmpc_get_target_offload()) {
+    case tgt_disabled:
+      Kind = DISABLED;
+      return;
+    case tgt_mandatory:
+      Kind = MANDATORY;
+      return;
+    default:
+      if (PM.getNumDevices()) {
+        DP("Default TARGET OFFLOAD policy is now mandatory "
+           "(devices were found)\n");
+        Kind = MANDATORY;
+      } else {
+        DP("Default TARGET OFFLOAD policy is now disabled "
+           "(no devices were found)\n");
+        Kind = DISABLED;
+      }
+      return;
+    };
+  }
+
+public:
+  static const OffloadPolicy &get(PluginManager &PM) {
+    static OffloadPolicy OP(PM);
+    return OP;
+  }
+
+  enum OffloadPolicyKind { DISABLED, MANDATORY };
+
+  OffloadPolicyKind Kind = MANDATORY;
+};
+
+#endif // OMPTARGET_OFFLOAD_POLICY_H

--- a/openmp/libomptarget/include/PluginManager.h
+++ b/openmp/libomptarget/include/PluginManager.h
@@ -107,10 +107,6 @@ struct PluginManager {
   HostPtrToTableMapTy HostPtrToTableMap;
   std::mutex TblMapMtx; ///< For HostPtrToTableMap
 
-  // Store target policy (disabled, mandatory, default)
-  kmp_target_offload_kind_t TargetOffloadPolicy = tgt_default;
-  std::mutex TargetOffloadMtx; ///< For TargetOffloadPolicy
-
   // Work around for plugins that call dlopen on shared libraries that call
   // tgt_register_lib during their initialisation. Stash the pointers in a
   // vector until the plugins are all initialised and then register them.

--- a/openmp/libomptarget/include/device.h
+++ b/openmp/libomptarget/include/device.h
@@ -33,14 +33,6 @@ struct PluginAdaptorTy;
 struct __tgt_bin_desc;
 struct __tgt_target_table;
 
-// enum for OMP_TARGET_OFFLOAD; keep in sync with kmp.h definition
-enum kmp_target_offload_kind {
-  tgt_disabled = 0,
-  tgt_default = 1,
-  tgt_mandatory = 2
-};
-typedef enum kmp_target_offload_kind kmp_target_offload_kind_t;
-
 ///
 struct PendingCtorDtorListsTy {
   std::list<void *> PendingCtors;


### PR DESCRIPTION
OpenMP allows 3 different offload policies, handling of which we want to encapsulate.