### PR TITLE
[libc++][test] Avoid non-Standard zero-length arrays

### DIFF
--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.py
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.py
@@ -76,7 +76,7 @@ class CheckResult(gdb.Command):
         except RuntimeError as e:
             # At this point, lots of different things could be wrong, so don't try to
             # recover or figure it out. Don't exit either, because then it's
-            # impossible debug the framework itself.
+            # impossible to debug the framework itself.
             print("FAIL: Something is wrong in the test framework.")
             print(str(e))
             test_failures += 1

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
@@ -27,19 +27,19 @@ template <class Iter>
 void
 test_with_iterator()
 {
-    std::array<int, 0> empty_arr = {};
-    int* const empty = empty_arr.data();
-    std::random_shuffle(Iter(empty), Iter(empty));
+  std::array<int, 0> empty_arr = {};
+  int* const empty             = empty_arr.data();
+  std::random_shuffle(Iter(empty), Iter(empty));
 
-    const int all_elements[] = {1, 2, 3, 4};
-    int           shuffled[] = {1, 2, 3, 4};
-    const unsigned size = sizeof(all_elements)/sizeof(all_elements[0]);
+  const int all_elements[] = {1, 2, 3, 4};
+  int shuffled[]           = {1, 2, 3, 4};
+  const unsigned size      = sizeof(all_elements) / sizeof(all_elements[0]);
 
-    std::random_shuffle(Iter(shuffled), Iter(shuffled+size));
-    assert(std::is_permutation(shuffled, shuffled+size, all_elements));
+  std::random_shuffle(Iter(shuffled), Iter(shuffled + size));
+  assert(std::is_permutation(shuffled, shuffled + size, all_elements));
 
-    std::random_shuffle(Iter(shuffled), Iter(shuffled+size));
-    assert(std::is_permutation(shuffled, shuffled+size, all_elements));
+  std::random_shuffle(Iter(shuffled), Iter(shuffled + size));
+  assert(std::is_permutation(shuffled, shuffled + size, all_elements));
 }
 
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
@@ -27,9 +27,8 @@ template <class Iter>
 void
 test_with_iterator()
 {
-  std::array<int, 0> empty_arr = {};
-  int* const empty             = empty_arr.data();
-  std::random_shuffle(Iter(empty), Iter(empty));
+  std::array<int, 0> empty = {};
+  std::random_shuffle(Iter(empty.data()), Iter(empty.data()));
 
   const int all_elements[] = {1, 2, 3, 4};
   int shuffled[]           = {1, 2, 3, 4};

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/random_shuffle.pass.cpp
@@ -17,6 +17,7 @@
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 
 #include "test_macros.h"
@@ -26,7 +27,8 @@ template <class Iter>
 void
 test_with_iterator()
 {
-    int empty[] = {};
+    std::array<int, 0> empty_arr = {};
+    int* const empty = empty_arr.data();
     std::random_shuffle(Iter(empty), Iter(empty));
 
     const int all_elements[] = {1, 2, 3, 4};

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
@@ -89,45 +89,41 @@ constexpr bool test_iterators() {
   }
 
   { // first range empty
-    std::array<int, 0> a_arr = {};
-    int* const a = a_arr.data();
+    std::array<int, 0> a = {};
     int b[] = {5, 4, 3, 2, 1};
     int c[5];
 
     auto ret = std::ranges::transform(
-        In1(a), Sent1(In1(a)), In2(b), Sent2(In2(b + 5)), Out(c), [](int i, int j) { return i + j; });
+        In1(a.data()), Sent1(In1(a.data())), In2(b), Sent2(In2(b + 5)), Out(c), [](int i, int j) { return i + j; });
 
-    assert(base(ret.in1) == a);
+    assert(base(ret.in1) == a.data());
     assert(base(ret.in2) == b);
     assert(base(ret.out) == c);
   }
 
   { // second range empty
     int a[] = {5, 4, 3, 2, 1};
-    std::array<int, 0> b_arr = {};
-    int* const b = b_arr.data();
+    std::array<int, 0> b = {};
     int c[5];
 
     auto ret = std::ranges::transform(
-        In1(a), Sent1(In1(a + 5)), In2(b), Sent2(In2(b)), Out(c), [](int i, int j) { return i + j; });
+        In1(a), Sent1(In1(a + 5)), In2(b.data()), Sent2(In2(b.data())), Out(c), [](int i, int j) { return i + j; });
 
     assert(base(ret.in1) == a);
-    assert(base(ret.in2) == b);
+    assert(base(ret.in2) == b.data());
     assert(base(ret.out) == c);
   }
 
   { // both ranges empty
-    std::array<int, 0> a_arr = {};
-    int* const a = a_arr.data();
-    std::array<int, 0> b_arr = {};
-    int* const b = b_arr.data();
+    std::array<int, 0> a = {};
+    std::array<int, 0> b = {};
     int c[5];
 
     auto ret = std::ranges::transform(
-        In1(a), Sent1(In1(a)), In2(b), Sent2(In2(b)), Out(c), [](int i, int j) { return i + j; });
+        In1(a.data()), Sent1(In1(a.data())), In2(b.data()), Sent2(In2(b.data())), Out(c), [](int i, int j) { return i + j; });
 
