### PR TITLE
[WIP][lld] Add lld warning for checking discarded sections via COMDAT

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -295,6 +295,9 @@ struct Config {
   bool useAndroidRelrTags = false;
   bool warnBackrefs;
   llvm::SmallVector<llvm::GlobPattern, 0> warnBackrefsExclude;
+  bool warnMismatchSectionsInComdatGroups;
+  llvm::SmallVector<llvm::GlobPattern, 0>
+      warnMismatchSectionsInComdatGroupsExclude;
   bool warnCommon;
   bool warnMissingEntry;
   bool warnSymbolOrdering;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1437,6 +1437,9 @@ static void readConfigs(opt::InputArgList &args) {
       OPT_use_android_relr_tags, OPT_no_use_android_relr_tags, false);
   config->warnBackrefs =
       args.hasFlag(OPT_warn_backrefs, OPT_no_warn_backrefs, false);
+  config->warnMismatchSectionsInComdatGroups =
+      args.hasFlag(OPT_warn_mismatch_sections_in_comdat_groups,
+                   OPT_no_warn_mismatch_sections_in_comdat_groups, false);
   config->warnCommon = args.hasFlag(OPT_warn_common, OPT_no_warn_common, false);
   config->warnSymbolOrdering =
       args.hasFlag(OPT_warn_symbol_ordering, OPT_no_warn_symbol_ordering, true);
@@ -1704,6 +1707,17 @@ static void readConfigs(opt::InputArgList &args) {
     StringRef pattern(arg->getValue());
     if (Expected<GlobPattern> pat = GlobPattern::create(pattern))
       config->warnBackrefsExclude.push_back(std::move(*pat));
+    else
+      error(arg->getSpelling() + ": " + toString(pat.takeError()) + ": " +
+            pattern);
+  }
+
+  for (opt::Arg *arg :
+       args.filtered(OPT_warn_mismatch_sections_in_comdat_groups_exclude)) {
+    StringRef pattern(arg->getValue());
+    if (Expected<GlobPattern> pat = GlobPattern::create(pattern))
+      config->warnMismatchSectionsInComdatGroupsExclude.push_back(
+          std::move(*pat));
     else
       error(arg->getSpelling() + ": " + toString(pat.takeError()) + ": " +
             pattern);

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -304,6 +304,10 @@ private:
 
   bool shouldMerge(const Elf_Shdr &sec, StringRef name);
 
+  void checkComdatGroups(bool recordedNewSection, const InputFile *otherFile,
+                         ArrayRef<Elf_Word> sectionsInGroup,
+                         StringRef signature);
+
   // Each ELF symbol contains a section index which the symbol belongs to.
   // However, because the number of bits dedicated for that is limited, a
   // symbol can directly point to a section only when the section index is

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -510,6 +510,15 @@ defm warn_backrefs_exclude
          "which should be ignored for --warn-backrefs.">,
       MetaVarName<"<glob>">;
 
+defm warn_mismatch_sections_in_comdat_groups: BB<"warn-mismatch-sections-in-comdat-groups",
+    "Warn about discarded sections in a comdat group that have different contents from a retained section in a comdat group with the same key",
+    "Do not warn about discarded sections in a comdat group that have different contents from a retained section in a comdat group with the same key">;
+
+defm warn_mismatch_sections_in_comdat_groups_exclude
+    : EEq<"warn-mismatch-sections-in-comdat-groups-exclude",
+         "Glob describing sections to ignore checking for --warn-mismatch-sections-in-comdat-groups.">,
+      MetaVarName<"<glob>">;
+
 defm warn_common: B<"warn-common",
     "Warn about duplicate common symbols",
     "Do not warn about duplicate common symbols (default)">;

--- a/lld/ELF/SymbolTable.h
+++ b/lld/ELF/SymbolTable.h
@@ -65,6 +65,16 @@ public:
   // is used to uniquify them.
   llvm::DenseMap<llvm::CachedHashStringRef, const InputFile *> comdatGroups;
 
+  // Map from a section name for a comdat section to its contents. These
+  // sections are the ones not discarded.
+  llvm::DenseMap<llvm::CachedHashStringRef, ArrayRef<uint8_t>>
+      comdatGroupSectionContents;
+
+  // Map from a comdat group signature to the names of sections part of the
+  // group.
+  llvm::DenseMap<llvm::CachedHashStringRef, llvm::StringSet<>>
+      comdatGroupSectionNames;
+
   // The Map of __acle_se_<sym>, <sym> pairs found in the input objects.
   // Key is the <sym> name.
   llvm::SmallMapVector<StringRef, ArmCmseEntryFunction, 1> cmseSymMap;

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/Inputs/func.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/Inputs/func.s
@@ -1,0 +1,4 @@
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 7

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-group-sizes.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-group-sizes.s
@@ -1,0 +1,17 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s --check-prefix=REVERSE
+
+// CHECK:   warning: comdat group with signature 'func' in '{{.*}}0.o' has 1 section(s) while group in '{{.*}}1.o' has 2 section(s)
+// REVERSE: warning: comdat group with signature 'func' in '{{.*}}1.o' has 2 section(s) while group in '{{.*}}0.o' has 1 section(s)
+
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 7
+
+  .global func2
+  .section .data.func2,"awG",@progbits,func,comdat
+func2:
+  .word 7

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-section-contents.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-section-contents.s
@@ -1,0 +1,12 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s --check-prefix=REVERSE
+
+// CHECK:   warning: section '.data.func' for comdat group with signature 'func' has different contents between '{{.*}}1.o' and '{{.*}}0.o'
+// REVERSE: warning: section '.data.func' for comdat group with signature 'func' has different contents between '{{.*}}0.o' and '{{.*}}1.o'
+
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 6

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-section-names.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/different-section-names.s
@@ -1,0 +1,12 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --warn-mismatch-sections-in-comdat-groups 2>&1 | FileCheck %s --check-prefix=REVERSE
+
+// CHECK:   warning: comdat group with signature 'func' in '{{.*}}0.o' does not have section '.data.func2' which is part of comdat group in '{{.*}}1.o'
+// REVERSE: warning: comdat group with signature 'func' in '{{.*}}1.o' does not have section '.data.func' which is part of comdat group in '{{.*}}0.o'
+
+  .global func
+  .section .data.func2,"awG",@progbits,func,comdat
+func:
+  .word 7

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/disabled-warning.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/disabled-warning.s
@@ -1,0 +1,13 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --fatal-warnings
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --fatal-warnings
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --fatal-warnings --no-warn-mismatch-sections-in-comdat-groups
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --fatal-warnings --no-warn-mismatch-sections-in-comdat-groups
+
+// No error since the warning is disabled, despite the mismatch.
+
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 6

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/ignore-section.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/ignore-section.s
@@ -1,0 +1,9 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --fatal-warnings --warn-mismatch-sections-in-comdat-groups --warn-mismatch-sections-in-comdat-groups-exclude=.data.f*
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --fatal-warnings --warn-mismatch-sections-in-comdat-groups --warn-mismatch-sections-in-comdat-groups-exclude=.data.f*
+
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 6

--- a/lld/test/ELF/mismatch-sections-in-comdat-group-warning/no-warning.s
+++ b/lld/test/ELF/mismatch-sections-in-comdat-group-warning/no-warning.s
@@ -1,0 +1,11 @@
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %p/Inputs/func.s -o %t0.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t1.o
+// RUN: ld.lld -shared %t0.o %t1.o -o /dev/null --fatal-warnings --warn-mismatch-sections-in-comdat-groups
+// RUN: ld.lld -shared %t1.o %t0.o -o /dev/null --fatal-warnings --warn-mismatch-sections-in-comdat-groups
+
+// No error since the sections in the comdat groups for `func` in both object files are the same.
+
+  .global func
+  .section .data.func,"awG",@progbits,func,comdat
+func:
+  .word 7


### PR DESCRIPTION
(Just an experiment, not sure if this is worth landing.)

The warning asserts that all sections that would be discarded from the rules for comdat groups have the same contents and sections as the ones retained in the final binary. Specifically, for a given comdat group signature, this checks:
- The number of sections in that group is the same for all comdat groups with that signature.
- The names of all sections in that group are the same for all other comdat groups with that signature.
- The contents of all sections with the same name in all groups for that signature are the same.

The idea here was to detect ODR violations at the link-level. On rare occasions we've run into instances where completely different implementations for a function or data structure win at link time which this might help catch. Note all instances caught by this may actually be indicative of bugs. Due to interprocedural optimizations, it can be entirely possible for the same function in different object files to have slightly different assembly. This wouldn't be practical for relocation sections as well. This comes with an exclude list for disallowing checks on those sections.

Practically, the most I can see this being used for is checking that comdat groups accross all object files have the same named sections in them, and that data sections in those groups have the same contents.