### PR TITLE
[RISCV][NFC] Use AddTargetFeature to add fast-unaligned-access

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -171,13 +171,8 @@ void riscv::getRISCVTargetFeatures(const Driver &D, const llvm::Triple &Triple,
     Features.push_back("-save-restore");
 
   // -mno-unaligned-access is default, unless -munaligned-access is specified.
-  if (const Arg *A = Args.getLastArg(options::OPT_munaligned_access,
-                                     options::OPT_mno_unaligned_access)) {
-    if (A->getOption().matches(options::OPT_munaligned_access))
-      Features.push_back("+fast-unaligned-access");
-    else
-      Features.push_back("-fast-unaligned-access");
-  }
+  AddTargetFeature(Args, Features, options::OPT_munaligned_access,
+                   options::OPT_mno_unaligned_access, "fast-unaligned-access");
 
   // Now add any that the user explicitly requested on the command line,
   // which may override the defaults.


### PR DESCRIPTION
We can reduce some code.