-    assert(base(ret.in1) == a);
-    assert(base(ret.in2) == b);
+    assert(base(ret.in1) == a.data());
+    assert(base(ret.in2) == b.data());
     assert(base(ret.out) == c);
   }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
@@ -89,7 +89,8 @@ constexpr bool test_iterators() {
   }
 
   { // first range empty
-    int a[] = {};
+    std::array<int, 0> a_arr = {};
+    int* const a = a_arr.data();
     int b[] = {5, 4, 3, 2, 1};
     int c[5];
 
@@ -103,7 +104,8 @@ constexpr bool test_iterators() {
 
   { // second range empty
     int a[] = {5, 4, 3, 2, 1};
-    int b[] = {};
+    std::array<int, 0> b_arr = {};
+    int* const b = b_arr.data();
     int c[5];
 
     auto ret = std::ranges::transform(
@@ -115,8 +117,10 @@ constexpr bool test_iterators() {
   }
 
   { // both ranges empty
-    int a[] = {};
-    int b[] = {};
+    std::array<int, 0> a_arr = {};
+    int* const a = a_arr.data();
+    std::array<int, 0> b_arr = {};
+    int* const b = b_arr.data();
     int c[5];
 
     auto ret = std::ranges::transform(

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
@@ -92,7 +92,8 @@ constexpr bool test_iterators() {
   }
 
   { // first range empty
-    int a[] = {};
+    std::array<int, 0> a_arr = {};
+    int* const a = a_arr.data();
     int b[] = {5, 4, 3, 2, 1};
     int c[5];
 
@@ -108,7 +109,8 @@ constexpr bool test_iterators() {
 
   { // second range empty
     int a[] = {5, 4, 3, 2, 1};
-    int b[] = {};
+    std::array<int, 0> b_arr = {};
+    int* const b = b_arr.data();
     int c[5];
 
     auto range1 = std::ranges::subrange(In1(a), Sent1(In1(a + 5)));
@@ -122,8 +124,10 @@ constexpr bool test_iterators() {
   }
 
   { // both ranges empty
-    int a[] = {};
-    int b[] = {};
+    std::array<int, 0> a_arr = {};
+    int* const a = a_arr.data();
+    std::array<int, 0> b_arr = {};
+    int* const b = b_arr.data();
     int c[5];
 
     auto range1 = std::ranges::subrange(In1(a), Sent1(In1(a)));

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
@@ -92,51 +92,47 @@ constexpr bool test_iterators() {
   }
 
   { // first range empty
-    std::array<int, 0> a_arr = {};
-    int* const a = a_arr.data();
+    std::array<int, 0> a = {};
     int b[] = {5, 4, 3, 2, 1};
     int c[5];
 
-    auto range1 = std::ranges::subrange(In1(a), Sent1(In1(a)));
+    auto range1 = std::ranges::subrange(In1(a.data()), Sent1(In1(a.data())));
     auto range2 = std::ranges::subrange(In2(b), Sent2(In2(b + 5)));
 
     auto ret = std::ranges::transform(range1, range2, Out(c), [](int i, int j) { return i + j; });
 
-    assert(base(ret.in1) == a);
+    assert(base(ret.in1) == a.data());
     assert(base(ret.in2) == b);
     assert(base(ret.out) == c);
   }
 
   { // second range empty
     int a[] = {5, 4, 3, 2, 1};
-    std::array<int, 0> b_arr = {};
-    int* const b = b_arr.data();
+    std::array<int, 0> b = {};
     int c[5];
 
     auto range1 = std::ranges::subrange(In1(a), Sent1(In1(a + 5)));
-    auto range2 = std::ranges::subrange(In2(b), Sent2(In2(b)));
+    auto range2 = std::ranges::subrange(In2(b.data()), Sent2(In2(b.data())));
 
     auto ret = std::ranges::transform(range1, range2, Out(c), [](int i, int j) { return i + j; });
 
     assert(base(ret.in1) == a);
-    assert(base(ret.in2) == b);
+    assert(base(ret.in2) == b.data());
     assert(base(ret.out) == c);
   }
 
   { // both ranges empty
-    std::array<int, 0> a_arr = {};
-    int* const a = a_arr.data();
-    std::array<int, 0> b_arr = {};
-    int* const b = b_arr.data();
+    std::array<int, 0> a = {};
+    std::array<int, 0> b = {};
     int c[5];
 
-    auto range1 = std::ranges::subrange(In1(a), Sent1(In1(a)));
-    auto range2 = std::ranges::subrange(In2(b), Sent2(In2(b)));
+    auto range1 = std::ranges::subrange(In1(a.data()), Sent1(In1(a.data())));
+    auto range2 = std::ranges::subrange(In2(b.data()), Sent2(In2(b.data())));
 
     auto ret = std::ranges::transform(range1, range2, Out(c), [](int i, int j) { return i + j; });
 
-    assert(base(ret.in1) == a);
-    assert(base(ret.in2) == b);
+    assert(base(ret.in1) == a.data());
+    assert(base(ret.in2) == b.data());
     assert(base(ret.out) == c);
   }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
@@ -108,21 +108,19 @@ constexpr bool test_iterators() {
 
   { // first range empty
     {
-      std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      std::array<int, 0> a = {};
       int b[5];
-      auto ret = std::ranges::transform(In1(a), Sent1(In1(a)), Out(b), [](int i) { return i * 2; });
-      assert(base(ret.in) == a);
+      auto ret = std::ranges::transform(In1(a.data()), Sent1(In1(a.data())), Out(b), [](int i) { return i * 2; });
+      assert(base(ret.in) == a.data());
       assert(base(ret.out) == b);
     }
 
     {
-      std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      std::array<int, 0> a = {};
       int b[5];
-      auto range = std::ranges::subrange(In1(a), Sent1(In1(a)));
+      auto range = std::ranges::subrange(In1(a.data()), Sent1(In1(a.data())));
       auto ret = std::ranges::transform(range, Out(b), [](int i) { return i * 2; });
-      assert(base(ret.in) == a);
+      assert(base(ret.in) == a.data());
       assert(base(ret.out) == b);
     }
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
@@ -108,7 +108,8 @@ constexpr bool test_iterators() {
 
   { // first range empty
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int b[5];
       auto ret = std::ranges::transform(In1(a), Sent1(In1(a)), Out(b), [](int i) { return i * 2; });
       assert(base(ret.in) == a);
@@ -116,7 +117,8 @@ constexpr bool test_iterators() {
     }
 
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int b[5];
       auto range = std::ranges::subrange(In1(a), Sent1(In1(a)));
       auto ret = std::ranges::transform(range, Out(b), [](int i) { return i * 2; });

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
@@ -156,7 +156,8 @@ constexpr void test_iterators() {
 
  { // suffix has zero length
    int a[] = {1, 2, 3, 4, 5, 6};
-   int p[] = {};
+   std::array<int, 0> p_arr = {};
+   int* const p = p_arr.data();
    auto whole = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 6)));
    auto suffix  = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
    {
@@ -170,7 +171,8 @@ constexpr void test_iterators() {
  }
 
  { // range has zero length
-   int a[] = {};
+   std::array<int, 0> a_arr = {};
+   int* const a = a_arr.data();
    int p[] = {1, 2, 3, 4, 5, 6, 7, 8};
    auto whole = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
    auto suffix  = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 8)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp
@@ -156,10 +156,9 @@ constexpr void test_iterators() {
 
  { // suffix has zero length
    int a[] = {1, 2, 3, 4, 5, 6};
-   std::array<int, 0> p_arr = {};
-   int* const p = p_arr.data();
+   std::array<int, 0> p = {};
    auto whole = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 6)));
-   auto suffix  = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
+   auto suffix  = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
    {
      bool ret = std::ranges::ends_with(whole.begin(), whole.end(), suffix.begin(), suffix.end());
      assert(ret);
@@ -171,10 +170,9 @@ constexpr void test_iterators() {
  }
 
  { // range has zero length
-   std::array<int, 0> a_arr = {};
-   int* const a = a_arr.data();
+   std::array<int, 0> a = {};
    int p[] = {1, 2, 3, 4, 5, 6, 7, 8};
-   auto whole = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
+   auto whole = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
    auto suffix  = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 8)));
    {
      bool ret = std::ranges::ends_with(whole.begin(), whole.end(), suffix.begin(), suffix.end());

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
@@ -209,8 +209,8 @@ constexpr void test_iterators() {
     {
       std::array<int, 0> a = {};
       std::array<int, 0> b = {};
-      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
-      auto range2 = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
+      auto range1          = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
+      auto range2          = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
       auto ret = std::ranges::equal(range1, range2);
       assert(ret);
     }
@@ -220,13 +220,13 @@ constexpr void test_iterators() {
     {
       std::array<int, 0> a = {};
       int b[] = {1, 2};
-      auto ret = std::ranges::equal(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(b), Sent2(Iter2(b + 2)));
+      auto ret             = std::ranges::equal(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(b), Sent2(Iter2(b + 2)));
       assert(!ret);
     }
     {
       std::array<int, 0> a = {};
       int b[] = {1, 2};
-      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
+      auto range1          = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b + 2)));
       auto ret = std::ranges::equal(range1, range2);
       assert(!ret);
@@ -237,14 +237,14 @@ constexpr void test_iterators() {
     {
       int a[] = {1, 2};
       std::array<int, 0> b = {};
-      auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b.data()), Sent2(Iter2(b.data())));
+      auto ret             = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b.data()), Sent2(Iter2(b.data())));
       assert(!ret);
     }
     {
       int a[] = {1, 2};
       std::array<int, 0> b = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 2)));
-      auto range2 = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
+      auto range2          = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
       auto ret = std::ranges::equal(range1, range2);
       assert(!ret);
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
@@ -202,17 +202,17 @@ constexpr void test_iterators() {
   { // check that two empty ranges work
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       std::array<int, 0> b_arr = {};
-      int* const b = b_arr.data();
+      int* const b             = b_arr.data();
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b)));
       assert(ret);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       std::array<int, 0> b_arr = {};
-      int* const b = b_arr.data();
+      int* const b             = b_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
       auto ret = std::ranges::equal(range1, range2);
@@ -223,14 +223,14 @@ constexpr void test_iterators() {
   { // check that it works with the first range empty
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int b[] = {1, 2};
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b + 2)));
       assert(!ret);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int b[] = {1, 2};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b + 2)));
@@ -243,14 +243,14 @@ constexpr void test_iterators() {
     {
       int a[] = {1, 2};
       std::array<int, 0> b_arr = {};
-      int* const b = b_arr.data();
+      int* const b             = b_arr.data();
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b), Sent2(Iter2(b)));
       assert(!ret);
     }
     {
       int a[] = {1, 2};
       std::array<int, 0> b_arr = {};
-      int* const b = b_arr.data();
+      int* const b             = b_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 2)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
       auto ret = std::ranges::equal(range1, range2);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
@@ -201,20 +201,16 @@ constexpr void test_iterators() {
 
   { // check that two empty ranges work
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      std::array<int, 0> b_arr = {};
-      int* const b             = b_arr.data();
-      auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b)));
+      std::array<int, 0> a = {};
+      std::array<int, 0> b = {};
+      auto ret = std::ranges::equal(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(b.data()), Sent2(Iter2(b.data())));
       assert(ret);
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      std::array<int, 0> b_arr = {};
-      int* const b             = b_arr.data();
-      auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
-      auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
+      std::array<int, 0> a = {};
+      std::array<int, 0> b = {};
+      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
+      auto range2 = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
       auto ret = std::ranges::equal(range1, range2);
       assert(ret);
     }
