### PR TITLE
[TargetInstrInfo] update INLINEASM memoperands once

### DIFF
--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -609,7 +609,8 @@ static MachineInstr *foldInlineAsmMemOperand(MachineInstr &MI,
   foldInlineAsmMemOperand(&NewMI, Op, FI, TII);
 
   // Update mayload/maystore metadata, and memoperands.
-  const VirtRegInfo &RI = AnalyzeVirtRegInBundle(MI, MI.getOperand(Op).getReg());
+  const VirtRegInfo &RI =
+      AnalyzeVirtRegInBundle(MI, MI.getOperand(Op).getReg());
   MachineOperand &ExtraMO = NewMI.getOperand(InlineAsm::MIOp_ExtraInfo);
   MachineMemOperand::Flags Flags = MachineMemOperand::MONone;
   if (RI.Reads) {


### PR DESCRIPTION
In commit b05335989239 ("[X86InstrInfo] support memfold on spillable inline asm
(#70832)"), I had a last minute fix to update the memoperands.  I originally
did this in the parent foldInlineAsmMemOperand call, updated the mir test via
update_mir_test_checks.py, but then decided to move it to the child call of
foldInlineAsmMemOperand.

But I forgot to rerun update_mir_test_checks.py. That last minute change caused
the same memoperand to be added twice when recursion occurred (for tied
operands). I happened to get lucky that trailing content omitted from the
CHECK line doesn't result in test failure.

But rerunning update_mir_test_checks.py on the mir test added in that commit
produces updated output. This is resulting in updates to the test that:
1. conflate additions to the test in child commits with simply updating the
   test as it should have been when first committed.
2. look wrong because the same memoperand is specified twice (we don't
   deduplicate memoperands when added). Example:

    INLINEASM ... :: (load (s32) from %stack.0) (load (s32) from %stack.0)

Fix the bug, so that in child commits, we don't have additional unrelated test
changes (which would be wrong anyways) from simply running
update_mir_test_checks.py.

Link: #20571
