### PR TITLE
Fix dr2xx clang test

### DIFF
--- a/clang/test/CXX/drs/dr2xx.cpp
+++ b/clang/test/CXX/drs/dr2xx.cpp
@@ -1298,7 +1298,7 @@ namespace dr299 { // dr299: 2.8 c++11
   // cxx98-11-error@#dr299-q {{ambiguous conversion of array size expression of type 'T' to an integral or enumeration type}}
   //  cxx98-11-note@#dr299-int {{conversion to integral type 'int' declared here}}
   //  cxx98-11-note@#dr299-ushort {{conversion to integral type 'unsigned short' declared here}}
-  // since-cxx14-error-re@#dr299-q {{{{conversion from 'T' to 'unsigned (long|int)' is ambiguous}}}}
+  // since-cxx14-error-re@#dr299-q {{conversion from 'T' to 'unsigned {{(long|int)}}' is ambiguous}}
   //  since-cxx14-note@#dr299-int {{candidate function}}
   //  since-cxx14-note@#dr299-ushort {{candidate function}}
 }


### PR DESCRIPTION
Currently windows build fails with:

```
# | error: 'cxx98-14-error' diagnostics expected but not seen: 
# |   File C:\ws\src\clang\test\CXX\drs\dr2xx.cpp Line 1297 (directive at C:\ws\src\clang\test\CXX\drs\dr2xx.cpp:1301): {{conversion from 'T' to 'unsigned (long|int)' is ambiguous}}
# | error: 'cxx98-14-error' diagnostics seen but not expected: 
# |   File C:\ws\src\clang\test\CXX\drs\dr2xx.cpp Line 1297: conversion from 'T' to 'unsigned long long' is ambiguous
```

Looks like brackets are messy