### PR TITLE
fix linking on riscv64

### DIFF
--- a/llvm/tools/dsymutil/CMakeLists.txt
+++ b/llvm/tools/dsymutil/CMakeLists.txt
@@ -44,4 +44,4 @@ if(APPLE AND NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
   target_link_libraries(dsymutil PRIVATE "-framework CoreFoundation")
 endif(APPLE AND NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
 
-# target_link_libraries(dsymutil PRIVATE ${LLVM_ATOMIC_LIB})
+target_link_libraries(dsymutil PRIVATE ${LLVM_ATOMIC_LIB})

--- a/mlir/lib/Pass/CMakeLists.txt
+++ b/mlir/lib/Pass/CMakeLists.txt
@@ -16,4 +16,6 @@ add_mlir_library(MLIRPass
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRIR
+  PRIVATE
+  ${LLVM_ATOMIC_LIB}
   )

--- a/mlir/lib/Tools/lsp-server-support/CMakeLists.txt
+++ b/mlir/lib/Tools/lsp-server-support/CMakeLists.txt
@@ -10,4 +10,6 @@ add_mlir_library(MLIRLspServerSupportLib
 
   LINK_LIBS PUBLIC
   MLIRSupport
+  PRIVATE
+  ${LLVM_ATOMIC_LIB}
   )

--- a/mlir/tools/mlir-shlib/CMakeLists.txt
+++ b/mlir/tools/mlir-shlib/CMakeLists.txt
@@ -39,6 +39,8 @@ if(LLVM_BUILD_LLVM_DYLIB)
     ${_OBJECTS}
     LINK_LIBS
     ${_DEPS}
+    PRIVATE
+    ${LLVM_ATOMIC_LIB}
 
     LINK_COMPONENTS
     ${mlir_llvm_link_components}


### PR DESCRIPTION
As libatomic is not included in libgcc_s, when building on riscv64
(on Ubuntu 22.04) using rtlib set to libgcc and gnu ld as the linker,
the linking of a few utilities fails on some __atomic_X symbols provided by libatomic.

For dsymutils, actually reviews.llvm.org/D137799 has commented out the line potentially adding a
`-latomic` when linking by using the LLVM_ATOMIC_LIB variable without providing any reason. Revert this piece of the change.

For several libMLIR consumers, add the LLVM_ATOMIC_LIB variable where needed. 