### PR TITLE
[flang][runtime] Crash more informatively in defined I/O error case

### DIFF
--- a/flang/include/flang/Runtime/iostat.h
+++ b/flang/include/flang/Runtime/iostat.h
@@ -85,6 +85,7 @@ enum Iostat {
   IostatBadOpOnChildUnit,
   IostatBadNewUnit,
   IostatBadListDirectedInputSeparator,
+  IostatNonExternalDefinedUnformattedIo,
 };
 
 const char *IostatErrorString(int);

--- a/flang/runtime/descriptor-io.cpp
+++ b/flang/runtime/descriptor-io.cpp
@@ -119,7 +119,10 @@ bool DefinedUnformattedIo(IoStatementState &io, const Descriptor &descriptor,
   // Unformatted I/O must have an external unit (or child thereof).
   IoErrorHandler &handler{io.GetIoErrorHandler()};
   ExternalFileUnit *external{io.GetExternalFileUnit()};
-  RUNTIME_CHECK(handler, external != nullptr);
+  if (!external) { // INQUIRE(IOLENGTH=)
+    handler.SignalError(IostatNonExternalDefinedUnformattedIo);
+    return false;
+  }
   ChildIo &child{external->PushChildIo(io)};
   int unit{external->unitNumber()};
   int ioStat{IostatOk};

--- a/flang/runtime/iostat.cpp
+++ b/flang/runtime/iostat.cpp
@@ -115,6 +115,8 @@ const char *IostatErrorString(int iostat) {
     return "NEWUNIT= without FILE= or STATUS='SCRATCH'";
   case IostatBadListDirectedInputSeparator:
     return "List-directed input value has trailing unused characters";
+  case IostatNonExternalDefinedUnformattedIo:
+    return "Defined unformatted I/O without an external unit";
   default:
     return nullptr;
   }


### PR DESCRIPTION
Defined unformatted I/O is not allowed except from/to an external unit. This restriction prohibits an INQUIRE(IOLENGTH=n) statement from using derived types with defined unformatted output in its I/O list.  The runtime currently detects this case and crashes with an internal error; this patch defines a new I/O error enum and causes the program to crash with a more useful message.