### PR TITLE
[libc] Move the pointer to pin off the stack to the heap

### DIFF
--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -471,7 +471,7 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
     handle_error(err);
 
   // Pin some memory we can use to obtain the address of the rpc client.
-  void *rpc_client_storage = nullptr;
+  void **rpc_client_storage = new void *;
   void *rpc_client_host = nullptr;
   if (hsa_status_t err =
           hsa_amd_memory_lock(&rpc_client_storage, sizeof(void *),

--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -474,7 +474,7 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
   void *rpc_client_storage = malloc(sizeof(void *));
   void *rpc_client_host = nullptr;
   if (hsa_status_t err =
-          hsa_amd_memory_lock(&rpc_client_storage, sizeof(void *),
+          hsa_amd_memory_lock(rpc_client_storage, sizeof(void *),
                               /*agents=*/nullptr, 0, &rpc_client_host))
     handle_error(err);
 

--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -471,7 +471,7 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
     handle_error(err);
 
   // Pin some memory we can use to obtain the address of the rpc client.
-  void *rpc_client_storage = /* Intentionally leaks */ malloc(sizeof(void *));
+  void *rpc_client_storage = malloc(sizeof(void *));
   void *rpc_client_host = nullptr;
   if (hsa_status_t err =
           hsa_amd_memory_lock(&rpc_client_storage, sizeof(void *),
@@ -501,6 +501,7 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
     handle_error(err);
   if (hsa_status_t err = hsa_amd_memory_unlock(rpc_client_host))
     handle_error(err);
+  free(rpc_client_storage);
 
   // Obtain the GPU's fixed-frequency clock rate and copy it to the GPU.
   // If the clock_freq symbol is missing, no work to do.

--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -471,12 +471,13 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
     handle_error(err);
 
   // Pin some memory we can use to obtain the address of the rpc client.
-  void **rpc_client_storage = new void *;
+  void *rpc_client_storage = malloc(sizeof(void *));
   void *rpc_client_host = nullptr;
   if (hsa_status_t err =
           hsa_amd_memory_lock(&rpc_client_storage, sizeof(void *),
                               /*agents=*/nullptr, 0, &rpc_client_host))
     handle_error(err);
+  free(rpc_client_storage);
 
   // Copy the address of the client buffer from the device to the host.
   if (hsa_status_t err = hsa_memcpy(rpc_client_host, host_agent, rpc_client_dev,

--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -471,13 +471,12 @@ int load(int argc, char **argv, char **envp, void *image, size_t size,
     handle_error(err);
 
   // Pin some memory we can use to obtain the address of the rpc client.
-  void *rpc_client_storage = malloc(sizeof(void *));
+  void *rpc_client_storage = /* Intentionally leaks */ malloc(sizeof(void *));
   void *rpc_client_host = nullptr;
   if (hsa_status_t err =
           hsa_amd_memory_lock(&rpc_client_storage, sizeof(void *),
                               /*agents=*/nullptr, 0, &rpc_client_host))
     handle_error(err);
-  free(rpc_client_storage);
 
   // Copy the address of the client buffer from the device to the host.
   if (hsa_status_t err = hsa_memcpy(rpc_client_host, host_agent, rpc_client_dev,


### PR DESCRIPTION
Summary:
This may be problematic to pin a stack pointer. Allocate it via the OS
allocator instead as the documentation suggests.

For some reason, if you attempt to free this pointer after the memory
region has been unlocked, it will return an invalid pointer.
