### PR TITLE
[RISCV] Support printing immediate of RISCV MCInst in hexadecimal format

### DIFF
--- a/bolt/test/RISCV/call-annotations.s
+++ b/bolt/test/RISCV/call-annotations.s
@@ -16,13 +16,13 @@ f:
 
 // CHECK-LABEL: Binary Function "_start" after building cfg {
 // CHECK:      auipc ra, f
-// CHECK-NEXT: jalr ra, -4(ra) # Offset: 4
+// CHECK-NEXT: jalr ra, -0x4(ra) # Offset: 4
 // CHECK-NEXT: jal ra, f # Offset: 8
 // CHECK-NEXT: jal zero, f # TAILCALL  # Offset: 12
 
 // CHECK-LABEL: Binary Function "long_tail" after building cfg {
 // CHECK:      auipc t1, f
-// CHECK-NEXT: jalr zero, -24(t1) # TAILCALL  # Offset: 8
+// CHECK-NEXT: jalr zero, -0x18(t1) # TAILCALL  # Offset: 8
 
 // CHECK-LABEL: Binary Function "compressed_tail" after building cfg {
 // CHECK:      jr a0 # TAILCALL  # Offset: 0

--- a/bolt/test/RISCV/relax.s
+++ b/bolt/test/RISCV/relax.s
@@ -7,7 +7,7 @@
 // CHECK:      Binary Function "_start" after building cfg {
 // CHECK:      jal ra, near_f
 // CHECK-NEXT: auipc ra, far_f@plt
-// CHECK-NEXT: jalr ra, 12(ra)
+// CHECK-NEXT: jalr ra, 0xc(ra)
 // CHECK-NEXT: j near_f
 
 // CHECK:      Binary Function "_start" after fix-riscv-calls {
@@ -17,8 +17,8 @@
 
 // OBJDUMP:      0000000000600000 <_start>:
 // OBJDUMP-NEXT:     jal 0x600040 <near_f>
-// OBJDUMP-NEXT:     auipc ra, 512
-// OBJDUMP-NEXT:     jalr 124(ra)
+// OBJDUMP-NEXT:     auipc ra, 0x200
+// OBJDUMP-NEXT:     jalr 0x7c(ra)
 // OBJDUMP-NEXT:     j 0x600040 <near_f>
 // OBJDUMP:      0000000000600040 <near_f>:
 // OBJDUMP:      0000000000800080 <far_f>:

--- a/bolt/test/RISCV/reloc-tls.s
+++ b/bolt/test/RISCV/reloc-tls.s
@@ -4,10 +4,10 @@
 // RUN:    | FileCheck %s
 
 // CHECK-LABEL: Binary Function "tls_le{{.*}}" after building cfg {
-// CHECK:      lui a5, 0
+// CHECK:      lui a5, 0x0
 // CHECK-NEXT: add a5, a5, tp
-// CHECK-NEXT: lw t0, 0(a5)
-// CHECK-NEXT: sw t0, 0(a5)
+// CHECK-NEXT: lw t0, 0x0(a5)
+// CHECK-NEXT: sw t0, 0x0(a5)
 
 // CHECK-LABEL: Binary Function "tls_ie" after building cfg {
 // CHECK-LABEL: .LBB01

--- a/bolt/test/RISCV/reorder-blocks-reverse.s
+++ b/bolt/test/RISCV/reorder-blocks-reverse.s
@@ -23,9 +23,9 @@ _start:
 // CHECK-NEXT:   {{.*}}00:       beq t0, t1, {{.*}} <_start+0x10>
 // CHECK-NEXT:   {{.*}}04:       j {{.*}} <_start+0x16>
 // CHECK-NEXT:   {{.*}}08:       ret
-// CHECK-NEXT:   {{.*}}0a:       li a0, 6
+// CHECK-NEXT:   {{.*}}0a:       li a0, 0x6
 // CHECK-NEXT:   {{.*}}0c:       j {{.*}} <_start+0x8>
-// CHECK-NEXT:   {{.*}}10:       li a0, 5
+// CHECK-NEXT:   {{.*}}10:       li a0, 0x5
 // CHECK-NEXT:   {{.*}}12:       j {{.*}} <_start+0x8>
 // CHECK-NEXT:   {{.*}}16:       beq t0, t2, {{.*}} <_start+0xa>
 // CHECK-NEXT:   {{.*}}1a:       j {{.*}} <_start+0x10>

--- a/bolt/test/RISCV/tls-le-gnu-ld.test
+++ b/bolt/test/RISCV/tls-le-gnu-ld.test
@@ -7,5 +7,5 @@
 // RUN:   | FileCheck %s
 
 // CHECK: Binary Function "_start" after building cfg {
-// CHECK:      lw t0, 0(tp)
-// CHECK-NEXT: sw t0, 0(tp)
+// CHECK:      lw t0, 0x0(tp)
+// CHECK-NEXT: sw t0, 0x0(tp)

--- a/lld/test/ELF/riscv-call.s
+++ b/lld/test/ELF/riscv-call.s
@@ -7,19 +7,19 @@
 # RUN: ld.lld %t.rv64.o --defsym foo=_start+8 --defsym bar=_start -o %t.rv64
 # RUN: llvm-objdump -d %t.rv32 | FileCheck %s
 # RUN: llvm-objdump -d %t.rv64 | FileCheck %s
-# CHECK:      97 00 00 00     auipc   ra, 0
-# CHECK-NEXT: e7 80 80 00     jalr    8(ra)
-# CHECK:      97 00 00 00     auipc   ra, 0
-# CHECK-NEXT: e7 80 80 ff     jalr    -8(ra)
+# CHECK:      97 00 00 00     auipc   ra, 0x0
+# CHECK-NEXT: e7 80 80 00     jalr    0x8(ra)
+# CHECK:      97 00 00 00     auipc   ra, 0x0
+# CHECK-NEXT: e7 80 80 ff     jalr    -0x8(ra)
 
 # RUN: ld.lld %t.rv32.o --defsym foo=_start+0x7ffff7ff --defsym bar=_start+8-0x80000800 -o %t.rv32.limits
 # RUN: ld.lld %t.rv64.o --defsym foo=_start+0x7ffff7ff --defsym bar=_start+8-0x80000800 -o %t.rv64.limits
 # RUN: llvm-objdump -d %t.rv32.limits | FileCheck --check-prefix=LIMITS %s
 # RUN: llvm-objdump -d %t.rv64.limits | FileCheck --check-prefix=LIMITS %s
-# LIMITS:      97 f0 ff 7f     auipc   ra, 524287
-# LIMITS-NEXT: e7 80 f0 7f     jalr    2047(ra)
-# LIMITS-NEXT: 97 00 00 80     auipc   ra, 524288
-# LIMITS-NEXT: e7 80 00 80     jalr    -2048(ra)
+# LIMITS:      97 f0 ff 7f     auipc   ra, 0x7ffff
+# LIMITS-NEXT: e7 80 f0 7f     jalr    0x7ff(ra)
+# LIMITS-NEXT: 97 00 00 80     auipc   ra, 0x80000
+# LIMITS-NEXT: e7 80 00 80     jalr    -0x800(ra)
 
 # RUN: ld.lld %t.rv32.o --defsym foo=_start+0x7ffff800 --defsym bar=_start+8-0x80000801 -o %t
 # RUN: not ld.lld %t.rv64.o --defsym foo=_start+0x7ffff800 --defsym bar=_start+8-0x80000801 -o /dev/null 2>&1 | \

--- a/lld/test/ELF/riscv-hi20-lo12.s
+++ b/lld/test/ELF/riscv-hi20-lo12.s
@@ -7,23 +7,23 @@
 # RUN: ld.lld %t.rv64.o --defsym foo=0 --defsym bar=42 -o %t.rv64
 # RUN: llvm-objdump -d %t.rv32 | FileCheck %s
 # RUN: llvm-objdump -d %t.rv64 | FileCheck %s
-# CHECK:      37 05 00 00     lui     a0, 0
+# CHECK:      37 05 00 00     lui     a0, 0x0
 # CHECK-NEXT: 13 05 05 00     mv      a0, a0
-# CHECK-NEXT: 23 20 a5 00     sw      a0, 0(a0)
-# CHECK-NEXT: b7 05 00 00     lui     a1, 0
-# CHECK-NEXT: 93 85 a5 02     addi    a1, a1, 42
-# CHECK-NEXT: 23 a5 b5 02     sw      a1, 42(a1)
+# CHECK-NEXT: 23 20 a5 00     sw      a0, 0x0(a0)
+# CHECK-NEXT: b7 05 00 00     lui     a1, 0x0
+# CHECK-NEXT: 93 85 a5 02     addi    a1, a1, 0x2a
+# CHECK-NEXT: 23 a5 b5 02     sw      a1, 0x2a(a1)
 
 # RUN: ld.lld %t.rv32.o --defsym foo=0x7ffff7ff --defsym bar=0x7ffff800 -o %t.rv32.limits
 # RUN: ld.lld %t.rv64.o --defsym foo=0x7ffff7ff --defsym bar=0xffffffff7ffff800 -o %t.rv64.limits
 # RUN: llvm-objdump -d %t.rv32.limits | FileCheck --check-prefix=LIMITS %s
 # RUN: llvm-objdump -d %t.rv64.limits | FileCheck --check-prefix=LIMITS %s
-# LIMITS:      37 f5 ff 7f     lui     a0, 524287
-# LIMITS-NEXT: 13 05 f5 7f     addi    a0, a0, 2047
-# LIMITS-NEXT: a3 2f a5 7e     sw      a0, 2047(a0)
-# LIMITS-NEXT: b7 05 00 80     lui     a1, 524288
-# LIMITS-NEXT: 93 85 05 80     addi    a1, a1, -2048
-# LIMITS-NEXT: 23 a0 b5 80     sw      a1, -2048(a1)
+# LIMITS:      37 f5 ff 7f     lui     a0, 0x7ffff
+# LIMITS-NEXT: 13 05 f5 7f     addi    a0, a0, 0x7ff
+# LIMITS-NEXT: a3 2f a5 7e     sw      a0, 0x7ff(a0)
+# LIMITS-NEXT: b7 05 00 80     lui     a1, 0x80000
+# LIMITS-NEXT: 93 85 05 80     addi    a1, a1, -0x800
+# LIMITS-NEXT: 23 a0 b5 80     sw      a1, -0x800(a1)
 
 # RUN: not ld.lld %t.rv64.o --defsym foo=0x7ffff800 --defsym bar=0xffffffff7ffff7ff -o /dev/null 2>&1 | FileCheck --check-prefix ERROR %s
 # ERROR: relocation R_RISCV_HI20 out of range: 524288 is not in [-524288, 524287]; references 'foo'

--- a/lld/test/ELF/riscv-ifunc-nonpreemptible.s
+++ b/lld/test/ELF/riscv-ifunc-nonpreemptible.s
@@ -26,13 +26,13 @@
 # SYM32: 0001190 0 FUNC GLOBAL DEFAULT {{.*}} func
 
 # DIS32:      <_start>:
-# DIS32-NEXT: 1180: auipc a0, 0
-# DIS32-NEXT:       addi a0, a0, 16
+# DIS32-NEXT: 1180: auipc a0, 0x0
+# DIS32-NEXT:       addi a0, a0, 0x10
 # DIS32:      Disassembly of section .iplt:
 # DIS32:      <func>:
 ## 32-bit: &.got.plt[func]-. = 0x3220-0x1190 = 4096*2+144
-# DIS32-NEXT: 1190: auipc t3, 2
-# DIS32-NEXT:       lw t3, 144(t3)
+# DIS32-NEXT: 1190: auipc t3, 0x2
+# DIS32-NEXT:       lw t3, 0x90(t3)
 # DIS32-NEXT:       jalr t1, t3
 # DIS32-NEXT:       nop
 
@@ -47,13 +47,13 @@
 # SYM64: 000000000001270 0 FUNC GLOBAL DEFAULT {{.*}} func
 
 # DIS64:      <_start>:
-# DIS64-NEXT: 1264: auipc a0, 0
-# DIS64-NEXT:       addi a0, a0, 12
+# DIS64-NEXT: 1264: auipc a0, 0x0
+# DIS64-NEXT:       addi a0, a0, 0xc
 # DIS64:      Disassembly of section .iplt:
 # DIS64:      <func>:
 ## 64-bit: &.got.plt[func]-. = 0x3380-0x1270 = 4096*2+272
-# DIS64-NEXT: 1270: auipc t3, 2
-# DIS64-NEXT:       ld t3, 272(t3)
+# DIS64-NEXT: 1270: auipc t3, 0x2
+# DIS64-NEXT:       ld t3, 0x110(t3)
 # DIS64-NEXT:       jalr t1, t3
 # DIS64-NEXT:       nop
 

--- a/lld/test/ELF/riscv-pcrel-hilo.s
+++ b/lld/test/ELF/riscv-pcrel-hilo.s
@@ -11,23 +11,23 @@
 # RUN: ld.lld -pie %t.rv64.o --defsym foo=_start+12 --defsym bar=_start -o %t.rv64
 # RUN: llvm-objdump -d --no-show-raw-insn %t.rv32 | FileCheck %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t.rv64 | FileCheck %s
-# CHECK:      auipc   a0, 0
-# CHECK-NEXT: addi    a0, a0, 12
-# CHECK-NEXT: sw      zero, 12(a0)
-# CHECK:      auipc   a0, 0
-# CHECK-NEXT: addi    a0, a0, -12
-# CHECK-NEXT: sw      zero, -12(a0)
+# CHECK:      auipc   a0, 0x0
+# CHECK-NEXT: addi    a0, a0, 0xc
+# CHECK-NEXT: sw      zero, 0xc(a0)
+# CHECK:      auipc   a0, 0x0
+# CHECK-NEXT: addi    a0, a0, -0xc
+# CHECK-NEXT: sw      zero, -0xc(a0)
 
 # RUN: ld.lld %t.rv32.o --defsym foo=_start+0x7ffff7ff --defsym bar=_start+12-0x80000800 -o %t.rv32.limits
 # RUN: ld.lld %t.rv64.o --defsym foo=_start+0x7ffff7ff --defsym bar=_start+12-0x80000800 -o %t.rv64.limits
 # RUN: llvm-objdump -d --no-show-raw-insn %t.rv32.limits | FileCheck --check-prefix=LIMITS %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t.rv64.limits | FileCheck --check-prefix=LIMITS %s
-# LIMITS:      auipc   a0, 524287
-# LIMITS-NEXT: addi    a0, a0, 2047
-# LIMITS-NEXT: sw      zero, 2047(a0)
-# LIMITS:      auipc   a0, 524288
-# LIMITS-NEXT: addi    a0, a0, -2048
-# LIMITS-NEXT: sw      zero, -2048(a0)
+# LIMITS:      auipc   a0, 0x7ffff
+# LIMITS-NEXT: addi    a0, a0, 0x7ff
+# LIMITS-NEXT: sw      zero, 0x7ff(a0)
+# LIMITS:      auipc   a0, 0x80000
+# LIMITS-NEXT: addi    a0, a0, -0x800
+# LIMITS-NEXT: sw      zero, -0x800(a0)
 
 # RUN: ld.lld %t.rv32.o --defsym foo=_start+0x7ffff800 --defsym bar=_start+12-0x80000801 -o %t
 # RUN: not ld.lld %t.rv64.o --defsym foo=_start+0x7ffff800 --defsym bar=_start+12-0x80000801 -o /dev/null 2>&1 | FileCheck --check-prefix=ERROR %s

--- a/lld/test/ELF/riscv-plt.s
+++ b/lld/test/ELF/riscv-plt.s
@@ -46,47 +46,47 @@
 # DIS:      <_start>:
 ## Direct call
 ## foo - . = 0x11020-0x11000 = 32
-# DIS-NEXT:   11000: auipc ra, 0
-# DIS-NEXT:          jalr 32(ra)
+# DIS-NEXT:   11000: auipc ra, 0x0
+# DIS-NEXT:          jalr 0x20(ra)
 ## bar@plt - . = 0x11050-0x11008 = 72
-# DIS-NEXT:   11008: auipc ra, 0
-# DIS-NEXT:          jalr 72(ra)
+# DIS-NEXT:   11008: auipc ra, 0x0
+# DIS-NEXT:          jalr 0x48(ra)
 ## bar@plt - . = 0x11050-0x11010 = 64
-# DIS-NEXT:   11010: auipc ra, 0
-# DIS-NEXT:          jalr 64(ra)
+# DIS-NEXT:   11010: auipc ra, 0x0
+# DIS-NEXT:          jalr 0x40(ra)
 ## weak@plt - . = 0x11060-0x11018 = 72
-# DIS-NEXT:   11018: auipc ra, 0
-# DIS-NEXT:          jalr 72(ra)
+# DIS-NEXT:   11018: auipc ra, 0x0
+# DIS-NEXT:          jalr 0x48(ra)
 # DIS:      <foo>:
 # DIS-NEXT:   11020:
 
 # DIS:      Disassembly of section .plt:
 # DIS:      <.plt>:
-# DIS-NEXT:     auipc t2, 2
+# DIS-NEXT:     auipc t2, 0x2
 # DIS-NEXT:     sub t1, t1, t3
 ## .got.plt - .plt = 0x13068 - 0x11030 = 4096*2+56
-# DIS32-NEXT:   lw t3, 56(t2)
-# DIS64-NEXT:   ld t3, 160(t2)
-# DIS-NEXT:     addi t1, t1, -44
-# DIS32-NEXT:   addi t0, t2, 56
-# DIS64-NEXT:   addi t0, t2, 160
-# DIS32-NEXT:   srli t1, t1, 2
-# DIS64-NEXT:   srli t1, t1, 1
-# DIS32-NEXT:   lw t0, 4(t0)
-# DIS64-NEXT:   ld t0, 8(t0)
+# DIS32-NEXT:   lw t3, 0x38(t2)
+# DIS64-NEXT:   ld t3, 0xa0(t2)
+# DIS-NEXT:     addi t1, t1, -0x2c
+# DIS32-NEXT:   addi t0, t2, 0x38
+# DIS64-NEXT:   addi t0, t2, 0xa0
+# DIS32-NEXT:   srli t1, t1, 0x2
+# DIS64-NEXT:   srli t1, t1, 0x1
+# DIS32-NEXT:   lw t0, 0x4(t0)
+# DIS64-NEXT:   ld t0, 0x8(t0)
 # DIS-NEXT:     jr t3
 
 ## 32-bit: &.got.plt[bar]-. = 0x13070-0x11050 = 4096*2+32
