### PR TITLE
[RemoveDI] Handle DPValues in SROA

### DIFF
--- a/llvm/test/DebugInfo/ARM/sroa-complex.ll
+++ b/llvm/test/DebugInfo/ARM/sroa-complex.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes='sroa' -S -o - %s | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes='sroa' -S -o - %s | FileCheck %s
 target datalayout = "e-m:o-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv7-apple-unknown-macho"
 

--- a/llvm/test/DebugInfo/Generic/sroa-larger.ll
+++ b/llvm/test/DebugInfo/Generic/sroa-larger.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes='sroa' -S -o - %s | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes='sroa' -S -o - %s | FileCheck %s
 ; Generated from clang -c  -O2 -g -target x86_64-pc-windows-msvc
 ; struct A {
 ;   int _Myval2;

--- a/llvm/test/DebugInfo/Generic/sroa-samesize.ll
+++ b/llvm/test/DebugInfo/Generic/sroa-samesize.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes='sroa' -S -o - %s | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes='sroa' -S -o - %s | FileCheck %s
 ; Generated from clang -c  -O2 -g -target x86_64-pc-windows-msvc
 ; struct A { double x1[]; };
 ; struct x2 {

--- a/llvm/test/DebugInfo/X86/sroa-after-inlining.ll
+++ b/llvm/test/DebugInfo/X86/sroa-after-inlining.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes='cgscc(function(sroa,instcombine),inline),function(instcombine,sroa),verify' -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='cgscc(function(sroa,instcombine),inline),function(instcombine,sroa),verify' -S -o - | FileCheck %s
 ;
 ; This test checks that SROA pass processes debug info correctly if applied twice.
 ; Specifically, after SROA works first time, instcombine converts dbg.declare

--- a/llvm/test/DebugInfo/X86/sroasplit-1.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-1.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes='sroa,verify' -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='sroa,verify' -S -o - | FileCheck %s
 ;
 ; Test that we can partial emit debug info for aggregates repeatedly
 ; split up by SROA.

--- a/llvm/test/DebugInfo/X86/sroasplit-2.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-2.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes='sroa,verify' -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='sroa,verify' -S -o - | FileCheck %s
 ;
 ; Test that we can partial emit debug info for aggregates repeatedly
 ; split up by SROA.

--- a/llvm/test/DebugInfo/X86/sroasplit-3.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-3.ll
@@ -1,4 +1,6 @@
 ; RUN: opt %s -passes='sroa,verify' -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='sroa,verify' -S -o - | FileCheck %s
+
 ; ModuleID = 'test.c'
 ; Test that SROA updates the debug info correctly if an alloca was rewritten but
 ; not partitioned into multiple allocas.

--- a/llvm/test/DebugInfo/X86/sroasplit-4.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-4.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes='sroa' < %s -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes='sroa' < %s -S -o - | FileCheck %s
 ;
 ; Test that recursively splitting an alloca updates the debug info correctly.
 ; CHECK: %[[T:.*]] = load i64, ptr @t, align 8

--- a/llvm/test/DebugInfo/X86/sroasplit-5.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-5.ll
@@ -1,4 +1,6 @@
 ; RUN: opt %s -passes='sroa,verify' -S -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='sroa,verify' -S -o - | FileCheck %s
+
 ; From:
 ; struct prog_src_register {
 ;   unsigned : 4;

--- a/llvm/test/DebugInfo/X86/sroasplit-dbg-declare.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-dbg-declare.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -S -passes='sroa' -o - %s | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -S -passes='sroa' -o - %s | FileCheck %s
 
 ; SROA should split the alloca in two new ones, each with its own dbg.declare.
 ; The original alloca and dbg.declare should be removed.
@@ -55,3 +56,4 @@ attributes #1 = { nounwind readnone speculatable }
 ; CHECK-NOT:  = alloca [9 x i32]
 ; CHECK-NOT:  call void @llvm.dbg.declare(metadata ptr
 
+; CHECK: declare void @llvm.dbg.declare(metadata, metadata, metadata)

--- a/llvm/test/DebugInfo/X86/sroasplit-dbg-declare.ll
+++ b/llvm/test/DebugInfo/X86/sroasplit-dbg-declare.ll
@@ -56,4 +56,3 @@ attributes #1 = { nounwind readnone speculatable }
 ; CHECK-NOT:  = alloca [9 x i32]
 ; CHECK-NOT:  call void @llvm.dbg.declare(metadata ptr
 
-; CHECK: declare void @llvm.dbg.declare(metadata, metadata, metadata)

--- a/llvm/test/DebugInfo/salvage-overflow.ll
+++ b/llvm/test/DebugInfo/salvage-overflow.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes='sroa,early-cse' -S | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes='sroa,early-cse' -S | FileCheck %s
 ; CHECK: DIExpression(DW_OP_constu, 9223372036854775808, DW_OP_minus, DW_OP_stack_value)
 ; Created from the following C input (and then delta-reduced the IR):
 ;

--- a/llvm/test/Transforms/Util/dbg-user-of-aext.ll
+++ b/llvm/test/Transforms/Util/dbg-user-of-aext.ll
@@ -2,6 +2,7 @@
 ; (here exposed through the SROA) pass refers to [s|z]exts of values (as
 ; opposed to the operand of a [s|z]ext).
 ; RUN: opt -S -passes='sroa' %s | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -S -passes='sroa' %s | FileCheck %s
 
 ; Built from:
 ; struct foo { bool b; long i; };


### PR DESCRIPTION
Handle dbg.declares in SROA using DPValues.

In order to reduce duplication, the migrate-debug-info loop has been changed to a generic lambda with some helper function overloads, which is called for dbg.declares, dbg.assigns, and DPValues alike.
