### PR TITLE
[clang][RISCVVEmitter] Remove no-op ptr-to-ptr bitcast (NFC)

### DIFF
--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -180,13 +180,10 @@ void emitCodeGenSwitchBody(const RVVIntrinsic *RVVI, raw_ostream &OS) {
     return;
   }
 
-  // Cast pointer operand of vector load intrinsic.
   for (const auto &I : enumerate(RVVI->getInputTypes())) {
     if (I.value()->isPointer()) {
       assert(RVVI->getIntrinsicTypes().front() == -1 &&
              "RVVI should be vector load intrinsic.");
-      OS << "  Ops[" << I.index() << "] = Builder.CreateBitCast(Ops[";
-      OS << I.index() << "], ResultType->getPointerTo());\n";
     }
   }
 


### PR DESCRIPTION
Remove ptr-to-ptr bitcast which was added back in 939352b6ec31db4e8defe07856868438fbc5340d . With opaque pointers, the bitcast is now redundant.

Opaque ptr cleanup effort.