-# DIS:        11050: auipc t3, 2
-# DIS32-NEXT:   lw t3, 32(t3)
-# DIS64-NEXT:   ld t3, 144(t3)
+# DIS:        11050: auipc t3, 0x2
+# DIS32-NEXT:   lw t3, 0x20(t3)
+# DIS64-NEXT:   ld t3, 0x90(t3)
 # DIS-NEXT:     jalr t1, t3
 # DIS-NEXT:     nop
 
 ## 32-bit: &.got.plt[weak]-. = 0x13074-0x11060 = 4096*2+20
-# DIS:        11060: auipc t3, 2
-# DIS32-NEXT:   lw t3, 20(t3)
-# DIS64-NEXT:   ld t3, 136(t3)
+# DIS:        11060: auipc t3, 0x2
+# DIS32-NEXT:   lw t3, 0x14(t3)
+# DIS64-NEXT:   ld t3, 0x88(t3)
 # DIS-NEXT:     jalr t1, t3
 # DIS-NEXT:     nop
 

--- a/lld/test/ELF/riscv-relax-align-rvc.s
+++ b/lld/test/ELF/riscv-relax-align-rvc.s
@@ -22,67 +22,67 @@
 # CHECK-DAG: 00010000 g       .text  {{0*}}36 _start
 
 # CHECK:      <_start>:
-# CHECK-NEXT:           c.addi    a0, 1
+# CHECK-NEXT:           c.addi    a0, 0x1
 # CHECK-EMPTY:
 # CHECK-NEXT: <a>:
 # CHECK-NEXT:           c.nop
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
 # CHECK-EMPTY:
 # CHECK-NEXT: <b>:
-# CHECK-NEXT:   10010:  c.addi  a0, 2
+# CHECK-NEXT:   10010:  c.addi  a0, 0x2
 # CHECK-EMPTY:
 # CHECK-NEXT: <c>:
-# CHECK-NEXT:           c.addi  a0, 3
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
+# CHECK-NEXT:           c.addi  a0, 0x3
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
 # CHECK-EMPTY:
 # CHECK-NEXT: <d>:
-# CHECK-NEXT:   10020:  c.addi  a0, 4
-# CHECK-NEXT:           c.addi  a0, 5
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:   10030:  c.addi  a0, 6
-# CHECK-NEXT:           c.addi  a0, 7
-# CHECK-NEXT:           c.addi  a0, 8
+# CHECK-NEXT:   10020:  c.addi  a0, 0x4
+# CHECK-NEXT:           c.addi  a0, 0x5
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:   10030:  c.addi  a0, 0x6
+# CHECK-NEXT:           c.addi  a0, 0x7
+# CHECK-NEXT:           c.addi  a0, 0x8
 # CHECK-EMPTY:
 
 # CHECK:      <.text2>:
-# CHECK-NEXT:           addi    a0, a1, 1
-# CHECK-NEXT:           c.addi  a0, 1
+# CHECK-NEXT:           addi    a0, a1, 0x1
+# CHECK-NEXT:           c.addi  a0, 0x1
 # CHECK-NEXT:           c.nop
-# CHECK-NEXT:           c.addi  a0, 2
+# CHECK-NEXT:           c.addi  a0, 0x2
 
 .global _start
 _start:
-  c.addi a0, 1
+  c.addi a0, 0x1
 a:
 .balign 16
 b:
-  c.addi a0, 2
+  c.addi a0, 0x2
 c:
-  c.addi a0, 3
+  c.addi a0, 0x3
 .balign 32
 .size a, . - a
 d:
-  c.addi a0, 4
-  c.addi a0, 5
+  c.addi a0, 0x4
+  c.addi a0, 0x5
 .balign 16
 .size c, . - c
-  c.addi a0, 6
+  c.addi a0, 0x6
 .size b, . - b
-  c.addi a0, 7
+  c.addi a0, 0x7
 .balign 4
-  c.addi a0, 8
+  c.addi a0, 0x8
 .size d, . - d
 .size _start, . - _start
 
 .section .text2,"ax"
 .balign 16
-  addi a0, a1, 1
-  c.addi a0, 1
+  addi a0, a1, 0x1
+  c.addi a0, 0x1
 .balign 8
-  c.addi a0, 2
+  c.addi a0, 0x2

--- a/lld/test/ELF/riscv-relax-align.s
+++ b/lld/test/ELF/riscv-relax-align.s
@@ -29,49 +29,49 @@
 # CHECK-DAG: 00010000 g       .text  {{0*}}38 _start
 
 # CHECK:       <_start>:
-# CHECK-NEXT:            addi    a0, a0, 1
+# CHECK-NEXT:            addi    a0, a0, 0x1
 # CHECK-EMPTY:
 # CHECK-NEXT:  <a>:
-# CHECK-NEXT:            addi    a0, a0, 2
+# CHECK-NEXT:            addi    a0, a0, 0x2
 # CHECK-EMPTY:
 # CHECK-NEXT:  <b>:
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:    10010:  addi    a0, a0, 3
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:    10010:  addi    a0, a0, 0x3
 # CHECK-EMPTY:
 # CHECK-NEXT:  <c>:
-# CHECK-NEXT:            addi    a0, a0, 4
-# CHECK-NEXT:            addi    a0, a0, 5
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:    10020:  addi    a0, a0, 6
-# CHECK-NEXT:            addi    a0, a0, 7
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:    10030:  addi    a0, a0, 8
-# CHECK-NEXT:            addi    a0, a0, 9
+# CHECK-NEXT:            addi    a0, a0, 0x4
+# CHECK-NEXT:            addi    a0, a0, 0x5
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:    10020:  addi    a0, a0, 0x6
+# CHECK-NEXT:            addi    a0, a0, 0x7
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:    10030:  addi    a0, a0, 0x8
+# CHECK-NEXT:            addi    a0, a0, 0x9
 # CHECK-EMPTY:
 # CHECK:       <e>:
-# CHECK-NEXT:            addi    a0, a0, 1
+# CHECK-NEXT:            addi    a0, a0, 0x1
 # CHECK-EMPTY:
 # CHECK-NEXT:  <f>:
-# CHECK-NEXT:    10044:  addi    a0, a0, 2
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:            addi    zero, zero, 0
-# CHECK-NEXT:    10060:  addi    a0, a0, 3
+# CHECK-NEXT:    10044:  addi    a0, a0, 0x2
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:            addi    zero, zero, 0x0
+# CHECK-NEXT:    10060:  addi    a0, a0, 0x3
 # CHECK-EMPTY:
 
 ## _start-0x10070 = 0x10000-0x10070 = -112
 # CHECK:      <.L1>:
-# CHECK-NEXT:   10070:  auipc   a0, 0
-# CHECK-NEXT:           addi    a0, a0, -112
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           addi    zero, zero, 0
-# CHECK-NEXT:           auipc   a0, 0
-# CHECK-NEXT:           addi    a0, a0, -112
+# CHECK-NEXT:   10070:  auipc   a0, 0x0
+# CHECK-NEXT:           addi    a0, a0, -0x70
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           addi    zero, zero, 0x0
+# CHECK-NEXT:           auipc   a0, 0x0
+# CHECK-NEXT:           addi    a0, a0, -0x70
 # CHECK-EMPTY:
 
 # GC-DAG:       00010004 l       .text  {{0*}}1c a
@@ -82,58 +82,58 @@
 # GC-NOT:       <d>:
 
 # CHECKR:       <_start>:
-# CHECKR-NEXT:          addi    a0, a0, 1
+# CHECKR-NEXT:          addi    a0, a0, 0x1
 # CHECKR-EMPTY:
 # CHECKR-NEXT:  <a>:
-# CHECKR-NEXT:          addi    a0, a0, 2
+# CHECKR-NEXT:          addi    a0, a0, 0x2
 # CHECKR-EMPTY:
 # CHECKR-NEXT:  <b>:
-# CHECKR-NEXT:          addi    zero, zero, 0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
 # CHECKR-NEXT:          0000000000000008:  R_RISCV_ALIGN        *ABS*+0xc
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    a0, a0, 3
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    a0, a0, 0x3
 # CHECKR-EMPTY:
 # CHECKR-NEXT:  <c>:
-# CHECKR-NEXT:          addi    a0, a0, 4
-# CHECKR-NEXT:          addi    a0, a0, 5
-# CHECKR-NEXT:          addi    zero, zero, 0
+# CHECKR-NEXT:          addi    a0, a0, 0x4
+# CHECKR-NEXT:          addi    a0, a0, 0x5
+# CHECKR-NEXT:          addi    zero, zero, 0x0
 # CHECKR-NEXT:          0000000000000020:  R_RISCV_ALIGN        *ABS*+0x1c
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    a0, a0, 6
-# CHECKR-NEXT:          addi    a0, a0, 7
-# CHECKR-NEXT:          addi    zero, zero, 0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    a0, a0, 0x6
+# CHECKR-NEXT:          addi    a0, a0, 0x7
+# CHECKR-NEXT:          addi    zero, zero, 0x0
 # CHECKR-NEXT:          0000000000000044:  R_RISCV_ALIGN        *ABS*+0xc
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    zero, zero, 0
-# CHECKR-NEXT:          addi    a0, a0, 8
-# CHECKR-NEXT:          addi    a0, a0, 9
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    zero, zero, 0x0
+# CHECKR-NEXT:          addi    a0, a0, 0x8
+# CHECKR-NEXT:          addi    a0, a0, 0x9
 
 .global _start
 _start:
-  addi a0, a0, 1
+  addi a0, a0, 0x1
 a:
-  addi a0, a0, 2
+  addi a0, a0, 0x2
 b:
 .balign 16
-  addi a0, a0, 3
+  addi a0, a0, 0x3
 c:
-  addi a0, a0, 4
-  addi a0, a0, 5
+  addi a0, a0, 0x4
+  addi a0, a0, 0x5
 .balign 32
 .size a, . - a
-  addi a0, a0, 6
-  addi a0, a0, 7
+  addi a0, a0, 0x6
+  addi a0, a0, 0x7
 .balign 16
 .size b, . - b
-  addi a0, a0, 8
+  addi a0, a0, 0x8
 .size c, . - c
-  addi a0, a0, 9
+  addi a0, a0, 0x9
 .size _start, . - _start
 
 ## Test another text section.
@@ -141,12 +141,12 @@ c:
 d:
 e:
 .balign 8
-  addi a0, a0, 1
+  addi a0, a0, 0x1
 f:
-  addi a0, a0, 2
+  addi a0, a0, 0x2
 .balign 32
 .size d, . - d
-  addi a0, a0, 3
+  addi a0, a0, 0x3
 .size e, . - e
 .size f, . - f
 

--- a/lld/test/ELF/riscv-relax-call.s
+++ b/lld/test/ELF/riscv-relax-call.s
@@ -41,8 +41,8 @@
 # NORVC-LABEL: <_start>:
 # NORVC-NEXT:    10000:  jal    zero, {{.*}} <a>
 # NORVC-NEXT:            jal    zero, {{.*}} <a>
-# NORVC-NEXT:            addi   zero, zero, 0
-# NORVC-NEXT:            addi   zero, zero, 0
+# NORVC-NEXT:            addi   zero, zero, 0x0
+# NORVC-NEXT:            addi   zero, zero, 0x0
 # NORVC-NEXT:    10010:  jal    ra, {{.*}} <a>
 # NORVC-NEXT:            jal    ra, 0x10420
 # NORVC-EMPTY:
@@ -57,10 +57,10 @@
 # NORVC-EMPTY:
 
 # NORVC-LABEL: <.high>:
-# NORVC-NEXT:   110006:  auipc  ra, 1048320
-# NORVC-NEXT:            jalr   ra, -6(ra)
-# NORVC-NEXT:            auipc  ra, 1048320
-# NORVC-NEXT:            jalr   ra, -14(ra)
+# NORVC-NEXT:   110006:  auipc  ra, 0xfff00
+# NORVC-NEXT:            jalr   ra, -0x6(ra)
+# NORVC-NEXT:            auipc  ra, 0xfff00
+# NORVC-NEXT:            jalr   ra, -0xe(ra)
 # NORVC-EMPTY:
 
 # RVC32:       00010000 g       .text  00000016 _start
@@ -75,9 +75,9 @@
 # RVC-LABEL:   <_start>:
 # RVC-NEXT:      10000:  c.j    {{.*}} <a>
 # RVC-NEXT:              c.j    {{.*}} <a>
-# RVC-NEXT:              addi   zero, zero, 0
-# RVC-NEXT:              addi   zero, zero, 0
-# RVC-NEXT:              addi   zero, zero, 0
+# RVC-NEXT:              addi   zero, zero, 0x0
+# RVC-NEXT:              addi   zero, zero, 0x0
+# RVC-NEXT:              addi   zero, zero, 0x0
 # RVC32-NEXT:    10010:  c.jal  {{.*}} <a>
 # RVC32-NEXT:            c.jal  0x10420
 # RVC64-NEXT:    10010:  jal    ra, {{.*}} <a>
@@ -100,23 +100,23 @@
 
 # RVC-LABEL:   <.high>:
 # RVC32-NEXT:   110000:  jal    ra, 0x10000 <_start>
-# RVC32-NEXT:            auipc  ra, 1048320
-# RVC32-NEXT:            jalr   ra, -4(ra)
-# RVC64-NEXT:   110004:  auipc  ra, 1048320
-# RVC64-NEXT:            jalr   ra, -4(ra)
-# RVC64-NEXT:            auipc  ra, 1048320
-# RVC64-NEXT:            jalr   ra, -12(ra)
+# RVC32-NEXT:            auipc  ra, 0xfff00
+# RVC32-NEXT:            jalr   ra, -0x4(ra)
+# RVC64-NEXT:   110004:  auipc  ra, 0xfff00
+# RVC64-NEXT:            jalr   ra, -0x4(ra)
+# RVC64-NEXT:            auipc  ra, 0xfff00
+# RVC64-NEXT:            jalr   ra, -0xc(ra)
 # RVC-EMPTY:
 
 # NORELAX-LABEL: <_start>:
-# NORELAX-NEXT:    10000:  auipc  t1, 0
-# NORELAX-NEXT:            jalr   zero, 32(t1)
-# NORELAX-NEXT:            auipc  t0, 0
-# NORELAX-NEXT:            jalr   zero, 24(t0)
-# NORELAX-NEXT:    10010:  auipc  ra, 0
-# NORELAX-NEXT:            jalr   ra, 16(ra)
-# NORELAX-NEXT:            auipc  ra, 0
-# NORELAX-NEXT:            jalr   ra, 1032(ra)
+# NORELAX-NEXT:    10000:  auipc  t1, 0x0
+# NORELAX-NEXT:            jalr   zero, 0x20(t1)
+# NORELAX-NEXT:            auipc  t0, 0x0
+# NORELAX-NEXT:            jalr   zero, 0x18(t0)
+# NORELAX-NEXT:    10010:  auipc  ra, 0x0
+# NORELAX-NEXT:            jalr   ra, 0x10(ra)
+# NORELAX-NEXT:            auipc  ra, 0x0
+# NORELAX-NEXT:            jalr   ra, 0x408(ra)
 # NORELAX-EMPTY:
 
 #--- a.s

--- a/lld/test/ELF/riscv-relax-call2.s
+++ b/lld/test/ELF/riscv-relax-call2.s
@@ -16,8 +16,8 @@
 # CHECK-NEXT:             jal    zero, 0x8 <abs>
 # CHECK-NEXT:             jal    zero, 0x8 <abs>
 # CHECK-NEXT:             jal    ra, 0x8 <abs>
-# CHECK-NEXT:             auipc  t1, 1048320
-# CHECK-NEXT:             jalr   zero, -4(t1)
+# CHECK-NEXT:             auipc  t1, 0xfff00
+# CHECK-NEXT:             jalr   zero, -0x4(t1)
 # CHECK-EMPTY:
 
 # CHECK-LABEL:  <.mid>:
@@ -26,10 +26,10 @@
 # CHECK-EMPTY:
 
 # CHECK2-LABEL: <.mid>:
-# CHECK2-NEXT:            auipc  t1, 0
-# CHECK2-NEXT:            jalr   zero, 0(t1)
-# CHECK2-NEXT:            auipc  t1, 0
-# CHECK2-NEXT:            jalr   zero, 0(t1)
+# CHECK2-NEXT:            auipc  t1, 0x0
+# CHECK2-NEXT:            jalr   zero, 0x0(t1)
+# CHECK2-NEXT:            auipc  t1, 0x0
+# CHECK2-NEXT:            jalr   zero, 0x0(t1)
 # CHECK2-EMPTY:
 
 #--- a.s

--- a/lld/test/ELF/riscv-relax-emit-relocs.s
+++ b/lld/test/ELF/riscv-relax-emit-relocs.s
@@ -28,36 +28,36 @@
 # CHECK-NEXT:         R_RISCV_RELAX *ABS*
 # CHECK-EMPTY:
 # CHECK-NEXT: <f>:
-# CHECK-NEXT:     jalr zero, 0(ra)
+# CHECK-NEXT:     jalr zero, 0x0(ra)
 # CHECK-NEXT:         R_RISCV_ALIGN *ABS*+0x4
 
 # CHECKR:      <_start>:
-# CHECKR-NEXT:     auipc ra, 0
+# CHECKR-NEXT:     auipc ra, 0x0
 # CHECKR-NEXT:         R_RISCV_CALL_PLT f
 # CHECKR-NEXT:         R_RISCV_RELAX *ABS*
-# CHECKR-NEXT:     jalr ra, 0(ra)
-# CHECKR-NEXT:     auipc ra, 0
+# CHECKR-NEXT:     jalr ra, 0x0(ra)
+# CHECKR-NEXT:     auipc ra, 0x0
 # CHECKR-NEXT:         R_RISCV_CALL_PLT f
 # CHECKR-NEXT:         R_RISCV_RELAX *ABS*
-# CHECKR-NEXT:     jalr ra, 0(ra)
-# CHECKR-NEXT:     addi zero, zero, 0
+# CHECKR-NEXT:     jalr ra, 0x0(ra)
+# CHECKR-NEXT:     addi zero, zero, 0x0
 # CHECKR-NEXT:         R_RISCV_ALIGN *ABS*+0x4
 # CHECKR-EMPTY:
 # CHECKR-NEXT: <f>:
-# CHECKR-NEXT:     jalr zero, 0(ra)
+# CHECKR-NEXT:     jalr zero, 0x0(ra)
 
 # CHECKNORELAX:      <_start>:
-# CHECKNORELAX-NEXT:     auipc ra, 0
+# CHECKNORELAX-NEXT:     auipc ra, 0x0
 # CHECKNORELAX-NEXT:         R_RISCV_CALL_PLT f
 # CHECKNORELAX-NEXT:         R_RISCV_RELAX *ABS*
