### PR TITLE
[asan][Windows] Synchronizing ASAN init on Windows

### DIFF
--- a/compiler-rt/lib/asan/asan_internal.h
+++ b/compiler-rt/lib/asan/asan_internal.h
@@ -130,6 +130,17 @@ void InstallAtExitCheckLeaks();
   if (&__asan_on_error) \
   __asan_on_error()
 
+// Unless synchronization is used during initialization, 
+// race conditions can appear causing incorrect states or internal check
+// failures, depending on the loading thread and when ASAN is loaded on Windows.
+// From a multithreaded managed environment, if an ASAN instrumented dll
+// is loading on a spawned thread, an intercepted function may be called on
+// multiple threads while ASAN is still in the process of initialization. This
+// can also cause the ASAN thread registry to create the "main" thread after
+// another thread, resulting in a TID != 0.
+//
+// Two threads can also race to initialize ASAN, resulting in either incorrect
+// state or internal check failures for init already running.
 bool AsanInited();
 bool AsanInitIsRunning();  // Used to avoid infinite recursion in __asan_init().
 extern bool replace_intrin_cached;

--- a/compiler-rt/lib/asan/asan_internal.h
+++ b/compiler-rt/lib/asan/asan_internal.h
@@ -130,7 +130,7 @@ void InstallAtExitCheckLeaks();
   if (&__asan_on_error) \
   __asan_on_error()
 
-// Unless synchronization is used during initialization, 
+// Unless synchronization is used during initialization,
 // race conditions can appear causing incorrect states or internal check
 // failures, depending on the loading thread and when ASAN is loaded on Windows.
 // From a multithreaded managed environment, if an ASAN instrumented dll


### PR DESCRIPTION
This is an attempt to synchronize ASAN initialization using `__sanitizer::atomic`s on Windows. One case in particular is a C# application that loads an ASan instrumented library.

This addresses:

1. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_interceptors.h#L29C36-L29C36) if a function is intercepted on T1 and called on T2 before T1 is done with ASAN initialization.
2. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_rtl.cpp#L387) can happen in parallel when two threads call `ENSURE_ASAN_INITED`.
3. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_rtl.cpp#L481) when thread is created before the main thread gets a chance to get created due to when `CreateThread` is intercepted.

Currently, everything is blocked by `#if SANITIZER_WINDOWS` because I'm not 100% sure about how ASan is loaded on other platforms and the implications.


SPR PRs [one](https://github.com/llvm/llvm-project/pull/74084) and [two](https://github.com/llvm/llvm-project/pull/74085)
