### PR TITLE
[RemoveDIs] Enable conversion from dbg.declare to DPValue

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -73,7 +73,10 @@ void BasicBlock::convertToNewDbgValues() {
   SmallVector<DPValue *, 4> DPVals;
   for (Instruction &I : make_early_inc_range(InstList)) {
     assert(!I.DbgMarker && "DbgMarker already set on old-format instrs?");
-    if (DbgValueInst *DVI = dyn_cast<DbgValueInst>(&I)) {
+    if (DbgVariableIntrinsic *DVI = dyn_cast<DbgVariableIntrinsic>(&I)) {
+      if (isa<DbgAssignIntrinsic>(DVI))
+        continue;
+
       // Convert this dbg.value to a DPValue.
       DPValue *Value = new DPValue(DVI);
       DPVals.push_back(Value);


### PR DESCRIPTION
The testing situation here is a little bit difficult. Most of the dbg.declare support patches depend on this patch to be able to test them. However, landing this patch first would result in ~10-15 test failures in tests that already `--try-experimental-debuginfo-iterators` that contain both dbg.values (already fully supported and being tested) and dbg.declares (support in flight: shouldn't really be tested yet - those updates would come as support is added to each pass etc, as we did with dbg.values, if that were possible).

Options:
1) Land this patch first. Remove `--try-experimental-debuginfo-iterators` from those failing tests in this patch, re-add as those passes get dbg.declare support/fixes.
2) Land this patch last. All the dbg.declare-support patches get test updates... but are rotten-green-tests until this patch lands (because the DPValue "declare" path isn't hit without this patch).
3) Squash all the dbg.declare support patches together.

Any strong opinions on the options above? I have listed them in order of personal preference (1 being most preferred), but am happy to go with any as they all have pros & cons.