### PR TITLE
[llvm-exegesis] Minor changes for downstream consumers

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -545,9 +545,10 @@ BenchmarkRunner::createFunctionExecutor(
   llvm_unreachable("ExecutionMode is outside expected range");
 }
 
-Expected<Benchmark> BenchmarkRunner::runConfiguration(
-    RunnableConfiguration &&RC,
-    const std::optional<StringRef> &DumpFile) const {
+Expected<Benchmark>
+BenchmarkRunner::runConfiguration(RunnableConfiguration &&RC,
+                                  const std::optional<StringRef> &DumpFile,
+                                  bool ErrorOnSnippetCrash /*= false*/) const {
   Benchmark &InstrBenchmark = RC.InstrBenchmark;
   object::OwningBinary<object::ObjectFile> &ObjectFile = RC.ObjectFile;
 

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -576,7 +576,7 @@ BenchmarkRunner::runConfiguration(RunnableConfiguration &&RC,
   auto NewMeasurements = runMeasurements(**Executor);
 
   if (Error E = NewMeasurements.takeError()) {
-    if (!E.isA<SnippetCrash>())
+    if (!E.isA<SnippetCrash>() || ErrorOnSnippetCrash)
       return std::move(E);
     InstrBenchmark.Error = toString(std::move(E));
     return std::move(InstrBenchmark);

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
@@ -65,9 +65,9 @@ public:
                            unsigned NumRepetitions, unsigned LoopUnrollFactor,
                            const SnippetRepetitor &Repetitor) const;
 
-  Expected<Benchmark>
-  runConfiguration(RunnableConfiguration &&RC,
-                   const std::optional<StringRef> &DumpFile) const;
+  Expected<Benchmark> runConfiguration(RunnableConfiguration &&RC,
+                                       const std::optional<StringRef> &DumpFile,
+                                       bool ErrorOnSnippetCrash = false) const;
 
   // Scratch space to run instructions that touch memory.
   struct ScratchSpace {

--- a/llvm/tools/llvm-exegesis/lib/Error.h
+++ b/llvm/tools/llvm-exegesis/lib/Error.h
@@ -52,6 +52,8 @@ public:
 
   std::error_code convertToErrorCode() const override;
 
+  intptr_t GetCrashAddress() const { return SIAddress; }
+
 private:
   std::string Msg;
   intptr_t SIAddress;


### PR DESCRIPTION
This patch adjust the runConfiguration function to allow passing a parameter to force returning SnippetCrashes as errors rather than serializing them as strings in the returned Benchmark object. In addition, this patch adds a getter for the signal information address in the SnippetCrash object.

These are both needed to allow for downstream consumption of the exegesis library within Gematria.