### PR TITLE
[libc++] tests with picolibc: Fix iterator diff_type to std::streamoff

### DIFF
--- a/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
@@ -11,11 +11,6 @@
 // This test uses iterator types from std::filesystem
 // XFAIL: availability-filesystem-missing
 
-// std::same_as<typename Traits::difference_type, DiffType> failed.
-// The former was long and the latter was long long.
-// Possibly related to "using streamoff = long int" in ios.h.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // template<class T>
 // struct iterator_traits;
 
@@ -152,8 +147,7 @@ static_assert(testIOIterator<std::insert_iterator<std::vector<int>>, std::output
 static_assert(testConst<std::istream_iterator<int, char>, std::input_iterator_tag, int>());
 
 #if !defined(TEST_HAS_NO_LOCALIZATION)
-// libc++-specific since pointer type is unspecified:
-LIBCPP_STATIC_ASSERT(test<std::istreambuf_iterator<char>, std::input_iterator_tag, char, long long, char, char*>());
+static_assert(test<std::istreambuf_iterator<char>, std::input_iterator_tag, char, std::streamoff, char, char*>());
 static_assert(test<std::move_iterator<int*>, std::random_access_iterator_tag, int, std::ptrdiff_t, int&&, int*>());
 static_assert(testIOIterator<std::ostream_iterator<int, char>, std::output_iterator_tag>());
 static_assert(testIOIterator<std::ostreambuf_iterator<int, char>, std::output_iterator_tag>());

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
@@ -147,7 +147,8 @@ static_assert(testIOIterator<std::insert_iterator<std::vector<int>>, std::output
 static_assert(testConst<std::istream_iterator<int, char>, std::input_iterator_tag, int>());
 
 #if !defined(TEST_HAS_NO_LOCALIZATION)
-static_assert(test<std::istreambuf_iterator<char>, std::input_iterator_tag, char, std::streamoff, char, char*>());
+// libc++-specific since pointer type is unspecified:
+LIBCPP_STATIC_ASSERT(test<std::istreambuf_iterator<char>, std::input_iterator_tag, char, std::streamoff, char, char*>());
 static_assert(test<std::move_iterator<int*>, std::random_access_iterator_tag, int, std::ptrdiff_t, int&&, int*>());
 static_assert(testIOIterator<std::ostream_iterator<int, char>, std::output_iterator_tag>());
 static_assert(testIOIterator<std::ostreambuf_iterator<int, char>, std::output_iterator_tag>());

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
@@ -147,8 +147,13 @@ static_assert(testIOIterator<std::insert_iterator<std::vector<int>>, std::output
 static_assert(testConst<std::istream_iterator<int, char>, std::input_iterator_tag, int>());
 
 #if !defined(TEST_HAS_NO_LOCALIZATION)
-// libc++-specific since pointer type is unspecified:
-LIBCPP_STATIC_ASSERT(test<std::istreambuf_iterator<char>, std::input_iterator_tag, char, std::streamoff, char, char*>());
+// We use std::istreambuf_iterator<char>::pointer because it's unspecified, it doesn't have to be char*
+static_assert(test<std::istreambuf_iterator<char>,
+                   std::input_iterator_tag,
+                   char,
+                   std::streamoff,
+                   char,
+                   std::istreambuf_iterator<char>::pointer>());
 static_assert(test<std::move_iterator<int*>, std::random_access_iterator_tag, int, std::ptrdiff_t, int&&, int*>());
 static_assert(testIOIterator<std::ostream_iterator<int, char>, std::output_iterator_tag>());
 static_assert(testIOIterator<std::ostreambuf_iterator<int, char>, std::output_iterator_tag>());


### PR DESCRIPTION
The hardcoded value of long int was not valid for newlib and picolibc.