### PR TITLE
[libc++][test] Fix more MSVC warnings

### DIFF
--- a/libcxx/test/std/input.output/string.streams/stringbuf/stringbuf.assign/member_swap_noexcept.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/stringbuf/stringbuf.assign/member_swap_noexcept.pass.cpp
@@ -27,7 +27,7 @@ struct test_alloc {
   using value_type = T;
 
   [[nodiscard]] constexpr T* allocate(std::size_t) { return nullptr; }
-  void deallocate(void*, unsigned) {}
+  void deallocate(void*, std::size_t) {}
 };
 
 template <class T>

--- a/libcxx/test/std/input.output/string.streams/stringbuf/stringbuf.assign/nonmember_swap_noexcept.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/stringbuf/stringbuf.assign/nonmember_swap_noexcept.pass.cpp
@@ -26,7 +26,7 @@ struct test_alloc {
   using value_type = T;
 
   [[nodiscard]] constexpr T* allocate(std::size_t) { return nullptr; }
-  void deallocate(void*, unsigned) {}
+  void deallocate(void*, std::size_t) {}
 };
 
 template <class T>

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
@@ -59,7 +59,7 @@ struct WithNonCopyableIterator : std::ranges::view_base {
     iterator(iterator&&);
     iterator& operator=(iterator&&);
     XYPoint& operator*() const;
-    iterator operator->() const;
+    XYPoint* operator->() const;
     iterator& operator++();
     iterator operator++(int);
 

--- a/libcxx/test/std/ranges/range.factories/range.repeat.view/size.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.repeat.view/size.pass.cpp
@@ -31,8 +31,9 @@ constexpr bool test() {
   }
 
   {
-    std::ranges::repeat_view<int, int> rv(10, std::numeric_limits<int>::max());
-    assert(rv.size() == std::numeric_limits<int>::max());
+    constexpr int int_max = std::numeric_limits<int>::max();
+    std::ranges::repeat_view<int, int> rv(10, int_max);
+    assert(rv.size() == int_max);
   }
 
   return true;


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

* Fix MSVC "warning C4285: return type for '`WithNonCopyableIterator::iterator::operator ->`' is recursive if applied using infix notation".
  + This warning is valid - the return type is super squirrelly :chipmunk: - even though the operator is never defined. This test doesn't care about this return type, and it appears to have been a simple typo. Changing it to `XYPoint*`, like `WithArrowOperator` immediately above, fixes the warning.
* Fix MSVC "warning C4389: '`==`': signed/unsigned mismatch".
  + This warning is valid-ish. MSVC is seeing a `repeat_view`'s `size()` being compared with the `int` return value of a function, and a negative value would undergo a value-modifying conversion, so it warns. This happens because MSVC is *exceptionally* lazy about `constexpr` function calls, so it's calling `std::numeric_limits<int>::max()` at runtime and doesn't realize that it's a positive constant. By extracting this into a `constexpr` variable, MSVC is satisfied that `int_max` will undergo a value-preserving conversion. This costs an extra line but slightly reduces the repetition of `std::numeric_limits<int>::max()` so I hope it's acceptable.
* Fix MSVC "warning C4244: 'argument': conversion from '`unsigned __int64`' to '`unsigned int`', possible loss of data".
  + An allocator's `deallocate()` should be able to take its size type. In these tests, MSVC is instantiating enough of the allocator machinery to emit this warning. These test allocators weren't intentionally trying to make `deallocate()` have a weird parameter type - these tests are interested in POCS etc. and the `allocate()`/`deallocate()` are just stubs.