@@ -222,17 +218,15 @@ constexpr void test_iterators() {
 
   { // check that it works with the first range empty
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int b[] = {1, 2};
-      auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b + 2)));
+      auto ret = std::ranges::equal(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(b), Sent2(Iter2(b + 2)));
       assert(!ret);
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int b[] = {1, 2};
-      auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
+      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b + 2)));
       auto ret = std::ranges::equal(range1, range2);
       assert(!ret);
@@ -242,17 +236,15 @@ constexpr void test_iterators() {
   { // check that it works with the second range empty
     {
       int a[] = {1, 2};
-      std::array<int, 0> b_arr = {};
-      int* const b             = b_arr.data();
-      auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b), Sent2(Iter2(b)));
+      std::array<int, 0> b = {};
+      auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b.data()), Sent2(Iter2(b.data())));
       assert(!ret);
     }
     {
       int a[] = {1, 2};
-      std::array<int, 0> b_arr = {};
-      int* const b             = b_arr.data();
+      std::array<int, 0> b = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 2)));
-      auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
+      auto range2 = std::ranges::subrange(Iter2(b.data()), Sent2(Iter2(b.data())));
       auto ret = std::ranges::equal(range1, range2);
       assert(!ret);
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
@@ -23,6 +23,7 @@
 //                                Proj1 proj1 = {}, Proj2 proj2 = {});
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <concepts>
 #include <functional>
