### PR TITLE
[GlobalISel] Improve combines for extend operation by taking hint ins…

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -2374,6 +2374,9 @@ bool CombinerHelper::matchCombineAnyExtTrunc(MachineInstr &MI, Register &Reg) {
   assert(MI.getOpcode() == TargetOpcode::G_ANYEXT && "Expected a G_ANYEXT");
   Register DstReg = MI.getOperand(0).getReg();
   Register SrcReg = MI.getOperand(1).getReg();
+  Register OriginalSrcReg = getSrcRegIgnoringCopies(SrcReg, MRI);
+  if (OriginalSrcReg.isValid())
+    SrcReg = OriginalSrcReg;
   LLT DstTy = MRI.getType(DstReg);
   return mi_match(SrcReg, MRI,
                   m_GTrunc(m_all_of(m_Reg(Reg), m_SpecificType(DstTy))));
@@ -2400,6 +2403,9 @@ bool CombinerHelper::matchCombineExtOfExt(
           MI.getOpcode() == TargetOpcode::G_ZEXT) &&
          "Expected a G_[ASZ]EXT");
   Register SrcReg = MI.getOperand(1).getReg();
+  Register OriginalSrcReg = getSrcRegIgnoringCopies(SrcReg, MRI);
+  if (OriginalSrcReg.isValid())
+    SrcReg = OriginalSrcReg;
   MachineInstr *SrcMI = MRI.getVRegDef(SrcReg);
   // Match exts with the same opcode, anyext([sz]ext) and sext(zext).
   unsigned Opc = MI.getOpcode();

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-ext.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-ext.mir
@@ -16,6 +16,22 @@ body:             |
     $x1 = COPY %2(s64)
 ...
 ---
+name:            test_combine_anyext_trunc_with_hint
+body:             |
+  bb.1:
+  liveins: $x0
+    ; CHECK-LABEL: name: test_combine_anyext_trunc_with_hint
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: $x1 = COPY [[COPY]](s64)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = G_TRUNC %0(s64)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_ANYEXT %2(s32)
+    $x1 = COPY %3(s64)
+...
+---
 name:            test_combine_anyext_trunc_vec
 body:             |
   bb.1:
@@ -45,6 +61,23 @@ body:             |
     %1:_(s32) = G_ANYEXT %0(s16)
     %2:_(s64) = G_ANYEXT %1(s32)
     $x0 = COPY %2(s64)
+...
+---
+name:            test_combine_anyext_anyext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_anyext_anyext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[ANYEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_ANYEXT %0(s16)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_ANYEXT %2(s32)
+    $x0 = COPY %3(s64)
 ...
 ---
 name:            test_combine_anyext_anyext_vec
@@ -79,6 +112,23 @@ body:             |
     $x0 = COPY %2(s64)
 ...
 ---
+name:            test_combine_anyext_sext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_anyext_sext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[SEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_SEXT %0(s16)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_ANYEXT %2(s32)
+    $x0 = COPY %3(s64)
+...
+---
 name:            test_combine_anyext_sext_vec
 body:             |
   bb.1:
@@ -109,6 +159,23 @@ body:             |
     %1:_(s32) = G_ZEXT %0(s16)
     %2:_(s64) = G_ANYEXT %1(s32)
     $x0 = COPY %2(s64)
+...
+---
+name:            test_combine_anyext_zext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_anyext_zext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[ZEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_ZEXT %0(s16)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_ANYEXT %2(s32)
+    $x0 = COPY %3(s64)
 ...
 ---
 name:            test_combine_anyext_zext_vec
@@ -143,6 +210,23 @@ body:             |
     $x0 = COPY %2(s64)
 ...
 ---
+name:            test_combine_sext_sext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_sext_sext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[SEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_SEXT %0(s16)
+    %2:_(s32) = G_ASSERT_SEXT %1(s32), 11
+    %3:_(s64) = G_SEXT %2(s32)
+    $x0 = COPY %3(s64)
+...
+---
 name:            test_combine_sext_sext_vec
 body:             |
   bb.1:
@@ -175,6 +259,23 @@ body:             |
     $x0 = COPY %2(s64)
 ...
 ---
+name:            test_combine_sext_zext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_sext_zext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[ZEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_ZEXT %0(s16)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_SEXT %2(s32)
+    $x0 = COPY %3(s64)
+...
+---
 name:            test_combine_sext_zext_vec
 body:             |
   bb.1:
@@ -205,6 +306,23 @@ body:             |
     %1:_(s32) = G_ZEXT %0(s16)
     %2:_(s64) = G_ZEXT %1(s32)
     $x0 = COPY %2(s64)
+...
+---
+name:            test_combine_zext_zext_with_hint
+body:             |
+  bb.1:
+  liveins: $h0
+    ; CHECK-LABEL: name: test_combine_zext_zext_with_hint
+    ; CHECK: liveins: $h0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[COPY]](s16)
+    ; CHECK-NEXT: $x0 = COPY [[ZEXT]](s64)
+    %0:_(s16) = COPY $h0
+    %1:_(s32) = G_ZEXT %0(s16)
+    %2:_(s32) = G_ASSERT_ZEXT %1(s32), 11
+    %3:_(s64) = G_ZEXT %2(s32)
+    $x0 = COPY %3(s64)
 ...
 ---
 name:            test_combine_zext_zext_vec


### PR DESCRIPTION
…tructions into account

Hint instructions like G_ASSERT_ZEXT cann be viewed as a copy. Including this fact into the combiner allows the match more patterns involving such instructions.