### PR TITLE
[libc++] Update `<source_location>` and `msvc_stdlib_force_include.h`

### DIFF
--- a/libcxx/include/source_location
+++ b/libcxx/include/source_location
@@ -35,8 +35,7 @@ namespace std {
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20 && __has_builtin(__builtin_source_location) &&                                               \
-    !(defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER <= 1403)
+#if _LIBCPP_STD_VER >= 20
 
 class source_location {
   // The names source_location::__impl, _M_file_name, _M_function_name, _M_line, and _M_column
@@ -79,8 +78,7 @@ public:
   }
 };
 
-#endif // _LIBCPP_STD_VER >= 20 && __has_builtin(__builtin_source_location) && !(defined(_LIBCPP_APPLE_CLANG_VER) &&
-       // _LIBCPP_APPLE_CLANG_VER <= 1403)
+#endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/version
+++ b/libcxx/include/version
@@ -414,9 +414,7 @@ __cpp_lib_within_lifetime                               202306L <type_traits>
 # define __cpp_lib_shared_ptr_arrays                    201707L
 # define __cpp_lib_shift                                201806L
 // # define __cpp_lib_smart_ptr_for_overwrite              202002L
-# if __has_builtin(__builtin_source_location) && !(defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER <= 1403)
-#   define __cpp_lib_source_location                    201907L
-# endif
+# define __cpp_lib_source_location                      201907L
 # define __cpp_lib_span                                 202002L
 # define __cpp_lib_ssize                                201902L
 # define __cpp_lib_starts_ends_with                     201711L

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/source_location.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/source_location.version.compile.pass.cpp
@@ -42,47 +42,29 @@
 
 #elif TEST_STD_VER == 20
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++20"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++20"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++20"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++20"
 # endif
 
 #elif TEST_STD_VER == 23
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++23"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++23"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++23"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++23"
 # endif
 
 #elif TEST_STD_VER > 23
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++26"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++26"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++26"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++26"
 # endif
 
 #endif // TEST_STD_VER > 23

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
@@ -4015,17 +4015,11 @@
 #   error "__cpp_lib_smart_ptr_owner_equality should not be defined before c++26"
 # endif
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++20"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++20"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++20"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++20"
 # endif
 
 # ifndef __cpp_lib_span
@@ -5539,17 +5533,11 @@
 #   error "__cpp_lib_smart_ptr_owner_equality should not be defined before c++26"
 # endif
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++23"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++23"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++23"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++23"
 # endif
 
 # ifndef __cpp_lib_span
@@ -7282,17 +7270,11 @@
 #   endif
 # endif
 
-# if __has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)
-#   ifndef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should be defined in c++26"
-#   endif
-#   if __cpp_lib_source_location != 201907L
-#     error "__cpp_lib_source_location should have the value 201907L in c++26"
-#   endif
-# else
-#   ifdef __cpp_lib_source_location
-#     error "__cpp_lib_source_location should not be defined when the requirement '__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)' is not met!"
-#   endif
+# ifndef __cpp_lib_source_location
+#   error "__cpp_lib_source_location should be defined in c++26"
+# endif
+# if __cpp_lib_source_location != 201907L
+#   error "__cpp_lib_source_location should have the value 201907L in c++26"
 # endif
 
 # ifndef __cpp_lib_span

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -13,38 +13,38 @@
 // MSVC standard library.
 
 #ifndef _LIBCXX_IN_DEVCRT
-    // Silence warnings about CRT machinery.
-    #define _CRT_SECURE_NO_WARNINGS 1
+// Silence warnings about CRT machinery.
+#  define _CRT_SECURE_NO_WARNINGS 1
 
-    // Avoid assertion dialogs.
-    #define _CRT_SECURE_INVALID_PARAMETER(EXPR) ::abort()
+// Avoid assertion dialogs.
+#  define _CRT_SECURE_INVALID_PARAMETER(EXPR) ::abort()
 
