### PR TITLE
[RISCV] Simplify computation of VarArgsSaveSize. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
@@ -441,14 +441,14 @@ void RISCVCallLowering::saveVarArgRegisters(
   // Offset of the first variable argument from stack pointer, and size of
   // the vararg save area. For now, the varargs save area is either zero or
   // large enough to hold a0-a7.
-  int VaArgOffset, VarArgsSaveSize;
+  int VaArgOffset;
+  int VarArgsSaveSize = XLenInBytes * (ArgRegs.size() - Idx);
+
   // If all registers are allocated, then all varargs must be passed on the
   // stack and we don't need to save any argregs.
-  if (ArgRegs.size() == Idx) {
+  if (VarArgsSaveSize == 0) {
     VaArgOffset = Assigner.StackSize;
-    VarArgsSaveSize = 0;
   } else {
-    VarArgsSaveSize = XLenInBytes * (ArgRegs.size() - Idx);
     VaArgOffset = -VarArgsSaveSize;
   }
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -17694,15 +17694,14 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
     // Offset of the first variable argument from stack pointer, and size of
     // the vararg save area. For now, the varargs save area is either zero or
     // large enough to hold a0-a7.
-    int VaArgOffset, VarArgsSaveSize;
+    int VaArgOffset;
+    int VarArgsSaveSize = XLenInBytes * (ArgRegs.size() - Idx);
 
     // If all registers are allocated, then all varargs must be passed on the
     // stack and we don't need to save any argregs.
-    if (ArgRegs.size() == Idx) {
+    if (VarArgsSaveSize == 0) {
       VaArgOffset = CCInfo.getStackSize();
-      VarArgsSaveSize = 0;
     } else {
-      VarArgsSaveSize = XLenInBytes * (ArgRegs.size() - Idx);
       VaArgOffset = -VarArgsSaveSize;
     }
 


### PR DESCRIPTION
The computation we use for computing the size already returns 0 when all registers are allocated. We don't need an if to set it to 0.

Use the size being 0 to check for whether we need to spill registers or not.

I have another change I want to make to this code, but this change seemed to stand on its own. I left the curly braces since I need them for the other change.