### PR TITLE
[libclang/python] Fix some minor typos

### DIFF
--- a/clang/bindings/python/README.txt
+++ b/clang/bindings/python/README.txt
@@ -8,7 +8,7 @@ You may need to set CLANG_LIBRARY_PATH so that the Clang library can be
 found. The unit tests are designed to be run with any standard test
 runner. For example:
 --
-$ env PYTHONPATH=$(echo ~/llvm/tools/clang/bindings/python/) \
+$ env PYTHONPATH=$(echo ~/llvm/clang/bindings/python/) \
       CLANG_LIBRARY_PATH=$(llvm-config --libdir) \
   python -m unittest discover -v
 tests.cindex.test_index.test_create ... ok

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -535,7 +535,7 @@ class Diagnostic(object):
 class FixIt(object):
     """
     A FixIt represents a transformation to be applied to the source to
-    "fix-it". The fix-it shouldbe applied by replacing the given source range
+    "fix-it". The fix-it should be applied by replacing the given source range
     with the given value.
     """
 


### PR DESCRIPTION
These patches do not change the functionality of the library. They simply correct comments and documentation.

* Add a missing space in a the `FixIt` class **comment**
* Fix an llvm-project path in the `README.txt`