### PR TITLE
[flang][openacc] Add loop expand pass

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -45,6 +45,7 @@ namespace fir {
 #define GEN_PASS_DECL_ALGEBRAICSIMPLIFICATION
 #define GEN_PASS_DECL_POLYMORPHICOPCONVERSION
 #define GEN_PASS_DECL_OPENACCDATAOPERANDCONVERSION
+#define GEN_PASS_DECL_OPENACCLOOPEXPAND
 #include "flang/Optimizer/Transforms/Passes.h.inc"
 
 std::unique_ptr<mlir::Pass> createAbstractResultOnFuncOptPass();
@@ -78,6 +79,8 @@ std::unique_ptr<mlir::Pass> createPolymorphicOpConversionPass();
 std::unique_ptr<mlir::Pass> createOMPFunctionFilteringPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createOMPMarkDeclareTargetPass();
+
+std::unique_ptr<mlir::Pass> createOpenACCLoopExpandPass();
 
 std::unique_ptr<mlir::Pass> createVScaleAttrPass();
 std::unique_ptr<mlir::Pass>

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -335,6 +335,14 @@ def OMPFunctionFiltering : Pass<"omp-function-filtering"> {
   ];
 }
 
+def OpenACCLoopExpand : Pass<"acc-loop-expand", "mlir::func::FuncOp"> {
+  let summary = "";
+  let constructor = "::fir::createOpenACCLoopExpandPass()";
+  let dependentDialects = [
+    "fir::FIROpsDialect"
+  ];
+}
+
 def VScaleAttr : Pass<"vscale-attr", "mlir::func::FuncOp"> {
   let summary = "Add vscale_range attribute to functions";
   let description = [{

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_flang_library(FIRTransforms
   LoopVersioning.cpp
   OMPFunctionFiltering.cpp
   OMPMarkDeclareTarget.cpp
+  OpenACCLoopExpand.cpp
   VScaleAttr.cpp
 
   DEPENDS

--- a/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
+++ b/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
@@ -167,12 +167,13 @@ void LoopExpand::runOnOperation() {
       bool isInnerLoop = i == (nbLoop - 1);
 
       lbs.push_back(
-          builder.createConvert(loc, idxTy, accLoopOp.getLowerbound()[i]));
+          createConvertOrConstant(builder, loc, idxTy, accLoopOp.getLowerbound()[i]));
       ubs.push_back(
-          builder.createConvert(loc, idxTy, accLoopOp.getUpperbound()[i]));
+          createConvertOrConstant(builder, loc, idxTy, accLoopOp.getUpperbound()[i]));
       steps.push_back(
           createConvertOrConstant(builder, loc, idxTy, accLoopOp.getStep()[i]));
-      iterArgs.push_back(builder.createConvert(loc, fir::unwrapRefType(ivs[i].getType()), accLoopOp.getLowerbound()[i]));
+      iterArgs.push_back(
+        builder.createConvert(loc, fir::unwrapRefType(ivs[i].getType()), accLoopOp.getLowerbound()[i]));
       fir::DoLoopOp doLoopOp = builder.create<fir::DoLoopOp>(
           loc, lbs[i], ubs[i], steps[i], /*unordered=*/false, finalCountValue,
           mlir::ValueRange{iterArgs[i]});

--- a/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
+++ b/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
@@ -166,14 +166,15 @@ void LoopExpand::runOnOperation() {
     for (unsigned i = 0; i < nbLoop; ++i) {
       bool isInnerLoop = i == (nbLoop - 1);
 
-      lbs.push_back(
-          createConvertOrConstant(builder, loc, idxTy, accLoopOp.getLowerbound()[i]));
-      ubs.push_back(
-          createConvertOrConstant(builder, loc, idxTy, accLoopOp.getUpperbound()[i]));
+      lbs.push_back(createConvertOrConstant(builder, loc, idxTy,
+                                            accLoopOp.getLowerbound()[i]));
+      ubs.push_back(createConvertOrConstant(builder, loc, idxTy,
+                                            accLoopOp.getUpperbound()[i]));
       steps.push_back(
           createConvertOrConstant(builder, loc, idxTy, accLoopOp.getStep()[i]));
       iterArgs.push_back(
-        builder.createConvert(loc, fir::unwrapRefType(ivs[i].getType()), accLoopOp.getLowerbound()[i]));
+          builder.createConvert(loc, fir::unwrapRefType(ivs[i].getType()),
+                                accLoopOp.getLowerbound()[i]));
       fir::DoLoopOp doLoopOp = builder.create<fir::DoLoopOp>(
           loc, lbs[i], ubs[i], steps[i], /*unordered=*/false, finalCountValue,
           mlir::ValueRange{iterArgs[i]});

--- a/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
+++ b/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
@@ -1,0 +1,170 @@
+//===- OpenACCLoopExpand.cpp - expand acc.loop operand to fir.do_loop nest ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/Support/FIRContext.h"
+#include "flang/Optimizer/Dialect/Support/KindMapping.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace fir {
+#define GEN_PASS_DEF_OPENACCLOOPEXPAND
+#include "flang/Optimizer/Transforms/Passes.h.inc"
+} // namespace fir
+
+class LoopExpand : public fir::impl::OpenACCLoopExpandBase<LoopExpand> {
+public:
+  void runOnOperation() override;
+};
+
+static mlir::Value retrievePrivatizedIv(mlir::acc::LoopOp &op,
+                                        mlir::Value value) {
+  for (auto p : op.getPrivateOperands()) {
+    if (p == value) {
+      auto privateOp = mlir::cast<mlir::acc::PrivateOp>(p.getDefiningOp());
+      return privateOp.getVarPtr();
+    }
+  }
+  return mlir::Value{};
+}
+
+/// Reset operands and operand segments for the induction ranges.
+static void clearInductionRangesAndAttrs(fir::FirOpBuilder &builder,
+                                         mlir::acc::LoopOp &accLoopOp) {
+  // Remove the ranges.
+  accLoopOp.getLowerboundMutable().clear();
+  accLoopOp.getUpperboundMutable().clear();
+  accLoopOp.getStepMutable().clear();
+}
+
+static llvm::SmallVector<mlir::Value>
+getOriginalInductionVars(mlir::acc::LoopOp &accLoopOp) {
+  llvm::SmallVector<mlir::Value> ivs;
+  for (auto arg : accLoopOp.getBody().getArguments()) {
+    mlir::Value privateValue;
+    for (mlir::OpOperand &u : arg.getUses()) {
+      mlir::Operation *owner = u.getOwner();
+      if (auto storeOp = mlir::dyn_cast<fir::StoreOp>(owner)) {
+        privateValue = storeOp.getMemref();
+        owner->erase();
+      }
+    }
+    mlir::Value originalIv = retrievePrivatizedIv(accLoopOp, privateValue);
+    assert(originalIv && "Expect induction variable to be found");
+    ivs.push_back(originalIv);
+  }
+  return ivs;
+}
+
+void LoopExpand::runOnOperation() {
+  mlir::func::FuncOp func = getOperation();
+
+  mlir::ModuleOp mod = func->getParentOfType<mlir::ModuleOp>();
+  fir::KindMapping kindMap = fir::getKindMapping(mod);
+  fir::FirOpBuilder builder{mod, std::move(kindMap)};
+
+  func.walk([&](mlir::acc::LoopOp accLoopOp) {
+    mlir::Location loc = accLoopOp.getLoc();
+    mlir::Type idxTy = builder.getIndexType();
+
+    bool isStructured = accLoopOp.getLoopRegions().front()->hasOneBlock();
+    bool finalCountValue = isStructured;
+    unsigned nbLoop = accLoopOp.getBody().getNumArguments();
+
+    // Gather original (non-privatized) induction variables.
+    llvm::SmallVector<mlir::Value> ivs = getOriginalInductionVars(accLoopOp);
+
+    // Remove block arguments in order to create loop-nest and move current body
+    // in the newly created loop nest.
+    accLoopOp.getBody().eraseArguments(0, nbLoop);
+    builder.setInsertionPointAfter(accLoopOp);
+
+    if (!isStructured) {
+      clearInductionRangesAndAttrs(builder, accLoopOp);
+      return;
+    }
+
+    llvm::SmallVector<mlir::Value> lbs, ubs, steps;
+    llvm::SmallVector<fir::DoLoopOp> loops;
+
+    // Create the loop nest, move the acc.loop body inside and move the loop
+    // nest inside the acc.loop again.
+    for (unsigned i = 0; i < nbLoop; ++i) {
+      bool isInnerLoop = i == (nbLoop - 1);
+
+      lbs.push_back(
+          builder.createConvert(loc, idxTy, accLoopOp.getLowerbound()[i]));
+      ubs.push_back(
+          builder.createConvert(loc, idxTy, accLoopOp.getUpperbound()[i]));
+      steps.push_back(
+          builder.createConvert(loc, idxTy, accLoopOp.getStep()[i]));
+      fir::DoLoopOp doLoopOp = builder.create<fir::DoLoopOp>(
+          loc, lbs[i], ubs[i], steps[i], /*unordered=*/false, finalCountValue,
+          mlir::ValueRange{accLoopOp.getLowerbound()[i]});
+      loops.push_back(doLoopOp);
+
+      if (isInnerLoop) {
+        // Move acc.loop body inside the newly created fir.do_loop.
+        accLoopOp.getBody().getTerminator()->erase();
+        doLoopOp.getRegion().takeBody(*accLoopOp.getLoopRegions().front());
+        // Recreate the block arguments.
+        doLoopOp.getBody()->addArgument(builder.getIndexType(), loc);
+        doLoopOp.getBody()->addArgument(accLoopOp.getLowerbound()[i].getType(),
+                                        loc);
+      } else {
+        builder.setInsertionPointToStart(doLoopOp.getBody());
+      }
+    }
+
+    // Move the loop nest inside the acc.loop region.
+    mlir::Block *newAccLoopBlock =
+        builder.createBlock(accLoopOp.getLoopRegions().front());
+    loops[0].getOperation()->moveBefore(newAccLoopBlock,
+                                        newAccLoopBlock->end());
+
+    for (unsigned i = 0; i < nbLoop; ++i) {
+      builder.setInsertionPointToStart(loops[i].getBody());
+      builder.create<fir::StoreOp>(loc, loops[i].getBody()->getArgument(1),
+                                   ivs[i]);
+
+      builder.setInsertionPointToEnd(loops[i].getBody());
+      llvm::SmallVector<mlir::Value, 2> results;
+      if (finalCountValue)
+        results.push_back(builder.create<mlir::arith::AddIOp>(
+            loc, loops[i].getInductionVar(), loops[i].getStep()));
+
+      // Step loopVariable to help optimizations such as vectorization.
+      // Induction variable elimination will clean up as necessary.
+      mlir::Value convStep = builder.create<fir::ConvertOp>(
+          loc, accLoopOp.getStep()[i].getType(), loops[i].getStep());
+      mlir::Value loopVar = builder.create<fir::LoadOp>(loc, ivs[i]);
+      results.push_back(
+          builder.create<mlir::arith::AddIOp>(loc, loopVar, convStep));
+      builder.create<fir::ResultOp>(loc, results);
+
+      // Convert ops have been created outside of the acc.loop operation. They
+      // need to be moved back before their uses.
+      lbs[i].getDefiningOp()->moveBefore(loops[i].getOperation());
+      ubs[i].getDefiningOp()->moveBefore(loops[i].getOperation());
+      steps[i].getDefiningOp()->moveBefore(loops[i].getOperation());
+    }
+
+    builder.setInsertionPointToEnd(newAccLoopBlock);
+    builder.create<mlir::acc::YieldOp>(loc);
+
+    clearInductionRangesAndAttrs(builder, accLoopOp);
+  });
+}
+
+std::unique_ptr<mlir::Pass> fir::createOpenACCLoopExpandPass() {
+  return std::make_unique<LoopExpand>();
+}

--- a/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
+++ b/flang/lib/Optimizer/Transforms/OpenACCLoopExpand.cpp
@@ -44,6 +44,8 @@ static void clearInductionRangesAndAttrs(fir::FirOpBuilder &builder,
   accLoopOp.getLowerboundMutable().clear();
   accLoopOp.getUpperboundMutable().clear();
   accLoopOp.getStepMutable().clear();
+
+  accLoopOp.removeInclusiveUpperboundAttr();
 }
 
 static llvm::SmallVector<mlir::Value>

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -12,7 +12,7 @@ subroutine singleloop(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPsingleloop
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingleloopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: acc.loop private
+! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
 ! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
@@ -42,7 +42,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPsingle_loop_with_nest
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingle_loop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: acc.loop private
+! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
 ! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
@@ -75,7 +75,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPloop_with_nest
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: %[[J:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>, @privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>) {
+! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK:   %[[STEP0:.*]] = fir.convert %{{.*}} : (i32) -> index
@@ -115,7 +115,7 @@ subroutine loop_unstructured(a)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPloop_unstructured
-! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>)
+! CHECK: acc.loop {
 
 subroutine loop_iv_8()
   integer(4), parameter :: N = 10
@@ -131,7 +131,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPloop_iv_8()
 
 ! CHECK: %[[II:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_iv_8Eii"} : (!fir.ref<i64>) -> (!fir.ref<i64>, !fir.ref<i64>)
-! CHECK: acc.loop
+! CHECK: acc.loop {
 ! CHECK: %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK: %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
 ! CHECK: %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -1,0 +1,118 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | fir-opt --split-input-file --acc-loop-expand | FileCheck %s
+
+subroutine singleloop(a)
+   real :: a(:)
+   integer :: i
+   a = 0.0
+
+   !$acc loop
+   do i = 1, 10
+     a(i) = i
+  end do
+end subroutine
+! CHECK-LABEL: func.func @_QPsingleloop
+! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingleloopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: acc.loop private
+! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
+! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
+! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
+! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
+! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
+! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP]] : i32
+! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
+! CHECK:   }
+! CHECK:   acc.yield
+! CHECK: }
+
+subroutine single_loop_with_nest(a)
+  real :: a(:,:)
+  integer :: i, j
+  a = 0.0
+
+  !$acc loop
+  do i = 1, 10
+    do j = 1, 10
+      a(i, j) = i
+    end do
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsingle_loop_with_nest
+! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingle_loop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: acc.loop private
+! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
+! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
+! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
+! CHECK:     fir.do_loop
+! CHECK:     }
+! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
+! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
+! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP]] : i32
+! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
+! CHECK:   }
+! CHECK:   acc.yield
+! CHECK: }
+
+subroutine loop_with_nest(a)
+  real :: a(:,:)
+  integer :: i, j
+  a = 0.0
+
+  !$acc loop collapse(2)
+  do i = 1, 10
+    do j = 1, 10
+      a(i, j) = i
+    end do
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPloop_with_nest
+! CHECK: %[[I:.*]]:2 = hlfir.declare %1 {uniq_name = "_QFloop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[J:.*]]:2 = hlfir.declare %3 {uniq_name = "_QFloop_with_nestEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>, @privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>) {
+! CHECK:   %[[LB0:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:   %[[UB0:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
+! CHECK:     fir.store %[[ARG2]] to %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[LB1:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:     %[[UB1:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:     %[[STEP1:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:     %{{.*}}:2 = fir.do_loop %[[ARG3:.*]] = %[[LB1]] to %[[UB1]] step %[[STEP1]] iter_args(%[[ARG4:.*]] = %{{.*}}) -> (index, i32) {
+! CHECK:       fir.store %[[ARG4]] to %[[J]]#1 : !fir.ref<i32>
+
+! CHECK:       %[[INCR1:.*]] = arith.addi %[[ARG3]], %[[STEP1]] : index
+! CHECK:       %[[CONV_STEP1:.*]] = fir.convert %[[STEP1]] : (index) -> i32
+! CHECK:       %[[LOAD_J:.*]] = fir.load %[[J]]#1 : !fir.ref<i32>
+! CHECK:       %[[INCR2:.*]] = arith.addi %[[LOAD_J]], %[[CONV_STEP1]] : i32
+! CHECK:       fir.result %[[INCR1]], %[[INCR2]] : index, i32
+! CHECK:     }
+! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
+! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i32
+! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %18 : i32
+! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
+! CHECK:   }
+! CHECK:   acc.yield
+! CHECK: }
+
+subroutine loop_unstructured(a)
+  real :: a(:)
+  integer :: i
+  a = 0.0
+
+  !$acc loop
+  do i = 1, 10
+    if (a(i) > 0.0) stop 'stop'
+    a(i) = i
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPloop_unstructured
+! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>)

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -15,7 +15,7 @@ end subroutine
 ! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
-! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
 ! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
@@ -45,7 +45,7 @@ end subroutine
 ! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
-! CHECK:   %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
 ! CHECK:     fir.do_loop
@@ -78,12 +78,12 @@ end subroutine
 ! CHECK: acc.loop {
 ! CHECK:   %[[LB0:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %{{.*}} : (i32) -> index
-! CHECK:   %[[STEP0:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %[[I]]#1 : !fir.ref<i32>
 ! CHECK:     %[[LB1:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK:     %[[UB1:.*]] = fir.convert %{{.*}} : (i32) -> index
-! CHECK:     %[[STEP1:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:     %[[STEP1:.*]] = arith.constant 1 : index
 ! CHECK:     %{{.*}}:2 = fir.do_loop %[[ARG3:.*]] = %[[LB1]] to %[[UB1]] step %[[STEP1]] iter_args(%[[ARG4:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:       fir.store %[[ARG4]] to %[[J]]#1 : !fir.ref<i32>
 
@@ -134,7 +134,7 @@ end subroutine
 ! CHECK: acc.loop {
 ! CHECK: %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
 ! CHECK: %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
-! CHECK: %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK: %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK: %[[ITER_ARG:.*]] = fir.convert %c1_i32 : (i32) -> i64
 ! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG0:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG1:.*]] = %[[ITER_ARG]]) -> (index, i64) {
 ! CHECK:     fir.store %[[ARG1]] to %[[II]]#1 : !fir.ref<i64>

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -19,8 +19,8 @@ end subroutine
 ! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
 ! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
-! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP]] : i32
 ! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
 ! CHECK:   }
@@ -51,8 +51,8 @@ end subroutine
 ! CHECK:     fir.do_loop
 ! CHECK:     }
 ! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
-! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
+! CHECK:     %[[CONV_STEP:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP]] : i32
 ! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
 ! CHECK:   }
@@ -73,8 +73,8 @@ subroutine loop_with_nest(a)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPloop_with_nest
-! CHECK: %[[I:.*]]:2 = hlfir.declare %1 {uniq_name = "_QFloop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[J:.*]]:2 = hlfir.declare %3 {uniq_name = "_QFloop_with_nestEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[J:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>, @privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>) {
 ! CHECK:   %[[LB0:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK:   %[[UB0:.*]] = fir.convert %{{.*}} : (i32) -> index
@@ -88,15 +88,15 @@ end subroutine
 ! CHECK:       fir.store %[[ARG4]] to %[[J]]#1 : !fir.ref<i32>
 
 ! CHECK:       %[[INCR1:.*]] = arith.addi %[[ARG3]], %[[STEP1]] : index
-! CHECK:       %[[CONV_STEP1:.*]] = fir.convert %[[STEP1]] : (index) -> i32
 ! CHECK:       %[[LOAD_J:.*]] = fir.load %[[J]]#1 : !fir.ref<i32>
+! CHECK:       %[[CONV_STEP1:.*]] = fir.convert %[[STEP1]] : (index) -> i32
 ! CHECK:       %[[INCR2:.*]] = arith.addi %[[LOAD_J]], %[[CONV_STEP1]] : i32
 ! CHECK:       fir.result %[[INCR1]], %[[INCR2]] : index, i32
 ! CHECK:     }
 ! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
-! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
-! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %18 : i32
+! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i32
+! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP0]] : i32
 ! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
 ! CHECK:   }
 ! CHECK:   acc.yield
@@ -116,3 +116,35 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPloop_unstructured
 ! CHECK: acc.loop private(@privatization_ref_i32 -> %{{.*}} : !fir.ref<i32>)
+
+subroutine loop_iv_8()
+  integer(4), parameter :: N = 10
+  integer(8) :: ii
+  real(4) :: array(N)
+
+  !$acc parallel loop
+  do ii = 1, N
+    array(ii) = ii
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPloop_iv_8()
+
+! CHECK: %[[II:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_iv_8Eii"} : (!fir.ref<i64>) -> (!fir.ref<i64>, !fir.ref<i64>)
+! CHECK: acc.loop
+! CHECK: %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
+! CHECK: %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK: %[[STEP0:.*]] = fir.convert %c1_i32_0 : (i32) -> index
+! CHECK: %[[ITER_ARG:.*]] = fir.convert %c1_i32 : (i32) -> i64
+! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG0:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG1:.*]] = %[[ITER_ARG]]) -> (index, i64) {
+! CHECK:     fir.store %[[ARG1]] to %[[II]]#1 : !fir.ref<i64>
+
+! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG0]], %[[STEP0]] : index
+! CHECK:     %[[LOAD_II:.*]] = fir.load %[[II]]#1 : !fir.ref<i64>
+! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i64
+! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_II]], %[[CONV_STEP0]] : i64
+! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i64
+! CHECK:   }
+! CHECK:   acc.yield
+! CHECK: }
+     

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -147,4 +147,24 @@ end subroutine
 ! CHECK:   }
 ! CHECK:   acc.yield
 ! CHECK: }
-     
+
+subroutine loop_lbound_ubound(arr)
+  implicit none
+  real(8) :: arr(:)
+  integer(4) :: i
+  !$acc parallel loop copy(arr)
+  do i = lbound(arr, 1), ubound(arr, 1)
+    arr(i) = 1.0
+  end do
+  !$acc end parallel loop
+end subroutine
+
+! CHECK-LABEL: func.func @_QPloop_lbound_ubound
+! CHECK: acc.parallel dataOperands(%{{.*}} : !fir.ref<!fir.array<?xf64>>) {
+! CHECK: acc.loop {
+! CHECK: %[[LBOUND:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK: %[[UBOUND:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK: %[[STEP:.*]] = arith.constant 1 : index
+! CHECK: %{{.*}}:2 = fir.do_loop %{{.*}} = %[[LBOUND]] to %[[UBOUND]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (index, i32) {
+! CHECK: acc.yield
+! CHECK: acc.yield

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -13,8 +13,8 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPsingleloop
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingleloopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: acc.loop {
-! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
-! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK:   %[[LB0:.*]] = arith.constant 1 : index
+! CHECK:   %[[UB0:.*]] = arith.constant 10 : index
 ! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
@@ -43,8 +43,8 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPsingle_loop_with_nest
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFsingle_loop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: acc.loop {
-! CHECK:   %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
-! CHECK:   %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK:   %[[LB0:.*]] = arith.constant 1 : index
+! CHECK:   %[[UB0:.*]] = arith.constant 10 : index
 ! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}} = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %2#1 : !fir.ref<i32>
@@ -76,13 +76,13 @@ end subroutine
 ! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: %[[J:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_with_nestEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: acc.loop {
-! CHECK:   %[[LB0:.*]] = fir.convert %{{.*}} : (i32) -> index
-! CHECK:   %[[UB0:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:   %[[LB0:.*]] = arith.constant 1 : index
+! CHECK:   %[[UB0:.*]] = arith.constant 10 : index
 ! CHECK:   %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG1:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG2:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:     fir.store %[[ARG2]] to %[[I]]#1 : !fir.ref<i32>
-! CHECK:     %[[LB1:.*]] = fir.convert %{{.*}} : (i32) -> index
-! CHECK:     %[[UB1:.*]] = fir.convert %{{.*}} : (i32) -> index
+! CHECK:     %[[LB1:.*]] = arith.constant 1 : index
+! CHECK:     %[[UB1:.*]] = arith.constant 10 : index
 ! CHECK:     %[[STEP1:.*]] = arith.constant 1 : index
 ! CHECK:     %{{.*}}:2 = fir.do_loop %[[ARG3:.*]] = %[[LB1]] to %[[UB1]] step %[[STEP1]] iter_args(%[[ARG4:.*]] = %{{.*}}) -> (index, i32) {
 ! CHECK:       fir.store %[[ARG4]] to %[[J]]#1 : !fir.ref<i32>
@@ -132,8 +132,8 @@ end subroutine
 
 ! CHECK: %[[II:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_iv_8Eii"} : (!fir.ref<i64>) -> (!fir.ref<i64>, !fir.ref<i64>)
 ! CHECK: acc.loop {
-! CHECK: %[[LB0:.*]] = fir.convert %c1_i32 : (i32) -> index
-! CHECK: %[[UB0:.*]] = fir.convert %c10_i32 : (i32) -> index
+! CHECK: %[[LB0:.*]] = arith.constant 1 : index
+! CHECK: %[[UB0:.*]] = arith.constant 10 : index
 ! CHECK: %[[STEP0:.*]] = arith.constant 1 : index
 ! CHECK: %[[ITER_ARG:.*]] = fir.convert %c1_i32 : (i32) -> i64
 ! CHECK:   %{{.*}}:2 = fir.do_loop %[[ARG0:.*]] = %[[LB0]] to %[[UB0]] step %[[STEP0]] iter_args(%[[ARG1:.*]] = %[[ITER_ARG]]) -> (index, i64) {

--- a/flang/test/Fir/OpenACC/loop-expand.f90
+++ b/flang/test/Fir/OpenACC/loop-expand.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -fopenacc -emit-hlfir %s -o - | fir-opt --split-input-file --acc-loop-expand | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir --mlir-print-debuginfo %s -o - | fir-opt --split-input-file --acc-loop-expand --mlir-print-debuginfo --mlir-print-local-scope | FileCheck %s
 
 subroutine singleloop(a)
    real :: a(:)
@@ -92,13 +92,13 @@ end subroutine
 ! CHECK:       %[[CONV_STEP1:.*]] = fir.convert %[[STEP1]] : (index) -> i32
 ! CHECK:       %[[INCR2:.*]] = arith.addi %[[LOAD_J]], %[[CONV_STEP1]] : i32
 ! CHECK:       fir.result %[[INCR1]], %[[INCR2]] : index, i32
-! CHECK:     }
+! CHECK:     } loc("{{.*}}loop-expand.f90":69:5)
 ! CHECK:     %[[INCR1:.*]] = arith.addi %[[ARG1]], %[[STEP0]] : index
 ! CHECK:     %[[LOAD_I:.*]] = fir.load %[[I]]#1 : !fir.ref<i32>
 ! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i32
 ! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_I]], %[[CONV_STEP0]] : i32
 ! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i32
-! CHECK:   }
+! CHECK:   } loc("{{.*}}loop-expand.f90":68:3)
 ! CHECK:   acc.yield
 ! CHECK: }
 
@@ -144,7 +144,7 @@ end subroutine
 ! CHECK:     %[[CONV_STEP0:.*]] = fir.convert %[[STEP0]] : (index) -> i64
 ! CHECK:     %[[INCR2:.*]] = arith.addi %[[LOAD_II]], %[[CONV_STEP0]] : i64
 ! CHECK:     fir.result %[[INCR1]], %[[INCR2]] : index, i64
-! CHECK:   }
+! CHECK:   } loc("{{.*}}loop-expand.f90":126:3)
 ! CHECK:   acc.yield
 ! CHECK: }
 
@@ -166,5 +166,6 @@ end subroutine
 ! CHECK: %[[UBOUND:.*]] = fir.convert %{{.*}} : (i32) -> index
 ! CHECK: %[[STEP:.*]] = arith.constant 1 : index
 ! CHECK: %{{.*}}:2 = fir.do_loop %{{.*}} = %[[LBOUND]] to %[[UBOUND]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (index, i32) {
+! CHECKL } loc("{{.*}}loop-expand.f90":156:3)
 ! CHECK: acc.yield
 ! CHECK: acc.yield

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -1218,6 +1218,8 @@ def OpenACC_LoopOp : OpenACC_Op<"loop",
 
     /// The i-th data operand passed.
     Value getDataOperand(unsigned i);
+
+    Block &getBody() { return getLoopRegions().front()->front(); }
   }];
 
   let hasCustomAssemblyFormat = 1;
@@ -1237,7 +1239,7 @@ def OpenACC_LoopOp : OpenACC_Op<"loop",
     )
     $region
     ( `(` type($results)^ `)` )?
-    attr-dict-with-keyword
+  attr-dict-with-keyword
   }];
 
   let hasVerifier = 1;


### PR DESCRIPTION
`acc.loop` operations get a new design where the induction ranges can be part of the operation directly. The operation can also be a simple wrapper around a loop nest.
This patch adds a loop-expand pass that can transform a acc.loop operation with induction ranges to a acc.loop operation with a fir.do_loop nest inside.
This patch depends on two patches that update the design and lowering:

https://github.com/llvm/llvm-project/pull/67355
https://github.com/llvm/llvm-project/pull/65417
