### PR TITLE
[OpenMP] Fix libomptarget build issue

### DIFF
--- a/openmp/libomptarget/src/interface.cpp
+++ b/openmp/libomptarget/src/interface.cpp
@@ -454,7 +454,6 @@ EXTERN void __tgt_target_nowait_query(void **AsyncHandle) {
   // for the device operations (work/spin wait on them) or block until they are
   // completed (use device side blocking mechanism). This allows the runtime to
   // adapt itself when there are a lot of long-running target regions in-flight.
-  using namespace llvm::omp::target;
   static thread_local utils::ExponentialBackoff QueryCounter(
       Int64Envar("OMPTARGET_QUERY_COUNT_MAX", 10),
       Int64Envar("OMPTARGET_QUERY_COUNT_THRESHOLD", 5),


### PR DESCRIPTION
Libomptarget cannot be build because of the recent refactoring introduced in patch 148dec9fa43b :
[OpenMP][NFC] Separate Envar (environment variable) handling (#73994)

This patch moved handling of environment variables from libomptarget library. That's why we don't need usage of "llvm::omp::target" namespace if we handle environment variables.