### PR TITLE
[OpenMP] return empty stmt for `nothing`

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2528,7 +2528,8 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
       skipUntilPragmaOpenMPEnd(DKind);
     if (Tok.is(tok::annot_pragma_openmp_end))
       ConsumeAnnotationToken();
-    break;
+    // return an empty statement
+    return StmtEmpty();
   case OMPD_metadirective: {
     ConsumeToken();
     SmallVector<VariantMatchInfo, 4> VMIs;

--- a/clang/test/OpenMP/nothing_ast_print.cpp
+++ b/clang/test/OpenMP/nothing_ast_print.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fopenmp -ast-print %s | FileCheck %s --check-prefix=PRINT
+// RUN: %clang_cc1 -ast-print %s | FileCheck %s --check-prefix=PRINT
+
+// Checks whether the `if` body looks same with and without OpenMP enabled
+
+void foo() {
+    return;
+}
+
+int main() {
+    int x = 3;
+    if (x % 2 == 0)
+        #pragma omp nothing
+    foo();
+
+    return 0;
+// PRINT: if (x % 2 == 0)
+// PRINT:    foo();
+// PRINT: return 0;
+}

--- a/openmp/runtime/test/misc_bugs/omp_nothing.c
+++ b/openmp/runtime/test/misc_bugs/omp_nothing.c
@@ -1,0 +1,27 @@
+// RUN: %libomp-compile
+// RUN: %libomp-run | FileCheck %s --check-prefix OMP-CHECK
+
+#include <stdio.h>
+
+void foo(int x) {
+  printf("foo");
+  return;
+}
+
+int main() {
+  int x = 4;
+  // should call foo()
+  if (x % 2 == 0)
+#pragma omp nothing
+    foo(x);
+
+  // should not call foo()
+  x = 3;
+  if (x % 2 == 0)
+#pragma omp nothing
+    foo(x);
+
+  // OMP-CHECK: foo
+  // OMP-CHECK-NOT: foo
+  return 0;
+}


### PR DESCRIPTION
- `nothing` directive was effecting the `if` block structure which it should not. So return an empty statement instead of an error statement while parsing to avoid this.