-# CHECKNORELAX-NEXT:     jalr ra, 16(ra)
-# CHECKNORELAX-NEXT:     auipc ra, 0
+# CHECKNORELAX-NEXT:     jalr ra, 0x10(ra)
+# CHECKNORELAX-NEXT:     auipc ra, 0x0
 # CHECKNORELAX-NEXT:         R_RISCV_CALL_PLT f
 # CHECKNORELAX-NEXT:         R_RISCV_RELAX *ABS*
-# CHECKNORELAX-NEXT:     jalr ra, 8(ra)
+# CHECKNORELAX-NEXT:     jalr ra, 0x8(ra)
 # CHECKNORELAX-EMPTY:
 # CHECKNORELAX-NEXT: <f>:
-# CHECKNORELAX-NEXT:     jalr zero, 0(ra)
+# CHECKNORELAX-NEXT:     jalr zero, 0x0(ra)
 # CHECKNORELAX-NEXT:         R_RISCV_ALIGN *ABS*+0x4
 
 .global _start

--- a/lld/test/ELF/riscv-relax-hi20-lo12-pie.s
+++ b/lld/test/ELF/riscv-relax-hi20-lo12-pie.s
@@ -10,10 +10,10 @@
 # RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv32 | FileCheck %s
 # RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv64 | FileCheck %s
 
-# CHECK:      lui     a0, 512
-# CHECK-NEXT: addi    a0, a0, 1
-# CHECK-NEXT: lw      a0, 1(a0)
-# CHECK-NEXT: sw      a0, 1(a0)
+# CHECK:      lui     a0, 0x200
+# CHECK-NEXT: addi    a0, a0, 0x1
+# CHECK-NEXT: lw      a0, 0x1(a0)
+# CHECK-NEXT: sw      a0, 0x1(a0)
 
 #--- a.s
 .globl abs

--- a/lld/test/ELF/riscv-relax-hi20-lo12.s
+++ b/lld/test/ELF/riscv-relax-hi20-lo12.s
@@ -12,20 +12,20 @@
 # CHECK: 00000028 l       .text {{0*}}0 a
 
 # CHECK-NOT:  lui
-# CHECK:      addi    a0, gp, -2048
-# CHECK-NEXT: lw      a0, -2048(gp)
-# CHECK-NEXT: sw      a0, -2048(gp)
+# CHECK:      addi    a0, gp, -0x800
+# CHECK-NEXT: lw      a0, -0x800(gp)
+# CHECK-NEXT: sw      a0, -0x800(gp)
 # CHECK-NOT:  lui
-# CHECK-NEXT: addi    a0, gp, 2047
-# CHECK-NEXT: lb      a0, 2047(gp)
-# CHECK-NEXT: sb      a0, 2047(gp)
-# CHECK-NEXT: lui     a0, 513
-# CHECK-NEXT: addi    a0, a0, 0
-# CHECK-NEXT: lw      a0, 0(a0)
-# CHECK-NEXT: sw      a0, 0(a0)
+# CHECK-NEXT: addi    a0, gp, 0x7ff
+# CHECK-NEXT: lb      a0, 0x7ff(gp)
+# CHECK-NEXT: sb      a0, 0x7ff(gp)
+# CHECK-NEXT: lui     a0, 0x201
+# CHECK-NEXT: addi    a0, a0, 0x0
+# CHECK-NEXT: lw      a0, 0x0(a0)
+# CHECK-NEXT: sw      a0, 0x0(a0)
 # CHECK-EMPTY:
 # CHECK-NEXT: <a>:
-# CHECK-NEXT: addi a0, a0, 1
+# CHECK-NEXT: addi a0, a0, 0x1
 
 #--- a.s
 .global _start

--- a/lld/test/ELF/riscv-reloc-got.s
+++ b/lld/test/ELF/riscv-reloc-got.s
@@ -46,18 +46,18 @@
 # HEX64: 0x00012368 70330100 00000000
 
 ## &.got[2]-. = 0x12214-0x1119c = 4096*1+120
-# DIS32:      1119c: auipc a0, 1
-# DIS32-NEXT:        lw a0, 120(a0)
+# DIS32:      1119c: auipc a0, 0x1
+# DIS32-NEXT:        lw a0, 0x78(a0)
 ## &.got[1]-. = 0x12210-0x111a4 = 4096*1+108
-# DIS32:      111a4: auipc a0, 1
-# DIS32-NEXT:        lw a0, 108(a0)
+# DIS32:      111a4: auipc a0, 0x1
+# DIS32-NEXT:        lw a0, 0x6c(a0)
 
 ## &.got[2]-. = 0x12368-0x11288 = 4096*1+224
-# DIS64:      11288: auipc a0, 1
-# DIS64-NEXT:        ld a0, 224(a0)
+# DIS64:      11288: auipc a0, 0x1
+# DIS64-NEXT:        ld a0, 0xe0(a0)
 ## &.got[1]-. = 0x12360-0x11290 = 4096*1+208
-# DIS64:      11290: auipc a0, 1
-# DIS64-NEXT:        ld a0, 208(a0)
+# DIS64:      11290: auipc a0, 0x1
+# DIS64-NEXT:        ld a0, 0xd0(a0)
 
 la a0,a
 la a0,b

--- a/lld/test/ELF/riscv-tls-gd.s
+++ b/lld/test/ELF/riscv-tls-gd.s
@@ -53,16 +53,16 @@
 # GD32-REL-NEXT: }
 
 ## &DTPMOD(a) - . = 0x2314 - 0x1250 = 4096*1+196
-# GD32:      1250: auipc a0, 1
-# GD32-NEXT:       addi a0, a0, 196
-# GD32-NEXT:       auipc ra, 0
-# GD32-NEXT:       jalr 56(ra)
+# GD32:      1250: auipc a0, 0x1
+# GD32-NEXT:       addi a0, a0, 0xc4
+# GD32-NEXT:       auipc ra, 0x0
+# GD32-NEXT:       jalr 0x38(ra)
 
 ## &DTPMOD(b) - . = 0x231C - 0x1260 = 4096*1+188
-# GD32:      1260: auipc a0, 1
-# GD32-NEXT:       addi a0, a0, 188
-# GD32-NEXT:       auipc ra, 0
-# GD32-NEXT:       jalr 40(ra)
+# GD32:      1260: auipc a0, 0x1
+# GD32-NEXT:       addi a0, a0, 0xbc
+# GD32-NEXT:       auipc ra, 0x0
+# GD32-NEXT:       jalr 0x28(ra)
 
 # GD64-REL:      .rela.dyn {
 # GD64-REL-NEXT:   0x24D8 R_RISCV_TLS_DTPMOD64 a 0x0
@@ -72,16 +72,16 @@
 # GD64-REL-NEXT: }
 
 ## &DTPMOD(a) - . = 0x24d8 - 0x1398 = 4096*1+320
-# GD64:      1398: auipc a0, 1
-# GD64-NEXT:       addi a0, a0, 320
-# GD64-NEXT:       auipc ra, 0
-# GD64-NEXT:       jalr 64(ra)
+# GD64:      1398: auipc a0, 0x1
+# GD64-NEXT:       addi a0, a0, 0x140
+# GD64-NEXT:       auipc ra, 0x0
+# GD64-NEXT:       jalr 0x40(ra)
 
 ## &DTPMOD(b) - . = 0x24e8 - 0x13a8 = 4096*1+320
-# GD64:      13a8: auipc a0, 1
-# GD64-NEXT:       addi a0, a0, 320
-# GD64-NEXT:       auipc ra, 0
-# GD64-NEXT:       jalr 48(ra)
+# GD64:      13a8: auipc a0, 0x1
+# GD64-NEXT:       addi a0, a0, 0x140
+# GD64-NEXT:       auipc ra, 0x0
+# GD64-NEXT:       jalr 0x30(ra)
 
 # NOREL: no relocations
 

--- a/lld/test/ELF/riscv-tls-ie.s
+++ b/lld/test/ELF/riscv-tls-ie.s
@@ -36,15 +36,15 @@
 
 ## rv32: &.got[0] - . = 0x2218 - . = 4096*1+116
 ## rv64: &.got[0] - . = 0x2378 - . = 4096*1+208
-# IE:              auipc a4, 1
-# IE32-NEXT:       lw a4, 116(a4)
-# IE64-NEXT:       ld a4, 208(a4)
+# IE:              auipc a4, 0x1
+# IE32-NEXT:       lw a4, 0x74(a4)
+# IE64-NEXT:       ld a4, 0xd0(a4)
 # IE-NEXT:         add a4, a4, tp
 ## rv32: &.got[1] - . = 0x221c - . = 4096*1+108
 ## rv64: &.got[1] - . = 0x2378 - . = 4096*1+204
-# IE:              auipc a5, 1
-# IE32-NEXT:       lw a5, 108(a5)
-# IE64-NEXT:       ld a5, 204(a5)
+# IE:              auipc a5, 0x1
+# IE32-NEXT:       lw a5, 0x6c(a5)
+# IE64-NEXT:       ld a5, 0xcc(a5)
 # IE-NEXT:         add a5, a5, tp
 
 # NOREL: no relocations
@@ -59,17 +59,17 @@
 
 ## rv32: &.got[0] - . = 0x12130 - 0x11114 = 4096*1+28
 ## rv64: &.got[0] - . = 0x121e8 - 0x111c8 = 4096*1+32
-# LE32:      11114: auipc a4, 1
-# LE32-NEXT:        lw a4, 28(a4)
-# LE64:      111c8: auipc a4, 1
-# LE64-NEXT:        ld a4, 32(a4)
+# LE32:      11114: auipc a4, 0x1
+# LE32-NEXT:        lw a4, 0x1c(a4)
+# LE64:      111c8: auipc a4, 0x1
+# LE64-NEXT:        ld a4, 0x20(a4)
 # LE-NEXT:          add a4, a4, tp
 ## rv32: &.got[1] - . = 0x12134 - 0x11120 = 4096*1+20
 ## rv64: &.got[1] - . = 0x121f0 - 0x111d4 = 4096*1+28
-# LE32:      11120: auipc a5, 1
-# LE32-NEXT:        lw a5, 20(a5)
-# LE64:      111d4: auipc a5, 1
-# LE64-NEXT:        ld a5, 28(a5)
+# LE32:      11120: auipc a5, 0x1
+# LE32-NEXT:        lw a5, 0x14(a5)
+# LE64:      111d4: auipc a5, 0x1
+# LE64-NEXT:        ld a5, 0x1c(a5)
 # LE-NEXT:          add a5, a5, tp
 
 la.tls.ie a4,a

--- a/lld/test/ELF/riscv-tls-ld.s
+++ b/lld/test/ELF/riscv-tls-ld.s
@@ -51,12 +51,12 @@
 
 ## rv32: &DTPMOD(a) - . = 0x22b0 - 0x11d8 = 4096*1+216
 ## rv64: &DTPMOD(a) - . = 0x2450 - 0x12f8 = 4096*1+344
-# LD32:      11d8: auipc a0, 1
-# LD32-NEXT:       addi a0, a0, 216
-# LD64:      12f8: auipc a0, 1
-# LD64-NEXT:       addi a0, a0, 344
-# LD-NEXT:         auipc ra, 0
-# LD-NEXT:         jalr 64(ra)
+# LD32:      11d8: auipc a0, 0x1
+# LD32-NEXT:       addi a0, a0, 0xd8
+# LD64:      12f8: auipc a0, 0x1
+# LD64-NEXT:       addi a0, a0, 0x158
+# LD-NEXT:         auipc ra, 0x0
+# LD-NEXT:         jalr 0x40(ra)
 
 # NOREL: no relocations
 
@@ -71,17 +71,17 @@
 
 ## rv32: DTPMOD(.LANCHOR0) - . = 0x1213c - 0x11114 = 4096*1+40
 ## rv64: DTPMOD(.LANCHOR0) - . = 0x121f8 - 0x111c8 = 4096*1+48
-# LE32:      11114: auipc a0, 1
-# LE32-NEXT:        addi a0, a0, 40
-# LE64:      111c8: auipc a0, 1
-# LE64-NEXT:        addi a0, a0, 48
-# LE-NEXT:          auipc ra, 0
-# LE-NEXT:          jalr 24(ra)
+# LE32:      11114: auipc a0, 0x1
+# LE32-NEXT:        addi a0, a0, 0x28
+# LE64:      111c8: auipc a0, 0x1
+# LE64-NEXT:        addi a0, a0, 0x30
+# LE-NEXT:          auipc ra, 0x0
+# LE-NEXT:          jalr 0x18(ra)
 
 la.tls.gd a0, .LANCHOR0
 call __tls_get_addr@plt
-lw a4, 0(a0)
-lh a0, 4(a0)
+lw a4, 0x0(a0)
+lh a0, 0x4(a0)
 
 ## This is irrelevant to TLS. We use it to take 2 GOT slots to check DTPREL
 ## offsets are correct.

--- a/lld/test/ELF/riscv-tls-le.s
+++ b/lld/test/ELF/riscv-tls-le.s
@@ -33,31 +33,31 @@
 
 ## .LANCHOR0@tprel = 8
 ## a@tprel = 12
-# LE:      lui a1, 0
+# LE:      lui a1, 0x0
 # LE-NEXT: add a1, a1, tp
-# LE-NEXT: addi a1, a1, 8
-# LE-NEXT: lui a2, 0
+# LE-NEXT: addi a1, a1, 0x8
+# LE-NEXT: lui a2, 0x0
 # LE-NEXT: add a2, a2, tp
-# LE-NEXT: addi a2, a2, 2044
-# LE-NEXT: lui a3, 0
-# LE-NEXT: addi a0, a0, 1
+# LE-NEXT: addi a2, a2, 0x7fc
+# LE-NEXT: lui a3, 0x0
+# LE-NEXT: addi a0, a0, 0x1
 # LE-NEXT: add a3, a3, tp
-# LE-NEXT: addi a0, a0, 2
-# LE-NEXT: sw a0, 2044(a3)
-# LE-NEXT: lui a4, 1
+# LE-NEXT: addi a0, a0, 0x2
+# LE-NEXT: sw a0, 0x7fc(a3)
+# LE-NEXT: lui a4, 0x1
 # LE-NEXT: add a4, a4, tp
-# LE-NEXT: sw a0, -2048(a4)
+# LE-NEXT: sw a0, -0x800(a4)
 # LE-EMPTY:
 
 # LE-RELAX:      <.text>:
-# LE-RELAX-NEXT:   addi a1, tp, 8
-# LE-RELAX-NEXT:   addi a2, tp, 2044
-# LE-RELAX-NEXT:   addi a0, a0, 1
-# LE-RELAX-NEXT:   addi a0, a0, 2
-# LE-RELAX-NEXT:   sw a0, 2044(tp)
-# LE-RELAX-NEXT:   lui a4, 1
+# LE-RELAX-NEXT:   addi a1, tp, 0x8
+# LE-RELAX-NEXT:   addi a2, tp, 0x7fc
+# LE-RELAX-NEXT:   addi a0, a0, 0x1
+# LE-RELAX-NEXT:   addi a0, a0, 0x2
+# LE-RELAX-NEXT:   sw a0, 0x7fc(tp)
+# LE-RELAX-NEXT:   lui a4, 0x1
 # LE-RELAX-NEXT:   add a4, a4, tp
-# LE-RELAX-NEXT:   sw a0, -2048(a4)
+# LE-RELAX-NEXT:   sw a0, -0x800(a4)
 # LE-RELAX-EMPTY:
 
 lui a1, %tprel_hi(.LANCHOR0)
@@ -72,9 +72,9 @@ addi a2, a2, %tprel_lo(a-4)
 ## hi20(a-4) = hi20(0x7fc) = 0. relaxable
 ## Test non-adjacent instructions.
 lui a3, %tprel_hi(a-4)
-addi a0, a0, 1
+addi a0, a0, 0x1
 add a3, a3, tp, %tprel_add(a-4)
-addi a0, a0, 2
+addi a0, a0, 0x2
 sw a0, %tprel_lo(a-4)(a3)
 
 ## hi20(a) = hi20(0x800) = 1. not relaxable

--- a/lld/test/ELF/riscv-undefined-weak.s
+++ b/lld/test/ELF/riscv-undefined-weak.s
@@ -18,8 +18,8 @@
 # RELOC-NEXT: 0x4 R_RISCV_LO12_I target 0x1
 
 # CHECK-LABEL: <absolute>:
-# CHECK-NEXT:  lui t0, 0
-# CHECK-NEXT:  addi t0, t0, 1
+# CHECK-NEXT:  lui t0, 0x0
+# CHECK-NEXT:  addi t0, t0, 0x1
 absolute:
   lui t0, %hi(target+1)
   addi t0, t0, %lo(target+1)
@@ -32,13 +32,13 @@ absolute:
 
 ## 1048559 should be -0x11.
 # CHECK-LABEL: <relative>:
-# CHECK-NEXT:  11{{...}}: auipc a1, 1048559
-# PC-NEXT:     addi a1, a1, -352
-# PLT-NEXT:    addi a1, a1, -792
+# CHECK-NEXT:  11{{...}}: auipc a1, 0xfffef
+# PC-NEXT:     addi a1, a1, -0x160
+# PLT-NEXT:    addi a1, a1, -0x318
 # CHECK-LABEL: <.Lpcrel_hi1>:
-# CHECK-NEXT:  11{{...}}: auipc t1, 1048559
-# PC-NEXT:     sd a2, -358(t1)
-# PLT-NEXT:    sd a2, -798(t1)
+# CHECK-NEXT:  11{{...}}: auipc t1, 0xfffef
+# PC-NEXT:     sd a2, -0x166(t1)
+# PLT-NEXT:    sd a2, -0x31e(t1)
 relative:
   la a1, target
   sd a2, target+2, t1
@@ -51,7 +51,7 @@ relative:
 # RELOC-NEXT: 0x24 R_RISCV_BRANCH target 0x0
 
 # PC-LABEL:    <branch>:
-# PC-NEXT:     auipc ra, 0
+# PC-NEXT:     auipc ra, 0x0
 # PC-NEXT:     jalr ra
 # PC-NEXT:     [[#%x,ADDR:]]:
 # PC-SAME:                    j 0x[[#ADDR]]
@@ -61,8 +61,8 @@ relative:
 ## If .dynsym exists, an undefined weak symbol is preemptible.
 ## We create a PLT entry and redirect the reference to it.
 # PLT-LABEL:   <branch>:
-# PLT-NEXT:    auipc ra, 0
-# PLT-NEXT:    jalr 56(ra)
+# PLT-NEXT:    auipc ra, 0x0
+# PLT-NEXT:    jalr 0x38(ra)
 # PLT-NEXT:    [[#%x,ADDR:]]:
 # PLT-SAME:                   j 0x[[#ADDR]]
 # PLT-NEXT:    [[#%x,ADDR:]]:

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -91,7 +91,7 @@ void RISCVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   }
 
   if (MO.isImm()) {
-    markup(O, Markup::Immediate) << MO.getImm();
+    markup(O, Markup::Immediate) << formatImm(MO.getImm());
     return;
   }
 
