### PR TITLE
BPF: Emit an error for illegal LD_imm64 insn when LLVM_ENABLE_ASSERTI…

### DIFF
--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.cpp
@@ -36,15 +36,16 @@ void BPFInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 }
 
 static void printExpr(const MCExpr *Expr, raw_ostream &O) {
-#ifndef NDEBUG
   const MCSymbolRefExpr *SRE;
 
   if (const MCBinaryExpr *BE = dyn_cast<MCBinaryExpr>(Expr))
     SRE = dyn_cast<MCSymbolRefExpr>(BE->getLHS());
   else
     SRE = dyn_cast<MCSymbolRefExpr>(Expr);
-  assert(SRE && "Unexpected MCExpr type.");
+  if (!SRE)
+    report_fatal_error("Unexpected MCExpr type.");
 
+#ifndef NDEBUG
   MCSymbolRefExpr::VariantKind Kind = SRE->getKind();
 
   assert(Kind == MCSymbolRefExpr::VK_None);


### PR DESCRIPTION
…ONS=OFF

Jose reported an issue ([1]) where for the below illegal asm code
```
  r0 = 1 + w3 ll
```
clang actually supports it and generates the object code.

Further investigation finds that clang actually intends to reject the above code as well but only when the clang is built with LLVM_ENABLE_ASSERTIONS=ON.

I later found that clang16 (built by redhat and centos) in fedora system has the same issue since they also have LLVM_ENABLE_ASSERTIONS=OFF ([2]).

So let BPF backend report an error for the above case regardless of the LLVM_ENABLE_ASSERTIONS setting.

  [1] https://lore.kernel.org/bpf/87leahx2xh.fsf@oracle.com/#t
  [2] https://lore.kernel.org/bpf/840e33ec-ea4c-4b55-bda1-0be8d1e0324f@linux.dev/