### PR TITLE
[libc++][test] disable all atomic<long double> tests

### DIFF
--- a/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -45,7 +45,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -45,7 +45,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
@@ -56,7 +56,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
@@ -56,7 +56,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp
@@ -220,7 +220,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
@@ -236,10 +236,8 @@ int main(int, char**) {
   test<float>();
   test<double>();
 
-// https://github.com/llvm/llvm-project/issues/47978
-#ifndef TEST_COMPILER_CLANG
-  test<long double>();
-#endif
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
@@ -68,7 +68,7 @@ void testBasic(MemoryOrder... memory_order) {
     assert(a.load() == T(1.2));
 
     // bug
-    // https://github.com/llvm/llvm-project/issues/47978
+    // TODO https://github.com/llvm/llvm-project/issues/47978
     if constexpr (!std::same_as<T, long double>) {
       assert(expected == T(1.2));
     }
@@ -236,7 +236,7 @@ int main(int, char**) {
   test<float>();
   test<double>();
 
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
@@ -56,7 +56,8 @@ constexpr void testOne() {
 constexpr bool test() {
   testOne<float>();
   testOne<double>();
-  testOne<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // testOne<long double>();
   return true;
 }
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
@@ -56,7 +56,7 @@ constexpr void testOne() {
 constexpr bool test() {
   testOne<float>();
   testOne<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // testOne<long double>();
   return true;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
@@ -69,7 +69,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: target={{x86_64-.*}} && tsan
-// XFAIL: target={{x86_64-.*}} && msan
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
@@ -72,7 +69,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -6,11 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: target={{x86_64-.*}} && tsan
-// Hangs with msan.
-// UNSUPPORTED: msan
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
@@ -114,7 +109,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -113,7 +113,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -10,6 +10,9 @@
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
+// https://github.com/llvm/llvm-project/issues/72893
+// XFAIL: target={{x86_64-.*}} && tsan
+
 // floating-point-type fetch_add(floating-point-type,
 //                               memory_order = memory_order::seq_cst) volatile noexcept;
 // floating-point-type fetch_add(floating-point-type,

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -6,11 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: target={{x86_64-.*}} && tsan
-// Hangs with msan.
-// UNSUPPORTED: msan
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
@@ -115,7 +110,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -10,6 +10,9 @@
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
+// https://github.com/llvm/llvm-project/issues/72893
+// XFAIL: target={{x86_64-.*}} && tsan
+
 // floating-point-type fetch_sub(floating-point-type,
 //                               memory_order = memory_order::seq_cst) volatile noexcept;
 // floating-point-type fetch_sub(floating-point-type,

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -114,7 +114,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: !has-64-bit-atomics
-// XFAIL: target={{x86_64-.*}} && tsan
 // UNSUPPORTED: !non-lockfree-atomics
 
 //  floating-point-type load(memory_order = memory_order::seq_cst) volatile noexcept;
@@ -134,7 +132,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
@@ -132,7 +132,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -55,7 +55,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -55,7 +55,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
@@ -93,7 +93,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
@@ -93,7 +93,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
@@ -77,7 +77,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
@@ -77,7 +77,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
@@ -52,7 +52,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
@@ -52,7 +52,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -7,10 +7,7 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: !has-64-bit-atomics
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // UNSUPPORTED: !non-lockfree-atomics
-// Hangs with msan.
-// UNSUPPORTED: msan
 
 // floating-point-type operator-=(floating-point-type) volatile noexcept;
 // floating-point-type operator-=(floating-point-type) noexcept;
@@ -98,7 +95,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -96,7 +96,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -96,7 +96,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -7,10 +7,7 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: !has-64-bit-atomics
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // UNSUPPORTED: !non-lockfree-atomics
-// Hangs with msan.
-// UNSUPPORTED: msan
 
 // floating-point-type operator+=(floating-point-type) volatile noexcept;
 // floating-point-type operator+=(floating-point-type) noexcept;
@@ -98,7 +95,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
@@ -107,7 +107,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: !has-64-bit-atomics
-// XFAIL: target={{x86_64-.*}} && tsan
 // UNSUPPORTED: !non-lockfree-atomics
 
 // void store(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
@@ -109,7 +107,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
@@ -117,7 +117,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://github.com/llvm/llvm-project/issues/47978
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
@@ -7,9 +7,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: availability-synchronization_library-missing
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: target={{x86_64-.*}} && tsan
-// XFAIL: target={{x86_64-.*}} && msan
 // XFAIL: !has-64-bit-atomics
 // UNSUPPORTED: !non-lockfree-atomics
 
@@ -120,7 +117,8 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  test<long double>();
+  // https://github.com/llvm/llvm-project/issues/47978
+  // test<long double>();
 
   return 0;
 }


### PR DESCRIPTION
fixes #73791