@@ -113,7 +113,7 @@ void RISCVInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
       Target &= 0xffffffff;
     markup(O, Markup::Target) << formatHex(Target);
   } else {
-    markup(O, Markup::Target) << MO.getImm();
+    markup(O, Markup::Target) << formatImm(MO.getImm());
   }
 }
 
@@ -128,7 +128,7 @@ void RISCVInstPrinter::printCSRSystemRegister(const MCInst *MI, unsigned OpNo,
   else if (SysReg && SysReg->haveRequiredFeatures(STI.getFeatureBits()))
     markup(O, Markup::Register) << SysReg->Name;
   else
-    markup(O, Markup::Register) << Imm;
+    markup(O, Markup::Register) << formatImm(Imm);
 }
 
 void RISCVInstPrinter::printFenceArg(const MCInst *MI, unsigned OpNo,
@@ -212,7 +212,7 @@ void RISCVInstPrinter::printVTypeI(const MCInst *MI, unsigned OpNo,
   // or non-zero in bits 8 and above.
   if (RISCVVType::getVLMUL(Imm) == RISCVII::VLMUL::LMUL_RESERVED ||
       RISCVVType::getSEW(Imm) > 64 || (Imm >> 8) != 0) {
-    O << Imm;
+    O << formatImm(Imm);
     return;
   }
   // Print the text form.

--- a/llvm/test/CodeGen/RISCV/compress-double.ll
+++ b/llvm/test/CodeGen/RISCV/compress-double.ll
@@ -33,7 +33,7 @@
 
 define double @double_load(ptr %a) #0 {
 ; RV32IFDC-LABEL: <double_load>:
-; RV32IFDC:         c.fld fa0, 0(a0)
+; RV32IFDC:         c.fld fa0, 0x0(a0)
 ; RV32IFDC-NEXT:    c.jr ra
   %1 = load volatile double, ptr %a
   ret double %1

--- a/llvm/test/CodeGen/RISCV/compress-float.ll
+++ b/llvm/test/CodeGen/RISCV/compress-float.ll
@@ -75,7 +75,7 @@
 
 define float @float_load(ptr %a) #0 {
 ; RV32IFDC-LABEL: <float_load>:
-; RV32IFDC:         c.flw fa0, 0(a0)
+; RV32IFDC:         c.flw fa0, 0x0(a0)
 ; RV32IFDC-NEXT:    c.jr ra
   %1 = load volatile float, ptr %a
   ret float %1

--- a/llvm/test/CodeGen/RISCV/compress-opt-branch.ll
+++ b/llvm/test/CodeGen/RISCV/compress-opt-branch.ll
@@ -34,11 +34,11 @@
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_pos>:
-; RV32IFDC: c.li [[REG:.*]], 20
+; RV32IFDC: c.li [[REG:.*]], 0x14
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 20
+; RV32IFD: addi [[REG:.*]], zero, 0x14
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 20
@@ -57,11 +57,11 @@ if.end:
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_neg>:
-; RV32IFDC: c.li [[REG:.*]], -20
+; RV32IFDC: c.li [[REG:.*]], -0x14
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -20
+; RV32IFD: addi [[REG:.*]], zero, -0x14
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -20
@@ -80,11 +80,11 @@ if.end:
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_edge_pos>:
-; RV32IFDC: c.li [[REG:.*]], 31
+; RV32IFDC: c.li [[REG:.*]], 0x1f
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_edge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 31
+; RV32IFD: addi [[REG:.*]], zero, 0x1f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_edge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 31
@@ -103,11 +103,11 @@ if.end:
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_edge_neg>:
-; RV32IFDC: c.li [[REG:.*]], -32
+; RV32IFDC: c.li [[REG:.*]], -0x20
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_edge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -32
+; RV32IFD: addi [[REG:.*]], zero, -0x20
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_edge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -32
@@ -127,11 +127,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_ledge_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -32
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x20
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_ledge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 32
+; RV32IFD: addi [[REG:.*]], zero, 0x20
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_ledge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 32
@@ -151,11 +151,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_ledge_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 33
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x21
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_ledge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -33
+; RV32IFD: addi [[REG:.*]], zero, -0x21
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_ledge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -33
@@ -175,11 +175,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -63
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x3f
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 63
+; RV32IFD: addi [[REG:.*]], zero, 0x3f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 63
@@ -199,11 +199,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 63
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x3f
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -63
+; RV32IFD: addi [[REG:.*]], zero, -0x3f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -63
@@ -223,11 +223,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_bedge_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -2047
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x7ff
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_bedge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 2047
+; RV32IFD: addi [[REG:.*]], zero, 0x7ff
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_bedge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 2047
@@ -247,11 +247,11 @@ if.end:
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm), negative value fit in 12 bit too.
 ; RV32IFDC-LABEL: <f_medium_bedge_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 2047
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x7ff
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_bedge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -2047
+; RV32IFD: addi [[REG:.*]], zero, -0x7ff
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_bedge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -2047

--- a/llvm/test/CodeGen/RISCV/compress-opt-select.ll
+++ b/llvm/test/CodeGen/RISCV/compress-opt-select.ll
@@ -34,11 +34,11 @@
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_pos>:
-; RV32IFDC: c.li [[REG:.*]], 20
+; RV32IFDC: c.li [[REG:.*]], 0x14
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 20
+; RV32IFD: addi [[REG:.*]], zero, 0x14
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 20
@@ -48,11 +48,11 @@ define i32 @f_small_pos(i32 %in0) minsize {
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_neg>:
-; RV32IFDC: c.li [[REG:.*]], -20
+; RV32IFDC: c.li [[REG:.*]], -0x14
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -20
+; RV32IFD: addi [[REG:.*]], zero, -0x14
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -20
@@ -62,11 +62,11 @@ define i32 @f_small_neg(i32 %in0) minsize {
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_edge_pos>:
-; RV32IFDC: c.li [[REG:.*]], 31
+; RV32IFDC: c.li [[REG:.*]], 0x1f
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_edge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 31
+; RV32IFD: addi [[REG:.*]], zero, 0x1f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_edge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 31
@@ -76,11 +76,11 @@ define i32 @f_small_edge_pos(i32 %in0) minsize {
 
 ; constant is small and fit in 6 bit (compress imm)
 ; RV32IFDC-LABEL: <f_small_edge_neg>:
-; RV32IFDC: c.li [[REG:.*]], -32
+; RV32IFDC: c.li [[REG:.*]], -0x20
 ; RV32IFDC: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_small_edge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -32
+; RV32IFD: addi [[REG:.*]], zero, -0x20
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_small_edge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -32
@@ -91,11 +91,11 @@ define i32 @f_small_edge_neg(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_ledge_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -32
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x20
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_ledge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 32
+; RV32IFD: addi [[REG:.*]], zero, 0x20
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_ledge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 32
@@ -106,11 +106,11 @@ define i32 @f_medium_ledge_pos(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_ledge_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 33
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x21
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_ledge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -33
+; RV32IFD: addi [[REG:.*]], zero, -0x21
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_ledge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -33
@@ -121,11 +121,11 @@ define i32 @f_medium_ledge_neg(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -63
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x3f
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 63
+; RV32IFD: addi [[REG:.*]], zero, 0x3f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 63
@@ -136,11 +136,11 @@ define i32 @f_medium_pos(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 63
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x3f
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -63
+; RV32IFD: addi [[REG:.*]], zero, -0x3f
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -63
@@ -151,11 +151,11 @@ define i32 @f_medium_neg(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm)
 ; RV32IFDC-LABEL: <f_medium_bedge_pos>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -2047
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], -0x7ff
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_bedge_pos>:
-; RV32IFD: addi [[REG:.*]], zero, 2047
+; RV32IFD: addi [[REG:.*]], zero, 0x7ff
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_bedge_pos(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, 2047
@@ -166,11 +166,11 @@ define i32 @f_medium_bedge_pos(i32 %in0) minsize {
 ; constant is medium and not fit in 6 bit (compress imm),
 ; but fit in 12 bit (imm), negative value fit in 12 bit too.
 ; RV32IFDC-LABEL: <f_medium_bedge_neg>:
-; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 2047
+; RV32IFDC: addi [[MAYZEROREG:.*]], [[REG:.*]], 0x7ff
 ; RV32IFDC: RESBROPT [[MAYZEROREG]], [[PLACE:.*]]
 ; --- no compress extension
 ; RV32IFD-LABEL: <f_medium_bedge_neg>:
-; RV32IFD: addi [[REG:.*]], zero, -2047
+; RV32IFD: addi [[REG:.*]], zero, -0x7ff
 ; RV32IFD: RESBRNORMAL [[ANOTHER:.*]], [[REG]], [[PLACE:.*]]
 define i32 @f_medium_bedge_neg(i32 %in0) minsize {
   %cmp = icmp CMPCOND i32 %in0, -2047

--- a/llvm/test/CodeGen/RISCV/compress.ll
+++ b/llvm/test/CodeGen/RISCV/compress.ll
@@ -31,10 +31,10 @@
 
 define i32 @simple_arith(i32 %a, i32 %b) #0 {
 ; RV32IC-LABEL: <simple_arith>:
-; RV32IC:         addi a2, a0, 1
-; RV32IC-NEXT:    c.andi a2, 11
-; RV32IC-NEXT:    c.slli a2, 7
-; RV32IC-NEXT:    c.srai a1, 9
+; RV32IC:         addi a2, a0, 0x1
+; RV32IC-NEXT:    c.andi a2, 0xb
+; RV32IC-NEXT:    c.slli a2, 0x7
+; RV32IC-NEXT:    c.srai a1, 0x9
 ; RV32IC-NEXT:    sub a0, a1, a0
 ; RV32IC-NEXT:    c.add a0, a2
 ; RV32IC-NEXT:    c.jr ra
@@ -49,34 +49,34 @@ define i32 @simple_arith(i32 %a, i32 %b) #0 {
 
 define i32 @select(i32 %a, ptr %b) #0 {
 ; RV32IC-LABEL: <select>:
-; RV32IC:         c.lw a2, 0(a1)
+; RV32IC:         c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    c.beqz a2, 0x18
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    c.bnez a2, 0x1e
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    bltu a2, a0, 0x26
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    bgeu a0, a2, 0x2e
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    bltu a0, a2, 0x36
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    bgeu a2, a0, 0x3e
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    blt a2, a0, 0x46
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    bge a0, a2, 0x4e
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a2, 0(a1)
+; RV32IC-NEXT:    c.lw a2, 0x0(a1)
 ; RV32IC-NEXT:    blt a0, a2, 0x56
 ; RV32IC-NEXT:    c.mv a0, a2
-; RV32IC-NEXT:    c.lw a1, 0(a1)
+; RV32IC-NEXT:    c.lw a1, 0x0(a1)
 ; RV32IC-NEXT:    bge a1, a0, 0x5e
 ; RV32IC-NEXT:    c.mv a0, a1
 ; RV32IC-NEXT:    c.jr ra
@@ -125,52 +125,52 @@ define i32 @select(i32 %a, ptr %b) #0 {
 
 define i32 @pos_tiny() #0 {
 ; RV32IC-LABEL: <pos_tiny>:
-; RV32IC:         c.li a0, 18
+; RV32IC:         c.li a0, 0x12
 ; RV32IC-NEXT:    c.jr ra
   ret i32 18
 }
 
 define i32 @pos_i32() #0 {
 ; RV32IC-LABEL: <pos_i32>:
-; RV32IC:         lui a0, 423811
-; RV32IC-NEXT:    addi a0, a0, -1297
+; RV32IC:         lui a0, 0x67783
+; RV32IC-NEXT:    addi a0, a0, -0x511
 ; RV32IC-NEXT:    c.jr ra
   ret i32 1735928559
 }
 
 define i32 @pos_i32_half_compressible() #0 {
 ; RV32IC-LABEL: <pos_i32_half_compressible>:
-; RV32IC:         lui a0, 423810
-; RV32IC-NEXT:    c.addi  a0, 28
+; RV32IC:         lui a0, 0x67782
+; RV32IC-NEXT:    c.addi  a0, 0x1c
 ; RV32IC-NEXT:    c.jr    ra
   ret i32 1735925788
 }
 
 define i32 @neg_tiny() #0 {
 ; RV32IC-LABEL: <neg_tiny>:
-; RV32IC:       c.li a0, -19
+; RV32IC:       c.li a0, -0x13
 ; RV32IC-NEXT:  c.jr ra
   ret i32 -19
 }
 
 define i32 @neg_i32() #0 {
 ; RV32IC-LABEL: <neg_i32>:
-; RV32IC:       lui a0, 912092
-; RV32IC-NEXT:  addi a0, a0, -273
+; RV32IC:       lui a0, 0xdeadc
+; RV32IC-NEXT:  addi a0, a0, -0x111
 ; RV32IC-NEXT:  c.jr ra
   ret i32 -559038737
 }
 
 define i32 @pos_i32_hi20_only() #0 {
 ; RV32IC-LABEL: <pos_i32_hi20_only>:
-; RV32IC:       c.lui a0, 16
+; RV32IC:       c.lui a0, 0x10
 ; RV32IC-NEXT:  c.jr ra
   ret i32 65536
 }
 
 define i32 @neg_i32_hi20_only() #0 {
 ; RV32IC-LABEL: <neg_i32_hi20_only>:
-; RV32IC:       c.lui a0, 1048560
+; RV32IC:       c.lui a0, 0xffff0
 ; RV32IC-NEXT:  c.jr ra
   ret i32 -65536
 }

--- a/llvm/test/CodeGen/RISCV/option-nopic.ll
+++ b/llvm/test/CodeGen/RISCV/option-nopic.ll
@@ -9,9 +9,9 @@
 
 define i32 @get_symbol() nounwind {
 ; CHECK-LABEL: <get_symbol>:
-; CHECK: auipc	a0, 0
-; CHECK: lw	a0, 0(a0)
-; CHECK: lw	a0, 0(a0)
+; CHECK: auipc	a0, 0x0
+; CHECK: lw	a0, 0x0(a0)
+; CHECK: lw	a0, 0x0(a0)
   tail call void asm sideeffect ".option nopic", ""()
   %v = load i32, ptr @symbol
   ret i32 %v

--- a/llvm/test/CodeGen/RISCV/option-pic.ll
+++ b/llvm/test/CodeGen/RISCV/option-pic.ll
@@ -9,8 +9,8 @@
 
 define i32 @get_symbol() nounwind {
 ; CHECK-LABEL: <get_symbol>:
-; CHECK: lui	a0, 0
-; CHECK: lw	a0, 0(a0)
+; CHECK: lui	a0, 0x0
+; CHECK: lw	a0, 0x0(a0)
   tail call void asm sideeffect ".option pic", ""()
   %v = load i32, ptr @symbol
   ret i32 %v

--- a/llvm/test/CodeGen/RISCV/option-rvc.ll
+++ b/llvm/test/CodeGen/RISCV/option-rvc.ll
@@ -8,7 +8,7 @@
 define i32 @add(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: <add>:
 ; CHECK:    add a0, a1, a0
-; CHECK-NEXT:    jalr zero, 0(ra)
+; CHECK-NEXT:    jalr zero, 0x0(ra)
   tail call void asm sideeffect ".option rvc", ""()
   %add = add nsw i32 %b, %a
   ret i32 %add

--- a/llvm/test/MC/RISCV/XTHeadBa-valid.s
+++ b/llvm/test/MC/RISCV/XTHeadBa-valid.s
@@ -4,10 +4,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+xtheadba -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xtheadba < %s \
-# RUN:     | llvm-objdump --mattr=+xtheadba -d -r - \
+# RUN:     | llvm-objdump --mattr=+xtheadba --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+xtheadba < %s \
-# RUN:     | llvm-objdump --mattr=+xtheadba -d -r - \
+# RUN:     | llvm-objdump --mattr=+xtheadba --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: th.addsl t0, t1, t2, 0

--- a/llvm/test/MC/RISCV/attribute-with-insts.s
+++ b/llvm/test/MC/RISCV/attribute-with-insts.s
@@ -15,7 +15,7 @@
 # CHECK-INST: lr.w t0, (t1)
 lr.w t0, (t1)
 
-# CHECK-INST: c.addi a3, -32
+# CHECK-INST: c.addi a3, -0x20
 c.addi a3, -32
 
 # CHECK-INST: fmadd.d fa0, fa1, fa2, fa3, dyn
@@ -24,7 +24,7 @@ fmadd.d f10, f11, f12, f13, dyn
 # CHECK-INST: fmadd.s fa0, fa1, fa2, fa3, dyn
 fmadd.s f10, f11, f12, f13, dyn
 
-# CHECK-INST: addi ra, sp, 2
+# CHECK-INST: addi ra, sp, 0x2
 addi ra, sp, 2
 
 # CHECK-INST: mul a4, ra, s0

--- a/llvm/test/MC/RISCV/compress-rv32d.s
+++ b/llvm/test/MC/RISCV/compress-rv32d.s
@@ -3,20 +3,20 @@
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+d -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+d -d - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv32 --mattr=+c,+d -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+d -d -M no-aliases - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv32 --mattr=+c,+d -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcd,+d -show-encoding < %s \
 # RUN:   | FileCheck -check-prefixes=CHECK,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcd,+d -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcd,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcd,+d -d - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv32 --mattr=+zcd,+d -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcd,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcd,+d -d -M no-aliases - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv32 --mattr=+zcd,+d -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # RUN: llvm-mc -triple riscv64 -mattr=+c,+d -show-encoding < %s \
@@ -24,20 +24,20 @@
 # RUN: llvm-mc -triple riscv64 -mattr=+c,+d -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK-INST %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c,+d -d - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv64 --mattr=+c,+d -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c,+d -d -M no-aliases - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv64 --mattr=+c,+d -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 # RUN: llvm-mc -triple riscv64 -mattr=+zcd,+d -show-encoding < %s \
 # RUN:   | FileCheck -check-prefixes=CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv64 -mattr=+zcd,+d -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK-INST %s
 # RUN: llvm-mc -triple riscv64 -mattr=+zcd,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+zcd,+d -d - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv64 --mattr=+zcd,+d -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv64 -mattr=+zcd,+d -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+zcd,+d -d -M no-aliases - \
+# RUN:   | llvm-objdump --no-print-imm-hex --triple=riscv64 --mattr=+zcd,+d -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # Tests double precision floating point instructions available in rv32 and in rv64.

--- a/llvm/test/MC/RISCV/compress-rv32f.s
+++ b/llvm/test/MC/RISCV/compress-rv32f.s
@@ -3,20 +3,20 @@
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+f -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+f -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+f -d - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+f --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c,+f -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+f -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+f --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcf,+f -show-encoding < %s \
 # RUN:   | FileCheck -check-prefixes=CHECK,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcf,+f -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcf,+f -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcf,+f -d - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcf,+f --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -mattr=+zcf,+f -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcf,+f -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+zcf,+f --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # Instructions that are 32 bit only.

--- a/llvm/test/MC/RISCV/compress-rv32i.s
+++ b/llvm/test/MC/RISCV/compress-rv32i.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc -triple riscv32 -mattr=+c -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST,CHECK-INSTASM %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c -d - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS,CHECK-ALIASOBJ32 %s
 # RUN: llvm-mc -triple riscv32 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST,CHECK-INSTOBJ32 %s
 
 # RUN: llvm-mc -triple riscv64 -mattr=+c -show-encoding < %s \
@@ -14,10 +14,10 @@
 # RUN: llvm-mc -triple riscv64 -mattr=+c -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK-INST,CHECK-INSTASM %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS,CHECK-ALIASOBJ64 %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST,CHECK-INSTOBJ64 %s
 
 # CHECK-BYTES: 2e 85

--- a/llvm/test/MC/RISCV/compress-rv64i.s
+++ b/llvm/test/MC/RISCV/compress-rv64i.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc -triple riscv64 -mattr=+c -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK-INST %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv64 -mattr=+c -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # Tests compressed instructions available in rv64 and not in rv32.

--- a/llvm/test/MC/RISCV/corev/XCValu-valid.s
+++ b/llvm/test/MC/RISCV/corev/XCValu-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvalu -riscv-no-aliases -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvalu < %s \
-# RUN:     | llvm-objdump --mattr=+xcvalu -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+xcvalu --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/corev/XCVbi.s
+++ b/llvm/test/MC/RISCV/corev/XCVbi.s
@@ -14,19 +14,19 @@ label1:
 
 cv.beqimm t0, 0, 0
 # CHECK-INSTR: cv.beqimm t0, 0, 0
-# CHECK-OBJDUMP: cv.beqimm t0, 0, 0x0 <label1>
+# CHECK-OBJDUMP: cv.beqimm t0, 0x0, 0x0 <label1>
 # CHECK-ENCODING: [0x0b,0xe0,0x02,0x00]
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}
 
 cv.beqimm a0, 5, 42
 # CHECK-INSTR: cv.beqimm a0, 5, 42
-# CHECK-OBJDUMP: cv.beqimm a0, 5, 0x2e <label2+0x22>
+# CHECK-OBJDUMP: cv.beqimm a0, 0x5, 0x2e <label2+0x22>
 # CHECK-ENCODING: [0x0b,0x65,0x55,0x02]
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}
 
 cv.beqimm a0, -5, label1
 # CHECK-INSTR: cv.beqimm a0, -5, label1
-# CHECK-OBJDUMP: cv.beqimm a0, -5, 0x0 <label1>
+# CHECK-OBJDUMP: cv.beqimm a0, -0x5, 0x0 <label1>
 # CHECK-ENCODING: [0x0b'A',0x60'A',0xb5'A',0x01'A']
 # CHECK-ENCODING: fixup A - offset: 0, value: label1, kind: fixup_riscv_branch
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}
@@ -39,19 +39,19 @@ label2:
 
 cv.bneimm t0, 0, 0
 # CHECK-INSTR: cv.bneimm t0, 0, 0
-# CHECK-OBJDUMP: cv.bneimm t0, 0, 0xc <label2>
+# CHECK-OBJDUMP: cv.bneimm t0, 0x0, 0xc <label2>
 # CHECK-ENCODING: [0x0b,0xf0,0x02,0x00]
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}
 
 cv.bneimm a0, 5, 42
 # CHECK-INSTR: cv.bneimm a0, 5, 42
-# CHECK-OBJDUMP: cv.bneimm a0, 5, 0x3a <label2+0x2e>
+# CHECK-OBJDUMP: cv.bneimm a0, 0x5, 0x3a <label2+0x2e>
 # CHECK-ENCODING: [0x0b,0x75,0x55,0x02]
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}
 
 cv.bneimm a0, -5, label2
 # CHECK-INSTR: cv.bneimm a0, -5, label2
-# CHECK-OBJDUMP: cv.bneimm a0, -5, 0xc <label2>
+# CHECK-OBJDUMP: cv.bneimm a0, -0x5, 0xc <label2>
 # CHECK-ENCODING: [0x0b'A',0x70'A',0xb5'A',0x01'A']
 # CHECK-ENCODING: fixup A - offset: 0, value: label2, kind: fixup_riscv_branch
 # CHECK-NO-EXT: instruction requires the following: 'XCVbi' (CORE-V Immediate Branching){{$}}

--- a/llvm/test/MC/RISCV/corev/XCVbitmanip.s
+++ b/llvm/test/MC/RISCV/corev/XCVbitmanip.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvbitmanip < %s \
-# RUN:     | llvm-objdump --mattr=+xcvbitmanip -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+xcvbitmanip --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/corev/XCVelw-valid.s
+++ b/llvm/test/MC/RISCV/corev/XCVelw-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvelw -show-encoding %s \
 # RUN:     | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvelw < %s \
-# RUN:     | llvm-objdump --mattr=+xcvelw -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+xcvelw --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/corev/XCVmac-valid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmac-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmac -riscv-no-aliases -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvmac < %s \
-# RUN:     | llvm-objdump --mattr=+xcvmac -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+xcvmac --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/corev/XCVmem-valid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmem-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:     | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvmem < %s \
-# RUN:     | llvm-objdump --mattr=+xcvmem -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+xcvmem -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/corev/XCVsimd.s
+++ b/llvm/test/MC/RISCV/corev/XCVsimd.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvsimd < %s \
-# RUN:     | llvm-objdump --mattr=+xcvsimd -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+xcvsimd --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: not llvm-mc -triple riscv32 %s 2>&1 \
 # RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s

--- a/llvm/test/MC/RISCV/csr-aliases.s
+++ b/llvm/test/MC/RISCV/csr-aliases.s
@@ -73,16 +73,16 @@ csrrw t0, 2, zero
 # CHECK-EXT-F-OFF: csrrw t0, frm, t1
 csrrw t0, 2, t1
 
-# CHECK-INST: csrrwi t0, frm, 31
-# CHECK-ALIAS: fsrmi t0, 31
-# CHECK-EXT-F-ON: fsrmi t0, 31
-# CHECK-EXT-F-OFF: csrrwi t0, frm, 31
+# CHECK-INST: csrrwi t0, frm, 0x1f
+# CHECK-ALIAS: fsrmi t0, 0x1f
+# CHECK-EXT-F-ON: fsrmi t0, 0x1f
+# CHECK-EXT-F-OFF: csrrwi t0, frm, 0x1f
 csrrwi t0, 2, 31
 
-# CHECK-INST: csrrwi zero, frm, 31
-# CHECK-ALIAS: fsrmi 31
-# CHECK-EXT-F-ON: fsrmi 31
-# CHECK-EXT-F-OFF:  csrwi frm, 31
+# CHECK-INST: csrrwi zero, frm, 0x1f
+# CHECK-ALIAS: fsrmi 0x1f
+# CHECK-EXT-F-ON: fsrmi 0x1f
+# CHECK-EXT-F-OFF:  csrwi frm, 0x1f
 csrrwi zero, 2, 31
 
 # CHECK-INST: csrrs t0, fflags, zero
@@ -103,15 +103,15 @@ csrrw t0, 1, t2
 # CHECK-EXT-F-OFF: csrw fflags, t2
 csrrw zero, 1, t2
 
-# CHECK-INST: csrrwi t0, fflags, 31
-# CHECK-ALIAS: fsflagsi t0, 31
-# CHECK-EXT-F: fsflagsi t0, 31
-# CHECK-EXT-F-OFF: csrrwi t0, fflags, 31
+# CHECK-INST: csrrwi t0, fflags, 0x1f
+# CHECK-ALIAS: fsflagsi t0, 0x1f
+# CHECK-EXT-F: fsflagsi t0, 0x1f
+# CHECK-EXT-F-OFF: csrrwi t0, fflags, 0x1f
 csrrwi t0, 1, 31
 
-# CHECK-INST: csrrwi zero, fflags, 31
-# CHECK-ALIAS: fsflagsi 31
-# CHECK-EXT-F: fsflagsi 31
-# CHECK-EXT-F-OFF: csrwi fflags, 31
+# CHECK-INST: csrrwi zero, fflags, 0x1f
+# CHECK-ALIAS: fsflagsi 0x1f
+# CHECK-EXT-F: fsflagsi 0x1f
+# CHECK-EXT-F-OFF: csrwi fflags, 0x1f
 csrrwi zero, 1, 31
 

--- a/llvm/test/MC/RISCV/fixups.s
+++ b/llvm/test/MC/RISCV/fixups.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple riscv32 -riscv-no-aliases < %s -show-encoding \
 # RUN:     | FileCheck -check-prefix=CHECK-FIXUP %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefix=CHECK-INSTR %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 %s \
 # RUN:     | llvm-readobj -r - | FileCheck %s -check-prefix=CHECK-REL

--- a/llvm/test/MC/RISCV/hilo-constaddr.s
+++ b/llvm/test/MC/RISCV/hilo-constaddr.s
@@ -11,7 +11,7 @@
 .equ addr, 0xdeadbeef
   lui t0, %hi(addr)
   lw ra, %lo(addr)(t0)
-# CHECK-INSTR: lui t0, 912092
-# CHECK-INSTR: lw ra, -273(t0)
+# CHECK-INSTR: lui t0, 0xdeadc
+# CHECK-INSTR: lw ra, -0x111(t0)
 
 # CHECK-REL-NOT: R_RISCV

--- a/llvm/test/MC/RISCV/insn.s
+++ b/llvm/test/MC/RISCV/insn.s
@@ -22,29 +22,29 @@ target:
 
 # CHECK-ASM: .insn i 19, 0, a0, a1, 13
 # CHECK-ASM: encoding: [0x13,0x85,0xd5,0x00]
-# CHECK-OBJ: addi a0, a1, 13
+# CHECK-OBJ: addi a0, a1, 0xd
 .insn i  0x13,  0, a0, a1, 13
 # CHECK-ASM: .insn i 19, 0, a0, a1, 13
 # CHECK-ASM: encoding: [0x13,0x85,0xd5,0x00]
-# CHECK-OBJ: addi a0, a1, 13
+# CHECK-OBJ: addi a0, a1, 0xd
 .insn i  OP_IMM,  0, a0, a1, 13
 
 # CHECK-ASM: .insn i 103, 0, a0, 10(a1)
 # CHECK-ASM: encoding: [0x67,0x85,0xa5,0x00]
-# CHECK-OBJ: jalr a0, 10(a1)
+# CHECK-OBJ: jalr a0, 0xa(a1)
 .insn i  0x67,  0, a0, 10(a1)
 # CHECK-ASM: .insn i 103, 0, a0, 10(a1)
 # CHECK-ASM: encoding: [0x67,0x85,0xa5,0x00]
-# CHECK-OBJ: jalr a0, 10(a1)
+# CHECK-OBJ: jalr a0, 0xa(a1)
 .insn i  JALR,  0, a0, 10(a1)
 
 # CHECK-ASM: .insn i 3, 0, a0, 4(a1)
 # CHECK-ASM: encoding: [0x03,0x85,0x45,0x00]
-# CHECK-OBJ: lb a0, 4(a1)
+# CHECK-OBJ: lb a0, 0x4(a1)
 .insn i   0x3,  0, a0, 4(a1)
 # CHECK-ASM: .insn i 3, 0, a0, 4(a1)
 # CHECK-ASM: encoding: [0x03,0x85,0x45,0x00]
-# CHECK-OBJ: lb a0, 4(a1)
+# CHECK-OBJ: lb a0, 0x4(a1)
 .insn i   LOAD,  0, a0, 4(a1)
 
 # CHECK-ASM: .insn b 99, 0, a0, a1, target
@@ -67,20 +67,20 @@ target:
 
 # CHECK-ASM: .insn s 35, 0, a0, 4(a1)
 # CHECK-ASM: encoding: [0x23,0x82,0xa5,0x00]
-# CHECK-OBJ: sb a0, 4(a1)
+# CHECK-OBJ: sb a0, 0x4(a1)
 .insn s  0x23,  0, a0, 4(a1)
 # CHECK-ASM: .insn s 35, 0, a0, 4(a1)
 # CHECK-ASM: encoding: [0x23,0x82,0xa5,0x00]
-# CHECK-OBJ: sb a0, 4(a1)
+# CHECK-OBJ: sb a0, 0x4(a1)
 .insn s  STORE,  0, a0, 4(a1)
 
 # CHECK-ASM: .insn u 55, a0, 4095
 # CHECK-ASM: encoding: [0x37,0xf5,0xff,0x00]
-# CHECK-OBJ: lui a0, 4095
+# CHECK-OBJ: lui a0, 0xfff
 .insn u  0x37, a0, 0xfff
 # CHECK-ASM: .insn u 55, a0, 4095
 # CHECK-ASM: encoding: [0x37,0xf5,0xff,0x00]
-# CHECK-OBJ: lui a0, 4095
+# CHECK-OBJ: lui a0, 0xfff
 .insn u  LUI, a0, 0xfff
 
 # CHECK-ASM: .insn j 111, a0, target
@@ -121,9 +121,9 @@ target:
 
 # CHECK-ASM: .insn i 3, 5, t1, -2048(t2)
 # CHECK-ASM: encoding: [0x03,0xd3,0x03,0x80]
-# CHECK-OBJ: lhu t1, -2048(t2)
+# CHECK-OBJ: lhu t1, -0x800(t2)
 .insn i 0x3, 0x5, x6, %lo(2048)(x7)
 # CHECK-ASM: .insn i 3, 5, t1, -2048(t2)
 # CHECK-ASM: encoding: [0x03,0xd3,0x03,0x80]
-# CHECK-OBJ: lhu t1, -2048(t2)
+# CHECK-OBJ: lhu t1, -0x800(t2)
 .insn i LOAD, 0x5, x6, %lo(2048)(x7)

--- a/llvm/test/MC/RISCV/insn_c.s
+++ b/llvm/test/MC/RISCV/insn_c.s
@@ -23,37 +23,37 @@ target:
 
 # CHECK-ASM: .insn ci  1, 0, a0, 13
 # CHECK-ASM: encoding: [0x35,0x05]
-# CHECK-OBJ: c.addi a0, 13
+# CHECK-OBJ: c.addi a0, 0xd
 .insn ci  1, 0, a0, 13
 
 # CHECK-ASM: .insn ci  1, 0, a0, 13
 # CHECK-ASM: encoding: [0x35,0x05]
-# CHECK-OBJ: c.addi a0, 13
+# CHECK-OBJ: c.addi a0, 0xd
 .insn ci C1, 0, a0, 13
 
 # CHECK-ASM: .insn ciw  0, 0, a0, 13
 # CHECK-ASM: encoding: [0xa8,0x01]
-# CHECK-OBJ: c.addi4spn a0, sp, 200
+# CHECK-OBJ: c.addi4spn a0, sp, 0xc8
 .insn ciw  0, 0, a0, 13
 
 # CHECK-ASM: .insn ciw  0, 0, a0, 13
 # CHECK-ASM: encoding: [0xa8,0x01]
-# CHECK-OBJ: c.addi4spn a0, sp, 200
+# CHECK-OBJ: c.addi4spn a0, sp, 0xc8
 .insn ciw C0, 0, a0, 13
 
 # CHECK-ASM: .insn css  2, 6, a0, 13
 # CHECK-ASM: encoding: [0xaa,0xc6]
-# CHECK-OBJ: c.swsp a0, 76(sp)
+# CHECK-OBJ: c.swsp a0, 0x4c(sp)
 .insn css  2, 6, a0, 13
 
 # CHECK-ASM: .insn cl  0, 2, a0, 13
 # CHECK-ASM: encoding: [0xa8,0x4d]
-# CHECK-OBJ: c.lw a0, 88(a1)
+# CHECK-OBJ: c.lw a0, 0x58(a1)
 .insn cl  0, 2, a0, 13(a1)
 
 # CHECK-ASM: .insn cs  0, 6, a0, 13
 # CHECK-ASM: encoding: [0xa8,0xcd]
-# CHECK-OBJ: c.sw a0, 88(a1)
+# CHECK-OBJ: c.sw a0, 0x58(a1)
 .insn cs  0, 6, a0, 13(a1)
 
 # CHECK-ASM: .insn ca  1, 35, 0, a0, a1

--- a/llvm/test/MC/RISCV/nop-slide.s
+++ b/llvm/test/MC/RISCV/nop-slide.s
@@ -12,16 +12,16 @@ auipc a0, 0
 # CHECK-RVC-NORELAX: 0000000000000000 <.text>:
 # CHECK-RVC-NORELAX-NEXT: 0: 00 00        	unimp
 # CHECK-RVC-NORELAX-NEXT: 2: 01 00        	nop
-# CHECK-RVC-NORELAX-NEXT: 4: 17 05 00 00  	auipc	a0, 0
+# CHECK-RVC-NORELAX-NEXT: 4: 17 05 00 00  	auipc	a0, 0x0
 
 # CHECK-RVC-RELAX: 0000000000000000 <.text>:
 # CHECK-RVC-RELAX-NEXT:   0: 01 00        	nop
-# CHECK-RVC-RELAX-NEXT:   2: 00 01        	addi	s0, sp, 128
-# CHECK-RVC-RELAX-NEXT:   4: 00 17        	addi	s0, sp, 928
-# CHECK-RVC-RELAX-NEXT:   6: 05 00        	c.nop	1
+# CHECK-RVC-RELAX-NEXT:   2: 00 01        	addi	s0, sp, 0x80
+# CHECK-RVC-RELAX-NEXT:   4: 00 17        	addi	s0, sp, 0x3a0
+# CHECK-RVC-RELAX-NEXT:   6: 05 00        	c.nop	0x1
 # CHECK-RVC-RELAX-NEXT:   8: 00           	<unknown>
 
 # CHECK: 0000000000000000 <.text>:
 # CHECK-NEXT: 0: 00 00        	<unknown>
 # CHECK-NEXT: 2: 00 00        	<unknown>
-# CHECK-NEXT: 4: 17 05 00 00  	auipc	a0, 0
+# CHECK-NEXT: 4: 17 05 00 00  	auipc	a0, 0x0

--- a/llvm/test/MC/RISCV/numeric-reg-names.s
+++ b/llvm/test/MC/RISCV/numeric-reg-names.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple riscv32 -M numeric %s \
 # RUN:     | FileCheck -check-prefix=CHECK-NUMERIC %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -d -M numeric - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -M numeric - \
 # RUN:     | FileCheck -check-prefix=CHECK-NUMERIC %s
 
 # CHECK-NUMERIC: li x10, 1

--- a/llvm/test/MC/RISCV/option-arch.s
+++ b/llvm/test/MC/RISCV/option-arch.s
@@ -7,11 +7,11 @@
 # Test '.option arch, +' and '.option arch, -' directive
 # The following test cases were copied from MC/RISCV/option-rvc.s
 
-# CHECK-INST: addi a0, a1, 0
+# CHECK-INST: addi a0, a1, 0x0
 # CHECK: # encoding:  [0x13,0x85,0x05,0x00]
 addi a0, a1, 0
 
-# CHECK-INST: addi s0, sp, 1020
+# CHECK-INST: addi s0, sp, 0x3fc
 # CHECK: # encoding:  [0x13,0x04,0xc1,0x3f]
 addi s0, sp, 1020
 
@@ -21,17 +21,17 @@ addi s0, sp, 1020
 # CHECK: # encoding:  [0x2e,0x85]
 addi a0, a1, 0
 
-# CHECK-INST: c.addi4spn s0, sp, 1020
+# CHECK-INST: c.addi4spn s0, sp, 0x3fc
 # CHECK: # encoding:  [0xe0,0x1f]
 addi s0, sp, 1020
 
 # CHECK: .option arch, -c
 .option arch, -c
-# CHECK-INST: addi a0, a1, 0
+# CHECK-INST: addi a0, a1, 0x0
 # CHECK: # encoding:  [0x13,0x85,0x05,0x00]
 addi a0, a1, 0
 
-# CHECK-INST: addi s0, sp, 1020
+# CHECK-INST: addi s0, sp, 0x3fc
 # CHECK: # encoding:  [0x13,0x04,0xc1,0x3f]
 addi s0, sp, 1020
 
@@ -41,23 +41,23 @@ addi s0, sp, 1020
 # CHECK: # encoding:  [0x2e,0x85]
 addi a0, a1, 0
 
-# CHECK-INST: c.addi4spn s0, sp, 1020
+# CHECK-INST: c.addi4spn s0, sp, 0x3fc
 # CHECK: # encoding:  [0xe0,0x1f]
 addi s0, sp, 1020
 
 # CHECK: .option arch, -c
 .option arch, -c
-# CHECK-INST: addi a0, a1, 0
+# CHECK-INST: addi a0, a1, 0x0
 # CHECK: # encoding:  [0x13,0x85,0x05,0x00]
 addi a0, a1, 0
 
-# CHECK-INST: addi s0, sp, 1020
+# CHECK-INST: addi s0, sp, 0x3fc
 # CHECK: # encoding:  [0x13,0x04,0xc1,0x3f]
 addi s0, sp, 1020
 
 # CHECK: .option arch, +d, -d
 .option arch, +d, -d
-# CHECK-INST: flw ft0, 12(a0)
+# CHECK-INST: flw ft0, 0xc(a0)
 # CHECK: # encoding:  [0x07,0x20,0xc5,0x00]
 flw f0, 12(a0)
 
@@ -101,7 +101,7 @@ lr.w t0, (t1)
 
 # Test +c, -c and vice-versa
 .option arch, +c, -c
-# CHECK-INST: addi a0, a1, 0
+# CHECK-INST: addi a0, a1, 0x0
 # CHECK: # encoding:  [0x13,0x85,0x05,0x00]
 addi a0, a1, 0
 
@@ -121,6 +121,6 @@ addi a0, a1, 0
 
 .option arch, rv32i
 .option arch, +zce, +f
-# CHECK-INST: flw fa0, 0(a0)
+# CHECK-INST: flw fa0, 0x0(a0)
 # CHECK: # encoding: [0x08,0x61]
 c.flw fa0, 0(a0)

--- a/llvm/test/MC/RISCV/option-mix.s
+++ b/llvm/test/MC/RISCV/option-mix.s
@@ -29,11 +29,11 @@
 # ASM-NEXT: addi    a1, a1, %pcrel_lo(.Lpcrel_hi1)
 
 # DISASM-LABEL: <.Lpcrel_hi0>:
-# DISASM-NEXT: auipc   a0, 0
-# DISASM-NEXT: addi    a0, a0, 0
+# DISASM-NEXT: auipc   a0, 0x0
+# DISASM-NEXT: addi    a0, a0, 0x0
 # DISASM-LABEL: <.Lpcrel_hi1>:
-# DISASM-NEXT: auipc   a1, 0
-# DISASM-NEXT: addi    a1, a1, 0
+# DISASM-NEXT: auipc   a1, 0x0
+# DISASM-NEXT: addi    a1, a1, 0x0
 
 .option push
 .option norelax
@@ -51,11 +51,11 @@
 # ASM-NEXT: addi    a1, a1, %pcrel_lo(.Ltmp1)
 
 # DISASM-LABEL: .Ltmp0{{>?}}:
-# DISASM-NEXT: auipc   a0, 0
-# DISASM-NEXT: addi    a0, a0, 0
+# DISASM-NEXT: auipc   a0, 0x0
+# DISASM-NEXT: addi    a0, a0, 0x0
 # DISASM-LABEL: .Ltmp1{{>?}}:
-# DISASM-NEXT: auipc   a1, 0
-# DISASM-NEXT: addi    a1, a1, 0
+# DISASM-NEXT: auipc   a1, 0x0
+# DISASM-NEXT: addi    a1, a1, 0x0
 
 .option push
 .option norelax
@@ -74,13 +74,13 @@ local_symbol1:
 # ASM-NEXT: addi    a1, a1, %pcrel_lo(.Lpcrel_hi3)
 
 # DISASM-LABEL: .Lpcrel_hi2{{>?}}:
-# DISASM-NEXT: auipc   a0, 0
-# DISASM-NEXT: addi    a0, a0, 0
-# DISASM-NORELAX-NEXT: auipc   a1, 0
-# DISASM-NORELAX-NEXT: addi    a1, a1, 8
+# DISASM-NEXT: auipc   a0, 0x0
+# DISASM-NEXT: addi    a0, a0, 0x0
+# DISASM-NORELAX-NEXT: auipc   a1, 0x0
+# DISASM-NORELAX-NEXT: addi    a1, a1, 0x8
 # DISASM-RELAX-LABEL: .Lpcrel_hi3{{>?}}:
-# DISASM-RELAX-NEXT: auipc   a1, 0
-# DISASM-RELAX-NEXT: addi    a1, a1, 0
+# DISASM-RELAX-NEXT: auipc   a1, 0x0
+# DISASM-RELAX-NEXT: addi    a1, a1, 0x0
 
 .option push
 .option norelax
@@ -101,10 +101,10 @@ local_symbol2:
 # ASM-NEXT: addi    a1, a1, %pcrel_lo(.Ltmp3)
 
 # DISASM-LABEL: .Ltmp2{{>?}}:
-# DISASM-NEXT: auipc   a0, 0
-# DISASM-NEXT: addi    a0, a0, 0
-# DISASM-NORELAX-NEXT: auipc   a1, 0
-# DISASM-NORELAX-NEXT: addi    a1, a1, 8
+# DISASM-NEXT: auipc   a0, 0x0
+# DISASM-NEXT: addi    a0, a0, 0x0
+# DISASM-NORELAX-NEXT: auipc   a1, 0x0
+# DISASM-NORELAX-NEXT: addi    a1, a1, 0x8
 # DISASM-RELAX-LABEL: .Ltmp3{{>?}}:
-# DISASM-RELAX-NEXT: auipc   a1, 0
-# DISASM-RELAX-NEXT: addi    a1, a1, 0
+# DISASM-RELAX-NEXT: auipc   a1, 0x0
+# DISASM-RELAX-NEXT: addi    a1, a1, 0x0

--- a/llvm/test/MC/RISCV/option-pushpop.s
+++ b/llvm/test/MC/RISCV/option-pushpop.s
@@ -3,7 +3,7 @@
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
 # RUN:     | llvm-readobj -r - | FileCheck -check-prefix=CHECK-RELOC %s
 # RUN: llvm-mc -triple riscv32 -filetype=obj < %s \
-# RUN:     | llvm-objdump  --triple=riscv32 --mattr=+c -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex --triple=riscv32 --mattr=+c -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 
 # RUN: llvm-mc -triple riscv64 -mattr=-relax -riscv-no-aliases < %s \
@@ -11,7 +11,7 @@
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
 # RUN:     | llvm-readobj -r - | FileCheck -check-prefix=CHECK-RELOC %s
 # RUN: llvm-mc -triple riscv64 -filetype=obj < %s \
-# RUN:     | llvm-objdump  --triple=riscv64 --mattr=+c -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex --triple=riscv64 --mattr=+c -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 
 # Test the operation of the push and pop assembler directives when

--- a/llvm/test/MC/RISCV/option-rvc.s
+++ b/llvm/test/MC/RISCV/option-rvc.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc -triple riscv32 -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK,CHECK-INST %s
 # RUN: llvm-mc -triple riscv32 -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c -d - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv32 -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # RUN: llvm-mc -triple riscv64 -show-encoding < %s \
@@ -14,10 +14,10 @@
 # RUN: llvm-mc -triple riscv64 -show-encoding \
 # RUN:   -riscv-no-aliases < %s | FileCheck -check-prefixes=CHECK-INST %s
 # RUN: llvm-mc -triple riscv64 -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-ALIAS %s
 # RUN: llvm-mc -triple riscv64 -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv64 --mattr=+c --no-print-imm-hex -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-BYTES,CHECK-INST %s
 
 # CHECK-BYTES: 13 85 05 00

--- a/llvm/test/MC/RISCV/pcrel-fixups.s
+++ b/llvm/test/MC/RISCV/pcrel-fixups.s
@@ -1,14 +1,14 @@
 # RUN: llvm-mc -triple riscv32 -mattr=-relax -filetype obj %s \
-# RUN:    | llvm-objdump -M no-aliases -d -r - \
+# RUN:    | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:    | FileCheck --check-prefix NORELAX %s
 # RUN: llvm-mc -triple riscv32 -mattr=+relax -filetype obj %s \
-# RUN:    | llvm-objdump -M no-aliases -d -r - \
+# RUN:    | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:    | FileCheck --check-prefix RELAX %s
 # RUN: llvm-mc -triple riscv64 -mattr=-relax -filetype obj %s \
-# RUN:    | llvm-objdump -M no-aliases -d -r - \
+# RUN:    | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:    | FileCheck --check-prefix NORELAX %s
 # RUN: llvm-mc -triple riscv64 -mattr=+relax -filetype obj %s \
-# RUN:    | llvm-objdump -M no-aliases -d -r - \
+# RUN:    | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:    | FileCheck --check-prefix RELAX %s
 
 # Fixups for %pcrel_hi / %pcrel_lo can be evaluated within a section,

--- a/llvm/test/MC/RISCV/print-imm-hex.s
+++ b/llvm/test/MC/RISCV/print-imm-hex.s
@@ -1,0 +1,42 @@
+# RUN: llvm-mc %s -triple=riscv32 -riscv-no-aliases -show-encoding -mattr=+v \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM %s
+# RUN: llvm-mc %s -triple=riscv32 -riscv-no-aliases -show-encoding -mattr=+v --print-imm-hex \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM-HEX %s
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+v < %s \
+# RUN:     | llvm-objdump -M no-aliases --mattr=+v --no-print-imm-hex -d -r - \
+# RUN:     | FileCheck -check-prefixes=CHECK-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+v < %s \
+# RUN:     | llvm-objdump -M no-aliases --mattr=+v --print-imm-hex -d -r - \
+# RUN:     | FileCheck -check-prefixes=CHECK-OBJ-HEX %s
+
+# CHECK-ASM: beq s1, s1, 102
+# CHECK-ASM-HEX: beq s1, s1, 0x66
+# CHECK-OBJ: beq s1, s1, 0x66
+# CHECK-OBJ-HEX: beq s1, s1, 0x66
+beq s1, s1, 102
+
+_sym:
+# CHECK-ASM: beq s1, s1, _sym
+# CHECK-ASM-HEX: beq s1, s1, _sym
+# CHECK-OBJ: beq s1, s1, 0x4
+# CHECK-OBJ-HEX: beq s1, s1, 0x4
+beq s1, s1, _sym
+
+# CHECK-ASM: lw a0, 97(a2)
+# CHECK-ASM-HEX: lw a0, 0x61(a2)
+# CHECK-OBJ: lw a0, 97(a2)
+# CHECK-OBJ-HEX: lw a0, 0x61(a2)
+lw a0, 97(a2)
+
+# CHECK-ASM: csrrwi t0, 4095, 31
+# CHECK-ASM-HEX: csrrwi t0, 0xfff, 0x1f
+# CHECK-OBJ: csrrwi t0, 4095, 31
+# CHECK-OBJ-HEX: csrrwi t0, 0xfff, 0x1f
+csrrwi t0, 0xfff, 31
+
+
+# CHECK-ASM: vsetvli a2, a0, 255
+# CHECK-ASM-HEX: vsetvli a2, a0, 0xff
+# CHECK-OBJ: vsetvli a2, a0, 255
+# CHECK-OBJ-HEX: vsetvli a2, a0, 0xff
+vsetvli a2, a0, 0xff

--- a/llvm/test/MC/RISCV/rv32c-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32c-aliases-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc -triple=riscv32 -mattr=+c -riscv-no-aliases < %s \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c < %s \
-# RUN:     | llvm-objdump -d -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -triple=riscv32 -mattr=+zca -riscv-no-aliases < %s \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zca < %s \
-# RUN:     | llvm-objdump --mattr=+zca -d -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zca -d -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv32c-only-valid.s
+++ b/llvm/test/MC/RISCV/rv32c-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c < %s \
-# RUN:     | llvm-objdump --mattr=+c -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv32 \

--- a/llvm/test/MC/RISCV/rv32c-valid.s
+++ b/llvm/test/MC/RISCV/rv32c-valid.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c < %s \
-# RUN:     | llvm-objdump --mattr=+c -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-OBJ,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zca -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zca < %s \
-# RUN:     | llvm-objdump --mattr=+zca -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zca --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-OBJ,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump --mattr=+c -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zca -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zca < %s \
-# RUN:     | llvm-objdump --mattr=+zca -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zca --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # RUN: not llvm-mc -triple riscv32 \

--- a/llvm/test/MC/RISCV/rv32d-valid.s
+++ b/llvm/test/MC/RISCV/rv32d-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+d < %s \
-# RUN:     | llvm-objdump --mattr=+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+d < %s \
-# RUN:     | llvm-objdump --mattr=+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # Support for the 'D' extension implies support for 'F'

--- a/llvm/test/MC/RISCV/rv32dc-valid.s
+++ b/llvm/test/MC/RISCV/rv32dc-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+c,+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c,+d < %s \
-# RUN:     | llvm-objdump --mattr=+c,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+c,+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zcd,+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zcd,+d < %s \
-# RUN:     | llvm-objdump --mattr=+zcd,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zcd,+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv32 -mattr=+c \

--- a/llvm/test/MC/RISCV/rv32e-valid.s
+++ b/llvm/test/MC/RISCV/rv32e-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv32 -riscv-no-aliases -mattr=+e -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+e < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -riscv-no-aliases -mattr=+e -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+e < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-ASM-AND-OBJ %s
 
 # This file provides a basic test for RV32E, checking that the expected

--- a/llvm/test/MC/RISCV/rv32f-valid.s
+++ b/llvm/test/MC/RISCV/rv32f-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+f -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+f < %s \
-# RUN:     | llvm-objdump --mattr=+f -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+f --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+f < %s \
-# RUN:     | llvm-objdump --mattr=+f -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+f --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: flw ft0, 12(a0)

--- a/llvm/test/MC/RISCV/rv32fc-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32fc-aliases-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+c,+f -riscv-no-aliases \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c,+f < %s \
-# RUN:     | llvm-objdump --mattr=+c,+f -M no-aliases -d - \
+# RUN:     | llvm-objdump --mattr=+c,+f --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 
 # CHECK-EXPAND: c.flw fs0, 0(s1)

--- a/llvm/test/MC/RISCV/rv32fc-valid.s
+++ b/llvm/test/MC/RISCV/rv32fc-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+c,+f -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c,+f < %s \
-# RUN:     | llvm-objdump --mattr=+c,+f -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c,+f --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zcf,+f -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zcf,+f < %s \
-# RUN:     | llvm-objdump --mattr=+zcf,+f -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zcf,+f --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv32 -mattr=+c \

--- a/llvm/test/MC/RISCV/rv32i-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32i-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv32 \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-ALIAS,CHECK-ASM %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ-NOALIAS,CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-ALIAS %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv32i-only-valid.s
+++ b/llvm/test/MC/RISCV/rv32i-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: addi a0, a1, -1

--- a/llvm/test/MC/RISCV/rv32i-valid.s
+++ b/llvm/test/MC/RISCV/rv32i-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple riscv64 -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-OBJ32,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-OBJ64,CHECK-ASM-AND-OBJ %s
 
 .equ CONST, 30

--- a/llvm/test/MC/RISCV/rv32xtheadbs-valid.s
+++ b/llvm/test/MC/RISCV/rv32xtheadbs-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+xtheadbs -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xtheadbs < %s \
-# RUN:     | llvm-objdump --mattr=+xtheadbs -d -r - \
+# RUN:     | llvm-objdump --mattr=+xtheadbs --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+xtheadbs < %s \
-# RUN:     | llvm-objdump --mattr=+xtheadbs -d -r - \
+# RUN:     | llvm-objdump --mattr=+xtheadbs --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: th.tst t0, t1, 1

--- a/llvm/test/MC/RISCV/rv32xtheadfmemidx-valid.s
+++ b/llvm/test/MC/RISCV/rv32xtheadfmemidx-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+d -mattr=+xtheadfmemidx -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+d -mattr=+xtheadfmemidx < %s \
-# RUN:     | llvm-objdump --mattr=+d --mattr=+xtheadfmemidx -d -r - \
+# RUN:     | llvm-objdump --mattr=+d --mattr=+xtheadfmemidx --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: th.flrd fa0, a1, a2, 0

--- a/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zbb \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases --mattr=+zbb - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases --mattr=+zbb - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump -d -r --mattr=+zbb - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r --mattr=+zbb - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv32zbb-only-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-only-valid.s
@@ -2,7 +2,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zbb -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump --mattr=+zbb -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zbb --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: zext.h t0, t1

--- a/llvm/test/MC/RISCV/rv32zbkb-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbkb-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zbkb -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zbkb < %s \
-# RUN:     | llvm-objdump --mattr=+zbkb -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zbkb -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbkb < %s \
-# RUN:     | llvm-objdump --mattr=+zbkb -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zbkb -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: ror t0, t1, t2

--- a/llvm/test/MC/RISCV/rv32zbs-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbs-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zbs \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases --mattr=+zbs - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases --mattr=+zbs - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump -d -r --mattr=+zbs - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r --mattr=+zbs - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv32zbs-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbs-valid.s
@@ -4,10 +4,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zbs -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump --mattr=+zbs -d -r - \
+# RUN:     | llvm-objdump --mattr=+zbs --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump --mattr=+zbs -d -r - \
+# RUN:     | llvm-objdump --mattr=+zbs --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: bclr t0, t1, t2

--- a/llvm/test/MC/RISCV/rv32zcb-valid.s
+++ b/llvm/test/MC/RISCV/rv32zcb-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+m,+zbb,+zba,+zcb -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+m,+zbb,+zba,+zcb < %s \
-# RUN:     | llvm-objdump --mattr=+m,+zbb,+zba,+zcb -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+m,+zbb,+zba,+zcb --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+m,+zbb,+zba,+zcb -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+m,+zbb,+zba,+zcb < %s \
-# RUN:     | llvm-objdump --mattr=+m,+zbb,+zba,zcb -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+m,+zbb,+zba,zcb --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv32 \

--- a/llvm/test/MC/RISCV/rv32zcmt-valid.s
+++ b/llvm/test/MC/RISCV/rv32zcmt-valid.s
@@ -3,7 +3,7 @@
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zcmt\
 # RUN:  -mattr=m < %s \
-# RUN:     | llvm-objdump --mattr=+zcmt\
+# RUN:     | llvm-objdump --mattr=+zcmt --no-print-imm-hex \
 # RUN:  -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zcmt\
@@ -11,7 +11,7 @@
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zcmt\
 # RUN:  -mattr=m < %s \
-# RUN:     | llvm-objdump --mattr=+zcmt\
+# RUN:     | llvm-objdump --mattr=+zcmt --no-print-imm-hex \
 # RUN:  -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
 #

--- a/llvm/test/MC/RISCV/rv32zfbfmin-valid.s
+++ b/llvm/test/MC/RISCV/rv32zfbfmin-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+experimental-zfbfmin -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+experimental-zfbfmin,+f < %s \
-# RUN:     | llvm-objdump --mattr=+experimental-zfbfmin -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+experimental-zfbfmin --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+experimental-zfbfmin,+f < %s \
-# RUN:     | llvm-objdump --mattr=+experimental-zfbfmin -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+experimental-zfbfmin --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: flh ft0, 12(a0)

--- a/llvm/test/MC/RISCV/rv32zfh-valid.s
+++ b/llvm/test/MC/RISCV/rv32zfh-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zfh -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump --mattr=+zfh -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zfh --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump --mattr=+zfh -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zfh --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: flh ft0, 12(a0)

--- a/llvm/test/MC/RISCV/rv32zfhmin-valid.s
+++ b/llvm/test/MC/RISCV/rv32zfhmin-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zfhmin,+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zfhmin,+d < %s \
-# RUN:     | llvm-objdump --mattr=+zfhmin,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zfhmin,+d --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zfhmin,+d < %s \
-# RUN:     | llvm-objdump --mattr=+zfhmin,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zfhmin,+d --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: flh ft0, 12(a0)

--- a/llvm/test/MC/RISCV/rv32zicbop-valid.s
+++ b/llvm/test/MC/RISCV/rv32zicbop-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zicbop -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zicbop < %s \
-# RUN:     | llvm-objdump --mattr=+zicbop -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zicbop -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zicbop < %s \
-# RUN:     | llvm-objdump --mattr=+zicbop -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zicbop -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: prefetch.i -2048(t0)

--- a/llvm/test/MC/RISCV/rv32zknd-only-valid.s
+++ b/llvm/test/MC/RISCV/rv32zknd-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zknd -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zknd < %s \
-# RUN:     | llvm-objdump --mattr=+zknd -d -r - \
+# RUN:     | llvm-objdump --mattr=+zknd --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: aes32dsi a0, a1, a2, 3

--- a/llvm/test/MC/RISCV/rv32zkne-only-valid.s
+++ b/llvm/test/MC/RISCV/rv32zkne-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+zkne -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zkne < %s \
-# RUN:     | llvm-objdump --mattr=+zkne -d -r - \
+# RUN:     | llvm-objdump --mattr=+zkne --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: aes32esi a0, a1, a2, 3

--- a/llvm/test/MC/RISCV/rv32zksed-valid.s
+++ b/llvm/test/MC/RISCV/rv32zksed-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zksed -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zksed < %s \
-# RUN:     | llvm-objdump --mattr=+zksed -d -r - \
+# RUN:     | llvm-objdump --mattr=+zksed --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zksed < %s \
-# RUN:     | llvm-objdump --mattr=+zksed -d -r - \
+# RUN:     | llvm-objdump --mattr=+zksed --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: sm4ed a0, a1, a2, 3

--- a/llvm/test/MC/RISCV/rv64-machine-csr-names.s
+++ b/llvm/test/MC/RISCV/rv64-machine-csr-names.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-INST,CHECK-ENC %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST-ALIAS %s
 
 # These machine mode CSR register names are RV32 only, but RV64

--- a/llvm/test/MC/RISCV/rv64-user-csr-names.s
+++ b/llvm/test/MC/RISCV/rv64-user-csr-names.s
@@ -15,222 +15,222 @@
 # uimm12
 # CHECK-INST: csrrs t2, 3200, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x00,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3200
+# CHECK-INST-ALIAS: csrr t2, 0xc80
 csrrs t2, 0xC80, zero
 
 # timeh
 # uimm12
 # CHECK-INST: csrrs t2, 3201, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x10,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3201
+# CHECK-INST-ALIAS: csrr t2, 0xc81
 csrrs t2, 0xC81, zero
 
 # instreth
 # uimm12
 # CHECK-INST: csrrs t2, 3202, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x20,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3202
+# CHECK-INST-ALIAS: csrr t2, 0xc82
 csrrs t2, 0xC82, zero
 
 # hpmcounter3h
 # uimm12
 # CHECK-INST: csrrs t2, 3203, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x30,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3203
+# CHECK-INST-ALIAS: csrr t2, 0xc83
 csrrs t2, 0xC83, zero
 
 # hpmcounter4h
 # uimm12
 # CHECK-INST: csrrs t2, 3204, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x40,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3204
+# CHECK-INST-ALIAS: csrr t2, 0xc84
 csrrs t2, 0xC84, zero
 
 # hpmcounter5h
 # uimm12
 # CHECK-INST: csrrs t2, 3205, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x50,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3205
+# CHECK-INST-ALIAS: csrr t2, 0xc85
 csrrs t2, 0xC85, zero
 
 # hpmcounter6h
 # uimm12
 # CHECK-INST: csrrs t2, 3206, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x60,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3206
+# CHECK-INST-ALIAS: csrr t2, 0xc86
 csrrs t2, 0xC86, zero
 
 # hpmcounter7h
 # uimm12
 # CHECK-INST: csrrs t2, 3207, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x70,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3207
+# CHECK-INST-ALIAS: csrr t2, 0xc87
 csrrs t2, 0xC87, zero
 
 # hpmcounter8h
 # uimm12
 # CHECK-INST: csrrs t2, 3208, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x80,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3208
+# CHECK-INST-ALIAS: csrr t2, 0xc88
 csrrs t2, 0xC88, zero
 
 # hpmcounter9h
 # uimm12
 # CHECK-INST: csrrs t2, 3209, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x90,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3209
+# CHECK-INST-ALIAS: csrr t2, 0xc89
 csrrs t2, 0xC89, zero
 
 # hpmcounter10h
 # uimm12
 # CHECK-INST: csrrs t2, 3210, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xa0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3210
+# CHECK-INST-ALIAS: csrr t2, 0xc8a
 csrrs t2, 0xC8A, zero
 
 # hpmcounter11h
 # uimm12
 # CHECK-INST: csrrs t2, 3211, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xb0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3211
+# CHECK-INST-ALIAS: csrr t2, 0xc8b
 csrrs t2, 0xC8B, zero
 
 # hpmcounter12h
 # uimm12
 # CHECK-INST: csrrs t2, 3212, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xc0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3212
+# CHECK-INST-ALIAS: csrr t2, 0xc8c
 csrrs t2, 0xC8C, zero
 
 # hpmcounter13h
 # uimm12
 # CHECK-INST: csrrs t2, 3213, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xd0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3213
+# CHECK-INST-ALIAS: csrr t2, 0xc8d
 csrrs t2, 0xC8D, zero
 
 # hpmcounter14h
 # uimm12
 # CHECK-INST: csrrs t2, 3214, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xe0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3214
+# CHECK-INST-ALIAS: csrr t2, 0xc8e
 csrrs t2, 0xC8E, zero
 
 # hpmcounter15h
 # uimm12
 # CHECK-INST: csrrs t2, 3215, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xf0,0xc8]
-# CHECK-INST-ALIAS: csrr t2, 3215
+# CHECK-INST-ALIAS: csrr t2, 0xc8f
 csrrs t2, 0xC8F, zero
 
 # hpmcounter16h
 # uimm12
 # CHECK-INST: csrrs t2, 3216, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x00,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3216
+# CHECK-INST-ALIAS: csrr t2, 0xc90
 csrrs t2, 0xC90, zero
 
 # hpmcounter17h
 # uimm12
 # CHECK-INST: csrrs t2, 3217, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x10,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3217
+# CHECK-INST-ALIAS: csrr t2, 0xc91
 csrrs t2, 0xC91, zero
 
 # hpmcounter18h
 # uimm12
 # CHECK-INST: csrrs t2, 3218, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x20,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3218
+# CHECK-INST-ALIAS: csrr t2, 0xc92
 csrrs t2, 0xC92, zero
 
 # hpmcounter19h
 # uimm12
 # CHECK-INST: csrrs t2, 3219, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x30,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3219
+# CHECK-INST-ALIAS: csrr t2, 0xc93
 csrrs t2, 0xC93, zero
 
 # hpmcounter20h
 # uimm12
 # CHECK-INST: csrrs t2, 3220, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x40,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3220
+# CHECK-INST-ALIAS: csrr t2, 0xc94
 csrrs t2, 0xC94, zero
 
 # hpmcounter21h
 # uimm12
 # CHECK-INST: csrrs t2, 3221, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x50,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3221
+# CHECK-INST-ALIAS: csrr t2, 0xc95
 csrrs t2, 0xC95, zero
 
 # hpmcounter22h
 # uimm12
 # CHECK-INST: csrrs t2, 3222, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x60,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3222
+# CHECK-INST-ALIAS: csrr t2, 0xc96
 csrrs t2, 0xC96, zero
 
 # hpmcounter23h
 # uimm12
 # CHECK-INST: csrrs t2, 3223, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x70,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3223
+# CHECK-INST-ALIAS: csrr t2, 0xc97
 csrrs t2, 0xC97, zero
 
 # hpmcounter24h
 # uimm12
 # CHECK-INST: csrrs t2, 3224, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x80,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3224
+# CHECK-INST-ALIAS: csrr t2, 0xc98
 csrrs t2, 0xC98, zero
 
 # hpmcounter25h
 # uimm12
 # CHECK-INST: csrrs t2, 3225, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0x90,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3225
+# CHECK-INST-ALIAS: csrr t2, 0xc99
 csrrs t2, 0xC99, zero
 
 # hpmcounter26h
 # uimm12
 # CHECK-INST: csrrs t2, 3226, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xa0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3226
+# CHECK-INST-ALIAS: csrr t2, 0xc9a
 csrrs t2, 0xC9A, zero
 
 # hpmcounter27h
 # uimm12
 # CHECK-INST: csrrs t2, 3227, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xb0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3227
+# CHECK-INST-ALIAS: csrr t2, 0xc9b
 csrrs t2, 0xC9B, zero
 
 # hpmcounter28h
 # uimm12
 # CHECK-INST: csrrs t2, 3228, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xc0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3228
+# CHECK-INST-ALIAS: csrr t2, 0xc9c
 csrrs t2, 0xC9C, zero
 
 # hpmcounter29h
 # uimm12
 # CHECK-INST: csrrs t2, 3229, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xd0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3229
+# CHECK-INST-ALIAS: csrr t2, 0xc9d
 csrrs t2, 0xC9D, zero
 
 # hpmcounter30h
 # uimm12
 # CHECK-INST: csrrs t2, 3230, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xe0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3230
+# CHECK-INST-ALIAS: csrr t2, 0xc9e
 csrrs t2, 0xC9E, zero
 
 # hpmcounter31h
 # uimm12
 # CHECK-INST: csrrs t2, 3231, zero
 # CHECK-ENC:  encoding: [0xf3,0x23,0xf0,0xc9]
-# CHECK-INST-ALIAS: csrr t2, 3231
+# CHECK-INST-ALIAS: csrr t2, 0xc9f
 csrrs t2, 0xC9F, zero

--- a/llvm/test/MC/RISCV/rv64c-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64c-aliases-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc -triple=riscv64 -mattr=+c -riscv-no-aliases < %s \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump -d -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -triple=riscv64 -mattr=+zca -riscv-no-aliases < %s \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zca < %s \
-# RUN:     | llvm-objdump --mattr=+zca -d -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zca -d -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-INST %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv64c-hints-valid.s
+++ b/llvm/test/MC/RISCV/rv64c-hints-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple riscv64 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple riscv64 -mattr=+zca -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zca < %s \
-# RUN:     | llvm-objdump --mattr=+zca -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zca -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: c.slli zero, 63

--- a/llvm/test/MC/RISCV/rv64c-valid.s
+++ b/llvm/test/MC/RISCV/rv64c-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump --mattr=+c -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zca -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump --mattr=+c -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+c --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 #
 #

--- a/llvm/test/MC/RISCV/rv64dc-valid.s
+++ b/llvm/test/MC/RISCV/rv64dc-valid.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+c,+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+d < %s \
-# RUN:     | llvm-objdump --mattr=+c,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+c,+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zcd,+d -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zcd,+d < %s \
-# RUN:     | llvm-objdump --mattr=+zcd,+d -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zcd,+d -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv64 -mattr=+c \

--- a/llvm/test/MC/RISCV/rv64e-valid.s
+++ b/llvm/test/MC/RISCV/rv64e-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -riscv-no-aliases -mattr=+e -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+e < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 
 # This file provides a basic test for RV64E, checking that the expected

--- a/llvm/test/MC/RISCV/rv64i-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64i-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-ALIAS,CHECK-ASM %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ-NOALIAS,CHECK-EXPAND,CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND,CHECK-ALIAS %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv64i-valid.s
+++ b/llvm/test/MC/RISCV/rv64i-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 .equ CONST, 31

--- a/llvm/test/MC/RISCV/rv64xtheadfmemidx-valid.s
+++ b/llvm/test/MC/RISCV/rv64xtheadfmemidx-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+d -mattr=+xtheadfmemidx -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+d -mattr=+xtheadfmemidx < %s \
-# RUN:     | llvm-objdump --mattr=+d --mattr=+xtheadfmemidx -d -r - \
+# RUN:     | llvm-objdump --mattr=+d --mattr=+xtheadfmemidx --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: th.flrd fa0, a1, a2, 0

--- a/llvm/test/MC/RISCV/rv64zba-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64zba-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s  -triple=riscv64 -mattr=+zba \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zba < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases --mattr=+zba - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases --mattr=+zba - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zba < %s \
-# RUN:     | llvm-objdump -d -r --mattr=+zba - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r --mattr=+zba - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv64zbb-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64zbb-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s  -triple=riscv64 -mattr=+zbb \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases --mattr=+zbb - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases --mattr=+zbb - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump -d -r --mattr=+zbb - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r --mattr=+zbb - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv64zbb-valid.s
+++ b/llvm/test/MC/RISCV/rv64zbb-valid.s
@@ -2,7 +2,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zbb -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbb < %s \
-# RUN:     | llvm-objdump --mattr=+zbb -M no-aliases -d -r - \
+# RUN:     | llvm-objdump --mattr=+zbb -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: zext.h t0, t1

--- a/llvm/test/MC/RISCV/rv64zbkb-valid.s
+++ b/llvm/test/MC/RISCV/rv64zbkb-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zbkb -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbkb < %s \
-# RUN:     | llvm-objdump --mattr=+zbkb -d -r - \
+# RUN:     | llvm-objdump --mattr=+zbkb --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: rev8 t0, t1

--- a/llvm/test/MC/RISCV/rv64zbs-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64zbs-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s  -triple=riscv64 -mattr=+zbs \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases --mattr=+zbs - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases --mattr=+zbs - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zbs < %s \
-# RUN:     | llvm-objdump -d -r --mattr=+zbs - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r --mattr=+zbs - \
 # RUN:     | FileCheck -check-prefixes=CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rv64zknd-only-valid.s
+++ b/llvm/test/MC/RISCV/rv64zknd-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zknd -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zknd < %s \
-# RUN:     | llvm-objdump --mattr=+zknd -d -r - \
+# RUN:     | llvm-objdump --mattr=+zknd --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: aes64ds a0, a1, a2

--- a/llvm/test/MC/RISCV/rv64zkne-only-valid.s
+++ b/llvm/test/MC/RISCV/rv64zkne-only-valid.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zkne -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zkne < %s \
-# RUN:     | llvm-objdump --mattr=+zkne -d -r - \
+# RUN:     | llvm-objdump --mattr=+zkne --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: aes64es a0, a1, a2

--- a/llvm/test/MC/RISCV/rvc-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvc-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+c -riscv-no-aliases \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c < %s \
-# RUN:     | llvm-objdump -M no-aliases -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump -M no-aliases -d - \
+# RUN:     | llvm-objdump --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 
 # CHECK-EXPAND: c.lw s0, 0(s1)

--- a/llvm/test/MC/RISCV/rvc-hints-valid.s
+++ b/llvm/test/MC/RISCV/rvc-hints-valid.s
@@ -3,13 +3,13 @@
 # RUN: llvm-mc %s -triple riscv64 -mattr=+c -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump -M no-aliases -d -r - \
+# RUN:     | llvm-objdump -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: c.nop 8

--- a/llvm/test/MC/RISCV/rvd-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvd-aliases-valid.s
@@ -7,16 +7,16 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+d \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+d < %s \
-# RUN:     | llvm-objdump -d --mattr=+d -M no-aliases - \
+# RUN:     | llvm-objdump -d --mattr=+d --no-print-imm-hex -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+d < %s \
-# RUN:     | llvm-objdump -d --mattr=+d - \
+# RUN:     | llvm-objdump -d --mattr=+d --no-print-imm-hex - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+d < %s \
-# RUN:     | llvm-objdump -d --mattr=+d -M no-aliases - \
+# RUN:     | llvm-objdump -d --mattr=+d --no-print-imm-hex -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+d < %s \
-# RUN:     | llvm-objdump -d --mattr=+d - \
+# RUN:     | llvm-objdump -d --mattr=+d --no-print-imm-hex - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 
 ##===----------------------------------------------------------------------===##

--- a/llvm/test/MC/RISCV/rvdc-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvdc-aliases-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+c,+d -riscv-no-aliases \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c,+d < %s \
-# RUN:     | llvm-objdump --mattr=+c,+d -M no-aliases -d - \
+# RUN:     | llvm-objdump --mattr=+c,+d --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+c,+d < %s \
-# RUN:     | llvm-objdump --mattr=+c,+d -M no-aliases -d - \
+# RUN:     | llvm-objdump --mattr=+c,+d --no-print-imm-hex -M no-aliases -d - \
 # RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
 
 c.fld f8, (x9)

--- a/llvm/test/MC/RISCV/rvf-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvf-aliases-valid.s
@@ -7,16 +7,16 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+f \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+f < %s \
-# RUN:     | llvm-objdump -d --mattr=+f -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d --mattr=+f -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+f < %s \
-# RUN:     | llvm-objdump -d --mattr=+f - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d --mattr=+f - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+f < %s \
-# RUN:     | llvm-objdump -d --mattr=+f -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d --mattr=+f -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+f < %s \
-# RUN:     | llvm-objdump -d --mattr=+f - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d --mattr=+f - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 
 ##===----------------------------------------------------------------------===##

--- a/llvm/test/MC/RISCV/rvi-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvi-aliases-valid.s
@@ -7,16 +7,16 @@
 # RUN: llvm-mc %s -triple=riscv64 \
 # RUN:     | FileCheck -check-prefixes=CHECK-S,CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ-NOALIAS,CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-S-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -d -r -M no-aliases - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r -M no-aliases - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ-NOALIAS,CHECK-S-OBJ-NOALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck -check-prefixes=CHECK-OBJ,CHECK-S-OBJ %s
 
 # The following check prefixes are used in this test:

--- a/llvm/test/MC/RISCV/rvi-alternate-abi-names.s
+++ b/llvm/test/MC/RISCV/rvi-alternate-abi-names.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 \
 # RUN:     | FileCheck %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
-# RUN:     | llvm-objdump -d -r - \
+# RUN:     | llvm-objdump --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck %s
 
 # 'fp' is an alternate ABI name for 's0' and it should be accepted in input.

--- a/llvm/test/MC/RISCV/rvv/add.s
+++ b/llvm/test/MC/RISCV/rvv/add.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/and.s
+++ b/llvm/test/MC/RISCV/rvv/and.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/clip.s
+++ b/llvm/test/MC/RISCV/rvv/clip.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/compare.s
+++ b/llvm/test/MC/RISCV/rvv/compare.s
@@ -39,13 +39,13 @@ vmseq.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 62 <unknown>
 
 vmseq.vi v8, v4, 15, v0.t
-# CHECK-INST: vmseq.vi v8, v4, 15, v0.t
+# CHECK-INST: vmseq.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x60]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 60 <unknown>
 
 vmseq.vi v8, v4, 15
-# CHECK-INST: vmseq.vi v8, v4, 15
+# CHECK-INST: vmseq.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x62]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 62 <unknown>
@@ -75,13 +75,13 @@ vmsne.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 66 <unknown>
 
 vmsne.vi v8, v4, 15, v0.t
-# CHECK-INST: vmsne.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsne.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x64]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 64 <unknown>
 
 vmsne.vi v8, v4, 15
-# CHECK-INST: vmsne.vi v8, v4, 15
+# CHECK-INST: vmsne.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x66]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 66 <unknown>
@@ -159,13 +159,13 @@ vmsleu.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 72 <unknown>
 
 vmsleu.vi v8, v4, 15, v0.t
-# CHECK-INST: vmsleu.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsleu.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x70]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 70 <unknown>
 
 vmsleu.vi v8, v4, 15
-# CHECK-INST: vmsleu.vi v8, v4, 15
+# CHECK-INST: vmsleu.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x72]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 72 <unknown>
@@ -195,13 +195,13 @@ vmsle.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 76 <unknown>
 
 vmsle.vi v8, v4, 15, v0.t
-# CHECK-INST: vmsle.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsle.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x74]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 74 <unknown>
 
 vmsle.vi v8, v4, 15
-# CHECK-INST: vmsle.vi v8, v4, 15
+# CHECK-INST: vmsle.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x76]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 76 <unknown>
@@ -219,13 +219,13 @@ vmsgtu.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 7a <unknown>
 
 vmsgtu.vi v8, v4, 15, v0.t
-# CHECK-INST: vmsgtu.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsgtu.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x78]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 78 <unknown>
 
 vmsgtu.vi v8, v4, 15
-# CHECK-INST: vmsgtu.vi v8, v4, 15
+# CHECK-INST: vmsgtu.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7a <unknown>
@@ -243,13 +243,13 @@ vmsgt.vx v8, v4, a0
 # CHECK-UNKNOWN: 57 44 45 7e <unknown>
 
 vmsgt.vi v8, v4, 15, v0.t
-# CHECK-INST: vmsgt.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsgt.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7c]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7c <unknown>
 
 vmsgt.vi v8, v4, 15
-# CHECK-INST: vmsgt.vi v8, v4, 15
+# CHECK-INST: vmsgt.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7e]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7e <unknown>
@@ -303,13 +303,13 @@ vmsge.vv v8, v20, v4
 # CHECK-UNKNOWN: 57 04 4a 76 <unknown>
 
 vmsltu.vi v8, v4, 16, v0.t
-# CHECK-INST: vmsleu.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsleu.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x70]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 70 <unknown>
 
 vmsltu.vi v8, v4, 16
-# CHECK-INST: vmsleu.vi v8, v4, 15
+# CHECK-INST: vmsleu.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x72]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 72 <unknown>
@@ -327,25 +327,25 @@ vmsltu.vi v8, v4, 0
 # CHECK-UNKNOWN: 57 04 42 66 <unknown>
 
 vmslt.vi v8, v4, 16, v0.t
-# CHECK-INST: vmsle.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsle.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x74]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 74 <unknown>
 
 vmslt.vi v8, v4, 16
-# CHECK-INST: vmsle.vi v8, v4, 15
+# CHECK-INST: vmsle.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x76]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 76 <unknown>
 
 vmsgeu.vi v8, v4, 16, v0.t
-# CHECK-INST: vmsgtu.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsgtu.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x78]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 78 <unknown>
 
 vmsgeu.vi v8, v4, 16
-# CHECK-INST: vmsgtu.vi v8, v4, 15
+# CHECK-INST: vmsgtu.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7a <unknown>
@@ -363,13 +363,13 @@ vmsgeu.vi v8, v4, 0
 # CHECK-UNKNOWN: 57 04 42 62 <unknown>
 
 vmsge.vi v8, v4, 16, v0.t
-# CHECK-INST: vmsgt.vi v8, v4, 15, v0.t
+# CHECK-INST: vmsgt.vi v8, v4, 0xf, v0.t
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7c]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7c <unknown>
 
 vmsge.vi v8, v4, 16
