### PR TITLE
[amdgpu] Default to 1.0, instead of unspecified, for dynamic hsa

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
@@ -14,6 +14,15 @@
 
 #include "hsa.h"
 
+/* Using this header means we do not know what version library will be linked.
+   Until such point as a CMake level override is requested, default to the
+   minimum. */
+/*
+ * - 1.0 - initial version
+ */
+#define HSA_AMD_INTERFACE_VERSION_MAJOR 1
+#define HSA_AMD_INTERFACE_VERSION_MINOR 0
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The plugin checks the values of HSA_AMD_INTERFACE_VERSION_* so we now set them to something safe in the header.