### PR TITLE
[llvm-exegesis] Enable dummy perf counters in subprocess mode

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/dummy-perf-counters-subprocess.s
+++ b/llvm/test/tools/llvm-exegesis/X86/dummy-perf-counters-subprocess.s
@@ -1,7 +1,0 @@
-# REQUIRES: exegesis-can-measure-latency, x86_64-linux
-
-# RUN: not llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess -use-dummy-perf-counters 2>&1 | FileCheck %s
-
-# CHECK: llvm-exegesis error: Dummy perf counters are not supported in the subprocess execution mode.
-
-mov $0, %rax

--- a/llvm/test/tools/llvm-exegesis/X86/latency/dummy-perf-counters-subprocess.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/dummy-perf-counters-subprocess.s
@@ -1,0 +1,9 @@
+# REQUIRES: exegesis-can-execute-x86_64, x86_64-linux
+
+# RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mcpu=x86-64 -mode=latency -snippets-file=%s -execution-mode=subprocess --use-dummy-perf-counters | FileCheck %s
+
+# LLVM-EXEGESIS-DEFREG RAX 0
+
+movq $5, %rax
+
+# CHECK: measurements:   []

--- a/llvm/tools/llvm-exegesis/lib/Assembler.h
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.h
@@ -51,7 +51,7 @@ public:
   void addInstructions(ArrayRef<MCInst> Insts, const DebugLoc &DL = DebugLoc());
 
   void addReturn(const ExegesisTarget &ET, bool SubprocessCleanup,
-                 const DebugLoc &DL = DebugLoc());
+                 bool UseDummyPerfCounters, const DebugLoc &DL = DebugLoc());
 
   MachineFunction &MF;
   MachineBasicBlock *const MBB;
@@ -93,8 +93,8 @@ Error assembleToStream(const ExegesisTarget &ET,
                        ArrayRef<unsigned> LiveIns,
                        ArrayRef<RegisterValue> RegisterInitialValues,
                        const FillFunction &Fill, raw_pwrite_stream &AsmStreamm,
-                       const BenchmarkKey &Key,
-                       bool GenerateMemoryInstructions);
+                       const BenchmarkKey &Key, bool GenerateMemoryInstructions,
+                       bool UseDummyPerfCounters);
 
 // Creates an ObjectFile in the format understood by the host.
 // Note: the resulting object keeps a copy of Buffer so it can be discarded once

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -76,14 +76,16 @@ Expected<LLVMState> LLVMState::Create(std::string TripleName,
   const PfmCountersInfo &PCI = UseDummyPerfCounters
                                    ? ET->getDummyPfmCounters()
                                    : ET->getPfmCounters(CpuName);
-  return LLVMState(std::move(TM), ET, &PCI);
+  return LLVMState(std::move(TM), ET, &PCI, UseDummyPerfCounters);
 }
 
 LLVMState::LLVMState(std::unique_ptr<const TargetMachine> TM,
-                     const ExegesisTarget *ET, const PfmCountersInfo *PCI)
+                     const ExegesisTarget *ET, const PfmCountersInfo *PCI,
+                     bool UseDummyPerfCounters_)
     : TheExegesisTarget(ET), TheTargetMachine(std::move(TM)), PfmCounters(PCI),
       OpcodeNameToOpcodeIdxMapping(createOpcodeNameToOpcodeIdxMapping()),
-      RegNameToRegNoMapping(createRegNameToRegNoMapping()) {
+      RegNameToRegNoMapping(createRegNameToRegNoMapping()),
+      UseDummyPerfCounters(UseDummyPerfCounters_) {
   BitVector ReservedRegs = getFunctionReservedRegs(getTargetMachine());
   for (const unsigned Reg : TheExegesisTarget->getUnavailableRegisters())
     ReservedRegs.set(Reg);

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.h
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.h
@@ -80,6 +80,8 @@ public:
     return *RegNameToRegNoMapping;
   }
 
+  bool usingDummyPerfCounters() const { return UseDummyPerfCounters; }
+
 private:
   std::unique_ptr<const DenseMap<StringRef, unsigned>>
   createOpcodeNameToOpcodeIdxMapping() const;
@@ -88,7 +90,7 @@ private:
   createRegNameToRegNoMapping() const;
 
   LLVMState(std::unique_ptr<const TargetMachine> TM, const ExegesisTarget *ET,
-            const PfmCountersInfo *PCI);
+            const PfmCountersInfo *PCI, bool UseDummyPerfCounters_);
 
   const ExegesisTarget *TheExegesisTarget;
   std::unique_ptr<const TargetMachine> TheTargetMachine;
@@ -98,6 +100,8 @@ private:
   std::unique_ptr<const DenseMap<StringRef, unsigned>>
       OpcodeNameToOpcodeIdxMapping;
   std::unique_ptr<const DenseMap<StringRef, unsigned>> RegNameToRegNoMapping;
+
+  const bool UseDummyPerfCounters;
 };
 
 } // namespace exegesis

--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -38,7 +38,8 @@ public:
           Entry.addInstruction(Instructions[I % Instructions.size()]);
         }
       }
-      Entry.addReturn(State.getExegesisTarget(), CleanupMemory);
+      Entry.addReturn(State.getExegesisTarget(), CleanupMemory,
+                      State.usingDummyPerfCounters());
     };
   }
 
@@ -70,7 +71,8 @@ public:
         const MCInstrDesc &MCID = Filler.MCII->get(Opcode);
         if (!MCID.isTerminator())
           continue;
-        Entry.addReturn(State.getExegesisTarget(), CleanupMemory);
+        Entry.addReturn(State.getExegesisTarget(), CleanupMemory,
+                        State.usingDummyPerfCounters());
         return;
       }
 
@@ -115,7 +117,8 @@ public:
 
       // Set up the exit basic block.
       Loop.MBB->addSuccessor(Exit.MBB, BranchProbability::getZero());
-      Exit.addReturn(State.getExegesisTarget(), CleanupMemory);
+      Exit.addReturn(State.getExegesisTarget(), CleanupMemory,
+                     State.usingDummyPerfCounters());
     };
   }
 

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -477,11 +477,6 @@ void benchmarkMain() {
   if (BenchmarkPhaseSelector == BenchmarkPhaseSelectorE::Measure)
     ExitOnErr(State.getExegesisTarget().checkFeatureSupport());
 
-  if (ExecutionMode == BenchmarkRunner::ExecutionModeE::SubProcess &&
-      UseDummyPerfCounters)
-    ExitWithError("Dummy perf counters are not supported in the subprocess "
-                  "execution mode.");
-
   const std::unique_ptr<BenchmarkRunner> Runner =
       ExitOnErr(State.getExegesisTarget().createBenchmarkRunner(
           BenchmarkMode, State, BenchmarkPhaseSelector, ExecutionMode,

--- a/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
+++ b/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
@@ -82,7 +82,7 @@ private:
     Key.RegisterInitialValues = RegisterInitialValues;
     EXPECT_FALSE(assembleToStream(*ET, createTargetMachine(), /*LiveIns=*/{},
                                   RegisterInitialValues, Fill, AsmStream, Key,
-                                  false));
+                                  false, false));
     Expected<ExecutableFunction> ExecFunc = ExecutableFunction::create(
         createTargetMachine(), getObjectFromBuffer(AsmStream.str()));
 


### PR DESCRIPTION
This patch enables the usage of dummy perf counters in the subprocess execution mode. This allows for users without libpfm installed/without access to performance counters to still use the subprocess execution mode to test the execution of snippets. This enables use cases like deriving memory annotations inside a virtual machine where performance counters will not be present.