### PR TITLE
Change how libc++ specifies the runners to use.

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -50,8 +50,7 @@ env:
 jobs:
   stage1:
     if: github.repository_owner == 'llvm'
-    runs-on:
-      group: libcxx-runners-8
+    runs-on: libcxx-runners-8-set
     continue-on-error: false
     strategy:
       fail-fast: true
@@ -89,8 +88,7 @@ jobs:
             **/crash_diagnostics/*
   stage2:
     if: github.repository_owner == 'llvm'
-    runs-on:
-      group: libcxx-runners-8
+    runs-on: libcxx-runners-8-set
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -169,27 +167,26 @@ jobs:
           'benchmarks',
           'bootstrapping-build'
         ]
-        machine: [ 'libcxx-runners-8' ]
+        machine: [ 'libcxx-runners-8-set' ]
         std_modules: [ 'OFF' ]
         include:
         - config: 'generic-cxx26'
-          machine: libcxx-runners-8
+          machine: libcxx-runners-8-set
           std_modules: 'ON'
         - config: 'generic-asan'
-          machine: libcxx-runners-8
+          machine: libcxx-runners-8-set
           std_modules: 'OFF'
         - config: 'generic-tsan'
-          machine: libcxx-runners-8
+          machine: libcxx-runners-8-set
           std_modules: 'OFF'
         - config: 'generic-ubsan'
-          machine: libcxx-runners-8
+          machine: libcxx-runners-8-set
           std_modules: 'OFF'
         # Use a larger machine for MSAN to avoid timeout and memory allocation issues.
         - config: 'generic-msan'
-          machine: libcxx-runners-32
+          machine: libcxx-runners-32-set
           std_modules: 'OFF'
-    runs-on:
-      group: ${{ matrix.machine }}
+    runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.config }}


### PR DESCRIPTION
Github actions has some quirks with how you use runner groups, labels,
names, etc... One of them is that groups can't "group" more than one set
of builders. To do that, you use the same name. So now we're specifying
the name.
