### PR TITLE
TargetInstrInfo: squelch a signedness warning on MSVC

### DIFF
--- a/llvm/include/llvm/MC/MCInstrItineraries.h
+++ b/llvm/include/llvm/MC/MCInstrItineraries.h
@@ -220,7 +220,7 @@ public:
       return std::nullopt;
 
     UseCycle = *DefCycle - *UseCycle + 1;
-    if (UseCycle > 0 &&
+    if (UseCycle > 0u &&
         hasPipelineForwarding(DefClass, DefIdx, UseClass, UseIdx))
       // FIXME: This assumes one cycle benefit for every pipeline forwarding.
       UseCycle = *UseCycle - 1;

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -4110,7 +4110,7 @@ std::optional<unsigned> ARMBaseInstrInfo::getOperandLatency(
     return std::nullopt;
 
   UseCycle = *DefCycle - *UseCycle + 1;
-  if (UseCycle > 0) {
+  if (UseCycle > 0u) {
     if (LdmBypass) {
       // It's a variable_ops instruction so we can't use DefIdx here. Just use
       // first def operand.


### PR DESCRIPTION
Follow up on 9468de4 (TargetInstrInfo: make getOperandLatency return optional (NFC)) to squelch a signedness warning on MSVC, reported by Simon Pilgrim.