-# CHECK-INST: vmsgt.vi v8, v4, 15
+# CHECK-INST: vmsgt.vi v8, v4, 0xf
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x7e]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 7e <unknown>

--- a/llvm/test/MC/RISCV/rvv/mv.s
+++ b/llvm/test/MC/RISCV/rvv/mv.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/or.s
+++ b/llvm/test/MC/RISCV/rvv/or.s
@@ -3,10 +3,10 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+# RUN:        | llvm-objdump -d --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 
 vor.vv v8, v4, v20, v0.t
 # CHECK-INST: vor.vv v8, v4, v20, v0.t

--- a/llvm/test/MC/RISCV/rvv/others.s
+++ b/llvm/test/MC/RISCV/rvv/others.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:   | llvm-objdump -d --mattr=+v -M no-aliases - \
+# RUN:   | llvm-objdump -d --mattr=+v --no-print-imm-hex -M no-aliases - \
 # RUN:   | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:   | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/rv32-immediate.s
+++ b/llvm/test/MC/RISCV/rvv/rv32-immediate.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple=riscv32 -show-encoding --mattr=+v %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 
 # For rv32, allow 32 bit constants that contains a simm5 value.

--- a/llvm/test/MC/RISCV/rvv/shift.s
+++ b/llvm/test/MC/RISCV/rvv/shift.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump --no-print-imm-hex -d --mattr=+v - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/snippet.s
+++ b/llvm/test/MC/RISCV/rvv/snippet.s
@@ -10,7 +10,7 @@ loop:
     vle16.v v4, (a1)              # Get 16b vector
 # CHECK-INST: 07 d2 05 02    vle16.v   v4, (a1)
     slli t1, a3, 1                # Multiply length by two bytes/element
