### PR TITLE
[ADT] Make use of the endian.h header on NetBSD and DragonFly

### DIFF
--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -28,7 +28,8 @@
 #endif
 
 #if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) ||            \
-    defined(__Fuchsia__) || defined(__EMSCRIPTEN__) || defined(__OpenBSD__)
+    defined(__Fuchsia__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__) ||  \
+    defined(__OpenBSD__) || defined(__DragonFly__)
 #include <endian.h>
 #elif defined(_AIX)
 #include <sys/machine.h>


### PR DESCRIPTION
Move away from machine/endian.h to POSIX endian.h header.