@@ -200,14 +201,18 @@ constexpr void test_iterators() {
 
   { // check that two empty ranges work
     {
-      int a[] = {};
-      int b[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
+      std::array<int, 0> b_arr = {};
+      int* const b = b_arr.data();
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b)));
       assert(ret);
     }
     {
-      int a[] = {};
-      int b[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
+      std::array<int, 0> b_arr = {};
+      int* const b = b_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
       auto ret = std::ranges::equal(range1, range2);
@@ -217,13 +222,15 @@ constexpr void test_iterators() {
 
   { // check that it works with the first range empty
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int b[] = {1, 2};
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a)), Iter2(b), Sent2(Iter2(b + 2)));
       assert(!ret);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int b[] = {1, 2};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b + 2)));
@@ -235,13 +242,15 @@ constexpr void test_iterators() {
   { // check that it works with the second range empty
     {
       int a[] = {1, 2};
-      int b[] = {};
+      std::array<int, 0> b_arr = {};
+      int* const b = b_arr.data();
       auto ret = std::ranges::equal(Iter1(a), Sent1(Iter1(a + 2)), Iter2(b), Sent2(Iter2(b)));
       assert(!ret);
     }
     {
       int a[] = {1, 2};
-      int b[] = {};
+      std::array<int, 0> b_arr = {};
+      int* const b = b_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 2)));
       auto range2 = std::ranges::subrange(Iter2(b), Sent2(Iter2(b)));
       auto ret = std::ranges::equal(range1, range2);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
