### PR TITLE
[clang-format] Fix a bug in `git-clang-format --binary`

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -153,6 +153,7 @@ def main():
   else:
     if len(commits) > 2:
       die('at most two commits allowed; %d given' % len(commits))
+  opts.binary=os.path.abspath(opts.binary)
   changed_lines = compute_diff_and_extract_lines(commits, files, opts.staged)
   if opts.verbose >= 1:
     ignored_files = set(changed_lines)


### PR DESCRIPTION
Fixed #74165.