-    // Declare POSIX function names. (By default, Clang -fno-ms-compatibility causes them to be omitted.)
-    #define _CRT_DECLARE_NONSTDC_NAMES 1
+// Declare POSIX function names. (By default, Clang -fno-ms-compatibility causes them to be omitted.)
+#  define _CRT_DECLARE_NONSTDC_NAMES 1
 
-    // Silence warnings about POSIX function names.
-    #define _CRT_NONSTDC_NO_WARNINGS 1
+// Silence warnings about POSIX function names.
+#  define _CRT_NONSTDC_NO_WARNINGS 1
 
-    // Avoid Windows.h macroizing min() and max().
-    #define NOMINMAX 1
+// Avoid Windows.h macroizing min() and max().
+#  define NOMINMAX 1
 #endif // _LIBCXX_IN_DEVCRT
 
 #include <crtdbg.h>
 #include <stdlib.h>
 
 #if defined(_LIBCPP_VERSION)
-    #error This header may not be used when targeting libc++
+#  error This header may not be used when targeting libc++
 #endif
 
 #ifndef _LIBCXX_IN_DEVCRT
 struct AssertionDialogAvoider {
-    AssertionDialogAvoider() {
-        _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-        _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+  AssertionDialogAvoider() {
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 
-        _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-        _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
-    }
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  }
 };
 
 const AssertionDialogAvoider assertion_dialog_avoider{};
@@ -52,72 +52,67 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 
 // MSVC frontend only configurations
 #if !defined(__clang__)
-    // Simulate feature-test macros.
-    #define __has_feature(X) _MSVC_HAS_FEATURE_ ## X
-    #define _MSVC_HAS_FEATURE_cxx_exceptions      1
-    #define _MSVC_HAS_FEATURE_cxx_rtti            1
-    #define _MSVC_HAS_FEATURE_address_sanitizer   0
-    #define _MSVC_HAS_FEATURE_hwaddress_sanitizer 0
-    #define _MSVC_HAS_FEATURE_memory_sanitizer    0
-    #define _MSVC_HAS_FEATURE_thread_sanitizer    0
+// Simulate feature-test macros.
+#  define __has_feature(X) _MSVC_HAS_FEATURE_##X
+#  define _MSVC_HAS_FEATURE_cxx_exceptions 1
+#  define _MSVC_HAS_FEATURE_cxx_rtti 1
+#  define _MSVC_HAS_FEATURE_address_sanitizer 0
+#  define _MSVC_HAS_FEATURE_hwaddress_sanitizer 0
+#  define _MSVC_HAS_FEATURE_memory_sanitizer 0
+#  define _MSVC_HAS_FEATURE_thread_sanitizer 0
 
-    #define __has_attribute(X) _MSVC_HAS_ATTRIBUTE_ ## X
-    #define _MSVC_HAS_ATTRIBUTE_vector_size     0
+#  define __has_attribute(X) _MSVC_HAS_ATTRIBUTE_##X
+#  define _MSVC_HAS_ATTRIBUTE_vector_size 0
 
-    #define __has_builtin(X) _MSVC_HAS_BUILTIN_ ## X
-    #define _MSVC_HAS_BUILTIN___builtin_source_location 1
+#  define __has_builtin(X) _MSVC_HAS_BUILTIN_##X
+#  define _MSVC_HAS_BUILTIN___builtin_source_location 1
 
-    // Silence compiler warnings.
-    #pragma warning(disable: 4180) // qualifier applied to function type has no meaning; ignored
-    #pragma warning(disable: 4324) // structure was padded due to alignment specifier
-    #pragma warning(disable: 4521) // multiple copy constructors specified
-    #pragma warning(disable: 4702) // unreachable code
-    #pragma warning(disable: 28251) // Inconsistent annotation for 'new': this instance has no annotations.
-#endif // !defined(__clang__)
+// Silence compiler warnings.
+#  pragma warning(disable : 4180)  // qualifier applied to function type has no meaning; ignored
+#  pragma warning(disable : 4324)  // structure was padded due to alignment specifier
+#  pragma warning(disable : 4521)  // multiple copy constructors specified
+#  pragma warning(disable : 4702)  // unreachable code
+#  pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
+#endif                             // !defined(__clang__)
 
 #ifndef _LIBCXX_IN_DEVCRT