-# CHECK-INST: 13 93 16 00    slli    t1, a3, 1
+# CHECK-INST: 13 93 16 00    slli    t1, a3, 0x1
     add a1, a1, t1                # Bump pointer
 # CHECK-INST: b3 85 65 00    add     a1, a1, t1
     vwmul.vx v8, v4, x10          # 32b in <v8--v15>
@@ -19,11 +19,11 @@ loop:
     vsetvli x0, a0, e32,m8,ta,ma  # Operate on 32b values
 # CHECK-INST: 57 70 35 0d    vsetvli zero, a0, e32, m8, ta, ma
     vsrl.vi v8, v8, 3
-# CHECK-INST: 57 b4 81 a2    vsrl.vi v8, v8, 3
+# CHECK-INST: 57 b4 81 a2    vsrl.vi v8, v8, 0x3
     vse32.v v8, (a2)              # Store vector of 32b
 # CHECK-INST: 27 64 06 02    vse32.v   v8, (a2)
     slli t1, a3, 2                # Multiply length by four bytes/element
-# CHECK-INST: 13 93 26 00    slli    t1, a3, 2
+# CHECK-INST: 13 93 26 00    slli    t1, a3, 0x2
     add a2, a2, t1                # Bump pointer
 # CHECK-INST: 33 06 66 00    add     a2, a2, t1
     sub a0, a0, a3                # Decrement count

