### PR TITLE
[lldb] Delete unreachable code and unnecessary string conversions

### DIFF
--- a/lldb/source/Interpreter/OptionArgParser.cpp
+++ b/lldb/source/Interpreter/OptionArgParser.cpp
@@ -243,12 +243,12 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
     llvm::SmallVector<llvm::StringRef, 4> matches;
     if (g_symbol_plus_offset_regex.Execute(sref, &matches)) {
       uint64_t offset = 0;
-      std::string name = matches[1].str();
-      std::string sign = matches[2].str();
-      std::string str_offset = matches[3].str();
-      if (!llvm::StringRef(str_offset).getAsInteger(0, offset)) {
+      llvm::StringRef name = matches[1];
+      llvm::StringRef sign = matches[2];
+      llvm::StringRef str_offset = matches[3];
+      if (!str_offset.getAsInteger(0, offset)) {
         Status error;
-        addr = ToAddress(exe_ctx, name.c_str(), LLDB_INVALID_ADDRESS, &error);
+        addr = ToAddress(exe_ctx, name, LLDB_INVALID_ADDRESS, &error);
         if (addr != LLDB_INVALID_ADDRESS) {
           if (sign[0] == '+')
             return addr + offset;


### PR DESCRIPTION
This PR cleans up OptionArgParser in a couple of ways:

1. We remove unnecessary std::string temporaries
2. Through else-after-return elimination, we prove the existence of unreachable code