### PR TITLE
[clang-format] Fix a bug in `git-clang-format --binary`

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -153,7 +153,10 @@ def main():
   else:
     if len(commits) > 2:
       die('at most two commits allowed; %d given' % len(commits))
-  opts.binary=os.path.abspath(opts.binary)
+
+  if os.path.dirname(opts.binary):
+    opts.binary = os.path.abspath(opts.binary)
+
   changed_lines = compute_diff_and_extract_lines(commits, files, opts.staged)
   if opts.verbose >= 1:
     ignored_files = set(changed_lines)


### PR DESCRIPTION
This is a rework of #74176, which erroneously changed the default clang-format filename (`clang-format`, `clang-format.exe`, etc.) to an absolute pathname. Instead, we should do that only if the name is a pathname, e.g. `./clang-format`, `llvm-project/build/bin/clang-format.exe`, etc. See also https://github.com/llvm/llvm-project/pull/74176#issuecomment-1837921351.