### PR TITLE
[objcopy] Return an error in case of an invalid regex

### DIFF
--- a/llvm/lib/ObjCopy/CommonConfig.cpp
+++ b/llvm/lib/ObjCopy/CommonConfig.cpp
@@ -39,7 +39,7 @@ NameOrPattern::create(StringRef Pattern, MatchStyle MS,
                          IsPositiveMatch);
   }
   case MatchStyle::Regex: {
-    auto RegEx = Regex(Pattern);
+    Regex RegEx(Pattern);
     std::string Err;
     if (!RegEx.isValid(Err))
       return createStringError(errc::invalid_argument,

--- a/llvm/lib/ObjCopy/CommonConfig.cpp
+++ b/llvm/lib/ObjCopy/CommonConfig.cpp
@@ -39,16 +39,15 @@ NameOrPattern::create(StringRef Pattern, MatchStyle MS,
                          IsPositiveMatch);
   }
   case MatchStyle::Regex: {
-    SmallVector<char, 32> Data;
-    auto AnchoredPattern =
-        ("^" + Pattern.ltrim('^').rtrim('$') + "$").toStringRef(Data);
-    auto RegEx = std::make_shared<Regex>(AnchoredPattern);
+    auto RegEx = Regex(Pattern);
     std::string Err;
-    if (!RegEx->isValid(Err))
+    if (!RegEx.isValid(Err))
       return createStringError(errc::invalid_argument,
                                "cannot compile regular expression \'" +
                                    Pattern + "\': " + Err);
-    return NameOrPattern(RegEx);
+    SmallVector<char, 32> Data;
+    return NameOrPattern(std::make_shared<Regex>(
+        ("^" + Pattern.ltrim('^').rtrim('$') + "$").toStringRef(Data)));
   }
   }
   llvm_unreachable("Unhandled llvm.objcopy.MatchStyle enum");

--- a/llvm/test/tools/llvm-objcopy/regex-error.test
+++ b/llvm/test/tools/llvm-objcopy/regex-error.test
@@ -1,0 +1,20 @@
+## Test if providing objcopy with an invalid regex generates an error.
+
+# RUN: yaml2obj %s -o %t
+
+# RUN: not llvm-objcopy --regex --strip-symbol='f[^)' %t /dev/null 2>&1 | FileCheck %s
+# CHECK: cannot compile regular expression
+
+!ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+Symbols:
+  - Name:    foo
+    Section: .text

--- a/llvm/test/tools/llvm-objcopy/regex-error.test
+++ b/llvm/test/tools/llvm-objcopy/regex-error.test
@@ -2,8 +2,8 @@
 
 # RUN: yaml2obj %s -o %t
 
-# RUN: not llvm-objcopy --regex --strip-symbol='f[^)' %t /dev/null 2>&1 | FileCheck %s
-# CHECK: cannot compile regular expression
+# RUN: not llvm-objcopy --regex --strip-symbol='[^)\' %t /dev/null 2>&1 | FileCheck %s
+# CHECK: error: cannot compile regular expression '[^)\'
 
 !ELF
 FileHeader:
@@ -11,10 +11,3 @@ FileHeader:
   Data:    ELFDATA2LSB
   Type:    ET_EXEC
   Machine: EM_X86_64
-Sections:
-  - Name:  .text
-    Type:  SHT_PROGBITS
-    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
-Symbols:
-  - Name:    foo
-    Section: .text


### PR DESCRIPTION
As of now, llvm-objcopy silently ignores a provided regex if it doesn't compile.

This patch adds returning an error saying that a regex couldn't be compiled, along with the compilation error message.