### PR TITLE
[mlir][python] allow upstream dialect registration

### DIFF
--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -40,9 +40,6 @@ add_mlir_python_common_capi_library(StandalonePythonCAPI
   RELATIVE_INSTALL_ROOT "../../../.."
   DECLARED_SOURCES
     StandalonePythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources.Core
 )
 
@@ -55,9 +52,6 @@ add_mlir_python_modules(StandalonePythonModules
   INSTALL_PREFIX "python_packages/standalone/mlir_standalone"
   DECLARED_SOURCES
     StandalonePythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources
   COMMON_CAPI_LINK_LIBS
     StandalonePythonCAPI

--- a/mlir/examples/standalone/test/python/smoketest.py
+++ b/mlir/examples/standalone/test/python/smoketest.py
@@ -3,6 +3,8 @@
 from mlir_standalone.ir import *
 from mlir_standalone.dialects import builtin as builtin_d, standalone as standalone_d
 
+add_dialect_to_dialect_registry(get_dialect_registry(), "arith")
+
 with Context():
     standalone_d.register_dialect()
     module = Module.parse(

--- a/mlir/include/mlir-c/Dialect/RemainingDialects.h
+++ b/mlir/include/mlir-c/Dialect/RemainingDialects.h
@@ -1,0 +1,41 @@
+#ifndef MLIR_C_REMAINING_DIALECTS_H
+#define MLIR_C_REMAINING_DIALECTS_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_(NAMESPACE)                      \
+  MLIR_CAPI_EXPORTED MlirDialectHandle mlirGetDialectHandle__##NAMESPACE##__();
+
+#define FORALL_DIALECTS(_)                                                     \
+  _(acc)                                                                       \
+  _(affine)                                                                    \
+  _(amx)                                                                       \
+  _(arm_neon)                                                                  \
+  _(arm_sme)                                                                   \
+  _(arm_sve)                                                                   \
+  _(bufferization)                                                             \
+  _(complex)                                                                   \
+  _(dlti)                                                                      \
+  _(emitc)                                                                     \
+  _(index)                                                                     \
+  _(irdl)                                                                      \
+  _(mesh)                                                                      \
+  _(spirv)                                                                     \
+  _(tosa)                                                                      \
+  _(ub)                                                                        \
+  _(x86vector)
+
+FORALL_DIALECTS(MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_)
+
+#undef MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_
+#undef FORALL_DIALECTS
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_REMAINING_DIALECTS_H

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -224,3 +224,14 @@ add_mlir_upstream_c_api_library(MLIRCAPIVector
   MLIRCAPIIR
   MLIRVectorDialect
 )
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_mlir_upstream_c_api_library(MLIRCAPIRemainingDialects
+  RemainingDialects.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  ${dialect_libs}
+)

--- a/mlir/lib/CAPI/Dialect/RemainingDialects.cpp
+++ b/mlir/lib/CAPI/Dialect/RemainingDialects.cpp
@@ -1,0 +1,53 @@
+#include "mlir-c/Dialect/RemainingDialects.h"
+
+#include "mlir/CAPI/Registration.h"
+#include "mlir/InitAllDialects.h"
+
+using namespace mlir;
+
+#define MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_(NAMESPACE, NAME)                \
+  MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(NAME, NAMESPACE,                       \
+                                        NAMESPACE::NAME##Dialect)
+
+#define FORALL_DIALECTS(_)                                                     \
+  _(acc, OpenACC)                                                              \
+  _(affine, Affine)                                                            \
+  _(amx, AMX)                                                                  \
+  _(arith, Arith)                                                              \
+  _(arm_neon, ArmNeon)                                                         \
+  _(arm_sme, ArmSME)                                                           \
+  _(arm_sve, ArmSVE)                                                           \
+  _(bufferization, Bufferization)                                              \
+  _(complex, Complex)                                                          \
+  _(emitc, EmitC)                                                              \
+  _(index, Index)                                                              \
+  _(irdl, IRDL)                                                                \
+  _(mesh, Mesh)                                                                \
+  _(spirv, SPIRV)                                                              \
+  _(tosa, Tosa)                                                                \
+  _(ub, UB)                                                                    \
+  _(x86vector, X86Vector)
+
+FORALL_DIALECTS(MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_)
+
+#undef MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_
+#undef FORALL_DIALECTS
+
+static void mlirDialectRegistryInsertDLTIDialect(MlirDialectRegistry registry) {
+  unwrap(registry)->insert<mlir::DLTIDialect>();
+}
+
+static MlirDialect mlirContextLoadDLTIDialect(MlirContext context) {
+  return wrap(unwrap(context)->getOrLoadDialect<mlir::DLTIDialect>());
+}
+
+static MlirStringRef mlirDLTIDialectGetNamespace() {
+  return wrap(mlir::DLTIDialect::getDialectNamespace());
+}
+
+MlirDialectHandle mlirGetDialectHandle__dlti__() {
+  static MlirDialectRegistrationHooks hooks = {
+      mlirDialectRegistryInsertDLTIDialect, mlirContextLoadDLTIDialect,
+      mlirDLTIDialectGetNamespace};
+  return MlirDialectHandle{&hooks};
+}

--- a/mlir/lib/CAPI/RegisterEverything/RegisterEverything.cpp
+++ b/mlir/lib/CAPI/RegisterEverything/RegisterEverything.cpp
@@ -14,8 +14,6 @@
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Target/LLVMIR/Dialect/All.h"
-#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 
 void mlirRegisterAllDialects(MlirDialectRegistry registry) {
   mlir::registerAllDialects(*unwrap(registry));

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -423,7 +423,30 @@ declare_mlir_python_extension(MLIRPythonExtension.Core
     MLIRCAPIInterfaces
 
     # Dialects
+    MLIRCAPIAMDGPU
+    MLIRCAPIArith
+    MLIRCAPIAsync
+    MLIRCAPIControlFlow
     MLIRCAPIFunc
+    MLIRCAPIGPU
+    MLIRCAPILLVM
+    MLIRCAPILinalg
+    MLIRCAPIMLProgram
+    MLIRCAPIMath
+    MLIRCAPIMemRef
+    MLIRCAPINVGPU
+    MLIRCAPINVVM
+    MLIRCAPIOpenMP
+    MLIRCAPIPDL
+    MLIRCAPIQuant
+    MLIRCAPIROCDL
+    MLIRCAPISCF
+    MLIRCAPIShape
+    MLIRCAPISparseTensor
+    MLIRCAPITensor
+    MLIRCAPITransformDialect
+    MLIRCAPIVector
+    MLIRCAPIRemainingDialects
 )
 
 # This extension exposes an API to register all dialects, extensions, and passes

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -4,7 +4,11 @@
 
 from ._mlir_libs._mlir.ir import *
 from ._mlir_libs._mlir.ir import _GlobalDebug
-from ._mlir_libs._mlir import register_type_caster, register_value_caster
+from ._mlir_libs._mlir import (
+    register_type_caster,
+    register_value_caster,
+    add_dialect_to_dialect_registry,
+)
 from ._mlir_libs import get_dialect_registry
 
 


### PR DESCRIPTION
This (currently just a sketch) PR allows users that **do not** build the `MLIRPythonExtension.RegisterEverything` target to still register upstream dialects from Python (discussed in https://github.com/llvm/llvm-project/issues/74245). It uses the `get_dialect_registry` API introduced in https://github.com/llvm/llvm-project/pull/72488 and adds/exposes `MlirDialectHandle`s for all upstream dialects (i.e., fills in those that weren't already generating).

Right now the API is lame - pass a string that's associated with the dialect (the dialect namespace) and the `MlirDialectHandle` is fetched/gotten/materialized internally (by calling the appropriate C API). Ignoring whether we should keep it like this, the basic idea is captured in the `m.def`:

```cpp
  m.def(
      "add_dialect_to_dialect_registry",
      [](MlirDialectRegistry registry, const std::string &dialectNamespace) {

#define MLIR_DEFINE_CAPI_DIALECT_REGISTRATION_(NAMESPACE)                      \
  if (dialectNamespace == #NAMESPACE) {                                        \
    mlirDialectHandleInsertDialect(mlirGetDialectHandle__##NAMESPACE##__(),    \
                                   registry);                                  \
    return;                                                                    \
  }
```

where (currently!) the user would do `ir.add_dialect_to_dialect_registry(get_dialect_registry(), "arith")` and achieve the desired effect i.e., the next `ir.Context()` will include the arith dialect in its dialect registry. At least I believe that's the desired effect (gleaned from https://github.com/llvm/llvm-project/issues/74245). So before I do more manicuring on the API I just want to make sure this is what everyone wants. 

~~Also I'm not sure how to test this upstream because it's not like I can turn off `MLIRPythonExtension.RegisterEverything` for the core bindings. There is the `Standalone` example that conveniently a TODO about [moving to finer grained registration](https://github.com/llvm/llvm-project/blob/5e83a5b4752da6631d79c446f21e5d128b5c5495/mlir/examples/standalone/python/CMakeLists.txt#L43) so maybe now is the time to check off that TODO?~~

This is now tested by removing `MLIRPythonExtension.RegisterEverything` from the standalone example and calling `add_dialect_to_dialect_registry(get_dialect_registry(), "arith")` explicitly (the smoketest has a module with an `arith` op in it).

cc @hawkinsp 