--- a/llvm/test/MC/RISCV/rvv/sub.s
+++ b/llvm/test/MC/RISCV/rvv/sub.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/vsetvl-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/vsetvl-invalid.s
@@ -6,35 +6,35 @@
 # CHECK: vsetvli a1, a0, e64, m1, tu, mu
 .word 0x018575d7
 
-# CHECK: vsetvli a1, a0, 28
+# CHECK: vsetvli a1, a0, 0x1c
 .word 0x01c575d7
 
-# CHECK: vsetvli a1, a0, 36
+# CHECK: vsetvli a1, a0, 0x24
 .word 0x024575d7
 
-# CHECK: vsetvli a1, a0, 41
+# CHECK: vsetvli a1, a0, 0x29
 .word 0x029575d7
 
-# CHECK: vsetvli a1, a0, 272
+# CHECK: vsetvli a1, a0, 0x110
 .word 0x110575d7
 
 # CHECK: vsetvli a1, a0, e64, mf8, tu, mu
 .word 0x01d575d7
 
-# CHECK: vsetivli a1, 16, e8, m4, tu, mu
+# CHECK: vsetivli a1, 0x10, e8, m4, tu, mu
 .word 0xc02875d7
 
-# CHECK: vsetivli a1, 16, 12
+# CHECK: vsetivli a1, 0x10, 0xc
 .word 0xc0c875d7
 
