### PR TITLE
[AMDGPU] Introduce isBottomOfStack helper. NFC

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMachineFunction.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMachineFunction.h
@@ -90,6 +90,11 @@ public:
 
   bool isChainFunction() const { return IsChainFunction; }
 
+  // The stack is empty upon entry to this function.
+  bool isBottomOfStack() const {
+    return isEntryFunction() || isChainFunction();
+  }
+
   bool hasNoSignedZerosFPMath() const {
     return NoSignedZerosFPMath;
   }

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -519,7 +519,7 @@ int SIMachineFunctionInfo::getScavengeFI(MachineFrameInfo &MFI,
                                          const SIRegisterInfo &TRI) {
   if (ScavengeFI)
     return *ScavengeFI;
-  if (isEntryFunction() || isChainFunction()) {
+  if (isBottomOfStack()) {
     ScavengeFI = MFI.CreateFixedObject(
         TRI.getSpillSize(AMDGPU::SGPR_32RegClass), 0, false);
   } else {


### PR DESCRIPTION
Introduce a helper to check if a function is at the bottom of the stack, i.e. if it's an entry function or a chain function.
This was suggested in #71913. 