### PR TITLE
[SPIR-V] Add pre-commit CI workflow

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -10,7 +10,7 @@ on:
         required: false
       projects:
         required: false
-      experimental_targets:
+      extra_cmake_args:
         required: false
   workflow_call:
     inputs:
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
 
-      experimental_targets:
+      extra_cmake_args:
         required: false
         type: string
 
@@ -91,7 +91,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
-          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="${{ inputs.experimental_targets }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ inputs.extra_cmake_args }}'
           build_target: '${{ inputs.build_target }}'
 
       - name: Build and Test libclc

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -12,6 +12,9 @@ on:
         required: false
       extra_cmake_args:
         required: false
+      os_list:
+        required: false
+        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
   workflow_call:
     inputs:
       build_target:
@@ -25,6 +28,15 @@ on:
       extra_cmake_args:
         required: false
         type: string
+
+      os_list:
+        required: false
+        type: string
+        # Use windows-2019 due to:
+        # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
+        # We're using a specific version of macOS due to:
+        # https://github.com/actions/virtual-environments/issues/5900
+        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
 
 concurrency:
   # Skip intermediate builds: always.
@@ -41,14 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          # Use windows-2019 due to:
-          # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-          - windows-2019
-          # We're using a specific version of macOS due to:
-          # https://github.com/actions/virtual-environments/issues/5900
-          - macOS-11
+        os: ${{ fromJSON(inputs.os_list) }}
     steps:
       - name: Setup Windows
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -10,6 +10,8 @@ on:
         required: false
       projects:
         required: false
+      experimental_targets:
+        required: false
   workflow_call:
     inputs:
       build_target:
@@ -18,6 +20,10 @@ on:
 
       projects:
         required: true
+        type: string
+
+      experimental_targets:
+        required: false
         type: string
 
 concurrency:
@@ -85,7 +91,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
-          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="${{ inputs.experimental_targets }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
           build_target: '${{ inputs.build_target }}'
 
       - name: Build and Test libclc

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -26,4 +26,4 @@ jobs:
       build_target: check-llvm-codegen-spirv
       projects:
       extra_cmake_args: '-DLLVM_TARGETS_TO_BUILD="" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'
-      os_list: '["ubuntu-latest"]'
+      os_list: '["arc-google-linux"]'

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -24,5 +24,5 @@ jobs:
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-llvm-codegen-spirv
-      projects: clang
-      experimental_targets: SPIRV
+      projects:
+      extra_cmake_args: '-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -26,4 +26,4 @@ jobs:
       build_target: check-llvm-codegen-spirv
       projects:
       extra_cmake_args: '-DLLVM_TARGETS_TO_BUILD="" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'
-      os_list: '["arc-google-linux"]'
+      os_list: '["ubuntu-latest"]'

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -25,4 +25,4 @@ jobs:
     with:
       build_target: check-llvm-codegen-spirv
       projects:
-      extra_cmake_args: '-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'
+      extra_cmake_args: '-DLLVM_TARGETS_TO_BUILD="" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -1,0 +1,28 @@
+name: SPIR-V Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'llvm/lib/Target/SPIRV/**'
+      - 'llvm/test/CodeGen/SPIRV/**'
+      - '.github/workflows/spirv-tests.yml'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check_spirv:
+    if: github.repository_owner == 'llvm'
+    name: Test SPIR-V
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-llvm-codegen-spirv
+      projects: clang
+      experimental_targets: SPIRV

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -26,3 +26,4 @@ jobs:
       build_target: check-llvm-codegen-spirv
       projects:
       extra_cmake_args: '-DLLVM_TARGETS_TO_BUILD="" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"'
+      os_list: '["ubuntu-latest"]'


### PR DESCRIPTION
Add a pre-commit CI workflow for the experimental SPIR-V backend. This action should only run when SPIR-V target or test files are modified. The `codegen-spirv` tests don't run as part of `check-all` because the SPIR-V backend is still experimental.

Depends on #73371 (for a green tree)