### PR TITLE
[OpenACC] Implement 'cache' construct parsing

### DIFF
--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -34,7 +34,7 @@ enum class OpenACCDirectiveKind {
 
   // Misc.
   Loop,
-  // FIXME: 'cache'
+  Cache,
 
   // Combined Constructs.
   ParallelLoop,

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3538,7 +3538,12 @@ public:
 
 private:
   void ParseOpenACCDirective();
-  ExprResult ParseOpenACCRoutineName();
+  /// Helper that parses an ID Expression based on the language options.
+  ExprResult ParseOpenACCIDExpression();
+  /// Parses the variable list for the `cache` construct.
+  void ParseOpenACCCacheVarList();
+  /// Parses a single variable in a variable list for the 'cache' construct.
+  void ParseOpenACCCacheVar();
 
 private:
   //===--------------------------------------------------------------------===//

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3543,7 +3543,7 @@ private:
   /// Parses the variable list for the `cache` construct.
   void ParseOpenACCCacheVarList();
   /// Parses a single variable in a variable list for the 'cache' construct.
-  void ParseOpenACCCacheVar();
+  bool ParseOpenACCCacheVar();
 
 private:
   //===--------------------------------------------------------------------===//

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -330,7 +330,7 @@ void Parser::ParseOpenACCCacheVarList() {
   // treat it like the beginning of a reference to a potentially-existing
   // `readonly` variable.
   if (getCurToken().is(tok::identifier) &&
-      getCurToken().getIdentifierInfo()->getName() == "readonly" &&
+      getCurToken().getIdentifierInfo()->isStr("readonly") &&
       NextToken().is(tok::colon)) {
     // Consume both tokens.
     ConsumeToken();

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -329,7 +329,8 @@ void Parser::ParseOpenACCCacheVarList() {
   // specifications.  First, see if we have `readonly:`, else we back-out and
   // treat it like the beginning of a reference to a potentially-existing
   // `readonly` variable.
-  if (getPreprocessor().getSpelling(getCurToken()) == "readonly" &&
+  if (getCurToken().is(tok::identifier) &&
+      getCurToken().getIdentifierInfo()->getName() == "readonly" &&
       NextToken().is(tok::colon)) {
     // Consume both tokens.
     ConsumeToken();

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -376,9 +376,9 @@ void Parser::ParseOpenACCDirective() {
     }
   } else if (DirKind == OpenACCDirectiveKind::Cache) {
     // Cache's paren var-list is required, so error here if it isn't provided.
-    // We know that the consumeOpen above left the first non-paren here, so use
-    // expectAndConsume to emit the proper dialog, then continue.
-    (void)T.expectAndConsume();
+    // We know that the consumeOpen above left the first non-paren here, so
+    // diagnose, then continue as if it was completely omitted.
+    Diag(Tok, diag::err_expected) << tok::l_paren;
   }
 
   // Parses the list of clauses, if present.

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -270,6 +270,14 @@ ExprResult Parser::ParseOpenACCIDExpression() {
   return getActions().CorrectDelayedTyposInExpr(Res);
 }
 
+/// OpenACC 3.3, section 2.10:
+/// A 'var' in a cache directive must be a single array element or a simple
+/// subarray.  In C and C++, a simple subarray is an array name followed by an
+/// extended array range specification in brackets, with a start and length such
+/// as:
+///
+/// arr[lower:length]
+///
 void Parser::ParseOpenACCCacheVar() {
   ExprResult ArrayName = ParseOpenACCIDExpression();
   // FIXME: Pass this to Sema.
@@ -307,6 +315,10 @@ void Parser::ParseOpenACCCacheVar() {
   SquareBrackets.consumeClose();
 }
 
+/// OpenACC 3.3, section 2.10:
+/// In C and C++, the syntax of the cache directive is:
+///
+/// #pragma acc cache ([readonly:]var-list) new-line
 void Parser::ParseOpenACCCacheVarList() {
   // If this is the end of the line, just return 'false' and count on the close
   // paren diagnostic to catch the issue.

--- a/clang/test/ParserOpenACC/parse-cache-construct.c
+++ b/clang/test/ParserOpenACC/parse-cache-construct.c
@@ -1,0 +1,178 @@
+// RUN: %clang_cc1 %s -verify -fopenacc
+
+char *getArrayPtr();
+void func() {
+  char Array[10];
+  char *ArrayPtr = getArrayPtr();
+  int *readonly;
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+3{{expected '('}}
+    // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache clause list
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache()
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache() clause-list
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+5{{use of undeclared identifier 'invalid'}}
+    // expected-error@+4{{expected '['}}
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(invalid
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+4{{expected '['}}
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(ArrayPtr
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+3{{use of undeclared identifier 'invalid'}}
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(invalid)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(ArrayPtr)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+6{{expected expression}}
+    // expected-error@+5{{expected ']'}}
+    // expected-note@+4{{to match this '['}}
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(ArrayPtr[
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+4{{expected expression}}
+    // expected-error@+3{{expected ']'}}
+    // expected-note@+2{{to match this '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(ArrayPtr[, 5)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+4{{expected expression}}
+    // expected-error@+3{{expected ']'}}
+    // expected-note@+2{{to match this '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(Array[)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(Array[*readonly])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+6{{expected expression}}
+    // expected-error@+5{{expected ']'}}
+    // expected-note@+4{{to match this '['}}
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(Array[*readonly:
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected expression}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:*readonly])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:*readonly], Array)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:*readonly], Array[*readonly:3])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5 + i:*readonly], Array[*readonly + i:3])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+5{{expected identifier}}
+    // expected-error@+4{{expected '['}}
+    // expected-error@+3{{expected ')'}}
+    // expected-note@+2{{to match this '('}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:*readonly],
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+3{{expected identifier}}
+    // expected-error@+2{{expected '['}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:*readonly],)
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+2{{left operand of comma operator has no effect}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5,6:*readonly])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+2{{left operand of comma operator has no effect}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(readonly:ArrayPtr[5:3, *readonly], ArrayPtr[0])
+  }
+
+}

--- a/clang/test/ParserOpenACC/parse-cache-construct.c
+++ b/clang/test/ParserOpenACC/parse-cache-construct.c
@@ -6,47 +6,46 @@ void func() {
   char *ArrayPtr = getArrayPtr();
   int *readonly;
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+3{{expected '('}}
     // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache clause list
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache()
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache() clause-list
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+5{{use of undeclared identifier 'invalid'}}
-    // expected-error@+4{{expected '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+4{{use of undeclared identifier 'invalid'}}
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(invalid
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+4{{expected '['}}
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
@@ -54,122 +53,111 @@ void func() {
     #pragma acc cache(ArrayPtr
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+3{{use of undeclared identifier 'invalid'}}
-    // expected-error@+2{{expected '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+2{{use of undeclared identifier 'invalid'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(invalid)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected '['}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(ArrayPtr)
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+6{{expected expression}}
-    // expected-error@+5{{expected ']'}}
-    // expected-note@+4{{to match this '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+4{{expected expression}}
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(ArrayPtr[
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+4{{expected expression}}
-    // expected-error@+3{{expected ']'}}
-    // expected-note@+2{{to match this '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+2{{expected expression}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(ArrayPtr[, 5)
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+4{{expected expression}}
-    // expected-error@+3{{expected ']'}}
-    // expected-note@+2{{to match this '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+2{{expected expression}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(Array[)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(Array[*readonly])
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+6{{expected expression}}
-    // expected-error@+5{{expected ']'}}
-    // expected-note@+4{{to match this '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+4{{expected expression}}
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(Array[*readonly:
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected '['}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected '['}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected expression}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:*readonly])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{expected '['}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:*readonly], Array)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:*readonly], Array[*readonly:3])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5 + i:*readonly], Array[*readonly + i:3])
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+5{{expected identifier}}
-    // expected-error@+4{{expected '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+4{{expected identifier}}
     // expected-error@+3{{expected ')'}}
     // expected-note@+2{{to match this '('}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:*readonly],
   }
 