-    // atomic_is_lock_free.pass.cpp needs this VS 2015 Update 2 fix.
-    #define _ENABLE_ATOMIC_ALIGNMENT_FIX
+// atomic_is_lock_free.pass.cpp needs this VS 2015 Update 2 fix.
+#  define _ENABLE_ATOMIC_ALIGNMENT_FIX
 
-    // Restore features that are removed in C++20.
-    #define _HAS_FEATURES_REMOVED_IN_CXX20 1
+// Restore features that are removed in C++20.
+#  define _HAS_FEATURES_REMOVED_IN_CXX20 1
 
-    // Silence warnings about the unspecified complex<non-floating-point>
-    #define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
+// Silence warnings about the unspecified complex<non-floating-point>
+#  define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
 
-    // Silence warnings about features that are deprecated in non-default language modes.
-    #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-    #define _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS
-    #define _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS
+// Silence warnings about features that are deprecated in non-default language modes.
+#  define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#  define _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS
+#  define _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS
 #endif // _LIBCXX_IN_DEVCRT
 
 #include <version>
 
 #if _HAS_CXX23
-    #define TEST_STD_VER 99
+#  define TEST_STD_VER 99
 #elif _HAS_CXX20
-    #define TEST_STD_VER 20
+#  define TEST_STD_VER 20
 #elif _HAS_CXX17
-    #define TEST_STD_VER 17
+#  define TEST_STD_VER 17
 #else
-    #define TEST_STD_VER 14
+#  define TEST_STD_VER 14
 #endif
 
 #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
 
 #ifdef __clang__
-#define _LIBCPP_SUPPRESS_DEPRECATED_PUSH \
-    _Pragma("GCC diagnostic push") \
-    _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
-#define _LIBCPP_SUPPRESS_DEPRECATED_POP \
-    _Pragma("GCC diagnostic pop")
+#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
+#  define _LIBCPP_SUPPRESS_DEPRECATED_POP _Pragma("GCC diagnostic pop")
 #else // ^^^ clang / MSVC vvv
-#define _LIBCPP_SUPPRESS_DEPRECATED_PUSH \
-    __pragma(warning(push)) \
-    __pragma(warning(disable : 4996)) \
-    __pragma(warning(disable : 5215))
-#define _LIBCPP_SUPPRESS_DEPRECATED_POP \
-    __pragma(warning(pop))
+#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
+    __pragma(warning(push)) __pragma(warning(disable : 4996)) __pragma(warning(disable : 5215))
+#  define _LIBCPP_SUPPRESS_DEPRECATED_POP __pragma(warning(pop))
 #endif // __clang__
 
 #endif // SUPPORT_MSVC_STDLIB_FORCE_INCLUDE_H

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -18,6 +18,15 @@
 
     // Avoid assertion dialogs.
     #define _CRT_SECURE_INVALID_PARAMETER(EXPR) ::abort()
+
+    // Declare POSIX function names. (By default, Clang -fno-ms-compatibility causes them to be omitted.)
+    #define _CRT_DECLARE_NONSTDC_NAMES 1
+
+    // Silence warnings about POSIX function names.
+    #define _CRT_NONSTDC_NO_WARNINGS 1
+
+    // Avoid Windows.h macroizing min() and max().
+    #define NOMINMAX 1
 #endif // _LIBCXX_IN_DEVCRT
 
 #include <crtdbg.h>

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -64,9 +64,6 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 #  define __has_attribute(X) _MSVC_HAS_ATTRIBUTE_##X
 #  define _MSVC_HAS_ATTRIBUTE_vector_size 0
 
-#  define __has_builtin(X) _MSVC_HAS_BUILTIN_##X
-#  define _MSVC_HAS_BUILTIN___builtin_source_location 1
-
 // Silence compiler warnings.
 #  pragma warning(disable : 4180)  // qualifier applied to function type has no meaning; ignored
 #  pragma warning(disable : 4324)  // structure was padded due to alignment specifier

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -54,14 +54,18 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 #if !defined(__clang__)
     // Simulate feature-test macros.
     #define __has_feature(X) _MSVC_HAS_FEATURE_ ## X