-# CHECK: vsetivli a1, 16, 20
+# CHECK: vsetivli a1, 0x10, 0x14
 .word 0xc14875d7
 
-# CHECK: vsetivli a1, 16, 56
+# CHECK: vsetivli a1, 0x10, 0x38
 .word 0xc38875d7
 
-# CHECK: vsetivli a1, 16, 259
+# CHECK: vsetivli a1, 0x10, 0x103
 .word 0xd03875d7
 
-# CHECK: vsetivli a1, 16, e8, mf4, tu, mu
+# CHECK: vsetivli a1, 0x10, e8, mf4, tu, mu
 .word 0xc06875d7

--- a/llvm/test/MC/RISCV/rvv/vsetvl.s
+++ b/llvm/test/MC/RISCV/rvv/vsetvl.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/xor.s
+++ b/llvm/test/MC/RISCV/rvv/xor.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
-# RUN:        | llvm-objdump -d --mattr=+v - \
+# RUN:        | llvm-objdump -d --mattr=+v --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/xsfvcp.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvcp.s
@@ -7,10 +7,10 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+v,+xsfvcp %s \
-# RUN:        | llvm-objdump -d --mattr=+v,+xsfvcp - \
+# RUN:        | llvm-objdump -d --mattr=+v,+xsfvcp --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v,+xsfvcp %s \
-# RUN:        | llvm-objdump -d --mattr=+v,+xsfvcp - \
+# RUN:        | llvm-objdump -d --mattr=+v,+xsfvcp --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+v,+xsfvcp %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvbb.s
+++ b/llvm/test/MC/RISCV/rvv/zvbb.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvbb %s \
-# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvbb  - \
+# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvbb --no-print-imm-hex  - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvbb %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvfbfwma.s
+++ b/llvm/test/MC/RISCV/rvv/zvfbfwma.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding -mattr=+v,+f %s 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj -mattr=+experimental-zvfbfwma %s \
-# RUN:    | llvm-objdump -d --mattr=+experimental-zvfbfwma - \
+# RUN:    | llvm-objdump -d --mattr=+experimental-zvfbfwma --no-print-imm-hex - \
 # RUN:    | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj -mattr=+experimental-zvfbfwma %s \
 # RUN:    | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
@@ -12,7 +12,7 @@
 # RUN: not llvm-mc -triple=riscv64 -show-encoding -mattr=+v,+f %s 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv64 -filetype=obj -mattr=+experimental-zvfbfwma %s \
-# RUN:    | llvm-objdump -d --mattr=+experimental-zvfbfwma - \
+# RUN:    | llvm-objdump -d --mattr=+experimental-zvfbfwma --no-print-imm-hex - \
 # RUN:    | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv64 -filetype=obj -mattr=+experimental-zvfbfwma %s \
 # RUN:    | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvkb.s
+++ b/llvm/test/MC/RISCV/rvv/zvkb.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvkb %s \
-# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvkb  - \
+# RUN:        | llvm-objdump --no-print-imm-hex -d --mattr=+zve32x --mattr=+experimental-zvkb  - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvkb %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvkned.s
+++ b/llvm/test/MC/RISCV/rvv/zvkned.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvkned %s \
-# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvkned  - \
+# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvkned --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvkned %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvksed.s
+++ b/llvm/test/MC/RISCV/rvv/zvksed.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvksed %s \
-# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvksed  - \
+# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvksed --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvksed %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvv/zvksh.s
+++ b/llvm/test/MC/RISCV/rvv/zvksh.s
@@ -3,7 +3,7 @@
 # RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvksh %s \
-# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvksh  - \
+# RUN:        | llvm-objdump -d --mattr=+zve32x --mattr=+experimental-zvksh --no-print-imm-hex - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
 # RUN: llvm-mc -triple=riscv32 -filetype=obj --mattr=+zve32x --mattr=+experimental-zvksh %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN

--- a/llvm/test/MC/RISCV/rvzfh-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvzfh-aliases-valid.s
@@ -7,16 +7,16 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+zfh \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump -d --mattr=+zfh -M no-aliases - \
+# RUN:     | llvm-objdump -d --mattr=+zfh --no-print-imm-hex -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump -d --mattr=+zfh - \
+# RUN:     | llvm-objdump -d --mattr=+zfh --no-print-imm-hex - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump -d --mattr=+zfh -M no-aliases - \
+# RUN:     | llvm-objdump -d --mattr=+zfh --no-print-imm-hex -M no-aliases - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 # RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+zfh < %s \
-# RUN:     | llvm-objdump -d --mattr=+zfh - \
+# RUN:     | llvm-objdump -d --mattr=+zfh --no-print-imm-hex - \
 # RUN:     | FileCheck -check-prefix=CHECK-ALIAS %s
 
 ##===----------------------------------------------------------------------===##

--- a/llvm/test/MC/RISCV/zicfilp-valid.s
+++ b/llvm/test/MC/RISCV/zicfilp-valid.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+experimental-zicfilp -riscv-no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+experimental-zicfilp < %s \
-# RUN:     | llvm-objdump --mattr=+experimental-zicfilp -d -r - \
+# RUN:     | llvm-objdump --mattr=+experimental-zicfilp --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+experimental-zicfilp < %s \
-# RUN:     | llvm-objdump --mattr=+experimental-zicfilp -d -r - \
+# RUN:     | llvm-objdump --mattr=+experimental-zicfilp --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 #
 # RUN: not llvm-mc -triple riscv32 -riscv-no-aliases -show-encoding < %s 2>&1 \

--- a/llvm/test/tools/llvm-objdump/ELF/RISCV/branches.s
+++ b/llvm/test/tools/llvm-objdump/ELF/RISCV/branches.s
@@ -56,12 +56,12 @@ c.jal bar
 # CHECK: c.j 0x60 <bar>
 c.j bar
 
-# CHECK: auipc ra, 0
-# CHECK: jalr	ra, 16(ra) <foo+0x58>
+# CHECK: auipc ra, 0x0
+# CHECK: jalr	ra, 0x10(ra) <foo+0x58>
 call .Llocal
 
-# CHECK: auipc ra, 0
-# CHECK: jalr	ra, 16(ra) <bar>
+# CHECK: auipc ra, 0x0
+# CHECK: jalr	ra, 0x10(ra) <bar>
 call bar
 
 .Llocal:

--- a/llvm/test/tools/llvm-objdump/ELF/RISCV/multi-instr-target.s
+++ b/llvm/test/tools/llvm-objdump/ELF/RISCV/multi-instr-target.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c < %s | \
-# RUN:     llvm-objdump -d -M no-aliases --no-show-raw-insn - | \
+# RUN:     llvm-objdump --no-print-imm-hex -d -M no-aliases --no-show-raw-insn - | \
 # RUN:     FileCheck %s
 
 ## Test multiple interleaved auipc/jalr pairs

--- a/llvm/test/tools/llvm-objdump/ELF/RISCV/tag-riscv-arch.s
+++ b/llvm/test/tools/llvm-objdump/ELF/RISCV/tag-riscv-arch.s
@@ -11,7 +11,7 @@ vsetvli a3, a2, e8, m8, tu, mu
 # CHECK: fadd.s fs10, fs11, ft8
 fadd.s f26, f27, f28
 
-# CHECK: fld ft0, 12(a0)
+# CHECK: fld ft0, 0xc(a0)
 fld f0, 12(a0)
 
 # CHECK: fmul.d ft0, ft1, ft2, dyn


### PR DESCRIPTION
Enable the llvm-objdump to disassemble the immediate of RISCV instruction in hexadecimal format with --print-imm-hex flag.