### PR TITLE
[lldb] Fix build on NetBSD

### DIFF
--- a/lldb/source/Host/netbsd/HostNetBSD.cpp
+++ b/lldb/source/Host/netbsd/HostNetBSD.cpp
@@ -108,10 +108,11 @@ static bool GetNetBSDProcessCPUType(ProcessInstanceInfo &process_info) {
     auto buffer_sp = FileSystem::Instance().CreateDataBuffer(
         process_info.GetExecutableFile(), 0x20, 0);
     if (buffer_sp) {
-      uint8_t exe_class = llvm::object::getElfArchType(
-                              {reinterpret_cast<char *>(buffer_sp->GetBytes()),
-                               size_t(buffer_sp->GetByteSize())})
-                              .first;
+      uint8_t exe_class =
+          llvm::object::getElfArchType(
+              {reinterpret_cast<const char *>(buffer_sp->GetBytes()),
+               size_t(buffer_sp->GetByteSize())})
+              .first;
 
       switch (exe_class) {
       case llvm::ELF::ELFCLASS32:


### PR DESCRIPTION
```
lldb/source/Host/netbsd/HostNetBSD.cpp:112:32: error: reinterpret_cast from 'const uint8_t *' (aka 'const unsigned char *') to 'char *' casts away qualifiers
                              {reinterpret_cast<char *>(buffer_sp->GetBytes()),
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```