### PR TITLE
[AssignmentTracking] Skip large types in redundant debug info pruning

### DIFF
--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -2304,7 +2304,6 @@ removeRedundantDbgLocsUsingBackwardScan(const BasicBlock *BB,
         // If the size is unknown (0) then keep this location def to be safe.
         // Do the same for defs of large variables, which would be expensive
         // to represent with a BitVector.
-        // FIXME: Don't use a BitVector.
         NewDefsReversed.push_back(*RIt);
         continue;
       }

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -2296,8 +2296,11 @@ removeRedundantDbgLocsUsingBackwardScan(const BasicBlock *BB,
           getAggregate(FnVarLocs.getVariable(RIt->VariableID));
       uint64_t SizeInBits = Aggr.first->getSizeInBits().value_or(0);
 
-      if (SizeInBits == 0) {
+      const uint64_t MaxSize = std::numeric_limits<unsigned>::max() - 63;
+      if (SizeInBits == 0 || SizeInBits > MaxSize) {
         // If the size is unknown (0) then keep this location def to be safe.
+        // Do the same for defs of very large variables, which can't be
+        // represented with a BitVector.
         NewDefsReversed.push_back(*RIt);
         continue;
       }

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -2295,7 +2295,7 @@ removeRedundantDbgLocsUsingBackwardScan(const BasicBlock *BB,
       DebugAggregate Aggr =
           getAggregate(FnVarLocs.getVariable(RIt->VariableID));
       uint64_t SizeInBits = Aggr.first->getSizeInBits().value_or(0);
-      uint64_t SizeInBytes = SizeInBits + 7 / 8;
+      uint64_t SizeInBytes = divideCeil(SizeInBits, 8);
 
       // Cutoff for large variables to prevent expensive bitvector operations.
       const uint64_t MaxSizeBytes = 2048;
@@ -2322,8 +2322,8 @@ removeRedundantDbgLocsUsingBackwardScan(const BasicBlock *BB,
           RIt->Expr->getFragmentInfo().value_or(
               DIExpression::FragmentInfo(SizeInBits, 0));
       bool InvalidFragment = Fragment.endInBits() > SizeInBits;
-      uint64_t StartInBytes = Fragment.startInBits() + 7 / 8;
-      uint64_t EndInBytes = Fragment.endInBits() + 7 / 8;
+      uint64_t StartInBytes = Fragment.startInBits() / 8;
+      uint64_t EndInBytes = divideCeil(Fragment.endInBits(), 8);
 
       // If this defines any previously undefined bytes, keep it.
       if (FirstDefinition || InvalidFragment ||

--- a/llvm/test/DebugInfo/assignment-tracking/X86/large-type.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/large-type.ll
@@ -1,0 +1,58 @@
+; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: | FileCheck %s --implicit-check-not=DBG_
+
+;; Based on optimized IR from C source:
+;; int main () {
+;;   char a1[__INT_MAX__];
+;;   a1[__INT_MAX__ - 1] = 5;
+;;   return a1[__INT_MAX__ - 1];
+;; }
+;;
+;; Check extremely large types don't cause a crash.
+; CHECK: DBG_VALUE 5, $noreg, ![[#]], !DIExpression(DW_OP_LLVM_fragment, 4294967280, 8)
+; CHECK: DBG_VALUE 6, $noreg, ![[#]], !DIExpression(DW_OP_LLVM_fragment, 0, 8)
+; CHECK: DBG_VALUE 7, $noreg, ![[#]], !DIExpression(DW_OP_LLVM_fragment, 0, 8)
+
+define dso_local i32 @main() local_unnamed_addr !dbg !10 {
+entry:
+;; FIXME: SROA currently creates incorrect fragments if bit_offset > max(u32),
+;; with and without assignment-tracking.
+  tail call void @llvm.dbg.value(metadata i8 5, metadata !15, metadata !DIExpression(DW_OP_LLVM_fragment, 4294967280, 8)), !dbg !20
+;; These two were inserted by hand.
+  tail call void @llvm.dbg.value(metadata i8 6, metadata !22, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !20
+  tail call void @llvm.dbg.value(metadata i8 7, metadata !23, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !20
+  ret i32 5, !dbg !21
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 18.0.0", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.c", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+!9 = !{!"clang version 18.0.0"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !11, scopeLine: 4, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{!15}
+!15 = !DILocalVariable(name: "a1", scope: !10, file: !1, line: 5, type: !16)
+!16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 17179869176, elements: !18)
+!17 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!18 = !{!19}
+!19 = !DISubrange(count: 2147483647)
+!20 = !DILocation(line: 0, scope: !10)
+!21 = !DILocation(line: 7, column: 3, scope: !10)
+!22 = !DILocalVariable(name: "a2", scope: !10, file: !1, line: 5, type: !16)
+!23 = !DILocalVariable(name: "a3", scope: !10, file: !1, line: 5, type: !16)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 4294967232, elements: !18)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 4294967233, elements: !18)


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/74189 (crash report).

The pruning code uses a BitVector to track which parts of a variable have been
defined in order to find redundant debug records. BitVector uses a u32 to track
size; variable of types with a bit-size greater than max(u32) ish* can't be
represented using a BitVector.

Fix the assertion by introducing a limit on type size. Improve performance by
bringing the limit down to a sensible number and tracking byte-sizes instead
of bit-sizes.

Skipping variables in this pruning code doesn't cause debug info correctness issues;
it just means there may be some extra redundant debug records.

(*) `max(u32) - 63` due to BitVector::NumBitWords implementation.