### PR TITLE
[DebugInfo][RemoveDIs] Cope with instructions moving after themselves

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -200,8 +200,9 @@ void Instruction::moveBeforeImpl(BasicBlock &BB, InstListType::iterator I,
   // If we've been given the "Preserve" flag, then just move the DPValues with
   // the instruction, no more special handling needed.
   if (BB.IsNewDbgInfoFormat && DbgMarker && !Preserve) {
-    if (I != this->getIterator()) {
-      // "this" is definitely moving; detach any existing DPValues.
+    if (I != this->getIterator() || InsertAtHead) {
+      // "this" is definitely moving in the list, or it's moving ahead of it's
+      // attached DPValues. Detach any existing DPValues.
       handleMarkerRemoval();
     }
   }

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -201,7 +201,7 @@ void Instruction::moveBeforeImpl(BasicBlock &BB, InstListType::iterator I,
   // the instruction, no more special handling needed.
   if (BB.IsNewDbgInfoFormat && DbgMarker && !Preserve) {
     if (I != this->getIterator() || InsertAtHead) {
-      // "this" is definitely moving in the list, or it's moving ahead of it's
+      // "this" is definitely moving in the list, or it's moving ahead of its
       // attached DPValues. Detach any existing DPValues.
       handleMarkerRemoval();
     }

--- a/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
+++ b/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
@@ -114,7 +114,6 @@ TEST(BasicBlockDbgInfoTest, InsertAfterSelf) {
   UseNewDbgInfoFormat = false;
 }
 
-
 TEST(BasicBlockDbgInfoTest, MarkerOperations) {
   LLVMContext C;
   UseNewDbgInfoFormat = true;

--- a/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
+++ b/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
@@ -79,7 +79,7 @@ TEST(BasicBlockDbgInfoTest, InsertAfterSelf) {
 
   // Convert the module to "new" form debug-info.
   M->convertToNewDbgValues();
-  // Fetch the entry block,
+  // Fetch the entry block.
   BasicBlock &BB = M->getFunction("f")->getEntryBlock();
 
   Instruction *Inst1 = &*BB.begin();


### PR DESCRIPTION
We occasionally move instructions to their own positions, which is not an error, and has no effect on the program. However, if dbg.value intrinsics are present then they can effectively be moved without any other effect on the program.

This is a problem if we're using non-instruction debug-info: a moveAfter that appears to be a no-op in RemoveDIs mode can jump in front of intrinsics in dbg.value mode. Thus: if an instruction is moved to itself and the head bit is set, force attached debug-info to shift down one instruction, which replicates the dbg.value behaviour.