### PR TITLE
[libc] Add the missing math_extras.h include

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -189,6 +189,7 @@ add_header_library(
     integer_utils.h
   DEPENDS
     .bit
+    .math_extras
     .number_pair
     libc.src.__support.common
     libc.src.__support.CPP.type_traits

--- a/libc/src/__support/integer_utils.h
+++ b/libc/src/__support/integer_utils.h
@@ -13,6 +13,7 @@
 #include "src/__support/common.h"
 
 #include "bit.h"
+#include "math_extras.h"
 #include "number_pair.h"
 
 #include <stdint.h>


### PR DESCRIPTION
math_extras.h is used in integer_utils.h when building for 32-bit platforms but the include is missing.