### PR TITLE
[clang-format] Remove duplicates in @property using std::set

### DIFF
--- a/clang/lib/Format/ObjCPropertyAttributeOrderFixer.cpp
+++ b/clang/lib/Format/ObjCPropertyAttributeOrderFixer.cpp
@@ -30,8 +30,8 @@ ObjCPropertyAttributeOrderFixer::ObjCPropertyAttributeOrderFixer(
 }
 
 struct ObjCPropertyEntry {
-  StringRef Attribute; // eg, "readwrite"
-  StringRef Value;     // eg, the "foo" of the attribute "getter=foo"
+  StringRef Attribute; // eg, `readwrite`
+  StringRef Value;     // eg, the `foo` of the attribute `getter=foo`
 };
 
 void ObjCPropertyAttributeOrderFixer::sortPropertyAttributes(
@@ -90,7 +90,7 @@ void ObjCPropertyAttributeOrderFixer::sortPropertyAttributes(
     if (It == SortOrderMap.end())
       It = SortOrderMap.insert({Attribute, SortOrderMap.size()}).first;
 
-    // Sort the indices based on the priority stored in 'SortOrderMap'.
+    // Sort the indices based on the priority stored in `SortOrderMap`.
     const auto Ordinal = It->second;
     if (!Ordinals.insert(Ordinal).second) {
       HasDuplicates = true;

--- a/clang/lib/Format/ObjCPropertyAttributeOrderFixer.h
+++ b/clang/lib/Format/ObjCPropertyAttributeOrderFixer.h
@@ -28,12 +28,12 @@ class ObjCPropertyAttributeOrderFixer : public TokenAnalyzer {
   void analyzeObjCPropertyDecl(const SourceManager &SourceMgr,
                                const AdditionalKeywords &Keywords,
                                tooling::Replacements &Fixes,
-                               const FormatToken *Tok) const;
+                               const FormatToken *Tok);
 
   void sortPropertyAttributes(const SourceManager &SourceMgr,
                               tooling::Replacements &Fixes,
                               const FormatToken *BeginTok,
-                              const FormatToken *EndTok) const;
+                              const FormatToken *EndTok);
 
   std::pair<tooling::Replacements, unsigned>
   analyze(TokenAnnotator &Annotator,

--- a/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
+++ b/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
@@ -171,18 +171,18 @@ TEST_F(ObjCPropertyAttributeOrderFixerTest, HandlesDuplicatedAttributes) {
   Style.ObjCPropertyAttributeOrder = {"a", "b", "c"};
 
   // Just a dup and nothing else.
-  verifyFormat("@property(a, a) int p;", Style);
+  verifyFormat("@property(a) int p;", "@property(a, a) int p;", Style);
 
   // A dup and something else.
-  verifyFormat("@property(a, a, b) int p;", "@property(a, b, a) int p;", Style);
+  verifyFormat("@property(a, b) int p;", "@property(a, b, a) int p;", Style);
 
   // Duplicates using `=`: stable-sort irrespective of their value.
-  verifyFormat("@property(a=A, a=A, b=X, b=Y) int p;",
+  verifyFormat("@property(a=A, b=X) int p;",
                "@property(a=A, b=X, a=A, b=Y) int p;", Style);
-  verifyFormat("@property(a=A, a=A, b=Y, b=X) int p;",
+  verifyFormat("@property(a=A, b=Y) int p;",
                "@property(a=A, b=Y, a=A, b=X) int p;", Style);
-  verifyFormat("@property(a, a=A, b=B, b) int p;",
-               "@property(a, b=B, a=A, b) int p;", Style);
+  verifyFormat("@property(a, b=B) int p;", "@property(a, b=B, a=A, b) int p;",
+               Style);
 }
 
 TEST_F(ObjCPropertyAttributeOrderFixerTest, SortsInPPDirective) {

--- a/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
+++ b/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
@@ -176,7 +176,7 @@ TEST_F(ObjCPropertyAttributeOrderFixerTest, HandlesDuplicatedAttributes) {
   // A dup and something else.
   verifyFormat("@property(a, b) int p;", "@property(a, b, a) int p;", Style);
 
-  // Duplicates using `=`: stable-sort irrespective of their value.
+  // Duplicates using `=`.
   verifyFormat("@property(a=A, b=X) int p;",
                "@property(a=A, b=X, a=A, b=Y) int p;", Style);
   verifyFormat("@property(a=A, b=Y) int p;",
@@ -200,7 +200,7 @@ TEST_F(ObjCPropertyAttributeOrderFixerTest, SortsInPPDirective) {
 }
 
 TEST_F(ObjCPropertyAttributeOrderFixerTest, HandlesAllAttributes) {
-  // 'class' is the only attribute that is a keyword, so make sure it works too.
+  // `class` is the only attribute that is a keyword, so make sure it works too.
   FormatStyle Style = getLLVMStyle();
   Style.Language = FormatStyle::LK_ObjC;
   Style.ObjCPropertyAttributeOrder = {"FIRST",
@@ -282,7 +282,7 @@ TEST_F(ObjCPropertyAttributeOrderFixerTest, HandlesAllAttributes) {
   verifyFormat("@property(FIRST, null_resettable, LAST) int p;", Style);
   verifyFormat("@property(FIRST, null_unspecified, LAST) int p;", Style);
 
-  // Reorder: put 'FIRST' and/or 'LAST' in the wrong spot.
+  // Reorder: put `FIRST` and/or `LAST` in the wrong spot.
   verifyFormat("@property(class, LAST) int p;", "@property(LAST, class) int p;",
                Style);
   verifyFormat("@property(direct, LAST) int p;",


### PR DESCRIPTION
Re-implement ObjCPropertyAttributeOrder using std::set for sorting and removing duplicates. (We can't use llvm::SmallSet because it's unordered.)