-  for (int i = 0; i  < 10; ++i) {
-    // expected-error@+3{{expected identifier}}
-    // expected-error@+2{{expected '['}}
+  for (int i = 0; i < 10; ++i) {
+    // expected-error@+2{{expected identifier}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:*readonly],)
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+2{{left operand of comma operator has no effect}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5,6:*readonly])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+2{{left operand of comma operator has no effect}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(readonly:ArrayPtr[5:3, *readonly], ArrayPtr[0])

--- a/clang/test/ParserOpenACC/parse-cache-construct.cpp
+++ b/clang/test/ParserOpenACC/parse-cache-construct.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 %s -verify -fopenacc
+
+namespace NS {
+  static char* NSArray;// expected-note{{declared here}}
+  static int NSInt;// expected-note 2{{declared here}}
+}
+char *getArrayPtr();
+template<typename T, int I>
+void func() {
+  char *ArrayPtr = getArrayPtr();
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(ArrayPtr[T::value + I:I + 5], T::array[(i + T::value, 5): 6])
+  }
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(NS::NSArray[NS::NSInt])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(NS::NSArray[NS::NSInt : NS::NSInt])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{use of undeclared identifier 'NSArray'; did you mean 'NS::NSArray'}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(NSArray[NS::NSInt : NS::NSInt])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{use of undeclared identifier 'NSInt'; did you mean 'NS::NSInt'}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(NS::NSArray[NSInt : NS::NSInt])
+  }
+
+  for (int i = 0; i  < 10; ++i) {
+    // expected-error@+2{{use of undeclared identifier 'NSInt'; did you mean 'NS::NSInt'}}
+    // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+    #pragma acc cache(NS::NSArray[NS::NSInt : NSInt])
+  }
+}
+
+struct S {
+  static constexpr int value = 5;
+  static constexpr char array[] ={1,2,3,4,5};
+};
+
+void use() {
+  func<S, 5>();
+}

--- a/clang/test/ParserOpenACC/parse-cache-construct.cpp
+++ b/clang/test/ParserOpenACC/parse-cache-construct.cpp
@@ -8,33 +8,33 @@ char *getArrayPtr();
 template<typename T, int I>
 void func() {
   char *ArrayPtr = getArrayPtr();
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(ArrayPtr[T::value + I:I + 5], T::array[(i + T::value, 5): 6])
   }
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(NS::NSArray[NS::NSInt])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(NS::NSArray[NS::NSInt : NS::NSInt])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{use of undeclared identifier 'NSArray'; did you mean 'NS::NSArray'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(NSArray[NS::NSInt : NS::NSInt])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{use of undeclared identifier 'NSInt'; did you mean 'NS::NSInt'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(NS::NSArray[NSInt : NS::NSInt])
   }
 
-  for (int i = 0; i  < 10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     // expected-error@+2{{use of undeclared identifier 'NSInt'; did you mean 'NS::NSInt'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache(NS::NSArray[NS::NSInt : NSInt])


### PR DESCRIPTION
The 'cache' construct takes a list of 'vars', which are array-section style definitions. This patch implements the parsing, leaving the lower bound and length of the bound as expressions, so that we can validate they are the correct 'thing' in sema.