@@ -182,18 +182,16 @@ constexpr void test_iterators() {
   { // pattern has zero length
     {
       int a[] = {6, 7, 8};
-      std::array<int, 0> p_arr = {};
-      int* const p             = p_arr.data();
-      auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
+      std::array<int, 0> p = {};
+      auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p.data()), Sent2(Iter2(p.data())));
       assert(base(ret.begin()) == a + 3);
       assert(base(ret.end()) == a + 3);
     }
     {
       int a[] = {6, 7, 8};
-      std::array<int, 0> p_arr = {};
-      int* const p             = p_arr.data();
+      std::array<int, 0> p = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
-      auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
+      auto range2 = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
       auto ret = std::ranges::find_end(range1, range2);
       assert(base(ret.begin()) == a + 3);
       assert(base(ret.end()) == a + 3);
@@ -202,22 +200,20 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      auto ret = std::ranges::find_end(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(p), Sent2(Iter2(p + 3)));
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
+      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));
       auto ret = std::ranges::find_end(range1, range2);
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
@@ -182,14 +182,16 @@ constexpr void test_iterators() {
   { // pattern has zero length
     {
       int a[] = {6, 7, 8};
-      int p[] = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
       assert(base(ret.begin()) == a + 3);
       assert(base(ret.end()) == a + 3);
     }
     {
       int a[] = {6, 7, 8};
-      int p[] = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
       auto ret = std::ranges::find_end(range1, range2);
@@ -200,14 +202,16 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[] = {6, 7, 8};
       auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[] = {6, 7, 8};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
@@ -183,7 +183,7 @@ constexpr void test_iterators() {
     {
       int a[] = {6, 7, 8};
       std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      int* const p             = p_arr.data();
       auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
       assert(base(ret.begin()) == a + 3);
       assert(base(ret.end()) == a + 3);
@@ -191,7 +191,7 @@ constexpr void test_iterators() {
     {
       int a[] = {6, 7, 8};
       std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      int* const p             = p_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
       auto ret = std::ranges::find_end(range1, range2);
@@ -203,7 +203,7 @@ constexpr void test_iterators() {
   { // range has zero length
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int p[] = {6, 7, 8};
       auto ret = std::ranges::find_end(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
       assert(base(ret.begin()) == a);
@@ -211,7 +211,7 @@ constexpr void test_iterators() {
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int p[] = {6, 7, 8};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.end/ranges.find_end.pass.cpp
@@ -191,7 +191,7 @@ constexpr void test_iterators() {
       int a[] = {6, 7, 8};
       std::array<int, 0> p = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
-      auto range2 = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
+      auto range2          = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
       auto ret = std::ranges::find_end(range1, range2);
       assert(base(ret.begin()) == a + 3);
       assert(base(ret.end()) == a + 3);
@@ -209,7 +209,7 @@ constexpr void test_iterators() {
     {
       std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
+      auto range1          = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));
       auto ret = std::ranges::find_end(range1, range2);
       assert(base(ret.begin()) == a.data());

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
@@ -19,6 +19,7 @@
 //     ranges::for_each(R&& r, Fun f, Proj proj = {});
 
 #include <algorithm>
+#include <array>
 #include <ranges>
 
 #include "almost_satisfies_types.h"
@@ -98,11 +99,13 @@ constexpr void test_iterator() {
 
   { // check that an empty range works
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       std::ranges::for_each(Iter(a), Sent(Iter(a)), [](auto&) { assert(false); });
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       std::ranges::for_each(range, [](auto&) { assert(false); });
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
@@ -99,14 +99,12 @@ constexpr void test_iterator() {
 
   { // check that an empty range works
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      std::ranges::for_each(Iter(a), Sent(Iter(a)), [](auto&) { assert(false); });
+      std::array<int, 0> a = {};
+      std::ranges::for_each(Iter(a.data()), Sent(Iter(a.data())), [](auto&) { assert(false); });
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       std::ranges::for_each(range, [](auto&) { assert(false); });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
@@ -100,12 +100,12 @@ constexpr void test_iterator() {
   { // check that an empty range works
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       std::ranges::for_each(Iter(a), Sent(Iter(a)), [](auto&) { assert(false); });
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       std::ranges::for_each(range, [](auto&) { assert(false); });
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each.pass.cpp
@@ -104,7 +104,7 @@ constexpr void test_iterator() {
     }
     {
       std::array<int, 0> a = {};
-      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+      auto range           = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       std::ranges::for_each(range, [](auto&) { assert(false); });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
@@ -59,9 +59,8 @@ constexpr void test_iterator() {
   }
 
   { // check that an empty range works
-    std::array<int, 0> a_arr = {};
-    int* const a             = a_arr.data();
-    std::ranges::for_each_n(Iter(a), 0, [](auto&) { assert(false); });
+    std::array<int, 0> a = {};
+    std::ranges::for_each_n(Iter(a.data()), 0, [](auto&) { assert(false); });
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
@@ -16,6 +16,7 @@
 //     ranges::for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
 
 #include <algorithm>
+#include <array>
 #include <ranges>
 
 #include "almost_satisfies_types.h"
@@ -58,7 +59,8 @@ constexpr void test_iterator() {
   }
 
   { // check that an empty range works
-    int a[] = {};
+    std::array<int, 0> a_arr = {};
+    int* const a = a_arr.data();
     std::ranges::for_each_n(Iter(a), 0, [](auto&) { assert(false); });
   }
 }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
@@ -60,7 +60,7 @@ constexpr void test_iterator() {
 
   { // check that an empty range works
     std::array<int, 0> a_arr = {};
-    int* const a = a_arr.data();
+    int* const a             = a_arr.data();
     std::ranges::for_each_n(Iter(a), 0, [](auto&) { assert(false); });
   }
 }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
@@ -183,14 +183,16 @@ constexpr void test_iterators() {
   { // pattern has zero length
     {
       int a[] = {6, 7, 8};
-      int p[] = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
       int a[] = {6, 7, 8};
-      int p[] = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
       auto ret = std::ranges::search(range1, range2);
@@ -201,14 +203,16 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[] = {6, 7, 8};
       auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[] = {6, 7, 8};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
@@ -184,7 +184,7 @@ constexpr void test_iterators() {
     {
       int a[] = {6, 7, 8};
       std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      int* const p             = p_arr.data();
       auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
@@ -192,7 +192,7 @@ constexpr void test_iterators() {
     {
       int a[] = {6, 7, 8};
       std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      int* const p             = p_arr.data();
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
       auto ret = std::ranges::search(range1, range2);
@@ -204,7 +204,7 @@ constexpr void test_iterators() {
   { // range has zero length
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int p[] = {6, 7, 8};
       auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
       assert(base(ret.begin()) == a);
@@ -212,7 +212,7 @@ constexpr void test_iterators() {
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       int p[] = {6, 7, 8};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
@@ -192,7 +192,7 @@ constexpr void test_iterators() {
       int a[] = {6, 7, 8};
       std::array<int, 0> p = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
-      auto range2 = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
+      auto range2          = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
       auto ret = std::ranges::search(range1, range2);
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
@@ -210,7 +210,7 @@ constexpr void test_iterators() {
     {
       std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
+      auto range1          = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));
       auto ret = std::ranges::search(range1, range2);
       assert(base(ret.begin()) == a.data());

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search.pass.cpp
@@ -183,18 +183,16 @@ constexpr void test_iterators() {
   { // pattern has zero length
     {
       int a[] = {6, 7, 8};
-      std::array<int, 0> p_arr = {};
-      int* const p             = p_arr.data();
-      auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p), Sent2(Iter2(p)));
+      std::array<int, 0> p = {};
+      auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a + 3)), Iter2(p.data()), Sent2(Iter2(p.data())));
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
       int a[] = {6, 7, 8};
-      std::array<int, 0> p_arr = {};
-      int* const p             = p_arr.data();
+      std::array<int, 0> p = {};
       auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 3)));
-      auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
+      auto range2 = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
       auto ret = std::ranges::search(range1, range2);
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
@@ -203,22 +201,20 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto ret = std::ranges::search(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 3)));
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      auto ret = std::ranges::search(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(p), Sent2(Iter2(p + 3)));
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
+      std::array<int, 0> a = {};
       int p[] = {6, 7, 8};
-      auto range1 = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
+      auto range1 = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto range2 = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 3)));
       auto ret = std::ranges::search(range1, range2);
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
@@ -171,13 +171,15 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto ret = std::ranges::search_n(Iter(a), Sent(Iter(a)), 1, 1);
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::search_n(range, 1, 1);
       assert(base(ret.begin()) == a);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
@@ -171,19 +171,17 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto ret = std::ranges::search_n(Iter(a), Sent(Iter(a)), 1, 1);
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      std::array<int, 0> a = {};
+      auto ret = std::ranges::search_n(Iter(a.data()), Sent(Iter(a.data())), 1, 1);
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::search_n(range, 1, 1);
-      assert(base(ret.begin()) == a);
-      assert(base(ret.end()) == a);
+      assert(base(ret.begin()) == a.data());
+      assert(base(ret.end()) == a.data());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
@@ -172,13 +172,13 @@ constexpr void test_iterators() {
   { // range has zero length
     {
       std::array<int, 0> a = {};
-      auto ret = std::ranges::search_n(Iter(a.data()), Sent(Iter(a.data())), 1, 1);
+      auto ret             = std::ranges::search_n(Iter(a.data()), Sent(Iter(a.data())), 1, 1);
       assert(base(ret.begin()) == a.data());
       assert(base(ret.end()) == a.data());
     }
     {
       std::array<int, 0> a = {};
-      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+      auto range           = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::search_n(range, 1, 1);
       assert(base(ret.begin()) == a.data());
       assert(base(ret.end()) == a.data());

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.search/ranges.search_n.pass.cpp
@@ -172,14 +172,14 @@ constexpr void test_iterators() {
   { // range has zero length
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto ret = std::ranges::search_n(Iter(a), Sent(Iter(a)), 1, 1);
       assert(base(ret.begin()) == a);
       assert(base(ret.end()) == a);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::search_n(range, 1, 1);
       assert(base(ret.begin()) == a);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
@@ -136,14 +136,16 @@ constexpr void test_iterators() {
   { // prefix has zero length
     {
       int a[] = {1, 2, 3, 4, 5, 6};
-      int p[] = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       std::same_as<bool> decltype(auto) ret =
           std::ranges::starts_with(Iter1(a), Sent1(Iter1(a + 6)), Iter2(p), Sent2(Iter2(p)));
       assert(ret);
     }
     {
       int a[]                               = {1, 2, 3, 4, 5, 6};
-      int p[]                               = {};
+      std::array<int, 0> p_arr = {};
+      int* const p = p_arr.data();
       auto whole                            = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 6)));
       auto prefix                           = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
       std::same_as<bool> decltype(auto) ret = std::ranges::starts_with(whole, prefix);
@@ -153,14 +155,16 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[] = {1, 2, 3, 4, 5, 6, 7, 8};
       std::same_as<bool> decltype(auto) ret =
           std::ranges::starts_with(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 8)));
       assert(!ret);
     }
     {
-      int a[]                               = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       int p[]                               = {1, 2, 3, 4, 5, 6, 7, 8};
       auto whole                            = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
       auto prefix                           = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 8)));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.starts_with/ranges.starts_with.pass.cpp
@@ -136,18 +136,16 @@ constexpr void test_iterators() {
   { // prefix has zero length
     {
       int a[] = {1, 2, 3, 4, 5, 6};
-      std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      std::array<int, 0> p = {};
       std::same_as<bool> decltype(auto) ret =
-          std::ranges::starts_with(Iter1(a), Sent1(Iter1(a + 6)), Iter2(p), Sent2(Iter2(p)));
+          std::ranges::starts_with(Iter1(a), Sent1(Iter1(a + 6)), Iter2(p.data()), Sent2(Iter2(p.data())));
       assert(ret);
     }
     {
       int a[]                               = {1, 2, 3, 4, 5, 6};
-      std::array<int, 0> p_arr = {};
-      int* const p = p_arr.data();
+      std::array<int, 0> p = {};
       auto whole                            = std::ranges::subrange(Iter1(a), Sent1(Iter1(a + 6)));
-      auto prefix                           = std::ranges::subrange(Iter2(p), Sent2(Iter2(p)));
+      auto prefix                           = std::ranges::subrange(Iter2(p.data()), Sent2(Iter2(p.data())));
       std::same_as<bool> decltype(auto) ret = std::ranges::starts_with(whole, prefix);
       assert(ret);
     }
@@ -155,18 +153,16 @@ constexpr void test_iterators() {
 
   { // range has zero length
     {
-      std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      std::array<int, 0> a = {};
       int p[] = {1, 2, 3, 4, 5, 6, 7, 8};
       std::same_as<bool> decltype(auto) ret =
-          std::ranges::starts_with(Iter1(a), Sent1(Iter1(a)), Iter2(p), Sent2(Iter2(p + 8)));
+          std::ranges::starts_with(Iter1(a.data()), Sent1(Iter1(a.data())), Iter2(p), Sent2(Iter2(p + 8)));
       assert(!ret);
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      std::array<int, 0> a = {};
       int p[]                               = {1, 2, 3, 4, 5, 6, 7, 8};
-      auto whole                            = std::ranges::subrange(Iter1(a), Sent1(Iter1(a)));
+      auto whole                            = std::ranges::subrange(Iter1(a.data()), Sent1(Iter1(a.data())));
       auto prefix                           = std::ranges::subrange(Iter2(p), Sent2(Iter2(p + 8)));
       std::same_as<bool> decltype(auto) ret = std::ranges::starts_with(whole, prefix);
       assert(!ret);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
@@ -133,13 +133,13 @@ constexpr void test_iterators() {
   { // check that an empty range is partitioned
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto ret = std::ranges::is_partitioned(Iter(a), Sent(Iter(a)), [](int i) { return i < 3; });
       assert(ret);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_partitioned(range, [](int i) { return i < 3; });
       assert(ret);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
@@ -132,15 +132,13 @@ constexpr void test_iterators() {
 
   { // check that an empty range is partitioned
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto ret = std::ranges::is_partitioned(Iter(a), Sent(Iter(a)), [](int i) { return i < 3; });
+      std::array<int, 0> a = {};
+      auto ret = std::ranges::is_partitioned(Iter(a.data()), Sent(Iter(a.data())), [](int i) { return i < 3; });
       assert(ret);
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_partitioned(range, [](int i) { return i < 3; });
       assert(ret);
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
@@ -19,6 +19,7 @@
 
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 
 #include "almost_satisfies_types.h"
@@ -131,12 +132,14 @@ constexpr void test_iterators() {
 
   { // check that an empty range is partitioned
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto ret = std::ranges::is_partitioned(Iter(a), Sent(Iter(a)), [](int i) { return i < 3; });
       assert(ret);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_partitioned(range, [](int i) { return i < 3; });
       assert(ret);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
@@ -138,7 +138,7 @@ constexpr void test_iterators() {
     }
     {
       std::array<int, 0> a = {};
-      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+      auto range           = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_partitioned(range, [](int i) { return i < 3; });
       assert(ret);
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
@@ -110,12 +110,12 @@ constexpr void test_iterators() {
   { // check that an empty range works
     {
       std::array<int, 0> a = {};
-      auto ret = std::ranges::is_sorted(Iter(a.data()), Sent(Iter(a.data())));
+      auto ret             = std::ranges::is_sorted(Iter(a.data()), Sent(Iter(a.data())));
       assert(ret);
     }
     {
       std::array<int, 0> a = {};
-      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+      auto range           = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_sorted(range);
       assert(ret);
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
@@ -109,12 +109,14 @@ constexpr void test_iterators() {
 
   { // check that an empty range works
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto ret = std::ranges::is_sorted(Iter(a), Sent(Iter(a)));
       assert(ret);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_sorted(range);
       assert(ret);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
@@ -110,13 +110,13 @@ constexpr void test_iterators() {
   { // check that an empty range works
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto ret = std::ranges::is_sorted(Iter(a), Sent(Iter(a)));
       assert(ret);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_sorted(range);
       assert(ret);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted.pass.cpp
@@ -109,15 +109,13 @@ constexpr void test_iterators() {
 
   { // check that an empty range works
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto ret = std::ranges::is_sorted(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto ret = std::ranges::is_sorted(Iter(a.data()), Sent(Iter(a.data())));
       assert(ret);
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_sorted(range);
       assert(ret);
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
@@ -111,13 +111,13 @@ constexpr void test_iterators() {
   { // check that an empty range works
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto ret = std::ranges::is_sorted_until(Iter(a), Sent(Iter(a)));
       assert(base(ret) == a);
     }
     {
       std::array<int, 0> a_arr = {};
-      int* const a = a_arr.data();
+      int* const a             = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_sorted_until(range);
       assert(base(ret) == a);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
@@ -111,12 +111,12 @@ constexpr void test_iterators() {
   { // check that an empty range works
     {
       std::array<int, 0> a = {};
-      auto ret = std::ranges::is_sorted_until(Iter(a.data()), Sent(Iter(a.data())));
+      auto ret             = std::ranges::is_sorted_until(Iter(a.data()), Sent(Iter(a.data())));
       assert(base(ret) == a.data());
     }
     {
       std::array<int, 0> a = {};
-      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+      auto range           = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_sorted_until(range);
       assert(base(ret) == a.data());
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
@@ -110,17 +110,15 @@ constexpr void test_iterators() {
 
   { // check that an empty range works
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto ret = std::ranges::is_sorted_until(Iter(a), Sent(Iter(a)));
-      assert(base(ret) == a);
+      std::array<int, 0> a = {};
+      auto ret = std::ranges::is_sorted_until(Iter(a.data()), Sent(Iter(a.data())));
+      assert(base(ret) == a.data());
     }
     {
-      std::array<int, 0> a_arr = {};
-      int* const a             = a_arr.data();
-      auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+      std::array<int, 0> a = {};
+      auto range = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
       auto ret = std::ranges::is_sorted_until(range);
-      assert(base(ret) == a);
+      assert(base(ret) == a.data());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/ranges.is_sorted_until.pass.cpp
@@ -110,12 +110,14 @@ constexpr void test_iterators() {
 
   { // check that an empty range works
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto ret = std::ranges::is_sorted_until(Iter(a), Sent(Iter(a)));
       assert(base(ret) == a);
     }
     {
-      int a[] = {};
+      std::array<int, 0> a_arr = {};
+      int* const a = a_arr.data();
       auto range = std::ranges::subrange(Iter(a), Sent(Iter(a)));
       auto ret = std::ranges::is_sorted_until(range);
       assert(base(ret) == a);

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <cassert>
 
-// TODO: Move TEST_IS_CONSTANT_EVALUATED into it's own header
+// TODO: Move TEST_IS_CONSTANT_EVALUATED into its own header
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -48,7 +48,6 @@ _warningFlags = [
     # These warnings should be enabled in order to support the MSVC
     # team using the test suite; They enable the warnings below and
     # expect the test suite to be clean.
-    "-Wzero-length-array",
     "-Wsign-compare",
     "-Wunused-variable",
     "-Wunused-parameter",

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -48,6 +48,7 @@ _warningFlags = [
     # These warnings should be enabled in order to support the MSVC
     # team using the test suite; They enable the warnings below and
     # expect the test suite to be clean.
+    "-Wzero-length-array",
     "-Wsign-compare",
     "-Wunused-variable",
     "-Wunused-parameter",

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -39,7 +39,7 @@ _warningFlags = [
     "-Wno-literal-suffix",  # GCC
     "-Wno-user-defined-literals",  # Clang
     # GCC warns about this when TEST_IS_CONSTANT_EVALUATED is used on a non-constexpr
-    # function. (This mostely happens in C++11 mode.)
+    # function. (This mostly happens in C++11 mode.)
     # TODO(mordante) investigate a solution for this issue.
     "-Wno-tautological-compare",
     # -Wstringop-overread and -Wstringop-overflow seem to be a bit buggy currently


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL, where we use both MSVC's compiler and Clang/LLVM.

MSVC's compiler rejects the non-Standard extension of zero-length arrays. For conformance, I'm changing these occurrences to `std::array<int, 0>`.

Many of these files already had `#include <array>`; I'm adding it to the rest.

I wanted to add `-Wzero-length-array` to `libcxx/utils/libcxx/test/params.py` to prevent future occurrences, but it complained about product code :crying_cat_face: :

```
In file included from /home/runner/_work/llvm-project/llvm-project/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long.pass.cpp:18:
In file included from /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/istream:170:
In file included from /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/ostream:172:
In file included from /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__system_error/error_code.h:18:
In file included from /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__system_error/error_category.h:15:
/home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/string:811:25: error: zero size arrays are an extension [-Werror,-Wzero-length-array]
  811 |         char __padding_[sizeof(value_type) - 1];
      |                         ^~~~~~~~~~~~~~~~~~~~~~
/home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/string:817:19: note: in instantiation of member class 'std::basic_string<char>::__short' requested here
  817 |     static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
      |                   ^
/home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/string:2069:5: note: in instantiation of template class 'std::basic_string<char>' requested here
 2069 |     _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, char)
      |     ^
/home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__string/extern_template_lists.h:31:60: note: expanded from macro '_LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST'
   31 |   _Func(_LIBCPP_EXPORTED_FROM_ABI basic_string<_CharType>& basic_string<_CharType>::replace(size_type, size_type, value_type const*, size_type)) \
      |                                                            ^
```

I pushed a tiny commit to fix unrelated comment typos, in an attempt to clear out spurious CI failures.