-    #define _MSVC_HAS_FEATURE_cxx_exceptions    1
-    #define _MSVC_HAS_FEATURE_cxx_rtti          1
-    #define _MSVC_HAS_FEATURE_address_sanitizer 0
-    #define _MSVC_HAS_FEATURE_memory_sanitizer  0
-    #define _MSVC_HAS_FEATURE_thread_sanitizer  0
+    #define _MSVC_HAS_FEATURE_cxx_exceptions      1
+    #define _MSVC_HAS_FEATURE_cxx_rtti            1
+    #define _MSVC_HAS_FEATURE_address_sanitizer   0
+    #define _MSVC_HAS_FEATURE_hwaddress_sanitizer 0
+    #define _MSVC_HAS_FEATURE_memory_sanitizer    0
+    #define _MSVC_HAS_FEATURE_thread_sanitizer    0
 
     #define __has_attribute(X) _MSVC_HAS_ATTRIBUTE_ ## X
     #define _MSVC_HAS_ATTRIBUTE_vector_size     0
+
+    #define __has_builtin(X) _MSVC_HAS_BUILTIN_ ## X
+    #define _MSVC_HAS_BUILTIN___builtin_source_location 1
 
     // Silence compiler warnings.
     #pragma warning(disable: 4180) // qualifier applied to function type has no meaning; ignored

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -1072,8 +1072,6 @@ feature_test_macros = [
             "name": "__cpp_lib_source_location",
             "values": {"c++20": 201907},
             "headers": ["source_location"],
-            "test_suite_guard": "__has_builtin(__builtin_source_location) && !(defined(TEST_APPLE_CLANG_VER) && TEST_APPLE_CLANG_VER <= 1403)",
-            "libcxx_guard": "__has_builtin(__builtin_source_location) && !(defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER <= 1403)",
         },
         {
             "name": "__cpp_lib_span",


### PR DESCRIPTION
Thanks to @mstorsjo's observation in https://github.com/llvm/llvm-project/pull/74182#issuecomment-1837617934, here's a far less intrusive way to make libc++'s filesystem tests compatible with MSVC's STL.

In `msvc_stdlib_force_include.h` (which, as the filename indicates, is force-included by the MSVC STL test environment, but never included by the libc++ test environment), we need to define 3 more macros:

* [`_CRT_DECLARE_NONSTDC_NAMES`][msvc_docs] activates the POSIX names of `getcwd` etc. As the comment explains, we need this because we test with Clang `-fno-ms-compatibility`, which defines `__STDC__` to `1`, which causes the UCRT headers to disable the POSIX names by default.
* Then we need [`_CRT_NONSTDC_NO_WARNINGS`][msvc_docs] to avoid emitting deprecation warnings about the POSIX names.
* Finally, we need `NOMINMAX` to seal away the ancient evil.

[msvc_docs]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/compatibility?view=msvc-170

Like the other macros, these are defined within `#ifndef _LIBCXX_IN_DEVCRT` because we want them only within libc++'s test suite. (Our own test suite, formerly called "devcrt", reaches into our llvm-project submodule to include this header in a few places, and we don't want these macros defined there.)

While I'm in the neighborhood, I'm also adding a "simulated" macro: `__has_feature(hwaddress_sanitizer)` as `0`.

I pushed a commit to clang-format all of `msvc_stdlib_force_include.h`. (The CI's suggested diff apparently clang-formatted just the modified lines, which led to an inconsistently gross look, so I figured it was time to format the whole thing.)

Finally, as @philnik777 requested, I'm removing `__has_builtin(__builtin_source_location)` guards, including in libc++ product code. `<version>`, `source_location.version.compile.pass.cpp` (which now passes for MSVC's STL), and `version.version.compile.pass.cpp` were regenerated, no manual changes.