### PR TITLE
[libc++] Replace uses of _VSTD:: by std::

### DIFF
--- a/libcxx/docs/Contributing.rst
+++ b/libcxx/docs/Contributing.rst
@@ -67,7 +67,6 @@ avoid invoking a user-defined ``operator,``, make sure to cast the result to
 In general, try to follow the style of existing code. There are a few
 exceptions:
 
-- ``_VSTD::foo`` is no longer used in new code. Use ``std::foo`` instead.
 - Prefer ``using foo = int`` over ``typedef int foo``. The compilers supported
   by libc++ accept alias declarations in all standard modes.
 

--- a/libcxx/include/__algorithm/clamp.h
+++ b/libcxx/include/__algorithm/clamp.h
@@ -35,7 +35,7 @@ _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI constexpr const _Tp&
 clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
       _LIBCPP_LIFETIMEBOUND const _Tp& __lo,
       _LIBCPP_LIFETIMEBOUND const _Tp& __hi) {
-  return _VSTD::clamp(__v, __lo, __hi, __less<>());
+  return std::clamp(__v, __lo, __hi, __less<>());
 }
 #endif
 

--- a/libcxx/include/__algorithm/copy_n.h
+++ b/libcxx/include/__algorithm/copy_n.h
@@ -28,7 +28,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 _OutputIterator
 copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {
-    typedef decltype(_VSTD::__convert_to_integral(__orig_n)) _IntegralSize;
+    typedef decltype(std::__convert_to_integral(__orig_n)) _IntegralSize;
     _IntegralSize __n = __orig_n;
     if (__n > 0)
     {
@@ -51,9 +51,9 @@ _OutputIterator
 copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {
     typedef typename iterator_traits<_InputIterator>::difference_type difference_type;
-    typedef decltype(_VSTD::__convert_to_integral(__orig_n)) _IntegralSize;
+    typedef decltype(std::__convert_to_integral(__orig_n)) _IntegralSize;
     _IntegralSize __n = __orig_n;
-    return _VSTD::copy(__first, __first + difference_type(__n), __result);
+    return std::copy(__first, __first + difference_type(__n), __result);
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/equal.h
+++ b/libcxx/include/__algorithm/equal.h
@@ -107,7 +107,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 __equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
         _RandomAccessIterator2 __last2, _BinaryPredicate __pred, random_access_iterator_tag,
         random_access_iterator_tag) {
-  if (_VSTD::distance(__first1, __last1) != _VSTD::distance(__first2, __last2))
+  if (std::distance(__first1, __last1) != std::distance(__first2, __last2))
     return false;
   __identity __proj;
   return std::__equal_impl(
@@ -124,7 +124,7 @@ template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2,
       _BinaryPredicate __pred) {
-  return _VSTD::__equal<_BinaryPredicate&>(
+  return std::__equal<_BinaryPredicate&>(
       __first1, __last1, __first2, __last2, __pred, typename iterator_traits<_InputIterator1>::iterator_category(),
       typename iterator_traits<_InputIterator2>::iterator_category());
 }

--- a/libcxx/include/__algorithm/fill.h
+++ b/libcxx/include/__algorithm/fill.h
@@ -35,7 +35,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 void
 __fill(_RandomAccessIterator __first, _RandomAccessIterator __last, const _Tp& __value, random_access_iterator_tag)
 {
-    _VSTD::fill_n(__first, __last - __first, __value);
+    std::fill_n(__first, __last - __first, __value);
 }
 
 template <class _ForwardIterator, class _Tp>
@@ -43,7 +43,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 void
 fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
-    _VSTD::__fill(__first, __last, __value, typename iterator_traits<_ForwardIterator>::iterator_category());
+    std::__fill(__first, __last, __value, typename iterator_traits<_ForwardIterator>::iterator_category());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/fill_n.h
+++ b/libcxx/include/__algorithm/fill_n.h
@@ -36,7 +36,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 _OutputIterator
 fill_n(_OutputIterator __first, _Size __n, const _Tp& __value)
 {
-   return _VSTD::__fill_n(__first, _VSTD::__convert_to_integral(__n), __value);
+   return std::__fill_n(__first, std::__convert_to_integral(__n), __value);
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/find_first_of.h
+++ b/libcxx/include/__algorithm/find_first_of.h
@@ -38,7 +38,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
 find_first_of(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
               _ForwardIterator2 __last2, _BinaryPredicate __pred) {
-  return _VSTD::__find_first_of_ce(__first1, __last1, __first2, __last2, __pred);
+  return std::__find_first_of_ce(__first1, __last1, __first2, __last2, __pred);
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>

--- a/libcxx/include/__algorithm/for_each_n.h
+++ b/libcxx/include/__algorithm/for_each_n.h
@@ -25,7 +25,7 @@ template <class _InputIterator, class _Size, class _Function>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator for_each_n(_InputIterator __first,
                                                                                          _Size __orig_n,
                                                                                          _Function __f) {
-  typedef decltype(_VSTD::__convert_to_integral(__orig_n)) _IntegralSize;
+  typedef decltype(std::__convert_to_integral(__orig_n)) _IntegralSize;
   _IntegralSize __n = __orig_n;
   while (__n > 0) {
     __f(*__first);

--- a/libcxx/include/__algorithm/generate_n.h
+++ b/libcxx/include/__algorithm/generate_n.h
@@ -23,7 +23,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 _OutputIterator
 generate_n(_OutputIterator __first, _Size __orig_n, _Generator __gen)
 {
-    typedef decltype(_VSTD::__convert_to_integral(__orig_n)) _IntegralSize;
+    typedef decltype(std::__convert_to_integral(__orig_n)) _IntegralSize;
     _IntegralSize __n = __orig_n;
     for (; __n > 0; ++__first, (void) --__n)
         *__first = __gen();

--- a/libcxx/include/__algorithm/inplace_merge.h
+++ b/libcxx/include/__algorithm/inplace_merge.h
@@ -224,10 +224,10 @@ __inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle,
     typedef typename iterator_traits<_BidirectionalIterator>::difference_type difference_type;
     difference_type __len1 = _IterOps<_AlgPolicy>::distance(__first, __middle);
     difference_type __len2 = _IterOps<_AlgPolicy>::distance(__middle, __last);
-    difference_type __buf_size = _VSTD::min(__len1, __len2);
+    difference_type __buf_size = std::min(__len1, __len2);
 // TODO: Remove the use of std::get_temporary_buffer
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-    pair<value_type*, ptrdiff_t> __buf = _VSTD::get_temporary_buffer<value_type>(__buf_size);
+    pair<value_type*, ptrdiff_t> __buf = std::get_temporary_buffer<value_type>(__buf_size);
 _LIBCPP_SUPPRESS_DEPRECATED_POP
     unique_ptr<value_type, __return_temporary_buffer> __h(__buf.first);
     return std::__inplace_merge<_AlgPolicy>(

--- a/libcxx/include/__algorithm/is_heap.h
+++ b/libcxx/include/__algorithm/is_heap.h
@@ -36,7 +36,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 bool
 is_heap(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {
-    return _VSTD::is_heap(__first, __last, __less<>());
+    return std::is_heap(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/is_heap_until.h
+++ b/libcxx/include/__algorithm/is_heap_until.h
@@ -58,7 +58,7 @@ template<class _RandomAccessIterator>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {
-    return _VSTD::__is_heap_until(__first, __last, __less<>());
+    return std::__is_heap_until(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/is_sorted.h
+++ b/libcxx/include/__algorithm/is_sorted.h
@@ -27,7 +27,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 bool
 is_sorted(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-    return _VSTD::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp) == __last;
+    return std::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp) == __last;
 }
 
 template<class _ForwardIterator>
@@ -36,7 +36,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 bool
 is_sorted(_ForwardIterator __first, _ForwardIterator __last)
 {
-    return _VSTD::is_sorted(__first, __last, __less<>());
+    return std::is_sorted(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/is_sorted_until.h
+++ b/libcxx/include/__algorithm/is_sorted_until.h
@@ -41,14 +41,14 @@ template <class _ForwardIterator, class _Compare>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-    return _VSTD::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp);
+    return std::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp);
 }
 
 template<class _ForwardIterator>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 is_sorted_until(_ForwardIterator __first, _ForwardIterator __last)
 {
-    return _VSTD::is_sorted_until(__first, __last, __less<>());
+    return std::is_sorted_until(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/lexicographical_compare.h
+++ b/libcxx/include/__algorithm/lexicographical_compare.h
@@ -42,7 +42,7 @@ bool
 lexicographical_compare(_InputIterator1 __first1, _InputIterator1 __last1,
                         _InputIterator2 __first2, _InputIterator2 __last2, _Compare __comp)
 {
-    return _VSTD::__lexicographical_compare<__comp_ref_type<_Compare> >(__first1, __last1, __first2, __last2, __comp);
+    return std::__lexicographical_compare<__comp_ref_type<_Compare> >(__first1, __last1, __first2, __last2, __comp);
 }
 
 template <class _InputIterator1, class _InputIterator2>
@@ -52,7 +52,7 @@ bool
 lexicographical_compare(_InputIterator1 __first1, _InputIterator1 __last1,
                         _InputIterator2 __first2, _InputIterator2 __last2)
 {
-    return _VSTD::lexicographical_compare(__first1, __last1, __first2, __last2, __less<>());
+    return std::lexicographical_compare(__first1, __last1, __first2, __last2, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/max.h
+++ b/libcxx/include/__algorithm/max.h
@@ -39,7 +39,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 const _Tp&
 max(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b)
 {
-    return _VSTD::max(__a, __b, __less<>());
+    return std::max(__a, __b, __less<>());
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -50,7 +50,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 _Tp
 max(initializer_list<_Tp> __t, _Compare __comp)
 {
-    return *_VSTD::__max_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
+    return *std::__max_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
 }
 
 template<class _Tp>
@@ -59,7 +59,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 _Tp
 max(initializer_list<_Tp> __t)
 {
-    return *_VSTD::max_element(__t.begin(), __t.end(), __less<>());
+    return *std::max_element(__t.begin(), __t.end(), __less<>());
 }
 
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/__algorithm/max_element.h
+++ b/libcxx/include/__algorithm/max_element.h
@@ -40,7 +40,7 @@ template <class _ForwardIterator, class _Compare>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-    return _VSTD::__max_element<__comp_ref_type<_Compare> >(__first, __last, __comp);
+    return std::__max_element<__comp_ref_type<_Compare> >(__first, __last, __comp);
 }
 
 
@@ -48,7 +48,7 @@ template <class _ForwardIterator>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 max_element(_ForwardIterator __first, _ForwardIterator __last)
 {
-    return _VSTD::max_element(__first, __last, __less<>());
+    return std::max_element(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/merge.h
+++ b/libcxx/include/__algorithm/merge.h
@@ -30,7 +30,7 @@ __merge(_InputIterator1 __first1, _InputIterator1 __last1,
     for (; __first1 != __last1; ++__result)
     {
         if (__first2 == __last2)
-            return _VSTD::copy(__first1, __last1, __result);
+            return std::copy(__first1, __last1, __result);
         if (__comp(*__first2, *__first1))
         {
             *__result = *__first2;
@@ -42,7 +42,7 @@ __merge(_InputIterator1 __first1, _InputIterator1 __last1,
             ++__first1;
         }
     }
-    return _VSTD::copy(__first2, __last2, __result);
+    return std::copy(__first2, __last2, __result);
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
@@ -51,7 +51,7 @@ _OutputIterator
 merge(_InputIterator1 __first1, _InputIterator1 __last1,
       _InputIterator2 __first2, _InputIterator2 __last2, _OutputIterator __result, _Compare __comp)
 {
-    return _VSTD::__merge<__comp_ref_type<_Compare> >(__first1, __last1, __first2, __last2, __result, __comp);
+    return std::__merge<__comp_ref_type<_Compare> >(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
@@ -60,7 +60,7 @@ _OutputIterator
 merge(_InputIterator1 __first1, _InputIterator1 __last1,
       _InputIterator2 __first2, _InputIterator2 __last2, _OutputIterator __result)
 {
-    return _VSTD::merge(__first1, __last1, __first2, __last2, __result, __less<>());
+    return std::merge(__first1, __last1, __first2, __last2, __result, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/min.h
+++ b/libcxx/include/__algorithm/min.h
@@ -39,7 +39,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 const _Tp&
 min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b)
 {
-    return _VSTD::min(__a, __b, __less<>());
+    return std::min(__a, __b, __less<>());
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -50,7 +50,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 _Tp
 min(initializer_list<_Tp> __t, _Compare __comp)
 {
-    return *_VSTD::__min_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
+    return *std::__min_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
 }
 
 template<class _Tp>
@@ -59,7 +59,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 _Tp
 min(initializer_list<_Tp> __t)
 {
-    return *_VSTD::min_element(__t.begin(), __t.end(), __less<>());
+    return *std::min_element(__t.begin(), __t.end(), __less<>());
 }
 
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/__algorithm/min_element.h
+++ b/libcxx/include/__algorithm/min_element.h
@@ -64,7 +64,7 @@ template <class _ForwardIterator>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last)
 {
-    return _VSTD::min_element(__first, __last, __less<>());
+    return std::min_element(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/next_permutation.h
+++ b/libcxx/include/__algorithm/next_permutation.h
@@ -69,7 +69,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 bool
 next_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last)
 {
-    return _VSTD::next_permutation(__first, __last, __less<>());
+    return std::next_permutation(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/nth_element.h
+++ b/libcxx/include/__algorithm/nth_element.h
@@ -92,7 +92,7 @@ __nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _Rando
         if (!__comp(*__i, *__m))  // if *__first == *__m
         {
             // *__first == *__m, *__first doesn't go in first part
-            if (_VSTD::__nth_element_find_guard<_Compare>(__i, __j, __m, __comp)) {
+            if (std::__nth_element_find_guard<_Compare>(__i, __j, __m, __comp)) {
                 _Ops::iter_swap(__i, __j);
                 ++__n_swaps;
             } else {
@@ -142,7 +142,7 @@ __nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _Rando
                     return;
                 }
                 // __nth_element the second part
-                // _VSTD::__nth_element<_Compare>(__i, __nth, __last, __comp);
+                // std::__nth_element<_Compare>(__i, __nth, __last, __comp);
                 __first = __i;
                 continue;
             }
@@ -228,12 +228,12 @@ __nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _Rando
         // __nth_element on range containing __nth
         if (__nth < __i)
         {
-            // _VSTD::__nth_element<_Compare>(__first, __nth, __i, __comp);
+            // std::__nth_element<_Compare>(__first, __nth, __i, __comp);
             __last = __i;
         }
         else
         {
-            // _VSTD::__nth_element<_Compare>(__i+1, __nth, __last, __comp);
+            // std::__nth_element<_Compare>(__i+1, __nth, __last, __comp);
             __first = ++__i;
         }
     }

--- a/libcxx/include/__algorithm/partial_sort.h
+++ b/libcxx/include/__algorithm/partial_sort.h
@@ -87,7 +87,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 void
 partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
-    _VSTD::partial_sort(__first, __middle, __last, __less<>());
+    std::partial_sort(__first, __middle, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/partial_sort_copy.h
+++ b/libcxx/include/__algorithm/partial_sort_copy.h
@@ -79,7 +79,7 @@ _RandomAccessIterator
 partial_sort_copy(_InputIterator __first, _InputIterator __last,
                   _RandomAccessIterator __result_first, _RandomAccessIterator __result_last)
 {
-    return _VSTD::partial_sort_copy(__first, __last, __result_first, __result_last, __less<>());
+    return std::partial_sort_copy(__first, __last, __result_first, __result_last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/partition_point.h
+++ b/libcxx/include/__algorithm/partition_point.h
@@ -26,12 +26,12 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 partition_point(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
     typedef typename iterator_traits<_ForwardIterator>::difference_type difference_type;
-    difference_type __len = _VSTD::distance(__first, __last);
+    difference_type __len = std::distance(__first, __last);
     while (__len != 0)
     {
-        difference_type __l2 = _VSTD::__half_positive(__len);
+        difference_type __l2 = std::__half_positive(__len);
         _ForwardIterator __m = __first;
-        _VSTD::advance(__m, __l2);
+        std::advance(__m, __l2);
         if (__pred(*__m))
         {
             __first = ++__m;

--- a/libcxx/include/__algorithm/prev_permutation.h
+++ b/libcxx/include/__algorithm/prev_permutation.h
@@ -70,7 +70,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 bool
 prev_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last)
 {
-    return _VSTD::prev_permutation(__first, __last, __less<>());
+    return std::prev_permutation(__first, __last, __less<>());
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/remove.h
+++ b/libcxx/include/__algorithm/remove.h
@@ -24,7 +24,7 @@ template <class _ForwardIterator, class _Tp>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 remove(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
-    __first = _VSTD::find(__first, __last, __value);
+    __first = std::find(__first, __last, __value);
     if (__first != __last)
     {
         _ForwardIterator __i = __first;
@@ -32,7 +32,7 @@ remove(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
         {
             if (!(*__i == __value))
             {
-                *__first = _VSTD::move(*__i);
+                *__first = std::move(*__i);
                 ++__first;
             }
         }

--- a/libcxx/include/__algorithm/remove_if.h
+++ b/libcxx/include/__algorithm/remove_if.h
@@ -23,7 +23,7 @@ template <class _ForwardIterator, class _Predicate>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 remove_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-    __first = _VSTD::find_if<_ForwardIterator, _Predicate&>(__first, __last, __pred);
+    __first = std::find_if<_ForwardIterator, _Predicate&>(__first, __last, __pred);
     if (__first != __last)
     {
         _ForwardIterator __i = __first;
@@ -31,7 +31,7 @@ remove_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
         {
             if (!__pred(*__i))
             {
-                *__first = _VSTD::move(*__i);
+                *__first = std::move(*__i);
                 ++__first;
             }
         }

--- a/libcxx/include/__algorithm/rotate.h
+++ b/libcxx/include/__algorithm/rotate.h
@@ -35,7 +35,7 @@ __rotate_left(_ForwardIterator __first, _ForwardIterator __last)
     value_type __tmp = _Ops::__iter_move(__first);
     _ForwardIterator __lm1 = std::__move<_AlgPolicy>(
         _Ops::next(__first), __last, __first).second;
-    *__lm1 = _VSTD::move(__tmp);
+    *__lm1 = std::move(__tmp);
     return __lm1;
 }
 
@@ -49,7 +49,7 @@ __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last)
     _BidirectionalIterator __lm1 = _Ops::prev(__last);
     value_type __tmp = _Ops::__iter_move(__lm1);
     _BidirectionalIterator __fp1 = std::__move_backward<_AlgPolicy>(__first, __lm1, std::move(__last)).second;
-    *__first = _VSTD::move(__tmp);
+    *__first = std::move(__tmp);
     return __fp1;
 }
 
@@ -117,7 +117,7 @@ __rotate_gcd(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Ran
         std::__swap_ranges<_AlgPolicy>(__first, __middle, __middle, __last);
         return __middle;
     }
-    const difference_type __g = _VSTD::__algo_gcd(__m1, __m2);
+    const difference_type __g = std::__algo_gcd(__m1, __m2);
     for (_RandomAccessIterator __p = __first + __g; __p != __first;)
     {
         value_type __t(_Ops::__iter_move(--__p));
@@ -133,7 +133,7 @@ __rotate_gcd(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Ran
             else
                 __p2 = __first + (__m1 - __d);
         } while (__p2 != __p);
-        *__p1 = _VSTD::move(__t);
+        *__p1 = std::move(__t);
     }
     return __first + __m2;
 }
@@ -142,7 +142,7 @@ template <class _AlgPolicy, class _ForwardIterator>
 inline _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 __rotate_impl(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
-         _VSTD::forward_iterator_tag)
+         std::forward_iterator_tag)
 {
     typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
     if (is_trivially_move_assignable<value_type>::value)

--- a/libcxx/include/__algorithm/rotate_copy.h
+++ b/libcxx/include/__algorithm/rotate_copy.h
@@ -23,7 +23,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 _OutputIterator
 rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result)
 {
-    return _VSTD::copy(__first, __middle, _VSTD::copy(__middle, __last, __result));
+    return std::copy(__first, __middle, std::copy(__middle, __last, __result));
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/sample.h
+++ b/libcxx/include/__algorithm/sample.h
@@ -47,7 +47,7 @@ _SampleIterator __sample(_PopulationIterator __first,
     if (__r < __sz)
       __output_iter[__r] = *__first;
   }
-  return __output_iter + _VSTD::min(__n, __k);
+  return __output_iter + std::min(__n, __k);
 }
 
 template <class _AlgPolicy,
@@ -60,7 +60,7 @@ _SampleIterator __sample(_PopulationIterator __first,
                          _UniformRandomNumberGenerator& __g,
                          forward_iterator_tag) {
   _Distance __unsampled_sz = _IterOps<_AlgPolicy>::distance(__first, __last);
-  for (__n = _VSTD::min(__n, __unsampled_sz); __n != 0; ++__first) {
+  for (__n = std::min(__n, __unsampled_sz); __n != 0; ++__first) {
     _Distance __r = uniform_int_distribution<_Distance>(0, --__unsampled_sz)(__g);
     if (__r < __n) {
       *__output_iter++ = *__first;

--- a/libcxx/include/__algorithm/shift_left.h
+++ b/libcxx/include/__algorithm/shift_left.h
@@ -45,7 +45,7 @@ shift_left(_ForwardIterator __first, _ForwardIterator __last,
             ++__m;
         }
     }
-    return _VSTD::move(__m, __last, __first);
+    return std::move(__m, __last, __first);
 }
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__algorithm/shift_right.h
+++ b/libcxx/include/__algorithm/shift_right.h
@@ -40,7 +40,7 @@ shift_right(_ForwardIterator __first, _ForwardIterator __last,
             return __last;
         }
         _ForwardIterator __m = __first + (__d - __n);
-        return _VSTD::move_backward(__first, __m, __last);
+        return std::move_backward(__first, __m, __last);
     } else if constexpr (__has_bidirectional_iterator_category<_ForwardIterator>::value) {
         _ForwardIterator __m = __last;
         for (; __n > 0; --__n) {
@@ -49,7 +49,7 @@ shift_right(_ForwardIterator __first, _ForwardIterator __last,
             }
             --__m;
         }
-        return _VSTD::move_backward(__first, __m, __last);
+        return std::move_backward(__first, __m, __last);
     } else {
         _ForwardIterator __ret = __first;
         for (; __n > 0; --__n) {
@@ -69,7 +69,7 @@ shift_right(_ForwardIterator __first, _ForwardIterator __last,
         auto __lead = __ret;
         while (__trail != __ret) {
             if (__lead == __last) {
-                _VSTD::move(__first, __trail, __ret);
+                std::move(__first, __trail, __ret);
                 return __ret;
             }
             ++__trail;
@@ -79,8 +79,8 @@ shift_right(_ForwardIterator __first, _ForwardIterator __last,
         _ForwardIterator __mid = __first;
         while (true) {
             if (__lead == __last) {
-                __trail = _VSTD::move(__mid, __ret, __trail);
-                _VSTD::move(__first, __mid, __trail);
+                __trail = std::move(__mid, __ret, __trail);
+                std::move(__first, __mid, __trail);
                 return __ret;
             }
             swap(*__mid, *__trail);

--- a/libcxx/include/__algorithm/sift_down.h
+++ b/libcxx/include/__algorithm/sift_down.h
@@ -77,7 +77,7 @@ __sift_down(_RandomAccessIterator __first, _Compare&& __comp,
 
         // check if we are in heap-order
     } while (!__comp(*__child_i, __top));
-    *__start = _VSTD::move(__top);
+    *__start = std::move(__top);
 }
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>

--- a/libcxx/include/__algorithm/stable_partition.h
+++ b/libcxx/include/__algorithm/stable_partition.h
@@ -144,7 +144,7 @@ __stable_partition_impl(_ForwardIterator __first, _ForwardIterator __last, _Pred
     {
 // TODO: Remove the use of std::get_temporary_buffer
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-        __p = _VSTD::get_temporary_buffer<value_type>(__len);
+        __p = std::get_temporary_buffer<value_type>(__len);
 _LIBCPP_SUPPRESS_DEPRECATED_POP
         __h.reset(__p.first);
     }
@@ -298,7 +298,7 @@ __stable_partition_impl(_BidirectionalIterator __first, _BidirectionalIterator _
     {
 // TODO: Remove the use of std::get_temporary_buffer
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-        __p = _VSTD::get_temporary_buffer<value_type>(__len);
+        __p = std::get_temporary_buffer<value_type>(__len);
 _LIBCPP_SUPPRESS_DEPRECATED_POP
         __h.reset(__p.first);
     }

--- a/libcxx/include/__algorithm/stable_sort.h
+++ b/libcxx/include/__algorithm/stable_sort.h
@@ -230,7 +230,7 @@ __stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp
         __d.__set(__len, (value_type*)nullptr);
         std::__merge_move_assign<_AlgPolicy, _Compare>(
             __buff, __buff + __l2, __buff + __l2, __buff + __len, __first, __comp);
-//         _VSTD::__merge<_Compare>(move_iterator<value_type*>(__buff),
+//         std::__merge<_Compare>(move_iterator<value_type*>(__buff),
 //                                  move_iterator<value_type*>(__buff + __l2),
 //                                  move_iterator<_RandomAccessIterator>(__buff + __l2),
 //                                  move_iterator<_RandomAccessIterator>(__buff + __len),

--- a/libcxx/include/__compare/compare_partial_order_fallback.h
+++ b/libcxx/include/__compare/compare_partial_order_fallback.h
@@ -32,34 +32,34 @@ namespace __compare_partial_order_fallback {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>)
-            noexcept(noexcept(_VSTD::partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            -> decltype(      _VSTD::partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))
-            { return          _VSTD::partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)); }
+            noexcept(noexcept(std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            -> decltype(      std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))
+            { return          std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)); }
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? partial_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? partial_ordering::less :
-                              _VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t) ? partial_ordering::greater :
+            noexcept(noexcept(std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? partial_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? partial_ordering::less :
+                              std::forward<_Up>(__u) < std::forward<_Tp>(__t) ? partial_ordering::greater :
                               partial_ordering::unordered))
-            -> decltype(      _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? partial_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? partial_ordering::less :
-                              _VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t) ? partial_ordering::greater :
+            -> decltype(      std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? partial_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? partial_ordering::less :
+                              std::forward<_Up>(__u) < std::forward<_Tp>(__t) ? partial_ordering::greater :
                               partial_ordering::unordered)
         {
-            return            _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? partial_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? partial_ordering::less :
-                              _VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t) ? partial_ordering::greater :
+            return            std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? partial_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? partial_ordering::less :
+                              std::forward<_Up>(__u) < std::forward<_Tp>(__t) ? partial_ordering::greater :
                               partial_ordering::unordered;
         }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()); }
     };
 } // namespace __compare_partial_order_fallback
 

--- a/libcxx/include/__compare/compare_strong_order_fallback.h
+++ b/libcxx/include/__compare/compare_strong_order_fallback.h
@@ -32,31 +32,31 @@ namespace __compare_strong_order_fallback {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>)
-            noexcept(noexcept(_VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            -> decltype(      _VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))
-            { return          _VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)); }
+            noexcept(noexcept(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            -> decltype(      std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))
+            { return          std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)); }
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? strong_ordering::equal :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? strong_ordering::less :
+            noexcept(noexcept(std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? strong_ordering::equal :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? strong_ordering::less :
                               strong_ordering::greater))
-            -> decltype(      _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? strong_ordering::equal :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? strong_ordering::less :
+            -> decltype(      std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? strong_ordering::equal :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? strong_ordering::less :
                               strong_ordering::greater)
         {
-            return            _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? strong_ordering::equal :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? strong_ordering::less :
+            return            std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? strong_ordering::equal :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? strong_ordering::less :
                               strong_ordering::greater;
         }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()); }
     };
 } // namespace __compare_strong_order_fallback
 

--- a/libcxx/include/__compare/compare_three_way.h
+++ b/libcxx/include/__compare/compare_three_way.h
@@ -28,8 +28,8 @@ struct _LIBCPP_TEMPLATE_VIS compare_three_way
         requires three_way_comparable_with<_T1, _T2>
     constexpr _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) <=> _VSTD::forward<_T2>(__u)))
-        { return          _VSTD::forward<_T1>(__t) <=> _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) <=> std::forward<_T2>(__u)))
+        { return          std::forward<_T1>(__t) <=> std::forward<_T2>(__u); }
 
     using is_transparent = void;
 };

--- a/libcxx/include/__compare/compare_weak_order_fallback.h
+++ b/libcxx/include/__compare/compare_weak_order_fallback.h
@@ -32,31 +32,31 @@ namespace __compare_weak_order_fallback {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>)
-            noexcept(noexcept(_VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            -> decltype(      _VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))
-            { return          _VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)); }
+            noexcept(noexcept(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            -> decltype(      std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))
+            { return          std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)); }
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? weak_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? weak_ordering::less :
+            noexcept(noexcept(std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? weak_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? weak_ordering::less :
                               weak_ordering::greater))
-            -> decltype(      _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? weak_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? weak_ordering::less :
+            -> decltype(      std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? weak_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? weak_ordering::less :
                               weak_ordering::greater)
         {
-            return            _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u) ? weak_ordering::equivalent :
-                              _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u) ? weak_ordering::less :
+            return            std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? weak_ordering::equivalent :
+                              std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? weak_ordering::less :
                               weak_ordering::greater;
         }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<1>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>()); }
     };
 } // namespace __compare_weak_order_fallback
 

--- a/libcxx/include/__compare/partial_order.h
+++ b/libcxx/include/__compare/partial_order.h
@@ -34,32 +34,32 @@ namespace __partial_order {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<2>)
-            noexcept(noexcept(partial_ordering(partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      partial_ordering(partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          partial_ordering(partial_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
     // NOLINTEND(libcpp-robust-against-adl)
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>)
-            noexcept(noexcept(partial_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      partial_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          partial_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(partial_ordering(_VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      partial_ordering(_VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          partial_ordering(_VSTD::weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>()); }
     };
 } // namespace __partial_order
 

--- a/libcxx/include/__compare/strong_order.h
+++ b/libcxx/include/__compare/strong_order.h
@@ -40,9 +40,9 @@ namespace __strong_order {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<2>)
-            noexcept(noexcept(strong_ordering(strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      strong_ordering(strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          strong_ordering(strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
     // NOLINTEND(libcpp-robust-against-adl)
 
         template<class _Tp, class _Up, class _Dp = decay_t<_Tp>>
@@ -51,14 +51,14 @@ namespace __strong_order {
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept
         {
             if constexpr (numeric_limits<_Dp>::is_iec559 && sizeof(_Dp) == sizeof(int32_t)) {
-                int32_t __rx = _VSTD::bit_cast<int32_t>(__t);
-                int32_t __ry = _VSTD::bit_cast<int32_t>(__u);
+                int32_t __rx = std::bit_cast<int32_t>(__t);
+                int32_t __ry = std::bit_cast<int32_t>(__u);
                 __rx = (__rx < 0) ? (numeric_limits<int32_t>::min() - __rx - 1) : __rx;
                 __ry = (__ry < 0) ? (numeric_limits<int32_t>::min() - __ry - 1) : __ry;
                 return (__rx <=> __ry);
             } else if constexpr (numeric_limits<_Dp>::is_iec559 && sizeof(_Dp) == sizeof(int64_t)) {
-                int64_t __rx = _VSTD::bit_cast<int64_t>(__t);
-                int64_t __ry = _VSTD::bit_cast<int64_t>(__u);
+                int64_t __rx = std::bit_cast<int64_t>(__t);
+                int64_t __ry = std::bit_cast<int64_t>(__u);
                 __rx = (__rx < 0) ? (numeric_limits<int64_t>::min() - __rx - 1) : __rx;
                 __ry = (__ry < 0) ? (numeric_limits<int64_t>::min() - __ry - 1) : __ry;
                 return (__rx <=> __ry);
@@ -68,27 +68,27 @@ namespace __strong_order {
                 return strong_ordering::greater;
             } else if (__t == __u) {
                 if constexpr (numeric_limits<_Dp>::radix == 2) {
-                    return _VSTD::signbit(__u) <=> _VSTD::signbit(__t);
+                    return std::signbit(__u) <=> std::signbit(__t);
                 } else {
                     // This is bullet 3 of the IEEE754 algorithm, relevant
                     // only for decimal floating-point;
                     // see https://stackoverflow.com/questions/69068075/
-                    if (__t == 0 || _VSTD::isinf(__t)) {
-                        return _VSTD::signbit(__u) <=> _VSTD::signbit(__t);
+                    if (__t == 0 || std::isinf(__t)) {
+                        return std::signbit(__u) <=> std::signbit(__t);
                     } else {
                         int __texp, __uexp;
-                        (void)_VSTD::frexp(__t, &__texp);
-                        (void)_VSTD::frexp(__u, &__uexp);
+                        (void)std::frexp(__t, &__texp);
+                        (void)std::frexp(__u, &__uexp);
                         return (__t < 0) ? (__texp <=> __uexp) : (__uexp <=> __texp);
                     }
                 }
             } else {
                 // They're unordered, so one of them must be a NAN.
                 // The order is -QNAN, -SNAN, numbers, +SNAN, +QNAN.
-                bool __t_is_nan = _VSTD::isnan(__t);
-                bool __u_is_nan = _VSTD::isnan(__u);
-                bool __t_is_negative = _VSTD::signbit(__t);
-                bool __u_is_negative = _VSTD::signbit(__u);
+                bool __t_is_nan = std::isnan(__t);
+                bool __u_is_nan = std::isnan(__u);
+                bool __t_is_negative = std::signbit(__t);
+                bool __u_is_negative = std::signbit(__u);
                 using _IntType = conditional_t<
                     sizeof(__t) == sizeof(int32_t), int32_t, conditional_t<
                     sizeof(__t) == sizeof(int64_t), int64_t, void>
@@ -100,7 +100,7 @@ namespace __strong_order {
                     if (__t_is_negative != __u_is_negative) {
                         return (__u_is_negative <=> __t_is_negative);
                     } else {
-                        return _VSTD::bit_cast<_IntType>(__t) <=> _VSTD::bit_cast<_IntType>(__u);
+                        return std::bit_cast<_IntType>(__t) <=> std::bit_cast<_IntType>(__u);
                     }
                 } else if (__t_is_nan) {
                     return __t_is_negative ? strong_ordering::less : strong_ordering::greater;
@@ -114,15 +114,15 @@ namespace __strong_order {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(strong_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      strong_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          strong_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<2>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>()); }
     };
 } // namespace __strong_order
 

--- a/libcxx/include/__compare/weak_order.h
+++ b/libcxx/include/__compare/weak_order.h
@@ -34,9 +34,9 @@ namespace __weak_order {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<3>)
-            noexcept(noexcept(weak_ordering(weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      weak_ordering(weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          weak_ordering(weak_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
     // NOLINTEND(libcpp-robust-against-adl)
 
         template<class _Tp, class _Up, class _Dp = decay_t<_Tp>>
@@ -53,10 +53,10 @@ namespace __weak_order {
                 return weak_ordering::greater;
             } else {
                 // Otherwise, at least one of them is a NaN.
-                bool __t_is_nan = _VSTD::isnan(__t);
-                bool __u_is_nan = _VSTD::isnan(__u);
-                bool __t_is_negative = _VSTD::signbit(__t);
-                bool __u_is_negative = _VSTD::signbit(__u);
+                bool __t_is_nan = std::isnan(__t);
+                bool __u_is_nan = std::isnan(__u);
+                bool __t_is_negative = std::signbit(__t);
+                bool __u_is_negative = std::signbit(__u);
                 if (__t_is_nan && __u_is_nan) {
                     return (__u_is_negative <=> __t_is_negative);
                 } else if (__t_is_nan) {
@@ -71,23 +71,23 @@ namespace __weak_order {
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<1>)
-            noexcept(noexcept(weak_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      weak_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          weak_ordering(compare_three_way()(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
 
         template<class _Tp, class _Up>
             requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
         _LIBCPP_HIDE_FROM_ABI static constexpr auto
         __go(_Tp&& __t, _Up&& __u, __priority_tag<0>)
-            noexcept(noexcept(weak_ordering(_VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))))
-            -> decltype(      weak_ordering(_VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))))
-            { return          weak_ordering(_VSTD::strong_order(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u))); }
+            noexcept(noexcept(weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
+            -> decltype(      weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
+            { return          weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))); }
 
         template<class _Tp, class _Up>
         _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
-            noexcept(noexcept(__go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<3>())))
-            -> decltype(      __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<3>()))
-            { return          __go(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u), __priority_tag<3>()); }
+            noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>())))
+            -> decltype(      __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>()))
+            { return          __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>()); }
     };
 } // namespace __weak_order
 

--- a/libcxx/include/__concepts/assignable.h
+++ b/libcxx/include/__concepts/assignable.h
@@ -31,7 +31,7 @@ concept assignable_from =
     is_lvalue_reference_v<_Lhs> &&
     common_reference_with<__make_const_lvalue_ref<_Lhs>, __make_const_lvalue_ref<_Rhs>> &&
     requires(_Lhs __lhs, _Rhs&& __rhs) {
-      { __lhs = _VSTD::forward<_Rhs>(__rhs) } -> same_as<_Lhs>;
+      { __lhs = std::forward<_Rhs>(__rhs) } -> same_as<_Lhs>;
     };
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__concepts/boolean_testable.h
+++ b/libcxx/include/__concepts/boolean_testable.h
@@ -28,7 +28,7 @@ concept __boolean_testable_impl = convertible_to<_Tp, bool>;
 
 template <class _Tp>
 concept __boolean_testable = __boolean_testable_impl<_Tp> && requires(_Tp&& __t) {
-  { !_VSTD::forward<_Tp>(__t) } -> __boolean_testable_impl;
+  { !std::forward<_Tp>(__t) } -> __boolean_testable_impl;
 };
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__concepts/invocable.h
+++ b/libcxx/include/__concepts/invocable.h
@@ -25,7 +25,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Fn, class... _Args>
 concept invocable = requires(_Fn&& __fn, _Args&&... __args) {
-  _VSTD::invoke(_VSTD::forward<_Fn>(__fn), _VSTD::forward<_Args>(__args)...); // not required to be equality preserving
+  std::invoke(std::forward<_Fn>(__fn), std::forward<_Args>(__args)...); // not required to be equality preserving
 };
 
 // [concept.regular.invocable]

--- a/libcxx/include/__concepts/swappable.h
+++ b/libcxx/include/__concepts/swappable.h
@@ -48,7 +48,7 @@ template <class _Tp, class _Up>
 concept __unqualified_swappable_with =
     (__class_or_enum<remove_cvref_t<_Tp>> || __class_or_enum<remove_cvref_t<_Up>>) &&
     requires(_Tp&& __t, _Up&& __u) {
-        swap(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u));
+        swap(std::forward<_Tp>(__t), std::forward<_Up>(__u));
     };
 // clang-format on
 
@@ -74,8 +74,8 @@ struct __fn {
   template <class _Tp, class _Up>
     requires __unqualified_swappable_with<_Tp, _Up>
   _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp&& __t, _Up&& __u) const
-      noexcept(noexcept(swap(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u)))) {
-    swap(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u));
+      noexcept(noexcept(swap(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
+    swap(std::forward<_Tp>(__t), std::forward<_Up>(__u));
   }
 
   // 2.2   Otherwise, if `E1` and `E2` are lvalues of array types with equal extent and...
@@ -93,7 +93,7 @@ struct __fn {
   template <__exchangeable _Tp>
   _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp& __x, _Tp& __y) const
       noexcept(is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>) {
-    __y = _VSTD::exchange(__x, _VSTD::move(__y));
+    __y = std::exchange(__x, std::move(__y));
   }
 };
 } // namespace __swap
@@ -108,10 +108,10 @@ concept swappable = requires(_Tp& __a, _Tp& __b) { ranges::swap(__a, __b); };
 
 template <class _Tp, class _Up>
 concept swappable_with = common_reference_with<_Tp, _Up> && requires(_Tp&& __t, _Up&& __u) {
-  ranges::swap(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Tp>(__t));
-  ranges::swap(_VSTD::forward<_Up>(__u), _VSTD::forward<_Up>(__u));
-  ranges::swap(_VSTD::forward<_Tp>(__t), _VSTD::forward<_Up>(__u));
-  ranges::swap(_VSTD::forward<_Up>(__u), _VSTD::forward<_Tp>(__t));
+  ranges::swap(std::forward<_Tp>(__t), std::forward<_Tp>(__t));
+  ranges::swap(std::forward<_Up>(__u), std::forward<_Up>(__u));
+  ranges::swap(std::forward<_Tp>(__t), std::forward<_Up>(__u));
+  ranges::swap(std::forward<_Up>(__u), std::forward<_Tp>(__t));
 };
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -815,16 +815,16 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_HIDE_FROM_ABI_AFTER_V1 _LIBCPP_HIDE_FROM_ABI
 #  endif
 
-// TODO(LLVM-19): Remove _LIBCPP_INLINE_VISIBILITY, which we're keeping around only to
-//                ease the renaming for downstreams.
+// TODO(LLVM-19): Remove _LIBCPP_INLINE_VISIBILITY and _VSTD, which we're keeping around
+//                only to ease the renaming for downstreams.
 #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+#  define _VSTD std
 
 // Inline namespaces are available in Clang/GCC/MSVC regardless of C++ dialect.
 // clang-format off
 #  define _LIBCPP_BEGIN_NAMESPACE_STD namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {                                  \
                                inline namespace _LIBCPP_ABI_NAMESPACE {
 #  define _LIBCPP_END_NAMESPACE_STD }}
-#  define _VSTD std
 
 #  define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM _LIBCPP_BEGIN_NAMESPACE_STD                                               \
                                              inline namespace __fs { namespace filesystem {

--- a/libcxx/include/__coroutine/coroutine_handle.h
+++ b/libcxx/include/__coroutine/coroutine_handle.h
@@ -117,7 +117,7 @@ public:
         using _RawPromise = __remove_cv_t<_Promise>;
         coroutine_handle __tmp;
         __tmp.__handle_ =
-            __builtin_coro_promise(_VSTD::addressof(const_cast<_RawPromise&>(__promise)), alignof(_Promise), true);
+            __builtin_coro_promise(std::addressof(const_cast<_RawPromise&>(__promise)), alignof(_Promise), true);
         return __tmp;
     }
 

--- a/libcxx/include/__filesystem/directory_entry.h
+++ b/libcxx/include/__filesystem/directory_entry.h
@@ -316,7 +316,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI
   void __assign_iter_entry(_Path&& __p, __cached_data __dt) {
-    __p_ = _VSTD::move(__p);
+    __p_ = std::move(__p);
     __data_ = __dt;
   }
 
@@ -502,7 +502,7 @@ private:
 class __dir_element_proxy {
 public:
   inline _LIBCPP_HIDE_FROM_ABI directory_entry operator*() {
-    return _VSTD::move(__elem_);
+    return std::move(__elem_);
   }
 
 private:
@@ -510,7 +510,7 @@ private:
   friend class recursive_directory_iterator;
   _LIBCPP_HIDE_FROM_ABI explicit __dir_element_proxy(directory_entry const& __e) : __elem_(__e) {}
   _LIBCPP_HIDE_FROM_ABI __dir_element_proxy(__dir_element_proxy&& __o)
-      : __elem_(_VSTD::move(__o.__elem_)) {}
+      : __elem_(std::move(__o.__elem_)) {}
   directory_entry __elem_;
 };
 

--- a/libcxx/include/__filesystem/directory_iterator.h
+++ b/libcxx/include/__filesystem/directory_iterator.h
@@ -74,7 +74,7 @@ public:
   directory_iterator& operator=(directory_iterator&& __o) noexcept {
     // non-default implementation provided to support self-move assign.
     if (this != &__o) {
-      __imp_ = _VSTD::move(__o.__imp_);
+      __imp_ = std::move(__o.__imp_);
     }
     return *this;
   }
@@ -156,11 +156,11 @@ _LIBCPP_END_NAMESPACE_FILESYSTEM
 
 template <>
 _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
-inline constexpr bool _VSTD::ranges::enable_borrowed_range<std::filesystem::directory_iterator> = true;
+inline constexpr bool std::ranges::enable_borrowed_range<std::filesystem::directory_iterator> = true;
 
 template <>
 _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
-inline constexpr bool _VSTD::ranges::enable_view<std::filesystem::directory_iterator> = true;
+inline constexpr bool std::ranges::enable_view<std::filesystem::directory_iterator> = true;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__filesystem/filesystem_error.h
+++ b/libcxx/include/__filesystem/filesystem_error.h
@@ -72,7 +72,7 @@ private:
 template <class... _Args>
 _LIBCPP_NORETURN inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY void
 __throw_filesystem_error(_Args&&... __args) {
-  throw filesystem_error(_VSTD::forward<_Args>(__args)...);
+  throw filesystem_error(std::forward<_Args>(__args)...);
 }
 #  else
 template <class... _Args>

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -469,11 +469,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI path() noexcept {}
   _LIBCPP_HIDE_FROM_ABI path(const path& __p) : __pn_(__p.__pn_) {}
   _LIBCPP_HIDE_FROM_ABI path(path&& __p) noexcept
-      : __pn_(_VSTD::move(__p.__pn_)) {}
+      : __pn_(std::move(__p.__pn_)) {}
 
   _LIBCPP_HIDE_FROM_ABI
   path(string_type&& __s, format = format::auto_format) noexcept
-      : __pn_(_VSTD::move(__s)) {}
+      : __pn_(std::move(__s)) {}
 
   template <class _Source, class = _EnableIfPathable<_Source, void> >
   _LIBCPP_HIDE_FROM_ABI
@@ -511,19 +511,19 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI
   path& operator=(path&& __p) noexcept {
-    __pn_ = _VSTD::move(__p.__pn_);
+    __pn_ = std::move(__p.__pn_);
     return *this;
   }
 
   _LIBCPP_HIDE_FROM_ABI
   path& operator=(string_type&& __s) noexcept {
-    __pn_ = _VSTD::move(__s);
+    __pn_ = std::move(__s);
     return *this;
   }
 
   _LIBCPP_HIDE_FROM_ABI
   path& assign(string_type&& __s) noexcept {
-    __pn_ = _VSTD::move(__s);
+    __pn_ = std::move(__s);
     return *this;
   }
 
@@ -709,7 +709,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   path& make_preferred() {
 #if defined(_LIBCPP_WIN32API)
-    _VSTD::replace(__pn_.begin(), __pn_.end(), L'/', L'\\');
+    std::replace(__pn_.begin(), __pn_.end(), L'/', L'\\');
 #endif
     return *this;
   }
@@ -778,13 +778,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI operator string_type() const { return __pn_; }
 
 #if defined(_LIBCPP_WIN32API)
-  _LIBCPP_HIDE_FROM_ABI _VSTD::wstring wstring() const { return __pn_; }
+  _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return __pn_; }
 
   _LIBCPP_HIDE_FROM_ABI
-  _VSTD::wstring generic_wstring() const {
-    _VSTD::wstring __s;
+  std::wstring generic_wstring() const {
+    std::wstring __s;
     __s.resize(__pn_.size());
-    _VSTD::replace_copy(__pn_.begin(), __pn_.end(), __s.begin(), '\\', '/');
+    std::replace_copy(__pn_.begin(), __pn_.end(), __s.begin(), '\\', '/');
     return __s;
   }
 
@@ -801,7 +801,7 @@ public:
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string string() const {
+  _LIBCPP_HIDE_FROM_ABI std::string string() const {
     return string<char>();
   }
   _LIBCPP_HIDE_FROM_ABI __u8_string u8string() const {
@@ -812,10 +812,10 @@ public:
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u16string u16string() const {
+  _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const {
     return string<char16_t>();
   }
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u32string u32string() const {
+  _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const {
     return string<char32_t>();
   }
 
@@ -830,28 +830,28 @@ public:
     // Note: This (and generic_u8string below) is slightly suboptimal as
     // it iterates twice over the string; once to convert it to the right
     // character type, and once to replace path delimiters.
-    _VSTD::replace(__s.begin(), __s.end(),
+    std::replace(__s.begin(), __s.end(),
                    static_cast<_ECharT>('\\'), static_cast<_ECharT>('/'));
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string generic_string() const { return generic_string<char>(); }
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u16string generic_u16string() const { return generic_string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u32string generic_u32string() const { return generic_string<char32_t>(); }
+  _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return generic_string<char>(); }
+  _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return generic_string<char16_t>(); }
+  _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return generic_string<char32_t>(); }
   _LIBCPP_HIDE_FROM_ABI
   __u8_string generic_u8string() const {
     __u8_string __s = u8string();
-    _VSTD::replace(__s.begin(), __s.end(), '\\', '/');
+    std::replace(__s.begin(), __s.end(), '\\', '/');
     return __s;
   }
 #endif /* !_LIBCPP_HAS_NO_LOCALIZATION */
 #else /* _LIBCPP_WIN32API */
 
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string string() const { return __pn_; }
+  _LIBCPP_HIDE_FROM_ABI std::string string() const { return __pn_; }
 #ifndef _LIBCPP_HAS_NO_CHAR8_T
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u8string u8string() const { return _VSTD::u8string(__pn_.begin(), __pn_.end()); }
+  _LIBCPP_HIDE_FROM_ABI std::u8string u8string() const { return std::u8string(__pn_.begin(), __pn_.end()); }
 #else
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string u8string() const { return __pn_; }
+  _LIBCPP_HIDE_FROM_ABI std::string u8string() const { return __pn_; }
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -869,24 +869,24 @@ public:
   }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-  _LIBCPP_HIDE_FROM_ABI _VSTD::wstring wstring() const {
+  _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const {
     return string<wchar_t>();
   }
 #endif
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u16string u16string() const {
+  _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const {
     return string<char16_t>();
   }
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u32string u32string() const {
+  _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const {
     return string<char32_t>();
   }
 #endif /* !_LIBCPP_HAS_NO_LOCALIZATION */
 
   // generic format observers
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string generic_string() const { return __pn_; }
+  _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return __pn_; }
 #ifndef _LIBCPP_HAS_NO_CHAR8_T
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u8string generic_u8string() const { return _VSTD::u8string(__pn_.begin(), __pn_.end()); }
+  _LIBCPP_HIDE_FROM_ABI std::u8string generic_u8string() const { return std::u8string(__pn_.begin(), __pn_.end()); }
 #else
-  _LIBCPP_HIDE_FROM_ABI _VSTD::string generic_u8string() const { return __pn_; }
+  _LIBCPP_HIDE_FROM_ABI std::string generic_u8string() const { return __pn_; }
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -899,10 +899,10 @@ public:
   }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-  _LIBCPP_HIDE_FROM_ABI _VSTD::wstring generic_wstring() const { return string<wchar_t>(); }
+  _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const { return string<wchar_t>(); }
 #endif
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u16string generic_u16string() const { return string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI _VSTD::u32string generic_u32string() const { return string<char32_t>(); }
+  _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return string<char16_t>(); }
+  _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return string<char32_t>(); }
 #endif /* !_LIBCPP_HAS_NO_LOCALIZATION */
 #endif /* !_LIBCPP_WIN32API */
 
@@ -1039,7 +1039,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI friend
   basic_ostream<_CharT, _Traits>&
       operator<<(basic_ostream<_CharT, _Traits>& __os, const path& __p) {
-    __os << _VSTD::__quoted(__p.native());
+    __os << std::__quoted(__p.native());
     return __os;
   }
 
@@ -1048,7 +1048,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI friend
   basic_ostream<_CharT, _Traits>&
       operator<<(basic_ostream<_CharT, _Traits>& __os, const path& __p) {
-    __os << _VSTD::__quoted(__p.string<_CharT, _Traits>());
+    __os << std::__quoted(__p.string<_CharT, _Traits>());
     return __os;
   }
 
@@ -1056,7 +1056,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI friend basic_istream<_CharT, _Traits>&
   operator>>(basic_istream<_CharT, _Traits>& __is, path& __p) {
     basic_string<_CharT, _Traits> __tmp;
-    __is >> _VSTD::__quoted(__tmp);
+    __is >> std::__quoted(__tmp);
     __p = __tmp;
     return __is;
   }

--- a/libcxx/include/__filesystem/recursive_directory_iterator.h
+++ b/libcxx/include/__filesystem/recursive_directory_iterator.h
@@ -72,7 +72,7 @@ public:
   operator=(recursive_directory_iterator&& __o) noexcept {
     // non-default implementation provided to support self-move assign.
     if (this != &__o) {
-      __imp_ = _VSTD::move(__o.__imp_);
+      __imp_ = std::move(__o.__imp_);
       __rec_ = __o.__rec_;
     }
     return *this;
@@ -170,11 +170,11 @@ _LIBCPP_END_NAMESPACE_FILESYSTEM
 
 template <>
 _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
-inline constexpr bool _VSTD::ranges::enable_borrowed_range<std::filesystem::recursive_directory_iterator> = true;
+inline constexpr bool std::ranges::enable_borrowed_range<std::filesystem::recursive_directory_iterator> = true;
 
 template <>
 _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
-inline constexpr bool _VSTD::ranges::enable_view<std::filesystem::recursive_directory_iterator> = true;
+inline constexpr bool std::ranges::enable_view<std::filesystem::recursive_directory_iterator> = true;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__filesystem/u8path.h
+++ b/libcxx/include/__filesystem/u8path.h
@@ -46,7 +46,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T
 #if defined(_LIBCPP_WIN32API)
   string __tmp(__f, __l);
   using _CVT = __widen_from_utf8<sizeof(wchar_t) * __CHAR_BIT__>;
-  _VSTD::wstring __w;
+  std::wstring __w;
   __w.reserve(__tmp.size());
   _CVT()(back_inserter(__w), __tmp.data(), __tmp.data() + __tmp.size());
   return path(__w);
@@ -72,7 +72,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T
   for (; *__f != __sentinel; ++__f)
     __tmp.push_back(*__f);
   using _CVT = __widen_from_utf8<sizeof(wchar_t) * __CHAR_BIT__>;
-  _VSTD::wstring __w;
+  std::wstring __w;
   __w.reserve(__tmp.size());
   _CVT()(back_inserter(__w), __tmp.data(), __tmp.data() + __tmp.size());
   return path(__w);
@@ -92,7 +92,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T
       "'char' or 'char8_t'");
 #if defined(_LIBCPP_WIN32API)
   using _Traits = __is_pathable<_Source>;
-  return u8path(_VSTD::__unwrap_iter(_Traits::__range_begin(__s)), _VSTD::__unwrap_iter(_Traits::__range_end(__s)));
+  return u8path(std::__unwrap_iter(_Traits::__range_begin(__s)), std::__unwrap_iter(_Traits::__range_end(__s)));
 #else
   return path(__s);
 #endif

--- a/libcxx/include/__format/buffer.h
+++ b/libcxx/include/__format/buffer.h
@@ -108,7 +108,7 @@ public:
 
     __flush_on_overflow(__n);
     if (__n < __capacity_) { //  push_back requires the buffer to have room for at least one character (so use <).
-      _VSTD::copy_n(__str.data(), __n, _VSTD::addressof(__ptr_[__size_]));
+      std::copy_n(__str.data(), __n, std::addressof(__ptr_[__size_]));
       __size_ += __n;
       return;
     }
@@ -118,8 +118,8 @@ public:
     _LIBCPP_ASSERT_UNCATEGORIZED(__size_ == 0, "the buffer should be flushed by __flush_on_overflow");
     const _InCharT* __first = __str.data();
     do {
-      size_t __chunk = _VSTD::min(__n, __capacity_);
-      _VSTD::copy_n(__first, __chunk, _VSTD::addressof(__ptr_[__size_]));
+      size_t __chunk = std::min(__n, __capacity_);
+      std::copy_n(__first, __chunk, std::addressof(__ptr_[__size_]));
       __size_ = __chunk;
       __first += __chunk;
       __n -= __chunk;
@@ -137,7 +137,7 @@ public:
     size_t __n = static_cast<size_t>(__last - __first);
     __flush_on_overflow(__n);
     if (__n < __capacity_) { //  push_back requires the buffer to have room for at least one character (so use <).
-      _VSTD::transform(__first, __last, _VSTD::addressof(__ptr_[__size_]), _VSTD::move(__operation));
+      std::transform(__first, __last, std::addressof(__ptr_[__size_]), std::move(__operation));
       __size_ += __n;
       return;
     }
@@ -146,8 +146,8 @@ public:
     // Transform the data in "__capacity_" sized chunks.
     _LIBCPP_ASSERT_UNCATEGORIZED(__size_ == 0, "the buffer should be flushed by __flush_on_overflow");
     do {
-      size_t __chunk = _VSTD::min(__n, __capacity_);
-      _VSTD::transform(__first, __first + __chunk, _VSTD::addressof(__ptr_[__size_]), __operation);
+      size_t __chunk = std::min(__n, __capacity_);
+      std::transform(__first, __first + __chunk, std::addressof(__ptr_[__size_]), __operation);
       __size_ = __chunk;
       __first += __chunk;
       __n -= __chunk;
@@ -159,7 +159,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void __fill(size_t __n, _CharT __value) {
     __flush_on_overflow(__n);
     if (__n < __capacity_) { //  push_back requires the buffer to have room for at least one character (so use <).
-      _VSTD::fill_n(_VSTD::addressof(__ptr_[__size_]), __n, __value);
+      std::fill_n(std::addressof(__ptr_[__size_]), __n, __value);
       __size_ += __n;
       return;
     }
@@ -168,8 +168,8 @@ public:
     // Fill the buffer in "__capacity_" sized chunks.
     _LIBCPP_ASSERT_UNCATEGORIZED(__size_ == 0, "the buffer should be flushed by __flush_on_overflow");
     do {
-      size_t __chunk = _VSTD::min(__n, __capacity_);
-      _VSTD::fill_n(_VSTD::addressof(__ptr_[__size_]), __chunk, __value);
+      size_t __chunk = std::min(__n, __capacity_);
+      std::fill_n(std::addressof(__ptr_[__size_]), __chunk, __value);
       __size_ = __chunk;
       __n -= __chunk;
       __flush();
@@ -282,7 +282,7 @@ template <class _OutIt, __fmt_char_type _CharT>
 class _LIBCPP_TEMPLATE_VIS __writer_iterator {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit __writer_iterator(_OutIt __out_it)
-      : __out_it_{_VSTD::move(__out_it)} {}
+      : __out_it_{std::move(__out_it)} {}
 
   _LIBCPP_HIDE_FROM_ABI _OutIt __out_it() && { return std::move(__out_it_); }
 
@@ -359,12 +359,12 @@ requires(output_iterator<_OutIt, const _CharT&>) class _LIBCPP_TEMPLATE_VIS
 public:
   _LIBCPP_HIDE_FROM_ABI explicit __format_buffer(_OutIt __out_it)
     requires(same_as<_Storage, __internal_storage<_CharT>>)
-      : __output_(__storage_.__begin(), __storage_.__buffer_size, this), __writer_(_VSTD::move(__out_it)) {}
+      : __output_(__storage_.__begin(), __storage_.__buffer_size, this), __writer_(std::move(__out_it)) {}
 
   _LIBCPP_HIDE_FROM_ABI explicit __format_buffer(_OutIt __out_it) requires(
       same_as<_Storage, __direct_storage<_CharT>>)
-      : __output_(_VSTD::__unwrap_iter(__out_it), size_t(-1), this),
-        __writer_(_VSTD::move(__out_it)) {}
+      : __output_(std::__unwrap_iter(__out_it), size_t(-1), this),
+        __writer_(std::move(__out_it)) {}
 
   _LIBCPP_HIDE_FROM_ABI auto __make_output_iterator() { return __output_.__make_output_iterator(); }
 
@@ -372,7 +372,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _OutIt __out_it() && {
     __output_.__flush();
-    return _VSTD::move(__writer_).__out_it();
+    return std::move(__writer_).__out_it();
   }
 
 private:
@@ -411,11 +411,11 @@ struct _LIBCPP_TEMPLATE_VIS __format_to_n_buffer_base {
 
 public:
   _LIBCPP_HIDE_FROM_ABI explicit __format_to_n_buffer_base(_OutIt __out_it, _Size __max_size)
-      : __writer_(_VSTD::move(__out_it)), __max_size_(_VSTD::max(_Size(0), __max_size)) {}
+      : __writer_(std::move(__out_it)), __max_size_(std::max(_Size(0), __max_size)) {}
 
   _LIBCPP_HIDE_FROM_ABI void __flush(_CharT* __ptr, size_t __n) {
     if (_Size(__size_) <= __max_size_)
-      __writer_.__flush(__ptr, _VSTD::min(_Size(__n), __max_size_ - __size_));
+      __writer_.__flush(__ptr, std::min(_Size(__n), __max_size_ - __size_));
     __size_ += __n;
   }
 
@@ -441,8 +441,8 @@ class _LIBCPP_TEMPLATE_VIS __format_to_n_buffer_base<_OutIt, _CharT, true> {
 
 public:
   _LIBCPP_HIDE_FROM_ABI explicit __format_to_n_buffer_base(_OutIt __out_it, _Size __max_size)
-      : __output_(_VSTD::__unwrap_iter(__out_it), __max_size, this),
-        __writer_(_VSTD::move(__out_it)),
+      : __output_(std::__unwrap_iter(__out_it), __max_size, this),
+        __writer_(std::move(__out_it)),
         __max_size_(__max_size) {
     if (__max_size <= 0) [[unlikely]]
       __output_.__reset(__storage_.__begin(), __storage_.__buffer_size);
@@ -466,7 +466,7 @@ public:
     } else if (__size_ < __max_size_) {
       // Copies a part of the internal buffer to the output up to n characters.
       // See __output_buffer<_CharT>::__flush_on_overflow for more information.
-      _Size __s = _VSTD::min(_Size(__n), __max_size_ - __size_);
+      _Size __s = std::min(_Size(__n), __max_size_ - __size_);
       std::copy_n(__ptr, __s, __writer_.__out_it());
       __writer_.__flush(__ptr, __s);
     }
@@ -493,12 +493,12 @@ struct _LIBCPP_TEMPLATE_VIS __format_to_n_buffer final
 
 public:
   _LIBCPP_HIDE_FROM_ABI explicit __format_to_n_buffer(_OutIt __out_it, _Size __max_size)
-      : _Base(_VSTD::move(__out_it), __max_size) {}
+      : _Base(std::move(__out_it), __max_size) {}
   _LIBCPP_HIDE_FROM_ABI auto __make_output_iterator() { return this->__output_.__make_output_iterator(); }
 
   _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt> __result() && {
     this->__output_.__flush();
-    return {_VSTD::move(this->__writer_).__out_it(), this->__size_};
+    return {std::move(this->__writer_).__out_it(), this->__size_};
   }
 };
 

--- a/libcxx/include/__format/format_arg.h
+++ b/libcxx/include/__format/format_arg.h
@@ -100,45 +100,45 @@ _LIBCPP_HIDE_FROM_ABI decltype(auto)
 __visit_format_arg(_Visitor&& __vis, basic_format_arg<_Context> __arg) {
   switch (__arg.__type_) {
   case __format::__arg_t::__none:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__monostate_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__monostate_);
   case __format::__arg_t::__boolean:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__boolean_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__boolean_);
   case __format::__arg_t::__char_type:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__char_type_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__char_type_);
   case __format::__arg_t::__int:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__int_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__int_);
   case __format::__arg_t::__long_long:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__long_long_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__long_long_);
   case __format::__arg_t::__i128:
 #  ifndef _LIBCPP_HAS_NO_INT128
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__i128_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__i128_);
 #  else
     __libcpp_unreachable();
 #  endif
   case __format::__arg_t::__unsigned:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__unsigned_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__unsigned_);
   case __format::__arg_t::__unsigned_long_long:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__unsigned_long_long_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__unsigned_long_long_);
   case __format::__arg_t::__u128:
 #  ifndef _LIBCPP_HAS_NO_INT128
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__u128_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__u128_);
 #  else
     __libcpp_unreachable();
 #  endif
   case __format::__arg_t::__float:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__float_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__float_);
   case __format::__arg_t::__double:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__double_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__double_);
   case __format::__arg_t::__long_double:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__long_double_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__long_double_);
   case __format::__arg_t::__const_char_type_ptr:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__const_char_type_ptr_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__const_char_type_ptr_);
   case __format::__arg_t::__string_view:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__string_view_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__string_view_);
   case __format::__arg_t::__ptr:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), __arg.__value_.__ptr_);
+    return std::invoke(std::forward<_Visitor>(__vis), __arg.__value_.__ptr_);
   case __format::__arg_t::__handle:
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis),
+    return std::invoke(std::forward<_Visitor>(__vis),
                          typename basic_format_arg<_Context>::handle{__arg.__value_.__handle_});
   }
 
@@ -158,7 +158,7 @@ public:
   struct __handle {
     template <class _Tp>
     _LIBCPP_HIDE_FROM_ABI explicit __handle(_Tp& __v) noexcept
-        : __ptr_(_VSTD::addressof(__v)),
+        : __ptr_(std::addressof(__v)),
           __format_([](basic_format_parse_context<_CharT>& __parse_ctx, _Context& __ctx, const void* __ptr) {
             using _Dp = remove_const_t<_Tp>;
             using _Qp = conditional_t<__formattable_with<const _Dp, _Context>, const _Dp, _Dp>;
@@ -278,16 +278,16 @@ visit_format_arg(_Visitor&& __vis, basic_format_arg<_Context> __arg) {
 #  ifndef _LIBCPP_HAS_NO_INT128
   case __format::__arg_t::__i128: {
     typename __basic_format_arg_value<_Context>::__handle __h{__arg.__value_.__i128_};
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), typename basic_format_arg<_Context>::handle{__h});
+    return std::invoke(std::forward<_Visitor>(__vis), typename basic_format_arg<_Context>::handle{__h});
   }
 
   case __format::__arg_t::__u128: {
     typename __basic_format_arg_value<_Context>::__handle __h{__arg.__value_.__u128_};
-    return _VSTD::invoke(_VSTD::forward<_Visitor>(__vis), typename basic_format_arg<_Context>::handle{__h});
+    return std::invoke(std::forward<_Visitor>(__vis), typename basic_format_arg<_Context>::handle{__h});
   }
 #  endif
   default:
-    return _VSTD::__visit_format_arg(_VSTD::forward<_Visitor>(__vis), __arg);
+    return std::__visit_format_arg(std::forward<_Visitor>(__vis), __arg);
   }
 }
 

--- a/libcxx/include/__format/format_context.h
+++ b/libcxx/include/__format/format_context.h
@@ -54,8 +54,8 @@ _LIBCPP_HIDE_FROM_ABI basic_format_context<_OutIt, _CharT>
 __format_context_create(
     _OutIt __out_it,
     basic_format_args<basic_format_context<_OutIt, _CharT>> __args,
-    optional<_VSTD::locale>&& __loc = nullopt) {
-  return _VSTD::basic_format_context(_VSTD::move(__out_it), __args, _VSTD::move(__loc));
+    optional<std::locale>&& __loc = nullopt) {
+  return std::basic_format_context(std::move(__out_it), __args, std::move(__loc));
 }
 #else
 template <class _OutIt, class _CharT>
@@ -63,7 +63,7 @@ _LIBCPP_HIDE_FROM_ABI basic_format_context<_OutIt, _CharT>
 __format_context_create(
     _OutIt __out_it,
     basic_format_args<basic_format_context<_OutIt, _CharT>> __args) {
-  return _VSTD::basic_format_context(_VSTD::move(__out_it), __args);
+  return std::basic_format_context(std::move(__out_it), __args);
 }
 #endif
 
@@ -95,9 +95,9 @@ public:
     return __args_.get(__id);
   }
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
-  _LIBCPP_HIDE_FROM_ABI _VSTD::locale locale() {
+  _LIBCPP_HIDE_FROM_ABI std::locale locale() {
     if (!__loc_)
-      __loc_ = _VSTD::locale{};
+      __loc_ = std::locale{};
     return *__loc_;
   }
 #endif
@@ -118,20 +118,20 @@ private:
   // locale() is called and the optional has no value the value will be created.
   // This allows the implementation to lazily create the locale.
   // TODO FMT Validate whether lazy creation is the best solution.
-  optional<_VSTD::locale> __loc_;
+  optional<std::locale> __loc_;
 
   template <class _OtherOutIt, class _OtherCharT>
   friend _LIBCPP_HIDE_FROM_ABI basic_format_context<_OtherOutIt, _OtherCharT>
   __format_context_create(_OtherOutIt, basic_format_args<basic_format_context<_OtherOutIt, _OtherCharT>>,
-                          optional<_VSTD::locale>&&);
+                          optional<std::locale>&&);
 
   // Note: the Standard doesn't specify the required constructors.
   _LIBCPP_HIDE_FROM_ABI
   explicit basic_format_context(_OutIt __out_it,
                                 basic_format_args<basic_format_context> __args,
-                                optional<_VSTD::locale>&& __loc)
-      : __out_it_(_VSTD::move(__out_it)), __args_(__args),
-        __loc_(_VSTD::move(__loc)) {}
+                                optional<std::locale>&& __loc)
+      : __out_it_(std::move(__out_it)), __args_(__args),
+        __loc_(std::move(__loc)) {}
 #else
   template <class _OtherOutIt, class _OtherCharT>
   friend _LIBCPP_HIDE_FROM_ABI basic_format_context<_OtherOutIt, _OtherCharT>
@@ -140,7 +140,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI
   explicit basic_format_context(_OutIt __out_it,
                                 basic_format_args<basic_format_context> __args)
-      : __out_it_(_VSTD::move(__out_it)), __args_(__args) {}
+      : __out_it_(std::move(__out_it)), __args_(__args) {}
 #endif
 };
 
@@ -198,7 +198,7 @@ public:
     return __arg_(__ctx_, __id);
   }
 #  ifndef _LIBCPP_HAS_NO_LOCALIZATION
-  _LIBCPP_HIDE_FROM_ABI _VSTD::locale locale() { return __loc_(__ctx_); }
+  _LIBCPP_HIDE_FROM_ABI std::locale locale() { return __loc_(__ctx_); }
 #  endif
   _LIBCPP_HIDE_FROM_ABI iterator out() { return std::move(__out_it_); }
   _LIBCPP_HIDE_FROM_ABI void advance_to(iterator __it) { __out_it_ = std::move(__it); }

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -64,14 +64,14 @@ using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...> make_format_args(_Args&&... __args) {
-  return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
+  return std::__format_arg_store<_Context, _Args...>(__args...);
 }
 
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<wformat_context, _Args...>
 make_wformat_args(_Args&&... __args) {
-  return _VSTD::__format_arg_store<wformat_context, _Args...>(__args...);
+  return std::__format_arg_store<wformat_context, _Args...>(__args...);
 }
 #  endif
 
@@ -271,7 +271,7 @@ __handle_replacement_field(_Iterator __begin, _Iterator __end,
     else if (__parse)
       __format::__compile_time_visit_format_arg(__parse_ctx, __ctx, __type);
   } else
-    _VSTD::__visit_format_arg(
+    std::__visit_format_arg(
         [&](auto __arg) {
           if constexpr (same_as<decltype(__arg), monostate>)
             std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
@@ -310,7 +310,7 @@ __vformat_to(_ParseCtx&& __parse_ctx, _Ctx&& __ctx) {
         std::__throw_format_error("The format string terminates at a '{'");
 
       if (*__begin != _CharT('{')) [[likely]] {
-        __ctx.advance_to(_VSTD::move(__out_it));
+        __ctx.advance_to(std::move(__out_it));
         __begin =
             __format::__handle_replacement_field(__begin, __end, __parse_ctx, __ctx);
         __out_it = __ctx.out();
@@ -410,13 +410,13 @@ requires(output_iterator<_OutIt, const _CharT&>) _LIBCPP_HIDE_FROM_ABI _OutIt
         _OutIt __out_it, basic_string_view<_CharT> __fmt,
         basic_format_args<basic_format_context<_FormatOutIt, _CharT>> __args) {
   if constexpr (same_as<_OutIt, _FormatOutIt>)
-    return _VSTD::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
-                                         _VSTD::__format_context_create(_VSTD::move(__out_it), __args));
+    return std::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
+                                         std::__format_context_create(std::move(__out_it), __args));
   else {
-    __format::__format_buffer<_OutIt, _CharT> __buffer{_VSTD::move(__out_it)};
-    _VSTD::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
-                                  _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args));
-    return _VSTD::move(__buffer).__out_it();
+    __format::__format_buffer<_OutIt, _CharT> __buffer{std::move(__out_it)};
+    std::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
+                                  std::__format_context_create(__buffer.__make_output_iterator(), __args));
+    return std::move(__buffer).__out_it();
   }
 }
 
@@ -426,30 +426,30 @@ requires(output_iterator<_OutIt, const _CharT&>) _LIBCPP_HIDE_FROM_ABI _OutIt
 template <output_iterator<const char&> _OutIt>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 vformat_to(_OutIt __out_it, string_view __fmt, format_args __args) {
-  return _VSTD::__vformat_to(_VSTD::move(__out_it), __fmt, __args);
+  return std::__vformat_to(std::move(__out_it), __fmt, __args);
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <output_iterator<const wchar_t&> _OutIt>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 vformat_to(_OutIt __out_it, wstring_view __fmt, wformat_args __args) {
-  return _VSTD::__vformat_to(_VSTD::move(__out_it), __fmt, __args);
+  return std::__vformat_to(std::move(__out_it), __fmt, __args);
 }
 #endif
 
 template <output_iterator<const char&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 format_to(_OutIt __out_it, format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat_to(_VSTD::move(__out_it), __fmt.get(),
-                           _VSTD::make_format_args(__args...));
+  return std::vformat_to(std::move(__out_it), __fmt.get(),
+                           std::make_format_args(__args...));
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <output_iterator<const wchar_t&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 format_to(_OutIt __out_it, wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat_to(_VSTD::move(__out_it), __fmt.get(),
-                           _VSTD::make_wformat_args(__args...));
+  return std::vformat_to(std::move(__out_it), __fmt.get(),
+                           std::make_wformat_args(__args...));
 }
 #endif
 
@@ -459,7 +459,7 @@ template <class = void>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI string
 vformat(string_view __fmt, format_args __args) {
   string __res;
-  _VSTD::vformat_to(_VSTD::back_inserter(__res), __fmt, __args);
+  std::vformat_to(std::back_inserter(__res), __fmt, __args);
   return __res;
 }
 
@@ -470,7 +470,7 @@ template <class = void>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI wstring
 vformat(wstring_view __fmt, wformat_args __args) {
   wstring __res;
-  _VSTD::vformat_to(_VSTD::back_inserter(__res), __fmt, __args);
+  std::vformat_to(std::back_inserter(__res), __fmt, __args);
   return __res;
 }
 #  endif
@@ -478,14 +478,14 @@ vformat(wstring_view __fmt, wformat_args __args) {
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI string
 format(format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat(__fmt.get(), _VSTD::make_format_args(__args...));
+  return std::vformat(__fmt.get(), std::make_format_args(__args...));
 }
 
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI wstring
 format(wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat(__fmt.get(), _VSTD::make_wformat_args(__args...));
+  return std::vformat(__fmt.get(), std::make_wformat_args(__args...));
 }
 #  endif
 
@@ -493,16 +493,16 @@ template <class _Context, class _OutIt, class _CharT>
 _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt> __vformat_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n,
                                                                 basic_string_view<_CharT> __fmt,
                                                                 basic_format_args<_Context> __args) {
-  __format::__format_to_n_buffer<_OutIt, _CharT> __buffer{_VSTD::move(__out_it), __n};
-  _VSTD::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
-                                _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args));
-  return _VSTD::move(__buffer).__result();
+  __format::__format_to_n_buffer<_OutIt, _CharT> __buffer{std::move(__out_it), __n};
+  std::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
+                                std::__format_context_create(__buffer.__make_output_iterator(), __args));
+  return std::move(__buffer).__result();
 }
 
 template <output_iterator<const char&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt>
 format_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n, format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::__vformat_to_n<format_context>(_VSTD::move(__out_it), __n, __fmt.get(), _VSTD::make_format_args(__args...));
+  return std::__vformat_to_n<format_context>(std::move(__out_it), __n, __fmt.get(), std::make_format_args(__args...));
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
@@ -510,29 +510,29 @@ template <output_iterator<const wchar_t&> _OutIt, class... _Args>
 _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt>
 format_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n, wformat_string<_Args...> __fmt,
             _Args&&... __args) {
-  return _VSTD::__vformat_to_n<wformat_context>(_VSTD::move(__out_it), __n, __fmt.get(), _VSTD::make_wformat_args(__args...));
+  return std::__vformat_to_n<wformat_context>(std::move(__out_it), __n, __fmt.get(), std::make_wformat_args(__args...));
 }
 #endif
 
 template <class _CharT>
 _LIBCPP_HIDE_FROM_ABI size_t __vformatted_size(basic_string_view<_CharT> __fmt, auto __args) {
   __format::__formatted_size_buffer<_CharT> __buffer;
-  _VSTD::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
-                                _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args));
-  return _VSTD::move(__buffer).__result();
+  std::__format::__vformat_to(basic_format_parse_context{__fmt, __args.__size()},
+                                std::__format_context_create(__buffer.__make_output_iterator(), __args));
+  return std::move(__buffer).__result();
 }
 
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI size_t
 formatted_size(format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::__vformatted_size(__fmt.get(), basic_format_args{_VSTD::make_format_args(__args...)});
+  return std::__vformatted_size(__fmt.get(), basic_format_args{std::make_format_args(__args...)});
 }
 
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI size_t
 formatted_size(wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::__vformatted_size(__fmt.get(), basic_format_args{_VSTD::make_wformat_args(__args...)});
+  return std::__vformatted_size(__fmt.get(), basic_format_args{std::make_wformat_args(__args...)});
 }
 #  endif
 
@@ -544,22 +544,22 @@ requires(output_iterator<_OutIt, const _CharT&>) _LIBCPP_HIDE_FROM_ABI _OutIt
         _OutIt __out_it, locale __loc, basic_string_view<_CharT> __fmt,
         basic_format_args<basic_format_context<_FormatOutIt, _CharT>> __args) {
   if constexpr (same_as<_OutIt, _FormatOutIt>)
-    return _VSTD::__format::__vformat_to(
+    return std::__format::__vformat_to(
         basic_format_parse_context{__fmt, __args.__size()},
-        _VSTD::__format_context_create(_VSTD::move(__out_it), __args, _VSTD::move(__loc)));
+        std::__format_context_create(std::move(__out_it), __args, std::move(__loc)));
   else {
-    __format::__format_buffer<_OutIt, _CharT> __buffer{_VSTD::move(__out_it)};
-    _VSTD::__format::__vformat_to(
+    __format::__format_buffer<_OutIt, _CharT> __buffer{std::move(__out_it)};
+    std::__format::__vformat_to(
         basic_format_parse_context{__fmt, __args.__size()},
-        _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args, _VSTD::move(__loc)));
-    return _VSTD::move(__buffer).__out_it();
+        std::__format_context_create(__buffer.__make_output_iterator(), __args, std::move(__loc)));
+    return std::move(__buffer).__out_it();
   }
 }
 
 template <output_iterator<const char&> _OutIt>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt vformat_to(
     _OutIt __out_it, locale __loc, string_view __fmt, format_args __args) {
-  return _VSTD::__vformat_to(_VSTD::move(__out_it), _VSTD::move(__loc), __fmt,
+  return std::__vformat_to(std::move(__out_it), std::move(__loc), __fmt,
                              __args);
 }
 
@@ -567,7 +567,7 @@ _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt vformat_to(
 template <output_iterator<const wchar_t&> _OutIt>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt vformat_to(
     _OutIt __out_it, locale __loc, wstring_view __fmt, wformat_args __args) {
-  return _VSTD::__vformat_to(_VSTD::move(__out_it), _VSTD::move(__loc), __fmt,
+  return std::__vformat_to(std::move(__out_it), std::move(__loc), __fmt,
                              __args);
 }
 #endif
@@ -575,16 +575,16 @@ _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt vformat_to(
 template <output_iterator<const char&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 format_to(_OutIt __out_it, locale __loc, format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat_to(_VSTD::move(__out_it), _VSTD::move(__loc), __fmt.get(),
-                           _VSTD::make_format_args(__args...));
+  return std::vformat_to(std::move(__out_it), std::move(__loc), __fmt.get(),
+                           std::make_format_args(__args...));
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <output_iterator<const wchar_t&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
 format_to(_OutIt __out_it, locale __loc, wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat_to(_VSTD::move(__out_it), _VSTD::move(__loc), __fmt.get(),
-                           _VSTD::make_wformat_args(__args...));
+  return std::vformat_to(std::move(__out_it), std::move(__loc), __fmt.get(),
+                           std::make_wformat_args(__args...));
 }
 #endif
 
@@ -594,7 +594,7 @@ template <class = void>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI string
 vformat(locale __loc, string_view __fmt, format_args __args) {
   string __res;
-  _VSTD::vformat_to(_VSTD::back_inserter(__res), _VSTD::move(__loc), __fmt,
+  std::vformat_to(std::back_inserter(__res), std::move(__loc), __fmt,
                     __args);
   return __res;
 }
@@ -606,7 +606,7 @@ template <class = void>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI wstring
 vformat(locale __loc, wstring_view __fmt, wformat_args __args) {
   wstring __res;
-  _VSTD::vformat_to(_VSTD::back_inserter(__res), _VSTD::move(__loc), __fmt,
+  std::vformat_to(std::back_inserter(__res), std::move(__loc), __fmt,
                     __args);
   return __res;
 }
@@ -615,16 +615,16 @@ vformat(locale __loc, wstring_view __fmt, wformat_args __args) {
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI string
 format(locale __loc, format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat(_VSTD::move(__loc), __fmt.get(),
-                        _VSTD::make_format_args(__args...));
+  return std::vformat(std::move(__loc), __fmt.get(),
+                        std::make_format_args(__args...));
 }
 
 #    ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI wstring
 format(locale __loc, wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::vformat(_VSTD::move(__loc), __fmt.get(),
-                        _VSTD::make_wformat_args(__args...));
+  return std::vformat(std::move(__loc), __fmt.get(),
+                        std::make_wformat_args(__args...));
 }
 #    endif
 
@@ -632,19 +632,19 @@ template <class _Context, class _OutIt, class _CharT>
 _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt> __vformat_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n,
                                                                 locale __loc, basic_string_view<_CharT> __fmt,
                                                                 basic_format_args<_Context> __args) {
-  __format::__format_to_n_buffer<_OutIt, _CharT> __buffer{_VSTD::move(__out_it), __n};
-  _VSTD::__format::__vformat_to(
+  __format::__format_to_n_buffer<_OutIt, _CharT> __buffer{std::move(__out_it), __n};
+  std::__format::__vformat_to(
       basic_format_parse_context{__fmt, __args.__size()},
-      _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args, _VSTD::move(__loc)));
-  return _VSTD::move(__buffer).__result();
+      std::__format_context_create(__buffer.__make_output_iterator(), __args, std::move(__loc)));
+  return std::move(__buffer).__result();
 }
 
 template <output_iterator<const char&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt>
 format_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n, locale __loc, format_string<_Args...> __fmt,
             _Args&&... __args) {
-  return _VSTD::__vformat_to_n<format_context>(_VSTD::move(__out_it), __n, _VSTD::move(__loc), __fmt.get(),
-                                               _VSTD::make_format_args(__args...));
+  return std::__vformat_to_n<format_context>(std::move(__out_it), __n, std::move(__loc), __fmt.get(),
+                                               std::make_format_args(__args...));
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
@@ -652,31 +652,31 @@ template <output_iterator<const wchar_t&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI format_to_n_result<_OutIt>
 format_to_n(_OutIt __out_it, iter_difference_t<_OutIt> __n, locale __loc, wformat_string<_Args...> __fmt,
             _Args&&... __args) {
-  return _VSTD::__vformat_to_n<wformat_context>(_VSTD::move(__out_it), __n, _VSTD::move(__loc), __fmt.get(),
-                                                _VSTD::make_wformat_args(__args...));
+  return std::__vformat_to_n<wformat_context>(std::move(__out_it), __n, std::move(__loc), __fmt.get(),
+                                                std::make_wformat_args(__args...));
 }
 #endif
 
 template <class _CharT>
 _LIBCPP_HIDE_FROM_ABI size_t __vformatted_size(locale __loc, basic_string_view<_CharT> __fmt, auto __args) {
   __format::__formatted_size_buffer<_CharT> __buffer;
-  _VSTD::__format::__vformat_to(
+  std::__format::__vformat_to(
       basic_format_parse_context{__fmt, __args.__size()},
-      _VSTD::__format_context_create(__buffer.__make_output_iterator(), __args, _VSTD::move(__loc)));
-  return _VSTD::move(__buffer).__result();
+      std::__format_context_create(__buffer.__make_output_iterator(), __args, std::move(__loc)));
+  return std::move(__buffer).__result();
 }
 
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI size_t
 formatted_size(locale __loc, format_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::__vformatted_size(_VSTD::move(__loc), __fmt.get(), basic_format_args{_VSTD::make_format_args(__args...)});
+  return std::__vformatted_size(std::move(__loc), __fmt.get(), basic_format_args{std::make_format_args(__args...)});
 }
 
 #    ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI size_t
 formatted_size(locale __loc, wformat_string<_Args...> __fmt, _Args&&... __args) {
-  return _VSTD::__vformatted_size(_VSTD::move(__loc), __fmt.get(), basic_format_args{_VSTD::make_wformat_args(__args...)});
+  return std::__vformatted_size(std::move(__loc), __fmt.get(), basic_format_args{std::make_wformat_args(__args...)});
 }
 #    endif
 

--- a/libcxx/include/__format/formatter_floating_point.h
+++ b/libcxx/include/__format/formatter_floating_point.h
@@ -56,21 +56,21 @@ namespace __formatter {
 
 template <floating_point _Tp>
 _LIBCPP_HIDE_FROM_ABI char* __to_buffer(char* __first, char* __last, _Tp __value) {
-  to_chars_result __r = _VSTD::to_chars(__first, __last, __value);
+  to_chars_result __r = std::to_chars(__first, __last, __value);
   _LIBCPP_ASSERT_UNCATEGORIZED(__r.ec == errc(0), "Internal buffer too small");
   return __r.ptr;
 }
 
 template <floating_point _Tp>
 _LIBCPP_HIDE_FROM_ABI char* __to_buffer(char* __first, char* __last, _Tp __value, chars_format __fmt) {
-  to_chars_result __r = _VSTD::to_chars(__first, __last, __value, __fmt);
+  to_chars_result __r = std::to_chars(__first, __last, __value, __fmt);
   _LIBCPP_ASSERT_UNCATEGORIZED(__r.ec == errc(0), "Internal buffer too small");
   return __r.ptr;
 }
 
 template <floating_point _Tp>
 _LIBCPP_HIDE_FROM_ABI char* __to_buffer(char* __first, char* __last, _Tp __value, chars_format __fmt, int __precision) {
-  to_chars_result __r = _VSTD::to_chars(__first, __last, __value, __fmt, __precision);
+  to_chars_result __r = std::to_chars(__first, __last, __value, __fmt, __precision);
   _LIBCPP_ASSERT_UNCATEGORIZED(__r.ec == errc(0), "Internal buffer too small");
   return __r.ptr;
 }
@@ -224,7 +224,7 @@ struct __float_result {
 constexpr inline _LIBCPP_HIDE_FROM_ABI char* __find_exponent(char* __first, char* __last) {
   ptrdiff_t __size = __last - __first;
   if (__size >= 4) {
-    __first = __last - _VSTD::min(__size, ptrdiff_t(6));
+    __first = __last - std::min(__size, ptrdiff_t(6));
     for (; __first != __last - 3; ++__first) {
       if (*__first == 'e')
         return __first;
@@ -245,7 +245,7 @@ _LIBCPP_HIDE_FROM_ABI __float_result __format_buffer_default(const __float_buffe
   // Constrains:
   // - There's at least one decimal digit before the radix point.
   // - The radix point, when present, is placed before the exponent.
-  __result.__radix_point = _VSTD::find(__result.__integral + 1, __result.__exponent, '.');
+  __result.__radix_point = std::find(__result.__integral + 1, __result.__exponent, '.');
 
   // When the radix point isn't found its position is the exponent instead of
   // __result.__last.
@@ -299,7 +299,7 @@ _LIBCPP_HIDE_FROM_ABI __float_result __format_buffer_hexadecimal_lower_case(cons
 
     char* __last = __result.__last - 2;
     __first = __last - __traits<_Fp>::__hex_precision_digits;
-    __result.__exponent = _VSTD::find(__first, __last, 'p');
+    __result.__exponent = std::find(__first, __last, 'p');
   } else {
     __result.__radix_point = __result.__last;
     __result.__exponent = __first;
@@ -321,7 +321,7 @@ _LIBCPP_HIDE_FROM_ABI __float_result __format_buffer_hexadecimal_upper_case(cons
                                                                             char* __integral) {
   __float_result __result =
       __formatter::__format_buffer_hexadecimal_lower_case(__buffer, __value, __precision, __integral);
-  _VSTD::transform(__result.__integral, __result.__exponent, __result.__integral, __hex_to_upper);
+  std::transform(__result.__integral, __result.__exponent, __result.__integral, __hex_to_upper);
   *__result.__exponent = 'P';
   return __result;
 }
@@ -411,7 +411,7 @@ _LIBCPP_HIDE_FROM_ABI __float_result __format_buffer_general_lower_case(__float_
       // In fixed mode the algorithm truncates trailing spaces and possibly the
       // radix point. There's no good guess for the position of the radix point
       // therefore scan the output after the first digit.
-      __result.__radix_point = _VSTD::find(__first, __result.__last, '.');
+      __result.__radix_point = std::find(__first, __result.__last, '.');
     }
   }
 
@@ -502,13 +502,13 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_locale_specific_form(
     _OutIt __out_it,
     const __float_buffer<_Fp>& __buffer,
     const __float_result& __result,
-    _VSTD::locale __loc,
+    std::locale __loc,
     __format_spec::__parsed_specifications<_CharT> __specs) {
   const auto& __np = std::use_facet<numpunct<_CharT>>(__loc);
   string __grouping = __np.grouping();
   char* __first = __result.__integral;
   // When no radix point or exponent are present __last will be __result.__last.
-  char* __last = _VSTD::min(__result.__radix_point, __result.__exponent);
+  char* __last = std::min(__result.__radix_point, __result.__exponent);
 
   ptrdiff_t __digits = __last - __first;
   if (!__grouping.empty()) {
@@ -538,13 +538,13 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_locale_specific_form(
   // sign and (zero padding or alignment)
   if (__zero_padding && __first != __buffer.begin())
     *__out_it++ = *__buffer.begin();
-  __out_it = __formatter::__fill(_VSTD::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it = __formatter::__fill(std::move(__out_it), __padding.__before_, __specs.__fill_);
   if (!__zero_padding && __first != __buffer.begin())
     *__out_it++ = *__buffer.begin();
 
   // integral part
   if (__grouping.empty()) {
-    __out_it = __formatter::__copy(__first, __digits, _VSTD::move(__out_it));
+    __out_it = __formatter::__copy(__first, __digits, std::move(__out_it));
   } else {
     auto __r = __grouping.rbegin();
     auto __e = __grouping.rend() - 1;
@@ -556,7 +556,7 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_locale_specific_form(
     // This loop achieves that process by testing the termination condition
     // midway in the loop.
     while (true) {
-      __out_it = __formatter::__copy(__first, *__r, _VSTD::move(__out_it));
+      __out_it = __formatter::__copy(__first, *__r, std::move(__out_it));
       __first += *__r;
 
       if (__r == __e)
@@ -570,16 +570,16 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_locale_specific_form(
   // fractional part
   if (__result.__radix_point != __result.__last) {
     *__out_it++ = __np.decimal_point();
-    __out_it    = __formatter::__copy(__result.__radix_point + 1, __result.__exponent, _VSTD::move(__out_it));
-    __out_it    = __formatter::__fill(_VSTD::move(__out_it), __buffer.__num_trailing_zeros(), _CharT('0'));
+    __out_it    = __formatter::__copy(__result.__radix_point + 1, __result.__exponent, std::move(__out_it));
+    __out_it    = __formatter::__fill(std::move(__out_it), __buffer.__num_trailing_zeros(), _CharT('0'));
   }
 
   // exponent
   if (__result.__exponent != __result.__last)
-    __out_it = __formatter::__copy(__result.__exponent, __result.__last, _VSTD::move(__out_it));
+    __out_it = __formatter::__copy(__result.__exponent, __result.__last, std::move(__out_it));
 
   // alignment
-  return __formatter::__fill(_VSTD::move(__out_it), __padding.__after_, __specs.__fill_);
+  return __formatter::__fill(std::move(__out_it), __padding.__after_, __specs.__fill_);
 }
 #  endif // _LIBCPP_HAS_NO_LOCALIZATION
 
@@ -597,7 +597,7 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_floating_point_non_finite(
       __specs.__std_.__type_ == __format_spec::__type::__scientific_upper_case ||
       __specs.__std_.__type_ == __format_spec::__type::__fixed_upper_case ||
       __specs.__std_.__type_ == __format_spec::__type::__general_upper_case;
-  __last = _VSTD::copy_n(&("infnanINFNAN"[6 * __upper_case + 3 * __isnan]), 3, __last);
+  __last = std::copy_n(&("infnanINFNAN"[6 * __upper_case + 3 * __isnan]), 3, __last);
 
   // [format.string.std]/13
   // A zero (0) character preceding the width field pads the field with
@@ -606,7 +606,7 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __format_floating_point_non_finite(
   if (__specs.__alignment_ == __format_spec::__alignment::__zero_padding)
     __specs.__alignment_ = __format_spec::__alignment::__right;
 
-  return __formatter::__write(__buffer, __last, _VSTD::move(__out_it), __specs);
+  return __formatter::__write(__buffer, __last, std::move(__out_it), __specs);
 }
 
 /// Writes additional zero's for the precision before the exponent.
@@ -632,21 +632,21 @@ _LIBCPP_HIDE_FROM_ABI auto __write_using_trailing_zeros(
 
   __padding_size_result __padding =
       __formatter::__padding_size(__size + __num_trailing_zeros, __specs.__width_, __specs.__alignment_);
-  __out_it = __formatter::__fill(_VSTD::move(__out_it), __padding.__before_, __specs.__fill_);
-  __out_it = __formatter::__copy(__first, __exponent, _VSTD::move(__out_it));
-  __out_it = __formatter::__fill(_VSTD::move(__out_it), __num_trailing_zeros, _CharT('0'));
-  __out_it = __formatter::__copy(__exponent, __last, _VSTD::move(__out_it));
-  return __formatter::__fill(_VSTD::move(__out_it), __padding.__after_, __specs.__fill_);
+  __out_it = __formatter::__fill(std::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it = __formatter::__copy(__first, __exponent, std::move(__out_it));
+  __out_it = __formatter::__fill(std::move(__out_it), __num_trailing_zeros, _CharT('0'));
+  __out_it = __formatter::__copy(__exponent, __last, std::move(__out_it));
+  return __formatter::__fill(std::move(__out_it), __padding.__after_, __specs.__fill_);
 }
 
 
 template <floating_point _Tp, class _CharT, class _FormatContext>
 _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator
 __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__parsed_specifications<_CharT> __specs) {
-  bool __negative = _VSTD::signbit(__value);
+  bool __negative = std::signbit(__value);
 
-  if (!_VSTD::isfinite(__value)) [[unlikely]]
-    return __formatter::__format_floating_point_non_finite(__ctx.out(), __specs, __negative, _VSTD::isnan(__value));
+  if (!std::isfinite(__value)) [[unlikely]]
+    return __formatter::__format_floating_point_non_finite(__ctx.out(), __specs, __negative, std::isnan(__value));
 
   // Depending on the std-format-spec string the sign and the value
   // might not be outputted together:
@@ -672,7 +672,7 @@ __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__par
       // When there is an exponent the point needs to be moved before the
       // exponent. When there's no exponent the rotate does nothing. Since
       // rotate tests whether the operation is a nop, call it unconditionally.
-      _VSTD::rotate(__result.__exponent, __result.__last - 1, __result.__last);
+      std::rotate(__result.__exponent, __result.__last - 1, __result.__last);
       __result.__radix_point = __result.__exponent;
 
       // The radix point is always placed before the exponent.
@@ -697,7 +697,7 @@ __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__par
       // Let P equal the precision if nonzero, 6 if the precision is not
       // specified, or 1 if the precision is 0. Then, if a conversion with
       // style E would have an exponent of X:
-      int __p = _VSTD::max(1, (__specs.__has_precision() ? __specs.__precision_ : 6));
+      int __p = std::max(1, (__specs.__has_precision() ? __specs.__precision_ : 6));
       if (__result.__exponent == __result.__last)
         // if P > X >= -4, the conversion is with style f or F and precision P - 1 - X.
         // By including the radix point it calculates P - (1 + X)
@@ -749,9 +749,9 @@ __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__par
 
   if (__num_trailing_zeros)
     return __formatter::__write_using_trailing_zeros(
-        __first, __result.__last, _VSTD::move(__out_it), __specs, __size, __result.__exponent, __num_trailing_zeros);
+        __first, __result.__last, std::move(__out_it), __specs, __size, __result.__exponent, __num_trailing_zeros);
 
-  return __formatter::__write(__first, __result.__last, _VSTD::move(__out_it), __specs, __size);
+  return __formatter::__write(__first, __result.__last, std::move(__out_it), __specs, __size);
 }
 
 } // namespace __formatter

--- a/libcxx/include/__format/formatter_integral.h
+++ b/libcxx/include/__format/formatter_integral.h
@@ -141,7 +141,7 @@ _LIBCPP_HIDE_FROM_ABI auto __format_char(
   }
 
   const auto __c = static_cast<_CharT>(__value);
-  return __formatter::__write(_VSTD::addressof(__c), _VSTD::addressof(__c) + 1, _VSTD::move(__out_it), __specs);
+  return __formatter::__write(std::addressof(__c), std::addressof(__c) + 1, std::move(__out_it), __specs);
 }
 
 //
@@ -153,7 +153,7 @@ template <integral _Tp>
 _LIBCPP_HIDE_FROM_ABI char* __to_buffer(char* __first, char* __last, _Tp __value, int __base) {
   // TODO FMT Evaluate code overhead due to not calling the internal function
   // directly. (Should be zero overhead.)
-  to_chars_result __r = _VSTD::to_chars(__first, __last, __value, __base);
+  to_chars_result __r = std::to_chars(__first, __last, __value, __base);
   _LIBCPP_ASSERT_UNCATEGORIZED(__r.ec == errc(0), "Internal buffer too small");
   return __r.ptr;
 }
@@ -214,22 +214,22 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, c
   __padding_size_result __padding = {0, 0};
   if (__specs.__alignment_ == __format_spec::__alignment::__zero_padding) {
     // Write [sign][prefix].
-    __out_it = __formatter::__copy(__begin, __first, _VSTD::move(__out_it));
+    __out_it = __formatter::__copy(__begin, __first, std::move(__out_it));
 
     if (__specs.__width_ > __size) {
       // Write zero padding.
       __padding.__before_ = __specs.__width_ - __size;
-      __out_it            = __formatter::__fill(_VSTD::move(__out_it), __specs.__width_ - __size, _CharT('0'));
+      __out_it            = __formatter::__fill(std::move(__out_it), __specs.__width_ - __size, _CharT('0'));
     }
   } else {
     if (__specs.__width_ > __size) {
       // Determine padding and write padding.
       __padding = __formatter::__padding_size(__size, __specs.__width_, __specs.__alignment_);
 
-      __out_it = __formatter::__fill(_VSTD::move(__out_it), __padding.__before_, __specs.__fill_);
+      __out_it = __formatter::__fill(std::move(__out_it), __padding.__before_, __specs.__fill_);
     }
     // Write [sign][prefix].
-    __out_it = __formatter::__copy(__begin, __first, _VSTD::move(__out_it));
+    __out_it = __formatter::__copy(__begin, __first, std::move(__out_it));
   }
 
   auto __r = __grouping.rbegin();
@@ -250,10 +250,10 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, c
   while (true) {
     if (__specs.__std_.__type_ == __format_spec::__type::__hexadecimal_upper_case) {
       __last = __first + *__r;
-      __out_it = __formatter::__transform(__first, __last, _VSTD::move(__out_it), __hex_to_upper);
+      __out_it = __formatter::__transform(__first, __last, std::move(__out_it), __hex_to_upper);
       __first = __last;
     } else {
-      __out_it = __formatter::__copy(__first, *__r, _VSTD::move(__out_it));
+      __out_it = __formatter::__copy(__first, *__r, std::move(__out_it));
       __first += *__r;
     }
 
@@ -264,7 +264,7 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, c
     *__out_it++ = __sep;
   }
 
-  return __formatter::__fill(_VSTD::move(__out_it), __padding.__after_, __specs.__fill_);
+  return __formatter::__fill(std::move(__out_it), __padding.__after_, __specs.__fill_);
 }
 
 
@@ -315,12 +315,12 @@ _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator __format_integer(
     // The zero padding is done like:
     // - Write [sign][prefix]
     // - Write data right aligned with '0' as fill character.
-    __out_it             = __formatter::__copy(__begin, __first, _VSTD::move(__out_it));
+    __out_it             = __formatter::__copy(__begin, __first, std::move(__out_it));
     __specs.__alignment_ = __format_spec::__alignment::__right;
     __specs.__fill_.__data[0] = _CharT('0');
     int32_t __size       = __first - __begin;
 
-    __specs.__width_ -= _VSTD::min(__size, __specs.__width_);
+    __specs.__width_ -= std::min(__size, __specs.__width_);
   }
 
   if (__specs.__std_.__type_ != __format_spec::__type::__hexadecimal_upper_case) [[likely]]

--- a/libcxx/include/__format/formatter_output.h
+++ b/libcxx/include/__format/formatter_output.h
@@ -98,15 +98,15 @@ __padding_size(size_t __size, size_t __width, __format_spec::__alignment __align
 template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
 _LIBCPP_HIDE_FROM_ABI auto __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it)
     -> decltype(__out_it) {
-  if constexpr (_VSTD::same_as<decltype(__out_it), _VSTD::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
+  if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__copy(__str);
     return __out_it;
-  } else if constexpr (_VSTD::same_as<decltype(__out_it),
+  } else if constexpr (std::same_as<decltype(__out_it),
                                       typename __format::__retarget_buffer<_OutCharT>::__iterator>) {
     __out_it.__buffer_->__copy(__str);
     return __out_it;
   } else {
-    return std::ranges::copy(__str, _VSTD::move(__out_it)).out;
+    return std::ranges::copy(__str, std::move(__out_it)).out;
   }
 }
 
@@ -114,13 +114,13 @@ template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
 _LIBCPP_HIDE_FROM_ABI auto
 __copy(const _CharT* __first, const _CharT* __last, output_iterator<const _OutCharT&> auto __out_it)
     -> decltype(__out_it) {
-  return __formatter::__copy(basic_string_view{__first, __last}, _VSTD::move(__out_it));
+  return __formatter::__copy(basic_string_view{__first, __last}, std::move(__out_it));
 }
 
 template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
 _LIBCPP_HIDE_FROM_ABI auto __copy(const _CharT* __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it)
     -> decltype(__out_it) {
-  return __formatter::__copy(basic_string_view{__first, __n}, _VSTD::move(__out_it));
+  return __formatter::__copy(basic_string_view{__first, __n}, std::move(__out_it));
 }
 
 /// Transform wrapper.
@@ -132,15 +132,15 @@ __transform(const _CharT* __first,
             const _CharT* __last,
             output_iterator<const _OutCharT&> auto __out_it,
             _UnaryOperation __operation) -> decltype(__out_it) {
-  if constexpr (_VSTD::same_as<decltype(__out_it), _VSTD::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
-    __out_it.__get_container()->__transform(__first, __last, _VSTD::move(__operation));
+  if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
+    __out_it.__get_container()->__transform(__first, __last, std::move(__operation));
     return __out_it;
-  } else if constexpr (_VSTD::same_as<decltype(__out_it),
+  } else if constexpr (std::same_as<decltype(__out_it),
                                       typename __format::__retarget_buffer<_OutCharT>::__iterator>) {
-    __out_it.__buffer_->__transform(__first, __last, _VSTD::move(__operation));
+    __out_it.__buffer_->__transform(__first, __last, std::move(__operation));
     return __out_it;
   } else {
-    return std::ranges::transform(__first, __last, _VSTD::move(__out_it), __operation).out;
+    return std::ranges::transform(__first, __last, std::move(__out_it), __operation).out;
   }
 }
 
@@ -149,14 +149,14 @@ __transform(const _CharT* __first,
 /// This uses a "mass output function" of __format::__output_buffer when possible.
 template <__fmt_char_type _CharT, output_iterator<const _CharT&> _OutIt>
 _LIBCPP_HIDE_FROM_ABI _OutIt __fill(_OutIt __out_it, size_t __n, _CharT __value) {
-  if constexpr (_VSTD::same_as<decltype(__out_it), _VSTD::back_insert_iterator<__format::__output_buffer<_CharT>>>) {
+  if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_CharT>>>) {
     __out_it.__get_container()->__fill(__n, __value);
     return __out_it;
-  } else if constexpr (_VSTD::same_as<decltype(__out_it), typename __format::__retarget_buffer<_CharT>::__iterator>) {
+  } else if constexpr (std::same_as<decltype(__out_it), typename __format::__retarget_buffer<_CharT>::__iterator>) {
     __out_it.__buffer_->__fill(__n, __value);
     return __out_it;
   } else {
-    return std::ranges::fill_n(_VSTD::move(__out_it), __n, __value);
+    return std::ranges::fill_n(std::move(__out_it), __n, __value);
   }
 }
 
@@ -228,12 +228,12 @@ __write(basic_string_view<_CharT> __str,
         __format_spec::__parsed_specifications<_ParserCharT> __specs,
         ptrdiff_t __size) -> decltype(__out_it) {
   if (__size >= __specs.__width_)
-    return __formatter::__copy(__str, _VSTD::move(__out_it));
+    return __formatter::__copy(__str, std::move(__out_it));
 
   __padding_size_result __padding = __formatter::__padding_size(__size, __specs.__width_, __specs.__std_.__alignment_);
-  __out_it                        = __formatter::__fill(_VSTD::move(__out_it), __padding.__before_, __specs.__fill_);
-  __out_it                        = __formatter::__copy(__str, _VSTD::move(__out_it));
-  return __formatter::__fill(_VSTD::move(__out_it), __padding.__after_, __specs.__fill_);
+  __out_it                        = __formatter::__fill(std::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it                        = __formatter::__copy(__str, std::move(__out_it));
+  return __formatter::__fill(std::move(__out_it), __padding.__after_, __specs.__fill_);
 }
 
 template <contiguous_iterator _Iterator, class _ParserCharT>
@@ -244,7 +244,7 @@ __write(_Iterator __first,
         __format_spec::__parsed_specifications<_ParserCharT> __specs,
         ptrdiff_t __size) -> decltype(__out_it) {
   _LIBCPP_ASSERT_UNCATEGORIZED(__first <= __last, "Not a valid range");
-  return __formatter::__write(basic_string_view{__first, __last}, _VSTD::move(__out_it), __specs, __size);
+  return __formatter::__write(basic_string_view{__first, __last}, std::move(__out_it), __specs, __size);
 }
 
 /// \overload
@@ -257,7 +257,7 @@ __write(_Iterator __first,
         output_iterator<const iter_value_t<_Iterator>&> auto __out_it,
         __format_spec::__parsed_specifications<_ParserCharT> __specs) -> decltype(__out_it) {
   _LIBCPP_ASSERT_UNCATEGORIZED(__first <= __last, "Not a valid range");
-  return __formatter::__write(__first, __last, _VSTD::move(__out_it), __specs, __last - __first);
+  return __formatter::__write(__first, __last, std::move(__out_it), __specs, __last - __first);
 }
 
 template <class _CharT, class _ParserCharT, class _UnaryOperation>
@@ -269,12 +269,12 @@ _LIBCPP_HIDE_FROM_ABI auto __write_transformed(const _CharT* __first, const _Cha
 
   ptrdiff_t __size = __last - __first;
   if (__size >= __specs.__width_)
-    return __formatter::__transform(__first, __last, _VSTD::move(__out_it), __op);
+    return __formatter::__transform(__first, __last, std::move(__out_it), __op);
 
   __padding_size_result __padding = __formatter::__padding_size(__size, __specs.__width_, __specs.__alignment_);
-  __out_it                        = __formatter::__fill(_VSTD::move(__out_it), __padding.__before_, __specs.__fill_);
-  __out_it                        = __formatter::__transform(__first, __last, _VSTD::move(__out_it), __op);
-  return __formatter::__fill(_VSTD::move(__out_it), __padding.__after_, __specs.__fill_);
+  __out_it                        = __formatter::__fill(std::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it                        = __formatter::__transform(__first, __last, std::move(__out_it), __op);
+  return __formatter::__fill(std::move(__out_it), __padding.__after_, __specs.__fill_);
 }
 
 /// Writes a string using format's width estimation algorithm.
@@ -292,7 +292,7 @@ _LIBCPP_HIDE_FROM_ABI auto __write_string_no_precision(
 
   // No padding -> copy the string
   if (!__specs.__has_width())
-    return __formatter::__copy(__str, _VSTD::move(__out_it));
+    return __formatter::__copy(__str, std::move(__out_it));
 
   // Note when the estimated width is larger than size there's no padding. So
   // there's no reason to get the real size when the estimate is larger than or
@@ -300,7 +300,7 @@ _LIBCPP_HIDE_FROM_ABI auto __write_string_no_precision(
   size_t __size =
       __format_spec::__estimate_column_width(__str, __specs.__width_, __format_spec::__column_width_rounding::__up)
           .__width_;
-  return __formatter::__write(__str, _VSTD::move(__out_it), __specs, __size);
+  return __formatter::__write(__str, std::move(__out_it), __specs, __size);
 }
 
 template <class _CharT>

--- a/libcxx/include/__format/parser_std_format_spec.h
+++ b/libcxx/include/__format/parser_std_format_spec.h
@@ -92,7 +92,7 @@ __substitute_arg_id(basic_format_arg<_Context> __format_arg) {
   // This means the 128-bit will not be valid anymore.
   // TODO FMT Verify this resolution is accepted and add a test to verify
   //          128-bit integrals fail and switch to visit_format_arg.
-  return _VSTD::__visit_format_arg(
+  return std::__visit_format_arg(
       [](auto __arg) -> uint32_t {
         using _Type = decltype(__arg);
         if constexpr (same_as<_Type, monostate>)
@@ -1158,7 +1158,7 @@ __estimate_column_width(basic_string_view<_CharT> __str, size_t __maximum, __col
   // When Unicode isn't supported assume ASCII and every code unit is one code
   // point. In ASCII the estimated column width is always one. Thus there's no
   // need for rounding.
-  size_t __width_ = _VSTD::min(__str.size(), __maximum);
+  size_t __width_ = std::min(__str.size(), __maximum);
   return {__width_, __str.begin() + __width_};
 }
 

--- a/libcxx/include/__format/write_escaped.h
+++ b/libcxx/include/__format/write_escaped.h
@@ -47,11 +47,11 @@ _LIBCPP_HIDE_FROM_ABI auto __write_string(
     output_iterator<const _CharT&> auto __out_it,
     __format_spec::__parsed_specifications<_CharT> __specs) -> decltype(__out_it) {
   if (!__specs.__has_precision())
-    return __formatter::__write_string_no_precision(__str, _VSTD::move(__out_it), __specs);
+    return __formatter::__write_string_no_precision(__str, std::move(__out_it), __specs);
 
   int __size = __formatter::__truncate(__str, __specs.__precision_);
 
-  return __formatter::__write(__str.begin(), __str.end(), _VSTD::move(__out_it), __specs, __size);
+  return __formatter::__write(__str.begin(), __str.end(), std::move(__out_it), __specs, __size);
 }
 
 #  endif // _LIBCPP_STD_VER >= 20
@@ -198,7 +198,7 @@ __format_escaped_char(_CharT __value,
   __str += _CharT('\'');
   __formatter::__escape(__str, basic_string_view{std::addressof(__value), 1}, __escape_quotation_mark::__apostrophe);
   __str += _CharT('\'');
-  return __formatter::__write(__str.data(), __str.data() + __str.size(), _VSTD::move(__out_it), __specs, __str.size());
+  return __formatter::__write(__str.data(), __str.data() + __str.size(), std::move(__out_it), __specs, __str.size());
 }
 
 template <class _CharT>
@@ -210,7 +210,7 @@ __format_escaped_string(basic_string_view<_CharT> __values,
   __str += _CharT('"');
   __formatter::__escape(__str, __values, __escape_quotation_mark::__double_quote);
   __str += _CharT('"');
-  return __formatter::__write_string(basic_string_view{__str}, _VSTD::move(__out_it), __specs);
+  return __formatter::__write_string(basic_string_view{__str}, std::move(__out_it), __specs);
 }
 
 #  endif // _LIBCPP_STD_VER >= 23

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -95,7 +95,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 typename __invoke_of<_Ti&, _Uj...>::type
 __mu_expand(_Ti& __ti, tuple<_Uj...>& __uj, __tuple_indices<_Indx...>)
 {
-    return __ti(_VSTD::forward<_Uj>(_VSTD::get<_Indx>(__uj))...);
+    return __ti(std::forward<_Uj>(std::get<_Indx>(__uj))...);
 }
 
 template <class _Ti, class ..._Uj, __enable_if_t<is_bind_expression<_Ti>::value, int> = 0>
@@ -104,7 +104,7 @@ typename __invoke_of<_Ti&, _Uj...>::type
 __mu(_Ti& __ti, tuple<_Uj...>& __uj)
 {
     typedef typename __make_tuple_indices<sizeof...(_Uj)>::type __indices;
-    return _VSTD::__mu_expand(__ti, __uj, __indices());
+    return std::__mu_expand(__ti, __uj, __indices());
 }
 
 template <bool IsPh, class _Ti, class _Uj>
@@ -122,7 +122,7 @@ typename __mu_return2<0 < is_placeholder<_Ti>::value, _Ti, _Uj>::type
 __mu(_Ti&, _Uj& __uj)
 {
     const size_t __indx = is_placeholder<_Ti>::value - 1;
-    return _VSTD::forward<typename tuple_element<__indx, _Uj>::type>(_VSTD::get<__indx>(__uj));
+    return std::forward<typename tuple_element<__indx, _Uj>::type>(std::get<__indx>(__uj));
 }
 
 template <class _Ti, class _Uj, __enable_if_t<!is_bind_expression<_Ti>::value &&
@@ -245,7 +245,7 @@ typename __bind_return<_Fp, _BoundArgs, _Args>::type
 __apply_functor(_Fp& __f, _BoundArgs& __bound_args, __tuple_indices<_Indx...>,
                 _Args&& __args)
 {
-    return _VSTD::__invoke(__f, _VSTD::__mu(_VSTD::get<_Indx>(__bound_args), __args)...);
+    return std::__invoke(__f, std::__mu(std::get<_Indx>(__bound_args), __args)...);
 }
 
 template<class _Fp, class ..._BoundArgs>
@@ -264,16 +264,16 @@ public:
               __enable_if_t<is_constructible<_Fd, _Gp>::value && !is_same<__libcpp_remove_reference_t<_Gp>, __bind>::value, int> = 0>
       _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
       explicit __bind(_Gp&& __f, _BA&& ...__bound_args)
-        : __f_(_VSTD::forward<_Gp>(__f)),
-          __bound_args_(_VSTD::forward<_BA>(__bound_args)...) {}
+        : __f_(std::forward<_Gp>(__f)),
+          __bound_args_(std::forward<_BA>(__bound_args)...) {}
 
     template <class ..._Args>
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
         typename __bind_return<_Fd, _Td, tuple<_Args&&...> >::type
         operator()(_Args&& ...__args)
         {
-            return _VSTD::__apply_functor(__f_, __bound_args_, __indices(),
-                                  tuple<_Args&&...>(_VSTD::forward<_Args>(__args)...));
+            return std::__apply_functor(__f_, __bound_args_, __indices(),
+                                  tuple<_Args&&...>(std::forward<_Args>(__args)...));
         }
 
     template <class ..._Args>
@@ -281,8 +281,8 @@ public:
         typename __bind_return<const _Fd, const _Td, tuple<_Args&&...> >::type
         operator()(_Args&& ...__args) const
         {
-            return _VSTD::__apply_functor(__f_, __bound_args_, __indices(),
-                                   tuple<_Args&&...>(_VSTD::forward<_Args>(__args)...));
+            return std::__apply_functor(__f_, __bound_args_, __indices(),
+                                   tuple<_Args&&...>(std::forward<_Args>(__args)...));
         }
 };
 
@@ -304,8 +304,8 @@ public:
               __enable_if_t<is_constructible<_Fd, _Gp>::value && !is_same<__libcpp_remove_reference_t<_Gp>, __bind_r>::value, int> = 0>
       _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
       explicit __bind_r(_Gp&& __f, _BA&& ...__bound_args)
-        : base(_VSTD::forward<_Gp>(__f),
-               _VSTD::forward<_BA>(__bound_args)...) {}
+        : base(std::forward<_Gp>(__f),
+               std::forward<_BA>(__bound_args)...) {}
 
     template <class ..._Args, __enable_if_t<is_convertible<typename __bind_return<_Fd, _Td, tuple<_Args&&...> >::type,
                                                            result_type>::value || is_void<_Rp>::value, int> = 0>
@@ -314,7 +314,7 @@ public:
         operator()(_Args&& ...__args)
         {
             typedef __invoke_void_return_wrapper<_Rp> _Invoker;
-            return _Invoker::__call(static_cast<base&>(*this), _VSTD::forward<_Args>(__args)...);
+            return _Invoker::__call(static_cast<base&>(*this), std::forward<_Args>(__args)...);
         }
 
     template <class ..._Args, __enable_if_t<is_convertible<typename __bind_return<const _Fd, const _Td, tuple<_Args&&...> >::type,
@@ -324,7 +324,7 @@ public:
         operator()(_Args&& ...__args) const
         {
             typedef __invoke_void_return_wrapper<_Rp> _Invoker;
-            return _Invoker::__call(static_cast<base const&>(*this), _VSTD::forward<_Args>(__args)...);
+            return _Invoker::__call(static_cast<base const&>(*this), std::forward<_Args>(__args)...);
         }
 };
 
@@ -337,7 +337,7 @@ __bind<_Fp, _BoundArgs...>
 bind(_Fp&& __f, _BoundArgs&&... __bound_args)
 {
     typedef __bind<_Fp, _BoundArgs...> type;
-    return type(_VSTD::forward<_Fp>(__f), _VSTD::forward<_BoundArgs>(__bound_args)...);
+    return type(std::forward<_Fp>(__f), std::forward<_BoundArgs>(__bound_args)...);
 }
 
 template<class _Rp, class _Fp, class ..._BoundArgs>
@@ -346,7 +346,7 @@ __bind_r<_Rp, _Fp, _BoundArgs...>
 bind(_Fp&& __f, _BoundArgs&&... __bound_args)
 {
     typedef __bind_r<_Rp, _Fp, _BoundArgs...> type;
-    return type(_VSTD::forward<_Fp>(__f), _VSTD::forward<_BoundArgs>(__bound_args)...);
+    return type(std::forward<_Fp>(__f), std::forward<_BoundArgs>(__bound_args)...);
 }
 
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/__functional/bind_back.h
+++ b/libcxx/include/__functional/bind_back.h
@@ -33,9 +33,9 @@ template <size_t _NBound, size_t ..._Ip>
 struct __bind_back_op<_NBound, index_sequence<_Ip...>> {
     template <class _Fn, class _BoundArgs, class... _Args>
     _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Fn&& __f, _BoundArgs&& __bound_args, _Args&&... __args) const
-        noexcept(noexcept(_VSTD::invoke(_VSTD::forward<_Fn>(__f), _VSTD::forward<_Args>(__args)..., _VSTD::get<_Ip>(_VSTD::forward<_BoundArgs>(__bound_args))...)))
-        -> decltype(      _VSTD::invoke(_VSTD::forward<_Fn>(__f), _VSTD::forward<_Args>(__args)..., _VSTD::get<_Ip>(_VSTD::forward<_BoundArgs>(__bound_args))...))
-        { return          _VSTD::invoke(_VSTD::forward<_Fn>(__f), _VSTD::forward<_Args>(__args)..., _VSTD::get<_Ip>(_VSTD::forward<_BoundArgs>(__bound_args))...); }
+        noexcept(noexcept(std::invoke(std::forward<_Fn>(__f), std::forward<_Args>(__args)..., std::get<_Ip>(std::forward<_BoundArgs>(__bound_args))...)))
+        -> decltype(      std::invoke(std::forward<_Fn>(__f), std::forward<_Args>(__args)..., std::get<_Ip>(std::forward<_BoundArgs>(__bound_args))...))
+        { return          std::invoke(std::forward<_Fn>(__f), std::forward<_Args>(__args)..., std::get<_Ip>(std::forward<_BoundArgs>(__bound_args))...); }
 };
 
 template <class _Fn, class _BoundArgs>
@@ -48,9 +48,9 @@ template <class _Fn, class... _Args>
            (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
 _LIBCPP_HIDE_FROM_ABI
 constexpr auto __bind_back(_Fn&& __f, _Args&&... __args)
-    noexcept(noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(_VSTD::forward<_Fn>(__f), _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...))))
-    -> decltype(      __bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(_VSTD::forward<_Fn>(__f), _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...)))
-    { return          __bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(_VSTD::forward<_Fn>(__f), _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...)); }
+    noexcept(noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...))))
+    -> decltype(      __bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...)))
+    { return          __bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...)); }
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__functional/bind_front.h
+++ b/libcxx/include/__functional/bind_front.h
@@ -32,9 +32,9 @@ struct __bind_front_op {
     template <class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     constexpr auto operator()(_Args&& ...__args) const
-        noexcept(noexcept(_VSTD::invoke(_VSTD::forward<_Args>(__args)...)))
-        -> decltype(      _VSTD::invoke(_VSTD::forward<_Args>(__args)...))
-        { return          _VSTD::invoke(_VSTD::forward<_Args>(__args)...); }
+        noexcept(noexcept(std::invoke(std::forward<_Args>(__args)...)))
+        -> decltype(      std::invoke(std::forward<_Args>(__args)...))
+        { return          std::invoke(std::forward<_Args>(__args)...); }
 };
 
 template <class _Fn, class ..._BoundArgs>
@@ -47,7 +47,7 @@ template <class _Fn, class... _Args>
            (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
 _LIBCPP_HIDE_FROM_ABI
 constexpr auto bind_front(_Fn&& __f, _Args&&... __args) {
-    return __bind_front_t<decay_t<_Fn>, decay_t<_Args>...>(_VSTD::forward<_Fn>(__f), _VSTD::forward<_Args>(__args)...);
+    return __bind_front_t<decay_t<_Fn>, decay_t<_Args>...>(std::forward<_Fn>(__f), std::forward<_Args>(__args)...);
 }
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__functional/compose.h
+++ b/libcxx/include/__functional/compose.h
@@ -28,9 +28,9 @@ struct __compose_op {
     template<class _Fn1, class _Fn2, class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     constexpr auto operator()(_Fn1&& __f1, _Fn2&& __f2, _Args&&... __args) const
-        noexcept(noexcept(_VSTD::invoke(_VSTD::forward<_Fn1>(__f1), _VSTD::invoke(_VSTD::forward<_Fn2>(__f2), _VSTD::forward<_Args>(__args)...))))
-        -> decltype(      _VSTD::invoke(_VSTD::forward<_Fn1>(__f1), _VSTD::invoke(_VSTD::forward<_Fn2>(__f2), _VSTD::forward<_Args>(__args)...)))
-        { return          _VSTD::invoke(_VSTD::forward<_Fn1>(__f1), _VSTD::invoke(_VSTD::forward<_Fn2>(__f2), _VSTD::forward<_Args>(__args)...)); }
+        noexcept(noexcept(std::invoke(std::forward<_Fn1>(__f1), std::invoke(std::forward<_Fn2>(__f2), std::forward<_Args>(__args)...))))
+        -> decltype(      std::invoke(std::forward<_Fn1>(__f1), std::invoke(std::forward<_Fn2>(__f2), std::forward<_Args>(__args)...)))
+        { return          std::invoke(std::forward<_Fn1>(__f1), std::invoke(std::forward<_Fn2>(__f2), std::forward<_Args>(__args)...)); }
 };
 
 template <class _Fn1, class _Fn2>
@@ -41,9 +41,9 @@ struct __compose_t : __perfect_forward<__compose_op, _Fn1, _Fn2> {
 template <class _Fn1, class _Fn2>
 _LIBCPP_HIDE_FROM_ABI
 constexpr auto __compose(_Fn1&& __f1, _Fn2&& __f2)
-    noexcept(noexcept(__compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(_VSTD::forward<_Fn1>(__f1), _VSTD::forward<_Fn2>(__f2))))
-    -> decltype(      __compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(_VSTD::forward<_Fn1>(__f1), _VSTD::forward<_Fn2>(__f2)))
-    { return          __compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(_VSTD::forward<_Fn1>(__f1), _VSTD::forward<_Fn2>(__f2)); }
+    noexcept(noexcept(__compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(std::forward<_Fn1>(__f1), std::forward<_Fn2>(__f2))))
+    -> decltype(      __compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(std::forward<_Fn1>(__f1), std::forward<_Fn2>(__f2)))
+    { return          __compose_t<decay_t<_Fn1>, decay_t<_Fn2>>(std::forward<_Fn1>(__f1), std::forward<_Fn2>(__f2)); }
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -162,29 +162,29 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)>
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __alloc_func(_Target&& __f)
-        : __f_(piecewise_construct, _VSTD::forward_as_tuple(_VSTD::move(__f)),
-               _VSTD::forward_as_tuple())
+        : __f_(piecewise_construct, std::forward_as_tuple(std::move(__f)),
+               std::forward_as_tuple())
     {
     }
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __alloc_func(const _Target& __f, const _Alloc& __a)
-        : __f_(piecewise_construct, _VSTD::forward_as_tuple(__f),
-               _VSTD::forward_as_tuple(__a))
+        : __f_(piecewise_construct, std::forward_as_tuple(__f),
+               std::forward_as_tuple(__a))
     {
     }
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __alloc_func(const _Target& __f, _Alloc&& __a)
-        : __f_(piecewise_construct, _VSTD::forward_as_tuple(__f),
-               _VSTD::forward_as_tuple(_VSTD::move(__a)))
+        : __f_(piecewise_construct, std::forward_as_tuple(__f),
+               std::forward_as_tuple(std::move(__a)))
     {
     }
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __alloc_func(_Target&& __f, _Alloc&& __a)
-        : __f_(piecewise_construct, _VSTD::forward_as_tuple(_VSTD::move(__f)),
-               _VSTD::forward_as_tuple(_VSTD::move(__a)))
+        : __f_(piecewise_construct, std::forward_as_tuple(std::move(__f)),
+               std::forward_as_tuple(std::move(__a)))
     {
     }
 
@@ -193,7 +193,7 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)>
     {
         typedef __invoke_void_return_wrapper<_Rp> _Invoker;
         return _Invoker::__call(__f_.first(),
-                                _VSTD::forward<_ArgTypes>(__arg)...);
+                                std::forward<_ArgTypes>(__arg)...);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -231,7 +231,7 @@ public:
   const _Target& __target() const { return __f_; }
 
   _LIBCPP_HIDE_FROM_ABI
-  explicit __default_alloc_func(_Target&& __f) : __f_(_VSTD::move(__f)) {}
+  explicit __default_alloc_func(_Target&& __f) : __f_(std::move(__f)) {}
 
   _LIBCPP_HIDE_FROM_ABI
   explicit __default_alloc_func(const _Target& __f) : __f_(__f) {}
@@ -239,7 +239,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   _Rp operator()(_ArgTypes&&... __arg) {
     typedef __invoke_void_return_wrapper<_Rp> _Invoker;
-    return _Invoker::__call(__f_, _VSTD::forward<_ArgTypes>(__arg)...);
+    return _Invoker::__call(__f_, std::forward<_ArgTypes>(__arg)...);
   }
 
   _LIBCPP_HIDE_FROM_ABI
@@ -296,7 +296,7 @@ class __func<_Fp, _Alloc, _Rp(_ArgTypes...)>
 public:
     _LIBCPP_HIDE_FROM_ABI
     explicit __func(_Fp&& __f)
-        : __f_(_VSTD::move(__f)) {}
+        : __f_(std::move(__f)) {}
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __func(const _Fp& __f, const _Alloc& __a)
@@ -304,11 +304,11 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __func(const _Fp& __f, _Alloc&& __a)
-        : __f_(__f, _VSTD::move(__a)) {}
+        : __f_(__f, std::move(__a)) {}
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __func(_Fp&& __f, _Alloc&& __a)
-        : __f_(_VSTD::move(__f), _VSTD::move(__a)) {}
+        : __f_(std::move(__f), std::move(__a)) {}
 
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual __base<_Rp(_ArgTypes...)>* __clone() const;
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __clone(__base<_Rp(_ArgTypes...)>*) const;
@@ -363,7 +363,7 @@ template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 _Rp
 __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&& ... __arg)
 {
-    return __f_(_VSTD::forward<_ArgTypes>(__arg)...);
+    return __f_(std::forward<_ArgTypes>(__arg)...);
 }
 
 #ifndef _LIBCPP_HAS_NO_RTTI
@@ -373,7 +373,7 @@ const void*
 __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const _NOEXCEPT
 {
     if (__ti == typeid(_Fp))
-        return _VSTD::addressof(__f_.__target());
+        return std::addressof(__f_.__target());
     return nullptr;
 }
 
@@ -424,13 +424,13 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
                 is_nothrow_copy_constructible<_FunAlloc>::value)
             {
                 __f_ =
-                    ::new ((void*)&__buf_) _Fun(_VSTD::move(__f), _Alloc(__af));
+                    ::new ((void*)&__buf_) _Fun(std::move(__f), _Alloc(__af));
             }
             else
             {
                 typedef __allocator_destructor<_FunAlloc> _Dp;
                 unique_ptr<__func, _Dp> __hold(__af.allocate(1), _Dp(__af, 1));
-                ::new ((void*)__hold.get()) _Fun(_VSTD::move(__f), _Alloc(__a));
+                ::new ((void*)__hold.get()) _Fun(std::move(__f), _Alloc(__a));
                 __f_ = __hold.release();
             }
         }
@@ -438,7 +438,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
 
     template <class _Fp, __enable_if_t<!is_same<__decay_t<_Fp>, __value_func>::value, int> = 0>
     _LIBCPP_HIDE_FROM_ABI explicit __value_func(_Fp&& __f)
-        : __value_func(_VSTD::forward<_Fp>(__f), allocator<_Fp>()) {}
+        : __value_func(std::forward<_Fp>(__f), allocator<_Fp>()) {}
 
     _LIBCPP_HIDE_FROM_ABI
     __value_func(const __value_func& __f)
@@ -516,7 +516,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
     {
         if (__f_ == nullptr)
             __throw_bad_function_call();
-        return (*__f_)(_VSTD::forward<_ArgTypes>(__args)...);
+        return (*__f_)(std::forward<_ArgTypes>(__args)...);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -556,7 +556,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
             __f_ = __as_base(&__buf_);
         }
         else
-            _VSTD::swap(__f_, __f.__f_);
+            std::swap(__f_, __f.__f_);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -722,7 +722,7 @@ struct __policy_invoker<_Rp(_ArgTypes...)>
         _Fun* __f = reinterpret_cast<_Fun*>(__use_small_storage<_Fun>::value
                                                 ? &__buf->__small
                                                 : __buf->__large);
-        return (*__f)(_VSTD::forward<_ArgTypes>(__args)...);
+        return (*__f)(std::forward<_ArgTypes>(__args)...);
     }
 };
 
@@ -767,14 +767,14 @@ template <class _Rp, class... _ArgTypes> class __policy_func<_Rp(_ArgTypes...)>
             if (__use_small_storage<_Fun>())
             {
                 ::new ((void*)&__buf_.__small)
-                    _Fun(_VSTD::move(__f), _Alloc(__af));
+                    _Fun(std::move(__f), _Alloc(__af));
             }
             else
             {
                 typedef __allocator_destructor<_FunAlloc> _Dp;
                 unique_ptr<_Fun, _Dp> __hold(__af.allocate(1), _Dp(__af, 1));
                 ::new ((void*)__hold.get())
-                    _Fun(_VSTD::move(__f), _Alloc(__af));
+                    _Fun(std::move(__f), _Alloc(__af));
                 __buf_.__large = __hold.release();
             }
         }
@@ -789,11 +789,11 @@ template <class _Rp, class... _ArgTypes> class __policy_func<_Rp(_ArgTypes...)>
         __invoker_ = __invoker::template __create<_Fun>();
         __policy_ = __policy::__create<_Fun>();
         if (__use_small_storage<_Fun>()) {
-          ::new ((void*)&__buf_.__small) _Fun(_VSTD::move(__f));
+          ::new ((void*)&__buf_.__small) _Fun(std::move(__f));
         } else {
           __builtin_new_allocator::__holder_t __hold =
               __builtin_new_allocator::__allocate_type<_Fun>(1);
-          __buf_.__large = ::new ((void*)__hold.get()) _Fun(_VSTD::move(__f));
+          __buf_.__large = ::new ((void*)__hold.get()) _Fun(std::move(__f));
           (void)__hold.release();
         }
       }
@@ -853,16 +853,16 @@ template <class _Rp, class... _ArgTypes> class __policy_func<_Rp(_ArgTypes...)>
     _LIBCPP_HIDE_FROM_ABI
     _Rp operator()(_ArgTypes&&... __args) const
     {
-        return __invoker_.__call_(_VSTD::addressof(__buf_),
-                                  _VSTD::forward<_ArgTypes>(__args)...);
+        return __invoker_.__call_(std::addressof(__buf_),
+                                  std::forward<_ArgTypes>(__args)...);
     }
 
     _LIBCPP_HIDE_FROM_ABI
     void swap(__policy_func& __f)
     {
-        _VSTD::swap(__invoker_, __f.__invoker_);
-        _VSTD::swap(__policy_, __f.__policy_);
-        _VSTD::swap(__buf_, __f.__buf_);
+        std::swap(__invoker_, __f.__invoker_);
+        std::swap(__policy_, __f.__policy_);
+        std::swap(__buf_, __f.__buf_);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -952,7 +952,7 @@ public:
     }
 
     virtual _Rp operator()(_ArgTypes&& ... __arg) {
-        return _VSTD::__invoke(__f_, _VSTD::forward<_ArgTypes>(__arg)...);
+        return std::__invoke(__f_, std::forward<_ArgTypes>(__arg)...);
     }
 
 #ifndef _LIBCPP_HAS_NO_RTTI
@@ -1048,7 +1048,7 @@ public:
     template<class _Fp, class _Alloc>
       _LIBCPP_HIDE_FROM_ABI
       void assign(_Fp&& __f, const _Alloc& __a)
-        {function(allocator_arg, __a, _VSTD::forward<_Fp>(__f)).swap(*this);}
+        {function(allocator_arg, __a, std::forward<_Fp>(__f)).swap(*this);}
 #endif
 
     // function capacity:
@@ -1098,26 +1098,26 @@ function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc&,
 
 template <class _Rp, class... _ArgTypes>
 function<_Rp(_ArgTypes...)>::function(function&& __f) _NOEXCEPT
-    : __f_(_VSTD::move(__f.__f_)) {}
+    : __f_(std::move(__f.__f_)) {}
 
 #if _LIBCPP_STD_VER <= 14
 template<class _Rp, class ..._ArgTypes>
 template <class _Alloc>
 function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc&,
                                       function&& __f)
-    : __f_(_VSTD::move(__f.__f_)) {}
+    : __f_(std::move(__f.__f_)) {}
 #endif
 
 template <class _Rp, class... _ArgTypes>
 template <class _Fp, class>
-function<_Rp(_ArgTypes...)>::function(_Fp __f) : __f_(_VSTD::move(__f)) {}
+function<_Rp(_ArgTypes...)>::function(_Fp __f) : __f_(std::move(__f)) {}
 
 #if _LIBCPP_STD_VER <= 14
 template <class _Rp, class... _ArgTypes>
 template <class _Fp, class _Alloc, class>
 function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc& __a,
                                       _Fp __f)
-    : __f_(_VSTD::move(__f), __a) {}
+    : __f_(std::move(__f), __a) {}
 #endif
 
 template<class _Rp, class ..._ArgTypes>
@@ -1132,7 +1132,7 @@ template<class _Rp, class ..._ArgTypes>
 function<_Rp(_ArgTypes...)>&
 function<_Rp(_ArgTypes...)>::operator=(function&& __f) _NOEXCEPT
 {
-    __f_ = _VSTD::move(__f.__f_);
+    __f_ = std::move(__f.__f_);
     return *this;
 }
 
@@ -1149,7 +1149,7 @@ template <class _Fp, class>
 function<_Rp(_ArgTypes...)>&
 function<_Rp(_ArgTypes...)>::operator=(_Fp&& __f)
 {
-    function(_VSTD::forward<_Fp>(__f)).swap(*this);
+    function(std::forward<_Fp>(__f)).swap(*this);
     return *this;
 }
 
@@ -1167,7 +1167,7 @@ template<class _Rp, class ..._ArgTypes>
 _Rp
 function<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __arg) const
 {
-    return __f_(_VSTD::forward<_ArgTypes>(__arg)...);
+    return __f_(std::forward<_ArgTypes>(__arg)...);
 }
 
 #ifndef _LIBCPP_HAS_NO_RTTI

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -40,7 +40,7 @@ _Size
 __loadword(const void* __p)
 {
     _Size __r;
-    _VSTD::memcpy(&__r, __p, sizeof(__r));
+    std::memcpy(&__r, __p, sizeof(__r));
     return __r;
 }
 
@@ -127,7 +127,7 @@ struct __murmur2_or_cityhash<_Size, 64>
         __v = __weak_hash_len_32_with_seeds(__s, __v.second * __k1, __x + __w.first);
         __w = __weak_hash_len_32_with_seeds(__s + 32, __z + __w.second,
                                             __y + std::__loadword<_Size>(__s + 16));
-        _VSTD::swap(__z, __x);
+        std::swap(__z, __x);
         __s += 64;
         __len -= 64;
     } while (__len != 0);

--- a/libcxx/include/__functional/identity.h
+++ b/libcxx/include/__functional/identity.h
@@ -41,7 +41,7 @@ struct identity {
     template<class _Tp>
     _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Tp&& operator()(_Tp&& __t) const noexcept
     {
-        return _VSTD::forward<_Tp>(__t);
+        return std::forward<_Tp>(__t);
     }
 
     using is_transparent = void;

--- a/libcxx/include/__functional/invoke.h
+++ b/libcxx/include/__functional/invoke.h
@@ -27,7 +27,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 invoke_result_t<_Fn, _Args..
 invoke(_Fn&& __f, _Args&&... __args)
     noexcept(is_nothrow_invocable_v<_Fn, _Args...>)
 {
-    return _VSTD::__invoke(_VSTD::forward<_Fn>(__f), _VSTD::forward<_Args>(__args)...);
+    return std::__invoke(std::forward<_Fn>(__f), std::forward<_Args>(__args)...);
 }
 
 #endif // _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__functional/not_fn.h
+++ b/libcxx/include/__functional/not_fn.h
@@ -31,9 +31,9 @@ struct __not_fn_op {
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     _LIBCPP_CONSTEXPR_SINCE_CXX20 auto operator()(_Args&&... __args) const
-        noexcept(noexcept(!_VSTD::invoke(_VSTD::forward<_Args>(__args)...)))
-        -> decltype(      !_VSTD::invoke(_VSTD::forward<_Args>(__args)...))
-        { return          !_VSTD::invoke(_VSTD::forward<_Args>(__args)...); }
+        noexcept(noexcept(!std::invoke(std::forward<_Args>(__args)...)))
+        -> decltype(      !std::invoke(std::forward<_Args>(__args)...))
+        { return          !std::invoke(std::forward<_Args>(__args)...); }
 };
 
 template <class _Fn>
@@ -47,7 +47,7 @@ template <class _Fn, class = enable_if_t<
 >>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR_SINCE_CXX20 auto not_fn(_Fn&& __f) {
-    return __not_fn_t<decay_t<_Fn>>(_VSTD::forward<_Fn>(__f));
+    return __not_fn_t<decay_t<_Fn>>(std::forward<_Fn>(__f));
 }
 
 #endif // _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__functional/operations.h
+++ b/libcxx/include/__functional/operations.h
@@ -55,9 +55,9 @@ struct _LIBCPP_TEMPLATE_VIS plus<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) + _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) + _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) + _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) + std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) + std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) + std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -84,9 +84,9 @@ struct _LIBCPP_TEMPLATE_VIS minus<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) - _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) - _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) - _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) - std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) - std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) - std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -113,9 +113,9 @@ struct _LIBCPP_TEMPLATE_VIS multiplies<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) * _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) * _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) * _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) * std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) * std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) * std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -142,9 +142,9 @@ struct _LIBCPP_TEMPLATE_VIS divides<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) / _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) / _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) / _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) / std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) / std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) / std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -171,9 +171,9 @@ struct _LIBCPP_TEMPLATE_VIS modulus<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) % _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) % _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) % _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) % std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) % std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) % std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -200,9 +200,9 @@ struct _LIBCPP_TEMPLATE_VIS negate<void>
     template <class _Tp>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_Tp&& __x) const
-        noexcept(noexcept(- _VSTD::forward<_Tp>(__x)))
-        -> decltype(      - _VSTD::forward<_Tp>(__x))
-        { return          - _VSTD::forward<_Tp>(__x); }
+        noexcept(noexcept(- std::forward<_Tp>(__x)))
+        -> decltype(      - std::forward<_Tp>(__x))
+        { return          - std::forward<_Tp>(__x); }
     typedef void is_transparent;
 };
 #endif
@@ -231,9 +231,9 @@ struct _LIBCPP_TEMPLATE_VIS bit_and<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) & _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) & _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) & _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) & std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) & std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) & std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -255,9 +255,9 @@ struct _LIBCPP_TEMPLATE_VIS bit_not<void>
     template <class _Tp>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_Tp&& __x) const
-        noexcept(noexcept(~_VSTD::forward<_Tp>(__x)))
-        -> decltype(      ~_VSTD::forward<_Tp>(__x))
-        { return          ~_VSTD::forward<_Tp>(__x); }
+        noexcept(noexcept(~std::forward<_Tp>(__x)))
+        -> decltype(      ~std::forward<_Tp>(__x))
+        { return          ~std::forward<_Tp>(__x); }
     typedef void is_transparent;
 };
 #endif
@@ -284,9 +284,9 @@ struct _LIBCPP_TEMPLATE_VIS bit_or<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) | _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) | _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) | _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) | std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) | std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) | std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -313,9 +313,9 @@ struct _LIBCPP_TEMPLATE_VIS bit_xor<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) ^ _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) ^ _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) ^ _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) ^ std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) ^ std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) ^ std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -344,9 +344,9 @@ struct _LIBCPP_TEMPLATE_VIS equal_to<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) == _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) == _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) == _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) == std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) == std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) == std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -382,9 +382,9 @@ struct _LIBCPP_TEMPLATE_VIS not_equal_to<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) != _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) != _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) != _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) != std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) != std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) != std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -411,9 +411,9 @@ struct _LIBCPP_TEMPLATE_VIS less<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) < _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) < _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) < _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) < std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) < std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) < std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -440,9 +440,9 @@ struct _LIBCPP_TEMPLATE_VIS less_equal<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) <= _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) <= _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) <= _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) <= std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) <= std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) <= std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -469,9 +469,9 @@ struct _LIBCPP_TEMPLATE_VIS greater_equal<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) >= _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) >= _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) >= _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) >= std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) >= std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) >= std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -498,9 +498,9 @@ struct _LIBCPP_TEMPLATE_VIS greater<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) > _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) > _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) > _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) > std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) > std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) > std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -529,9 +529,9 @@ struct _LIBCPP_TEMPLATE_VIS logical_and<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) && _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) && _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) && _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) && std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) && std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) && std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif
@@ -558,9 +558,9 @@ struct _LIBCPP_TEMPLATE_VIS logical_not<void>
     template <class _Tp>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_Tp&& __x) const
-        noexcept(noexcept(!_VSTD::forward<_Tp>(__x)))
-        -> decltype(      !_VSTD::forward<_Tp>(__x))
-        { return          !_VSTD::forward<_Tp>(__x); }
+        noexcept(noexcept(!std::forward<_Tp>(__x)))
+        -> decltype(      !std::forward<_Tp>(__x))
+        { return          !std::forward<_Tp>(__x); }
     typedef void is_transparent;
 };
 #endif
@@ -587,9 +587,9 @@ struct _LIBCPP_TEMPLATE_VIS logical_or<void>
     template <class _T1, class _T2>
     _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
     auto operator()(_T1&& __t, _T2&& __u) const
-        noexcept(noexcept(_VSTD::forward<_T1>(__t) || _VSTD::forward<_T2>(__u)))
-        -> decltype(      _VSTD::forward<_T1>(__t) || _VSTD::forward<_T2>(__u))
-        { return          _VSTD::forward<_T1>(__t) || _VSTD::forward<_T2>(__u); }
+        noexcept(noexcept(std::forward<_T1>(__t) || std::forward<_T2>(__u)))
+        -> decltype(      std::forward<_T1>(__t) || std::forward<_T2>(__u))
+        { return          std::forward<_T1>(__t) || std::forward<_T2>(__u); }
     typedef void is_transparent;
 };
 #endif

--- a/libcxx/include/__functional/perfect_forward.h
+++ b/libcxx/include/__functional/perfect_forward.h
@@ -44,7 +44,7 @@ public:
     is_constructible_v<tuple<_BoundArgs...>, _Args&&...>
   >>
   _LIBCPP_HIDE_FROM_ABI explicit constexpr __perfect_forward_impl(_Args&&... __bound_args)
-    : __bound_args_(_VSTD::forward<_Args>(__bound_args)...) {}
+    : __bound_args_(std::forward<_Args>(__bound_args)...) {}
 
   _LIBCPP_HIDE_FROM_ABI __perfect_forward_impl(__perfect_forward_impl const&) = default;
   _LIBCPP_HIDE_FROM_ABI __perfect_forward_impl(__perfect_forward_impl&&) = default;
@@ -54,36 +54,36 @@ public:
 
   template <class... _Args, class = enable_if_t<is_invocable_v<_Op, _BoundArgs&..., _Args...>>>
   _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) &
-    noexcept(noexcept(_Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...)))
-    -> decltype(      _Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...))
-    { return          _Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...); }
+    noexcept(noexcept(_Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...)))
+    -> decltype(      _Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...))
+    { return          _Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...); }
 
   template <class... _Args, class = enable_if_t<!is_invocable_v<_Op, _BoundArgs&..., _Args...>>>
   auto operator()(_Args&&...) & = delete;
 
   template <class... _Args, class = enable_if_t<is_invocable_v<_Op, _BoundArgs const&..., _Args...>>>
   _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const&
-    noexcept(noexcept(_Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...)))
-    -> decltype(      _Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...))
-    { return          _Op()(_VSTD::get<_Idx>(__bound_args_)..., _VSTD::forward<_Args>(__args)...); }
+    noexcept(noexcept(_Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...)))
+    -> decltype(      _Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...))
+    { return          _Op()(std::get<_Idx>(__bound_args_)..., std::forward<_Args>(__args)...); }
 
   template <class... _Args, class = enable_if_t<!is_invocable_v<_Op, _BoundArgs const&..., _Args...>>>
   auto operator()(_Args&&...) const& = delete;
 
   template <class... _Args, class = enable_if_t<is_invocable_v<_Op, _BoundArgs..., _Args...>>>
   _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) &&
-    noexcept(noexcept(_Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...)))
-    -> decltype(      _Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...))
-    { return          _Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...); }
+    noexcept(noexcept(_Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...)))
+    -> decltype(      _Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...))
+    { return          _Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...); }
 
   template <class... _Args, class = enable_if_t<!is_invocable_v<_Op, _BoundArgs..., _Args...>>>
   auto operator()(_Args&&...) && = delete;
 
   template <class... _Args, class = enable_if_t<is_invocable_v<_Op, _BoundArgs const..., _Args...>>>
   _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const&&
-    noexcept(noexcept(_Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...)))
-    -> decltype(      _Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...))
-    { return          _Op()(_VSTD::get<_Idx>(_VSTD::move(__bound_args_))..., _VSTD::forward<_Args>(__args)...); }
+    noexcept(noexcept(_Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...)))
+    -> decltype(      _Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...))
+    { return          _Op()(std::get<_Idx>(std::move(__bound_args_))..., std::forward<_Args>(__args)...); }
 
   template <class... _Args, class = enable_if_t<!is_invocable_v<_Op, _BoundArgs const..., _Args...>>>
   auto operator()(_Args&&...) const&& = delete;

--- a/libcxx/include/__functional/ranges_operations.h
+++ b/libcxx/include/__functional/ranges_operations.h
@@ -31,8 +31,8 @@ struct equal_to {
   template <class _Tp, class _Up>
   requires equality_comparable_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u)))) {
-    return _VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u);
+      noexcept(noexcept(bool(std::forward<_Tp>(__t) == std::forward<_Up>(__u)))) {
+    return std::forward<_Tp>(__t) == std::forward<_Up>(__u);
   }
 
   using is_transparent = void;
@@ -42,8 +42,8 @@ struct not_equal_to {
   template <class _Tp, class _Up>
   requires equality_comparable_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(!(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u))))) {
-    return !(_VSTD::forward<_Tp>(__t) == _VSTD::forward<_Up>(__u));
+      noexcept(noexcept(bool(!(std::forward<_Tp>(__t) == std::forward<_Up>(__u))))) {
+    return !(std::forward<_Tp>(__t) == std::forward<_Up>(__u));
   }
 
   using is_transparent = void;
@@ -53,8 +53,8 @@ struct less {
   template <class _Tp, class _Up>
   requires totally_ordered_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(_VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u)))) {
-    return _VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u);
+      noexcept(noexcept(bool(std::forward<_Tp>(__t) < std::forward<_Up>(__u)))) {
+    return std::forward<_Tp>(__t) < std::forward<_Up>(__u);
   }
 
   using is_transparent = void;
@@ -64,8 +64,8 @@ struct less_equal {
   template <class _Tp, class _Up>
   requires totally_ordered_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(!(_VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t))))) {
-    return !(_VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t));
+      noexcept(noexcept(bool(!(std::forward<_Up>(__u) < std::forward<_Tp>(__t))))) {
+    return !(std::forward<_Up>(__u) < std::forward<_Tp>(__t));
   }
 
   using is_transparent = void;
@@ -75,8 +75,8 @@ struct greater {
   template <class _Tp, class _Up>
   requires totally_ordered_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(_VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t)))) {
-    return _VSTD::forward<_Up>(__u) < _VSTD::forward<_Tp>(__t);
+      noexcept(noexcept(bool(std::forward<_Up>(__u) < std::forward<_Tp>(__t)))) {
+    return std::forward<_Up>(__u) < std::forward<_Tp>(__t);
   }
 
   using is_transparent = void;
@@ -86,8 +86,8 @@ struct greater_equal {
   template <class _Tp, class _Up>
   requires totally_ordered_with<_Tp, _Up>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp &&__t, _Up &&__u) const
-      noexcept(noexcept(bool(!(_VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u))))) {
-    return !(_VSTD::forward<_Tp>(__t) < _VSTD::forward<_Up>(__u));
+      noexcept(noexcept(bool(!(std::forward<_Tp>(__t) < std::forward<_Up>(__u))))) {
+    return !(std::forward<_Tp>(__t) < std::forward<_Up>(__u));
   }
 
   using is_transparent = void;

--- a/libcxx/include/__functional/reference_wrapper.h
+++ b/libcxx/include/__functional/reference_wrapper.h
@@ -42,7 +42,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     reference_wrapper(_Up&& __u) _NOEXCEPT_(noexcept(__fun(std::declval<_Up>()))) {
         type& __f = static_cast<_Up&&>(__u);
-        __f_ = _VSTD::addressof(__f);
+        __f_ = std::addressof(__f);
     }
 
     // access

--- a/libcxx/include/__functional/weak_result_type.h
+++ b/libcxx/include/__functional/weak_result_type.h
@@ -286,7 +286,7 @@ struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...) const volatile>
 template <class _Tp, class ..._Args>
 struct __invoke_return
 {
-    typedef decltype(_VSTD::__invoke(std::declval<_Tp>(), std::declval<_Args>()...)) type;
+    typedef decltype(std::__invoke(std::declval<_Tp>(), std::declval<_Args>()...)) type;
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -199,11 +199,11 @@ struct __hash_key_value_types {
   }
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type* __get_ptr(__node_value_type& __n) {
-    return _VSTD::addressof(__n);
+    return std::addressof(__n);
   }
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type&& __move(__node_value_type& __v) {
-    return _VSTD::move(__v);
+    return std::move(__v);
   }
 };
 
@@ -237,7 +237,7 @@ struct __hash_key_value_types<__hash_value_type<_Key, _Tp> > {
 
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type* __get_ptr(__node_value_type& __n) {
-    return _VSTD::addressof(__n.__get_value());
+    return std::addressof(__n.__get_value());
   }
   _LIBCPP_HIDE_FROM_ABI
   static pair<key_type&&, mapped_type&&> __move(__node_value_type& __v) {
@@ -643,7 +643,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __bucket_list_deallocator(__bucket_list_deallocator&& __x)
         _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
-        : __data_(_VSTD::move(__x.__data_))
+        : __data_(std::move(__x.__data_))
     {
         __x.size() = 0;
     }
@@ -889,7 +889,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     size_type max_size() const _NOEXCEPT
     {
-        return _VSTD::min<size_type>(
+        return std::min<size_type>(
             __node_traits::max_size(__node_alloc()),
             numeric_limits<difference_type >::max()
         );
@@ -929,7 +929,7 @@ public:
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __emplace_unique(_Pp&& __x) {
-      return __emplace_unique_extract_key(_VSTD::forward<_Pp>(__x),
+      return __emplace_unique_extract_key(std::forward<_Pp>(__x),
                                           __can_extract_key<_Pp, key_type>());
     }
 
@@ -938,33 +938,33 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique(_First&& __f, _Second&& __s) {
-        return __emplace_unique_key_args(__f, _VSTD::forward<_First>(__f),
-                                              _VSTD::forward<_Second>(__s));
+        return __emplace_unique_key_args(__f, std::forward<_First>(__f),
+                                              std::forward<_Second>(__s));
     }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __emplace_unique(_Args&&... __args) {
-      return __emplace_unique_impl(_VSTD::forward<_Args>(__args)...);
+      return __emplace_unique_impl(std::forward<_Args>(__args)...);
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_fail_tag) {
-      return __emplace_unique_impl(_VSTD::forward<_Pp>(__x));
+      return __emplace_unique_impl(std::forward<_Pp>(__x));
     }
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_self_tag) {
-      return __emplace_unique_key_args(__x, _VSTD::forward<_Pp>(__x));
+      return __emplace_unique_key_args(__x, std::forward<_Pp>(__x));
     }
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_first_tag) {
-      return __emplace_unique_key_args(__x.first, _VSTD::forward<_Pp>(__x));
+      return __emplace_unique_key_args(__x.first, std::forward<_Pp>(__x));
     }
 
     template <class... _Args>
@@ -978,25 +978,25 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __insert_unique(__container_value_type&& __x) {
-      return __emplace_unique_key_args(_NodeTypes::__get_key(__x), _VSTD::move(__x));
+      return __emplace_unique_key_args(_NodeTypes::__get_key(__x), std::move(__x));
     }
 
     template <class _Pp, class = __enable_if_t<!__is_same_uncvref<_Pp, __container_value_type>::value> >
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __insert_unique(_Pp&& __x) {
-      return __emplace_unique(_VSTD::forward<_Pp>(__x));
+      return __emplace_unique(std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(_Pp&& __x) {
-      return __emplace_multi(_VSTD::forward<_Pp>(__x));
+      return __emplace_multi(std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(const_iterator __p, _Pp&& __x) {
-        return __emplace_hint_multi(__p, _VSTD::forward<_Pp>(__x));
+        return __emplace_hint_multi(__p, std::forward<_Pp>(__x));
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1132,7 +1132,7 @@ public:
     {
         _LIBCPP_ASSERT_UNCATEGORIZED(__mlf > 0,
             "unordered container::max_load_factor(lf) called with lf <= 0");
-        max_load_factor() = _VSTD::max(__mlf, load_factor());
+        max_load_factor() = std::max(__mlf, load_factor());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1213,8 +1213,8 @@ private:
             is_nothrow_move_assignable<__node_allocator>::value)
     {
         __bucket_list_.get_deleter().__alloc() =
-                _VSTD::move(__u.__bucket_list_.get_deleter().__alloc());
-        __node_alloc() = _VSTD::move(__u.__node_alloc());
+                std::move(__u.__bucket_list_.get_deleter().__alloc());
+        __node_alloc() = std::move(__u.__node_alloc());
     }
     _LIBCPP_HIDE_FROM_ABI
         void __move_assign_alloc(__hash_table&, false_type) _NOEXCEPT {}
@@ -1302,10 +1302,10 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table(__hash_table&& __u)
             is_nothrow_move_constructible<__node_allocator>::value &&
             is_nothrow_move_constructible<hasher>::value &&
             is_nothrow_move_constructible<key_equal>::value)
-    : __bucket_list_(_VSTD::move(__u.__bucket_list_)),
-      __p1_(_VSTD::move(__u.__p1_)),
-      __p2_(_VSTD::move(__u.__p2_)),
-      __p3_(_VSTD::move(__u.__p3_))
+    : __bucket_list_(std::move(__u.__bucket_list_)),
+      __p1_(std::move(__u.__p1_)),
+      __p2_(std::move(__u.__p2_)),
+      __p3_(std::move(__u.__p3_))
 {
     if (size() > 0)
     {
@@ -1321,8 +1321,8 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table(__hash_table&& __u,
                                                        const allocator_type& __a)
     : __bucket_list_(nullptr, __bucket_list_deleter(__pointer_allocator(__a), 0)),
       __p1_(__default_init_tag(), __node_allocator(__a)),
-      __p2_(0, _VSTD::move(__u.hash_function())),
-      __p3_(_VSTD::move(__u.__p3_))
+      __p2_(0, std::move(__u.hash_function())),
+      __p3_(std::move(__u.__p3_))
 {
     if (__a == allocator_type(__u.__node_alloc()))
     {
@@ -1373,7 +1373,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 __hash_table<_Tp, _Hash, _Equal, _Alloc>&
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::operator=(const __hash_table& __u)
 {
-    if (this != _VSTD::addressof(__u))
+    if (this != std::addressof(__u))
     {
         __copy_assign_alloc(__u);
         hash_function() = __u.hash_function();
@@ -1429,9 +1429,9 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(
     __u.__bucket_list_.get_deleter().size() = 0;
     __move_assign_alloc(__u);
     size() = __u.size();
-    hash_function() = _VSTD::move(__u.hash_function());
+    hash_function() = std::move(__u.hash_function());
     max_load_factor() = __u.max_load_factor();
-    key_eq() = _VSTD::move(__u.key_eq());
+    key_eq() = std::move(__u.key_eq());
     __p1_.first().__next_ = __u.__p1_.first().__next_;
     if (size() > 0)
     {
@@ -1451,8 +1451,8 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(
         __move_assign(__u, true_type());
     else
     {
-        hash_function() = _VSTD::move(__u.hash_function());
-        key_eq() = _VSTD::move(__u.key_eq());
+        hash_function() = std::move(__u.hash_function());
+        key_eq() = std::move(__u.key_eq());
         max_load_factor() = __u.max_load_factor();
         if (bucket_count() != 0)
         {
@@ -1465,7 +1465,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(
                 while (__cache != nullptr && __u.size() != 0)
                 {
                     __cache->__upcast()->__get_value() =
-                        _VSTD::move(__u.remove(__i++)->__get_value());
+                        std::move(__u.remove(__i++)->__get_value());
                     __next_pointer __next = __cache->__next_;
                     __node_insert_multi(__cache->__upcast());
                     __cache = __next;
@@ -1666,7 +1666,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_unique_prepare(
     }
     if (size()+1 > __bc * max_load_factor() || __bc == 0)
     {
-        __rehash_unique(_VSTD::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
+        __rehash_unique(std::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
                                      size_type(std::ceil(float(size() + 1) / max_load_factor()))));
     }
     return nullptr;
@@ -1738,7 +1738,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_multi_prepare(
     size_type __bc = bucket_count();
     if (size()+1 > __bc * max_load_factor() || __bc == 0)
     {
-        __rehash_multi(_VSTD::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
+        __rehash_multi(std::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
                        size_type(std::ceil(float(size() + 1) / max_load_factor()))));
         __bc = bucket_count();
     }
@@ -1829,7 +1829,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_multi(
         size_type __bc = bucket_count();
         if (size()+1 > __bc * max_load_factor() || __bc == 0)
         {
-            __rehash_multi(_VSTD::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
+            __rehash_multi(std::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
                            size_type(std::ceil(float(size() + 1) / max_load_factor()))));
             __bc = bucket_count();
         }
@@ -1875,10 +1875,10 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__emplace_unique_key_args(_Key const& 
         }
     }
     {
-        __node_holder __h = __construct_node_hash(__hash, _VSTD::forward<_Args>(__args)...);
+        __node_holder __h = __construct_node_hash(__hash, std::forward<_Args>(__args)...);
         if (size()+1 > __bc * max_load_factor() || __bc == 0)
         {
-            __rehash_unique(_VSTD::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
+            __rehash_unique(std::max<size_type>(2 * __bc + !std::__is_hash_power2(__bc),
                            size_type(std::ceil(float(size() + 1) / max_load_factor()))));
             __bc = bucket_count();
             __chash = std::__constrain_hash(__hash, __bc);
@@ -1915,7 +1915,7 @@ template <class... _Args>
 pair<typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::iterator, bool>
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__emplace_unique_impl(_Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     pair<iterator, bool> __r = __node_insert_unique(__h.get());
     if (__r.second)
         __h.release();
@@ -1927,7 +1927,7 @@ template <class... _Args>
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::iterator
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__emplace_multi(_Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     iterator __r = __node_insert_multi(__h.get());
     __h.release();
     return __r;
@@ -1939,7 +1939,7 @@ typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::iterator
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__emplace_hint_multi(
         const_iterator __p, _Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     iterator __r = __node_insert_multi(__p, __h.get());
     __h.release();
     return __r;
@@ -1958,7 +1958,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_handle_insert_unique(
     pair<iterator, bool> __result = __node_insert_unique(__nh.__ptr_);
     if (__result.second)
         __nh.__release_ptr();
-    return _InsertReturnType{__result.first, __result.second, _VSTD::move(__nh)};
+    return _InsertReturnType{__result.first, __result.second, std::move(__nh)};
 }
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
@@ -2092,7 +2092,7 @@ _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
         __do_rehash<_UniqueKeys>(__n);
     else if (__n < __bc)
     {
-        __n = _VSTD::max<size_type>
+        __n = std::max<size_type>
               (
                   __n,
                   std::__is_hash_power2(__bc) ? std::__next_hash_pow2(size_t(std::ceil(float(size()) / max_load_factor()))) :
@@ -2233,7 +2233,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__construct_node(_Args&& ...__args)
     std::__construct_at(std::addressof(*__h), /* next = */nullptr, /* hash = */0);
 
     // Now construct the value_type using the allocator's construct() method.
-    __node_traits::construct(__na, _NodeTypes::__get_ptr(__h->__get_value()), _VSTD::forward<_Args>(__args)...);
+    __node_traits::construct(__na, _NodeTypes::__get_ptr(__h->__get_value()), std::forward<_Args>(__args)...);
     __h.get_deleter().__value_constructed = true;
 
     __h->__hash_ = hash_function()(__h->__get_value());
@@ -2252,8 +2252,8 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__construct_node_hash(
     __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
     std::__construct_at(std::addressof(*__h), /* next = */nullptr, /* hash = */__hash);
     __node_traits::construct(__na, _NodeTypes::__get_ptr(__h->__get_value()),
-                             _VSTD::forward<_First>(__f),
-                             _VSTD::forward<_Rest>(__rest)...);
+                             std::forward<_First>(__f),
+                             std::forward<_Rest>(__rest)...);
     __h.get_deleter().__value_constructed = true;
     return __h;
 }
@@ -2472,11 +2472,11 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::swap(__hash_table& __u)
     __bucket_list_.reset(__u.__bucket_list_.release());
     __u.__bucket_list_.reset(__npp);
     }
-    _VSTD::swap(__bucket_list_.get_deleter().size(), __u.__bucket_list_.get_deleter().size());
-    _VSTD::__swap_allocator(__bucket_list_.get_deleter().__alloc(),
+    std::swap(__bucket_list_.get_deleter().size(), __u.__bucket_list_.get_deleter().size());
+    std::__swap_allocator(__bucket_list_.get_deleter().__alloc(),
              __u.__bucket_list_.get_deleter().__alloc());
-    _VSTD::__swap_allocator(__node_alloc(), __u.__node_alloc());
-    _VSTD::swap(__p1_.first().__next_, __u.__p1_.first().__next_);
+    std::__swap_allocator(__node_alloc(), __u.__node_alloc());
+    std::swap(__p1_.first().__next_, __u.__p1_.first().__next_);
     __p2_.swap(__u.__p2_);
     __p3_.swap(__u.__p3_);
     if (size() > 0)

--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -60,15 +60,15 @@ void __advance(_RandIter& __i, typename iterator_traits<_RandIter>::difference_t
 
 template <
     class _InputIter, class _Distance,
-    class _IntegralDistance = decltype(_VSTD::__convert_to_integral(std::declval<_Distance>())),
+    class _IntegralDistance = decltype(std::__convert_to_integral(std::declval<_Distance>())),
     class = __enable_if_t<is_integral<_IntegralDistance>::value> >
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
 void advance(_InputIter& __i, _Distance __orig_n) {
   typedef typename iterator_traits<_InputIter>::difference_type _Difference;
-  _Difference __n = static_cast<_Difference>(_VSTD::__convert_to_integral(__orig_n));
+  _Difference __n = static_cast<_Difference>(std::__convert_to_integral(__orig_n));
   _LIBCPP_ASSERT_UNCATEGORIZED(__n >= 0 || __has_bidirectional_iterator_category<_InputIter>::value,
                                "Attempt to advance(it, n) with negative n on a non-bidirectional iterator");
-  _VSTD::__advance(__i, __n, typename iterator_traits<_InputIter>::iterator_category());
+  std::__advance(__i, __n, typename iterator_traits<_InputIter>::iterator_category());
 }
 
 #if _LIBCPP_STD_VER >= 20
@@ -128,7 +128,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Ip& __i, _Sp __bound_sentinel) const {
     // If `I` and `S` model `assignable_from<I&, S>`, equivalent to `i = std::move(bound_sentinel)`.
     if constexpr (assignable_from<_Ip&, _Sp>) {
-      __i = _VSTD::move(__bound_sentinel);
+      __i = std::move(__bound_sentinel);
     }
     // Otherwise, if `S` and `I` model `sized_sentinel_for<S, I>`, equivalent to `ranges::advance(i, bound_sentinel - i)`.
     else if constexpr (sized_sentinel_for<_Sp, _Ip>) {

--- a/libcxx/include/__iterator/back_insert_iterator.h
+++ b/libcxx/include/__iterator/back_insert_iterator.h
@@ -48,12 +48,12 @@ public:
     typedef void reference;
     typedef _Container container_type;
 
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit back_insert_iterator(_Container& __x) : container(_VSTD::addressof(__x)) {}
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit back_insert_iterator(_Container& __x) : container(std::addressof(__x)) {}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 back_insert_iterator& operator=(const typename _Container::value_type& __value)
         {container->push_back(__value); return *this;}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 back_insert_iterator& operator=(typename _Container::value_type&& __value)
-        {container->push_back(_VSTD::move(__value)); return *this;}
+        {container->push_back(std::move(__value)); return *this;}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 back_insert_iterator& operator*()     {return *this;}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 back_insert_iterator& operator++()    {return *this;}

--- a/libcxx/include/__iterator/common_iterator.h
+++ b/libcxx/include/__iterator/common_iterator.h
@@ -51,7 +51,7 @@ template<input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 class common_iterator {
   struct __proxy {
     _LIBCPP_HIDE_FROM_ABI constexpr const iter_value_t<_Iter>* operator->() const noexcept {
-      return _VSTD::addressof(__value_);
+      return std::addressof(__value_);
     }
     iter_value_t<_Iter> __value_;
   };
@@ -71,8 +71,8 @@ class common_iterator {
 public:
   _LIBCPP_HIDE_FROM_ABI common_iterator() requires default_initializable<_Iter> = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr common_iterator(_Iter __i) : __hold_(in_place_type<_Iter>, _VSTD::move(__i)) {}
-  _LIBCPP_HIDE_FROM_ABI constexpr common_iterator(_Sent __s) : __hold_(in_place_type<_Sent>, _VSTD::move(__s)) {}
+  _LIBCPP_HIDE_FROM_ABI constexpr common_iterator(_Iter __i) : __hold_(in_place_type<_Iter>, std::move(__i)) {}
+  _LIBCPP_HIDE_FROM_ABI constexpr common_iterator(_Sent __s) : __hold_(in_place_type<_Sent>, std::move(__s)) {}
 
   template<class _I2, class _S2>
     requires convertible_to<const _I2&, _Iter> && convertible_to<const _S2&, _Sent>
@@ -81,8 +81,8 @@ public:
       _LIBCPP_ASSERT_UNCATEGORIZED(!__other.__hold_.valueless_by_exception(),
                                    "Attempted to construct from a valueless common_iterator");
       if (__other.__hold_.index() == 0)
-        return variant<_Iter, _Sent>{in_place_index<0>, _VSTD::__unchecked_get<0>(__other.__hold_)};
-      return variant<_Iter, _Sent>{in_place_index<1>, _VSTD::__unchecked_get<1>(__other.__hold_)};
+        return variant<_Iter, _Sent>{in_place_index<0>, std::__unchecked_get<0>(__other.__hold_)};
+      return variant<_Iter, _Sent>{in_place_index<1>, std::__unchecked_get<1>(__other.__hold_)};
     }()) {}
 
   template<class _I2, class _S2>
@@ -97,15 +97,15 @@ public:
 
     // If they're the same index, just assign.
     if (__idx == 0 && __other_idx == 0)
-      _VSTD::__unchecked_get<0>(__hold_) = _VSTD::__unchecked_get<0>(__other.__hold_);
+      std::__unchecked_get<0>(__hold_) = std::__unchecked_get<0>(__other.__hold_);
     else if (__idx == 1 && __other_idx == 1)
-      _VSTD::__unchecked_get<1>(__hold_) = _VSTD::__unchecked_get<1>(__other.__hold_);
+      std::__unchecked_get<1>(__hold_) = std::__unchecked_get<1>(__other.__hold_);
 
     // Otherwise replace with the oposite element.
     else if (__other_idx == 1)
-      __hold_.template emplace<1>(_VSTD::__unchecked_get<1>(__other.__hold_));
+      __hold_.template emplace<1>(std::__unchecked_get<1>(__other.__hold_));
     else if (__other_idx == 0)
-      __hold_.template emplace<0>(_VSTD::__unchecked_get<0>(__other.__hold_));
+      __hold_.template emplace<0>(std::__unchecked_get<0>(__other.__hold_));
 
     return *this;
   }
@@ -114,7 +114,7 @@ public:
   {
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_Iter>(__hold_),
                                  "Attempted to dereference a non-dereferenceable common_iterator");
-    return *_VSTD::__unchecked_get<_Iter>(__hold_);
+    return *std::__unchecked_get<_Iter>(__hold_);
   }
 
   _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator*() const
@@ -122,7 +122,7 @@ public:
   {
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_Iter>(__hold_),
                                  "Attempted to dereference a non-dereferenceable common_iterator");
-    return *_VSTD::__unchecked_get<_Iter>(__hold_);
+    return *std::__unchecked_get<_Iter>(__hold_);
   }
 
   template<class _I2 = _Iter>
@@ -135,19 +135,19 @@ public:
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_Iter>(__hold_),
                                  "Attempted to dereference a non-dereferenceable common_iterator");
     if constexpr (is_pointer_v<_Iter> || requires(const _Iter& __i) { __i.operator->(); })    {
-      return _VSTD::__unchecked_get<_Iter>(__hold_);
+      return std::__unchecked_get<_Iter>(__hold_);
     } else if constexpr (is_reference_v<iter_reference_t<_Iter>>) {
-      auto&& __tmp = *_VSTD::__unchecked_get<_Iter>(__hold_);
-      return _VSTD::addressof(__tmp);
+      auto&& __tmp = *std::__unchecked_get<_Iter>(__hold_);
+      return std::addressof(__tmp);
     } else {
-      return __proxy{*_VSTD::__unchecked_get<_Iter>(__hold_)};
+      return __proxy{*std::__unchecked_get<_Iter>(__hold_)};
     }
   }
 
   _LIBCPP_HIDE_FROM_ABI common_iterator& operator++() {
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_Iter>(__hold_),
                                  "Attempted to increment a non-dereferenceable common_iterator");
-    ++_VSTD::__unchecked_get<_Iter>(__hold_); return *this;
+    ++std::__unchecked_get<_Iter>(__hold_); return *this;
   }
 
   _LIBCPP_HIDE_FROM_ABI decltype(auto) operator++(int) {
@@ -159,7 +159,7 @@ public:
       return __tmp;
     } else if constexpr (requires (_Iter& __i) { { *__i++ } -> __can_reference; } ||
                          !__can_use_postfix_proxy<_Iter>) {
-      return _VSTD::__unchecked_get<_Iter>(__hold_)++;
+      return std::__unchecked_get<_Iter>(__hold_)++;
     } else {
       auto __p = __postfix_proxy{**this};
       ++*this;
@@ -183,9 +183,9 @@ public:
       return true;
 
     if (__x_index == 0)
-      return _VSTD::__unchecked_get<_Iter>(__x.__hold_) == _VSTD::__unchecked_get<_S2>(__y.__hold_);
+      return std::__unchecked_get<_Iter>(__x.__hold_) == std::__unchecked_get<_S2>(__y.__hold_);
 
-    return _VSTD::__unchecked_get<_Sent>(__x.__hold_) == _VSTD::__unchecked_get<_I2>(__y.__hold_);
+    return std::__unchecked_get<_Sent>(__x.__hold_) == std::__unchecked_get<_I2>(__y.__hold_);
   }
 
   template<class _I2, sentinel_for<_Iter> _S2>
@@ -204,12 +204,12 @@ public:
       return true;
 
     if (__x_index == 0 && __y_index == 0)
-      return  _VSTD::__unchecked_get<_Iter>(__x.__hold_) ==  _VSTD::__unchecked_get<_I2>(__y.__hold_);
+      return  std::__unchecked_get<_Iter>(__x.__hold_) ==  std::__unchecked_get<_I2>(__y.__hold_);
 
     if (__x_index == 0)
-      return  _VSTD::__unchecked_get<_Iter>(__x.__hold_) == _VSTD::__unchecked_get<_S2>(__y.__hold_);
+      return  std::__unchecked_get<_Iter>(__x.__hold_) == std::__unchecked_get<_S2>(__y.__hold_);
 
-    return _VSTD::__unchecked_get<_Sent>(__x.__hold_) ==  _VSTD::__unchecked_get<_I2>(__y.__hold_);
+    return std::__unchecked_get<_Sent>(__x.__hold_) ==  std::__unchecked_get<_I2>(__y.__hold_);
   }
 
   template<sized_sentinel_for<_Iter> _I2, sized_sentinel_for<_Iter> _S2>
@@ -228,12 +228,12 @@ public:
       return 0;
 
     if (__x_index == 0 && __y_index == 0)
-      return  _VSTD::__unchecked_get<_Iter>(__x.__hold_) - _VSTD::__unchecked_get<_I2>(__y.__hold_);
+      return  std::__unchecked_get<_Iter>(__x.__hold_) - std::__unchecked_get<_I2>(__y.__hold_);
 
     if (__x_index == 0)
-      return  _VSTD::__unchecked_get<_Iter>(__x.__hold_) - _VSTD::__unchecked_get<_S2>(__y.__hold_);
+      return  std::__unchecked_get<_Iter>(__x.__hold_) - std::__unchecked_get<_S2>(__y.__hold_);
 
-    return _VSTD::__unchecked_get<_Sent>(__x.__hold_) - _VSTD::__unchecked_get<_I2>(__y.__hold_);
+    return std::__unchecked_get<_Sent>(__x.__hold_) - std::__unchecked_get<_I2>(__y.__hold_);
   }
 
   _LIBCPP_HIDE_FROM_ABI friend constexpr iter_rvalue_reference_t<_Iter> iter_move(const common_iterator& __i)
@@ -242,7 +242,7 @@ public:
   {
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_Iter>(__i.__hold_),
                                  "Attempted to iter_move a non-dereferenceable common_iterator");
-    return ranges::iter_move( _VSTD::__unchecked_get<_Iter>(__i.__hold_));
+    return ranges::iter_move( std::__unchecked_get<_Iter>(__i.__hold_));
   }
 
   template<indirectly_swappable<_Iter> _I2, class _S2>
@@ -253,7 +253,7 @@ public:
                                  "Attempted to iter_swap a non-dereferenceable common_iterator");
     _LIBCPP_ASSERT_UNCATEGORIZED(std::holds_alternative<_I2>(__y.__hold_),
                                  "Attempted to iter_swap a non-dereferenceable common_iterator");
-    return ranges::iter_swap(_VSTD::__unchecked_get<_Iter>(__x.__hold_), _VSTD::__unchecked_get<_I2>(__y.__hold_));
+    return ranges::iter_swap(std::__unchecked_get<_Iter>(__x.__hold_), std::__unchecked_get<_I2>(__y.__hold_));
   }
 };
 

--- a/libcxx/include/__iterator/concepts.h
+++ b/libcxx/include/__iterator/concepts.h
@@ -72,10 +72,10 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 template<class _Out, class _Tp>
 concept indirectly_writable =
   requires(_Out&& __o, _Tp&& __t) {
-    *__o = _VSTD::forward<_Tp>(__t);                        // not required to be equality-preserving
-    *_VSTD::forward<_Out>(__o) = _VSTD::forward<_Tp>(__t);  // not required to be equality-preserving
-    const_cast<const iter_reference_t<_Out>&&>(*__o) = _VSTD::forward<_Tp>(__t);                       // not required to be equality-preserving
-    const_cast<const iter_reference_t<_Out>&&>(*_VSTD::forward<_Out>(__o)) = _VSTD::forward<_Tp>(__t); // not required to be equality-preserving
+    *__o = std::forward<_Tp>(__t);                        // not required to be equality-preserving
+    *std::forward<_Out>(__o) = std::forward<_Tp>(__t);  // not required to be equality-preserving
+    const_cast<const iter_reference_t<_Out>&&>(*__o) = std::forward<_Tp>(__t);                       // not required to be equality-preserving
+    const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o)) = std::forward<_Tp>(__t); // not required to be equality-preserving
   };
 
 // [iterator.concept.winc]
@@ -147,7 +147,7 @@ concept output_iterator =
   input_or_output_iterator<_Ip> &&
   indirectly_writable<_Ip, _Tp> &&
   requires (_Ip __it, _Tp&& __t) {
-    *__it++ = _VSTD::forward<_Tp>(__t); // not required to be equality-preserving
+    *__it++ = std::forward<_Tp>(__t); // not required to be equality-preserving
   };
 
 // [iterator.concept.forward]
@@ -190,7 +190,7 @@ concept contiguous_iterator =
   is_lvalue_reference_v<iter_reference_t<_Ip>> &&
   same_as<iter_value_t<_Ip>, remove_cvref_t<iter_reference_t<_Ip>>> &&
   requires(const _Ip& __i) {
-    { _VSTD::to_address(__i) } -> same_as<add_pointer_t<iter_reference_t<_Ip>>>;
+    { std::to_address(__i) } -> same_as<add_pointer_t<iter_reference_t<_Ip>>>;
   };
 
 template<class _Ip>

--- a/libcxx/include/__iterator/counted_iterator.h
+++ b/libcxx/include/__iterator/counted_iterator.h
@@ -82,7 +82,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI
   constexpr counted_iterator(_Iter __iter, iter_difference_t<_Iter> __n)
-   : __current_(_VSTD::move(__iter)), __count_(__n) {
+   : __current_(std::move(__iter)), __count_(__n) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__n >= 0, "__n must not be negative.");
   }
 
@@ -105,7 +105,7 @@ public:
   constexpr const _Iter& base() const& noexcept { return __current_; }
 
   _LIBCPP_HIDE_FROM_ABI
-  constexpr _Iter base() && { return _VSTD::move(__current_); }
+  constexpr _Iter base() && { return std::move(__current_); }
 
   _LIBCPP_HIDE_FROM_ABI
   constexpr iter_difference_t<_Iter> count() const noexcept { return __count_; }
@@ -128,7 +128,7 @@ public:
   constexpr auto operator->() const noexcept
     requires contiguous_iterator<_Iter>
   {
-    return _VSTD::to_address(__current_);
+    return std::to_address(__current_);
   }
 
   _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -50,7 +50,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
 typename iterator_traits<_InputIter>::difference_type
 distance(_InputIter __first, _InputIter __last)
 {
-    return _VSTD::__distance(__first, __last, typename iterator_traits<_InputIter>::iterator_category());
+    return std::__distance(__first, __last, typename iterator_traits<_InputIter>::iterator_category());
 }
 
 #if _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/front_insert_iterator.h
+++ b/libcxx/include/__iterator/front_insert_iterator.h
@@ -48,12 +48,12 @@ public:
     typedef void reference;
     typedef _Container container_type;
 
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit front_insert_iterator(_Container& __x) : container(_VSTD::addressof(__x)) {}
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit front_insert_iterator(_Container& __x) : container(std::addressof(__x)) {}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 front_insert_iterator& operator=(const typename _Container::value_type& __value)
         {container->push_front(__value); return *this;}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 front_insert_iterator& operator=(typename _Container::value_type&& __value)
-        {container->push_front(_VSTD::move(__value)); return *this;}
+        {container->push_front(std::move(__value)); return *this;}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 front_insert_iterator& operator*()     {return *this;}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 front_insert_iterator& operator++()    {return *this;}

--- a/libcxx/include/__iterator/insert_iterator.h
+++ b/libcxx/include/__iterator/insert_iterator.h
@@ -59,12 +59,12 @@ public:
     typedef _Container container_type;
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 insert_iterator(_Container& __x, __insert_iterator_iter_t<_Container> __i)
-        : container(_VSTD::addressof(__x)), iter(__i) {}
+        : container(std::addressof(__x)), iter(__i) {}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 insert_iterator& operator=(const typename _Container::value_type& __value)
         {iter = container->insert(iter, __value); ++iter; return *this;}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 insert_iterator& operator=(typename _Container::value_type&& __value)
-        {iter = container->insert(iter, _VSTD::move(__value)); ++iter; return *this;}
+        {iter = container->insert(iter, std::move(__value)); ++iter; return *this;}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 insert_iterator& operator*()        {return *this;}
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 insert_iterator& operator++()       {return *this;}

--- a/libcxx/include/__iterator/istream_iterator.h
+++ b/libcxx/include/__iterator/istream_iterator.h
@@ -51,14 +51,14 @@ public:
 #if _LIBCPP_STD_VER >= 20
     _LIBCPP_HIDE_FROM_ABI constexpr istream_iterator(default_sentinel_t) : istream_iterator() {}
 #endif // _LIBCPP_STD_VER >= 20
-    _LIBCPP_HIDE_FROM_ABI istream_iterator(istream_type& __s) : __in_stream_(_VSTD::addressof(__s))
+    _LIBCPP_HIDE_FROM_ABI istream_iterator(istream_type& __s) : __in_stream_(std::addressof(__s))
         {
             if (!(*__in_stream_ >> __value_))
                 __in_stream_ = nullptr;
         }
 
     _LIBCPP_HIDE_FROM_ABI const _Tp& operator*() const {return __value_;}
-    _LIBCPP_HIDE_FROM_ABI const _Tp* operator->() const {return _VSTD::addressof((operator*()));}
+    _LIBCPP_HIDE_FROM_ABI const _Tp* operator->() const {return std::addressof((operator*()));}
     _LIBCPP_HIDE_FROM_ABI istream_iterator& operator++()
         {
             if (!(*__in_stream_ >> __value_))

--- a/libcxx/include/__iterator/iter_swap.h
+++ b/libcxx/include/__iterator/iter_swap.h
@@ -45,7 +45,7 @@ namespace __iter_swap {
     (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>) &&
     requires (_T1&& __x, _T2&& __y) {
       // NOLINTNEXTLINE(libcpp-robust-against-adl) iter_swap ADL calls should only be made through ranges::iter_swap
-      iter_swap(_VSTD::forward<_T1>(__x), _VSTD::forward<_T2>(__y));
+      iter_swap(std::forward<_T1>(__x), std::forward<_T2>(__y));
     };
 
   template<class _T1, class _T2>
@@ -60,9 +60,9 @@ namespace __iter_swap {
       requires __unqualified_iter_swap<_T1, _T2>
     _LIBCPP_HIDE_FROM_ABI
     constexpr void operator()(_T1&& __x, _T2&& __y) const
-      noexcept(noexcept(iter_swap(_VSTD::forward<_T1>(__x), _VSTD::forward<_T2>(__y))))
+      noexcept(noexcept(iter_swap(std::forward<_T1>(__x), std::forward<_T2>(__y))))
     {
-      (void)iter_swap(_VSTD::forward<_T1>(__x), _VSTD::forward<_T2>(__y));
+      (void)iter_swap(std::forward<_T1>(__x), std::forward<_T2>(__y));
     }
     // NOLINTEND(libcpp-robust-against-adl)
 
@@ -71,9 +71,9 @@ namespace __iter_swap {
                __readable_swappable<_T1, _T2>
     _LIBCPP_HIDE_FROM_ABI
     constexpr void operator()(_T1&& __x, _T2&& __y) const
-      noexcept(noexcept(ranges::swap(*_VSTD::forward<_T1>(__x), *_VSTD::forward<_T2>(__y))))
+      noexcept(noexcept(ranges::swap(*std::forward<_T1>(__x), *std::forward<_T2>(__y))))
     {
-      ranges::swap(*_VSTD::forward<_T1>(__x), *_VSTD::forward<_T2>(__y));
+      ranges::swap(*std::forward<_T1>(__x), *std::forward<_T2>(__y));
     }
 
     template <class _T1, class _T2>
@@ -85,11 +85,11 @@ namespace __iter_swap {
     constexpr void operator()(_T1&& __x, _T2&& __y) const
       noexcept(noexcept(iter_value_t<_T2>(ranges::iter_move(__y))) && //
                noexcept(*__y = ranges::iter_move(__x)) && //
-               noexcept(*_VSTD::forward<_T1>(__x) = std::declval<iter_value_t<_T2>>()))
+               noexcept(*std::forward<_T1>(__x) = std::declval<iter_value_t<_T2>>()))
     {
       iter_value_t<_T2> __old(ranges::iter_move(__y));
       *__y = ranges::iter_move(__x);
-      *_VSTD::forward<_T1>(__x) = _VSTD::move(__old);
+      *std::forward<_T1>(__x) = std::move(__old);
     }
   };
 } // namespace __iter_swap

--- a/libcxx/include/__iterator/next.h
+++ b/libcxx/include/__iterator/next.h
@@ -31,7 +31,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
   _LIBCPP_ASSERT_UNCATEGORIZED(__n >= 0 || __has_bidirectional_iterator_category<_InputIter>::value,
                                "Attempt to next(it, n) with negative n on a non-bidirectional iterator");
 
-  _VSTD::advance(__x, __n);
+  std::advance(__x, __n);
   return __x;
 }
 

--- a/libcxx/include/__iterator/ostream_iterator.h
+++ b/libcxx/include/__iterator/ostream_iterator.h
@@ -51,9 +51,9 @@ private:
     const char_type* __delim_;
 public:
     _LIBCPP_HIDE_FROM_ABI ostream_iterator(ostream_type& __s) _NOEXCEPT
-        : __out_stream_(_VSTD::addressof(__s)), __delim_(nullptr) {}
+        : __out_stream_(std::addressof(__s)), __delim_(nullptr) {}
     _LIBCPP_HIDE_FROM_ABI ostream_iterator(ostream_type& __s, const _CharT* __delimiter) _NOEXCEPT
-        : __out_stream_(_VSTD::addressof(__s)), __delim_(__delimiter) {}
+        : __out_stream_(std::addressof(__s)), __delim_(__delimiter) {}
     _LIBCPP_HIDE_FROM_ABI ostream_iterator& operator=(const _Tp& __value)
         {
             *__out_stream_ << __value;

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -30,7 +30,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
     prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1) {
   _LIBCPP_ASSERT_UNCATEGORIZED(__n <= 0 || __has_bidirectional_iterator_category<_InputIter>::value,
                                "Attempt to prev(it, n) with a positive n on a non-bidirectional iterator");
-  _VSTD::advance(__x, -__n);
+  std::advance(__x, -__n);
   return __x;
 }
 

--- a/libcxx/include/__iterator/reverse_access.h
+++ b/libcxx/include/__iterator/reverse_access.h
@@ -81,16 +81,16 @@ auto rend(const _Cp& __c) -> decltype(__c.rend())
 
 template <class _Cp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
-auto crbegin(const _Cp& __c) -> decltype(_VSTD::rbegin(__c))
+auto crbegin(const _Cp& __c) -> decltype(std::rbegin(__c))
 {
-    return _VSTD::rbegin(__c);
+    return std::rbegin(__c);
 }
 
 template <class _Cp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17
-auto crend(const _Cp& __c) -> decltype(_VSTD::rend(__c))
+auto crend(const _Cp& __c) -> decltype(std::rend(__c))
 {
-    return _VSTD::rend(__c);
+    return std::rend(__c);
 }
 
 #endif // _LIBCPP_STD_VER >= 14

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -56,7 +56,7 @@ public:
     }
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pointer operator->() const _NOEXCEPT
     {
-        return _VSTD::__to_address(__i_);
+        return std::__to_address(__i_);
     }
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter& operator++() _NOEXCEPT
     {
@@ -222,7 +222,7 @@ struct _LIBCPP_TEMPLATE_VIS pointer_traits<__wrap_iter<_It> >
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
     static element_type *to_address(pointer __w) _NOEXCEPT {
-        return _VSTD::__to_address(__w.base());
+        return std::__to_address(__w.base());
     }
 };
 

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -186,10 +186,10 @@ template <class _Facet>
 locale
 locale::combine(const locale& __other) const
 {
-    if (!_VSTD::has_facet<_Facet>(__other))
+    if (!std::has_facet<_Facet>(__other))
         __throw_runtime_error("locale::combine: locale missing facet");
 
-    return locale(*this, &const_cast<_Facet&>(_VSTD::use_facet<_Facet>(__other)));
+    return locale(*this, &const_cast<_Facet&>(std::use_facet<_Facet>(__other)));
 }
 
 template <class _Facet>
@@ -348,7 +348,7 @@ bool
 locale::operator()(const basic_string<_CharT, _Traits, _Allocator>& __x,
                    const basic_string<_CharT, _Traits, _Allocator>& __y) const
 {
-    return _VSTD::use_facet<_VSTD::collate<_CharT> >(*this).compare(
+    return std::use_facet<std::collate<_CharT> >(*this).compare(
                                        __x.data(), __x.data() + __x.size(),
                                        __y.data(), __y.data() + __y.size()) < 0;
 }

--- a/libcxx/include/__locale_dir/locale_base_api/locale_guard.h
+++ b/libcxx/include/__locale_dir/locale_base_api/locale_guard.h
@@ -46,7 +46,7 @@ struct __libcpp_locale_guard {
       // locale name, otherwise it will be a semicolon-separated string listing
       // each category.  In the second case, we know at least one category won't
       // be what we want, so we only have to check the first case.
-      if (_VSTD::strcmp(__l.__get_locale(), __lc) != 0) {
+      if (std::strcmp(__l.__get_locale(), __lc) != 0) {
         __locale_all = _strdup(__lc);
         if (__locale_all == nullptr)
           __throw_bad_alloc();

--- a/libcxx/include/__memory/allocation_guard.h
+++ b/libcxx/include/__memory/allocation_guard.h
@@ -52,7 +52,7 @@ struct __allocation_guard {
     template<class _AllocT> // we perform the allocator conversion inside the constructor
     _LIBCPP_HIDE_FROM_ABI
     explicit __allocation_guard(_AllocT __alloc, _Size __n)
-        : __alloc_(_VSTD::move(__alloc))
+        : __alloc_(std::move(__alloc))
         , __n_(__n)
         , __ptr_(allocator_traits<_Alloc>::allocate(__alloc_, __n_)) // initialization order is important
     { }

--- a/libcxx/include/__memory/allocator.h
+++ b/libcxx/include/__memory/allocator.h
@@ -111,7 +111,7 @@ public:
         if (__libcpp_is_constant_evaluated()) {
             return static_cast<_Tp*>(::operator new(__n * sizeof(_Tp)));
         } else {
-            return static_cast<_Tp*>(_VSTD::__libcpp_allocate(__n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp)));
+            return static_cast<_Tp*>(std::__libcpp_allocate(__n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp)));
         }
     }
 
@@ -127,7 +127,7 @@ public:
         if (__libcpp_is_constant_evaluated()) {
             ::operator delete(__p);
         } else {
-            _VSTD::__libcpp_deallocate((void*)__p, __n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp));
+            std::__libcpp_deallocate((void*)__p, __n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp));
         }
     }
 
@@ -145,11 +145,11 @@ public:
 
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
     pointer address(reference __x) const _NOEXCEPT {
-        return _VSTD::addressof(__x);
+        return std::addressof(__x);
     }
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
     const_pointer address(const_reference __x) const _NOEXCEPT {
-        return _VSTD::addressof(__x);
+        return std::addressof(__x);
     }
 
     _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_IN_CXX17
@@ -164,7 +164,7 @@ public:
     template <class _Up, class... _Args>
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
     void construct(_Up* __p, _Args&&... __args) {
-        ::new ((void*)__p) _Up(_VSTD::forward<_Args>(__args)...);
+        ::new ((void*)__p) _Up(std::forward<_Args>(__args)...);
     }
 
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
@@ -199,7 +199,7 @@ public:
         if (__libcpp_is_constant_evaluated()) {
             return static_cast<const _Tp*>(::operator new(__n * sizeof(_Tp)));
         } else {
-            return static_cast<const _Tp*>(_VSTD::__libcpp_allocate(__n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp)));
+            return static_cast<const _Tp*>(std::__libcpp_allocate(__n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp)));
         }
     }
 
@@ -215,7 +215,7 @@ public:
         if (__libcpp_is_constant_evaluated()) {
             ::operator delete(const_cast<_Tp*>(__p));
         } else {
-            _VSTD::__libcpp_deallocate((void*) const_cast<_Tp *>(__p), __n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp));
+            std::__libcpp_deallocate((void*) const_cast<_Tp *>(__p), __n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp));
         }
     }
 
@@ -233,7 +233,7 @@ public:
 
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
     const_pointer address(const_reference __x) const _NOEXCEPT {
-        return _VSTD::addressof(__x);
+        return std::addressof(__x);
     }
 
     _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_IN_CXX17
@@ -248,7 +248,7 @@ public:
     template <class _Up, class... _Args>
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI
     void construct(_Up* __p, _Args&&... __args) {
-        ::new ((void*)__p) _Up(_VSTD::forward<_Args>(__args)...);
+        ::new ((void*)__p) _Up(std::forward<_Args>(__args)...);
     }
 
     _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/__memory/allocator_arg_t.h
+++ b/libcxx/include/__memory/allocator_arg_t.h
@@ -54,7 +54,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 0>, _Tp *__storage, const _Allocator &, _Args &&... __args )
 {
-    new (__storage) _Tp (_VSTD::forward<_Args>(__args)...);
+    new (__storage) _Tp (std::forward<_Args>(__args)...);
 }
 
 // FIXME: This should have a version which takes a non-const alloc.
@@ -62,7 +62,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 1>, _Tp *__storage, const _Allocator &__a, _Args &&... __args )
 {
-    new (__storage) _Tp (allocator_arg, __a, _VSTD::forward<_Args>(__args)...);
+    new (__storage) _Tp (allocator_arg, __a, std::forward<_Args>(__args)...);
 }
 
 // FIXME: This should have a version which takes a non-const alloc.
@@ -70,7 +70,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 2>, _Tp *__storage, const _Allocator &__a, _Args &&... __args )
 {
-    new (__storage) _Tp (_VSTD::forward<_Args>(__args)..., __a);
+    new (__storage) _Tp (std::forward<_Args>(__args)..., __a);
 }
 
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/__memory/allocator_traits.h
+++ b/libcxx/include/__memory/allocator_traits.h
@@ -293,7 +293,7 @@ struct _LIBCPP_TEMPLATE_VIS allocator_traits
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     static void construct(allocator_type& __a, _Tp* __p, _Args&&... __args) {
         _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-        __a.construct(__p, _VSTD::forward<_Args>(__args)...);
+        __a.construct(__p, std::forward<_Args>(__args)...);
         _LIBCPP_SUPPRESS_DEPRECATED_POP
     }
     template <class _Tp, class... _Args, class = void, class =

--- a/libcxx/include/__memory/builtin_new_allocator.h
+++ b/libcxx/include/__memory/builtin_new_allocator.h
@@ -32,7 +32,7 @@ struct __builtin_new_allocator {
         : __size_(__size), __align_(__align) {}
 
     _LIBCPP_HIDE_FROM_ABI void operator()(void* __p) const _NOEXCEPT {
-        _VSTD::__libcpp_deallocate(__p, __size_, __align_);
+        std::__libcpp_deallocate(__p, __size_, __align_);
     }
 
    private:
@@ -43,13 +43,13 @@ struct __builtin_new_allocator {
   typedef unique_ptr<void, __builtin_new_deleter> __holder_t;
 
   _LIBCPP_HIDE_FROM_ABI static __holder_t __allocate_bytes(size_t __s, size_t __align) {
-      return __holder_t(_VSTD::__libcpp_allocate(__s, __align),
+      return __holder_t(std::__libcpp_allocate(__s, __align),
                      __builtin_new_deleter(__s, __align));
   }
 
   _LIBCPP_HIDE_FROM_ABI static void __deallocate_bytes(void* __p, size_t __s,
                                  size_t __align) _NOEXCEPT {
-      _VSTD::__libcpp_deallocate(__p, __s, __align);
+      std::__libcpp_deallocate(__p, __s, __align);
   }
 
   template <class _Tp>

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -156,7 +156,7 @@ private:
 public:
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     static pointer pointer_to(__conditional_t<is_void<element_type>::value, __nat, element_type>& __r) _NOEXCEPT
-        {return _VSTD::addressof(__r);}
+        {return std::addressof(__r);}
 };
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -213,9 +213,9 @@ __to_address(const _Pointer& __p) _NOEXCEPT {
 template <class _Pointer, class>
 struct __to_address_helper {
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    static decltype(_VSTD::__to_address(std::declval<const _Pointer&>().operator->()))
+    static decltype(std::__to_address(std::declval<const _Pointer&>().operator->()))
     __call(const _Pointer& __p) _NOEXCEPT {
-        return _VSTD::__to_address(__p.operator->());
+        return std::__to_address(__p.operator->());
     }
 };
 
@@ -232,13 +232,13 @@ struct __to_address_helper<_Pointer, decltype((void)pointer_traits<_Pointer>::to
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI constexpr
 auto to_address(_Tp *__p) noexcept {
-    return _VSTD::__to_address(__p);
+    return std::__to_address(__p);
 }
 
 template <class _Pointer>
 inline _LIBCPP_HIDE_FROM_ABI constexpr
 auto to_address(const _Pointer& __p) noexcept -> decltype(std::__to_address(__p)) {
-    return _VSTD::__to_address(__p);
+    return std::__to_address(__p);
 }
 #endif
 

--- a/libcxx/include/__memory/ranges_construct_at.h
+++ b/libcxx/include/__memory/ranges_construct_at.h
@@ -46,7 +46,7 @@ struct __fn {
   )>
   _LIBCPP_HIDE_FROM_ABI
   constexpr _Tp* operator()(_Tp* __location, _Args&& ...__args) const {
-    return _VSTD::construct_at(__location, _VSTD::forward<_Args>(__args)...);
+    return std::construct_at(__location, std::forward<_Args>(__args)...);
   }
 };
 
@@ -64,7 +64,7 @@ struct __fn {
   template <destructible _Tp>
   _LIBCPP_HIDE_FROM_ABI
   constexpr void operator()(_Tp* __location) const noexcept {
-    _VSTD::destroy_at(__location);
+    std::destroy_at(__location);
   }
 };
 
@@ -83,7 +83,7 @@ struct __fn {
     requires destructible<iter_value_t<_InputIterator>>
   _LIBCPP_HIDE_FROM_ABI
   constexpr _InputIterator operator()(_InputIterator __first, _Sentinel __last) const noexcept {
-    return _VSTD::__destroy(_VSTD::move(__first), _VSTD::move(__last));
+    return std::__destroy(std::move(__first), std::move(__last));
   }
 
   template <__nothrow_input_range _InputRange>
@@ -109,7 +109,7 @@ struct __fn {
     requires destructible<iter_value_t<_InputIterator>>
   _LIBCPP_HIDE_FROM_ABI
   constexpr _InputIterator operator()(_InputIterator __first, iter_difference_t<_InputIterator> __n) const noexcept {
-    return _VSTD::destroy_n(_VSTD::move(__first), __n);
+    return std::destroy_n(std::move(__first), __n);
   }
 };
 

--- a/libcxx/include/__memory/ranges_uninitialized_algorithms.h
+++ b/libcxx/include/__memory/ranges_uninitialized_algorithms.h
@@ -47,8 +47,8 @@ struct __fn {
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_default_construct<_ValueType>(
-        _VSTD::move(__first), _VSTD::move(__last));
+    return std::__uninitialized_default_construct<_ValueType>(
+        std::move(__first), std::move(__last));
   }
 
   template <__nothrow_forward_range _ForwardRange>
@@ -74,7 +74,7 @@ struct __fn {
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first,
                               iter_difference_t<_ForwardIterator> __n) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_default_construct_n<_ValueType>(_VSTD::move(__first), __n);
+    return std::__uninitialized_default_construct_n<_ValueType>(std::move(__first), __n);
   }
 };
 
@@ -94,8 +94,8 @@ struct __fn {
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_value_construct<_ValueType>(
-        _VSTD::move(__first), _VSTD::move(__last));
+    return std::__uninitialized_value_construct<_ValueType>(
+        std::move(__first), std::move(__last));
   }
 
   template <__nothrow_forward_range _ForwardRange>
@@ -121,7 +121,7 @@ struct __fn {
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first,
                               iter_difference_t<_ForwardIterator> __n) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_value_construct_n<_ValueType>(_VSTD::move(__first), __n);
+    return std::__uninitialized_value_construct_n<_ValueType>(std::move(__first), __n);
   }
 };
 
@@ -142,7 +142,7 @@ struct __fn {
     requires constructible_from<iter_value_t<_ForwardIterator>, const _Tp&>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last, const _Tp& __x) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_fill<_ValueType>(_VSTD::move(__first), _VSTD::move(__last), __x);
+    return std::__uninitialized_fill<_ValueType>(std::move(__first), std::move(__last), __x);
   }
 
   template <__nothrow_forward_range _ForwardRange, class _Tp>
@@ -169,7 +169,7 @@ struct __fn {
                               iter_difference_t<_ForwardIterator> __n,
                               const _Tp& __x) const {
     using _ValueType = remove_reference_t<iter_reference_t<_ForwardIterator>>;
-    return _VSTD::__uninitialized_fill_n<_ValueType>(_VSTD::move(__first), __n, __x);
+    return std::__uninitialized_fill_n<_ValueType>(std::move(__first), __n, __x);
   }
 };
 
@@ -199,7 +199,7 @@ struct __fn {
     auto __stop_copying = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
     auto __result       = std::__uninitialized_copy<_ValueType>(
         std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __stop_copying);
-    return {_VSTD::move(__result.first), _VSTD::move(__result.second)};
+    return {std::move(__result.first), std::move(__result.second)};
   }
 
   template <input_range _InputRange, __nothrow_forward_range _OutputRange>
@@ -236,7 +236,7 @@ struct __fn {
     auto __stop_copying = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
     auto __result =
         std::__uninitialized_copy_n<_ValueType>(std::move(__ifirst), __n, std::move(__ofirst), __stop_copying);
-    return {_VSTD::move(__result.first), _VSTD::move(__result.second)};
+    return {std::move(__result.first), std::move(__result.second)};
   }
 };
 
@@ -266,7 +266,7 @@ struct __fn {
     auto __stop_moving = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
     auto __result      = std::__uninitialized_move<_ValueType>(
         std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __stop_moving, __iter_move);
-    return {_VSTD::move(__result.first), _VSTD::move(__result.second)};
+    return {std::move(__result.first), std::move(__result.second)};
   }
 
   template <input_range _InputRange, __nothrow_forward_range _OutputRange>
@@ -304,7 +304,7 @@ struct __fn {
     auto __stop_moving = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
     auto __result      = std::__uninitialized_move_n<_ValueType>(
         std::move(__ifirst), __n, std::move(__ofirst), __stop_moving, __iter_move);
-    return {_VSTD::move(__result.first), _VSTD::move(__result.second)};
+    return {std::move(__result.first), std::move(__result.second)};
   }
 };
 

--- a/libcxx/include/__memory/raw_storage_iterator.h
+++ b/libcxx/include/__memory/raw_storage_iterator.h
@@ -50,10 +50,10 @@ public:
     _LIBCPP_HIDE_FROM_ABI explicit raw_storage_iterator(_OutputIterator __x) : __x_(__x) {}
     _LIBCPP_HIDE_FROM_ABI raw_storage_iterator& operator*() {return *this;}
     _LIBCPP_HIDE_FROM_ABI raw_storage_iterator& operator=(const _Tp& __element)
-        {::new ((void*)_VSTD::addressof(*__x_)) _Tp(__element); return *this;}
+        {::new ((void*)std::addressof(*__x_)) _Tp(__element); return *this;}
 #if _LIBCPP_STD_VER >= 14
     _LIBCPP_HIDE_FROM_ABI raw_storage_iterator& operator=(_Tp&& __element)
-        {::new ((void*)_VSTD::addressof(*__x_)) _Tp(_VSTD::move(__element)); return *this;}
+        {::new ((void*)std::addressof(*__x_)) _Tp(std::move(__element)); return *this;}
 #endif
     _LIBCPP_HIDE_FROM_ABI raw_storage_iterator& operator++() {++__x_; return *this;}
     _LIBCPP_HIDE_FROM_ABI raw_storage_iterator  operator++(int)

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -233,7 +233,7 @@ class __shared_ptr_pointer
 public:
     _LIBCPP_HIDE_FROM_ABI
     __shared_ptr_pointer(_Tp __p, _Dp __d, _Alloc __a)
-        :  __data_(__compressed_pair<_Tp, _Dp>(__p, _VSTD::move(__d)), _VSTD::move(__a)) {}
+        :  __data_(__compressed_pair<_Tp, _Dp>(__p, std::move(__d)), std::move(__a)) {}
 
 #ifndef _LIBCPP_HAS_NO_RTTI
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL const void* __get_deleter(const type_info&) const _NOEXCEPT override;
@@ -250,7 +250,7 @@ template <class _Tp, class _Dp, class _Alloc>
 const void*
 __shared_ptr_pointer<_Tp, _Dp, _Alloc>::__get_deleter(const type_info& __t) const _NOEXCEPT
 {
-    return __t == typeid(_Dp) ? _VSTD::addressof(__data_.first().second()) : nullptr;
+    return __t == typeid(_Dp) ? std::addressof(__data_.first().second()) : nullptr;
 }
 
 #endif // _LIBCPP_HAS_NO_RTTI
@@ -288,7 +288,7 @@ struct __shared_ptr_emplace
     template <class... _Args, class _Allocator = _Alloc, __enable_if_t<is_same<typename _Allocator::value_type, __for_overwrite_tag>::value, int> = 0>
     _LIBCPP_HIDE_FROM_ABI
     explicit __shared_ptr_emplace(_Alloc __a, _Args&& ...)
-        : __storage_(_VSTD::move(__a))
+        : __storage_(std::move(__a))
     {
         static_assert(sizeof...(_Args) == 0, "No argument should be provided to the control block when using _for_overwrite");
         ::new ((void*)__get_elem()) _Tp;
@@ -297,11 +297,11 @@ struct __shared_ptr_emplace
     template <class... _Args, class _Allocator = _Alloc, __enable_if_t<!is_same<typename _Allocator::value_type, __for_overwrite_tag>::value, int> = 0>
     _LIBCPP_HIDE_FROM_ABI
     explicit __shared_ptr_emplace(_Alloc __a, _Args&& ...__args)
-        : __storage_(_VSTD::move(__a))
+        : __storage_(std::move(__a))
     {
         using _TpAlloc = typename __allocator_traits_rebind<_Alloc, _Tp>::type;
         _TpAlloc __tmp(*__get_alloc());
-        allocator_traits<_TpAlloc>::construct(__tmp, __get_elem(), _VSTD::forward<_Args>(__args)...);
+        allocator_traits<_TpAlloc>::construct(__tmp, __get_elem(), std::forward<_Args>(__args)...);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -349,7 +349,7 @@ private:
         char __blob_[sizeof(_CompressedPair)];
 
         _LIBCPP_HIDE_FROM_ABI explicit _Storage(_Alloc&& __a) {
-            ::new ((void*)__get_alloc()) _Alloc(_VSTD::move(__a));
+            ::new ((void*)__get_alloc()) _Alloc(std::move(__a));
         }
         _LIBCPP_HIDE_FROM_ABI ~_Storage() {
             __get_alloc()->~_Alloc();
@@ -533,7 +533,7 @@ public:
             typedef typename __shared_ptr_default_allocator<_Yp>::type _AllocT;
             typedef __shared_ptr_pointer<_Yp*, _Dp, _AllocT> _CntrlBlk;
 #ifndef _LIBCPP_CXX03_LANG
-            __cntrl_ = new _CntrlBlk(__p, _VSTD::move(__d), _AllocT());
+            __cntrl_ = new _CntrlBlk(__p, std::move(__d), _AllocT());
 #else
             __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
 #endif // not _LIBCPP_CXX03_LANG
@@ -562,13 +562,13 @@ public:
             typedef __allocator_destructor<_A2> _D2;
             _A2 __a2(__a);
             unique_ptr<_CntrlBlk, _D2> __hold2(__a2.allocate(1), _D2(__a2, 1));
-            ::new ((void*)_VSTD::addressof(*__hold2.get()))
+            ::new ((void*)std::addressof(*__hold2.get()))
 #ifndef _LIBCPP_CXX03_LANG
-                _CntrlBlk(__p, _VSTD::move(__d), __a);
+                _CntrlBlk(__p, std::move(__d), __a);
 #else
                 _CntrlBlk(__p, __d, __a);
 #endif // not _LIBCPP_CXX03_LANG
-            __cntrl_ = _VSTD::addressof(*__hold2.release());
+            __cntrl_ = std::addressof(*__hold2.release());
             __enable_weak_this(__p, __p);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
         }
@@ -592,7 +592,7 @@ public:
             typedef typename __shared_ptr_default_allocator<_Tp>::type _AllocT;
             typedef __shared_ptr_pointer<nullptr_t, _Dp, _AllocT> _CntrlBlk;
 #ifndef _LIBCPP_CXX03_LANG
-            __cntrl_ = new _CntrlBlk(__p, _VSTD::move(__d), _AllocT());
+            __cntrl_ = new _CntrlBlk(__p, std::move(__d), _AllocT());
 #else
             __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
 #endif // not _LIBCPP_CXX03_LANG
@@ -620,13 +620,13 @@ public:
             typedef __allocator_destructor<_A2> _D2;
             _A2 __a2(__a);
             unique_ptr<_CntrlBlk, _D2> __hold2(__a2.allocate(1), _D2(__a2, 1));
-            ::new ((void*)_VSTD::addressof(*__hold2.get()))
+            ::new ((void*)std::addressof(*__hold2.get()))
 #ifndef _LIBCPP_CXX03_LANG
-                _CntrlBlk(__p, _VSTD::move(__d), __a);
+                _CntrlBlk(__p, std::move(__d), __a);
 #else
                 _CntrlBlk(__p, __d, __a);
 #endif // not _LIBCPP_CXX03_LANG
-            __cntrl_ = _VSTD::addressof(*__hold2.release());
+            __cntrl_ = std::addressof(*__hold2.release());
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
         }
         catch (...)
@@ -762,7 +762,7 @@ public:
             typedef __shared_ptr_pointer<typename unique_ptr<_Yp, _Dp>::pointer,
                                         reference_wrapper<__libcpp_remove_reference_t<_Dp> >,
                                         _AllocT> _CntrlBlk;
-            __cntrl_ = new _CntrlBlk(__r.get(), _VSTD::ref(__r.get_deleter()), _AllocT());
+            __cntrl_ = new _CntrlBlk(__r.get(), std::ref(__r.get_deleter()), _AllocT());
             __enable_weak_this(__r.get(), __r.get());
         }
         __r.release();
@@ -793,7 +793,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_ptr<_Tp>& operator=(shared_ptr&& __r) _NOEXCEPT
     {
-        shared_ptr(_VSTD::move(__r)).swap(*this);
+        shared_ptr(std::move(__r)).swap(*this);
         return *this;
     }
 
@@ -801,7 +801,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_ptr<_Tp>& operator=(shared_ptr<_Yp>&& __r)
     {
-        shared_ptr(_VSTD::move(__r)).swap(*this);
+        shared_ptr(std::move(__r)).swap(*this);
         return *this;
     }
 
@@ -813,7 +813,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_ptr<_Tp>& operator=(auto_ptr<_Yp>&& __r)
     {
-        shared_ptr(_VSTD::move(__r)).swap(*this);
+        shared_ptr(std::move(__r)).swap(*this);
         return *this;
     }
 #endif
@@ -825,15 +825,15 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_ptr<_Tp>& operator=(unique_ptr<_Yp, _Dp>&& __r)
     {
-        shared_ptr(_VSTD::move(__r)).swap(*this);
+        shared_ptr(std::move(__r)).swap(*this);
         return *this;
     }
 
     _LIBCPP_HIDE_FROM_ABI
     void swap(shared_ptr& __r) _NOEXCEPT
     {
-        _VSTD::swap(__ptr_, __r.__ptr_);
-        _VSTD::swap(__cntrl_, __r.__cntrl_);
+        std::swap(__ptr_, __r.__ptr_);
+        std::swap(__cntrl_, __r.__cntrl_);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1022,16 +1022,16 @@ shared_ptr<_Tp> allocate_shared(const _Alloc& __a, _Args&& ...__args)
     using _ControlBlock = __shared_ptr_emplace<_Tp, _Alloc>;
     using _ControlBlockAllocator = typename __allocator_traits_rebind<_Alloc, _ControlBlock>::type;
     __allocation_guard<_ControlBlockAllocator> __guard(__a, 1);
-    ::new ((void*)_VSTD::addressof(*__guard.__get())) _ControlBlock(__a, _VSTD::forward<_Args>(__args)...);
+    ::new ((void*)std::addressof(*__guard.__get())) _ControlBlock(__a, std::forward<_Args>(__args)...);
     auto __control_block = __guard.__release_ptr();
-    return shared_ptr<_Tp>::__create_with_control_block((*__control_block).__get_elem(), _VSTD::addressof(*__control_block));
+    return shared_ptr<_Tp>::__create_with_control_block((*__control_block).__get_elem(), std::addressof(*__control_block));
 }
 
 template<class _Tp, class ..._Args, class = __enable_if_t<!is_array<_Tp>::value> >
 _LIBCPP_HIDE_FROM_ABI
 shared_ptr<_Tp> make_shared(_Args&& ...__args)
 {
-    return _VSTD::allocate_shared<_Tp>(allocator<_Tp>(), _VSTD::forward<_Args>(__args)...);
+    return std::allocate_shared<_Tp>(allocator<_Tp>(), std::forward<_Args>(__args)...);
 }
 
 #if _LIBCPP_STD_VER >= 20
@@ -1789,7 +1789,7 @@ inline
 weak_ptr<_Tp>&
 weak_ptr<_Tp>::operator=(weak_ptr&& __r) _NOEXCEPT
 {
-    weak_ptr(_VSTD::move(__r)).swap(*this);
+    weak_ptr(std::move(__r)).swap(*this);
     return *this;
 }
 
@@ -1799,7 +1799,7 @@ inline
 weak_ptr<_Tp>&
 weak_ptr<_Tp>::operator=(weak_ptr<_Yp>&& __r) _NOEXCEPT
 {
-    weak_ptr(_VSTD::move(__r)).swap(*this);
+    weak_ptr(std::move(__r)).swap(*this);
     return *this;
 }
 
@@ -1818,8 +1818,8 @@ inline
 void
 weak_ptr<_Tp>::swap(weak_ptr& __r) _NOEXCEPT
 {
-    _VSTD::swap(__ptr_, __r.__ptr_);
-    _VSTD::swap(__cntrl_, __r.__cntrl_);
+    std::swap(__ptr_, __r.__ptr_);
+    std::swap(__cntrl_, __r.__cntrl_);
 }
 
 template<class _Tp>
@@ -2060,12 +2060,12 @@ atomic_compare_exchange_strong(shared_ptr<_Tp>* __p, shared_ptr<_Tp>* __v, share
     __m.lock();
     if (__p->__owner_equivalent(*__v))
     {
-        _VSTD::swap(__temp, *__p);
+        std::swap(__temp, *__p);
         *__p = __w;
         __m.unlock();
         return true;
     }
-    _VSTD::swap(__temp, *__v);
+    std::swap(__temp, *__v);
     *__v = *__p;
     __m.unlock();
     return false;

--- a/libcxx/include/__memory/swap_allocator.h
+++ b/libcxx/include/__memory/swap_allocator.h
@@ -29,7 +29,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __swap_allocator(_Alloc
     _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
 #endif
 {
-  using _VSTD::swap;
+  using std::swap;
   swap(__a1, __a2);
 }
 
@@ -45,7 +45,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __swap_allocator
     _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
 #endif
 {
-  _VSTD::__swap_allocator(
+  std::__swap_allocator(
       __a1, __a2, integral_constant<bool, allocator_traits<_Alloc>::propagate_on_container_swap::value>());
 }
 

--- a/libcxx/include/__memory/temporary_buffer.h
+++ b/libcxx/include/__memory/temporary_buffer.h
@@ -70,14 +70,14 @@ template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_IN_CXX17
 void return_temporary_buffer(_Tp* __p) _NOEXCEPT
 {
-  _VSTD::__libcpp_deallocate_unsized((void*)__p, _LIBCPP_ALIGNOF(_Tp));
+  std::__libcpp_deallocate_unsized((void*)__p, _LIBCPP_ALIGNOF(_Tp));
 }
 
 struct __return_temporary_buffer
 {
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     template <class _Tp>
-    _LIBCPP_HIDE_FROM_ABI void operator()(_Tp* __p) const {_VSTD::return_temporary_buffer(__p);}
+    _LIBCPP_HIDE_FROM_ABI void operator()(_Tp* __p) const {std::return_temporary_buffer(__p);}
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 };
 

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -61,15 +61,15 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #endif
     for (; __ifirst != __ilast && !__stop_copying(__idx); ++__ifirst, (void)++__idx)
-      ::new (_VSTD::__voidify(*__idx)) _ValueType(*__ifirst);
+      ::new (std::__voidify(*__idx)) _ValueType(*__ifirst);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
-    _VSTD::__destroy(__ofirst, __idx);
+    std::__destroy(__ofirst, __idx);
     throw;
   }
 #endif
 
-  return pair<_InputIterator, _ForwardIterator>(_VSTD::move(__ifirst), _VSTD::move(__idx));
+  return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
 }
 
 template <class _InputIterator, class _ForwardIterator>
@@ -79,7 +79,7 @@ _ForwardIterator uninitialized_copy(_InputIterator __ifirst, _InputIterator __il
   typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
   auto __result = std::__uninitialized_copy<_ValueType>(
       std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __always_false());
-  return _VSTD::move(__result.second);
+  return std::move(__result.second);
 }
 
 // uninitialized_copy_n
@@ -92,15 +92,15 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #endif
     for (; __n > 0 && !__stop_copying(__idx); ++__ifirst, (void)++__idx, (void)--__n)
-      ::new (_VSTD::__voidify(*__idx)) _ValueType(*__ifirst);
+      ::new (std::__voidify(*__idx)) _ValueType(*__ifirst);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
-    _VSTD::__destroy(__ofirst, __idx);
+    std::__destroy(__ofirst, __idx);
     throw;
   }
 #endif
 
-  return pair<_InputIterator, _ForwardIterator>(_VSTD::move(__ifirst), _VSTD::move(__idx));
+  return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
 }
 
 template <class _InputIterator, class _Size, class _ForwardIterator>
@@ -109,7 +109,7 @@ inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator uninitialized_copy_n(_InputIterato
   typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
   auto __result =
       std::__uninitialized_copy_n<_ValueType>(std::move(__ifirst), __n, std::move(__ofirst), __always_false());
-  return _VSTD::move(__result.second);
+  return std::move(__result.second);
 }
 
 // uninitialized_fill
@@ -124,12 +124,12 @@ _ForwardIterator __uninitialized_fill(_ForwardIterator __first, _Sentinel __last
     {
 #endif
         for (; __idx != __last; ++__idx)
-            ::new (_VSTD::__voidify(*__idx)) _ValueType(__x);
+            ::new (std::__voidify(*__idx)) _ValueType(__x);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
     catch (...)
     {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -142,7 +142,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 void uninitialized_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __x)
 {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    (void)_VSTD::__uninitialized_fill<_ValueType>(__first, __last, __x);
+    (void)std::__uninitialized_fill<_ValueType>(__first, __last, __x);
 }
 
 // uninitialized_fill_n
@@ -157,12 +157,12 @@ _ForwardIterator __uninitialized_fill_n(_ForwardIterator __first, _Size __n, con
     {
 #endif
         for (; __n > 0; ++__idx, (void) --__n)
-            ::new (_VSTD::__voidify(*__idx)) _ValueType(__x);
+            ::new (std::__voidify(*__idx)) _ValueType(__x);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
     catch (...)
     {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -175,7 +175,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 _ForwardIterator uninitialized_fill_n(_ForwardIterator __first, _Size __n, const _Tp& __x)
 {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    return _VSTD::__uninitialized_fill_n<_ValueType>(__first, __n, __x);
+    return std::__uninitialized_fill_n<_ValueType>(__first, __n, __x);
 }
 
 #if _LIBCPP_STD_VER >= 17
@@ -190,10 +190,10 @@ _ForwardIterator __uninitialized_default_construct(_ForwardIterator __first, _Se
     try {
 #endif
     for (; __idx != __last; ++__idx)
-        ::new (_VSTD::__voidify(*__idx)) _ValueType;
+        ::new (std::__voidify(*__idx)) _ValueType;
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -205,8 +205,8 @@ template <class _ForwardIterator>
 inline _LIBCPP_HIDE_FROM_ABI
 void uninitialized_default_construct(_ForwardIterator __first, _ForwardIterator __last) {
     using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-    (void)_VSTD::__uninitialized_default_construct<_ValueType>(
-        _VSTD::move(__first), _VSTD::move(__last));
+    (void)std::__uninitialized_default_construct<_ValueType>(
+        std::move(__first), std::move(__last));
 }
 
 // uninitialized_default_construct_n
@@ -219,10 +219,10 @@ _ForwardIterator __uninitialized_default_construct_n(_ForwardIterator __first, _
     try {
 #endif
     for (; __n > 0; ++__idx, (void) --__n)
-        ::new (_VSTD::__voidify(*__idx)) _ValueType;
+        ::new (std::__voidify(*__idx)) _ValueType;
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -234,7 +234,7 @@ template <class _ForwardIterator, class _Size>
 inline _LIBCPP_HIDE_FROM_ABI
 _ForwardIterator uninitialized_default_construct_n(_ForwardIterator __first, _Size __n) {
     using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-    return _VSTD::__uninitialized_default_construct_n<_ValueType>(_VSTD::move(__first), __n);
+    return std::__uninitialized_default_construct_n<_ValueType>(std::move(__first), __n);
 }
 
 // uninitialized_value_construct
@@ -247,10 +247,10 @@ _ForwardIterator __uninitialized_value_construct(_ForwardIterator __first, _Sent
     try {
 #endif
     for (; __idx != __last; ++__idx)
-        ::new (_VSTD::__voidify(*__idx)) _ValueType();
+        ::new (std::__voidify(*__idx)) _ValueType();
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -262,8 +262,8 @@ template <class _ForwardIterator>
 inline _LIBCPP_HIDE_FROM_ABI
 void uninitialized_value_construct(_ForwardIterator __first, _ForwardIterator __last) {
     using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-    (void)_VSTD::__uninitialized_value_construct<_ValueType>(
-        _VSTD::move(__first), _VSTD::move(__last));
+    (void)std::__uninitialized_value_construct<_ValueType>(
+        std::move(__first), std::move(__last));
 }
 
 // uninitialized_value_construct_n
@@ -276,10 +276,10 @@ _ForwardIterator __uninitialized_value_construct_n(_ForwardIterator __first, _Si
     try {
 #endif
     for (; __n > 0; ++__idx, (void) --__n)
-        ::new (_VSTD::__voidify(*__idx)) _ValueType();
+        ::new (std::__voidify(*__idx)) _ValueType();
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
-        _VSTD::__destroy(__first, __idx);
+        std::__destroy(__first, __idx);
         throw;
     }
 #endif
@@ -291,7 +291,7 @@ template <class _ForwardIterator, class _Size>
 inline _LIBCPP_HIDE_FROM_ABI
 _ForwardIterator uninitialized_value_construct_n(_ForwardIterator __first, _Size __n) {
     using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-    return std::__uninitialized_value_construct_n<_ValueType>(_VSTD::move(__first), __n);
+    return std::__uninitialized_value_construct_n<_ValueType>(std::move(__first), __n);
 }
 
 // uninitialized_move
@@ -313,27 +313,27 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #endif
     for (; __ifirst != __ilast && !__stop_moving(__idx); ++__idx, (void)++__ifirst) {
-      ::new (_VSTD::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
+      ::new (std::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
     }
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
-    _VSTD::__destroy(__ofirst, __idx);
+    std::__destroy(__ofirst, __idx);
     throw;
   }
 #endif
 
-  return {_VSTD::move(__ifirst), _VSTD::move(__idx)};
+  return {std::move(__ifirst), std::move(__idx)};
 }
 
 template <class _InputIterator, class _ForwardIterator>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator uninitialized_move(_InputIterator __ifirst, _InputIterator __ilast,
                                                                  _ForwardIterator __ofirst) {
   using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-  auto __iter_move = [](auto&& __iter) -> decltype(auto) { return _VSTD::move(*__iter); };
+  auto __iter_move = [](auto&& __iter) -> decltype(auto) { return std::move(*__iter); };
 
   auto __result = std::__uninitialized_move<_ValueType>(
       std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __always_false(), __iter_move);
-  return _VSTD::move(__result.second);
+  return std::move(__result.second);
 }
 
 // uninitialized_move_n
@@ -351,22 +351,22 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #endif
     for (; __n > 0 && !__stop_moving(__idx); ++__idx, (void)++__ifirst, --__n)
-      ::new (_VSTD::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
+      ::new (std::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
-    _VSTD::__destroy(__ofirst, __idx);
+    std::__destroy(__ofirst, __idx);
     throw;
   }
 #endif
 
-  return {_VSTD::move(__ifirst), _VSTD::move(__idx)};
+  return {std::move(__ifirst), std::move(__idx)};
 }
 
 template <class _InputIterator, class _Size, class _ForwardIterator>
 inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator>
 uninitialized_move_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst) {
   using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
-  auto __iter_move = [](auto&& __iter) -> decltype(auto) { return _VSTD::move(*__iter); };
+  auto __iter_move = [](auto&& __iter) -> decltype(auto) { return std::move(*__iter); };
 
   return std::__uninitialized_move_n<_ValueType>(
       std::move(__ifirst), __n, std::move(__ofirst), __always_false(), __iter_move);

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -200,7 +200,7 @@ public:
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> > >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
-  unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) _NOEXCEPT : __ptr_(__p, _VSTD::move(__d)) {
+  unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) _NOEXCEPT : __ptr_(__p, std::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
   }
@@ -211,14 +211,14 @@ public:
   unique_ptr(pointer __p, _BadRValRefType<_Dummy> __d) = delete;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& __u) _NOEXCEPT
-      : __ptr_(__u.release(), _VSTD::forward<deleter_type>(__u.get_deleter())) {}
+      : __ptr_(__u.release(), std::forward<deleter_type>(__u.get_deleter())) {}
 
   template <class _Up,
             class _Ep,
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterConvertible<_Ep> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT
-      : __ptr_(__u.release(), _VSTD::forward<_Ep>(__u.get_deleter())) {}
+      : __ptr_(__u.release(), std::forward<_Ep>(__u.get_deleter())) {}
 
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
   template <class _Up, __enable_if_t<is_convertible<_Up*, _Tp*>::value &&
@@ -230,7 +230,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
     reset(__u.release());
-    __ptr_.second() = _VSTD::forward<deleter_type>(__u.get_deleter());
+    __ptr_.second() = std::forward<deleter_type>(__u.get_deleter());
     return *this;
   }
 
@@ -240,7 +240,7 @@ public:
             class = _EnableIfDeleterAssignable<_Ep> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
     reset(__u.release());
-    __ptr_.second() = _VSTD::forward<_Ep>(__u.get_deleter());
+    __ptr_.second() = std::forward<_Ep>(__u.get_deleter());
     return *this;
   }
 
@@ -408,14 +408,14 @@ public:
             class       = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> >,
             class       = _EnableIfPointerConvertible<_Pp> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) _NOEXCEPT
-      : __ptr_(__p, _VSTD::move(__d)) {
+      : __ptr_(__p, std::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
   }
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> > >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) _NOEXCEPT
-      : __ptr_(nullptr, _VSTD::move(__d)) {
+      : __ptr_(nullptr, std::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
   }
@@ -427,11 +427,11 @@ public:
   unique_ptr(_Pp __p, _BadRValRefType<_Dummy> __d) = delete;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& __u) _NOEXCEPT
-      : __ptr_(__u.release(), _VSTD::forward<deleter_type>(__u.get_deleter())) {}
+      : __ptr_(__u.release(), std::forward<deleter_type>(__u.get_deleter())) {}
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
     reset(__u.release());
-    __ptr_.second() = _VSTD::forward<deleter_type>(__u.get_deleter());
+    __ptr_.second() = std::forward<deleter_type>(__u.get_deleter());
     return *this;
   }
 
@@ -440,7 +440,7 @@ public:
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterConvertible<_Ep> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT
-      : __ptr_(__u.release(), _VSTD::forward<_Ep>(__u.get_deleter())) {}
+      : __ptr_(__u.release(), std::forward<_Ep>(__u.get_deleter())) {}
 
   template <class _Up,
             class _Ep,
@@ -448,7 +448,7 @@ public:
             class = _EnableIfDeleterAssignable<_Ep> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
     reset(__u.release());
-    __ptr_.second() = _VSTD::forward<_Ep>(__u.get_deleter());
+    __ptr_.second() = std::forward<_Ep>(__u.get_deleter());
     return *this;
   }
 
@@ -682,7 +682,7 @@ struct __unique_if<_Tp[_Np]>
 template <class _Tp, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename __unique_if<_Tp>::__unique_single
 make_unique(_Args&&... __args) {
-  return unique_ptr<_Tp>(new _Tp(_VSTD::forward<_Args>(__args)...));
+  return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
 }
 
 template <class _Tp>

--- a/libcxx/include/__memory/voidify.h
+++ b/libcxx/include/__memory/voidify.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <typename _Tp>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void* __voidify(_Tp& __from) {
   // Cast away cv-qualifiers to allow modifying elements of a range through const iterators.
-  return const_cast<void*>(static_cast<const volatile void*>(_VSTD::addressof(__from)));
+  return const_cast<void*>(static_cast<const volatile void*>(std::addressof(__from)));
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -91,7 +91,7 @@ public:
 private:
   template <size_t... _Indices>
   _LIBCPP_HIDE_FROM_ABI void __execute(__tuple_indices<_Indices...>) {
-    _VSTD::__invoke(_VSTD::get<0>(_VSTD::move(__f_)), _VSTD::get<_Indices>(_VSTD::move(__f_))...);
+    std::__invoke(std::get<0>(std::move(__f_)), std::get<_Indices>(std::move(__f_))...);
   }
 };
 
@@ -123,7 +123,7 @@ template <class _Callable, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable&& __func, _Args&&... __args) {
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
     typedef tuple<_Callable&&, _Args&&...> _Gp;
-    _Gp __f(_VSTD::forward<_Callable>(__func), _VSTD::forward<_Args>(__args)...);
+    _Gp __f(std::forward<_Callable>(__func), std::forward<_Args>(__args)...);
     __call_once_param<_Gp> __p(__f);
     std::__call_once(__flag.__state_, &__p, &__call_once_proxy<_Gp>);
   }

--- a/libcxx/include/__node_handle
+++ b/libcxx/include/__node_handle
@@ -109,7 +109,7 @@ private:
     void __release_ptr()
     {
         __ptr_ = nullptr;
-        __alloc_ = _VSTD::nullopt;
+        __alloc_ = std::nullopt;
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -140,17 +140,17 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __basic_node_handle(__basic_node_handle&& __other) noexcept
             : __ptr_(__other.__ptr_),
-              __alloc_(_VSTD::move(__other.__alloc_))
+              __alloc_(std::move(__other.__alloc_))
     {
         __other.__ptr_ = nullptr;
-        __other.__alloc_ = _VSTD::nullopt;
+        __other.__alloc_ = std::nullopt;
     }
 
     _LIBCPP_HIDE_FROM_ABI
     __basic_node_handle& operator=(__basic_node_handle&& __other)
     {
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
-            __alloc_ == _VSTD::nullopt ||
+            __alloc_ == std::nullopt ||
             __alloc_traits::propagate_on_container_move_assignment::value ||
             __alloc_ == __other.__alloc_,
             "node_type with incompatible allocator passed to "
@@ -160,11 +160,11 @@ public:
         __ptr_ = __other.__ptr_;
 
         if (__alloc_traits::propagate_on_container_move_assignment::value ||
-            __alloc_ == _VSTD::nullopt)
-            __alloc_ = _VSTD::move(__other.__alloc_);
+            __alloc_ == std::nullopt)
+            __alloc_ = std::move(__other.__alloc_);
 
         __other.__ptr_ = nullptr;
-        __other.__alloc_ = _VSTD::nullopt;
+        __other.__alloc_ = std::nullopt;
 
         return *this;
     }
@@ -183,10 +183,10 @@ public:
         __alloc_traits::propagate_on_container_swap::value ||
         __alloc_traits::is_always_equal::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(__ptr_, __other.__ptr_);
         if (__alloc_traits::propagate_on_container_swap::value ||
-            __alloc_ == _VSTD::nullopt || __other.__alloc_ == _VSTD::nullopt)
+            __alloc_ == std::nullopt || __other.__alloc_ == std::nullopt)
             swap(__alloc_, __other.__alloc_);
     }
 

--- a/libcxx/include/__numeric/accumulate.h
+++ b/libcxx/include/__numeric/accumulate.h
@@ -29,7 +29,7 @@ accumulate(_InputIterator __first, _InputIterator __last, _Tp __init)
 {
     for (; __first != __last; ++__first)
 #if _LIBCPP_STD_VER >= 20
-        __init = _VSTD::move(__init) + *__first;
+        __init = std::move(__init) + *__first;
 #else
         __init = __init + *__first;
 #endif
@@ -43,7 +43,7 @@ accumulate(_InputIterator __first, _InputIterator __last, _Tp __init, _BinaryOpe
 {
     for (; __first != __last; ++__first)
 #if _LIBCPP_STD_VER >= 20
-        __init = __binary_op(_VSTD::move(__init), *__first);
+        __init = __binary_op(std::move(__init), *__first);
 #else
         __init = __binary_op(__init, *__first);
 #endif

--- a/libcxx/include/__numeric/adjacent_difference.h
+++ b/libcxx/include/__numeric/adjacent_difference.h
@@ -36,11 +36,11 @@ adjacent_difference(_InputIterator __first, _InputIterator __last, _OutputIterat
         {
             typename iterator_traits<_InputIterator>::value_type __val(*__first);
 #if _LIBCPP_STD_VER >= 20
-            *__result = __val - _VSTD::move(__acc);
+            *__result = __val - std::move(__acc);
 #else
             *__result = __val - __acc;
 #endif
-            __acc = _VSTD::move(__val);
+            __acc = std::move(__val);
         }
     }
     return __result;
@@ -60,11 +60,11 @@ adjacent_difference(_InputIterator __first, _InputIterator __last, _OutputIterat
         {
             typename iterator_traits<_InputIterator>::value_type __val(*__first);
 #if _LIBCPP_STD_VER >= 20
-            *__result = __binary_op(__val, _VSTD::move(__acc));
+            *__result = __binary_op(__val, std::move(__acc));
 #else
             *__result = __binary_op(__val, __acc);
 #endif
-            __acc = _VSTD::move(__val);
+            __acc = std::move(__val);
         }
     }
     return __result;

--- a/libcxx/include/__numeric/exclusive_scan.h
+++ b/libcxx/include/__numeric/exclusive_scan.h
@@ -31,12 +31,12 @@ exclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __
   if (__first != __last) {
     _Tp __tmp(__b(__init, *__first));
     while (true) {
-      *__result = _VSTD::move(__init);
+      *__result = std::move(__init);
       ++__result;
       ++__first;
       if (__first == __last)
         break;
-      __init = _VSTD::move(__tmp);
+      __init = std::move(__tmp);
       __tmp = __b(__init, *__first);
     }
   }
@@ -46,7 +46,7 @@ exclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __
 template <class _InputIterator, class _OutputIterator, class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 exclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Tp __init) {
-  return _VSTD::exclusive_scan(__first, __last, __result, __init, _VSTD::plus<>());
+  return std::exclusive_scan(__first, __last, __result, __init, std::plus<>());
 }
 
 #endif // _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__numeric/gcd_lcm.h
+++ b/libcxx/include/__numeric/gcd_lcm.h
@@ -55,7 +55,7 @@ _LIBCPP_CONSTEXPR _LIBCPP_HIDDEN
 _Tp __gcd(_Tp __m, _Tp __n)
 {
     static_assert((!is_signed<_Tp>::value), "");
-    return __n == 0 ? __m : _VSTD::__gcd<_Tp>(__n, __m % __n);
+    return __n == 0 ? __m : std::__gcd<_Tp>(__n, __m % __n);
 }
 
 template<class _Tp, class _Up>
@@ -68,7 +68,7 @@ gcd(_Tp __m, _Up __n)
     static_assert((!is_same<__remove_cv_t<_Up>, bool>::value), "Second argument to gcd cannot be bool" );
     using _Rp = common_type_t<_Tp,_Up>;
     using _Wp = make_unsigned_t<_Rp>;
-    return static_cast<_Rp>(_VSTD::__gcd(
+    return static_cast<_Rp>(std::__gcd(
         static_cast<_Wp>(__ct_abs<_Rp, _Tp>()(__m)),
         static_cast<_Wp>(__ct_abs<_Rp, _Up>()(__n))));
 }
@@ -85,7 +85,7 @@ lcm(_Tp __m, _Up __n)
         return 0;
 
     using _Rp = common_type_t<_Tp,_Up>;
-    _Rp __val1 = __ct_abs<_Rp, _Tp>()(__m) / _VSTD::gcd(__m, __n);
+    _Rp __val1 = __ct_abs<_Rp, _Tp>()(__m) / std::gcd(__m, __n);
     _Rp __val2 = __ct_abs<_Rp, _Up>()(__n);
     _LIBCPP_ASSERT_UNCATEGORIZED((numeric_limits<_Rp>::max() / __val1 > __val2), "Overflow in lcm");
     return __val1 * __val2;

--- a/libcxx/include/__numeric/inclusive_scan.h
+++ b/libcxx/include/__numeric/inclusive_scan.h
@@ -40,7 +40,7 @@ inclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __
     typename iterator_traits<_InputIterator>::value_type __init = *__first;
     *__result++ = __init;
     if (++__first != __last)
-      return _VSTD::inclusive_scan(__first, __last, __result, __b, __init);
+      return std::inclusive_scan(__first, __last, __result, __b, __init);
   }
 
   return __result;
@@ -50,7 +50,7 @@ template <class _InputIterator, class _OutputIterator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator inclusive_scan(_InputIterator __first,
                                                                                        _InputIterator __last,
                                                                                        _OutputIterator __result) {
-  return _VSTD::inclusive_scan(__first, __last, __result, _VSTD::plus<>());
+  return std::inclusive_scan(__first, __last, __result, std::plus<>());
 }
 
 #endif // _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__numeric/inner_product.h
+++ b/libcxx/include/__numeric/inner_product.h
@@ -29,7 +29,7 @@ inner_product(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2
 {
     for (; __first1 != __last1; ++__first1, (void) ++__first2)
 #if _LIBCPP_STD_VER >= 20
-        __init = _VSTD::move(__init) + *__first1 * *__first2;
+        __init = std::move(__init) + *__first1 * *__first2;
 #else
         __init = __init + *__first1 * *__first2;
 #endif
@@ -44,7 +44,7 @@ inner_product(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2
 {
     for (; __first1 != __last1; ++__first1, (void) ++__first2)
 #if _LIBCPP_STD_VER >= 20
-        __init = __binary_op1(_VSTD::move(__init), __binary_op2(*__first1, *__first2));
+        __init = __binary_op1(std::move(__init), __binary_op2(*__first1, *__first2));
 #else
         __init = __binary_op1(__init, __binary_op2(*__first1, *__first2));
 #endif

--- a/libcxx/include/__numeric/midpoint.h
+++ b/libcxx/include/__numeric/midpoint.h
@@ -60,7 +60,7 @@ enable_if_t<is_pointer_v<_TPtr>
              && (sizeof(remove_pointer_t<_TPtr>) > 0), _TPtr>
 midpoint(_TPtr __a, _TPtr __b) noexcept
 {
-    return __a + _VSTD::midpoint(ptrdiff_t(0), __b - __a);
+    return __a + std::midpoint(ptrdiff_t(0), __b - __a);
 }
 
 

--- a/libcxx/include/__numeric/partial_sum.h
+++ b/libcxx/include/__numeric/partial_sum.h
@@ -35,7 +35,7 @@ partial_sum(_InputIterator __first, _InputIterator __last, _OutputIterator __res
         for (++__first, (void) ++__result; __first != __last; ++__first, (void) ++__result)
         {
 #if _LIBCPP_STD_VER >= 20
-            __t = _VSTD::move(__t) + *__first;
+            __t = std::move(__t) + *__first;
 #else
             __t = __t + *__first;
 #endif
@@ -58,7 +58,7 @@ partial_sum(_InputIterator __first, _InputIterator __last, _OutputIterator __res
         for (++__first, (void) ++__result; __first != __last; ++__first, (void) ++__result)
         {
 #if _LIBCPP_STD_VER >= 20
-            __t = __binary_op(_VSTD::move(__t), *__first);
+            __t = __binary_op(std::move(__t), *__first);
 #else
             __t = __binary_op(__t, *__first);
 #endif

--- a/libcxx/include/__numeric/reduce.h
+++ b/libcxx/include/__numeric/reduce.h
@@ -33,13 +33,13 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp reduce(_InputIterator __
 template <class _InputIterator, class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp reduce(_InputIterator __first, _InputIterator __last,
                                                                    _Tp __init) {
-  return _VSTD::reduce(__first, __last, __init, _VSTD::plus<>());
+  return std::reduce(__first, __last, __init, std::plus<>());
 }
 
 template <class _InputIterator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 typename iterator_traits<_InputIterator>::value_type
 reduce(_InputIterator __first, _InputIterator __last) {
-  return _VSTD::reduce(__first, __last, typename iterator_traits<_InputIterator>::value_type{});
+  return std::reduce(__first, __last, typename iterator_traits<_InputIterator>::value_type{});
 }
 #endif
 

--- a/libcxx/include/__numeric/transform_inclusive_scan.h
+++ b/libcxx/include/__numeric/transform_inclusive_scan.h
@@ -45,7 +45,7 @@ transform_inclusive_scan(_InputIterator __first, _InputIterator __last,
         typename iterator_traits<_InputIterator>::value_type __init = __u(*__first);
         *__result++ = __init;
         if (++__first != __last)
-            return _VSTD::transform_inclusive_scan(__first, __last, __result, __b, __u, __init);
+            return std::transform_inclusive_scan(__first, __last, __result, __b, __u, __init);
     }
 
     return __result;

--- a/libcxx/include/__numeric/transform_reduce.h
+++ b/libcxx/include/__numeric/transform_reduce.h
@@ -44,8 +44,8 @@ template <class _InputIterator1, class _InputIterator2, class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp transform_reduce(_InputIterator1 __first1,
                                                                              _InputIterator1 __last1,
                                                                              _InputIterator2 __first2, _Tp __init) {
-  return _VSTD::transform_reduce(__first1, __last1, __first2, _VSTD::move(__init), _VSTD::plus<>(),
-                                 _VSTD::multiplies<>());
+  return std::transform_reduce(__first1, __last1, __first2, std::move(__init), std::plus<>(),
+                                 std::multiplies<>());
 }
 #endif
 

--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -134,10 +134,10 @@ binomial_distribution<_IntType>::param_type::param_type(result_type __t, double 
     if (0 < __p_ && __p_ < 1)
     {
         __r0_ = static_cast<result_type>((__t_ + 1) * __p_);
-        __pr_ = _VSTD::exp(std::__libcpp_lgamma(__t_ + 1.) -
+        __pr_ = std::exp(std::__libcpp_lgamma(__t_ + 1.) -
                            std::__libcpp_lgamma(__r0_ + 1.) -
-                           std::__libcpp_lgamma(__t_ - __r0_ + 1.) + __r0_ * _VSTD::log(__p_) +
-                           (__t_ - __r0_) * _VSTD::log(1 - __p_));
+                           std::__libcpp_lgamma(__t_ - __r0_ + 1.) + __r0_ * std::log(__p_) +
+                           (__t_ - __r0_) * std::log(1 - __p_));
         __odds_ratio_ = __p_ / (1 - __p_);
     }
 }

--- a/libcxx/include/__random/cauchy_distribution.h
+++ b/libcxx/include/__random/cauchy_distribution.h
@@ -120,7 +120,7 @@ cauchy_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     uniform_real_distribution<result_type> __gen;
     // purposefully let tan arg get as close to pi/2 as it wants, tan will return a finite
-    return __p.a() + __p.b() * _VSTD::tan(3.1415926535897932384626433832795 * __gen(__g));
+    return __p.a() + __p.b() * std::tan(3.1415926535897932384626433832795 * __gen(__g));
 }
 
 template <class _CharT, class _Traits, class _RT>

--- a/libcxx/include/__random/discard_block_engine.h
+++ b/libcxx/include/__random/discard_block_engine.h
@@ -68,7 +68,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit discard_block_engine(_Engine&& __e)
-        : __e_(_VSTD::move(__e)), __n_(0) {}
+        : __e_(std::move(__e)), __n_(0) {}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit discard_block_engine(result_type __sd) : __e_(__sd), __n_(0) {}

--- a/libcxx/include/__random/discrete_distribution.h
+++ b/libcxx/include/__random/discrete_distribution.h
@@ -180,11 +180,11 @@ discrete_distribution<_IntType>::param_type::__init()
     {
         if (__p_.size() > 1)
         {
-            double __s = _VSTD::accumulate(__p_.begin(), __p_.end(), 0.0);
+            double __s = std::accumulate(__p_.begin(), __p_.end(), 0.0);
             for (vector<double>::iterator __i = __p_.begin(), __e = __p_.end(); __i < __e; ++__i)
                 *__i /= __s;
             vector<double> __t(__p_.size() - 1);
-            _VSTD::partial_sum(__p_.begin(), __p_.end() - 1, __t.begin());
+            std::partial_sum(__p_.begin(), __p_.end() - 1, __t.begin());
             swap(__p_, __t);
         }
         else
@@ -201,7 +201,7 @@ discrete_distribution<_IntType>::param_type::probabilities() const
 {
     size_t __n = __p_.size();
     vector<double> __p(__n+1);
-    _VSTD::adjacent_difference(__p_.begin(), __p_.end(), __p.begin());
+    std::adjacent_difference(__p_.begin(), __p_.end(), __p.begin());
     if (__n > 0)
         __p[__n] = 1 - __p_[__n-1];
     else
@@ -217,7 +217,7 @@ discrete_distribution<_IntType>::operator()(_URNG& __g, const param_type& __p)
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     uniform_real_distribution<double> __gen;
     return static_cast<_IntType>(
-           _VSTD::upper_bound(__p.__p_.begin(), __p.__p_.end(), __gen(__g)) -
+           std::upper_bound(__p.__p_.begin(), __p.__p_.end(), __gen(__g)) -
                                                               __p.__p_.begin());
 }
 

--- a/libcxx/include/__random/exponential_distribution.h
+++ b/libcxx/include/__random/exponential_distribution.h
@@ -112,10 +112,10 @@ _RealType
 exponential_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
 {
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
-    return -_VSTD::log
+    return -std::log
                   (
                       result_type(1) -
-                      _VSTD::generate_canonical<result_type,
+                      std::generate_canonical<result_type,
                                        numeric_limits<result_type>::digits>(__g)
                   )
                   / __p.lambda();

--- a/libcxx/include/__random/extreme_value_distribution.h
+++ b/libcxx/include/__random/extreme_value_distribution.h
@@ -120,7 +120,7 @@ extreme_value_distribution<_RealType>::operator()(_URNG& __g, const param_type& 
 {
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     return __p.a() - __p.b() *
-         _VSTD::log(-_VSTD::log(1-uniform_real_distribution<result_type>()(__g)));
+         std::log(-std::log(1-uniform_real_distribution<result_type>()(__g)));
 }
 
 template <class _CharT, class _Traits, class _RT>

--- a/libcxx/include/__random/gamma_distribution.h
+++ b/libcxx/include/__random/gamma_distribution.h
@@ -137,7 +137,7 @@ gamma_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
             const result_type __w = __u * (1 - __u);
             if (__w != 0)
             {
-                const result_type __y = _VSTD::sqrt(__c / __w) *
+                const result_type __y = std::sqrt(__c / __w) *
                                         (__u - result_type(0.5));
                 __x = __b + __y;
                 if (__x >= 0)
@@ -145,7 +145,7 @@ gamma_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
                     const result_type __z = 64 * __w * __w * __w * __v * __v;
                     if (__z <= 1 - 2 * __y * __y / __x)
                         break;
-                    if (_VSTD::log(__z) <= 2 * (__b * _VSTD::log(__x / __b) - __y))
+                    if (std::log(__z) <= 2 * (__b * std::log(__x / __b) - __y))
                         break;
                 }
             }
@@ -159,14 +159,14 @@ gamma_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
             const result_type __es = __egen(__g);
             if (__u <= 1 - __a)
             {
-                __x = _VSTD::pow(__u, 1 / __a);
+                __x = std::pow(__u, 1 / __a);
                 if (__x <= __es)
                     break;
             }
             else
             {
-                const result_type __e = -_VSTD::log((1-__u)/__a);
-                __x = _VSTD::pow(1 - __a + __a * __e, 1 / __a);
+                const result_type __e = -std::log((1-__u)/__a);
+                __x = std::pow(1 - __a + __a * __e, 1 / __a);
                 if (__x <= __e + __es)
                     break;
             }

--- a/libcxx/include/__random/independent_bits_engine.h
+++ b/libcxx/include/__random/independent_bits_engine.h
@@ -101,7 +101,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit independent_bits_engine(_Engine&& __e)
-        : __e_(_VSTD::move(__e)) {}
+        : __e_(std::move(__e)) {}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit independent_bits_engine(result_type __sd) : __e_(__sd) {}

--- a/libcxx/include/__random/lognormal_distribution.h
+++ b/libcxx/include/__random/lognormal_distribution.h
@@ -83,7 +83,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     result_type operator()(_URNG& __g)
     {
-        return _VSTD::exp(__nd_(__g));
+        return std::exp(__nd_(__g));
     }
 
     template<class _URNG>
@@ -91,7 +91,7 @@ public:
     result_type operator()(_URNG& __g, const param_type& __p)
     {
         typename normal_distribution<result_type>::param_type __pn(__p.m(), __p.s());
-        return _VSTD::exp(__nd_(__g, __pn));
+        return std::exp(__nd_(__g, __pn));
     }
 
     // property functions

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -401,37 +401,37 @@ operator==(const mersenne_twister_engine<_UInt, _Wp, _Np, _Mp, _Rp, _Ap, _Up, _D
                                          _Bp, _Tp, _Cp, _Lp, _Fp>& __y)
 {
     if (__x.__i_ == __y.__i_)
-        return _VSTD::equal(__x.__x_, __x.__x_ + _Np, __y.__x_);
+        return std::equal(__x.__x_, __x.__x_ + _Np, __y.__x_);
     if (__x.__i_ == 0 || __y.__i_ == 0)
     {
-        size_t __j = _VSTD::min(_Np - __x.__i_, _Np - __y.__i_);
-        if (!_VSTD::equal(__x.__x_ + __x.__i_, __x.__x_ + __x.__i_ + __j,
+        size_t __j = std::min(_Np - __x.__i_, _Np - __y.__i_);
+        if (!std::equal(__x.__x_ + __x.__i_, __x.__x_ + __x.__i_ + __j,
                          __y.__x_ + __y.__i_))
             return false;
         if (__x.__i_ == 0)
-            return _VSTD::equal(__x.__x_ + __j, __x.__x_ + _Np, __y.__x_);
-        return _VSTD::equal(__x.__x_, __x.__x_ + (_Np - __j), __y.__x_ + __j);
+            return std::equal(__x.__x_ + __j, __x.__x_ + _Np, __y.__x_);
+        return std::equal(__x.__x_, __x.__x_ + (_Np - __j), __y.__x_ + __j);
     }
     if (__x.__i_ < __y.__i_)
     {
         size_t __j = _Np - __y.__i_;
-        if (!_VSTD::equal(__x.__x_ + __x.__i_, __x.__x_ + (__x.__i_ + __j),
+        if (!std::equal(__x.__x_ + __x.__i_, __x.__x_ + (__x.__i_ + __j),
                          __y.__x_ + __y.__i_))
             return false;
-        if (!_VSTD::equal(__x.__x_ + (__x.__i_ + __j), __x.__x_ + _Np,
+        if (!std::equal(__x.__x_ + (__x.__i_ + __j), __x.__x_ + _Np,
                          __y.__x_))
             return false;
-        return _VSTD::equal(__x.__x_, __x.__x_ + __x.__i_,
+        return std::equal(__x.__x_, __x.__x_ + __x.__i_,
                            __y.__x_ + (_Np - (__x.__i_ + __j)));
     }
     size_t __j = _Np - __x.__i_;
-    if (!_VSTD::equal(__y.__x_ + __y.__i_, __y.__x_ + (__y.__i_ + __j),
+    if (!std::equal(__y.__x_ + __y.__i_, __y.__x_ + (__y.__i_ + __j),
                      __x.__x_ + __x.__i_))
         return false;
-    if (!_VSTD::equal(__y.__x_ + (__y.__i_ + __j), __y.__x_ + _Np,
+    if (!std::equal(__y.__x_ + (__y.__i_ + __j), __y.__x_ + _Np,
                      __x.__x_))
         return false;
-    return _VSTD::equal(__y.__x_, __y.__x_ + __y.__i_,
+    return std::equal(__y.__x_, __y.__x_ + __y.__i_,
                        __x.__x_ + (_Np - (__y.__i_ + __j)));
 }
 

--- a/libcxx/include/__random/normal_distribution.h
+++ b/libcxx/include/__random/normal_distribution.h
@@ -152,7 +152,7 @@ normal_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
             __v = __uni(__g);
             __s = __u * __u + __v * __v;
         } while (__s > 1 || __s == 0);
-        result_type __fp = _VSTD::sqrt(-2 * _VSTD::log(__s) / __s);
+        result_type __fp = std::sqrt(-2 * std::log(__s) / __s);
         __v_ = __v * __fp;
         __v_hot_ = true;
         __up = __u * __fp;

--- a/libcxx/include/__random/piecewise_constant_distribution.h
+++ b/libcxx/include/__random/piecewise_constant_distribution.h
@@ -188,14 +188,14 @@ void
 piecewise_constant_distribution<_RealType>::param_type::__init()
 {
     // __densities_ contains non-normalized areas
-    result_type __total_area = _VSTD::accumulate(__densities_.begin(),
+    result_type __total_area = std::accumulate(__densities_.begin(),
                                                 __densities_.end(),
                                                 result_type());
     for (size_t __i = 0; __i < __densities_.size(); ++__i)
         __densities_[__i] /= __total_area;
     // __densities_ contains normalized areas
     __areas_.assign(__densities_.size(), result_type());
-    _VSTD::partial_sum(__densities_.begin(), __densities_.end() - 1,
+    std::partial_sum(__densities_.begin(), __densities_.end() - 1,
                                                           __areas_.begin() + 1);
     // __areas_ contains partial sums of normalized areas: [0, __densities_ - 1]
     __densities_.back() = 1 - __areas_.back();  // correct round off error
@@ -289,7 +289,7 @@ piecewise_constant_distribution<_RealType>::operator()(_URNG& __g, const param_t
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     typedef uniform_real_distribution<result_type> _Gen;
     result_type __u = _Gen()(__g);
-    ptrdiff_t __k = _VSTD::upper_bound(__p.__areas_.begin(), __p.__areas_.end(),
+    ptrdiff_t __k = std::upper_bound(__p.__areas_.begin(), __p.__areas_.end(),
                                       __u) - __p.__areas_.begin() - 1;
     return (__u - __p.__areas_[__k]) / __p.__densities_[__k] + __p.__b_[__k];
 }

--- a/libcxx/include/__random/piecewise_linear_distribution.h
+++ b/libcxx/include/__random/piecewise_linear_distribution.h
@@ -294,7 +294,7 @@ piecewise_linear_distribution<_RealType>::operator()(_URNG& __g, const param_typ
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     typedef uniform_real_distribution<result_type> _Gen;
     result_type __u = _Gen()(__g);
-    ptrdiff_t __k = _VSTD::upper_bound(__p.__areas_.begin(), __p.__areas_.end(),
+    ptrdiff_t __k = std::upper_bound(__p.__areas_.begin(), __p.__areas_.end(),
                                       __u) - __p.__areas_.begin() - 1;
     __u -= __p.__areas_[__k];
     const result_type __dk = __p.__densities_[__k];
@@ -306,7 +306,7 @@ piecewise_linear_distribution<_RealType>::operator()(_URNG& __g, const param_typ
     const result_type __bk1 = __p.__b_[__k+1];
     const result_type __deltab = __bk1 - __bk;
     return (__bk * __dk1 - __bk1 * __dk +
-        _VSTD::sqrt(__deltab * (__deltab * __dk * __dk + 2 * __deltad * __u))) /
+        std::sqrt(__deltab * (__deltab * __dk * __dk + 2 * __deltad * __u))) /
         __deltad;
 }
 

--- a/libcxx/include/__random/poisson_distribution.h
+++ b/libcxx/include/__random/poisson_distribution.h
@@ -131,7 +131,7 @@ poisson_distribution<_IntType>::param_type::param_type(double __mean)
     {
         __s_ = 0;
         __d_ = 0;
-        __l_ = _VSTD::exp(-__mean_);
+        __l_ = std::exp(-__mean_);
         __omega_ = 0;
         __c3_ = 0;
         __c2_ = 0;
@@ -141,9 +141,9 @@ poisson_distribution<_IntType>::param_type::param_type(double __mean)
     }
     else
     {
-        __s_ = _VSTD::sqrt(__mean_);
+        __s_ = std::sqrt(__mean_);
         __d_ = 6 * __mean_ * __mean_;
-        __l_ = _VSTD::trunc(__mean_ - 1.1484);
+        __l_ = std::trunc(__mean_ - 1.1484);
         __omega_ = .3989423 / __s_;
         double __b1 = .4166667E-1 / __mean_;
         double __b2 = .3 * __b1 * __b1;
@@ -176,13 +176,13 @@ poisson_distribution<_IntType>::operator()(_URNG& __urng, const param_type& __pr
         double __u;
         if (__g > 0)
         {
-            __tx = _VSTD::trunc(__g);
+            __tx = std::trunc(__g);
             if (__tx >= __pr.__l_)
-                return _VSTD::__clamp_to_integral<result_type>(__tx);
+                return std::__clamp_to_integral<result_type>(__tx);
             __difmuk = __pr.__mean_ - __tx;
             __u = __urd(__urng);
             if (__pr.__d_ * __u >= __difmuk * __difmuk * __difmuk)
-                return _VSTD::__clamp_to_integral<result_type>(__tx);
+                return std::__clamp_to_integral<result_type>(__tx);
         }
         exponential_distribution<double> __edist;
         for (bool __using_exp_dist = false; true; __using_exp_dist = true)
@@ -198,7 +198,7 @@ poisson_distribution<_IntType>::operator()(_URNG& __urng, const param_type& __pr
                     __u += __u - 1;
                     __t = 1.8 + (__u < 0 ? -__e : __e);
                 } while (__t <= -.6744);
-                __tx = _VSTD::trunc(__pr.__mean_ + __pr.__s_ * __t);
+                __tx = std::trunc(__pr.__mean_ + __pr.__s_ * __t);
                 __difmuk = __pr.__mean_ - __tx;
                 __using_exp_dist = true;
             }
@@ -209,20 +209,20 @@ poisson_distribution<_IntType>::operator()(_URNG& __urng, const param_type& __pr
                 const double __fac[] = {1, 1, 2, 6, 24, 120, 720, 5040,
                                              40320, 362880};
                 __px = -__pr.__mean_;
-                __py = _VSTD::pow(__pr.__mean_, (double)__tx) / __fac[static_cast<int>(__tx)];
+                __py = std::pow(__pr.__mean_, (double)__tx) / __fac[static_cast<int>(__tx)];
             }
             else
             {
                 double __del = .8333333E-1 / __tx;
                 __del -= 4.8 * __del * __del * __del;
                 double __v = __difmuk / __tx;
-                if (_VSTD::abs(__v) > 0.25)
-                    __px = __tx * _VSTD::log(1 + __v) - __difmuk - __del;
+                if (std::abs(__v) > 0.25)
+                    __px = __tx * std::log(1 + __v) - __difmuk - __del;
                 else
                     __px = __tx * __v * __v * (((((((.1250060 * __v + -.1384794) *
                            __v + .1421878) * __v + -.1661269) * __v + .2000118) *
                            __v + -.2500068) * __v + .3333333) * __v + -.5) - __del;
-                __py = .3989423 / _VSTD::sqrt(__tx);
+                __py = .3989423 / std::sqrt(__tx);
             }
             double __r = (0.5 - __difmuk) / __pr.__s_;
             double __r2 = __r * __r;
@@ -231,18 +231,18 @@ poisson_distribution<_IntType>::operator()(_URNG& __urng, const param_type& __pr
                                         __r2 + __pr.__c1_) * __r2 + __pr.__c0_);
             if (__using_exp_dist)
             {
-                if (__pr.__c_ * _VSTD::abs(__u) <= __py * _VSTD::exp(__px + __e) -
-                                                   __fy * _VSTD::exp(__fx + __e))
+                if (__pr.__c_ * std::abs(__u) <= __py * std::exp(__px + __e) -
+                                                   __fy * std::exp(__fx + __e))
                     break;
             }
             else
             {
-                if (__fy - __u * __fy <= __py * _VSTD::exp(__px - __fx))
+                if (__fy - __u * __fy <= __py * std::exp(__px - __fx))
                     break;
             }
         }
     }
-    return _VSTD::__clamp_to_integral<result_type>(__tx);
+    return std::__clamp_to_integral<result_type>(__tx);
 }
 
 template <class _CharT, class _Traits, class _IntType>

--- a/libcxx/include/__random/seed_seq.h
+++ b/libcxx/include/__random/seed_seq.h
@@ -62,7 +62,7 @@ public:
     template<class _OutputIterator>
         _LIBCPP_HIDE_FROM_ABI
         void param(_OutputIterator __dest) const
-            {_VSTD::copy(__v_.begin(), __v_.end(), __dest);}
+            {std::copy(__v_.begin(), __v_.end(), __dest);}
 
     seed_seq(const seed_seq&) = delete;
     void operator=(const seed_seq&) = delete;
@@ -91,7 +91,7 @@ seed_seq::generate(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {
     if (__first != __last)
     {
-        _VSTD::fill(__first, __last, 0x8b8b8b8b);
+        std::fill(__first, __last, 0x8b8b8b8b);
         const size_t __n = static_cast<size_t>(__last - __first);
         const size_t __s = __v_.size();
         const size_t __t = (__n >= 623) ? 11
@@ -101,7 +101,7 @@ seed_seq::generate(_RandomAccessIterator __first, _RandomAccessIterator __last)
                          : (__n - 1) / 2;
         const size_t __p = (__n - __t) / 2;
         const size_t __q = __p + __t;
-        const size_t __m = _VSTD::max(__s + 1, __n);
+        const size_t __m = std::max(__s + 1, __n);
         // __k = 0;
         {
             result_type __r = 1664525 * _Tp(__first[0] ^ __first[__p]

--- a/libcxx/include/__random/shuffle_order_engine.h
+++ b/libcxx/include/__random/shuffle_order_engine.h
@@ -94,7 +94,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit shuffle_order_engine(_Engine&& __e)
-        : __e_(_VSTD::move(__e)) {__init();}
+        : __e_(std::move(__e)) {__init();}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     explicit shuffle_order_engine(result_type __sd) : __e_(__sd) {__init();}
@@ -210,7 +210,7 @@ operator==(
     const shuffle_order_engine<_Eng, _Kp>& __x,
     const shuffle_order_engine<_Eng, _Kp>& __y)
 {
-    return __x.__y_ == __y.__y_ && _VSTD::equal(__x.__v_, __x.__v_ + _Kp, __y.__v_) &&
+    return __x.__y_ == __y.__y_ && std::equal(__x.__v_, __x.__v_ + _Kp, __y.__v_) &&
            __x.__e_ == __y.__e_;
 }
 

--- a/libcxx/include/__random/student_t_distribution.h
+++ b/libcxx/include/__random/student_t_distribution.h
@@ -115,7 +115,7 @@ student_t_distribution<_RealType>::operator()(_URNG& __g, const param_type& __p)
 {
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     gamma_distribution<result_type> __gd(__p.n() * .5, 2);
-    return __nd_(__g) * _VSTD::sqrt(__p.n()/__gd(__g));
+    return __nd_(__g) * std::sqrt(__p.n()/__gd(__g));
 }
 
 template <class _CharT, class _Traits, class _RT>

--- a/libcxx/include/__random/subtract_with_carry_engine.h
+++ b/libcxx/include/__random/subtract_with_carry_engine.h
@@ -253,37 +253,37 @@ operator==(
     if (__x.__c_ != __y.__c_)
         return false;
     if (__x.__i_ == __y.__i_)
-        return _VSTD::equal(__x.__x_, __x.__x_ + _Rp, __y.__x_);
+        return std::equal(__x.__x_, __x.__x_ + _Rp, __y.__x_);
     if (__x.__i_ == 0 || __y.__i_ == 0)
     {
-        size_t __j = _VSTD::min(_Rp - __x.__i_, _Rp - __y.__i_);
-        if (!_VSTD::equal(__x.__x_ + __x.__i_, __x.__x_ + __x.__i_ + __j,
+        size_t __j = std::min(_Rp - __x.__i_, _Rp - __y.__i_);
+        if (!std::equal(__x.__x_ + __x.__i_, __x.__x_ + __x.__i_ + __j,
                          __y.__x_ + __y.__i_))
             return false;
         if (__x.__i_ == 0)
-            return _VSTD::equal(__x.__x_ + __j, __x.__x_ + _Rp, __y.__x_);
-        return _VSTD::equal(__x.__x_, __x.__x_ + (_Rp - __j), __y.__x_ + __j);
+            return std::equal(__x.__x_ + __j, __x.__x_ + _Rp, __y.__x_);
+        return std::equal(__x.__x_, __x.__x_ + (_Rp - __j), __y.__x_ + __j);
     }
     if (__x.__i_ < __y.__i_)
     {
         size_t __j = _Rp - __y.__i_;
-        if (!_VSTD::equal(__x.__x_ + __x.__i_, __x.__x_ + (__x.__i_ + __j),
+        if (!std::equal(__x.__x_ + __x.__i_, __x.__x_ + (__x.__i_ + __j),
                          __y.__x_ + __y.__i_))
             return false;
-        if (!_VSTD::equal(__x.__x_ + (__x.__i_ + __j), __x.__x_ + _Rp,
+        if (!std::equal(__x.__x_ + (__x.__i_ + __j), __x.__x_ + _Rp,
                          __y.__x_))
             return false;
-        return _VSTD::equal(__x.__x_, __x.__x_ + __x.__i_,
+        return std::equal(__x.__x_, __x.__x_ + __x.__i_,
                            __y.__x_ + (_Rp - (__x.__i_ + __j)));
     }
     size_t __j = _Rp - __x.__i_;
-    if (!_VSTD::equal(__y.__x_ + __y.__i_, __y.__x_ + (__y.__i_ + __j),
+    if (!std::equal(__y.__x_ + __y.__i_, __y.__x_ + (__y.__i_ + __j),
                      __x.__x_ + __x.__i_))
         return false;
-    if (!_VSTD::equal(__y.__x_ + (__y.__i_ + __j), __y.__x_ + _Rp,
+    if (!std::equal(__y.__x_ + (__y.__i_ + __j), __y.__x_ + _Rp,
                      __x.__x_))
         return false;
-    return _VSTD::equal(__y.__x_, __y.__x_ + __y.__i_,
+    return std::equal(__y.__x_, __y.__x_ + __y.__i_,
                        __x.__x_ + (_Rp - (__y.__i_ + __j)));
 }
 

--- a/libcxx/include/__random/uniform_real_distribution.h
+++ b/libcxx/include/__random/uniform_real_distribution.h
@@ -117,7 +117,7 @@ uniform_real_distribution<_RealType>::operator()(_URNG& __g, const param_type& _
 {
     static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
     return (__p.b() - __p.a())
-        * _VSTD::generate_canonical<_RealType, numeric_limits<_RealType>::digits>(__g)
+        * std::generate_canonical<_RealType, numeric_limits<_RealType>::digits>(__g)
         + __p.a();
 }
 

--- a/libcxx/include/__random/weibull_distribution.h
+++ b/libcxx/include/__random/weibull_distribution.h
@@ -86,7 +86,7 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         result_type operator()(_URNG& __g, const param_type& __p)
         {return __p.b() *
-            _VSTD::pow(exponential_distribution<result_type>()(__g), 1/__p.a());}
+            std::pow(exponential_distribution<result_type>()(__g), 1/__p.a());}
 
     // property functions
     _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -198,7 +198,7 @@ public:
 private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(__split_buffer& __c, true_type)
       _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
-    __alloc() = _VSTD::move(__c.__alloc());
+    __alloc() = std::move(__c.__alloc());
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(__split_buffer&, false_type) _NOEXCEPT {}
@@ -258,7 +258,7 @@ __split_buffer<_Tp, _Allocator>::__construct_at_end(size_type __n)
 {
     _ConstructTransaction __tx(&this->__end_, __n);
     for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
-        __alloc_traits::construct(this->__alloc(), _VSTD::__to_address(__tx.__pos_));
+        __alloc_traits::construct(this->__alloc(), std::__to_address(__tx.__pos_));
     }
 }
 
@@ -276,7 +276,7 @@ __split_buffer<_Tp, _Allocator>::__construct_at_end(size_type __n, const_referen
     _ConstructTransaction __tx(&this->__end_, __n);
     for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
         __alloc_traits::construct(this->__alloc(),
-            _VSTD::__to_address(__tx.__pos_), __x);
+            std::__to_address(__tx.__pos_), __x);
     }
 }
 
@@ -298,14 +298,14 @@ void __split_buffer<_Tp, _Allocator>::__construct_at_end_with_sentinel(_Iterator
         if (__end_ == __end_cap())
         {
             size_type __old_cap = __end_cap() - __first_;
-            size_type __new_cap = _VSTD::max<size_type>(2 * __old_cap, 8);
+            size_type __new_cap = std::max<size_type>(2 * __old_cap, 8);
             __split_buffer __buf(__new_cap, 0, __a);
             for (pointer __p = __begin_; __p != __end_; ++__p, (void) ++__buf.__end_)
                 __alloc_traits::construct(__buf.__alloc(),
-                        _VSTD::__to_address(__buf.__end_), _VSTD::move(*__p));
+                        std::__to_address(__buf.__end_), std::move(*__p));
             swap(__buf);
         }
-        __alloc_traits::construct(__a, _VSTD::__to_address(this->__end_), *__first);
+        __alloc_traits::construct(__a, std::__to_address(this->__end_), *__first);
         ++this->__end_;
     }
 }
@@ -324,7 +324,7 @@ void __split_buffer<_Tp, _Allocator>::__construct_at_end_with_size(_ForwardItera
     _ConstructTransaction __tx(&this->__end_, __n);
     for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_, (void) ++__first) {
         __alloc_traits::construct(this->__alloc(),
-            _VSTD::__to_address(__tx.__pos_), *__first);
+            std::__to_address(__tx.__pos_), *__first);
     }
 }
 
@@ -335,7 +335,7 @@ void
 __split_buffer<_Tp, _Allocator>::__destruct_at_begin(pointer __new_begin, false_type)
 {
     while (__begin_ != __new_begin)
-        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(__begin_++));
+        __alloc_traits::destroy(__alloc(), std::__to_address(__begin_++));
 }
 
 template <class _Tp, class _Allocator>
@@ -354,7 +354,7 @@ void
 __split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, false_type) _NOEXCEPT
 {
     while (__new_last != __end_)
-        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(--__end_));
+        __alloc_traits::destroy(__alloc(), std::__to_address(--__end_));
 }
 
 template <class _Tp, class _Allocator>
@@ -395,10 +395,10 @@ template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20
 __split_buffer<_Tp, _Allocator>::__split_buffer(__split_buffer&& __c)
     _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
-    : __first_(_VSTD::move(__c.__first_)),
-      __begin_(_VSTD::move(__c.__begin_)),
-      __end_(_VSTD::move(__c.__end_)),
-      __end_cap_(_VSTD::move(__c.__end_cap_))
+    : __first_(std::move(__c.__first_)),
+      __begin_(std::move(__c.__begin_)),
+      __end_(std::move(__c.__end_)),
+      __end_cap_(std::move(__c.__end_cap_))
 {
     __c.__first_ = nullptr;
     __c.__begin_ = nullptr;
@@ -461,11 +461,11 @@ __split_buffer<_Tp, _Allocator>::swap(__split_buffer& __x)
         _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value||
                    __is_nothrow_swappable<__alloc_rr>::value)
 {
-    _VSTD::swap(__first_, __x.__first_);
-    _VSTD::swap(__begin_, __x.__begin_);
-    _VSTD::swap(__end_, __x.__end_);
-    _VSTD::swap(__end_cap(), __x.__end_cap());
-    _VSTD::__swap_allocator(__alloc(), __x.__alloc());
+    std::swap(__first_, __x.__first_);
+    std::swap(__begin_, __x.__begin_);
+    std::swap(__end_, __x.__end_);
+    std::swap(__end_cap(), __x.__end_cap());
+    std::__swap_allocator(__alloc(), __x.__alloc());
 }
 
 template <class _Tp, class _Allocator>
@@ -478,10 +478,10 @@ __split_buffer<_Tp, _Allocator>::reserve(size_type __n)
         __split_buffer<value_type, __alloc_rr&> __t(__n, 0, __alloc());
         __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                move_iterator<pointer>(__end_));
-        _VSTD::swap(__first_, __t.__first_);
-        _VSTD::swap(__begin_, __t.__begin_);
-        _VSTD::swap(__end_, __t.__end_);
-        _VSTD::swap(__end_cap(), __t.__end_cap());
+        std::swap(__first_, __t.__first_);
+        std::swap(__begin_, __t.__begin_);
+        std::swap(__end_, __t.__end_);
+        std::swap(__end_cap(), __t.__end_cap());
     }
 }
 
@@ -500,10 +500,10 @@ __split_buffer<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
             __t.__end_ = __t.__begin_ + (__end_ - __begin_);
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
         }
         catch (...)
@@ -524,7 +524,7 @@ __split_buffer<_Tp, _Allocator>::push_front(const_reference __x)
         {
             difference_type __d = __end_cap() - __end_;
             __d = (__d + 1) / 2;
-            __begin_ = _VSTD::move_backward(__begin_, __end_, __end_ + __d);
+            __begin_ = std::move_backward(__begin_, __end_, __end_ + __d);
             __end_ += __d;
         }
         else
@@ -533,13 +533,13 @@ __split_buffer<_Tp, _Allocator>::push_front(const_reference __x)
             __split_buffer<value_type, __alloc_rr&> __t(__c, (__c + 3) / 4, __alloc());
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
         }
     }
-    __alloc_traits::construct(__alloc(), _VSTD::__to_address(__begin_-1), __x);
+    __alloc_traits::construct(__alloc(), std::__to_address(__begin_-1), __x);
     --__begin_;
 }
 
@@ -554,7 +554,7 @@ __split_buffer<_Tp, _Allocator>::push_front(value_type&& __x)
         {
             difference_type __d = __end_cap() - __end_;
             __d = (__d + 1) / 2;
-            __begin_ = _VSTD::move_backward(__begin_, __end_, __end_ + __d);
+            __begin_ = std::move_backward(__begin_, __end_, __end_ + __d);
             __end_ += __d;
         }
         else
@@ -563,14 +563,14 @@ __split_buffer<_Tp, _Allocator>::push_front(value_type&& __x)
             __split_buffer<value_type, __alloc_rr&> __t(__c, (__c + 3) / 4, __alloc());
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
         }
     }
-    __alloc_traits::construct(__alloc(), _VSTD::__to_address(__begin_-1),
-            _VSTD::move(__x));
+    __alloc_traits::construct(__alloc(), std::__to_address(__begin_-1),
+            std::move(__x));
     --__begin_;
 }
 
@@ -586,7 +586,7 @@ __split_buffer<_Tp, _Allocator>::push_back(const_reference __x)
         {
             difference_type __d = __begin_ - __first_;
             __d = (__d + 1) / 2;
-            __end_ = _VSTD::move(__begin_, __end_, __begin_ - __d);
+            __end_ = std::move(__begin_, __end_, __begin_ - __d);
             __begin_ -= __d;
         }
         else
@@ -595,13 +595,13 @@ __split_buffer<_Tp, _Allocator>::push_back(const_reference __x)
             __split_buffer<value_type, __alloc_rr&> __t(__c, __c / 4, __alloc());
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
         }
     }
-    __alloc_traits::construct(__alloc(), _VSTD::__to_address(__end_), __x);
+    __alloc_traits::construct(__alloc(), std::__to_address(__end_), __x);
     ++__end_;
 }
 
@@ -616,7 +616,7 @@ __split_buffer<_Tp, _Allocator>::push_back(value_type&& __x)
         {
             difference_type __d = __begin_ - __first_;
             __d = (__d + 1) / 2;
-            __end_ = _VSTD::move(__begin_, __end_, __begin_ - __d);
+            __end_ = std::move(__begin_, __end_, __begin_ - __d);
             __begin_ -= __d;
         }
         else
@@ -625,14 +625,14 @@ __split_buffer<_Tp, _Allocator>::push_back(value_type&& __x)
             __split_buffer<value_type, __alloc_rr&> __t(__c, __c / 4, __alloc());
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
         }
     }
-    __alloc_traits::construct(__alloc(), _VSTD::__to_address(__end_),
-            _VSTD::move(__x));
+    __alloc_traits::construct(__alloc(), std::__to_address(__end_),
+            std::move(__x));
     ++__end_;
 }
 
@@ -648,7 +648,7 @@ __split_buffer<_Tp, _Allocator>::emplace_back(_Args&&... __args)
         {
             difference_type __d = __begin_ - __first_;
             __d = (__d + 1) / 2;
-            __end_ = _VSTD::move(__begin_, __end_, __begin_ - __d);
+            __end_ = std::move(__begin_, __end_, __begin_ - __d);
             __begin_ -= __d;
         }
         else
@@ -657,14 +657,14 @@ __split_buffer<_Tp, _Allocator>::emplace_back(_Args&&... __args)
             __split_buffer<value_type, __alloc_rr&> __t(__c, __c / 4, __alloc());
             __t.__construct_at_end(move_iterator<pointer>(__begin_),
                                    move_iterator<pointer>(__end_));
-            _VSTD::swap(__first_, __t.__first_);
-            _VSTD::swap(__begin_, __t.__begin_);
-            _VSTD::swap(__end_, __t.__end_);
-            _VSTD::swap(__end_cap(), __t.__end_cap());
+            std::swap(__first_, __t.__first_);
+            std::swap(__begin_, __t.__begin_);
+            std::swap(__end_, __t.__end_);
+            std::swap(__end_cap(), __t.__end_cap());
         }
     }
-    __alloc_traits::construct(__alloc(), _VSTD::__to_address(__end_),
-                              _VSTD::forward<_Args>(__args)...);
+    __alloc_traits::construct(__alloc(), std::__to_address(__end_),
+                              std::forward<_Args>(__args)...);
     ++__end_;
 }
 

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -710,7 +710,7 @@ inline _SizeT _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
 __str_rfind(const _CharT *__p, _SizeT __sz,
         const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
 {
-    __pos = _VSTD::min(__pos, __sz);
+    __pos = std::min(__pos, __sz);
     if (__n < __sz - __pos)
         __pos += __n;
     else
@@ -729,7 +729,7 @@ __str_find_first_of(const _CharT *__p, _SizeT __sz,
 {
     if (__pos >= __sz || __n == 0)
         return __npos;
-    const _CharT* __r = _VSTD::__find_first_of_ce
+    const _CharT* __r = std::__find_first_of_ce
         (__p + __pos, __p + __sz, __s, __s + __n, _Traits::eq );
     if (__r == __p + __sz)
         return __npos;

--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -196,7 +196,7 @@ public:
     }
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(thread& __t) _NOEXCEPT {_VSTD::swap(__t_, __t.__t_);}
+    void swap(thread& __t) _NOEXCEPT {std::swap(__t_, __t.__t_);}
 
     _LIBCPP_HIDE_FROM_ABI
     bool joinable() const _NOEXCEPT {return !__libcpp_thread_isnull(&__t_);}
@@ -217,7 +217,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 void
 __thread_execute(tuple<_TSp, _Fp, _Args...>& __t, __tuple_indices<_Indices...>)
 {
-    _VSTD::__invoke(_VSTD::move(_VSTD::get<1>(__t)), _VSTD::move(_VSTD::get<_Indices>(__t))...);
+    std::__invoke(std::move(std::get<1>(__t)), std::move(std::get<_Indices>(__t))...);
 }
 
 template <class _Fp>
@@ -226,9 +226,9 @@ void* __thread_proxy(void* __vp)
 {
     // _Fp = tuple< unique_ptr<__thread_struct>, Functor, Args...>
     unique_ptr<_Fp> __p(static_cast<_Fp*>(__vp));
-    __thread_local_data().set_pointer(_VSTD::get<0>(*__p.get()).release());
+    __thread_local_data().set_pointer(std::get<0>(*__p.get()).release());
     typedef typename __make_tuple_indices<tuple_size<_Fp>::value, 2>::type _Index;
-    _VSTD::__thread_execute(*__p.get(), _Index());
+    std::__thread_execute(*__p.get(), _Index());
     return nullptr;
 }
 
@@ -241,10 +241,10 @@ thread::thread(_Fp&& __f, _Args&&... __args)
     _TSPtr __tsp(new __thread_struct);
     typedef tuple<_TSPtr, __decay_t<_Fp>, __decay_t<_Args>...> _Gp;
     unique_ptr<_Gp> __p(
-            new _Gp(_VSTD::move(__tsp),
-                    _VSTD::forward<_Fp>(__f),
-                    _VSTD::forward<_Args>(__args)...));
-    int __ec = _VSTD::__libcpp_thread_create(&__t_, &__thread_proxy<_Gp>, __p.get());
+            new _Gp(std::move(__tsp),
+                    std::forward<_Fp>(__f),
+                    std::forward<_Args>(__args)...));
+    int __ec = std::__libcpp_thread_create(&__t_, &__thread_proxy<_Gp>, __p.get());
     if (__ec == 0)
         __p.release();
     else
@@ -279,7 +279,7 @@ thread::thread(_Fp __f)
     typedef __thread_invoke_pair<_Fp> _InvokePair;
     typedef unique_ptr<_InvokePair> _PairPtr;
     _PairPtr __pp(new _InvokePair(__f));
-    int __ec = _VSTD::__libcpp_thread_create(&__t_, &__thread_proxy_cxx03<_InvokePair>, __pp.get());
+    int __ec = std::__libcpp_thread_create(&__t_, &__thread_proxy_cxx03<_InvokePair>, __pp.get());
     if (__ec == 0)
         __pp.release();
     else

--- a/libcxx/include/__threading_support
+++ b/libcxx/include/__threading_support
@@ -404,7 +404,7 @@ void __libcpp_thread_yield()
 
 void __libcpp_thread_sleep_for(const chrono::nanoseconds& __ns)
 {
-   __libcpp_timespec_t __ts = _VSTD::__convert_to_timespec<__libcpp_timespec_t>(__ns);
+   __libcpp_timespec_t __ts = std::__convert_to_timespec<__libcpp_timespec_t>(__ns);
    while (nanosleep(&__ts, &__ts) == -1 && errno == EINTR);
 }
 
@@ -561,7 +561,7 @@ void __libcpp_thread_yield()
 
 void __libcpp_thread_sleep_for(const chrono::nanoseconds& __ns)
 {
-   __libcpp_timespec_t __ts = _VSTD::__convert_to_timespec<__libcpp_timespec_t>(__ns);
+   __libcpp_timespec_t __ts = std::__convert_to_timespec<__libcpp_timespec_t>(__ns);
   thrd_sleep(&__ts, nullptr);
 }
 

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -132,10 +132,10 @@ __tree_sub_invariant(_NodePtr __x)
         if (__x->__right_ && !__x->__right_->__is_black_)
             return 0;
     }
-    unsigned __h = _VSTD::__tree_sub_invariant(__x->__left_);
+    unsigned __h = std::__tree_sub_invariant(__x->__left_);
     if (__h == 0)
         return 0;  // invalid left subtree
-    if (__h != _VSTD::__tree_sub_invariant(__x->__right_))
+    if (__h != std::__tree_sub_invariant(__x->__right_))
         return 0;  // invalid or different height right subtree
     return __h + __x->__is_black_;  // return black height of this node
 }
@@ -152,13 +152,13 @@ __tree_invariant(_NodePtr __root)
     // check __x->__parent_ consistency
     if (__root->__parent_ == nullptr)
         return false;
-    if (!_VSTD::__tree_is_left_child(__root))
+    if (!std::__tree_is_left_child(__root))
         return false;
     // root must be black
     if (!__root->__is_black_)
         return false;
     // do normal node checks
-    return _VSTD::__tree_sub_invariant(__root) != 0;
+    return std::__tree_sub_invariant(__root) != 0;
 }
 
 // Returns:  pointer to the left-most node under __x.
@@ -192,8 +192,8 @@ __tree_next(_NodePtr __x) _NOEXCEPT
 {
     _LIBCPP_ASSERT_INTERNAL(__x != nullptr, "node shouldn't be null");
     if (__x->__right_ != nullptr)
-        return _VSTD::__tree_min(__x->__right_);
-    while (!_VSTD::__tree_is_left_child(__x))
+        return std::__tree_min(__x->__right_);
+    while (!std::__tree_is_left_child(__x))
         __x = __x->__parent_unsafe();
     return __x->__parent_unsafe();
 }
@@ -205,8 +205,8 @@ __tree_next_iter(_NodePtr __x) _NOEXCEPT
 {
     _LIBCPP_ASSERT_INTERNAL(__x != nullptr, "node shouldn't be null");
     if (__x->__right_ != nullptr)
-        return static_cast<_EndNodePtr>(_VSTD::__tree_min(__x->__right_));
-    while (!_VSTD::__tree_is_left_child(__x))
+        return static_cast<_EndNodePtr>(std::__tree_min(__x->__right_));
+    while (!std::__tree_is_left_child(__x))
         __x = __x->__parent_unsafe();
     return static_cast<_EndNodePtr>(__x->__parent_);
 }
@@ -220,9 +220,9 @@ __tree_prev_iter(_EndNodePtr __x) _NOEXCEPT
 {
     _LIBCPP_ASSERT_INTERNAL(__x != nullptr, "node shouldn't be null");
     if (__x->__left_ != nullptr)
-        return _VSTD::__tree_max(__x->__left_);
+        return std::__tree_max(__x->__left_);
     _NodePtr __xx = static_cast<_NodePtr>(__x);
-    while (_VSTD::__tree_is_left_child(__xx))
+    while (std::__tree_is_left_child(__xx))
         __xx = __xx->__parent_unsafe();
     return __xx->__parent_unsafe();
 }
@@ -263,7 +263,7 @@ __tree_left_rotate(_NodePtr __x) _NOEXCEPT
     if (__x->__right_ != nullptr)
         __x->__right_->__set_parent(__x);
     __y->__parent_ = __x->__parent_;
-    if (_VSTD::__tree_is_left_child(__x))
+    if (std::__tree_is_left_child(__x))
         __x->__parent_->__left_ = __y;
     else
         __x->__parent_unsafe()->__right_ = __y;
@@ -284,7 +284,7 @@ __tree_right_rotate(_NodePtr __x) _NOEXCEPT
     if (__x->__left_ != nullptr)
         __x->__left_->__set_parent(__x);
     __y->__parent_ = __x->__parent_;
-    if (_VSTD::__tree_is_left_child(__x))
+    if (std::__tree_is_left_child(__x))
         __x->__parent_->__left_ = __y;
     else
         __x->__parent_unsafe()->__right_ = __y;
@@ -309,7 +309,7 @@ __tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT
     while (__x != __root && !__x->__parent_unsafe()->__is_black_)
     {
         // __x->__parent_ != __root because __x->__parent_->__is_black == false
-        if (_VSTD::__tree_is_left_child(__x->__parent_unsafe()))
+        if (std::__tree_is_left_child(__x->__parent_unsafe()))
         {
             _NodePtr __y = __x->__parent_unsafe()->__parent_unsafe()->__right_;
             if (__y != nullptr && !__y->__is_black_)
@@ -322,16 +322,16 @@ __tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT
             }
             else
             {
-                if (!_VSTD::__tree_is_left_child(__x))
+                if (!std::__tree_is_left_child(__x))
                 {
                     __x = __x->__parent_unsafe();
-                    _VSTD::__tree_left_rotate(__x);
+                    std::__tree_left_rotate(__x);
                 }
                 __x = __x->__parent_unsafe();
                 __x->__is_black_ = true;
                 __x = __x->__parent_unsafe();
                 __x->__is_black_ = false;
-                _VSTD::__tree_right_rotate(__x);
+                std::__tree_right_rotate(__x);
                 break;
             }
         }
@@ -348,16 +348,16 @@ __tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT
             }
             else
             {
-                if (_VSTD::__tree_is_left_child(__x))
+                if (std::__tree_is_left_child(__x))
                 {
                     __x = __x->__parent_unsafe();
-                    _VSTD::__tree_right_rotate(__x);
+                    std::__tree_right_rotate(__x);
                 }
                 __x = __x->__parent_unsafe();
                 __x->__is_black_ = true;
                 __x = __x->__parent_unsafe();
                 __x->__is_black_ = false;
-                _VSTD::__tree_left_rotate(__x);
+                std::__tree_left_rotate(__x);
                 break;
             }
         }
@@ -381,7 +381,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
     // __y will have at most one child.
     // __y will be the initial hole in the tree (make the hole at a leaf)
     _NodePtr __y = (__z->__left_ == nullptr || __z->__right_ == nullptr) ?
-                    __z : _VSTD::__tree_next(__z);
+                    __z : std::__tree_next(__z);
     // __x is __y's possibly null single child
     _NodePtr __x = __y->__left_ != nullptr ? __y->__left_ : __y->__right_;
     // __w is __x's possibly null uncle (will become __x's sibling)
@@ -389,7 +389,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
     // link __x to __y's parent, and find __w
     if (__x != nullptr)
         __x->__parent_ = __y->__parent_;
-    if (_VSTD::__tree_is_left_child(__y))
+    if (std::__tree_is_left_child(__y))
     {
         __y->__parent_->__left_ = __x;
         if (__y != __root)
@@ -410,7 +410,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
     {
         // __z->__left_ != nulptr but __z->__right_ might == __x == nullptr
         __y->__parent_ = __z->__parent_;
-        if (_VSTD::__tree_is_left_child(__z))
+        if (std::__tree_is_left_child(__z))
             __y->__parent_->__left_ = __y;
         else
             __y->__parent_unsafe()->__right_ = __y;
@@ -450,13 +450,13 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
             //     with a non-null black child).
             while (true)
             {
-                if (!_VSTD::__tree_is_left_child(__w))  // if x is left child
+                if (!std::__tree_is_left_child(__w))  // if x is left child
                 {
                     if (!__w->__is_black_)
                     {
                         __w->__is_black_ = true;
                         __w->__parent_unsafe()->__is_black_ = false;
-                        _VSTD::__tree_left_rotate(__w->__parent_unsafe());
+                        std::__tree_left_rotate(__w->__parent_unsafe());
                         // __x is still valid
                         // reset __root only if necessary
                         if (__root == __w->__left_)
@@ -477,7 +477,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                             break;
                         }
                         // reset sibling, and it still can't be null
-                        __w = _VSTD::__tree_is_left_child(__x) ?
+                        __w = std::__tree_is_left_child(__x) ?
                                     __x->__parent_unsafe()->__right_ :
                                     __x->__parent_->__left_;
                         // continue;
@@ -489,7 +489,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                             // __w left child is non-null and red
                             __w->__left_->__is_black_ = true;
                             __w->__is_black_ = false;
-                            _VSTD::__tree_right_rotate(__w);
+                            std::__tree_right_rotate(__w);
                             // __w is known not to be root, so root hasn't changed
                             // reset sibling, and it still can't be null
                             __w = __w->__parent_unsafe();
@@ -498,7 +498,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                         __w->__is_black_ = __w->__parent_unsafe()->__is_black_;
                         __w->__parent_unsafe()->__is_black_ = true;
                         __w->__right_->__is_black_ = true;
-                        _VSTD::__tree_left_rotate(__w->__parent_unsafe());
+                        std::__tree_left_rotate(__w->__parent_unsafe());
                         break;
                     }
                 }
@@ -508,7 +508,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                     {
                         __w->__is_black_ = true;
                         __w->__parent_unsafe()->__is_black_ = false;
-                        _VSTD::__tree_right_rotate(__w->__parent_unsafe());
+                        std::__tree_right_rotate(__w->__parent_unsafe());
                         // __x is still valid
                         // reset __root only if necessary
                         if (__root == __w->__right_)
@@ -529,7 +529,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                             break;
                         }
                         // reset sibling, and it still can't be null
-                        __w = _VSTD::__tree_is_left_child(__x) ?
+                        __w = std::__tree_is_left_child(__x) ?
                                     __x->__parent_unsafe()->__right_ :
                                     __x->__parent_->__left_;
                         // continue;
@@ -541,7 +541,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                             // __w right child is non-null and red
                             __w->__right_->__is_black_ = true;
                             __w->__is_black_ = false;
-                            _VSTD::__tree_left_rotate(__w);
+                            std::__tree_left_rotate(__w);
                             // __w is known not to be root, so root hasn't changed
                             // reset sibling, and it still can't be null
                             __w = __w->__parent_unsafe();
@@ -550,7 +550,7 @@ __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
                         __w->__is_black_ = __w->__parent_unsafe()->__is_black_;
                         __w->__parent_unsafe()->__is_black_ = true;
                         __w->__left_->__is_black_ = true;
-                        _VSTD::__tree_right_rotate(__w->__parent_unsafe());
+                        std::__tree_right_rotate(__w->__parent_unsafe());
                         break;
                     }
                 }
@@ -591,11 +591,11 @@ struct __tree_key_value_types {
   }
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type* __get_ptr(__node_value_type& __n) {
-    return _VSTD::addressof(__n);
+    return std::addressof(__n);
   }
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type&& __move(__node_value_type& __v) {
-    return _VSTD::move(__v);
+    return std::move(__v);
   }
 };
 
@@ -636,7 +636,7 @@ struct __tree_key_value_types<__value_type<_Key, _Tp> > {
 
   _LIBCPP_HIDE_FROM_ABI
   static __container_value_type* __get_ptr(__node_value_type& __n) {
-    return _VSTD::addressof(__n.__get_value());
+    return std::addressof(__n.__get_value());
   }
 
   _LIBCPP_HIDE_FROM_ABI
@@ -864,7 +864,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __tree_iterator& operator++() {
       __ptr_ = static_cast<__iter_pointer>(
-          _VSTD::__tree_next_iter<__end_node_pointer>(static_cast<__node_base_pointer>(__ptr_)));
+          std::__tree_next_iter<__end_node_pointer>(static_cast<__node_base_pointer>(__ptr_)));
       return *this;
     }
     _LIBCPP_HIDE_FROM_ABI
@@ -873,7 +873,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     __tree_iterator& operator--() {
-      __ptr_ = static_cast<__iter_pointer>(_VSTD::__tree_prev_iter<__node_base_pointer>(
+      __ptr_ = static_cast<__iter_pointer>(std::__tree_prev_iter<__node_base_pointer>(
           static_cast<__end_node_pointer>(__ptr_)));
       return *this;
     }
@@ -945,7 +945,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __tree_const_iterator& operator++() {
       __ptr_ = static_cast<__iter_pointer>(
-          _VSTD::__tree_next_iter<__end_node_pointer>(static_cast<__node_base_pointer>(__ptr_)));
+          std::__tree_next_iter<__end_node_pointer>(static_cast<__node_base_pointer>(__ptr_)));
       return *this;
     }
 
@@ -955,7 +955,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     __tree_const_iterator& operator--() {
-      __ptr_ = static_cast<__iter_pointer>(_VSTD::__tree_prev_iter<__node_base_pointer>(
+      __ptr_ = static_cast<__iter_pointer>(std::__tree_prev_iter<__node_base_pointer>(
           static_cast<__end_node_pointer>(__ptr_)));
       return *this;
     }
@@ -1103,7 +1103,7 @@ public:
         {return static_cast<__node_pointer>(__end_node()->__left_);}
 
     _LIBCPP_HIDE_FROM_ABI __node_base_pointer* __root_ptr() const _NOEXCEPT {
-        return _VSTD::addressof(__end_node()->__left_);
+        return std::addressof(__end_node()->__left_);
     }
 
     typedef __tree_iterator<value_type, __node_pointer, difference_type>             iterator;
@@ -1144,7 +1144,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     size_type max_size() const _NOEXCEPT
-        {return _VSTD::min<size_type>(
+        {return std::min<size_type>(
                 __node_traits::max_size(__node_alloc()),
                 numeric_limits<difference_type >::max());}
 
@@ -1183,7 +1183,7 @@ public:
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __emplace_unique(_Pp&& __x) {
-        return __emplace_unique_extract_key(_VSTD::forward<_Pp>(__x),
+        return __emplace_unique_extract_key(std::forward<_Pp>(__x),
                                             __can_extract_key<_Pp, key_type>());
     }
 
@@ -1192,41 +1192,41 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique(_First&& __f, _Second&& __s) {
-        return __emplace_unique_key_args(__f, _VSTD::forward<_First>(__f),
-                                              _VSTD::forward<_Second>(__s));
+        return __emplace_unique_key_args(__f, std::forward<_First>(__f),
+                                              std::forward<_Second>(__s));
     }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __emplace_unique(_Args&&... __args) {
-        return __emplace_unique_impl(_VSTD::forward<_Args>(__args)...);
+        return __emplace_unique_impl(std::forward<_Args>(__args)...);
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_fail_tag) {
-      return __emplace_unique_impl(_VSTD::forward<_Pp>(__x));
+      return __emplace_unique_impl(std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_self_tag) {
-      return __emplace_unique_key_args(__x, _VSTD::forward<_Pp>(__x));
+      return __emplace_unique_key_args(__x, std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
     __emplace_unique_extract_key(_Pp&& __x, __extract_key_first_tag) {
-      return __emplace_unique_key_args(__x.first, _VSTD::forward<_Pp>(__x));
+      return __emplace_unique_key_args(__x.first, std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator __emplace_hint_unique(const_iterator __p, _Pp&& __x) {
-        return __emplace_hint_unique_extract_key(__p, _VSTD::forward<_Pp>(__x),
+        return __emplace_hint_unique_extract_key(__p, std::forward<_Pp>(__x),
                                             __can_extract_key<_Pp, key_type>());
     }
 
@@ -1236,35 +1236,35 @@ public:
     iterator
     __emplace_hint_unique(const_iterator __p, _First&& __f, _Second&& __s) {
         return __emplace_hint_unique_key_args(__p, __f,
-                                              _VSTD::forward<_First>(__f),
-                                              _VSTD::forward<_Second>(__s)).first;
+                                              std::forward<_First>(__f),
+                                              std::forward<_Second>(__s)).first;
     }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator __emplace_hint_unique(const_iterator __p, _Args&&... __args) {
-        return __emplace_hint_unique_impl(__p, _VSTD::forward<_Args>(__args)...);
+        return __emplace_hint_unique_impl(__p, std::forward<_Args>(__args)...);
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator
     __emplace_hint_unique_extract_key(const_iterator __p, _Pp&& __x, __extract_key_fail_tag) {
-      return __emplace_hint_unique_impl(__p, _VSTD::forward<_Pp>(__x));
+      return __emplace_hint_unique_impl(__p, std::forward<_Pp>(__x));
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator
     __emplace_hint_unique_extract_key(const_iterator __p, _Pp&& __x, __extract_key_self_tag) {
-      return __emplace_hint_unique_key_args(__p, __x, _VSTD::forward<_Pp>(__x)).first;
+      return __emplace_hint_unique_key_args(__p, __x, std::forward<_Pp>(__x)).first;
     }
 
     template <class _Pp>
     _LIBCPP_HIDE_FROM_ABI
     iterator
     __emplace_hint_unique_extract_key(const_iterator __p, _Pp&& __x, __extract_key_first_tag) {
-      return __emplace_hint_unique_key_args(__p, __x.first, _VSTD::forward<_Pp>(__x)).first;
+      return __emplace_hint_unique_key_args(__p, __x.first, std::forward<_Pp>(__x)).first;
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1279,48 +1279,48 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __insert_unique(__container_value_type&& __v) {
-        return __emplace_unique_key_args(_NodeTypes::__get_key(__v), _VSTD::move(__v));
+        return __emplace_unique_key_args(_NodeTypes::__get_key(__v), std::move(__v));
     }
 
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_unique(const_iterator __p, __container_value_type&& __v) {
-        return __emplace_hint_unique_key_args(__p, _NodeTypes::__get_key(__v), _VSTD::move(__v)).first;
+        return __emplace_hint_unique_key_args(__p, _NodeTypes::__get_key(__v), std::move(__v)).first;
     }
 
     template <class _Vp,
               class = __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value> >
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> __insert_unique(_Vp&& __v) {
-        return __emplace_unique(_VSTD::forward<_Vp>(__v));
+        return __emplace_unique(std::forward<_Vp>(__v));
     }
 
     template <class _Vp,
               class = __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value> >
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_unique(const_iterator __p, _Vp&& __v) {
-        return __emplace_hint_unique(__p, _VSTD::forward<_Vp>(__v));
+        return __emplace_hint_unique(__p, std::forward<_Vp>(__v));
     }
 
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(__container_value_type&& __v) {
-        return __emplace_multi(_VSTD::move(__v));
+        return __emplace_multi(std::move(__v));
     }
 
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(const_iterator __p, __container_value_type&& __v) {
-        return __emplace_hint_multi(__p, _VSTD::move(__v));
+        return __emplace_hint_multi(__p, std::move(__v));
     }
 
     template <class _Vp>
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(_Vp&& __v) {
-        return __emplace_multi(_VSTD::forward<_Vp>(__v));
+        return __emplace_multi(std::forward<_Vp>(__v));
     }
 
     template <class _Vp>
     _LIBCPP_HIDE_FROM_ABI
     iterator __insert_multi(const_iterator __p, _Vp&& __v) {
-        return __emplace_hint_multi(__p, _VSTD::forward<_Vp>(__v));
+        return __emplace_hint_multi(__p, std::forward<_Vp>(__v));
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1493,7 +1493,7 @@ private:
     _LIBCPP_HIDE_FROM_ABI
     void __move_assign_alloc(__tree& __t, true_type)
         _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
-        {__node_alloc() = _VSTD::move(__t.__node_alloc());}
+        {__node_alloc() = std::move(__t.__node_alloc());}
     _LIBCPP_HIDE_FROM_ABI
     void __move_assign_alloc(__tree&, false_type) _NOEXCEPT {}
 
@@ -1603,27 +1603,27 @@ __tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_next(__node_poin
 {
     if (__cache->__parent_ == nullptr)
         return nullptr;
-    if (_VSTD::__tree_is_left_child(static_cast<__node_base_pointer>(__cache)))
+    if (std::__tree_is_left_child(static_cast<__node_base_pointer>(__cache)))
     {
         __cache->__parent_->__left_ = nullptr;
         __cache = static_cast<__node_pointer>(__cache->__parent_);
         if (__cache->__right_ == nullptr)
             return __cache;
-        return static_cast<__node_pointer>(_VSTD::__tree_leaf(__cache->__right_));
+        return static_cast<__node_pointer>(std::__tree_leaf(__cache->__right_));
     }
     // __cache is right child
     __cache->__parent_unsafe()->__right_ = nullptr;
     __cache = static_cast<__node_pointer>(__cache->__parent_);
     if (__cache->__left_ == nullptr)
         return __cache;
-    return static_cast<__node_pointer>(_VSTD::__tree_leaf(__cache->__left_));
+    return static_cast<__node_pointer>(std::__tree_leaf(__cache->__left_));
 }
 
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>&
 __tree<_Tp, _Compare, _Allocator>::operator=(const __tree& __t)
 {
-    if (this != _VSTD::addressof(__t))
+    if (this != std::addressof(__t))
     {
         value_comp() = __t.value_comp();
         __copy_assign_alloc(__t);
@@ -1693,9 +1693,9 @@ __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t)
     _NOEXCEPT_(
         is_nothrow_move_constructible<__node_allocator>::value &&
         is_nothrow_move_constructible<value_compare>::value)
-    : __begin_node_(_VSTD::move(__t.__begin_node_)),
-      __pair1_(_VSTD::move(__t.__pair1_)),
-      __pair3_(_VSTD::move(__t.__pair3_))
+    : __begin_node_(std::move(__t.__begin_node_)),
+      __pair1_(std::move(__t.__pair1_)),
+      __pair3_(std::move(__t.__pair3_))
 {
     if (size() == 0)
         __begin_node() = __end_node();
@@ -1711,7 +1711,7 @@ __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t)
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t, const allocator_type& __a)
     : __pair1_(__default_init_tag(), __node_allocator(__a)),
-      __pair3_(0, _VSTD::move(__t.value_comp()))
+      __pair3_(0, std::move(__t.value_comp()))
 {
     if (__a == __t.__alloc())
     {
@@ -1744,7 +1744,7 @@ __tree<_Tp, _Compare, _Allocator>::__move_assign(__tree& __t, true_type)
     __begin_node_ = __t.__begin_node_;
     __pair1_.first() = __t.__pair1_.first();
     __move_assign_alloc(__t);
-    __pair3_ = _VSTD::move(__t.__pair3_);
+    __pair3_ = std::move(__t.__pair3_);
     if (size() == 0)
         __begin_node() = __end_node();
     else
@@ -1764,13 +1764,13 @@ __tree<_Tp, _Compare, _Allocator>::__move_assign(__tree& __t, false_type)
         __move_assign(__t, true_type());
     else
     {
-        value_comp() = _VSTD::move(__t.value_comp());
+        value_comp() = std::move(__t.value_comp());
         const_iterator __e = end();
         if (size() != 0)
         {
             _DetachedTreeCache __cache(this);
             while (__cache.__get() != nullptr && __t.size() != 0) {
-              __cache.__get()->__value_ = _VSTD::move(__t.remove(__t.begin())->__value_);
+              __cache.__get()->__value_ = std::move(__t.remove(__t.begin())->__value_);
               __node_insert_multi(__cache.__get());
               __cache.__advance();
             }
@@ -1829,10 +1829,10 @@ __tree<_Tp, _Compare, _Allocator>::swap(__tree& __t)
         _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value)
 #endif
 {
-    using _VSTD::swap;
+    using std::swap;
     swap(__begin_node_, __t.__begin_node_);
     swap(__pair1_.first(), __t.__pair1_.first());
-    _VSTD::__swap_allocator(__node_alloc(), __t.__node_alloc());
+    std::__swap_allocator(__node_alloc(), __t.__node_alloc());
     __pair3_.swap(__t.__pair3_);
     if (size() == 0)
         __begin_node() = __end_node();
@@ -1988,7 +1988,7 @@ __tree<_Tp, _Compare, _Allocator>::__find_equal(__parent_pointer& __parent,
             if (value_comp()(__v, __nd->__value_))
             {
                 if (__nd->__left_ != nullptr) {
-                    __nd_ptr = _VSTD::addressof(__nd->__left_);
+                    __nd_ptr = std::addressof(__nd->__left_);
                     __nd = static_cast<__node_pointer>(__nd->__left_);
                 } else {
                     __parent = static_cast<__parent_pointer>(__nd);
@@ -1998,7 +1998,7 @@ __tree<_Tp, _Compare, _Allocator>::__find_equal(__parent_pointer& __parent,
             else if (value_comp()(__nd->__value_, __v))
             {
                 if (__nd->__right_ != nullptr) {
-                    __nd_ptr = _VSTD::addressof(__nd->__right_);
+                    __nd_ptr = std::addressof(__nd->__right_);
                     __nd = static_cast<__node_pointer>(__nd->__right_);
                 } else {
                     __parent = static_cast<__parent_pointer>(__nd);
@@ -2055,10 +2055,10 @@ __tree<_Tp, _Compare, _Allocator>::__find_equal(const_iterator __hint,
     else if (value_comp()(*__hint, __v))  // check after
     {
         // *__hint < __v
-        const_iterator __next = _VSTD::next(__hint);
+        const_iterator __next = std::next(__hint);
         if (__next == end() || value_comp()(__v, *__next))
         {
-            // *__hint < __v < *_VSTD::next(__hint)
+            // *__hint < __v < *std::next(__hint)
             if (__hint.__get_np()->__right_ == nullptr)
             {
                 __parent = static_cast<__parent_pointer>(__hint.__ptr_);
@@ -2091,7 +2091,7 @@ void __tree<_Tp, _Compare, _Allocator>::__insert_node_at(
     __child = __new_node;
     if (__begin_node()->__left_ != nullptr)
         __begin_node() = static_cast<__iter_pointer>(__begin_node()->__left_);
-    _VSTD::__tree_balance_after_insert(__end_node()->__left_, __child);
+    std::__tree_balance_after_insert(__end_node()->__left_, __child);
     ++size();
 }
 
@@ -2106,7 +2106,7 @@ __tree<_Tp, _Compare, _Allocator>::__emplace_unique_key_args(_Key const& __k, _A
     bool __inserted = false;
     if (__child == nullptr)
     {
-        __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+        __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
         __insert_node_at(__parent, __child, static_cast<__node_base_pointer>(__h.get()));
         __r = __h.release();
         __inserted = true;
@@ -2127,7 +2127,7 @@ __tree<_Tp, _Compare, _Allocator>::__emplace_hint_unique_key_args(
     bool __inserted = false;
     if (__child == nullptr)
     {
-        __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+        __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
         __insert_node_at(__parent, __child, static_cast<__node_base_pointer>(__h.get()));
         __r = __h.release();
         __inserted = true;
@@ -2144,7 +2144,7 @@ __tree<_Tp, _Compare, _Allocator>::__construct_node(_Args&& ...__args)
                   "Cannot construct from __value_type");
     __node_allocator& __na = __node_alloc();
     __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
-    __node_traits::construct(__na, _NodeTypes::__get_ptr(__h->__value_), _VSTD::forward<_Args>(__args)...);
+    __node_traits::construct(__na, _NodeTypes::__get_ptr(__h->__value_), std::forward<_Args>(__args)...);
     __h.get_deleter().__value_constructed = true;
     return __h;
 }
@@ -2155,7 +2155,7 @@ template <class... _Args>
 pair<typename __tree<_Tp, _Compare, _Allocator>::iterator, bool>
 __tree<_Tp, _Compare, _Allocator>::__emplace_unique_impl(_Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     __parent_pointer __parent;
     __node_base_pointer& __child = __find_equal(__parent, __h->__value_);
     __node_pointer __r = static_cast<__node_pointer>(__child);
@@ -2174,7 +2174,7 @@ template <class... _Args>
 typename __tree<_Tp, _Compare, _Allocator>::iterator
 __tree<_Tp, _Compare, _Allocator>::__emplace_hint_unique_impl(const_iterator __p, _Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     __parent_pointer __parent;
     __node_base_pointer __dummy;
     __node_base_pointer& __child = __find_equal(__p, __parent, __dummy, __h->__value_);
@@ -2192,7 +2192,7 @@ template <class... _Args>
 typename __tree<_Tp, _Compare, _Allocator>::iterator
 __tree<_Tp, _Compare, _Allocator>::__emplace_multi(_Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     __parent_pointer __parent;
     __node_base_pointer& __child = __find_leaf_high(__parent, _NodeTypes::__get_key(__h->__value_));
     __insert_node_at(__parent, __child, static_cast<__node_base_pointer>(__h.get()));
@@ -2205,7 +2205,7 @@ typename __tree<_Tp, _Compare, _Allocator>::iterator
 __tree<_Tp, _Compare, _Allocator>::__emplace_hint_multi(const_iterator __p,
                                                         _Args&&... __args)
 {
-    __node_holder __h = __construct_node(_VSTD::forward<_Args>(__args)...);
+    __node_holder __h = __construct_node(std::forward<_Args>(__args)...);
     __parent_pointer __parent;
     __node_base_pointer& __child = __find_leaf(__p, __parent, _NodeTypes::__get_key(__h->__value_));
     __insert_node_at(__parent, __child, static_cast<__node_base_pointer>(__h.get()));
@@ -2261,7 +2261,7 @@ __tree<_Tp, _Compare, _Allocator>::__remove_node_pointer(__node_pointer __ptr) _
     if (__begin_node() == __ptr)
         __begin_node() = __r.__ptr_;
     --size();
-    _VSTD::__tree_remove(__end_node()->__left_,
+    std::__tree_remove(__end_node()->__left_,
                          static_cast<__node_base_pointer>(__ptr));
     return __r;
 }
@@ -2284,7 +2284,7 @@ __tree<_Tp, _Compare, _Allocator>::__node_handle_insert_unique(
     if (__child != nullptr)
         return _InsertReturnType{
             iterator(static_cast<__node_pointer>(__child)),
-            false, _VSTD::move(__nh)};
+            false, std::move(__nh)};
 
     __insert_node_at(__parent, __child,
                      static_cast<__node_base_pointer>(__ptr));
@@ -2530,7 +2530,7 @@ __tree<_Tp, _Compare, _Allocator>::__count_multi(const _Key& __k) const
         else if (value_comp()(__rt->__value_, __k))
             __rt = static_cast<__node_pointer>(__rt->__right_);
         else
-            return _VSTD::distance(
+            return std::distance(
                 __lower_bound(__k, static_cast<__node_pointer>(__rt->__left_), static_cast<__iter_pointer>(__rt)),
                 __upper_bound(__k, static_cast<__node_pointer>(__rt->__right_), __result)
             );
@@ -2640,7 +2640,7 @@ __tree<_Tp, _Compare, _Allocator>::__equal_range_unique(const _Key& __k)
             return _Pp(iterator(__rt),
                       iterator(
                           __rt->__right_ != nullptr ?
-                              static_cast<__iter_pointer>(_VSTD::__tree_min(__rt->__right_))
+                              static_cast<__iter_pointer>(std::__tree_min(__rt->__right_))
                             : __result));
     }
     return _Pp(iterator(__result), iterator(__result));
@@ -2668,7 +2668,7 @@ __tree<_Tp, _Compare, _Allocator>::__equal_range_unique(const _Key& __k) const
             return _Pp(const_iterator(__rt),
                       const_iterator(
                           __rt->__right_ != nullptr ?
-                              static_cast<__iter_pointer>(_VSTD::__tree_min(__rt->__right_))
+                              static_cast<__iter_pointer>(std::__tree_min(__rt->__right_))
                             : __result));
     }
     return _Pp(const_iterator(__result), const_iterator(__result));
@@ -2737,7 +2737,7 @@ __tree<_Tp, _Compare, _Allocator>::remove(const_iterator __p) _NOEXCEPT
             __begin_node() = static_cast<__iter_pointer>(__np->__parent_);
     }
     --size();
-    _VSTD::__tree_remove(__end_node()->__left_,
+    std::__tree_remove(__end_node()->__left_,
                          static_cast<__node_base_pointer>(__np));
     return __node_holder(__np, _Dp(__node_alloc(), true));
 }

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -380,7 +380,7 @@ struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...> {
   static const bool value = false;
 #else
   static const bool value =
-      noexcept(_ThisT::__test_noexcept<_Ret>(_VSTD::__invoke(std::declval<_Fp>(), std::declval<_Args>()...)));
+      noexcept(_ThisT::__test_noexcept<_Ret>(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...)));
 #endif
 };
 
@@ -389,7 +389,7 @@ struct __nothrow_invokable_r_imp<true, true, _Ret, _Fp, _Args...> {
 #ifdef _LIBCPP_CXX03_LANG
   static const bool value = false;
 #else
-  static const bool value = noexcept(_VSTD::__invoke(std::declval<_Fp>(), std::declval<_Args>()...));
+  static const bool value = noexcept(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...));
 #endif
 };
 

--- a/libcxx/include/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_constructible.h
@@ -42,7 +42,7 @@ void __implicit_conversion_to(_Tp) noexcept {}
 
 template <class _Tp, class _Arg>
 struct __libcpp_is_nothrow_constructible</*is constructible*/ true, /*is reference*/ true, _Tp, _Arg>
-    : public integral_constant<bool, noexcept(_VSTD::__implicit_conversion_to<_Tp>(std::declval<_Arg>()))> {};
+    : public integral_constant<bool, noexcept(std::__implicit_conversion_to<_Tp>(std::declval<_Arg>()))> {};
 
 template <class _Tp, bool _IsReference, class... _Args>
 struct __libcpp_is_nothrow_constructible</*is constructible*/ false, _IsReference, _Tp, _Args...> : public false_type {

--- a/libcxx/include/__type_traits/is_nothrow_convertible.h
+++ b/libcxx/include/__type_traits/is_nothrow_convertible.h
@@ -30,7 +30,7 @@ template <typename _Tp>
 void __test_noexcept(_Tp) noexcept;
 
 template <typename _Fm, typename _To>
-bool_constant<noexcept(_VSTD::__test_noexcept<_To>(std::declval<_Fm>()))> __is_nothrow_convertible_test();
+bool_constant<noexcept(std::__test_noexcept<_To>(std::declval<_Fm>()))> __is_nothrow_convertible_test();
 
 template <typename _Fm, typename _To>
 struct __is_nothrow_convertible_helper : decltype(__is_nothrow_convertible_test<_Fm, _To>()) {};

--- a/libcxx/include/__utility/cmp.h
+++ b/libcxx/include/__utility/cmp.h
@@ -59,7 +59,7 @@ template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr
 bool cmp_not_equal(_Tp __t, _Up __u) noexcept
 {
-  return !_VSTD::cmp_equal(__t, __u);
+  return !std::cmp_equal(__t, __u);
 }
 
 template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
@@ -78,29 +78,29 @@ template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr
 bool cmp_greater(_Tp __t, _Up __u) noexcept
 {
-  return _VSTD::cmp_less(__u, __t);
+  return std::cmp_less(__u, __t);
 }
 
 template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr
 bool cmp_less_equal(_Tp __t, _Up __u) noexcept
 {
-  return !_VSTD::cmp_greater(__t, __u);
+  return !std::cmp_greater(__t, __u);
 }
 
 template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr
 bool cmp_greater_equal(_Tp __t, _Up __u) noexcept
 {
-  return !_VSTD::cmp_less(__t, __u);
+  return !std::cmp_less(__t, __u);
 }
 
 template<__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr
 bool in_range(_Up __u) noexcept
 {
-  return _VSTD::cmp_less_equal(__u, numeric_limits<_Tp>::max()) &&
-         _VSTD::cmp_greater_equal(__u, numeric_limits<_Tp>::min());
+  return std::cmp_less_equal(__u, numeric_limits<_Tp>::max()) &&
+         std::cmp_greater_equal(__u, numeric_limits<_Tp>::min());
 }
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__utility/exchange.h
+++ b/libcxx/include/__utility/exchange.h
@@ -30,8 +30,8 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 _T1 exchange(_T1& __obj, _T2&& __new_value)
     noexcept(is_nothrow_move_constructible<_T1>::value && is_nothrow_assignable<_T1&, _T2>::value)
 {
-    _T1 __old_value = _VSTD::move(__obj);
-    __obj = _VSTD::forward<_T2>(__new_value);
+    _T1 __old_value = std::move(__obj);
+    __obj = std::forward<_T2>(__new_value);
     return __old_value;
 }
 #endif // _LIBCPP_STD_VER >= 14

--- a/libcxx/include/__utility/swap.h
+++ b/libcxx/include/__utility/swap.h
@@ -39,9 +39,9 @@ using __swap_result_t = void;
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI __swap_result_t<_Tp> _LIBCPP_CONSTEXPR_SINCE_CXX20 swap(_Tp& __x, _Tp& __y)
     _NOEXCEPT_(is_nothrow_move_constructible<_Tp>::value&& is_nothrow_move_assignable<_Tp>::value) {
-  _Tp __t(_VSTD::move(__x));
-  __x = _VSTD::move(__y);
-  __y = _VSTD::move(__t);
+  _Tp __t(std::move(__x));
+  __x = std::move(__y);
+  __y = std::move(__t);
 }
 
 template <class _Tp, size_t _Np, __enable_if_t<__is_swappable<_Tp>::value, int> >

--- a/libcxx/include/__utility/to_underlying.h
+++ b/libcxx/include/__utility/to_underlying.h
@@ -31,7 +31,7 @@ __to_underlying(_Tp __val) noexcept {
 template <class _Tp>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr underlying_type_t<_Tp>
 to_underlying(_Tp __val) noexcept {
-  return _VSTD::__to_underlying(__val);
+  return std::__to_underlying(__val);
 }
 #endif
 

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -266,7 +266,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI
   any & operator=(any && __rhs) _NOEXCEPT {
-    any(_VSTD::move(__rhs)).swap(*this);
+    any(std::move(__rhs)).swap(*this);
     return *this;
   }
 
@@ -399,7 +399,7 @@ namespace __any_imp
         typedef allocator_traits<_Alloc> _ATraits;
         _Alloc __a;
         _Tp * __ret = static_cast<_Tp*>(static_cast<void*>(&__dest.__s_.__buf));
-        _ATraits::construct(__a, __ret, _VSTD::forward<_Args>(__args)...);
+        _ATraits::construct(__a, __ret, std::forward<_Args>(__args)...);
         __dest.__h_ = &_SmallHandler::__handle;
         return *__ret;
     }
@@ -423,7 +423,7 @@ namespace __any_imp
 
     _LIBCPP_HIDE_FROM_ABI
     static void __move(any & __this, any & __dest) {
-        _SmallHandler::__create(__dest, _VSTD::move(
+        _SmallHandler::__create(__dest, std::move(
             *static_cast<_Tp*>(static_cast<void*>(&__this.__s_.__buf))));
         __destroy(__this);
     }
@@ -485,7 +485,7 @@ namespace __any_imp
         _Alloc __a;
         unique_ptr<_Tp, _Dp> __hold(_ATraits::allocate(__a, 1), _Dp(__a, 1));
         _Tp * __ret = __hold.get();
-        _ATraits::construct(__a, __ret, _VSTD::forward<_Args>(__args)...);
+        _ATraits::construct(__a, __ret, std::forward<_Args>(__args)...);
         __dest.__s_.__ptr = __hold.release();
         __dest.__h_ = &_LargeHandler::__handle;
         return *__ret;
@@ -543,24 +543,24 @@ namespace __any_imp
 template <class _ValueType, class _Tp, class>
 any::any(_ValueType && __v) : __h_(nullptr)
 {
-  __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_ValueType>(__v));
+  __any_imp::_Handler<_Tp>::__create(*this, std::forward<_ValueType>(__v));
 }
 
 template <class _ValueType, class ..._Args, class _Tp, class>
 any::any(in_place_type_t<_ValueType>, _Args&&... __args) {
-  __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_Args>(__args)...);
+  __any_imp::_Handler<_Tp>::__create(*this, std::forward<_Args>(__args)...);
 }
 
 template <class _ValueType, class _Up, class ..._Args, class _Tp, class>
 any::any(in_place_type_t<_ValueType>, initializer_list<_Up> __il, _Args&&... __args) {
-  __any_imp::_Handler<_Tp>::__create(*this, __il, _VSTD::forward<_Args>(__args)...);
+  __any_imp::_Handler<_Tp>::__create(*this, __il, std::forward<_Args>(__args)...);
 }
 
 template <class _ValueType, class, class>
 inline _LIBCPP_HIDE_FROM_ABI
 any & any::operator=(_ValueType && __v)
 {
-  any(_VSTD::forward<_ValueType>(__v)).swap(*this);
+  any(std::forward<_ValueType>(__v)).swap(*this);
   return *this;
 }
 
@@ -568,14 +568,14 @@ template <class _ValueType, class ..._Args, class _Tp, class>
 inline _LIBCPP_HIDE_FROM_ABI
 _Tp& any::emplace(_Args&&... __args) {
   reset();
-  return __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_Args>(__args)...);
+  return __any_imp::_Handler<_Tp>::__create(*this, std::forward<_Args>(__args)...);
 }
 
 template <class _ValueType, class _Up, class ..._Args, class _Tp, class>
 inline _LIBCPP_HIDE_FROM_ABI
 _Tp& any::emplace(initializer_list<_Up> __il, _Args&&... __args) {
   reset();
-  return __any_imp::_Handler<_Tp>::__create(*this, __il, _VSTD::forward<_Args>(__args)...);
+  return __any_imp::_Handler<_Tp>::__create(*this, __il, std::forward<_Args>(__args)...);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI
@@ -608,13 +608,13 @@ void swap(any & __lhs, any & __rhs) _NOEXCEPT
 template <class _Tp, class ..._Args>
 inline _LIBCPP_HIDE_FROM_ABI
 any make_any(_Args&&... __args) {
-    return any(in_place_type<_Tp>, _VSTD::forward<_Args>(__args)...);
+    return any(in_place_type<_Tp>, std::forward<_Args>(__args)...);
 }
 
 template <class _Tp, class _Up, class ..._Args>
 inline _LIBCPP_HIDE_FROM_ABI
 any make_any(initializer_list<_Up> __il, _Args&&... __args) {
-    return any(in_place_type<_Tp>, __il, _VSTD::forward<_Args>(__args)...);
+    return any(in_place_type<_Tp>, __il, std::forward<_Args>(__args)...);
 }
 
 template <class _ValueType>
@@ -626,7 +626,7 @@ _ValueType any_cast(any const & __v)
     static_assert(is_constructible<_ValueType, _RawValueType const &>::value,
                   "ValueType is required to be a const lvalue reference "
                   "or a CopyConstructible type");
-    auto __tmp = _VSTD::any_cast<add_const_t<_RawValueType>>(&__v);
+    auto __tmp = std::any_cast<add_const_t<_RawValueType>>(&__v);
     if (__tmp == nullptr)
         __throw_bad_any_cast();
     return static_cast<_ValueType>(*__tmp);
@@ -641,7 +641,7 @@ _ValueType any_cast(any & __v)
     static_assert(is_constructible<_ValueType, _RawValueType &>::value,
                   "ValueType is required to be an lvalue reference "
                   "or a CopyConstructible type");
-    auto __tmp = _VSTD::any_cast<_RawValueType>(&__v);
+    auto __tmp = std::any_cast<_RawValueType>(&__v);
     if (__tmp == nullptr)
         __throw_bad_any_cast();
     return static_cast<_ValueType>(*__tmp);
@@ -656,10 +656,10 @@ _ValueType any_cast(any && __v)
     static_assert(is_constructible<_ValueType, _RawValueType>::value,
                   "ValueType is required to be an rvalue reference "
                   "or a CopyConstructible type");
-    auto __tmp = _VSTD::any_cast<_RawValueType>(&__v);
+    auto __tmp = std::any_cast<_RawValueType>(&__v);
     if (__tmp == nullptr)
         __throw_bad_any_cast();
-    return static_cast<_ValueType>(_VSTD::move(*__tmp));
+    return static_cast<_ValueType>(std::move(*__tmp));
 }
 
 template <class _ValueType>
@@ -669,7 +669,7 @@ any_cast(any const * __any) _NOEXCEPT
 {
     static_assert(!is_reference<_ValueType>::value,
                   "_ValueType may not be a reference.");
-    return _VSTD::any_cast<_ValueType>(const_cast<any *>(__any));
+    return std::any_cast<_ValueType>(const_cast<any *>(__any));
 }
 
 template <class _RetType>
@@ -701,7 +701,7 @@ any_cast(any * __any) _NOEXCEPT
                           nullptr,
 #endif
                           __any_imp::__get_fallback_typeid<_ValueType>());
-        return _VSTD::__pointer_or_func_cast<_ReturnType>(
+        return std::__pointer_or_func_cast<_ReturnType>(
             __p, is_function<_ValueType>{});
     }
     return nullptr;

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -174,20 +174,20 @@ struct _LIBCPP_TEMPLATE_VIS array
     typedef const value_type*                     const_pointer;
     typedef size_t                                size_type;
     typedef ptrdiff_t                             difference_type;
-    typedef _VSTD::reverse_iterator<iterator>       reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>       reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
     _Tp __elems_[_Size];
 
     // No explicit construct/copy/destroy for aggregate type
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     void fill(const value_type& __u) {
-        _VSTD::fill_n(data(), _Size, __u);
+        std::fill_n(data(), _Size, __u);
     }
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     void swap(array& __a) _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
-        _VSTD::swap_ranges(data(), data() + _Size, __a.data());
+        std::swap_ranges(data(), data() + _Size, __a.data());
     }
 
     // iterators:
@@ -277,8 +277,8 @@ struct _LIBCPP_TEMPLATE_VIS array<_Tp, 0>
     typedef const value_type*                     const_pointer;
     typedef size_t                                size_type;
     typedef ptrdiff_t                             difference_type;
-    typedef _VSTD::reverse_iterator<iterator>       reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>       reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
     typedef __conditional_t<is_const<_Tp>::value, const char, char> _CharType;
 
@@ -403,7 +403,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 operator==(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y)
 {
-    return _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -415,7 +415,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const array<_Tp, _Size>& __x, const
 
 template <class _Tp, size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI bool operator<(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Tp, size_t _Size>
@@ -488,7 +488,7 @@ _Tp&&
 get(array<_Tp, _Size>&& __a) _NOEXCEPT
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (std::array &&)");
-    return _VSTD::move(__a.__elems_[_Ip]);
+    return std::move(__a.__elems_[_Ip]);
 }
 
 template <size_t _Ip, class _Tp, size_t _Size>
@@ -497,7 +497,7 @@ const _Tp&&
 get(const array<_Tp, _Size>&& __a) _NOEXCEPT
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (const std::array &&)");
-    return _VSTD::move(__a.__elems_[_Ip]);
+    return std::move(__a.__elems_[_Ip]);
 }
 
 #if _LIBCPP_STD_VER >= 20
@@ -511,7 +511,7 @@ __to_array_lvalue_impl(_Tp (&__arr)[_Size], index_sequence<_Index...>) {
 template <typename _Tp, size_t _Size, size_t... _Index>
 _LIBCPP_HIDE_FROM_ABI constexpr array<remove_cv_t<_Tp>, _Size>
 __to_array_rvalue_impl(_Tp(&&__arr)[_Size], index_sequence<_Index...>) {
-  return {{_VSTD::move(__arr[_Index])...}};
+  return {{std::move(__arr[_Index])...}};
 }
 
 template <typename _Tp, size_t _Size>
@@ -523,7 +523,7 @@ to_array(_Tp (&__arr)[_Size]) noexcept(is_nothrow_constructible_v<_Tp, _Tp&>) {
   static_assert(
       is_constructible_v<_Tp, _Tp&>,
       "[array.creation]/1: to_array requires copy constructible elements.");
-  return _VSTD::__to_array_lvalue_impl(__arr, make_index_sequence<_Size>());
+  return std::__to_array_lvalue_impl(__arr, make_index_sequence<_Size>());
 }
 
 template <typename _Tp, size_t _Size>
@@ -535,7 +535,7 @@ to_array(_Tp(&&__arr)[_Size]) noexcept(is_nothrow_move_constructible_v<_Tp>) {
   static_assert(
       is_move_constructible_v<_Tp>,
       "[array.creation]/4: to_array requires move constructible elements.");
-  return _VSTD::__to_array_rvalue_impl(_VSTD::move(__arr),
+  return std::__to_array_rvalue_impl(std::move(__arr),
                                        make_index_sequence<_Size>());
 }
 

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -310,7 +310,7 @@ public:
 
     _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI
     explicit barrier(ptrdiff_t __count, _CompletionF __completion = _CompletionF())
-        : __b_(__count, _VSTD::move(__completion)) {
+        : __b_(__count, std::move(__completion)) {
         _LIBCPP_ASSERT_UNCATEGORIZED(
             __count >= 0,
             "barrier::barrier(ptrdiff_t, CompletionFunction): barrier cannot be initialized with a negative value");
@@ -332,7 +332,7 @@ public:
     _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI
     void wait(arrival_token&& __phase) const
     {
-        __b_.wait(_VSTD::move(__phase));
+        __b_.wait(std::move(__phase));
     }
     _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI
     void arrive_and_wait()

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -252,7 +252,7 @@ __bitset<_N_words, _Size>::__bitset() _NOEXCEPT
 #endif
 {
 #ifdef _LIBCPP_CXX03_LANG
-    _VSTD::fill_n(__first_, _N_words, __storage_type(0));
+    std::fill_n(__first_, _N_words, __storage_type(0));
 #endif
 }
 
@@ -270,8 +270,8 @@ __bitset<_N_words, _Size>::__init(unsigned long long __v, false_type) _NOEXCEPT
         else
             __t[__i] = static_cast<__storage_type>(__v);
 
-    _VSTD::copy(__t, __t + sizeof(__t)/sizeof(__t[0]), __first_);
-    _VSTD::fill(__first_ + sizeof(__t)/sizeof(__t[0]), __first_ + sizeof(__first_)/sizeof(__first_[0]),
+    std::copy(__t, __t + sizeof(__t)/sizeof(__t[0]), __first_);
+    std::fill(__first_ + sizeof(__t)/sizeof(__t[0]), __first_ + sizeof(__first_)/sizeof(__first_[0]),
                __storage_type(0));
 }
 
@@ -284,7 +284,7 @@ __bitset<_N_words, _Size>::__init(unsigned long long __v, true_type) _NOEXCEPT
     if (_Size < __bits_per_word)
         __first_[0] &= ( 1ULL << _Size ) - 1;
 
-    _VSTD::fill(__first_ + 1, __first_ + sizeof(__first_)/sizeof(__first_[0]), __storage_type(0));
+    std::fill(__first_ + 1, __first_ + sizeof(__first_)/sizeof(__first_[0]), __storage_type(0));
 }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -361,7 +361,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long
 __bitset<_N_words, _Size>::to_ulong(false_type) const
 {
     const_iterator __e = __make_iter(_Size);
-    const_iterator __i = _VSTD::find(__make_iter(sizeof(unsigned long) * CHAR_BIT), __e, true);
+    const_iterator __i = std::find(__make_iter(sizeof(unsigned long) * CHAR_BIT), __e, true);
     if (__i != __e)
         __throw_overflow_error("bitset to_ulong overflow error");
 
@@ -381,7 +381,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long long
 __bitset<_N_words, _Size>::to_ullong(false_type) const
 {
     const_iterator __e = __make_iter(_Size);
-    const_iterator __i = _VSTD::find(__make_iter(sizeof(unsigned long long) * CHAR_BIT), __e, true);
+    const_iterator __i = std::find(__make_iter(sizeof(unsigned long long) * CHAR_BIT), __e, true);
     if (__i != __e)
         __throw_overflow_error("bitset to_ullong overflow error");
 
@@ -884,9 +884,9 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
 bitset<_Size>&
 bitset<_Size>::operator<<=(size_t __pos) _NOEXCEPT
 {
-    __pos = _VSTD::min(__pos, _Size);
-    _VSTD::copy_backward(base::__make_iter(0), base::__make_iter(_Size - __pos), base::__make_iter(_Size));
-    _VSTD::fill_n(base::__make_iter(0), __pos, false);
+    __pos = std::min(__pos, _Size);
+    std::copy_backward(base::__make_iter(0), base::__make_iter(_Size - __pos), base::__make_iter(_Size));
+    std::fill_n(base::__make_iter(0), __pos, false);
     return *this;
 }
 
@@ -895,9 +895,9 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
 bitset<_Size>&
 bitset<_Size>::operator>>=(size_t __pos) _NOEXCEPT
 {
-    __pos = _VSTD::min(__pos, _Size);
-    _VSTD::copy(base::__make_iter(__pos), base::__make_iter(_Size), base::__make_iter(0));
-    _VSTD::fill_n(base::__make_iter(_Size - __pos), __pos, false);
+    __pos = std::min(__pos, _Size);
+    std::copy(base::__make_iter(__pos), base::__make_iter(_Size), base::__make_iter(0));
+    std::fill_n(base::__make_iter(_Size - __pos), __pos, false);
     return *this;
 }
 
@@ -907,7 +907,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
 bitset<_Size>&
 bitset<_Size>::set() _NOEXCEPT
 {
-    _VSTD::fill_n(base::__make_iter(0), _Size, true);
+    std::fill_n(base::__make_iter(0), _Size, true);
     return *this;
 }
 
@@ -929,7 +929,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
 bitset<_Size>&
 bitset<_Size>::reset() _NOEXCEPT
 {
-    _VSTD::fill_n(base::__make_iter(0), _Size, false);
+    std::fill_n(base::__make_iter(0), _Size, false);
     return *this;
 }
 
@@ -1056,7 +1056,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
 bool
 bitset<_Size>::operator==(const bitset& __rhs) const _NOEXCEPT
 {
-    return _VSTD::equal(base::__make_iter(0), base::__make_iter(_Size), __rhs.__make_iter(0));
+    return std::equal(base::__make_iter(0), base::__make_iter(_Size), __rhs.__make_iter(0));
 }
 
 #if _LIBCPP_STD_VER <= 17

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1150,7 +1150,7 @@ complex<typename __promote<_Tp, _Up>::type>
 pow(const complex<_Tp>& __x, const complex<_Up>& __y)
 {
     typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-    return _VSTD::pow(result_type(__x), result_type(__y));
+    return std::pow(result_type(__x), result_type(__y));
 }
 
 template<class _Tp, class _Up, __enable_if_t<is_arithmetic<_Up>::value, int> = 0>
@@ -1159,7 +1159,7 @@ complex<typename __promote<_Tp, _Up>::type>
 pow(const complex<_Tp>& __x, const _Up& __y)
 {
     typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-    return _VSTD::pow(result_type(__x), result_type(__y));
+    return std::pow(result_type(__x), result_type(__y));
 }
 
 template<class _Tp, class _Up, __enable_if_t<is_arithmetic<_Tp>::value, int> = 0>
@@ -1168,7 +1168,7 @@ complex<typename __promote<_Tp, _Up>::type>
 pow(const _Tp& __x, const complex<_Up>& __y)
 {
     typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-    return _VSTD::pow(result_type(__x), result_type(__y));
+    return std::pow(result_type(__x), result_type(__y));
 }
 
 // __sqr, computes pow(x, 2)

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -295,7 +295,7 @@ condition_variable_any::wait_for(_Lock& __lock,
                                  _Predicate __pred)
 {
     return wait_until(__lock, chrono::steady_clock::now() + __d,
-                      _VSTD::move(__pred));
+                      std::move(__pred));
 }
 
 #if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN)

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -750,7 +750,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     size_type max_size() const _NOEXCEPT
-        {return _VSTD::min<size_type>(
+        {return std::min<size_type>(
             __alloc_traits::max_size(__alloc()),
             numeric_limits<difference_type>::max());}
     _LIBCPP_HIDE_FROM_ABI void resize(size_type __n);
@@ -894,7 +894,7 @@ public:
     void __move_assign_alloc(deque& __c, true_type)
         _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
         {
-            __alloc() = _VSTD::move(__c.__alloc());
+            __alloc() = std::move(__c.__alloc());
         }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -906,7 +906,7 @@ public:
         _NOEXCEPT_(__alloc_traits::propagate_on_container_move_assignment::value &&
                    is_nothrow_move_assignable<allocator_type>::value)
     {
-        __map_ = _VSTD::move(__c.__map_);
+        __map_ = std::move(__c.__map_);
         __start_ = __c.__start_;
         __size() = __c.size();
         __move_assign_alloc(__c);
@@ -1405,7 +1405,7 @@ template <class _Tp, class _Allocator>
 deque<_Tp, _Allocator>&
 deque<_Tp, _Allocator>::operator=(const deque& __c)
 {
-    if (this != _VSTD::addressof(__c))
+    if (this != std::addressof(__c))
     {
         __copy_assign_alloc(__c);
         assign(__c.begin(), __c.end());
@@ -1570,12 +1570,12 @@ deque<_Tp, _Allocator>::assign(size_type __n, const value_type& __v)
 {
     if (__n > size())
     {
-        _VSTD::fill_n(begin(), size(), __v);
+        std::fill_n(begin(), size(), __v);
         __n -= size();
         __append(__n, __v);
     }
     else
-        __erase_to_end(_VSTD::fill_n(begin(), __n, __v));
+        __erase_to_end(std::fill_n(begin(), __n, __v));
 }
 
 template <class _Tp, class _Allocator>
@@ -1653,7 +1653,7 @@ typename deque<_Tp, _Allocator>::reference
 deque<_Tp, _Allocator>::at(size_type __i)
 {
     if (__i >= size())
-        _VSTD::__throw_out_of_range("deque");
+        std::__throw_out_of_range("deque");
     size_type __p = __start_ + __i;
     return *(*(__map_.begin() + __p / __block_size) + __p % __block_size);
 }
@@ -1664,7 +1664,7 @@ typename deque<_Tp, _Allocator>::const_reference
 deque<_Tp, _Allocator>::at(size_type __i) const
 {
     if (__i >= size())
-        _VSTD::__throw_out_of_range("deque");
+        std::__throw_out_of_range("deque");
     size_type __p = __start_ + __i;
     return *(*(__map_.begin() + __p / __block_size) + __p % __block_size);
 }
@@ -1714,7 +1714,7 @@ deque<_Tp, _Allocator>::push_back(const value_type& __v)
         __add_back_capacity();
     // __back_spare() >= 1
     __annotate_increase_back(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*end()), __v);
+    __alloc_traits::construct(__a, std::addressof(*end()), __v);
     ++__size();
 }
 
@@ -1727,7 +1727,7 @@ deque<_Tp, _Allocator>::push_front(const value_type& __v)
         __add_front_capacity();
     // __front_spare() >= 1
     __annotate_increase_front(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), __v);
+    __alloc_traits::construct(__a, std::addressof(*--begin()), __v);
     --__start_;
     ++__size();
 }
@@ -1742,7 +1742,7 @@ deque<_Tp, _Allocator>::push_back(value_type&& __v)
         __add_back_capacity();
     // __back_spare() >= 1
     __annotate_increase_back(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*end()), _VSTD::move(__v));
+    __alloc_traits::construct(__a, std::addressof(*end()), std::move(__v));
     ++__size();
 }
 
@@ -1760,8 +1760,8 @@ deque<_Tp, _Allocator>::emplace_back(_Args&&... __args)
         __add_back_capacity();
     // __back_spare() >= 1
     __annotate_increase_back(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*end()),
-                              _VSTD::forward<_Args>(__args)...);
+    __alloc_traits::construct(__a, std::addressof(*end()),
+                              std::forward<_Args>(__args)...);
     ++__size();
 #if _LIBCPP_STD_VER >= 17
     return *--end();
@@ -1777,7 +1777,7 @@ deque<_Tp, _Allocator>::push_front(value_type&& __v)
         __add_front_capacity();
     // __front_spare() >= 1
     __annotate_increase_front(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), _VSTD::move(__v));
+    __alloc_traits::construct(__a, std::addressof(*--begin()), std::move(__v));
     --__start_;
     ++__size();
 }
@@ -1797,7 +1797,7 @@ deque<_Tp, _Allocator>::emplace_front(_Args&&... __args)
         __add_front_capacity();
     // __front_spare() >= 1
     __annotate_increase_front(1);
-    __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), _VSTD::forward<_Args>(__args)...);
+    __alloc_traits::construct(__a, std::addressof(*--begin()), std::forward<_Args>(__args)...);
     --__start_;
     ++__size();
 #if _LIBCPP_STD_VER >= 17
@@ -1820,20 +1820,20 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, value_type&& __v)
         __annotate_increase_front(1);
         if (__pos == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), _VSTD::move(__v));
+            __alloc_traits::construct(__a, std::addressof(*--begin()), std::move(__v));
             --__start_;
             ++__size();
         }
         else
         {
             iterator __b = begin();
-            iterator __bm1 = _VSTD::prev(__b);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__bm1), _VSTD::move(*__b));
+            iterator __bm1 = std::prev(__b);
+            __alloc_traits::construct(__a, std::addressof(*__bm1), std::move(*__b));
             --__start_;
             ++__size();
             if (__pos > 1)
-                __b = _VSTD::move(_VSTD::next(__b), __b + __pos, __b);
-            *__b = _VSTD::move(__v);
+                __b = std::move(std::next(__b), __b + __pos, __b);
+            *__b = std::move(__v);
         }
     }
     else
@@ -1845,18 +1845,18 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, value_type&& __v)
         size_type __de = size() - __pos;
         if (__de == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*end()), _VSTD::move(__v));
+            __alloc_traits::construct(__a, std::addressof(*end()), std::move(__v));
             ++__size();
         }
         else
         {
             iterator __e = end();
-            iterator __em1 = _VSTD::prev(__e);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__e), _VSTD::move(*__em1));
+            iterator __em1 = std::prev(__e);
+            __alloc_traits::construct(__a, std::addressof(*__e), std::move(*__em1));
             ++__size();
             if (__de > 1)
-                __e = _VSTD::move_backward(__e - __de, __em1, __e);
-            *--__e = _VSTD::move(__v);
+                __e = std::move_backward(__e - __de, __em1, __e);
+            *--__e = std::move(__v);
         }
     }
     return begin() + __pos;
@@ -1878,21 +1878,21 @@ deque<_Tp, _Allocator>::emplace(const_iterator __p, _Args&&... __args)
         __annotate_increase_front(1);
         if (__pos == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), _VSTD::forward<_Args>(__args)...);
+            __alloc_traits::construct(__a, std::addressof(*--begin()), std::forward<_Args>(__args)...);
             --__start_;
             ++__size();
         }
         else
         {
-            __temp_value<value_type, _Allocator> __tmp(__alloc(), _VSTD::forward<_Args>(__args)...);
+            __temp_value<value_type, _Allocator> __tmp(__alloc(), std::forward<_Args>(__args)...);
             iterator __b = begin();
-            iterator __bm1 = _VSTD::prev(__b);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__bm1), _VSTD::move(*__b));
+            iterator __bm1 = std::prev(__b);
+            __alloc_traits::construct(__a, std::addressof(*__bm1), std::move(*__b));
             --__start_;
             ++__size();
             if (__pos > 1)
-                __b = _VSTD::move(_VSTD::next(__b), __b + __pos, __b);
-            *__b = _VSTD::move(__tmp.get());
+                __b = std::move(std::next(__b), __b + __pos, __b);
+            *__b = std::move(__tmp.get());
         }
     }
     else
@@ -1904,19 +1904,19 @@ deque<_Tp, _Allocator>::emplace(const_iterator __p, _Args&&... __args)
         size_type __de = size() - __pos;
         if (__de == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*end()), _VSTD::forward<_Args>(__args)...);
+            __alloc_traits::construct(__a, std::addressof(*end()), std::forward<_Args>(__args)...);
             ++__size();
         }
         else
         {
-            __temp_value<value_type, _Allocator> __tmp(__alloc(), _VSTD::forward<_Args>(__args)...);
+            __temp_value<value_type, _Allocator> __tmp(__alloc(), std::forward<_Args>(__args)...);
             iterator __e = end();
-            iterator __em1 = _VSTD::prev(__e);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__e), _VSTD::move(*__em1));
+            iterator __em1 = std::prev(__e);
+            __alloc_traits::construct(__a, std::addressof(*__e), std::move(*__em1));
             ++__size();
             if (__de > 1)
-                __e = _VSTD::move_backward(__e - __de, __em1, __e);
-            *--__e = _VSTD::move(__tmp.get());
+                __e = std::move_backward(__e - __de, __em1, __e);
+            *--__e = std::move(__tmp.get());
         }
     }
     return begin() + __pos;
@@ -1940,7 +1940,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, const value_type& __v)
         __annotate_increase_front(1);
         if (__pos == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*--begin()), __v);
+            __alloc_traits::construct(__a, std::addressof(*--begin()), __v);
             --__start_;
             ++__size();
         }
@@ -1948,14 +1948,14 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, const value_type& __v)
         {
             const_pointer __vt = pointer_traits<const_pointer>::pointer_to(__v);
             iterator __b = begin();
-            iterator __bm1 = _VSTD::prev(__b);
+            iterator __bm1 = std::prev(__b);
             if (__vt == pointer_traits<const_pointer>::pointer_to(*__b))
                 __vt = pointer_traits<const_pointer>::pointer_to(*__bm1);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__bm1), _VSTD::move(*__b));
+            __alloc_traits::construct(__a, std::addressof(*__bm1), std::move(*__b));
             --__start_;
             ++__size();
             if (__pos > 1)
-                __b = __move_and_check(_VSTD::next(__b), __b + __pos, __b, __vt);
+                __b = __move_and_check(std::next(__b), __b + __pos, __b, __vt);
             *__b = *__vt;
         }
     }
@@ -1968,17 +1968,17 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, const value_type& __v)
         size_type __de = size() - __pos;
         if (__de == 0)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*end()), __v);
+            __alloc_traits::construct(__a, std::addressof(*end()), __v);
             ++__size();
         }
         else
         {
             const_pointer __vt = pointer_traits<const_pointer>::pointer_to(__v);
             iterator __e = end();
-            iterator __em1 = _VSTD::prev(__e);
+            iterator __em1 = std::prev(__e);
             if (__vt == pointer_traits<const_pointer>::pointer_to(*__em1))
                 __vt = pointer_traits<const_pointer>::pointer_to(*__e);
-            __alloc_traits::construct(__a, _VSTD::addressof(*__e), _VSTD::move(*__em1));
+            __alloc_traits::construct(__a, std::addressof(*__e), std::move(*__em1));
             ++__size();
             if (__de > 1)
                 __e = __move_backward_and_check(__e - __de, __em1, __e, __vt);
@@ -2006,7 +2006,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, size_type __n, const value_ty
         if (__n > __pos)
         {
             for (size_type __m = __n - __pos; __m; --__m, --__start_, ++__size())
-                __alloc_traits::construct(__a, _VSTD::addressof(*--__i), __v);
+                __alloc_traits::construct(__a, std::addressof(*--__i), __v);
             __n = __pos;
         }
         if (__n > 0)
@@ -2016,7 +2016,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, size_type __n, const value_ty
             __move_construct_backward_and_check(__old_begin, __obn, __i, __vt);
             if (__n < __pos)
                 __old_begin = __move_and_check(__obn, __old_begin + __pos, __old_begin, __vt);
-            _VSTD::fill_n(__old_begin, __n, *__vt);
+            std::fill_n(__old_begin, __n, *__vt);
         }
     }
     else
@@ -2032,7 +2032,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, size_type __n, const value_ty
         if (__n > __de)
         {
             for (size_type __m = __n - __de; __m; --__m, (void) ++__i, ++__size())
-                __alloc_traits::construct(__a, _VSTD::addressof(*__i), __v);
+                __alloc_traits::construct(__a, std::addressof(*__i), __v);
             __n = __de;
         }
         if (__n > 0)
@@ -2042,7 +2042,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, size_type __n, const value_ty
             __move_construct_and_check(__oen, __old_end, __i, __vt);
             if (__n < __de)
                 __old_end = __move_backward_and_check(__old_end - __de, __oen, __old_end, __vt);
-            _VSTD::fill_n(__old_end - __n, __n, *__vt);
+            std::fill_n(__old_end - __n, __n, *__vt);
         }
     }
     return begin() + __pos;
@@ -2121,9 +2121,9 @@ deque<_Tp, _Allocator>::__insert_bidirectional(const_iterator __p, _BiIter __f, 
         _BiIter __m = __f;
         if (__n > __pos)
         {
-            __m = __pos < __n / 2 ? _VSTD::prev(__l, __pos) : _VSTD::next(__f, __n - __pos);
+            __m = __pos < __n / 2 ? std::prev(__l, __pos) : std::next(__f, __n - __pos);
             for (_BiIter __j = __m; __j != __f; --__start_, ++__size())
-                __alloc_traits::construct(__a, _VSTD::addressof(*--__i), *--__j);
+                __alloc_traits::construct(__a, std::addressof(*--__i), *--__j);
             __n = __pos;
         }
         if (__n > 0)
@@ -2131,13 +2131,13 @@ deque<_Tp, _Allocator>::__insert_bidirectional(const_iterator __p, _BiIter __f, 
             iterator __obn = __old_begin + __n;
             for (iterator __j = __obn; __j != __old_begin;)
             {
-                __alloc_traits::construct(__a, _VSTD::addressof(*--__i), _VSTD::move(*--__j));
+                __alloc_traits::construct(__a, std::addressof(*--__i), std::move(*--__j));
                 --__start_;
                 ++__size();
             }
             if (__n < __pos)
-                __old_begin = _VSTD::move(__obn, __old_begin + __pos, __old_begin);
-            _VSTD::copy(__m, __l, __old_begin);
+                __old_begin = std::move(__obn, __old_begin + __pos, __old_begin);
+            std::copy(__m, __l, __old_begin);
         }
     }
     else
@@ -2153,19 +2153,19 @@ deque<_Tp, _Allocator>::__insert_bidirectional(const_iterator __p, _BiIter __f, 
         size_type __de = size() - __pos;
         if (__n > __de)
         {
-            __m = __de < __n / 2 ? _VSTD::next(__f, __de) : _VSTD::prev(__l, __n - __de);
+            __m = __de < __n / 2 ? std::next(__f, __de) : std::prev(__l, __n - __de);
             for (_BiIter __j = __m; __j != __l; ++__i, (void) ++__j, ++__size())
-                __alloc_traits::construct(__a, _VSTD::addressof(*__i), *__j);
+                __alloc_traits::construct(__a, std::addressof(*__i), *__j);
             __n = __de;
         }
         if (__n > 0)
         {
             iterator __oen = __old_end - __n;
             for (iterator __j = __oen; __j != __old_end; ++__i, (void) ++__j, ++__size())
-                __alloc_traits::construct(__a, _VSTD::addressof(*__i), _VSTD::move(*__j));
+                __alloc_traits::construct(__a, std::addressof(*__i), std::move(*__j));
             if (__n < __de)
-                __old_end = _VSTD::move_backward(__old_end - __de, __oen, __old_end);
-            _VSTD::copy_backward(__f, __m, __old_end);
+                __old_end = std::move_backward(__old_end - __de, __oen, __old_end);
+            std::copy_backward(__f, __m, __old_end);
         }
     }
     return begin() + __pos;
@@ -2213,7 +2213,7 @@ void deque<_Tp, _Allocator>::__append_with_size(_InputIterator __f, size_type __
     for (__deque_block_range __br : __deque_range(end(), end() + __n)) {
       _ConstructTransaction __tx(this, __br);
       for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_, (void)++__f) {
-        __alloc_traits::construct(__a, _VSTD::__to_address(__tx.__pos_), *__f);
+        __alloc_traits::construct(__a, std::__to_address(__tx.__pos_), *__f);
       }
     }
 }
@@ -2231,7 +2231,7 @@ deque<_Tp, _Allocator>::__append(size_type __n)
     for (__deque_block_range __br : __deque_range(end(), end() + __n)) {
       _ConstructTransaction __tx(this, __br);
       for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
-        __alloc_traits::construct(__a, _VSTD::__to_address(__tx.__pos_));
+        __alloc_traits::construct(__a, std::__to_address(__tx.__pos_));
       }
     }
 }
@@ -2249,7 +2249,7 @@ deque<_Tp, _Allocator>::__append(size_type __n, const value_type& __v)
     for (__deque_block_range __br : __deque_range(end(), end() + __n)) {
       _ConstructTransaction __tx(this, __br);
       for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
-        __alloc_traits::construct(__a, _VSTD::__to_address(__tx.__pos_), __v);
+        __alloc_traits::construct(__a, std::__to_address(__tx.__pos_), __v);
       }
     }
 
@@ -2305,10 +2305,10 @@ deque<_Tp, _Allocator>::__add_front_capacity()
         for (__map_pointer __i = __map_.begin();
                 __i != __map_.end(); ++__i)
             __buf.push_back(*__i);
-        _VSTD::swap(__map_.__first_, __buf.__first_);
-        _VSTD::swap(__map_.__begin_, __buf.__begin_);
-        _VSTD::swap(__map_.__end_, __buf.__end_);
-        _VSTD::swap(__map_.__end_cap(), __buf.__end_cap());
+        std::swap(__map_.__first_, __buf.__first_);
+        std::swap(__map_.__begin_, __buf.__begin_);
+        std::swap(__map_.__end_, __buf.__end_);
+        std::swap(__map_.__end_cap(), __buf.__end_cap());
         __start_ = __map_.size() == 1 ?
                                __block_size / 2 :
                                __start_ + __block_size;
@@ -2326,7 +2326,7 @@ deque<_Tp, _Allocator>::__add_front_capacity(size_type __n)
     size_type __nb = __recommend_blocks(__n + __map_.empty());
     // Number of unused blocks at back:
     size_type __back_capacity = __back_spare() / __block_size;
-    __back_capacity = _VSTD::min(__back_capacity, __nb);  // don't take more than you need
+    __back_capacity = std::min(__back_capacity, __nb);  // don't take more than you need
     __nb -= __back_capacity;  // number of blocks need to allocate
     // If __nb == 0, then we have sufficient capacity.
     if (__nb == 0)
@@ -2401,10 +2401,10 @@ deque<_Tp, _Allocator>::__add_front_capacity(size_type __n)
         for (__map_pointer __i = __map_.begin();
                 __i != __map_.end(); ++__i)
             __buf.push_back(*__i);
-        _VSTD::swap(__map_.__first_, __buf.__first_);
-        _VSTD::swap(__map_.__begin_, __buf.__begin_);
-        _VSTD::swap(__map_.__end_, __buf.__end_);
-        _VSTD::swap(__map_.__end_cap(), __buf.__end_cap());
+        std::swap(__map_.__first_, __buf.__first_);
+        std::swap(__map_.__begin_, __buf.__begin_);
+        std::swap(__map_.__end_, __buf.__end_);
+        std::swap(__map_.__end_cap(), __buf.__end_cap());
         __start_ += __ds;
     }
 }
@@ -2458,10 +2458,10 @@ deque<_Tp, _Allocator>::__add_back_capacity()
         for (__map_pointer __i = __map_.end();
                 __i != __map_.begin();)
             __buf.push_front(*--__i);
-        _VSTD::swap(__map_.__first_, __buf.__first_);
-        _VSTD::swap(__map_.__begin_, __buf.__begin_);
-        _VSTD::swap(__map_.__end_, __buf.__end_);
-        _VSTD::swap(__map_.__end_cap(), __buf.__end_cap());
+        std::swap(__map_.__first_, __buf.__first_);
+        std::swap(__map_.__begin_, __buf.__begin_);
+        std::swap(__map_.__end_, __buf.__end_);
+        std::swap(__map_.__end_cap(), __buf.__end_cap());
         __annotate_whole_block(__map_.size() - 1, __asan_poison);
     }
 }
@@ -2476,7 +2476,7 @@ deque<_Tp, _Allocator>::__add_back_capacity(size_type __n)
     size_type __nb = __recommend_blocks(__n + __map_.empty());
     // Number of unused blocks at front:
     size_type __front_capacity = __front_spare() / __block_size;
-    __front_capacity = _VSTD::min(__front_capacity, __nb);  // don't take more than you need
+    __front_capacity = std::min(__front_capacity, __nb);  // don't take more than you need
     __nb -= __front_capacity;  // number of blocks need to allocate
     // If __nb == 0, then we have sufficient capacity.
     if (__nb == 0)
@@ -2554,10 +2554,10 @@ deque<_Tp, _Allocator>::__add_back_capacity(size_type __n)
         for (__map_pointer __i = __map_.end();
                 __i != __map_.begin();)
             __buf.push_front(*--__i);
-        _VSTD::swap(__map_.__first_, __buf.__first_);
-        _VSTD::swap(__map_.__begin_, __buf.__begin_);
-        _VSTD::swap(__map_.__end_, __buf.__end_);
-        _VSTD::swap(__map_.__end_cap(), __buf.__end_cap());
+        std::swap(__map_.__first_, __buf.__first_);
+        std::swap(__map_.__begin_, __buf.__begin_);
+        std::swap(__map_.__end_, __buf.__end_);
+        std::swap(__map_.__end_cap(), __buf.__end_cap());
         __start_ -= __ds;
     }
 }
@@ -2569,7 +2569,7 @@ deque<_Tp, _Allocator>::pop_front()
     size_type __old_sz    = size();
     size_type __old_start = __start_;
     allocator_type& __a = __alloc();
-    __alloc_traits::destroy(__a, _VSTD::__to_address(*(__map_.begin() +
+    __alloc_traits::destroy(__a, std::__to_address(*(__map_.begin() +
                                                     __start_ / __block_size) +
                                                     __start_ % __block_size));
     --__size();
@@ -2587,7 +2587,7 @@ deque<_Tp, _Allocator>::pop_back()
     size_type __old_start = __start_;
     allocator_type& __a = __alloc();
     size_type __p = size() + __start_ - 1;
-    __alloc_traits::destroy(__a, _VSTD::__to_address(*(__map_.begin() +
+    __alloc_traits::destroy(__a, std::__to_address(*(__map_.begin() +
                                                     __p / __block_size) +
                                                     __p % __block_size));
     --__size();
@@ -2604,7 +2604,7 @@ deque<_Tp, _Allocator>::__move_and_check(iterator __f, iterator __l, iterator __
 {
     // as if
     //   for (; __f != __l; ++__f, ++__r)
-    //       *__r = _VSTD::move(*__f);
+    //       *__r = std::move(*__f);
     difference_type __n = __l - __f;
     while (__n > 0)
     {
@@ -2618,7 +2618,7 @@ deque<_Tp, _Allocator>::__move_and_check(iterator __f, iterator __l, iterator __
         }
         if (__fb <= __vt && __vt < __fe)
             __vt = (const_iterator(static_cast<__map_const_pointer>(__f.__m_iter_), __vt) -= __f - __r).__ptr_;
-        __r = _VSTD::move(__fb, __fe, __r);
+        __r = std::move(__fb, __fe, __r);
         __n -= __bs;
         __f += __bs;
     }
@@ -2634,7 +2634,7 @@ deque<_Tp, _Allocator>::__move_backward_and_check(iterator __f, iterator __l, it
 {
     // as if
     //   while (__f != __l)
-    //       *--__r = _VSTD::move(*--__l);
+    //       *--__r = std::move(*--__l);
     difference_type __n = __l - __f;
     while (__n > 0)
     {
@@ -2649,7 +2649,7 @@ deque<_Tp, _Allocator>::__move_backward_and_check(iterator __f, iterator __l, it
         }
         if (__lb <= __vt && __vt < __le)
             __vt = (const_iterator(static_cast<__map_const_pointer>(__l.__m_iter_), __vt) += __r - __l - 1).__ptr_;
-        __r = _VSTD::move_backward(__lb, __le, __r);
+        __r = std::move_backward(__lb, __le, __r);
         __n -= __bs;
         __l -= __bs - 1;
     }
@@ -2666,7 +2666,7 @@ deque<_Tp, _Allocator>::__move_construct_and_check(iterator __f, iterator __l,
     allocator_type& __a = __alloc();
     // as if
     //   for (; __f != __l; ++__r, ++__f, ++__size())
-    //       __alloc_traits::construct(__a, _VSTD::addressof(*__r), _VSTD::move(*__f));
+    //       __alloc_traits::construct(__a, std::addressof(*__r), std::move(*__f));
     difference_type __n = __l - __f;
     while (__n > 0)
     {
@@ -2681,7 +2681,7 @@ deque<_Tp, _Allocator>::__move_construct_and_check(iterator __f, iterator __l,
         if (__fb <= __vt && __vt < __fe)
             __vt = (const_iterator(static_cast<__map_const_pointer>(__f.__m_iter_), __vt) += __r - __f).__ptr_;
         for (; __fb != __fe; ++__fb, ++__r, ++__size())
-            __alloc_traits::construct(__a, _VSTD::addressof(*__r), _VSTD::move(*__fb));
+            __alloc_traits::construct(__a, std::addressof(*__r), std::move(*__fb));
         __n -= __bs;
         __f += __bs;
     }
@@ -2698,7 +2698,7 @@ deque<_Tp, _Allocator>::__move_construct_backward_and_check(iterator __f, iterat
     // as if
     //   for (iterator __j = __l; __j != __f;)
     //   {
-    //       __alloc_traitsconstruct(__a, _VSTD::addressof(*--__r), _VSTD::move(*--__j));
+    //       __alloc_traitsconstruct(__a, std::addressof(*--__r), std::move(*--__j));
     //       --__start_;
     //       ++__size();
     //   }
@@ -2718,7 +2718,7 @@ deque<_Tp, _Allocator>::__move_construct_backward_and_check(iterator __f, iterat
             __vt = (const_iterator(static_cast<__map_const_pointer>(__l.__m_iter_), __vt) -= __l - __r + 1).__ptr_;
         while (__le != __lb)
         {
-            __alloc_traits::construct(__a, _VSTD::addressof(*--__r), _VSTD::move(*--__le));
+            __alloc_traits::construct(__a, std::addressof(*--__r), std::move(*--__le));
             --__start_;
             ++__size();
         }
@@ -2739,8 +2739,8 @@ deque<_Tp, _Allocator>::erase(const_iterator __f)
     allocator_type& __a = __alloc();
     if (static_cast<size_t>(__pos) <= (size() - 1) / 2)
     {   // erase from front
-        _VSTD::move_backward(__b, __p, _VSTD::next(__p));
-        __alloc_traits::destroy(__a, _VSTD::addressof(*__b));
+        std::move_backward(__b, __p, std::next(__p));
+        __alloc_traits::destroy(__a, std::addressof(*__b));
         --__size();
         ++__start_;
         __annotate_shrink_front(__old_sz, __old_start);
@@ -2748,8 +2748,8 @@ deque<_Tp, _Allocator>::erase(const_iterator __f)
     }
     else
     {   // erase from back
-        iterator __i = _VSTD::move(_VSTD::next(__p), end(), __p);
-        __alloc_traits::destroy(__a, _VSTD::addressof(*__i));
+        iterator __i = std::move(std::next(__p), end(), __p);
+        __alloc_traits::destroy(__a, std::addressof(*__i));
         --__size();
         __annotate_shrink_back(__old_sz, __old_start);
         __maybe_remove_back_spare();
@@ -2772,9 +2772,9 @@ deque<_Tp, _Allocator>::erase(const_iterator __f, const_iterator __l)
         allocator_type& __a = __alloc();
         if (static_cast<size_t>(__pos) <= (size() - __n) / 2)
         {   // erase from front
-            iterator __i = _VSTD::move_backward(__b, __p, __p + __n);
+            iterator __i = std::move_backward(__b, __p, __p + __n);
             for (; __b != __i; ++__b)
-                __alloc_traits::destroy(__a, _VSTD::addressof(*__b));
+                __alloc_traits::destroy(__a, std::addressof(*__b));
             __size() -= __n;
             __start_ += __n;
             __annotate_shrink_front(__old_sz, __old_start);
@@ -2783,9 +2783,9 @@ deque<_Tp, _Allocator>::erase(const_iterator __f, const_iterator __l)
         }
         else
         {   // erase from back
-            iterator __i = _VSTD::move(__p + __n, end(), __p);
+            iterator __i = std::move(__p + __n, end(), __p);
             for (iterator __e = end(); __i != __e; ++__i)
-                __alloc_traits::destroy(__a, _VSTD::addressof(*__i));
+                __alloc_traits::destroy(__a, std::addressof(*__i));
             __size() -= __n;
             __annotate_shrink_back(__old_sz, __old_start);
             while (__maybe_remove_back_spare()) {
@@ -2809,7 +2809,7 @@ deque<_Tp, _Allocator>::__erase_to_end(const_iterator __f)
         iterator __b = begin();
         difference_type __pos = __f - __b;
         for (iterator __p = __b + __pos; __p != __e; ++__p)
-            __alloc_traits::destroy(__a, _VSTD::addressof(*__p));
+            __alloc_traits::destroy(__a, std::addressof(*__p));
         __size() -= __n;
         __annotate_shrink_back(__old_sz, __old_start);
         while (__maybe_remove_back_spare()) {
@@ -2829,9 +2829,9 @@ deque<_Tp, _Allocator>::swap(deque& __c)
 #endif
 {
     __map_.swap(__c.__map_);
-    _VSTD::swap(__start_, __c.__start_);
-    _VSTD::swap(__size(), __c.__size());
-    _VSTD::__swap_allocator(__alloc(), __c.__alloc());
+    std::swap(__start_, __c.__start_);
+    std::swap(__size(), __c.__size());
+    std::__swap_allocator(__alloc(), __c.__alloc());
 }
 
 template <class _Tp, class _Allocator>
@@ -2842,7 +2842,7 @@ deque<_Tp, _Allocator>::clear() _NOEXCEPT
     __annotate_delete();
     allocator_type& __a = __alloc();
     for (iterator __i = begin(), __e = end(); __i != __e; ++__i)
-        __alloc_traits::destroy(__a, _VSTD::addressof(*__i));
+        __alloc_traits::destroy(__a, std::addressof(*__i));
     __size() = 0;
     while (__map_.size() > 2)
     {
@@ -2867,7 +2867,7 @@ bool
 operator==(const deque<_Tp, _Allocator>& __x, const deque<_Tp, _Allocator>& __y)
 {
     const typename deque<_Tp, _Allocator>::size_type __sz = __x.size();
-    return __sz == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __sz == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -2885,7 +2885,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 bool
 operator< (const deque<_Tp, _Allocator>& __x, const deque<_Tp, _Allocator>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Tp, class _Allocator>
@@ -2937,7 +2937,7 @@ template <class _Tp, class _Allocator, class _Up>
 inline _LIBCPP_HIDE_FROM_ABI typename deque<_Tp, _Allocator>::size_type
 erase(deque<_Tp, _Allocator>& __c, const _Up& __v) {
   auto __old_size = __c.size();
-  __c.erase(_VSTD::remove(__c.begin(), __c.end(), __v), __c.end());
+  __c.erase(std::remove(__c.begin(), __c.end(), __v), __c.end());
   return __old_size - __c.size();
 }
 
@@ -2945,7 +2945,7 @@ template <class _Tp, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename deque<_Tp, _Allocator>::size_type
 erase_if(deque<_Tp, _Allocator>& __c, _Predicate __pred) {
   auto __old_size = __c.size();
-  __c.erase(_VSTD::remove_if(__c.begin(), __c.end(), __pred), __c.end());
+  __c.erase(std::remove_if(__c.begin(), __c.end(), __pred), __c.end());
   return __old_size - __c.size();
 }
 

--- a/libcxx/include/experimental/__config
+++ b/libcxx/include/experimental/__config
@@ -18,15 +18,12 @@
 
 #define _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL namespace std { namespace experimental {
 #define _LIBCPP_END_NAMESPACE_EXPERIMENTAL  } }
-#define _VSTD_EXPERIMENTAL std::experimental
 
 #define _LIBCPP_BEGIN_NAMESPACE_LFTS _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v1 {
 #define _LIBCPP_END_NAMESPACE_LFTS  } } }
-#define _VSTD_LFTS _VSTD_EXPERIMENTAL::fundamentals_v1
 
 #define _LIBCPP_BEGIN_NAMESPACE_LFTS_V2 _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v2 {
 #define _LIBCPP_END_NAMESPACE_LFTS_V2  } } }
-#define _VSTD_LFTS_V2 _VSTD_EXPERIMENTAL::fundamentals_v2
 
 // TODO: support more targets
 #if defined(__AVX__)

--- a/libcxx/include/experimental/__memory
+++ b/libcxx/include/experimental/__memory
@@ -85,7 +85,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 0>, _Tp *__storage, const _Allocator &, _Args &&... __args )
 {
-    new (__storage) _Tp (_VSTD::forward<_Args>(__args)...);
+    new (__storage) _Tp (std::forward<_Args>(__args)...);
 }
 
 // FIXME: This should have a version which takes a non-const alloc.
@@ -93,7 +93,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 1>, _Tp *__storage, const _Allocator &__a, _Args &&... __args )
 {
-    new (__storage) _Tp (allocator_arg_t(), __a, _VSTD::forward<_Args>(__args)...);
+    new (__storage) _Tp (allocator_arg_t(), __a, std::forward<_Args>(__args)...);
 }
 
 // FIXME: This should have a version which takes a non-const alloc.
@@ -101,7 +101,7 @@ template <class _Tp, class _Allocator, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 void __user_alloc_construct_impl (integral_constant<int, 2>, _Tp *__storage, const _Allocator &__a, _Args &&... __args )
 {
-    new (__storage) _Tp (_VSTD::forward<_Args>(__args)..., __a);
+    new (__storage) _Tp (std::forward<_Args>(__args)..., __a);
 }
 
 template <class _Tp, class _Alloc, class ..._Args>
@@ -111,7 +111,7 @@ void __lfts_user_alloc_construct(
 {
     ::std::experimental::fundamentals_v1::__user_alloc_construct_impl(
         typename __lfts_uses_alloc_ctor<_Tp, _Alloc, _Args...>::type()
-       , __store, __a, _VSTD::forward<_Args>(__args)...
+       , __store, __a, std::forward<_Args>(__args)...
        );
 }
 

--- a/libcxx/include/experimental/iterator
+++ b/libcxx/include/experimental/iterator
@@ -82,10 +82,10 @@ public:
     typedef void                                 reference;
 
     _LIBCPP_HIDE_FROM_ABI ostream_joiner(ostream_type& __os, _Delim&& __d)
-        : __output_iter_(_VSTD::addressof(__os)), __delim_(_VSTD::move(__d)), __first_(true) {}
+        : __output_iter_(std::addressof(__os)), __delim_(std::move(__d)), __first_(true) {}
 
     _LIBCPP_HIDE_FROM_ABI ostream_joiner(ostream_type& __os, const _Delim& __d)
-        : __output_iter_(_VSTD::addressof(__os)), __delim_(__d), __first_(true) {}
+        : __output_iter_(std::addressof(__os)), __delim_(__d), __first_(true) {}
 
 
     template<typename _Tp>
@@ -112,7 +112,7 @@ private:
 template <class _CharT, class _Traits, class _Delim>
 _LIBCPP_HIDE_FROM_ABI ostream_joiner<__decay_t<_Delim>, _CharT, _Traits>
 make_ostream_joiner(basic_ostream<_CharT, _Traits>& __os, _Delim && __d)
-{ return ostream_joiner<__decay_t<_Delim>, _CharT, _Traits>(__os, _VSTD::forward<_Delim>(__d)); }
+{ return ostream_joiner<__decay_t<_Delim>, _CharT, _Traits>(__os, std::forward<_Delim>(__d)); }
 
 _LIBCPP_END_NAMESPACE_LFTS
 

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -19,8 +19,8 @@
     template <class T> class propagate_const;
 
     // [propagate_const.underlying], underlying pointer access
-    constexpr const _Tp& _VSTD_LFTS_V2::get_underlying(const propagate_const<T>& pt) noexcept;
-    constexpr T& _VSTD_LFTS_V2::get_underlying(propagate_const<T>& pt) noexcept;
+    constexpr const _Tp& get_underlying(const propagate_const<T>& pt) noexcept;
+    constexpr T& get_underlying(propagate_const<T>& pt) noexcept;
 
     // [propagate_const.relational], relational operators
     template <class T> constexpr bool operator==(const propagate_const<T>& pt, nullptr_t);
@@ -93,15 +93,15 @@
   } // namespace experimental
 
   // [propagate_const.hash], hash support
-  template <class T> struct hash<experimental::fundamentals_v2::propagate_const<T>>;
+  template <class T> struct hash<experimental::propagate_const<T>>;
 
   // [propagate_const.comparison_function_objects], comparison function objects
-  template <class T> struct equal_to<experimental::fundamentals_v2::propagate_const<T>>;
-  template <class T> struct not_equal_to<experimental::fundamentals_v2::propagate_const<T>>;
-  template <class T> struct less<experimental::fundamentals_v2::propagate_const<T>>;
-  template <class T> struct greater<experimental::fundamentals_v2::propagate_const<T>>;
-  template <class T> struct less_equal<experimental::fundamentals_v2::propagate_const<T>>;
-  template <class T> struct greater_equal<experimental::fundamentals_v2::propagate_const<T>>;
+  template <class T> struct equal_to<experimental::propagate_const<T>>;
+  template <class T> struct not_equal_to<experimental::propagate_const<T>>;
+  template <class T> struct less<experimental::propagate_const<T>>;
+  template <class T> struct greater<experimental::propagate_const<T>>;
+  template <class T> struct less_equal<experimental::propagate_const<T>>;
+  template <class T> struct greater_equal<experimental::propagate_const<T>>;
 
 } // namespace std
 
@@ -207,8 +207,8 @@ private:
 
 public:
 
-  template <class _Up> friend _LIBCPP_CONSTEXPR const _Up& ::_VSTD_LFTS_V2::get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
-  template <class _Up> friend _LIBCPP_CONSTEXPR _Up& ::_VSTD_LFTS_V2::get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
+  template <class _Up> friend _LIBCPP_CONSTEXPR const _Up& experimental::get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
+  template <class _Up> friend _LIBCPP_CONSTEXPR _Up& experimental::get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR propagate_const() = default;
 
@@ -219,14 +219,14 @@ public:
   template <class _Up, enable_if_t<!is_convertible<_Up, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value,bool> = true>
   explicit _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR propagate_const(propagate_const<_Up>&& __pu)
-      : __t_(std::move(_VSTD_LFTS_V2::get_underlying(__pu)))
+      : __t_(std::move(experimental::get_underlying(__pu)))
   {
   }
 
   template <class _Up, enable_if_t<is_convertible<_Up&&, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value,bool> = false>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR propagate_const(propagate_const<_Up>&& __pu)
-      : __t_(std::move(_VSTD_LFTS_V2::get_underlying(__pu)))
+      : __t_(std::move(experimental::get_underlying(__pu)))
   {
   }
 
@@ -253,7 +253,7 @@ public:
   template <class _Up>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR propagate_const& operator=(propagate_const<_Up>&& __pu)
   {
-    __t_ = std::move(_VSTD_LFTS_V2::get_underlying(__pu));
+    __t_ = std::move(experimental::get_underlying(__pu));
     return *this;
   }
 
@@ -313,7 +313,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR void swap(propagate_const& __pt)
       _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
-    using _VSTD::swap;
+    using std::swap;
     swap(__t_, __pt.__t_);
   }
 };
@@ -323,28 +323,28 @@ template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt, nullptr_t)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) == nullptr;
+  return experimental::get_underlying(__pt) == nullptr;
 }
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator==(nullptr_t, const propagate_const<_Tp>& __pt)
 {
-  return nullptr == _VSTD_LFTS_V2::get_underlying(__pt);
+  return nullptr == experimental::get_underlying(__pt);
 }
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt, nullptr_t)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) != nullptr;
+  return experimental::get_underlying(__pt) != nullptr;
 }
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator!=(nullptr_t, const propagate_const<_Tp>& __pt)
 {
-  return nullptr != _VSTD_LFTS_V2::get_underlying(__pt);
+  return nullptr != experimental::get_underlying(__pt);
 }
 
 template <class _Tp, class _Up>
@@ -352,7 +352,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) == _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) == experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
@@ -360,7 +360,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) != _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) != experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
@@ -368,7 +368,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<(const propagate_const<_Tp>& __pt,
                          const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) < _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) < experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
@@ -376,7 +376,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>(const propagate_const<_Tp>& __pt,
                          const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) > _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) > experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
@@ -384,7 +384,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) <= _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) <= experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
@@ -392,49 +392,49 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) >= _VSTD_LFTS_V2::get_underlying(__pu);
+  return experimental::get_underlying(__pt) >= experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) == __u;
+  return experimental::get_underlying(__pt) == __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) != __u;
+  return experimental::get_underlying(__pt) != __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) < __u;
+  return experimental::get_underlying(__pt) < __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) > __u;
+  return experimental::get_underlying(__pt) > __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) <= __u;
+  return experimental::get_underlying(__pt) <= __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
-  return _VSTD_LFTS_V2::get_underlying(__pt) >= __u;
+  return experimental::get_underlying(__pt) >= __u;
 }
 
 
@@ -442,42 +442,42 @@ template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator==(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t == _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t == experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator!=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t != _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t != experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t < _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t < experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t > _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t > experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator<=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t <= _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t <= experimental::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_CONSTEXPR bool operator>=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
-  return __t >= _VSTD_LFTS_V2::get_underlying(__pu);
+  return __t >= experimental::get_underlying(__pu);
 }
 
 template <class _Tp>
@@ -504,92 +504,92 @@ _LIBCPP_END_NAMESPACE_LFTS_V2
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct hash<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct hash<experimental::propagate_const<_Tp>>
 {
   typedef size_t result_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> argument_type;
+  typedef experimental::propagate_const<_Tp> argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI size_t operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1) const
+  _LIBCPP_HIDE_FROM_ABI size_t operator()(const experimental::propagate_const<_Tp>& __pc1) const
   {
-    return std::hash<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1));
+    return std::hash<_Tp>()(experimental::get_underlying(__pc1));
   }
 };
 
 template <class _Tp>
-struct equal_to<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct equal_to<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::equal_to<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::equal_to<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 
 template <class _Tp>
-struct not_equal_to<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct not_equal_to<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::not_equal_to<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::not_equal_to<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 
 template <class _Tp>
-struct less<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct less<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::less<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::less<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 
 template <class _Tp>
-struct greater<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct greater<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::greater<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::greater<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 
 template <class _Tp>
-struct less_equal<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct less_equal<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::less_equal<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::less_equal<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 
 template <class _Tp>
-struct greater_equal<experimental::fundamentals_v2::propagate_const<_Tp>>
+struct greater_equal<experimental::propagate_const<_Tp>>
 {
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> first_argument_type;
-  typedef experimental::fundamentals_v2::propagate_const<_Tp> second_argument_type;
+  typedef experimental::propagate_const<_Tp> first_argument_type;
+  typedef experimental::propagate_const<_Tp> second_argument_type;
 
-  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::fundamentals_v2::propagate_const<_Tp>& __pc1,
-      const experimental::fundamentals_v2::propagate_const<_Tp>& __pc2) const
+  _LIBCPP_HIDE_FROM_ABI bool operator()(const experimental::propagate_const<_Tp>& __pc1,
+      const experimental::propagate_const<_Tp>& __pc2) const
   {
-    return std::greater_equal<_Tp>()(_VSTD_LFTS_V2::get_underlying(__pc1), _VSTD_LFTS_V2::get_underlying(__pc2));
+    return std::greater_equal<_Tp>()(experimental::get_underlying(__pc1), experimental::get_underlying(__pc2));
   }
 };
 

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -207,8 +207,8 @@ private:
 
 public:
 
-  template <class _Up> friend _LIBCPP_CONSTEXPR const _Up& experimental::get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
-  template <class _Up> friend _LIBCPP_CONSTEXPR _Up& experimental::get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
+  template <class _Up> friend _LIBCPP_CONSTEXPR const _Up& experimental::fundamentals_v2::get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
+  template <class _Up> friend _LIBCPP_CONSTEXPR _Up& experimental::fundamentals_v2::get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR propagate_const() = default;
 

--- a/libcxx/include/ext/hash_map
+++ b/libcxx/include/ext/hash_map
@@ -356,9 +356,9 @@ public:
     void operator()(pointer __p)
     {
         if (__second_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__get_value().second));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__get_value().second));
         if (__first_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__get_value().first));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__get_value().first));
         if (__p)
             __alloc_traits::deallocate(__na_, __p, 1);
     }
@@ -666,9 +666,9 @@ hash_map<_Key, _Tp, _Hash, _Pred, _Alloc>::__construct_node(const key_type& __k)
 {
     __node_allocator& __na = __table_.__node_alloc();
     __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
-    __node_traits::construct(__na, _VSTD::addressof(__h->__get_value().first), __k);
+    __node_traits::construct(__na, std::addressof(__h->__get_value().first), __k);
     __h.get_deleter().__first_constructed = true;
-    __node_traits::construct(__na, _VSTD::addressof(__h->__get_value().second));
+    __node_traits::construct(__na, std::addressof(__h->__get_value().second));
     __h.get_deleter().__second_constructed = true;
     return __h;
 }
@@ -960,9 +960,9 @@ operator==(const hash_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
     {
         _EqRng __xeq = __x.equal_range(__i->first);
         _EqRng __yeq = __y.equal_range(__i->first);
-        if (_VSTD::distance(__xeq.first, __xeq.second) !=
-            _VSTD::distance(__yeq.first, __yeq.second) ||
-                  !_VSTD::is_permutation(__xeq.first, __xeq.second, __yeq.first))
+        if (std::distance(__xeq.first, __xeq.second) !=
+            std::distance(__yeq.first, __yeq.second) ||
+                  !std::is_permutation(__xeq.first, __xeq.second, __yeq.first))
             return false;
         __i = __xeq.second;
     }

--- a/libcxx/include/ext/hash_set
+++ b/libcxx/include/ext/hash_set
@@ -642,9 +642,9 @@ operator==(const hash_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
     {
         _EqRng __xeq = __x.equal_range(*__i);
         _EqRng __yeq = __y.equal_range(*__i);
-        if (_VSTD::distance(__xeq.first, __xeq.second) !=
-            _VSTD::distance(__yeq.first, __yeq.second) ||
-                  !_VSTD::is_permutation(__xeq.first, __xeq.second, __yeq.first))
+        if (std::distance(__xeq.first, __xeq.second) !=
+            std::distance(__yeq.first, __yeq.second) ||
+                  !std::is_permutation(__xeq.first, __xeq.second, __yeq.first))
             return false;
         __i = __xeq.second;
     }

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -649,7 +649,7 @@ private:
     _LIBCPP_HIDE_FROM_ABI
     void __move_assign_alloc(__forward_list_base& __x, true_type)
         _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
-        {__alloc() = _VSTD::move(__x.__alloc());}
+        {__alloc() = std::move(__x.__alloc());}
 };
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -658,7 +658,7 @@ template <class _Tp, class _Alloc>
 inline
 __forward_list_base<_Tp, _Alloc>::__forward_list_base(__forward_list_base&& __x)
         _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value)
-    : __before_begin_(_VSTD::move(__x.__before_begin_))
+    : __before_begin_(std::move(__x.__before_begin_))
 {
     __x.__before_begin()->__next_ = nullptr;
 }
@@ -695,9 +695,9 @@ __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
                     __is_nothrow_swappable<__node_allocator>::value)
 #endif
 {
-    _VSTD::__swap_allocator(__alloc(), __x.__alloc(),
+    std::__swap_allocator(__alloc(), __x.__alloc(),
             integral_constant<bool, __node_traits::propagate_on_container_swap::value>());
-    using _VSTD::swap;
+    using std::swap;
     swap(__before_begin()->__next_, __x.__before_begin()->__next_);
 }
 
@@ -798,7 +798,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     forward_list(forward_list&& __x)
         _NOEXCEPT_(is_nothrow_move_constructible<base>::value)
-        : base(_VSTD::move(__x)) {}
+        : base(std::move(__x)) {}
     _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a);
 
     _LIBCPP_HIDE_FROM_ABI forward_list(initializer_list<value_type> __il);
@@ -872,7 +872,7 @@ public:
         {return base::__before_begin()->__next_ == nullptr;}
     _LIBCPP_HIDE_FROM_ABI
     size_type max_size() const _NOEXCEPT {
-        return _VSTD::min<size_type>(
+        return std::min<size_type>(
             __node_traits::max_size(base::__alloc()),
             numeric_limits<difference_type>::max());
     }
@@ -973,7 +973,7 @@ public:
     template <class _Compare>
         _LIBCPP_HIDE_FROM_ABI
         void merge(forward_list&& __x, _Compare __comp)
-        {merge(__x, _VSTD::move(__comp));}
+        {merge(__x, std::move(__comp));}
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     void merge(forward_list& __x) {merge(__x, __less<>());}
@@ -1116,7 +1116,7 @@ template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>&
 forward_list<_Tp, _Alloc>::operator=(const forward_list& __x)
 {
-    if (this != _VSTD::addressof(__x))
+    if (this != std::addressof(__x))
     {
         base::__copy_assign_alloc(__x);
         assign(__x.begin(), __x.end());
@@ -1128,7 +1128,7 @@ forward_list<_Tp, _Alloc>::operator=(const forward_list& __x)
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(forward_list&& __x,
                                         const __type_identity_t<allocator_type>& __a)
-    : base(_VSTD::move(__x), __a)
+    : base(std::move(__x), __a)
 {
     if (base::__alloc() != __x.__alloc())
     {
@@ -1212,7 +1212,7 @@ template <class _Iter, class _Sent>
 _LIBCPP_HIDE_FROM_ABI
 void forward_list<_Tp, _Alloc>::__assign_with_sentinel(_Iter __f, _Sent __l) {
     iterator __i = before_begin();
-    iterator __j = _VSTD::next(__i);
+    iterator __j = std::next(__i);
     iterator __e = end();
     for (; __j != __e && __f != __l; ++__i, (void) ++__j, ++__f)
         *__j = *__f;
@@ -1227,7 +1227,7 @@ void
 forward_list<_Tp, _Alloc>::assign(size_type __n, const value_type& __v)
 {
     iterator __i = before_begin();
-    iterator __j = _VSTD::next(__i);
+    iterator __j = std::next(__i);
     iterator __e = end();
     for (; __j != __e && __n > 0; --__n, ++__i, ++__j)
         *__j = __v;
@@ -1520,7 +1520,7 @@ forward_list<_Tp, _Alloc>::splice_after(const_iterator __p,
                                         forward_list& /*__other*/,
                                         const_iterator __i)
 {
-    const_iterator __lm1 = _VSTD::next(__i);
+    const_iterator __lm1 = std::next(__i);
     if (__p != __i && __p != __lm1)
     {
         __i.__get_begin()->__next_ = __lm1.__get_begin()->__next_;
@@ -1590,7 +1590,7 @@ forward_list<_Tp, _Alloc>::remove(const value_type& __v)
         if (__i.__get_begin()->__next_->__get_value() == __v)
         {
             ++__count_removed;
-            iterator __j = _VSTD::next(__i, 2);
+            iterator __j = std::next(__i, 2);
             for (; __j != __e && *__j == __v; ++__j)
                 ++__count_removed;
             __deleted_nodes.splice_after(__deleted_nodes.before_begin(), *this, __i, __j);
@@ -1618,7 +1618,7 @@ forward_list<_Tp, _Alloc>::remove_if(_Predicate __pred)
         if (__pred(__i.__get_begin()->__next_->__get_value()))
         {
             ++__count_removed;
-            iterator __j = _VSTD::next(__i, 2);
+            iterator __j = std::next(__i, 2);
             for (; __j != __e && __pred(*__j); ++__j)
                 ++__count_removed;
             __deleted_nodes.splice_after(__deleted_nodes.before_begin(), *this, __i, __j);
@@ -1642,7 +1642,7 @@ forward_list<_Tp, _Alloc>::unique(_BinaryPredicate __binary_pred)
     typename forward_list<_Tp, _Alloc>::size_type __count_removed = 0;
     for (iterator __i = begin(), __e = end(); __i != __e;)
     {
-        iterator __j = _VSTD::next(__i);
+        iterator __j = std::next(__i);
         for (; __j != __e && __binary_pred(*__i, *__j); ++__j)
             ++__count_removed;
         if (__i.__get_begin()->__next_ != __j.__get_unsafe_node_pointer())
@@ -1658,7 +1658,7 @@ template <class _Compare>
 void
 forward_list<_Tp, _Alloc>::merge(forward_list& __x, _Compare __comp)
 {
-    if (this != _VSTD::addressof(__x))
+    if (this != std::addressof(__x))
     {
         base::__before_begin()->__next_ = __merge(base::__before_begin()->__next_,
                                                     __x.__before_begin()->__next_,
@@ -1719,7 +1719,7 @@ void
 forward_list<_Tp, _Alloc>::sort(_Compare __comp)
 {
     base::__before_begin()->__next_ = __sort(base::__before_begin()->__next_,
-                                       _VSTD::distance(begin(), end()), __comp);
+                                       std::distance(begin(), end()), __comp);
 }
 
 template <class _Tp, class _Alloc>
@@ -1745,7 +1745,7 @@ forward_list<_Tp, _Alloc>::__sort(__node_pointer __f1, difference_type __sz,
     }
     difference_type __sz1 = __sz / 2;
     difference_type __sz2 = __sz - __sz1;
-    __node_pointer __t = _VSTD::next(iterator(__f1), __sz1 - 1).__get_unsafe_node_pointer();
+    __node_pointer __t = std::next(iterator(__f1), __sz1 - 1).__get_unsafe_node_pointer();
     __node_pointer __f2 = __t->__next_;
     __t->__next_ = nullptr;
     return __merge(__sort(__f1, __sz1, __comp),
@@ -1804,7 +1804,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 bool operator< (const forward_list<_Tp, _Alloc>& __x,
                 const forward_list<_Tp, _Alloc>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(),
+    return std::lexicographical_compare(__x.begin(), __x.end(),
                                          __y.begin(), __y.end());
 }
 
@@ -1864,7 +1864,7 @@ template <class _Tp, class _Allocator, class _Up>
 inline _LIBCPP_HIDE_FROM_ABI
     typename forward_list<_Tp, _Allocator>::size_type
     erase(forward_list<_Tp, _Allocator>& __c, const _Up& __v) {
-  return _VSTD::erase_if(__c, [&](auto& __elem) { return __elem == __v; });
+  return std::erase_if(__c, [&](auto& __elem) { return __elem == __v; });
 }
 #endif
 

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -456,18 +456,18 @@ basic_filebuf<_CharT, _Traits>::swap(basic_filebuf& __rhs)
         __rhs.__extbufnext_ = __rhs.__extbuf_ + __ln;
         __rhs.__extbufend_ = __rhs.__extbuf_ + __le;
     }
-    _VSTD::swap(__ebs_, __rhs.__ebs_);
-    _VSTD::swap(__intbuf_, __rhs.__intbuf_);
-    _VSTD::swap(__ibs_, __rhs.__ibs_);
-    _VSTD::swap(__file_, __rhs.__file_);
-    _VSTD::swap(__cv_, __rhs.__cv_);
-    _VSTD::swap(__st_, __rhs.__st_);
-    _VSTD::swap(__st_last_, __rhs.__st_last_);
-    _VSTD::swap(__om_, __rhs.__om_);
-    _VSTD::swap(__cm_, __rhs.__cm_);
-    _VSTD::swap(__owns_eb_, __rhs.__owns_eb_);
-    _VSTD::swap(__owns_ib_, __rhs.__owns_ib_);
-    _VSTD::swap(__always_noconv_, __rhs.__always_noconv_);
+    std::swap(__ebs_, __rhs.__ebs_);
+    std::swap(__intbuf_, __rhs.__intbuf_);
+    std::swap(__ibs_, __rhs.__ibs_);
+    std::swap(__file_, __rhs.__file_);
+    std::swap(__cv_, __rhs.__cv_);
+    std::swap(__st_, __rhs.__st_);
+    std::swap(__st_last_, __rhs.__st_last_);
+    std::swap(__om_, __rhs.__om_);
+    std::swap(__cm_, __rhs.__cm_);
+    std::swap(__owns_eb_, __rhs.__owns_eb_);
+    std::swap(__owns_ib_, __rhs.__owns_ib_);
+    std::swap(__always_noconv_, __rhs.__always_noconv_);
     if (this->eback() == (char_type*)__rhs.__extbuf_min_)
     {
         ptrdiff_t __n = this->gptr() - this->eback();
@@ -762,7 +762,7 @@ basic_filebuf<_CharT, _Traits>::underflow()
     int_type __c = traits_type::eof();
     if (this->gptr() == this->egptr())
     {
-        _VSTD::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
+        std::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
         if (__always_noconv_)
         {
             size_t __nmemb = static_cast<size_t>(this->egptr() - this->eback() - __unget_sz);
@@ -780,11 +780,11 @@ basic_filebuf<_CharT, _Traits>::underflow()
             if (__extbufend_ != __extbufnext_) {
                 _LIBCPP_ASSERT_NON_NULL(__extbufnext_ != nullptr, "underflow moving from nullptr");
                 _LIBCPP_ASSERT_NON_NULL(__extbuf_ != nullptr, "underflow moving into nullptr");
-                _VSTD::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
+                std::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
             }
             __extbufnext_ = __extbuf_ + (__extbufend_ - __extbufnext_);
             __extbufend_ = __extbuf_ + (__extbuf_ == __extbuf_min_ ? sizeof(__extbuf_min_) : __ebs_);
-            size_t __nmemb = _VSTD::min(static_cast<size_t>(__ibs_ - __unget_sz),
+            size_t __nmemb = std::min(static_cast<size_t>(__ibs_ - __unget_sz),
                                  static_cast<size_t>(__extbufend_ - __extbufnext_));
             codecvt_base::result __r;
             __st_last_ = __st_;
@@ -1270,8 +1270,8 @@ basic_ifstream<_CharT, _Traits>::basic_ifstream(const string& __s, ios_base::ope
 template <class _CharT, class _Traits>
 inline
 basic_ifstream<_CharT, _Traits>::basic_ifstream(basic_ifstream&& __rhs)
-    : basic_istream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_istream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
@@ -1281,8 +1281,8 @@ inline
 basic_ifstream<_CharT, _Traits>&
 basic_ifstream<_CharT, _Traits>::operator=(basic_ifstream&& __rhs)
 {
-    basic_istream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_istream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 
@@ -1471,8 +1471,8 @@ basic_ofstream<_CharT, _Traits>::basic_ofstream(const string& __s, ios_base::ope
 template <class _CharT, class _Traits>
 inline
 basic_ofstream<_CharT, _Traits>::basic_ofstream(basic_ofstream&& __rhs)
-    : basic_ostream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_ostream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
@@ -1482,8 +1482,8 @@ inline
 basic_ofstream<_CharT, _Traits>&
 basic_ofstream<_CharT, _Traits>::operator=(basic_ofstream&& __rhs)
 {
-    basic_ostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_ostream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 
@@ -1672,8 +1672,8 @@ basic_fstream<_CharT, _Traits>::basic_fstream(const string& __s, ios_base::openm
 template <class _CharT, class _Traits>
 inline
 basic_fstream<_CharT, _Traits>::basic_fstream(basic_fstream&& __rhs)
-    : basic_iostream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_iostream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
@@ -1683,8 +1683,8 @@ inline
 basic_fstream<_CharT, _Traits>&
 basic_fstream<_CharT, _Traits>::operator=(basic_fstream&& __rhs)
 {
-    basic_iostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_iostream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -673,7 +673,7 @@ __assoc_state<_Rp>::set_value(_Arg&& __arg)
     unique_lock<mutex> __lk(this->__mut_);
     if (this->__has_value())
         __throw_future_error(future_errc::promise_already_satisfied);
-    ::new ((void*)&__value_) _Rp(_VSTD::forward<_Arg>(__arg));
+    ::new ((void*)&__value_) _Rp(std::forward<_Arg>(__arg));
     this->__state_ |= base::__constructed | base::ready;
     __cv_.notify_all();
 }
@@ -686,7 +686,7 @@ __assoc_state<_Rp>::set_value_at_thread_exit(_Arg&& __arg)
     unique_lock<mutex> __lk(this->__mut_);
     if (this->__has_value())
         __throw_future_error(future_errc::promise_already_satisfied);
-    ::new ((void*)&__value_) _Rp(_VSTD::forward<_Arg>(__arg));
+    ::new ((void*)&__value_) _Rp(std::forward<_Arg>(__arg));
     this->__state_ |= base::__constructed;
     __thread_local_data()->__make_ready_at_thread_exit(this);
 }
@@ -699,7 +699,7 @@ __assoc_state<_Rp>::move()
     this->__sub_wait(__lk);
     if (this->__exception_ != nullptr)
         std::rethrow_exception(this->__exception_);
-    return _VSTD::move(*reinterpret_cast<_Rp*>(&__value_));
+    return std::move(*reinterpret_cast<_Rp*>(&__value_));
 }
 
 template <class _Rp>
@@ -744,7 +744,7 @@ __assoc_state<_Rp&>::set_value(_Rp& __arg)
     unique_lock<mutex> __lk(this->__mut_);
     if (this->__has_value())
         __throw_future_error(future_errc::promise_already_satisfied);
-    __value_ = _VSTD::addressof(__arg);
+    __value_ = std::addressof(__arg);
     this->__state_ |= base::__constructed | base::ready;
     __cv_.notify_all();
 }
@@ -756,7 +756,7 @@ __assoc_state<_Rp&>::set_value_at_thread_exit(_Rp& __arg)
     unique_lock<mutex> __lk(this->__mut_);
     if (this->__has_value())
         __throw_future_error(future_errc::promise_already_satisfied);
-    __value_ = _VSTD::addressof(__arg);
+    __value_ = std::addressof(__arg);
     this->__state_ |= base::__constructed;
     __thread_local_data()->__make_ready_at_thread_exit(this);
 }
@@ -790,7 +790,7 @@ void
 __assoc_state_alloc<_Rp, _Alloc>::__on_zero_shared() _NOEXCEPT
 {
     if (this->__state_ & base::__constructed)
-        reinterpret_cast<_Rp*>(_VSTD::addressof(this->__value_))->~_Rp();
+        reinterpret_cast<_Rp*>(std::addressof(this->__value_))->~_Rp();
     typedef typename __allocator_traits_rebind<_Alloc, __assoc_state_alloc>::type _Al;
     typedef allocator_traits<_Al> _ATraits;
     typedef pointer_traits<typename _ATraits::pointer> _PTraits;
@@ -866,7 +866,7 @@ public:
 template <class _Rp, class _Fp>
 inline
 __deferred_assoc_state<_Rp, _Fp>::__deferred_assoc_state(_Fp&& __f)
-    : __func_(_VSTD::forward<_Fp>(__f))
+    : __func_(std::forward<_Fp>(__f))
 {
     this->__set_deferred();
 }
@@ -906,7 +906,7 @@ public:
 template <class _Fp>
 inline
 __deferred_assoc_state<void, _Fp>::__deferred_assoc_state(_Fp&& __f)
-    : __func_(_VSTD::forward<_Fp>(__f))
+    : __func_(std::forward<_Fp>(__f))
 {
     this->__set_deferred();
 }
@@ -948,7 +948,7 @@ public:
 template <class _Rp, class _Fp>
 inline
 __async_assoc_state<_Rp, _Fp>::__async_assoc_state(_Fp&& __f)
-    : __func_(_VSTD::forward<_Fp>(__f))
+    : __func_(std::forward<_Fp>(__f))
 {
 }
 
@@ -996,7 +996,7 @@ public:
 template <class _Fp>
 inline
 __async_assoc_state<void, _Fp>::__async_assoc_state(_Fp&& __f)
-    : __func_(_VSTD::forward<_Fp>(__f))
+    : __func_(std::forward<_Fp>(__f))
 {
 }
 
@@ -1068,7 +1068,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     future& operator=(future&& __rhs) _NOEXCEPT
         {
-            future(_VSTD::move(__rhs)).swap(*this);
+            future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -1080,7 +1080,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI _Rp get();
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -1155,7 +1155,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     future& operator=(future&& __rhs) _NOEXCEPT
         {
-            future(_VSTD::move(__rhs)).swap(*this);
+            future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -1167,7 +1167,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI _Rp& get();
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -1237,7 +1237,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     future& operator=(future&& __rhs) _NOEXCEPT
         {
-            future(_VSTD::move(__rhs)).swap(*this);
+            future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -1249,7 +1249,7 @@ public:
     void get();
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -1304,13 +1304,13 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     promise& operator=(promise&& __rhs) _NOEXCEPT
         {
-            promise(_VSTD::move(__rhs)).swap(*this);
+            promise(std::move(__rhs)).swap(*this);
             return *this;
         }
     promise& operator=(const promise& __rhs) = delete;
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(promise& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     _LIBCPP_HIDE_FROM_ABI future<_Rp> get_future();
@@ -1341,8 +1341,8 @@ promise<_Rp>::promise(allocator_arg_t, const _Alloc& __a0)
     typedef __allocator_destructor<_A2> _D2;
     _A2 __a(__a0);
     unique_ptr<_State, _D2> __hold(__a.allocate(1), _D2(__a, 1));
-    ::new ((void*)_VSTD::addressof(*__hold.get())) _State(__a0);
-    __state_ = _VSTD::addressof(*__hold.release());
+    ::new ((void*)std::addressof(*__hold.get())) _State(__a0);
+    __state_ = std::addressof(*__hold.release());
 }
 
 template <class _Rp>
@@ -1380,7 +1380,7 @@ promise<_Rp>::set_value(_Rp&& __r)
 {
     if (__state_ == nullptr)
         __throw_future_error(future_errc::no_state);
-    __state_->set_value(_VSTD::move(__r));
+    __state_->set_value(std::move(__r));
 }
 
 template <class _Rp>
@@ -1408,7 +1408,7 @@ promise<_Rp>::set_value_at_thread_exit(_Rp&& __r)
 {
     if (__state_ == nullptr)
         __throw_future_error(future_errc::no_state);
-    __state_->set_value_at_thread_exit(_VSTD::move(__r));
+    __state_->set_value_at_thread_exit(std::move(__r));
 }
 
 template <class _Rp>
@@ -1447,13 +1447,13 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     promise& operator=(promise&& __rhs) _NOEXCEPT
         {
-            promise(_VSTD::move(__rhs)).swap(*this);
+            promise(std::move(__rhs)).swap(*this);
             return *this;
         }
     promise& operator=(const promise& __rhs) = delete;
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(promise& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     _LIBCPP_HIDE_FROM_ABI future<_Rp&> get_future();
@@ -1482,8 +1482,8 @@ promise<_Rp&>::promise(allocator_arg_t, const _Alloc& __a0)
     typedef __allocator_destructor<_A2> _D2;
     _A2 __a(__a0);
     unique_ptr<_State, _D2> __hold(__a.allocate(1), _D2(__a, 1));
-    ::new ((void*)_VSTD::addressof(*__hold.get())) _State(__a0);
-    __state_ = _VSTD::addressof(*__hold.release());
+    ::new ((void*)std::addressof(*__hold.get())) _State(__a0);
+    __state_ = std::addressof(*__hold.release());
 }
 
 template <class _Rp>
@@ -1571,13 +1571,13 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     promise& operator=(promise&& __rhs) _NOEXCEPT
         {
-            promise(_VSTD::move(__rhs)).swap(*this);
+            promise(std::move(__rhs)).swap(*this);
             return *this;
         }
     promise& operator=(const promise& __rhs) = delete;
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(promise& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     future<void> get_future();
@@ -1599,8 +1599,8 @@ promise<void>::promise(allocator_arg_t, const _Alloc& __a0)
     typedef __allocator_destructor<_A2> _D2;
     _A2 __a(__a0);
     unique_ptr<_State, _D2> __hold(__a.allocate(1), _D2(__a, 1));
-    ::new ((void*)_VSTD::addressof(*__hold.get())) _State(__a0);
-    __state_ = _VSTD::addressof(*__hold.release());
+    ::new ((void*)std::addressof(*__hold.get())) _State(__a0);
+    __state_ = std::addressof(*__hold.release());
 }
 
 template <class _Rp>
@@ -1645,13 +1645,13 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     explicit __packaged_task_func(const _Fp& __f) : __f_(__f, __default_init_tag()) {}
     _LIBCPP_HIDE_FROM_ABI
-    explicit __packaged_task_func(_Fp&& __f) : __f_(_VSTD::move(__f), __default_init_tag()) {}
+    explicit __packaged_task_func(_Fp&& __f) : __f_(std::move(__f), __default_init_tag()) {}
     _LIBCPP_HIDE_FROM_ABI
     __packaged_task_func(const _Fp& __f, const _Alloc& __a)
         : __f_(__f, __a) {}
     _LIBCPP_HIDE_FROM_ABI
     __packaged_task_func(_Fp&& __f, const _Alloc& __a)
-        : __f_(_VSTD::move(__f), __a) {}
+        : __f_(std::move(__f), __a) {}
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __move_to(__packaged_task_base<_Rp(_ArgTypes...)>*) _NOEXCEPT;
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void destroy();
     _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void destroy_deallocate();
@@ -1663,7 +1663,7 @@ void
 __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__move_to(
                               __packaged_task_base<_Rp(_ArgTypes...)>* __p) _NOEXCEPT
 {
-    ::new ((void*)__p) __packaged_task_func(_VSTD::move(__f_.first()), _VSTD::move(__f_.second()));
+    ::new ((void*)__p) __packaged_task_func(std::move(__f_.first()), std::move(__f_.second()));
 }
 
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
@@ -1689,7 +1689,7 @@ template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 _Rp
 __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&& ... __arg)
 {
-    return _VSTD::__invoke(__f_.first(), _VSTD::forward<_ArgTypes>(__arg)...);
+    return std::__invoke(__f_.first(), std::forward<_ArgTypes>(__arg)...);
 }
 
 template <class _Callable> class __packaged_task_function;
@@ -1758,7 +1758,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(_Fp&& __f)
     typedef __packaged_task_func<_FR, allocator<_FR>, _Rp(_ArgTypes...)> _FF;
     if (sizeof(_FF) <= sizeof(__buf_))
     {
-        ::new ((void*)&__buf_) _FF(_VSTD::forward<_Fp>(__f));
+        ::new ((void*)&__buf_) _FF(std::forward<_Fp>(__f));
         __f_ = (__base*)&__buf_;
     }
     else
@@ -1767,7 +1767,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(_Fp&& __f)
         _Ap __a;
         typedef __allocator_destructor<_Ap> _Dp;
         unique_ptr<__base, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
-        ::new ((void*)__hold.get()) _FF(_VSTD::forward<_Fp>(__f), allocator<_FR>(__a));
+        ::new ((void*)__hold.get()) _FF(std::forward<_Fp>(__f), allocator<_FR>(__a));
         __f_ = __hold.release();
     }
 }
@@ -1783,7 +1783,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(
     if (sizeof(_FF) <= sizeof(__buf_))
     {
         __f_ = (__base*)&__buf_;
-        ::new ((void*)__f_) _FF(_VSTD::forward<_Fp>(__f));
+        ::new ((void*)__f_) _FF(std::forward<_Fp>(__f));
     }
     else
     {
@@ -1791,9 +1791,9 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(
         _Ap __a(__a0);
         typedef __allocator_destructor<_Ap> _Dp;
         unique_ptr<__base, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
-        ::new ((void*)_VSTD::addressof(*__hold.get()))
-            _FF(_VSTD::forward<_Fp>(__f), _Alloc(__a));
-        __f_ = _VSTD::addressof(*__hold.release());
+        ::new ((void*)std::addressof(*__hold.get()))
+            _FF(std::forward<_Fp>(__f), _Alloc(__a));
+        __f_ = std::addressof(*__hold.release());
     }
 }
 
@@ -1867,7 +1867,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::swap(__packaged_task_function& __f)
         __f_ = (__base*)&__buf_;
     }
     else
-        _VSTD::swap(__f_, __f.__f_);
+        std::swap(__f_, __f.__f_);
 }
 
 template<class _Rp, class ..._ArgTypes>
@@ -1875,7 +1875,7 @@ inline
 _Rp
 __packaged_task_function<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __arg) const
 {
-    return (*__f_)(_VSTD::forward<_ArgTypes>(__arg)...);
+    return (*__f_)(std::forward<_ArgTypes>(__arg)...);
 }
 
 template<class _Rp, class ..._ArgTypes>
@@ -1895,12 +1895,12 @@ public:
     template <class _Fp,
               class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
         _LIBCPP_HIDE_FROM_ABI
-        explicit packaged_task(_Fp&& __f) : __f_(_VSTD::forward<_Fp>(__f)) {}
+        explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
     template <class _Fp, class _Allocator,
               class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
         _LIBCPP_HIDE_FROM_ABI
         packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
-             : __f_(allocator_arg_t(), __a, _VSTD::forward<_Fp>(__f)),
+             : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)),
                __p_(allocator_arg_t(), __a) {}
     // ~packaged_task() = default;
 
@@ -1911,12 +1911,12 @@ public:
     // move support
     _LIBCPP_HIDE_FROM_ABI
     packaged_task(packaged_task&& __other) _NOEXCEPT
-        : __f_(_VSTD::move(__other.__f_)), __p_(_VSTD::move(__other.__p_)) {}
+        : __f_(std::move(__other.__f_)), __p_(std::move(__other.__p_)) {}
     _LIBCPP_HIDE_FROM_ABI
     packaged_task& operator=(packaged_task&& __other) _NOEXCEPT
     {
-        __f_ = _VSTD::move(__other.__f_);
-        __p_ = _VSTD::move(__other.__p_);
+        __f_ = std::move(__other.__f_);
+        __p_ = std::move(__other.__p_);
         return *this;
     }
     _LIBCPP_HIDE_FROM_ABI
@@ -1952,7 +1952,7 @@ packaged_task<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __args)
     try
     {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-        __p_.set_value(__f_(_VSTD::forward<_ArgTypes>(__args)...));
+        __p_.set_value(__f_(std::forward<_ArgTypes>(__args)...));
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
     catch (...)
@@ -1974,7 +1974,7 @@ packaged_task<_Rp(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... __args)
     try
     {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-        __p_.set_value_at_thread_exit(__f_(_VSTD::forward<_ArgTypes>(__args)...));
+        __p_.set_value_at_thread_exit(__f_(std::forward<_ArgTypes>(__args)...));
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
     catch (...)
@@ -2010,12 +2010,12 @@ public:
     template <class _Fp,
               class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
         _LIBCPP_HIDE_FROM_ABI
-        explicit packaged_task(_Fp&& __f) : __f_(_VSTD::forward<_Fp>(__f)) {}
+        explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
     template <class _Fp, class _Allocator,
               class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
         _LIBCPP_HIDE_FROM_ABI
         packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
-             : __f_(allocator_arg_t(), __a, _VSTD::forward<_Fp>(__f)),
+             : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)),
                __p_(allocator_arg_t(), __a) {}
     // ~packaged_task() = default;
 
@@ -2026,12 +2026,12 @@ public:
     // move support
     _LIBCPP_HIDE_FROM_ABI
     packaged_task(packaged_task&& __other) _NOEXCEPT
-        : __f_(_VSTD::move(__other.__f_)), __p_(_VSTD::move(__other.__p_)) {}
+        : __f_(std::move(__other.__f_)), __p_(std::move(__other.__p_)) {}
     _LIBCPP_HIDE_FROM_ABI
     packaged_task& operator=(packaged_task&& __other) _NOEXCEPT
     {
-        __f_ = _VSTD::move(__other.__f_);
-        __p_ = _VSTD::move(__other.__p_);
+        __f_ = std::move(__other.__f_);
+        __p_ = std::move(__other.__p_);
         return *this;
     }
     _LIBCPP_HIDE_FROM_ABI
@@ -2077,7 +2077,7 @@ packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args)
     try
     {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-        __f_(_VSTD::forward<_ArgTypes>(__args)...);
+        __f_(std::forward<_ArgTypes>(__args)...);
         __p_.set_value();
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
@@ -2100,7 +2100,7 @@ packaged_task<void(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... __args
     try
     {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-        __f_(_VSTD::forward<_ArgTypes>(__args)...);
+        __f_(std::forward<_ArgTypes>(__args)...);
         __p_.set_value_at_thread_exit();
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
@@ -2137,7 +2137,7 @@ _LIBCPP_HIDE_FROM_ABI future<_Rp>
 __make_deferred_assoc_state(_Fp&& __f)
 {
     unique_ptr<__deferred_assoc_state<_Rp, _Fp>, __release_shared_count>
-        __h(new __deferred_assoc_state<_Rp, _Fp>(_VSTD::forward<_Fp>(__f)));
+        __h(new __deferred_assoc_state<_Rp, _Fp>(std::forward<_Fp>(__f)));
     return future<_Rp>(__h.get());
 }
 
@@ -2146,8 +2146,8 @@ _LIBCPP_HIDE_FROM_ABI future<_Rp>
 __make_async_assoc_state(_Fp&& __f)
 {
     unique_ptr<__async_assoc_state<_Rp, _Fp>, __release_shared_count>
-        __h(new __async_assoc_state<_Rp, _Fp>(_VSTD::forward<_Fp>(__f)));
-    _VSTD::thread(&__async_assoc_state<_Rp, _Fp>::__execute, __h.get()).detach();
+        __h(new __async_assoc_state<_Rp, _Fp>(std::forward<_Fp>(__f)));
+    std::thread(&__async_assoc_state<_Rp, _Fp>::__execute, __h.get()).detach();
     return future<_Rp>(__h.get());
 }
 
@@ -2163,10 +2163,10 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __async_func(_Fp&& __f, _Args&&... __args)
-        : __f_(_VSTD::move(__f), _VSTD::move(__args)...) {}
+        : __f_(std::move(__f), std::move(__args)...) {}
 
     _LIBCPP_HIDE_FROM_ABI
-    __async_func(__async_func&& __f) : __f_(_VSTD::move(__f.__f_)) {}
+    __async_func(__async_func&& __f) : __f_(std::move(__f.__f_)) {}
 
     _LIBCPP_HIDE_FROM_ABI _Rp operator()()
     {
@@ -2178,7 +2178,7 @@ private:
     _LIBCPP_HIDE_FROM_ABI _Rp
     __execute(__tuple_indices<_Indices...>)
     {
-        return _VSTD::__invoke(_VSTD::move(_VSTD::get<0>(__f_)), _VSTD::move(_VSTD::get<_Indices>(__f_))...);
+        return std::__invoke(std::move(std::get<0>(__f_)), std::move(std::get<_Indices>(__f_))...);
     }
 };
 
@@ -2198,16 +2198,16 @@ async(launch __policy, _Fp&& __f, _Args&&... __args)
     {
 #endif
         if (__does_policy_contain(__policy, launch::async))
-        return _VSTD::__make_async_assoc_state<_Rp>(_BF(_LIBCPP_AUTO_CAST(_VSTD::forward<_Fp>(__f)),
-                                                        _LIBCPP_AUTO_CAST(_VSTD::forward<_Args>(__args))...));
+        return std::__make_async_assoc_state<_Rp>(_BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)),
+                                                        _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     }
     catch ( ... ) { if (__policy == launch::async) throw ; }
 #endif
 
     if (__does_policy_contain(__policy, launch::deferred))
-        return _VSTD::__make_deferred_assoc_state<_Rp>(_BF(_LIBCPP_AUTO_CAST(_VSTD::forward<_Fp>(__f)),
-                                                           _LIBCPP_AUTO_CAST(_VSTD::forward<_Args>(__args))...));
+        return std::__make_deferred_assoc_state<_Rp>(_BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)),
+                                                           _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
     return future<_Rp>{};
 }
 
@@ -2216,8 +2216,8 @@ _LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_HIDE_FROM_ABI
 future<typename __invoke_of<__decay_t<_Fp>, __decay_t<_Args>...>::type>
 async(_Fp&& __f, _Args&&... __args)
 {
-    return _VSTD::async(launch::any, _VSTD::forward<_Fp>(__f),
-                                    _VSTD::forward<_Args>(__args)...);
+    return std::async(launch::any, std::forward<_Fp>(__f),
+                                    std::forward<_Args>(__args)...);
 }
 
 #endif // C++03
@@ -2246,7 +2246,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
         {
-            shared_future(_VSTD::move(__rhs)).swap(*this);
+            shared_future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -2255,7 +2255,7 @@ public:
     const _Rp& get() const {return __state_->copy();}
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(shared_future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -2316,7 +2316,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
         {
-            shared_future(_VSTD::move(__rhs)).swap(*this);
+            shared_future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -2325,7 +2325,7 @@ public:
     _Rp& get() const {return __state_->copy();}
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(shared_future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -2386,7 +2386,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
         {
-            shared_future(_VSTD::move(__rhs)).swap(*this);
+            shared_future(std::move(__rhs)).swap(*this);
             return *this;
         }
 
@@ -2395,7 +2395,7 @@ public:
     void get() const {__state_->copy();}
 
     _LIBCPP_HIDE_FROM_ABI
-    void swap(shared_future& __rhs) _NOEXCEPT {_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) _NOEXCEPT {std::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCPP_HIDE_FROM_ABI
@@ -2428,7 +2428,7 @@ inline
 shared_future<_Rp>
 future<_Rp>::share() _NOEXCEPT
 {
-    return shared_future<_Rp>(_VSTD::move(*this));
+    return shared_future<_Rp>(std::move(*this));
 }
 
 template <class _Rp>
@@ -2436,14 +2436,14 @@ inline
 shared_future<_Rp&>
 future<_Rp&>::share() _NOEXCEPT
 {
-    return shared_future<_Rp&>(_VSTD::move(*this));
+    return shared_future<_Rp&>(std::move(*this));
 }
 
 inline
 shared_future<void>
 future<void>::share() _NOEXCEPT
 {
-    return shared_future<void>(_VSTD::move(*this));
+    return shared_future<void>(std::move(*this));
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -526,7 +526,7 @@ __quoted_output(basic_ostream<_CharT, _Traits>& __os,
         __str.push_back(*__first);
     }
     __str.push_back(__delim);
-    return _VSTD::__put_character_sequence(__os, __str.data(), __str.size());
+    return std::__put_character_sequence(__os, __str.data(), __str.size());
 }
 
 template <class _CharT, class _Traits, class _String>

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -295,8 +295,8 @@ public:
     typedef openmode     open_mode;
     typedef seekdir      seek_dir;
 
-    typedef _VSTD::streamoff streamoff;
-    typedef _VSTD::streampos streampos;
+    typedef std::streamoff streamoff;
+    typedef std::streampos streampos;
 #endif
 
     class _LIBCPP_EXPORTED_FROM_ABI Init;
@@ -839,8 +839,8 @@ void
 basic_ios<_CharT, _Traits>::swap(basic_ios& __rhs) _NOEXCEPT
 {
     ios_base::swap(__rhs);
-    _VSTD::swap(__tie_, __rhs.__tie_);
-    _VSTD::swap(__fill_, __rhs.__fill_);
+    std::swap(__tie_, __rhs.__tie_);
+    std::swap(__fill_, __rhs.__fill_);
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -213,7 +213,7 @@ protected:
 
     inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1
     void swap(basic_istream& __rhs) {
-      _VSTD::swap(__gc_, __rhs.__gc_);
+      std::swap(__gc_, __rhs.__gc_);
       basic_ios<char_type, traits_type>::swap(__rhs);
     }
 
@@ -398,77 +398,77 @@ template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(unsigned short& __n)
 {
-    return _VSTD::__input_arithmetic<unsigned short>(*this, __n);
+    return std::__input_arithmetic<unsigned short>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(unsigned int& __n)
 {
-    return _VSTD::__input_arithmetic<unsigned int>(*this, __n);
+    return std::__input_arithmetic<unsigned int>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(long& __n)
 {
-    return _VSTD::__input_arithmetic<long>(*this, __n);
+    return std::__input_arithmetic<long>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(unsigned long& __n)
 {
-    return _VSTD::__input_arithmetic<unsigned long>(*this, __n);
+    return std::__input_arithmetic<unsigned long>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(long long& __n)
 {
-    return _VSTD::__input_arithmetic<long long>(*this, __n);
+    return std::__input_arithmetic<long long>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(unsigned long long& __n)
 {
-    return _VSTD::__input_arithmetic<unsigned long long>(*this, __n);
+    return std::__input_arithmetic<unsigned long long>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(float& __n)
 {
-    return _VSTD::__input_arithmetic<float>(*this, __n);
+    return std::__input_arithmetic<float>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(double& __n)
 {
-    return _VSTD::__input_arithmetic<double>(*this, __n);
+    return std::__input_arithmetic<double>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(long double& __n)
 {
-    return _VSTD::__input_arithmetic<long double>(*this, __n);
+    return std::__input_arithmetic<long double>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(bool& __n)
 {
-    return _VSTD::__input_arithmetic<bool>(*this, __n);
+    return std::__input_arithmetic<bool>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(void*& __n)
 {
-    return _VSTD::__input_arithmetic<void*>(*this, __n);
+    return std::__input_arithmetic<void*>(*this, __n);
 }
 
 template <class _Tp, class _CharT, class _Traits>
@@ -522,14 +522,14 @@ template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(short& __n)
 {
-    return _VSTD::__input_arithmetic_with_numeric_limits<short>(*this, __n);
+    return std::__input_arithmetic_with_numeric_limits<short>(*this, __n);
 }
 
 template <class _CharT, class _Traits>
 basic_istream<_CharT, _Traits>&
 basic_istream<_CharT, _Traits>::operator>>(int& __n)
 {
-    return _VSTD::__input_arithmetic_with_numeric_limits<int>(*this, __n);
+    return std::__input_arithmetic_with_numeric_limits<int>(*this, __n);
 }
 
 template<class _CharT, class _Traits>
@@ -591,8 +591,8 @@ operator>>(basic_istream<_CharT, _Traits>& __is, _CharT (&__buf)[_Np])
 {
     size_t __n = _Np;
     if (__is.width() > 0)
-        __n = _VSTD::min(size_t(__is.width()), _Np);
-    return _VSTD::__input_c_string(__is, __buf, __n);
+        __n = std::min(size_t(__is.width()), _Np);
+    return std::__input_c_string(__is, __buf, __n);
 }
 
 template<class _Traits, size_t _Np>
@@ -621,7 +621,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, _CharT* __s)
     streamsize __n = __is.width();
     if (__n <= 0)
         __n = numeric_limits<streamsize>::max() / sizeof(_CharT) - 1;
-    return _VSTD::__input_c_string(__is, __s, size_t(__n));
+    return std::__input_c_string(__is, __s, size_t(__n));
 }
 
 template<class _Traits>
@@ -1105,7 +1105,7 @@ basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize __n)
             case 0:
                 break;
             default:
-                __n = _VSTD::min(__c, __n);
+                __n = std::min(__c, __n);
                 __gc_ = this->rdbuf()->sgetn(__s, __n);
                 if (__gc_ != __n)
                     __state |= ios_base::failbit | ios_base::eofbit;
@@ -1393,8 +1393,8 @@ template <class _Stream, class _Tp, __enable_if_t<
 _LIBCPP_HIDE_FROM_ABI
 _Stream&& operator>>(_Stream&& __is, _Tp&& __x)
 {
-    __is >> _VSTD::forward<_Tp>(__x);
-    return _VSTD::move(__is);
+    __is >> std::forward<_Tp>(__x);
+    return std::move(__is);
 }
 
 template <class _CharT, class _Traits>
@@ -1432,7 +1432,7 @@ protected:
 
 template <class _CharT, class _Traits>
 basic_iostream<_CharT, _Traits>::basic_iostream(basic_iostream&& __rhs)
-    : basic_istream<_CharT, _Traits>(_VSTD::move(__rhs))
+    : basic_istream<_CharT, _Traits>(std::move(__rhs))
 {
 }
 

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -233,7 +233,7 @@ protected:
 
     static _LIBCPP_CONSTEXPR const bool is_iec559 = false;
     static _LIBCPP_CONSTEXPR const bool is_bounded = true;
-    static _LIBCPP_CONSTEXPR const bool is_modulo = !_VSTD::is_signed<_Tp>::value;
+    static _LIBCPP_CONSTEXPR const bool is_modulo = !std::is_signed<_Tp>::value;
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || \
     defined(__wasm__)

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -666,7 +666,7 @@ private:
     void __move_assign_alloc(__list_imp& __c, true_type)
         _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
         {
-            __node_alloc() = _VSTD::move(__c.__node_alloc());
+            __node_alloc() = std::move(__c.__node_alloc());
         }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -708,7 +708,7 @@ inline __list_imp<_Tp, _Alloc>::__list_imp(const __node_allocator& __a)
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Alloc>
 inline __list_imp<_Tp, _Alloc>::__list_imp(__node_allocator&& __a) _NOEXCEPT
-    : __size_alloc_(0, _VSTD::move(__a)) {}
+    : __size_alloc_(0, std::move(__a)) {}
 #endif
 
 template <class _Tp, class _Alloc>
@@ -749,8 +749,8 @@ __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
                                         this->__node_alloc() == __c.__node_alloc(),
                                         "list::swap: Either propagate_on_container_swap must be true"
                                         " or the allocators must compare equal");
-    using _VSTD::swap;
-    _VSTD::__swap_allocator(__node_alloc(), __c.__node_alloc());
+    using std::swap;
+    std::__swap_allocator(__node_alloc(), __c.__node_alloc());
     swap(__sz(), __c.__sz());
     swap(__end_, __c.__end_);
     if (__sz() == 0)
@@ -789,8 +789,8 @@ public:
     typedef typename base::difference_type                 difference_type;
     typedef typename base::iterator                        iterator;
     typedef typename base::const_iterator                  const_iterator;
-    typedef _VSTD::reverse_iterator<iterator>              reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator>        const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>              reverse_iterator;
+    typedef std::reverse_iterator<const_iterator>        const_reverse_iterator;
 #if _LIBCPP_STD_VER >= 20
     typedef size_type                                      __remove_return_type;
 #else
@@ -889,7 +889,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     size_type max_size() const _NOEXCEPT
         {
-            return _VSTD::min<size_type>(
+            return std::min<size_type>(
                 base::__node_alloc_max_size(),
                 numeric_limits<difference_type >::max());
         }
@@ -997,7 +997,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     template <class _Arg>
     _LIBCPP_HIDE_FROM_ABI
-    void __emplace_back(_Arg&& __arg) { emplace_back(_VSTD::forward<_Arg>(__arg)); }
+    void __emplace_back(_Arg&& __arg) { emplace_back(std::forward<_Arg>(__arg)); }
 #else
     _LIBCPP_HIDE_FROM_ABI
     void __emplace_back(value_type const& __arg) { push_back(__arg); }
@@ -1176,8 +1176,8 @@ inline
 typename list<_Tp, _Alloc>::iterator
 list<_Tp, _Alloc>::__iterator(size_type __n)
 {
-    return __n <= base::__sz() / 2 ? _VSTD::next(begin(), __n)
-                                   : _VSTD::prev(end(), base::__sz() - __n);
+    return __n <= base::__sz() / 2 ? std::next(begin(), __n)
+                                   : std::prev(end(), base::__sz() - __n);
 }
 
 template <class _Tp, class _Alloc>
@@ -1264,7 +1264,7 @@ list<_Tp, _Alloc>::list(initializer_list<value_type> __il)
 template <class _Tp, class _Alloc>
 inline list<_Tp, _Alloc>::list(list&& __c)
         _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value)
-        : base(_VSTD::move(__c.__node_alloc())) {
+        : base(std::move(__c.__node_alloc())) {
     splice(end(), __c);
 }
 
@@ -1325,7 +1325,7 @@ inline
 list<_Tp, _Alloc>&
 list<_Tp, _Alloc>::operator=(const list& __c)
 {
-    if (this != _VSTD::addressof(__c))
+    if (this != std::addressof(__c))
     {
         base::__copy_assign_alloc(__c);
         assign(__c.begin(), __c.end());
@@ -1730,7 +1730,7 @@ template <class _Tp, class _Alloc>
 void
 list<_Tp, _Alloc>::splice(const_iterator __p, list& __c)
 {
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(this != _VSTD::addressof(__c),
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(this != std::addressof(__c),
                                      "list::splice(iterator, list) called with this == &list");
     if (!__c.empty())
     {
@@ -1766,9 +1766,9 @@ list<_Tp, _Alloc>::splice(const_iterator __p, list& __c, const_iterator __f, con
         __link_pointer __first = __f.__ptr_;
         --__l;
         __link_pointer __last = __l.__ptr_;
-        if (this != _VSTD::addressof(__c))
+        if (this != std::addressof(__c))
         {
-            size_type __s = _VSTD::distance(__f, __l) + 1;
+            size_type __s = std::distance(__f, __l) + 1;
             __c.__sz() -= __s;
             base::__sz() += __s;
         }
@@ -1786,7 +1786,7 @@ list<_Tp, _Alloc>::remove(const value_type& __x)
     {
         if (*__i == __x)
         {
-            const_iterator __j = _VSTD::next(__i);
+            const_iterator __j = std::next(__i);
             for (; __j != __e && *__j == __x; ++__j)
                 ;
             __deleted_nodes.splice(__deleted_nodes.end(), *this, __i, __j);
@@ -1811,7 +1811,7 @@ list<_Tp, _Alloc>::remove_if(_Pred __pred)
     {
         if (__pred(*__i))
         {
-            iterator __j = _VSTD::next(__i);
+            iterator __j = std::next(__i);
             for (; __j != __e && __pred(*__j); ++__j)
                 ;
             __deleted_nodes.splice(__deleted_nodes.end(), *this, __i, __j);
@@ -1834,7 +1834,7 @@ list<_Tp, _Alloc>::unique(_BinaryPred __binary_pred)
     list<_Tp, _Alloc> __deleted_nodes(get_allocator()); // collect the nodes we're removing
     for (iterator __i = begin(), __e = end(); __i != __e;)
     {
-        iterator __j = _VSTD::next(__i);
+        iterator __j = std::next(__i);
         for (; __j != __e && __binary_pred(*__i, *__j); ++__j)
             ;
         if (++__i != __j) {
@@ -1859,7 +1859,7 @@ template <class _Comp>
 void
 list<_Tp, _Alloc>::merge(list& __c, _Comp __comp)
 {
-    if (this != _VSTD::addressof(__c))
+    if (this != std::addressof(__c))
     {
         iterator __f1 = begin();
         iterator __e1 = end();
@@ -1870,7 +1870,7 @@ list<_Tp, _Alloc>::merge(list& __c, _Comp __comp)
             if (__comp(*__f2, *__f1))
             {
                 size_type __ds = 1;
-                iterator __m2 = _VSTD::next(__f2);
+                iterator __m2 = std::next(__f2);
                 for (; __m2 != __e2 && __comp(*__m2, *__f1); ++__m2, (void) ++__ds)
                     ;
                 base::__sz() += __ds;
@@ -1879,7 +1879,7 @@ list<_Tp, _Alloc>::merge(list& __c, _Comp __comp)
                 __link_pointer __l = __m2.__ptr_->__prev_;
                 __f2 = __m2;
                 base::__unlink_nodes(__f, __l);
-                __m2 = _VSTD::next(__f1);
+                __m2 = std::next(__f1);
                 __link_nodes(__f1.__ptr_, __f, __l);
                 __f1 = __m2;
             }
@@ -1928,12 +1928,12 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
         return __f1;
     }
     size_type __n2 = __n / 2;
-    iterator __e1 = _VSTD::next(__f1, __n2);
+    iterator __e1 = std::next(__f1, __n2);
     iterator  __r = __f1 = __sort(__f1, __e1, __n2, __comp);
     iterator __f2 = __e1 = __sort(__e1, __e2, __n - __n2, __comp);
     if (__comp(*__f2, *__f1))
     {
-        iterator __m2 = _VSTD::next(__f2);
+        iterator __m2 = std::next(__f2);
         for (; __m2 != __e2 && __comp(*__m2, *__f1); ++__m2)
             ;
         __link_pointer __f = __f2.__ptr_;
@@ -1941,7 +1941,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
         __r = __f2;
         __e1 = __f2 = __m2;
         base::__unlink_nodes(__f, __l);
-        __m2 = _VSTD::next(__f1);
+        __m2 = std::next(__f1);
         __link_nodes(__f1.__ptr_, __f, __l);
         __f1 = __m2;
     }
@@ -1951,7 +1951,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
     {
         if (__comp(*__f2, *__f1))
         {
-            iterator __m2 = _VSTD::next(__f2);
+            iterator __m2 = std::next(__f2);
             for (; __m2 != __e2 && __comp(*__m2, *__f1); ++__m2)
                 ;
             __link_pointer __f = __f2.__ptr_;
@@ -1960,7 +1960,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
                 __e1 = __m2;
             __f2 = __m2;
             base::__unlink_nodes(__f, __l);
-            __m2 = _VSTD::next(__f1);
+            __m2 = std::next(__f1);
             __link_nodes(__f1.__ptr_, __f, __l);
             __f1 = __m2;
         }
@@ -1979,10 +1979,10 @@ list<_Tp, _Alloc>::reverse() _NOEXCEPT
         iterator __e = end();
         for (iterator __i = begin(); __i.__ptr_ != __e.__ptr_;)
         {
-            _VSTD::swap(__i.__ptr_->__prev_, __i.__ptr_->__next_);
+            std::swap(__i.__ptr_->__prev_, __i.__ptr_->__next_);
             __i.__ptr_ = __i.__ptr_->__prev_;
         }
-        _VSTD::swap(__e.__ptr_->__prev_, __e.__ptr_->__next_);
+        std::swap(__e.__ptr_->__prev_, __e.__ptr_->__next_);
     }
 }
 
@@ -1990,7 +1990,7 @@ template <class _Tp, class _Alloc>
 bool
 list<_Tp, _Alloc>::__invariants() const
 {
-    return size() == _VSTD::distance(begin(), end());
+    return size() == std::distance(begin(), end());
 }
 
 template <class _Tp, class _Alloc>
@@ -1998,7 +1998,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 bool
 operator==(const list<_Tp, _Alloc>& __x, const list<_Tp, _Alloc>& __y)
 {
-    return __x.size() == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -2008,7 +2008,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 bool
 operator< (const list<_Tp, _Alloc>& __x, const list<_Tp, _Alloc>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Tp, class _Alloc>
@@ -2073,7 +2073,7 @@ erase_if(list<_Tp, _Allocator>& __c, _Predicate __pred) {
 template <class _Tp, class _Allocator, class _Up>
 inline _LIBCPP_HIDE_FROM_ABI typename list<_Tp, _Allocator>::size_type
 erase(list<_Tp, _Allocator>& __c, const _Up& __v) {
-  return _VSTD::erase_if(__c, [&](auto& __elem) { return __elem == __v; });
+  return std::erase_if(__c, [&](auto& __elem) { return __elem == __v; });
 }
 
 template <>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -277,7 +277,7 @@ __scan_keyword(_InputIterator& __b, _InputIterator __e,
                bool __case_sensitive = true)
 {
     typedef typename iterator_traits<_InputIterator>::value_type _CharT;
-    size_t __nkw = static_cast<size_t>(_VSTD::distance(__kb, __ke));
+    size_t __nkw = static_cast<size_t>(std::distance(__kb, __ke));
     const unsigned char __doesnt_match = '\0';
     const unsigned char __might_match = '\1';
     const unsigned char __does_match = '\2';
@@ -899,7 +899,7 @@ num_get<_CharT, _InputIterator>::do_get(iter_type __b, iter_type __e,
     const numpunct<_CharT>& __np = std::use_facet<numpunct<_CharT> >(__iob.getloc());
     typedef typename numpunct<_CharT>::string_type string_type;
     const string_type __names[2] = {__np.truename(), __np.falsename()};
-    const string_type* __i = _VSTD::__scan_keyword(__b, __e, __names, __names+2,
+    const string_type* __i = std::__scan_keyword(__b, __e, __names, __names+2,
                                                    __ct, __err);
     __v = __i == __names;
     return __b;
@@ -1881,7 +1881,7 @@ time_get<_CharT, _InputIterator>::__get_weekdayname(int& __w,
 {
     // Note:  ignoring case comes from the POSIX strptime spec
     const string_type* __wk = this->__weeks();
-    ptrdiff_t __i = _VSTD::__scan_keyword(__b, __e, __wk, __wk+14, __ct, __err, false) - __wk;
+    ptrdiff_t __i = std::__scan_keyword(__b, __e, __wk, __wk+14, __ct, __err, false) - __wk;
     if (__i < 14)
         __w = __i % 7;
 }
@@ -1895,7 +1895,7 @@ time_get<_CharT, _InputIterator>::__get_monthname(int& __m,
 {
     // Note:  ignoring case comes from the POSIX strptime spec
     const string_type* __month = this->__months();
-    ptrdiff_t __i = _VSTD::__scan_keyword(__b, __e, __month, __month+24, __ct, __err, false) - __month;
+    ptrdiff_t __i = std::__scan_keyword(__b, __e, __month, __month+24, __ct, __err, false) - __month;
     if (__i < 24)
         __m = __i % 12;
 }
@@ -1907,7 +1907,7 @@ time_get<_CharT, _InputIterator>::__get_day(int& __d,
                                             ios_base::iostate& __err,
                                             const ctype<char_type>& __ct) const
 {
-    int __t = _VSTD::__get_up_to_n_digits(__b, __e, __err, __ct, 2);
+    int __t = std::__get_up_to_n_digits(__b, __e, __err, __ct, 2);
     if (!(__err & ios_base::failbit) && 1 <= __t && __t <= 31)
         __d = __t;
     else
@@ -2067,7 +2067,7 @@ time_get<_CharT, _InputIterator>::__get_am_pm(int& __h,
         __err |= ios_base::failbit;
         return;
     }
-    ptrdiff_t __i = _VSTD::__scan_keyword(__b, __e, __ap, __ap+2, __ct, __err, false) - __ap;
+    ptrdiff_t __i = std::__scan_keyword(__b, __e, __ap, __ap+2, __ct, __err, false) - __ap;
     if (__i == 0 && __h == 12)
         __h = 0;
     else if (__i == 1 && __h < 12)
@@ -2535,7 +2535,7 @@ time_put<_CharT, _OutputIterator>::do_put(iter_type __s, ios_base&,
     char_type* __nb = __nar;
     char_type* __ne = __nb + 100;
     __do_put(__nb, __ne, __tm, __fmt, __mod);
-    return _VSTD::copy(__nb, __ne, __s);
+    return std::copy(__nb, __ne, __s);
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<char>;
@@ -3071,7 +3071,7 @@ money_get<_CharT, _InputIterator>::do_get(iter_type __b, iter_type __e,
         if (__neg)
             *__nc++ = '-';
         for (const char_type* __w = __wb.get(); __w < __wn; ++__w, ++__nc)
-            *__nc = __src[std::find(__atoms, _VSTD::end(__atoms), *__w) - __atoms];
+            *__nc = __src[std::find(__atoms, std::end(__atoms), *__w) - __atoms];
         *__nc = char();
         if (sscanf(__nbuf, "%Lf", &__v) != 1)
             __throw_runtime_error("money_get error");
@@ -3224,7 +3224,7 @@ __money_put<_CharT>::__format(char_type* __mb, char_type*& __mi, char_type*& __m
             break;
         case money_base::symbol:
             if (!__sym.empty() && (__flags & ios_base::showbase))
-                __me = _VSTD::copy(__sym.begin(), __sym.end(), __me);
+                __me = std::copy(__sym.begin(), __sym.end(), __me);
             break;
         case money_base::value:
             {
@@ -3283,7 +3283,7 @@ __money_put<_CharT>::__format(char_type* __mb, char_type*& __mi, char_type*& __m
     }
     // print rest of sign, if any
     if (__sn.size() > 1)
-        __me = _VSTD::copy(__sn.begin()+1, __sn.end(), __me);
+        __me = std::copy(__sn.begin()+1, __sn.end(), __me);
     // set alignment
     if ((__flags & ios_base::adjustfield) == ios_base::left)
         __mi = __me;
@@ -3534,7 +3534,7 @@ messages<_CharT>::do_get(catalog __c, int __set, int __msgid,
     char* __n = catgets(__cat, __set, __msgid, __ndflt.c_str());
     string_type __w;
     __widen_from_utf8<sizeof(char_type)*__CHAR_BIT__>()(std::back_inserter(__w),
-                                                        __n, __n + _VSTD::strlen(__n));
+                                                        __n, __n + std::strlen(__n));
     return __w;
 #else // !_LIBCPP_HAS_CATOPEN
     (void)__c;
@@ -3688,8 +3688,8 @@ template<class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
 inline
 wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::
     wstring_convert(wstring_convert&& __wc)
-        : __byte_err_string_(_VSTD::move(__wc.__byte_err_string_)),
-          __wide_err_string_(_VSTD::move(__wc.__wide_err_string_)),
+        : __byte_err_string_(std::move(__wc.__byte_err_string_)),
+          __wide_err_string_(std::move(__wc.__wide_err_string_)),
           __cvtptr_(__wc.__cvtptr_),
           __cvtstate_(__wc.__cvtstate_), __cvtcount_(__wc.__cvtcount_)
 {
@@ -3981,7 +3981,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
     int_type __c = traits_type::eof();
     if (this->gptr() == this->egptr())
     {
-        _VSTD::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
+        std::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
         if (__always_noconv_)
         {
             streamsize __nmemb = static_cast<streamsize>(this->egptr() - this->eback() - __unget_sz);
@@ -3999,11 +3999,11 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
              if (__extbufend_ != __extbufnext_) {
                 _LIBCPP_ASSERT_NON_NULL(__extbufnext_ != nullptr, "underflow moving from nullptr");
                 _LIBCPP_ASSERT_NON_NULL(__extbuf_ != nullptr, "underflow moving into nullptr");
-                _VSTD::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
+                std::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
              }
             __extbufnext_ = __extbuf_ + (__extbufend_ - __extbufnext_);
             __extbufend_ = __extbuf_ + (__extbuf_ == __extbuf_min_ ? sizeof(__extbuf_min_) : __ebs_);
-            streamsize __nmemb = _VSTD::min(static_cast<streamsize>(this->egptr() - this->eback() - __unget_sz),
+            streamsize __nmemb = std::min(static_cast<streamsize>(this->egptr() - this->eback() - __unget_sz),
                                  static_cast<streamsize>(__extbufend_ - __extbufnext_));
             codecvt_base::result __r;
             // FIXME: Do we ever need to restore the state here?

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -647,7 +647,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI void swap(__map_value_compare& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value)
     {
-      using _VSTD::swap;
+      using std::swap;
       swap(static_cast<_Compare&>(*this), static_cast<_Compare&>(__y));
     }
 
@@ -693,7 +693,7 @@ public:
     void swap(__map_value_compare& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(__comp_, __y.__comp_);
     }
 
@@ -760,9 +760,9 @@ public:
     void operator()(pointer __p) _NOEXCEPT
     {
         if (__second_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__value_.__get_value().second));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__value_.__get_value().second));
         if (__first_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__value_.__get_value().first));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__value_.__get_value().first));
         if (__p)
             __alloc_traits::deallocate(__na_, __p, 1);
     }
@@ -793,7 +793,7 @@ public:
     value_type& __get_value()
     {
 #if _LIBCPP_STD_VER >= 17
-        return *_VSTD::launder(_VSTD::addressof(__cc_));
+        return *std::launder(std::addressof(__cc_));
 #else
         return __cc_;
 #endif
@@ -803,7 +803,7 @@ public:
     const value_type& __get_value() const
     {
 #if _LIBCPP_STD_VER >= 17
-        return *_VSTD::launder(_VSTD::addressof(__cc_));
+        return *std::launder(std::addressof(__cc_));
 #else
         return __cc_;
 #endif
@@ -821,8 +821,8 @@ public:
     {
         value_type& __v = __get_value();
         return __nc_rref_pair_type(
-            _VSTD::move(const_cast<key_type&>(__v.first)),
-            _VSTD::move(__v.second));
+            std::move(const_cast<key_type&>(__v.first)),
+            std::move(__v.second));
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -845,7 +845,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __value_type& operator=(_ValueTp&& __v)
     {
-        __ref() = _VSTD::forward<_ValueTp>(__v);
+        __ref() = std::forward<_ValueTp>(__v);
         return *this;
     }
 
@@ -1047,7 +1047,7 @@ public:
 
 private:
 
-    typedef _VSTD::__value_type<key_type, mapped_type>             __value_type;
+    typedef std::__value_type<key_type, mapped_type>             __value_type;
     typedef __map_value_compare<key_type, __value_type, key_compare> __vc;
     typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
     typedef __tree<__value_type, __vc, __allocator_type>   __base;
@@ -1067,8 +1067,8 @@ public:
     typedef typename __alloc_traits::difference_type       difference_type;
     typedef __map_iterator<typename __base::iterator>             iterator;
     typedef __map_const_iterator<typename __base::const_iterator> const_iterator;
-    typedef _VSTD::reverse_iterator<iterator>               reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator>         const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>               reverse_iterator;
+    typedef std::reverse_iterator<const_iterator>         const_reverse_iterator;
 
 #if _LIBCPP_STD_VER >= 17
     typedef __map_node_handle<typename __base::__node, allocator_type> node_type;
@@ -1154,7 +1154,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
             __tree_ = __m.__tree_;
 #else
-            if (this != _VSTD::addressof(__m)) {
+            if (this != std::addressof(__m)) {
                 __tree_.clear();
                 __tree_.value_comp() = __m.__tree_.value_comp();
                 __tree_.__copy_assign_alloc(__m.__tree_);
@@ -1169,7 +1169,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     map(map&& __m)
         _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
-        : __tree_(_VSTD::move(__m.__tree_))
+        : __tree_(std::move(__m.__tree_))
         {
         }
 
@@ -1179,7 +1179,7 @@ public:
     map& operator=(map&& __m)
         _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
         {
-            __tree_ = _VSTD::move(__m.__tree_);
+            __tree_ = std::move(__m.__tree_);
             return *this;
         }
 
@@ -1286,26 +1286,26 @@ public:
     template <class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> emplace(_Args&& ...__args) {
-        return __tree_.__emplace_unique(_VSTD::forward<_Args>(__args)...);
+        return __tree_.__emplace_unique(std::forward<_Args>(__args)...);
     }
 
     template <class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator emplace_hint(const_iterator __p, _Args&& ...__args) {
-        return __tree_.__emplace_hint_unique(__p.__i_, _VSTD::forward<_Args>(__args)...);
+        return __tree_.__emplace_hint_unique(__p.__i_, std::forward<_Args>(__args)...);
     }
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
         _LIBCPP_HIDE_FROM_ABI
         pair<iterator, bool> insert(_Pp&& __p)
-            {return __tree_.__insert_unique(_VSTD::forward<_Pp>(__p));}
+            {return __tree_.__insert_unique(std::forward<_Pp>(__p));}
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
         _LIBCPP_HIDE_FROM_ABI
         iterator insert(const_iterator __pos, _Pp&& __p)
-            {return __tree_.__insert_unique(__pos.__i_, _VSTD::forward<_Pp>(__p));}
+            {return __tree_.__insert_unique(__pos.__i_, std::forward<_Pp>(__p));}
 
 #endif // _LIBCPP_CXX03_LANG
 
@@ -1321,11 +1321,11 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool>
-    insert(value_type&& __v) {return __tree_.__insert_unique(_VSTD::move(__v));}
+    insert(value_type&& __v) {return __tree_.__insert_unique(std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p,  value_type&& __v)
-    {return __tree_.__insert_unique(__p.__i_, _VSTD::move(__v));}
+    {return __tree_.__insert_unique(__p.__i_, std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     void insert(initializer_list<value_type> __il)
@@ -1358,9 +1358,9 @@ public:
         pair<iterator, bool> try_emplace(const key_type& __k, _Args&&... __args)
     {
         return __tree_.__emplace_unique_key_args(__k,
-            _VSTD::piecewise_construct,
-            _VSTD::forward_as_tuple(__k),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...));
+            std::piecewise_construct,
+            std::forward_as_tuple(__k),
+            std::forward_as_tuple(std::forward<_Args>(__args)...));
     }
 
     template <class... _Args>
@@ -1368,9 +1368,9 @@ public:
         pair<iterator, bool> try_emplace(key_type&& __k, _Args&&... __args)
     {
         return __tree_.__emplace_unique_key_args(__k,
-            _VSTD::piecewise_construct,
-            _VSTD::forward_as_tuple(_VSTD::move(__k)),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...));
+            std::piecewise_construct,
+            std::forward_as_tuple(std::move(__k)),
+            std::forward_as_tuple(std::forward<_Args>(__args)...));
     }
 
     template <class... _Args>
@@ -1378,9 +1378,9 @@ public:
         iterator try_emplace(const_iterator __h, const key_type& __k, _Args&&... __args)
     {
         return __tree_.__emplace_hint_unique_key_args(__h.__i_, __k,
-            _VSTD::piecewise_construct,
-            _VSTD::forward_as_tuple(__k),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...)).first;
+            std::piecewise_construct,
+            std::forward_as_tuple(__k),
+            std::forward_as_tuple(std::forward<_Args>(__args)...)).first;
     }
 
     template <class... _Args>
@@ -1388,9 +1388,9 @@ public:
         iterator try_emplace(const_iterator __h, key_type&& __k, _Args&&... __args)
     {
         return __tree_.__emplace_hint_unique_key_args(__h.__i_, __k,
-            _VSTD::piecewise_construct,
-            _VSTD::forward_as_tuple(_VSTD::move(__k)),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...)).first;
+            std::piecewise_construct,
+            std::forward_as_tuple(std::move(__k)),
+            std::forward_as_tuple(std::forward<_Args>(__args)...)).first;
     }
 
     template <class _Vp>
@@ -1400,10 +1400,10 @@ public:
         iterator __p = lower_bound(__k);
         if ( __p != end() && !key_comp()(__k, __p->first))
         {
-            __p->second = _VSTD::forward<_Vp>(__v);
-            return _VSTD::make_pair(__p, false);
+            __p->second = std::forward<_Vp>(__v);
+            return std::make_pair(__p, false);
         }
-        return _VSTD::make_pair(emplace_hint(__p, __k, _VSTD::forward<_Vp>(__v)), true);
+        return std::make_pair(emplace_hint(__p, __k, std::forward<_Vp>(__v)), true);
     }
 
     template <class _Vp>
@@ -1413,10 +1413,10 @@ public:
         iterator __p = lower_bound(__k);
         if ( __p != end() && !key_comp()(__k, __p->first))
         {
-            __p->second = _VSTD::forward<_Vp>(__v);
-            return _VSTD::make_pair(__p, false);
+            __p->second = std::forward<_Vp>(__v);
+            return std::make_pair(__p, false);
         }
-        return _VSTD::make_pair(emplace_hint(__p, _VSTD::move(__k), _VSTD::forward<_Vp>(__v)), true);
+        return std::make_pair(emplace_hint(__p, std::move(__k), std::forward<_Vp>(__v)), true);
     }
 
     template <class _Vp>
@@ -1424,10 +1424,10 @@ public:
                                                         const key_type& __k,
                                                         _Vp&& __v) {
       auto [__r, __inserted] = __tree_.__emplace_hint_unique_key_args(
-          __h.__i_, __k, __k, _VSTD::forward<_Vp>(__v));
+          __h.__i_, __k, __k, std::forward<_Vp>(__v));
 
       if (!__inserted)
-        __r->__get_value().second = _VSTD::forward<_Vp>(__v);
+        __r->__get_value().second = std::forward<_Vp>(__v);
 
       return __r;
     }
@@ -1437,10 +1437,10 @@ public:
                                                         key_type&& __k,
                                                         _Vp&& __v) {
       auto [__r, __inserted] = __tree_.__emplace_hint_unique_key_args(
-          __h.__i_, __k, _VSTD::move(__k), _VSTD::forward<_Vp>(__v));
+          __h.__i_, __k, std::move(__k), std::forward<_Vp>(__v));
 
       if (!__inserted)
-        __r->__get_value().second = _VSTD::forward<_Vp>(__v);
+        __r->__get_value().second = std::forward<_Vp>(__v);
 
       return __r;
     }
@@ -1467,7 +1467,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to map::insert()");
         return __tree_.template __node_handle_insert_unique<
-            node_type, insert_return_type>(_VSTD::move(__nh));
+            node_type, insert_return_type>(std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -1475,7 +1475,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to map::insert()");
         return __tree_.template __node_handle_insert_unique<node_type>(
-            __hint.__i_, _VSTD::move(__nh));
+            __hint.__i_, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -1675,7 +1675,7 @@ map(initializer_list<pair<_Key, _Tp>>, _Allocator)
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 map<_Key, _Tp, _Compare, _Allocator>::map(map&& __m, const allocator_type& __a)
-    : __tree_(_VSTD::move(__m.__tree_), typename __base::allocator_type(__a))
+    : __tree_(std::move(__m.__tree_), typename __base::allocator_type(__a))
 {
     if (__a != __m.get_allocator())
     {
@@ -1691,9 +1691,9 @@ _Tp&
 map<_Key, _Tp, _Compare, _Allocator>::operator[](const key_type& __k)
 {
     return __tree_.__emplace_unique_key_args(__k,
-        _VSTD::piecewise_construct,
-        _VSTD::forward_as_tuple(__k),
-        _VSTD::forward_as_tuple()).first->__get_value().second;
+        std::piecewise_construct,
+        std::forward_as_tuple(__k),
+        std::forward_as_tuple()).first->__get_value().second;
 }
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
@@ -1703,9 +1703,9 @@ map<_Key, _Tp, _Compare, _Allocator>::operator[](key_type&& __k)
     // TODO investigate this clang-tidy warning.
     // NOLINTNEXTLINE(bugprone-use-after-move)
     return __tree_.__emplace_unique_key_args(__k,
-        _VSTD::piecewise_construct,
-        _VSTD::forward_as_tuple(_VSTD::move(__k)),
-        _VSTD::forward_as_tuple()).first->__get_value().second;
+        std::piecewise_construct,
+        std::forward_as_tuple(std::move(__k)),
+        std::forward_as_tuple()).first->__get_value().second;
 }
 
 #else // _LIBCPP_CXX03_LANG
@@ -1716,9 +1716,9 @@ map<_Key, _Tp, _Compare, _Allocator>::__construct_node_with_key(const key_type& 
 {
     __node_allocator& __na = __tree_.__node_alloc();
     __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
-    __node_traits::construct(__na, _VSTD::addressof(__h->__value_.__get_value().first), __k);
+    __node_traits::construct(__na, std::addressof(__h->__value_.__get_value().first), __k);
     __h.get_deleter().__first_constructed = true;
-    __node_traits::construct(__na, _VSTD::addressof(__h->__value_.__get_value().second));
+    __node_traits::construct(__na, std::addressof(__h->__value_.__get_value().second));
     __h.get_deleter().__second_constructed = true;
     return __h;
 }
@@ -1770,7 +1770,7 @@ bool
 operator==(const map<_Key, _Tp, _Compare, _Allocator>& __x,
            const map<_Key, _Tp, _Compare, _Allocator>& __y)
 {
-    return __x.size() == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -1781,7 +1781,7 @@ bool
 operator< (const map<_Key, _Tp, _Compare, _Allocator>& __x,
            const map<_Key, _Tp, _Compare, _Allocator>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
@@ -1851,7 +1851,7 @@ template <class _Key, class _Tp, class _Compare, class _Allocator,
 inline _LIBCPP_HIDE_FROM_ABI
     typename map<_Key, _Tp, _Compare, _Allocator>::size_type
     erase_if(map<_Key, _Tp, _Compare, _Allocator>& __c, _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -1890,7 +1890,7 @@ public:
 
 private:
 
-    typedef _VSTD::__value_type<key_type, mapped_type>             __value_type;
+    typedef std::__value_type<key_type, mapped_type>             __value_type;
     typedef __map_value_compare<key_type, __value_type, key_compare> __vc;
     typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
     typedef __tree<__value_type, __vc, __allocator_type>            __base;
@@ -1910,8 +1910,8 @@ public:
     typedef typename __alloc_traits::difference_type       difference_type;
     typedef __map_iterator<typename __base::iterator>      iterator;
     typedef __map_const_iterator<typename __base::const_iterator> const_iterator;
-    typedef _VSTD::reverse_iterator<iterator>               reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator>         const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>               reverse_iterator;
+    typedef std::reverse_iterator<const_iterator>         const_reverse_iterator;
 
 #if _LIBCPP_STD_VER >= 17
     typedef __map_node_handle<typename __base::__node, allocator_type> node_type;
@@ -1997,7 +1997,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
             __tree_ = __m.__tree_;
 #else
-            if (this != _VSTD::addressof(__m)) {
+            if (this != std::addressof(__m)) {
                 __tree_.clear();
                 __tree_.value_comp() = __m.__tree_.value_comp();
                 __tree_.__copy_assign_alloc(__m.__tree_);
@@ -2012,7 +2012,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     multimap(multimap&& __m)
         _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
-        : __tree_(_VSTD::move(__m.__tree_))
+        : __tree_(std::move(__m.__tree_))
         {
         }
 
@@ -2022,7 +2022,7 @@ public:
     multimap& operator=(multimap&& __m)
         _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
         {
-            __tree_ = _VSTD::move(__m.__tree_);
+            __tree_ = std::move(__m.__tree_);
             return *this;
         }
 
@@ -2122,34 +2122,34 @@ public:
     template <class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator emplace(_Args&& ...__args) {
-        return __tree_.__emplace_multi(_VSTD::forward<_Args>(__args)...);
+        return __tree_.__emplace_multi(std::forward<_Args>(__args)...);
     }
 
     template <class ..._Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator emplace_hint(const_iterator __p, _Args&& ...__args) {
-        return __tree_.__emplace_hint_multi(__p.__i_, _VSTD::forward<_Args>(__args)...);
+        return __tree_.__emplace_hint_multi(__p.__i_, std::forward<_Args>(__args)...);
     }
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value>>
         _LIBCPP_HIDE_FROM_ABI
         iterator insert(_Pp&& __p)
-            {return __tree_.__insert_multi(_VSTD::forward<_Pp>(__p));}
+            {return __tree_.__insert_multi(std::forward<_Pp>(__p));}
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value>>
         _LIBCPP_HIDE_FROM_ABI
         iterator insert(const_iterator __pos, _Pp&& __p)
-            {return __tree_.__insert_multi(__pos.__i_, _VSTD::forward<_Pp>(__p));}
+            {return __tree_.__insert_multi(__pos.__i_, std::forward<_Pp>(__p));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(value_type&& __v)
-        {return __tree_.__insert_multi(_VSTD::move(__v));}
+        {return __tree_.__insert_multi(std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, value_type&& __v)
-        {return __tree_.__insert_multi(__p.__i_, _VSTD::move(__v));}
+        {return __tree_.__insert_multi(__p.__i_, std::move(__v));}
 
 
     _LIBCPP_HIDE_FROM_ABI
@@ -2201,7 +2201,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to multimap::insert()");
         return __tree_.template __node_handle_insert_multi<node_type>(
-            _VSTD::move(__nh));
+            std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -2209,7 +2209,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to multimap::insert()");
         return __tree_.template __node_handle_insert_multi<node_type>(
-            __hint.__i_, _VSTD::move(__nh));
+            __hint.__i_, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -2407,14 +2407,14 @@ multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 multimap<_Key, _Tp, _Compare, _Allocator>::multimap(multimap&& __m, const allocator_type& __a)
-    : __tree_(_VSTD::move(__m.__tree_), typename __base::allocator_type(__a))
+    : __tree_(std::move(__m.__tree_), typename __base::allocator_type(__a))
 {
     if (__a != __m.get_allocator())
     {
         const_iterator __e = cend();
         while (!__m.empty())
             __tree_.__insert_multi(__e.__i_,
-                    _VSTD::move(__m.__tree_.remove(__m.begin().__i_)->__value_.__move()));
+                    std::move(__m.__tree_.remove(__m.begin().__i_)->__value_.__move()));
     }
 }
 #endif
@@ -2425,7 +2425,7 @@ bool
 operator==(const multimap<_Key, _Tp, _Compare, _Allocator>& __x,
            const multimap<_Key, _Tp, _Compare, _Allocator>& __y)
 {
-    return __x.size() == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -2436,7 +2436,7 @@ bool
 operator< (const multimap<_Key, _Tp, _Compare, _Allocator>& __x,
            const multimap<_Key, _Tp, _Compare, _Allocator>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
@@ -2508,7 +2508,7 @@ inline _LIBCPP_HIDE_FROM_ABI
     typename multimap<_Key, _Tp, _Compare, _Allocator>::size_type
     erase_if(multimap<_Key, _Tp, _Compare, _Allocator>& __c,
              _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -471,7 +471,7 @@ inline _LIBCPP_HIDE_FROM_ABI
 void __unlock(_L0& __l0, _L1& __l1, _L2& __l2, _L3&... __l3) {
     __l0.unlock();
     __l1.unlock();
-    _VSTD::__unlock(__l2, __l3...);
+    std::__unlock(__l2, __l3...);
 }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -524,7 +524,7 @@ public:
     explicit scoped_lock(_MArgs&... __margs)
       : __t_(__margs...)
     {
-        _VSTD::lock(__margs...);
+        std::lock(__margs...);
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -546,7 +546,7 @@ private:
     template <size_t ..._Indx>
     _LIBCPP_HIDE_FROM_ABI
     static void __unlock_unpack(__tuple_indices<_Indx...>, _MutexTuple& __mt) {
-        _VSTD::__unlock(_VSTD::get<_Indx>(__mt)...);
+        std::__unlock(std::get<_Indx>(__mt)...);
     }
 
     _MutexTuple __t_;

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -349,7 +349,7 @@ template <class _Tp>
 _LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _Tp* launder(_Tp* __p) noexcept
 {
-    return _VSTD::__launder(__p);
+    return std::__launder(__p);
 }
 #endif
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -315,14 +315,14 @@ struct __optional_destruct_base<_Tp, false>
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
-        :  __val_(_VSTD::forward<_Args>(__args)...),
+        :  __val_(std::forward<_Args>(__args)...),
            __engaged_(true) {}
 
 #if _LIBCPP_STD_VER >= 23
   template <class _Fp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI
   constexpr __optional_destruct_base(__optional_construct_from_invoke_tag, _Fp&& __f, _Args&&... __args)
-      : __val_(_VSTD::invoke(_VSTD::forward<_Fp>(__f), _VSTD::forward<_Args>(__args)...)), __engaged_(true) {}
+      : __val_(std::invoke(std::forward<_Fp>(__f), std::forward<_Args>(__args)...)), __engaged_(true) {}
 #endif
 
     _LIBCPP_HIDE_FROM_ABI
@@ -357,14 +357,14 @@ struct __optional_destruct_base<_Tp, true>
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
-        :  __val_(_VSTD::forward<_Args>(__args)...),
+        :  __val_(std::forward<_Args>(__args)...),
            __engaged_(true) {}
 
 #if _LIBCPP_STD_VER >= 23
   template <class _Fp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI
   constexpr __optional_destruct_base(__optional_construct_from_invoke_tag, _Fp&& __f, _Args&&... __args)
-      : __val_(_VSTD::invoke(_VSTD::forward<_Fp>(__f), _VSTD::forward<_Args>(__args)...)), __engaged_(true) {}
+      : __val_(std::invoke(std::forward<_Fp>(__f), std::forward<_Args>(__args)...)), __engaged_(true) {}
 #endif
 
     _LIBCPP_HIDE_FROM_ABI
@@ -403,12 +403,12 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
     _LIBCPP_HIDE_FROM_ABI
     constexpr value_type&& __get() && noexcept
     {
-        return _VSTD::move(this->__val_);
+        return std::move(this->__val_);
     }
     _LIBCPP_HIDE_FROM_ABI
     constexpr const value_type&& __get() const&& noexcept
     {
-        return _VSTD::move(this->__val_);
+        return std::move(this->__val_);
     }
 
     template <class... _Args>
@@ -425,7 +425,7 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
     _LIBCPP_CONSTEXPR_SINCE_CXX20 void __construct_from(_That&& __opt)
     {
         if (__opt.has_value())
-            __construct(_VSTD::forward<_That>(__opt).__get());
+            __construct(std::forward<_That>(__opt).__get());
     }
 
     template <class _That>
@@ -435,14 +435,14 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
         if (this->__engaged_ == __opt.has_value())
         {
             if (this->__engaged_)
-                this->__val_ = _VSTD::forward<_That>(__opt).__get();
+                this->__val_ = std::forward<_That>(__opt).__get();
         }
         else
         {
             if (this->__engaged_)
                 this->reset();
             else
-                __construct(_VSTD::forward<_That>(__opt).__get());
+                __construct(std::forward<_That>(__opt).__get());
         }
     }
 };
@@ -480,7 +480,7 @@ struct __optional_storage_base<_Tp, true>
     template <class _UArg>
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit __optional_storage_base(in_place_t, _UArg&& __uarg)
-        :  __value_(_VSTD::addressof(__uarg))
+        :  __value_(std::addressof(__uarg))
     {
       static_assert(__can_bind_reference<_UArg>(),
         "Attempted to construct a reference element in tuple from a "
@@ -500,7 +500,7 @@ struct __optional_storage_base<_Tp, true>
 
     _LIBCPP_HIDE_FROM_ABI
     constexpr value_type&& __get() const&& noexcept
-      { return _VSTD::forward<value_type>(*__value_); }
+      { return std::forward<value_type>(*__value_); }
 
     template <class _UArg>
     _LIBCPP_HIDE_FROM_ABI
@@ -510,7 +510,7 @@ struct __optional_storage_base<_Tp, true>
         static_assert(__can_bind_reference<_UArg>(),
             "Attempted to construct a reference element in tuple from a "
             "possible temporary");
-        __value_ = _VSTD::addressof(__val);
+        __value_ = std::addressof(__val);
     }
 
     template <class _That>
@@ -518,7 +518,7 @@ struct __optional_storage_base<_Tp, true>
     _LIBCPP_CONSTEXPR_SINCE_CXX20 void __construct_from(_That&& __opt)
     {
         if (__opt.has_value())
-            __construct(_VSTD::forward<_That>(__opt).__get());
+            __construct(std::forward<_That>(__opt).__get());
     }
 
     template <class _That>
@@ -528,14 +528,14 @@ struct __optional_storage_base<_Tp, true>
         if (has_value() == __opt.has_value())
         {
             if (has_value())
-                *__value_ = _VSTD::forward<_That>(__opt).__get();
+                *__value_ = std::forward<_That>(__opt).__get();
         }
         else
         {
             if (has_value())
                 reset();
             else
-                __construct(_VSTD::forward<_That>(__opt).__get());
+                __construct(std::forward<_That>(__opt).__get());
         }
     }
 };
@@ -589,7 +589,7 @@ struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
     _LIBCPP_CONSTEXPR_SINCE_CXX20 __optional_move_base(__optional_move_base&& __opt)
         noexcept(is_nothrow_move_constructible_v<value_type>)
     {
-        this->__construct_from(_VSTD::move(__opt));
+        this->__construct_from(std::move(__opt));
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -659,7 +659,7 @@ struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp
         noexcept(is_nothrow_move_assignable_v<value_type> &&
                  is_nothrow_move_constructible_v<value_type>)
     {
-        this->__assign_from(_VSTD::move(__opt));
+        this->__assign_from(std::move(__opt));
         return *this;
     }
 };
@@ -810,28 +810,28 @@ public:
     >
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit optional(_InPlaceT, _Args&&... __args)
-        : __base(in_place, _VSTD::forward<_Args>(__args)...) {}
+        : __base(in_place, std::forward<_Args>(__args)...) {}
 
     template <class _Up, class... _Args, class = enable_if_t<
         is_constructible_v<value_type, initializer_list<_Up>&, _Args...>>
     >
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
-        : __base(in_place, __il, _VSTD::forward<_Args>(__args)...) {}
+        : __base(in_place, __il, std::forward<_Args>(__args)...) {}
 
     template <class _Up = value_type, enable_if_t<
         _CheckOptionalArgsCtor<_Up>::template __enable_implicit<_Up>()
     , int> = 0>
     _LIBCPP_HIDE_FROM_ABI
     constexpr optional(_Up&& __v)
-        : __base(in_place, _VSTD::forward<_Up>(__v)) {}
+        : __base(in_place, std::forward<_Up>(__v)) {}
 
     template <class _Up, enable_if_t<
         _CheckOptionalArgsCtor<_Up>::template __enable_explicit<_Up>()
     , int> = 0>
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit optional(_Up&& __v)
-        : __base(in_place, _VSTD::forward<_Up>(__v)) {}
+        : __base(in_place, std::forward<_Up>(__v)) {}
 
     // LWG2756: conditionally explicit conversion from const optional<_Up>&
     template <class _Up, enable_if_t<
@@ -858,7 +858,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     _LIBCPP_CONSTEXPR_SINCE_CXX20 optional(optional<_Up>&& __v)
     {
-        this->__construct_from(_VSTD::move(__v));
+        this->__construct_from(std::move(__v));
     }
     template <class _Up, enable_if_t<
         _CheckOptionalLikeCtor<_Up, _Up &&>::template __enable_explicit<_Up>()
@@ -866,14 +866,14 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit optional(optional<_Up>&& __v)
     {
-        this->__construct_from(_VSTD::move(__v));
+        this->__construct_from(std::move(__v));
     }
 
 #if _LIBCPP_STD_VER >= 23
   template<class _Fp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI
   constexpr explicit optional(__optional_construct_from_invoke_tag, _Fp&& __f, _Args&&... __args)
-      : __base(__optional_construct_from_invoke_tag{}, _VSTD::forward<_Fp>(__f), _VSTD::forward<_Args>(__args)...) {
+      : __base(__optional_construct_from_invoke_tag{}, std::forward<_Fp>(__f), std::forward<_Args>(__args)...) {
   }
 #endif
 
@@ -905,9 +905,9 @@ public:
     operator=(_Up&& __v)
     {
         if (this->has_value())
-            this->__get() = _VSTD::forward<_Up>(__v);
+            this->__get() = std::forward<_Up>(__v);
         else
-            this->__construct(_VSTD::forward<_Up>(__v));
+            this->__construct(std::forward<_Up>(__v));
         return *this;
     }
 
@@ -931,7 +931,7 @@ public:
     _LIBCPP_CONSTEXPR_SINCE_CXX20 optional&
     operator=(optional<_Up>&& __v)
     {
-        this->__assign_from(_VSTD::move(__v));
+        this->__assign_from(std::move(__v));
         return *this;
     }
 
@@ -946,7 +946,7 @@ public:
     emplace(_Args&&... __args)
     {
         reset();
-        this->__construct(_VSTD::forward<_Args>(__args)...);
+        this->__construct(std::forward<_Args>(__args)...);
         return this->__get();
     }
 
@@ -961,7 +961,7 @@ public:
     emplace(initializer_list<_Up> __il, _Args&&... __args)
     {
         reset();
-        this->__construct(__il, _VSTD::forward<_Args>(__args)...);
+        this->__construct(__il, std::forward<_Args>(__args)...);
         return this->__get();
     }
 
@@ -972,7 +972,7 @@ public:
     {
         if (this->has_value() == __opt.has_value())
         {
-            using _VSTD::swap;
+            using std::swap;
             if (this->has_value())
                 swap(this->__get(), __opt.__get());
         }
@@ -980,12 +980,12 @@ public:
         {
             if (this->has_value())
             {
-                __opt.__construct(_VSTD::move(this->__get()));
+                __opt.__construct(std::move(this->__get()));
                 reset();
             }
             else
             {
-                this->__construct(_VSTD::move(__opt.__get()));
+                this->__construct(std::move(__opt.__get()));
                 __opt.reset();
             }
         }
@@ -997,7 +997,7 @@ public:
     operator->() const
     {
         _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(this->has_value(), "optional operator-> called on a disengaged value");
-        return _VSTD::addressof(this->__get());
+        return std::addressof(this->__get());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1006,7 +1006,7 @@ public:
     operator->()
     {
         _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(this->has_value(), "optional operator-> called on a disengaged value");
-        return _VSTD::addressof(this->__get());
+        return std::addressof(this->__get());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1033,7 +1033,7 @@ public:
     operator*() && noexcept
     {
         _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(this->has_value(), "optional operator* called on a disengaged value");
-        return _VSTD::move(this->__get());
+        return std::move(this->__get());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1042,7 +1042,7 @@ public:
     operator*() const&& noexcept
     {
         _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(this->has_value(), "optional operator* called on a disengaged value");
-        return _VSTD::move(this->__get());
+        return std::move(this->__get());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1075,7 +1075,7 @@ public:
     {
         if (!this->has_value())
             __throw_bad_optional_access();
-        return _VSTD::move(this->__get());
+        return std::move(this->__get());
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1084,7 +1084,7 @@ public:
     {
         if (!this->has_value())
             __throw_bad_optional_access();
-        return _VSTD::move(this->__get());
+        return std::move(this->__get());
     }
 
     template <class _Up>
@@ -1096,7 +1096,7 @@ public:
         static_assert(is_convertible_v<_Up, value_type>,
                       "optional<T>::value_or: U must be convertible to T");
         return this->has_value() ? this->__get() :
-                                  static_cast<value_type>(_VSTD::forward<_Up>(__v));
+                                  static_cast<value_type>(std::forward<_Up>(__v));
     }
 
     template <class _Up>
@@ -1107,8 +1107,8 @@ public:
                       "optional<T>::value_or: T must be move constructible");
         static_assert(is_convertible_v<_Up, value_type>,
                       "optional<T>::value_or: U must be convertible to T");
-        return this->has_value() ? _VSTD::move(this->__get()) :
-                                  static_cast<value_type>(_VSTD::forward<_Up>(__v));
+        return this->has_value() ? std::move(this->__get()) :
+                                  static_cast<value_type>(std::forward<_Up>(__v));
     }
 
 #if _LIBCPP_STD_VER >= 23
@@ -1119,7 +1119,7 @@ public:
     static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
                   "Result of f(value()) must be a specialization of std::optional");
     if (*this)
-      return _VSTD::invoke(_VSTD::forward<_Func>(__f), value());
+      return std::invoke(std::forward<_Func>(__f), value());
     return remove_cvref_t<_Up>();
   }
 
@@ -1130,7 +1130,7 @@ public:
     static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
                   "Result of f(value()) must be a specialization of std::optional");
     if (*this)
-      return _VSTD::invoke(_VSTD::forward<_Func>(__f), value());
+      return std::invoke(std::forward<_Func>(__f), value());
     return remove_cvref_t<_Up>();
   }
 
@@ -1141,7 +1141,7 @@ public:
     static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
                   "Result of f(std::move(value())) must be a specialization of std::optional");
     if (*this)
-      return _VSTD::invoke(_VSTD::forward<_Func>(__f), _VSTD::move(value()));
+      return std::invoke(std::forward<_Func>(__f), std::move(value()));
     return remove_cvref_t<_Up>();
   }
 
@@ -1152,7 +1152,7 @@ public:
     static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
                   "Result of f(std::move(value())) must be a specialization of std::optional");
     if (*this)
-      return _VSTD::invoke(_VSTD::forward<_Func>(__f), _VSTD::move(value()));
+      return std::invoke(std::forward<_Func>(__f), std::move(value()));
     return remove_cvref_t<_Up>();
   }
 
@@ -1167,7 +1167,7 @@ public:
                   "Result of f(value()) should not be std::nullopt_t");
     static_assert(is_object_v<_Up>, "Result of f(value()) should be an object type");
     if (*this)
-      return optional<_Up>(__optional_construct_from_invoke_tag{}, _VSTD::forward<_Func>(__f), value());
+      return optional<_Up>(__optional_construct_from_invoke_tag{}, std::forward<_Func>(__f), value());
     return optional<_Up>();
   }
 
@@ -1182,7 +1182,7 @@ public:
                   "Result of f(value()) should not be std::nullopt_t");
     static_assert(is_object_v<_Up>, "Result of f(value()) should be an object type");
     if (*this)
-      return optional<_Up>(__optional_construct_from_invoke_tag{}, _VSTD::forward<_Func>(__f), value());
+      return optional<_Up>(__optional_construct_from_invoke_tag{}, std::forward<_Func>(__f), value());
     return optional<_Up>();
   }
 
@@ -1197,7 +1197,7 @@ public:
                   "Result of f(std::move(value())) should not be std::nullopt_t");
     static_assert(is_object_v<_Up>, "Result of f(std::move(value())) should be an object type");
     if (*this)
-      return optional<_Up>(__optional_construct_from_invoke_tag{}, _VSTD::forward<_Func>(__f), _VSTD::move(value()));
+      return optional<_Up>(__optional_construct_from_invoke_tag{}, std::forward<_Func>(__f), std::move(value()));
     return optional<_Up>();
   }
 
@@ -1212,7 +1212,7 @@ public:
                   "Result of f(std::move(value())) should not be std::nullopt_t");
     static_assert(is_object_v<_Up>, "Result of f(std::move(value())) should be an object type");
     if (*this)
-      return optional<_Up>(__optional_construct_from_invoke_tag{}, _VSTD::forward<_Func>(__f), _VSTD::move(value()));
+      return optional<_Up>(__optional_construct_from_invoke_tag{}, std::forward<_Func>(__f), std::move(value()));
     return optional<_Up>();
   }
 
@@ -1223,7 +1223,7 @@ public:
                   "Result of f() should be the same type as this optional");
     if (*this)
       return *this;
-    return _VSTD::forward<_Func>(__f)();
+    return std::forward<_Func>(__f)();
   }
 
   template<invocable _Func>
@@ -1232,8 +1232,8 @@ public:
     static_assert(is_same_v<remove_cvref_t<invoke_result_t<_Func>>, optional>,
                   "Result of f() should be the same type as this optional");
     if (*this)
-      return _VSTD::move(*this);
-    return _VSTD::forward<_Func>(__f)();
+      return std::move(*this);
+    return std::forward<_Func>(__f)();
   }
 #endif // _LIBCPP_STD_VER >= 23
 
@@ -1634,21 +1634,21 @@ template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI constexpr
 optional<decay_t<_Tp>> make_optional(_Tp&& __v)
 {
-    return optional<decay_t<_Tp>>(_VSTD::forward<_Tp>(__v));
+    return optional<decay_t<_Tp>>(std::forward<_Tp>(__v));
 }
 
 template <class _Tp, class... _Args>
 _LIBCPP_HIDE_FROM_ABI constexpr
 optional<_Tp> make_optional(_Args&&... __args)
 {
-    return optional<_Tp>(in_place, _VSTD::forward<_Args>(__args)...);
+    return optional<_Tp>(in_place, std::forward<_Args>(__args)...);
 }
 
 template <class _Tp, class _Up, class... _Args>
 _LIBCPP_HIDE_FROM_ABI constexpr
 optional<_Tp> make_optional(initializer_list<_Up> __il,  _Args&&... __args)
 {
-    return optional<_Tp>(in_place, __il, _VSTD::forward<_Args>(__args)...);
+    return optional<_Tp>(in_place, __il, std::forward<_Args>(__args)...);
 }
 
 template <class _Tp>

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -792,7 +792,7 @@ template<class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, _CharT __c)
 {
-    return _VSTD::__put_character_sequence(__os, &__c, 1);
+    return std::__put_character_sequence(__os, &__c, 1);
 }
 
 template<class _CharT, class _Traits>
@@ -832,28 +832,28 @@ template<class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, char __c)
 {
-    return _VSTD::__put_character_sequence(__os, &__c, 1);
+    return std::__put_character_sequence(__os, &__c, 1);
 }
 
 template<class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, signed char __c)
 {
-    return _VSTD::__put_character_sequence(__os, (char *) &__c, 1);
+    return std::__put_character_sequence(__os, (char *) &__c, 1);
 }
 
 template<class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, unsigned char __c)
 {
-    return _VSTD::__put_character_sequence(__os, (char *) &__c, 1);
+    return std::__put_character_sequence(__os, (char *) &__c, 1);
 }
 
 template<class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str)
 {
-    return _VSTD::__put_character_sequence(__os, __str, _Traits::length(__str));
+    return std::__put_character_sequence(__os, __str, _Traits::length(__str));
 }
 
 template<class _CharT, class _Traits>
@@ -906,7 +906,7 @@ template<class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, const char* __str)
 {
-    return _VSTD::__put_character_sequence(__os, __str, _Traits::length(__str));
+    return std::__put_character_sequence(__os, __str, _Traits::length(__str));
 }
 
 template<class _Traits>
@@ -914,7 +914,7 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, const signed char* __str)
 {
     const char *__s = (const char *) __str;
-    return _VSTD::__put_character_sequence(__os, __s, _Traits::length(__s));
+    return std::__put_character_sequence(__os, __s, _Traits::length(__s));
 }
 
 template<class _Traits>
@@ -922,7 +922,7 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<char, _Traits>&
 operator<<(basic_ostream<char, _Traits>& __os, const unsigned char* __str)
 {
     const char *__s = (const char *) __str;
-    return _VSTD::__put_character_sequence(__os, __s, _Traits::length(__s));
+    return std::__put_character_sequence(__os, __s, _Traits::length(__s));
 }
 
 template <class _CharT, class _Traits>
@@ -1081,7 +1081,7 @@ _LIBCPP_HIDE_FROM_ABI
 _Stream&& operator<<(_Stream&& __os, const _Tp& __x)
 {
     __os << __x;
-    return _VSTD::move(__os);
+    return std::move(__os);
 }
 
 template<class _CharT, class _Traits, class _Allocator>
@@ -1089,7 +1089,7 @@ basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os,
            const basic_string<_CharT, _Traits, _Allocator>& __str)
 {
-    return _VSTD::__put_character_sequence(__os, __str.data(), __str.size());
+    return std::__put_character_sequence(__os, __str.data(), __str.size());
 }
 
 template<class _CharT, class _Traits>
@@ -1097,7 +1097,7 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os,
            basic_string_view<_CharT, _Traits> __sv)
 {
-    return _VSTD::__put_character_sequence(__os, __sv.data(), __sv.size());
+    return std::__put_character_sequence(__os, __sv.data(), __sv.size());
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -353,19 +353,19 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     queue(queue&& __q)
         _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value)
-        : c(_VSTD::move(__q.c)) {}
+        : c(std::move(__q.c)) {}
 
     _LIBCPP_HIDE_FROM_ABI
     queue& operator=(queue&& __q)
         _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value)
-        {c = _VSTD::move(__q.c); return *this;}
+        {c = std::move(__q.c); return *this;}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
     explicit queue(const container_type& __c)  : c(__c) {}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
-    explicit queue(container_type&& __c) : c(_VSTD::move(__c)) {}
+    explicit queue(container_type&& __c) : c(std::move(__c)) {}
 #endif // _LIBCPP_CXX03_LANG
     template <class _Alloc>
         _LIBCPP_HIDE_FROM_ABI
@@ -387,12 +387,12 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         queue(container_type&& __c, const _Alloc& __a,
                        __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-            : c(_VSTD::move(__c), __a) {}
+            : c(std::move(__c), __a) {}
     template <class _Alloc>
         _LIBCPP_HIDE_FROM_ABI
         queue(queue&& __q, const _Alloc& __a,
                        __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-            : c(_VSTD::move(__q.c), __a) {}
+            : c(std::move(__q.c), __a) {}
 
 #endif // _LIBCPP_CXX03_LANG
 
@@ -414,7 +414,7 @@ public:
     void push(const value_type& __v) {c.push_back(__v);}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
-    void push(value_type&& __v)      {c.push_back(_VSTD::move(__v));}
+    void push(value_type&& __v)      {c.push_back(std::move(__v));}
 
 #if _LIBCPP_STD_VER >= 23
     template <_ContainerCompatibleRange<_Tp> _Range>
@@ -434,10 +434,10 @@ public:
         _LIBCPP_HIDE_FROM_ABI
 #if _LIBCPP_STD_VER >= 17
         decltype(auto) emplace(_Args&&... __args)
-            { return c.emplace_back(_VSTD::forward<_Args>(__args)...);}
+            { return c.emplace_back(std::forward<_Args>(__args)...);}
 #else
         void     emplace(_Args&&... __args)
-            {        c.emplace_back(_VSTD::forward<_Args>(__args)...);}
+            {        c.emplace_back(std::forward<_Args>(__args)...);}
 #endif
 #endif // _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
@@ -447,7 +447,7 @@ public:
     void swap(queue& __q)
         _NOEXCEPT_(__is_nothrow_swappable<container_type>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(c, __q.c);
     }
 
@@ -616,13 +616,13 @@ public:
     priority_queue(priority_queue&& __q)
         _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value &&
                    is_nothrow_move_constructible<value_compare>::value)
-        : c(_VSTD::move(__q.c)), comp(_VSTD::move(__q.comp)) {}
+        : c(std::move(__q.c)), comp(std::move(__q.comp)) {}
 
     _LIBCPP_HIDE_FROM_ABI
     priority_queue& operator=(priority_queue&& __q)
         _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value &&
                    is_nothrow_move_assignable<value_compare>::value)
-        {c = _VSTD::move(__q.c); comp = _VSTD::move(__q.comp); return *this;}
+        {c = std::move(__q.c); comp = std::move(__q.comp); return *this;}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
@@ -870,7 +870,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(const _Compare& __comp
     : c(__c),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -879,10 +879,10 @@ template <class _Tp, class _Container, class _Compare>
 inline
 priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_compare& __comp,
                                                           container_type&& __c)
-    : c(_VSTD::move(__c)),
+    : c(std::move(__c)),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -895,7 +895,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(_InputIter __f, _Input
     : c(__f, __l),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -908,7 +908,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(_InputIter __f, _Input
       comp(__comp)
 {
     c.insert(c.end(), __f, __l);
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -919,11 +919,11 @@ inline
 priority_queue<_Tp, _Container, _Compare>::priority_queue(_InputIter __f, _InputIter __l,
                                                           const value_compare& __comp,
                                                           container_type&& __c)
-    : c(_VSTD::move(__c)),
+    : c(std::move(__c)),
       comp(__comp)
 {
     c.insert(c.end(), __f, __l);
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -958,7 +958,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_compare& _
     : c(__c, __a),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -981,10 +981,10 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_compare& _
                                                           container_type&& __c,
                                                           const _Alloc& __a,
                        __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
-    : c(_VSTD::move(__c), __a),
+    : c(std::move(__c), __a),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -993,8 +993,8 @@ inline
 priority_queue<_Tp, _Container, _Compare>::priority_queue(priority_queue&& __q,
                                                           const _Alloc& __a,
                        __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
-    : c(_VSTD::move(__q.c), __a),
-      comp(_VSTD::move(__q.comp))
+    : c(std::move(__q.c), __a),
+      comp(std::move(__q.comp))
 {
 }
 
@@ -1009,7 +1009,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(
     : c(__f, __l, __a),
       comp()
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -1022,7 +1022,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(
     : c(__f, __l, __a),
       comp(__comp)
 {
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -1036,7 +1036,7 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(
       comp(__comp)
 {
     c.insert(c.end(), __f, __l);
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -1047,11 +1047,11 @@ priority_queue<_Tp, _Container, _Compare>::priority_queue(
         _InputIter __f, _InputIter __l, const value_compare& __comp,
         container_type&& __c, const _Alloc& __a,
         __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
-    : c(_VSTD::move(__c), __a),
+    : c(std::move(__c), __a),
       comp(__comp)
 {
     c.insert(c.end(), __f, __l);
-    _VSTD::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(c.begin(), c.end(), comp);
 }
 #endif  // _LIBCPP_CXX03_LANG
 
@@ -1061,7 +1061,7 @@ void
 priority_queue<_Tp, _Container, _Compare>::push(const value_type& __v)
 {
     c.push_back(__v);
-    _VSTD::push_heap(c.begin(), c.end(), comp);
+    std::push_heap(c.begin(), c.end(), comp);
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -1071,8 +1071,8 @@ inline
 void
 priority_queue<_Tp, _Container, _Compare>::push(value_type&& __v)
 {
-    c.push_back(_VSTD::move(__v));
-    _VSTD::push_heap(c.begin(), c.end(), comp);
+    c.push_back(std::move(__v));
+    std::push_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
@@ -1081,8 +1081,8 @@ inline
 void
 priority_queue<_Tp, _Container, _Compare>::emplace(_Args&&... __args)
 {
-    c.emplace_back(_VSTD::forward<_Args>(__args)...);
-    _VSTD::push_heap(c.begin(), c.end(), comp);
+    c.emplace_back(std::forward<_Args>(__args)...);
+    std::push_heap(c.begin(), c.end(), comp);
 }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -1092,7 +1092,7 @@ inline
 void
 priority_queue<_Tp, _Container, _Compare>::pop()
 {
-    _VSTD::pop_heap(c.begin(), c.end(), comp);
+    std::pop_heap(c.begin(), c.end(), comp);
     c.pop_back();
 }
 
@@ -1103,7 +1103,7 @@ priority_queue<_Tp, _Container, _Compare>::swap(priority_queue& __q)
         _NOEXCEPT_(__is_nothrow_swappable<container_type>::value &&
                    __is_nothrow_swappable<value_compare>::value)
 {
-    using _VSTD::swap;
+    using std::swap;
     swap(c, __q.c);
     swap(comp, __q.comp);
 }

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -1470,7 +1470,7 @@ class __node
     __node(const __node&);
     __node& operator=(const __node&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __node() {}
@@ -1490,7 +1490,7 @@ class __end_state
     : public __node<_CharT>
 {
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __end_state() {}
@@ -1555,7 +1555,7 @@ class __empty_state
     typedef __owns_one_state<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __empty_state(__node<_CharT>* __s)
@@ -1581,7 +1581,7 @@ class __empty_non_own_state
     typedef __has_one_state<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __empty_non_own_state(__node<_CharT>* __s)
@@ -1607,7 +1607,7 @@ class __repeat_one_loop
     typedef __has_one_state<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __repeat_one_loop(__node<_CharT>* __s)
@@ -1669,7 +1669,7 @@ class __loop
     bool __greedy_;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __loop(unsigned __loop_id,
@@ -1768,7 +1768,7 @@ class __alternate
     typedef __owns_two_states<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __alternate(__owns_one_state<_CharT>* __s1,
@@ -1807,7 +1807,7 @@ class __begin_marked_subexpression
 
     unsigned __mexp_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __begin_marked_subexpression(unsigned __mexp, __node<_CharT>* __s)
@@ -1835,7 +1835,7 @@ class __end_marked_subexpression
 
     unsigned __mexp_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __end_marked_subexpression(unsigned __mexp, __node<_CharT>* __s)
@@ -1864,7 +1864,7 @@ class __back_ref
 
     unsigned __mexp_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __back_ref(unsigned __mexp, __node<_CharT>* __s)
@@ -1884,7 +1884,7 @@ __back_ref<_CharT>::__exec(__state& __s) const
     {
         ptrdiff_t __len = __sm.second - __sm.first;
         if (__s.__last_ - __s.__current_ >= __len &&
-            _VSTD::equal(__sm.first, __sm.second, __s.__current_))
+            std::equal(__sm.first, __sm.second, __s.__current_))
         {
             __s.__do_ = __state::__accept_but_not_consume;
             __s.__current_ += __len;
@@ -1914,7 +1914,7 @@ class __back_ref_icase
     _Traits __traits_;
     unsigned __mexp_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __back_ref_icase(const _Traits& __traits, unsigned __mexp,
@@ -1969,7 +1969,7 @@ class __back_ref_collate
     _Traits __traits_;
     unsigned __mexp_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __back_ref_collate(const _Traits& __traits, unsigned __mexp,
@@ -2024,7 +2024,7 @@ class __word_boundary
     _Traits __traits_;
     bool __invert_;
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     explicit __word_boundary(const _Traits& __traits, bool __invert,
@@ -2101,7 +2101,7 @@ class __l_anchor_multiline
     bool __multiline_;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __l_anchor_multiline(bool __multiline, __node<_CharT>* __s)
@@ -2122,7 +2122,7 @@ __l_anchor_multiline<_CharT>::__exec(__state& __s) const
     }
     else if (__multiline_ &&
              !__s.__at_first_ &&
-             std::__is_eol(*_VSTD::prev(__s.__current_)))
+             std::__is_eol(*std::prev(__s.__current_)))
     {
         __s.__do_ = __state::__accept_but_not_consume;
         __s.__node_ = this->first();
@@ -2145,7 +2145,7 @@ class __r_anchor_multiline
     bool __multiline_;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __r_anchor_multiline(bool __multiline, __node<_CharT>* __s)
@@ -2185,7 +2185,7 @@ class __match_any
     typedef __owns_one_state<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __match_any(__node<_CharT>* __s)
@@ -2220,7 +2220,7 @@ class __match_any_but_newline
     typedef __owns_one_state<_CharT> base;
 
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __match_any_but_newline(__node<_CharT>* __s)
@@ -2247,7 +2247,7 @@ class __match_char
     __match_char(const __match_char&);
     __match_char& operator=(const __match_char&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __match_char(_CharT __c, __node<_CharT>* __s)
@@ -2287,7 +2287,7 @@ class __match_char_icase
     __match_char_icase(const __match_char_icase&);
     __match_char_icase& operator=(const __match_char_icase&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __match_char_icase(const _Traits& __traits, _CharT __c, __node<_CharT>* __s)
@@ -2328,7 +2328,7 @@ class __match_char_collate
     __match_char_collate(const __match_char_collate&);
     __match_char_collate& operator=(const __match_char_collate&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __match_char_collate(const _Traits& __traits, _CharT __c, __node<_CharT>* __s)
@@ -2380,7 +2380,7 @@ class __bracket_expression
     __bracket_expression(const __bracket_expression&);
     __bracket_expression& operator=(const __bracket_expression&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __bracket_expression(const _Traits& __traits, __node<_CharT>* __s,
@@ -2446,7 +2446,7 @@ public:
                     __b[0] = __traits_.translate_nocase(__b[0]);
                     __e[0] = __traits_.translate_nocase(__e[0]);
                 }
-                __ranges_.push_back(std::make_pair(_VSTD::move(__b), _VSTD::move(__e)));
+                __ranges_.push_back(std::make_pair(std::move(__b), std::move(__e)));
             }
         }
     _LIBCPP_HIDE_FROM_ABI
@@ -2483,7 +2483,7 @@ __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const
         ++__consumed;
         if (__might_have_digraph_)
         {
-            const _CharT* __next = _VSTD::next(__s.__current_);
+            const _CharT* __next = std::next(__s.__current_);
             if (__next != __s.__last_)
             {
                 pair<_CharT, _CharT> __ch2(*__s.__current_, *__next);
@@ -2577,7 +2577,7 @@ __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const
         {
             const bool __in_neg_mask = __traits_.isctype(__ch, __neg_mask_);
           const bool __in_neg_chars =
-              _VSTD::find(__neg_chars_.begin(), __neg_chars_.end(), __ch) !=
+              std::find(__neg_chars_.begin(), __neg_chars_.end(), __ch) !=
               __neg_chars_.end();
           if (!(__in_neg_mask || __in_neg_chars))
           {
@@ -2667,8 +2667,8 @@ private:
     shared_ptr<__empty_state<_CharT> > __start_;
     __owns_one_state<_CharT>* __end_;
 
-    typedef _VSTD::__state<_CharT> __state;
-    typedef _VSTD::__node<_CharT> __node;
+    typedef std::__state<_CharT> __state;
+    typedef std::__node<_CharT> __node;
 
 public:
     // constants:
@@ -2762,7 +2762,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     basic_regex& assign(basic_regex&& __that) _NOEXCEPT
-        {return *this = _VSTD::move(__that);}
+        {return *this = std::move(__that);}
 #endif
     _LIBCPP_HIDE_FROM_ABI
     basic_regex& assign(const value_type* __p, flag_type __f = regex_constants::ECMAScript)
@@ -3137,7 +3137,7 @@ template <class _CharT, class _Traits>
 void
 basic_regex<_CharT, _Traits>::swap(basic_regex& __r)
 {
-    using _VSTD::swap;
+    using std::swap;
     swap(__traits_, __r.__traits_);
     swap(__flags_, __r.__flags_);
     swap(__marked_count_, __r.__marked_count_);
@@ -3170,7 +3170,7 @@ class __lookahead
     __lookahead(const __lookahead&);
     __lookahead& operator=(const __lookahead&);
 public:
-    typedef _VSTD::__state<_CharT> __state;
+    typedef std::__state<_CharT> __state;
 
     _LIBCPP_HIDE_FROM_ABI
     __lookahead(const basic_regex<_CharT, _Traits>& __exp, bool __invert, __node<_CharT>* __s, unsigned __mexp)
@@ -3271,7 +3271,7 @@ basic_regex<_CharT, _Traits>::__parse_basic_reg_exp(_ForwardIterator __first,
             __first = __parse_RE_expression(__first, __last);
             if (__first != __last)
             {
-                _ForwardIterator __temp = _VSTD::next(__first);
+                _ForwardIterator __temp = std::next(__first);
                 if (__temp == __last && *__first == '$')
                 {
                     __push_r_anchor();
@@ -3488,7 +3488,7 @@ basic_regex<_CharT, _Traits>::__parse_Back_open_paren(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\' && *__temp == '(')
@@ -3506,7 +3506,7 @@ basic_regex<_CharT, _Traits>::__parse_Back_close_paren(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\' && *__temp == ')')
@@ -3524,7 +3524,7 @@ basic_regex<_CharT, _Traits>::__parse_Back_open_brace(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\' && *__temp == '{')
@@ -3542,7 +3542,7 @@ basic_regex<_CharT, _Traits>::__parse_Back_close_brace(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\' && *__temp == '}')
@@ -3560,7 +3560,7 @@ basic_regex<_CharT, _Traits>::__parse_BACKREF(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last && *__first == '\\' && __test_back_ref(*__temp))
             __first = ++__temp;
     }
@@ -3575,7 +3575,7 @@ basic_regex<_CharT, _Traits>::__parse_ORD_CHAR(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp == __last && *__first == '$')
             return __first;
         // Not called inside a bracket
@@ -3633,7 +3633,7 @@ basic_regex<_CharT, _Traits>::__parse_QUOTED_CHAR(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\')
@@ -3664,7 +3664,7 @@ basic_regex<_CharT, _Traits>::__parse_QUOTED_CHAR_ERE(_ForwardIterator __first,
 {
     if (__first != __last)
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         if (__temp != __last)
         {
             if (*__first == '\\')
@@ -3945,7 +3945,7 @@ basic_regex<_CharT, _Traits>::__parse_expression_term(_ForwardIterator __first,
 {
     if (__first != __last && *__first != ']')
     {
-        _ForwardIterator __temp = _VSTD::next(__first);
+        _ForwardIterator __temp = std::next(__first);
         basic_string<_CharT> __start_range;
         if (__temp != __last && *__first == '[')
         {
@@ -3974,7 +3974,7 @@ basic_regex<_CharT, _Traits>::__parse_expression_term(_ForwardIterator __first,
         }
         if (__first != __last && *__first != ']')
         {
-            __temp = _VSTD::next(__first);
+            __temp = std::next(__first);
             if (__temp != __last && *__first == '-' && *__temp != ']')
             {
                 // parse a range
@@ -4000,7 +4000,7 @@ basic_regex<_CharT, _Traits>::__parse_expression_term(_ForwardIterator __first,
                         ++__first;
                     }
                 }
-                __ml->__add_range(_VSTD::move(__start_range), _VSTD::move(__end_range));
+                __ml->__add_range(std::move(__start_range), std::move(__end_range));
             }
             else if (!__start_range.empty())
             {
@@ -4155,7 +4155,7 @@ basic_regex<_CharT, _Traits>::__parse_equivalence_class(_ForwardIterator __first
     // Found [=
     //   This means =] must exist
     value_type __equal_close[2] = {'=', ']'};
-    _ForwardIterator __temp = _VSTD::search(__first, __last, __equal_close,
+    _ForwardIterator __temp = std::search(__first, __last, __equal_close,
                                                             __equal_close+2);
     if (__temp == __last)
         __throw_regex_error<regex_constants::error_brack>();
@@ -4183,7 +4183,7 @@ basic_regex<_CharT, _Traits>::__parse_equivalence_class(_ForwardIterator __first
             __throw_regex_error<regex_constants::error_collate>();
         }
     }
-    __first = _VSTD::next(__temp, 2);
+    __first = std::next(__temp, 2);
     return __first;
 }
 
@@ -4197,7 +4197,7 @@ basic_regex<_CharT, _Traits>::__parse_character_class(_ForwardIterator __first,
     // Found [:
     //   This means :] must exist
     value_type __colon_close[2] = {':', ']'};
-    _ForwardIterator __temp = _VSTD::search(__first, __last, __colon_close,
+    _ForwardIterator __temp = std::search(__first, __last, __colon_close,
                                                             __colon_close+2);
     if (__temp == __last)
         __throw_regex_error<regex_constants::error_brack>();
@@ -4208,7 +4208,7 @@ basic_regex<_CharT, _Traits>::__parse_character_class(_ForwardIterator __first,
     if (__class_type == 0)
         __throw_regex_error<regex_constants::error_ctype>();
     __ml->__add_class(__class_type);
-    __first = _VSTD::next(__temp, 2);
+    __first = std::next(__temp, 2);
     return __first;
 }
 
@@ -4222,7 +4222,7 @@ basic_regex<_CharT, _Traits>::__parse_collating_symbol(_ForwardIterator __first,
     // Found [.
     //   This means .] must exist
     value_type __dot_close[2] = {'.', ']'};
-    _ForwardIterator __temp = _VSTD::search(__first, __last, __dot_close,
+    _ForwardIterator __temp = std::search(__first, __last, __dot_close,
                                                             __dot_close+2);
     if (__temp == __last)
         __throw_regex_error<regex_constants::error_brack>();
@@ -4236,7 +4236,7 @@ basic_regex<_CharT, _Traits>::__parse_collating_symbol(_ForwardIterator __first,
     default:
         __throw_regex_error<regex_constants::error_collate>();
     }
-    __first = _VSTD::next(__temp, 2);
+    __first = std::next(__temp, 2);
     return __first;
 }
 
@@ -4347,7 +4347,7 @@ basic_regex<_CharT, _Traits>::__parse_assertion(_ForwardIterator __first,
             break;
         case '\\':
             {
-                _ForwardIterator __temp = _VSTD::next(__first);
+                _ForwardIterator __temp = std::next(__first);
                 if (__temp != __last)
                 {
                     if (*__temp == 'b')
@@ -4365,7 +4365,7 @@ basic_regex<_CharT, _Traits>::__parse_assertion(_ForwardIterator __first,
             break;
         case '(':
             {
-                _ForwardIterator __temp = _VSTD::next(__first);
+                _ForwardIterator __temp = std::next(__first);
                 if (__temp != __last && *__temp == '?')
                 {
                     if (++__temp != __last)
@@ -4378,7 +4378,7 @@ basic_regex<_CharT, _Traits>::__parse_assertion(_ForwardIterator __first,
                                 __exp.__flags_ = __flags_;
                                 __temp = __exp.__parse(++__temp, __last);
                                 unsigned __mexp = __exp.__marked_count_;
-                                __push_lookahead(_VSTD::move(__exp), false, __marked_count_);
+                                __push_lookahead(std::move(__exp), false, __marked_count_);
                                 __marked_count_ += __mexp;
                                 if (__temp == __last || *__temp != ')')
                                     __throw_regex_error<regex_constants::error_paren>();
@@ -4391,7 +4391,7 @@ basic_regex<_CharT, _Traits>::__parse_assertion(_ForwardIterator __first,
                                 __exp.__flags_ = __flags_;
                                 __temp = __exp.__parse(++__temp, __last);
                                 unsigned __mexp = __exp.__marked_count_;
-                                __push_lookahead(_VSTD::move(__exp), true, __marked_count_);
+                                __push_lookahead(std::move(__exp), true, __marked_count_);
                                 __marked_count_ += __mexp;
                                 if (__temp == __last || *__temp != ')')
                                     __throw_regex_error<regex_constants::error_paren>();
@@ -4433,7 +4433,7 @@ basic_regex<_CharT, _Traits>::__parse_atom(_ForwardIterator __first,
                 ++__first;
                 if (__first == __last)
                     __throw_regex_error<regex_constants::error_paren>();
-                _ForwardIterator __temp = _VSTD::next(__first);
+                _ForwardIterator __temp = std::next(__first);
                 if (__temp != __last && *__first == '?' && *__temp == ':')
                 {
                     ++__open_count_;
@@ -4479,7 +4479,7 @@ basic_regex<_CharT, _Traits>::__parse_atom_escape(_ForwardIterator __first,
 {
     if (__first != __last && *__first == '\\')
     {
-        _ForwardIterator __t1 = _VSTD::next(__first);
+        _ForwardIterator __t1 = std::next(__first);
         if (__t1 == __last)
             __throw_regex_error<regex_constants::error_escape>();
 
@@ -4631,7 +4631,7 @@ basic_regex<_CharT, _Traits>::__parse_character_escape(_ForwardIterator __first,
             ++__first;
             break;
         case 'c':
-            if ((__t = _VSTD::next(__first)) != __last)
+            if ((__t = std::next(__first)) != __last)
             {
                 if (('A' <= *__t && *__t <= 'Z') ||
                     ('a' <= *__t && *__t <= 'z'))
@@ -4750,7 +4750,7 @@ basic_regex<_CharT, _Traits>::__parse_grep(_ForwardIterator __first,
                                            _ForwardIterator __last)
 {
     __owns_one_state<_CharT>* __sa = __end_;
-    _ForwardIterator __t1 = _VSTD::find(__first, __last, _CharT('\n'));
+    _ForwardIterator __t1 = std::find(__first, __last, _CharT('\n'));
     if (__t1 != __first)
         __parse_basic_reg_exp(__first, __t1);
     else
@@ -4760,7 +4760,7 @@ basic_regex<_CharT, _Traits>::__parse_grep(_ForwardIterator __first,
         ++__first;
     while (__first != __last)
     {
-        __t1 = _VSTD::find(__first, __last, _CharT('\n'));
+        __t1 = std::find(__first, __last, _CharT('\n'));
         __owns_one_state<_CharT>* __sb = __end_;
         if (__t1 != __first)
             __parse_basic_reg_exp(__first, __t1);
@@ -4781,7 +4781,7 @@ basic_regex<_CharT, _Traits>::__parse_egrep(_ForwardIterator __first,
                                             _ForwardIterator __last)
 {
     __owns_one_state<_CharT>* __sa = __end_;
-    _ForwardIterator __t1 = _VSTD::find(__first, __last, _CharT('\n'));
+    _ForwardIterator __t1 = std::find(__first, __last, _CharT('\n'));
     if (__t1 != __first)
         __parse_extended_reg_exp(__first, __t1);
     else
@@ -4791,7 +4791,7 @@ basic_regex<_CharT, _Traits>::__parse_egrep(_ForwardIterator __first,
         ++__first;
     while (__first != __last)
     {
-        __t1 = _VSTD::find(__first, __last, _CharT('\n'));
+        __t1 = std::find(__first, __last, _CharT('\n'));
         __owns_one_state<_CharT>* __sb = __end_;
         if (__t1 != __first)
             __parse_extended_reg_exp(__first, __t1);
@@ -5015,7 +5015,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     difference_type length() const
-        {return matched ? _VSTD::distance(this->first, this->second) : 0;}
+        {return matched ? std::distance(this->first, this->second) : 0;}
     _LIBCPP_HIDE_FROM_ABI
     string_type str() const
         {return matched ? string_type(this->first, this->second) : string_type();}
@@ -5536,7 +5536,7 @@ public:
     difference_type position(size_type __sub = 0) const
         {
         _LIBCPP_ASSERT_UNCATEGORIZED(ready(), "match_results::position() called when not ready");
-        return _VSTD::distance(__position_start_, (*this)[__sub].first);
+        return std::distance(__position_start_, (*this)[__sub].first);
         }
     _LIBCPP_HIDE_FROM_ABI
     string_type str(size_type __sub = 0) const
@@ -5623,18 +5623,18 @@ public:
         __matches_.resize(__m.size());
         for (size_type __i = 0; __i < __matches_.size(); ++__i)
         {
-            __matches_[__i].first = _VSTD::next(__f, _VSTD::distance(__mf, __m[__i].first));
-            __matches_[__i].second = _VSTD::next(__f, _VSTD::distance(__mf, __m[__i].second));
+            __matches_[__i].first = std::next(__f, std::distance(__mf, __m[__i].first));
+            __matches_[__i].second = std::next(__f, std::distance(__mf, __m[__i].second));
             __matches_[__i].matched = __m[__i].matched;
         }
         __unmatched_.first   = __l;
         __unmatched_.second  = __l;
         __unmatched_.matched = false;
-        __prefix_.first = _VSTD::next(__f, _VSTD::distance(__mf, __m.prefix().first));
-        __prefix_.second = _VSTD::next(__f, _VSTD::distance(__mf, __m.prefix().second));
+        __prefix_.first = std::next(__f, std::distance(__mf, __m.prefix().first));
+        __prefix_.second = std::next(__f, std::distance(__mf, __m.prefix().second));
         __prefix_.matched = __m.prefix().matched;
-        __suffix_.first = _VSTD::next(__f, _VSTD::distance(__mf, __m.suffix().first));
-        __suffix_.second = _VSTD::next(__f, _VSTD::distance(__mf, __m.suffix().second));
+        __suffix_.first = std::next(__f, std::distance(__mf, __m.suffix().first));
+        __suffix_.second = std::next(__f, std::distance(__mf, __m.suffix().second));
         __suffix_.matched = __m.suffix().matched;
         if (!__no_update_pos)
             __position_start_ = __prefix_.first;
@@ -5706,7 +5706,7 @@ match_results<_BidirectionalIterator, _Allocator>::format(_OutputIter __output_i
         for (; __fmt_first != __fmt_last; ++__fmt_first)
         {
             if (*__fmt_first == '&')
-                __output_iter = _VSTD::copy(__matches_[0].first, __matches_[0].second,
+                __output_iter = std::copy(__matches_[0].first, __matches_[0].second,
                                    __output_iter);
             else if (*__fmt_first == '\\' && __fmt_first + 1 != __fmt_last)
             {
@@ -5714,7 +5714,7 @@ match_results<_BidirectionalIterator, _Allocator>::format(_OutputIter __output_i
                 if ('0' <= *__fmt_first && *__fmt_first <= '9')
                 {
                     size_t __i = *__fmt_first - '0';
-                    __output_iter = _VSTD::copy((*this)[__i].first,
+                    __output_iter = std::copy((*this)[__i].first,
                                         (*this)[__i].second, __output_iter);
                 }
                 else
@@ -5744,16 +5744,16 @@ match_results<_BidirectionalIterator, _Allocator>::format(_OutputIter __output_i
                     break;
                 case '&':
                     ++__fmt_first;
-                    __output_iter = _VSTD::copy(__matches_[0].first, __matches_[0].second,
+                    __output_iter = std::copy(__matches_[0].first, __matches_[0].second,
                                        __output_iter);
                     break;
                 case '`':
                     ++__fmt_first;
-                    __output_iter = _VSTD::copy(__prefix_.first, __prefix_.second, __output_iter);
+                    __output_iter = std::copy(__prefix_.first, __prefix_.second, __output_iter);
                     break;
                 case '\'':
                     ++__fmt_first;
-                    __output_iter = _VSTD::copy(__suffix_.first, __suffix_.second, __output_iter);
+                    __output_iter = std::copy(__suffix_.first, __suffix_.second, __output_iter);
                     break;
                 default:
                     if ('0' <= __fmt_first[1] && __fmt_first[1] <= '9')
@@ -5768,7 +5768,7 @@ match_results<_BidirectionalIterator, _Allocator>::format(_OutputIter __output_i
                                 __throw_regex_error<regex_constants::error_escape>();
                             __idx = 10 * __idx + *__fmt_first - '0';
                         }
-                        __output_iter = _VSTD::copy((*this)[__idx].first,
+                        __output_iter = std::copy((*this)[__idx].first,
                                             (*this)[__idx].second, __output_iter);
                     }
                     else
@@ -5793,7 +5793,7 @@ template <class _BidirectionalIterator, class _Allocator>
 void
 match_results<_BidirectionalIterator, _Allocator>::swap(match_results& __m)
 {
-    using _VSTD::swap;
+    using std::swap;
     swap(__matches_, __m.__matches_);
     swap(__unmatched_, __m.__unmatched_);
     swap(__prefix_, __m.__prefix_);
@@ -5892,7 +5892,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_ecma(
                   break;
                 }
                 __m.__matches_[0].first = __first;
-                __m.__matches_[0].second = _VSTD::next(__first, __s.__current_ - __first);
+                __m.__matches_[0].second = std::next(__first, __s.__current_ - __first);
                 __m.__matches_[0].matched = true;
                 for (unsigned __i = 0; __i < __s.__sub_matches_.size(); ++__i)
                     __m.__matches_[__i+1] = __s.__sub_matches_[__i];
@@ -5906,7 +5906,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_ecma(
                 __state __snext = __s;
                 __s.__node_->__exec_split(true, __s);
                 __snext.__node_->__exec_split(false, __snext);
-                __states.push_back(_VSTD::move(__snext));
+                __states.push_back(std::move(__snext));
                 }
                 break;
             case __state::__reject:
@@ -5932,7 +5932,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_nosubs(
 {
     deque<__state> __states;
     ptrdiff_t __highest_j = 0;
-    ptrdiff_t __np = _VSTD::distance(__first, __last);
+    ptrdiff_t __np = std::distance(__first, __last);
     __node* __st = __start_.get();
     if (__st)
     {
@@ -5983,7 +5983,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_nosubs(
             case __state::__consume_input:
                 break;
             case __state::__accept_and_consume:
-                __states.push_front(_VSTD::move(__s));
+                __states.push_front(std::move(__s));
                 __states.pop_back();
                 break;
             case __state::__repeat:
@@ -5994,7 +5994,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_nosubs(
                 __state __snext = __s;
                 __s.__node_->__exec_split(true, __s);
                 __snext.__node_->__exec_split(false, __snext);
-                __states.push_back(_VSTD::move(__snext));
+                __states.push_back(std::move(__snext));
                 }
                 break;
             case __state::__reject:
@@ -6008,7 +6008,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_nosubs(
         if (__matched)
         {
             __m.__matches_[0].first = __first;
-            __m.__matches_[0].second = _VSTD::next(__first, __highest_j);
+            __m.__matches_[0].second = std::next(__first, __highest_j);
             __m.__matches_[0].matched = true;
             return true;
         }
@@ -6027,7 +6027,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_subs(
     vector<__state> __states;
     __state __best_state;
     ptrdiff_t __highest_j = 0;
-    ptrdiff_t __np = _VSTD::distance(__first, __last);
+    ptrdiff_t __np = std::distance(__first, __last);
     __node* __st = __start_.get();
     if (__st)
     {
@@ -6093,7 +6093,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_subs(
                 __state __snext = __s;
                 __s.__node_->__exec_split(true, __s);
                 __snext.__node_->__exec_split(false, __snext);
-                __states.push_back(_VSTD::move(__snext));
+                __states.push_back(std::move(__snext));
                 }
                 break;
             case __state::__reject:
@@ -6107,7 +6107,7 @@ basic_regex<_CharT, _Traits>::__match_at_start_posix_subs(
         if (__matched)
         {
             __m.__matches_[0].first = __first;
-            __m.__matches_[0].second = _VSTD::next(__first, __highest_j);
+            __m.__matches_[0].second = std::next(__first, __highest_j);
             __m.__matches_[0].matched = true;
             for (unsigned __i = 0; __i < __best_state.__sub_matches_.size(); ++__i)
                 __m.__matches_[__i+1] = __best_state.__sub_matches_[__i];
@@ -6184,7 +6184,7 @@ regex_search(_BidirectionalIterator __first, _BidirectionalIterator __last,
              regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     int __offset = (__flags & regex_constants::match_prev_avail) ? 1 : 0;
-    basic_string<_CharT> __s(_VSTD::prev(__first, __offset), __last);
+    basic_string<_CharT> __s(std::prev(__first, __offset), __last);
     match_results<const _CharT*> __mc;
     bool __r = __e.__search(__s.data() + __offset, __s.data() + __s.size(), __mc, __flags);
     __m.__assign(__first, __last, __mc, __flags & regex_constants::__no_update_pos);
@@ -6257,7 +6257,7 @@ regex_search(const _CharT* __str, const basic_regex<_CharT, _Traits>& __e,
              regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     match_results<const _CharT*> __m;
-    return _VSTD::regex_search(__str, __m, __e, __flags);
+    return std::regex_search(__str, __m, __e, __flags);
 }
 
 template <class _ST, class _SA, class _CharT, class _Traits>
@@ -6303,7 +6303,7 @@ regex_match(_BidirectionalIterator __first, _BidirectionalIterator __last,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    bool __r = _VSTD::regex_search(
+    bool __r = std::regex_search(
         __first, __last, __m, __e,
         __flags | regex_constants::match_continuous |
         regex_constants::__full_match);
@@ -6324,7 +6324,7 @@ regex_match(_BidirectionalIterator __first, _BidirectionalIterator __last,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     match_results<_BidirectionalIterator> __m;
-    return _VSTD::regex_match(__first, __last, __m, __e, __flags);
+    return std::regex_match(__first, __last, __m, __e, __flags);
 }
 
 template <class _CharT, class _Allocator, class _Traits>
@@ -6334,7 +6334,7 @@ regex_match(const _CharT* __str, match_results<const _CharT*, _Allocator>& __m,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_match(__str, __str + _Traits::length(__str), __m, __e, __flags);
+    return std::regex_match(__str, __str + _Traits::length(__str), __m, __e, __flags);
 }
 
 template <class _ST, class _SA, class _Allocator, class _CharT, class _Traits>
@@ -6345,7 +6345,7 @@ regex_match(const basic_string<_CharT, _ST, _SA>& __s,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_match(__s.begin(), __s.end(), __m, __e, __flags);
+    return std::regex_match(__s.begin(), __s.end(), __m, __e, __flags);
 }
 
 #if _LIBCPP_STD_VER >= 14
@@ -6364,7 +6364,7 @@ bool
 regex_match(const _CharT* __str, const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_match(__str, __str + _Traits::length(__str), __e, __flags);
+    return std::regex_match(__str, __str + _Traits::length(__str), __e, __flags);
 }
 
 template <class _ST, class _SA, class _CharT, class _Traits>
@@ -6374,7 +6374,7 @@ regex_match(const basic_string<_CharT, _ST, _SA>& __s,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_match(__s.begin(), __s.end(), __e, __flags);
+    return std::regex_match(__s.begin(), __s.end(), __e, __flags);
 }
 
 // regex_iterator
@@ -6440,7 +6440,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     reference operator*() const {return  __match_;}
     _LIBCPP_HIDE_FROM_ABI
-    pointer operator->() const  {return _VSTD::addressof(__match_);}
+    pointer operator->() const  {return std::addressof(__match_);}
 
     regex_iterator& operator++();
     _LIBCPP_HIDE_FROM_ABI
@@ -6464,10 +6464,10 @@ regex_iterator<_BidirectionalIterator, _CharT, _Traits>::
                    const regex_type& __re, regex_constants::match_flag_type __m)
     : __begin_(__a),
       __end_(__b),
-      __pregex_(_VSTD::addressof(__re)),
+      __pregex_(std::addressof(__re)),
       __flags_(__m)
 {
-    _VSTD::regex_search(__begin_, __end_, __match_, *__pregex_, __flags_);
+    std::regex_search(__begin_, __end_, __match_, *__pregex_, __flags_);
 }
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
@@ -6499,7 +6499,7 @@ regex_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++()
             __match_ = value_type();
             return *this;
         }
-        else if (_VSTD::regex_search(__start, __end_, __match_, *__pregex_,
+        else if (std::regex_search(__start, __end_, __match_, *__pregex_,
                                     __flags_ | regex_constants::match_not_null |
                                     regex_constants::match_continuous))
             return *this;
@@ -6507,7 +6507,7 @@ regex_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++()
             ++__start;
     }
     __flags_ |= regex_constants::match_prev_avail;
-    if (!_VSTD::regex_search(__start, __end_, __match_, *__pregex_, __flags_))
+    if (!std::regex_search(__start, __end_, __match_, *__pregex_, __flags_))
         __match_ = value_type();
     return *this;
 }
@@ -6803,7 +6803,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++()
             __establish_result();
         else
         {
-            if (_VSTD::find(__subs_.begin(), __subs_.end(), -1) != __subs_.end()
+            if (std::find(__subs_.begin(), __subs_.end(), -1) != __subs_.end()
                 && __prev->suffix().length() != 0)
             {
                 __suffix_.matched = true;
@@ -6834,7 +6834,7 @@ regex_replace(_OutputIterator __output_iter,
     if (__i == __eof)
     {
         if (!(__flags & regex_constants::format_no_copy))
-            __output_iter = _VSTD::copy(__first, __last, __output_iter);
+            __output_iter = std::copy(__first, __last, __output_iter);
     }
     else
     {
@@ -6842,14 +6842,14 @@ regex_replace(_OutputIterator __output_iter,
         for (size_t __len = char_traits<_CharT>::length(__fmt); __i != __eof; ++__i)
         {
             if (!(__flags & regex_constants::format_no_copy))
-                __output_iter = _VSTD::copy(__i->prefix().first, __i->prefix().second, __output_iter);
+                __output_iter = std::copy(__i->prefix().first, __i->prefix().second, __output_iter);
             __output_iter = __i->format(__output_iter, __fmt, __fmt + __len, __flags);
             __lm = __i->suffix();
             if (__flags & regex_constants::format_first_only)
                 break;
         }
         if (!(__flags & regex_constants::format_no_copy))
-            __output_iter = _VSTD::copy(__lm.first, __lm.second, __output_iter);
+            __output_iter = std::copy(__lm.first, __lm.second, __output_iter);
     }
     return __output_iter;
 }
@@ -6864,7 +6864,7 @@ regex_replace(_OutputIterator __output_iter,
               const basic_string<_CharT, _ST, _SA>& __fmt,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_replace(__output_iter, __first, __last, __e, __fmt.c_str(), __flags);
+    return std::regex_replace(__output_iter, __first, __last, __e, __fmt.c_str(), __flags);
 }
 
 template <class _Traits, class _CharT, class _ST, class _SA, class _FST,
@@ -6877,7 +6877,7 @@ regex_replace(const basic_string<_CharT, _ST, _SA>& __s,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     basic_string<_CharT, _ST, _SA> __r;
-    _VSTD::regex_replace(std::back_inserter(__r), __s.begin(), __s.end(), __e,
+    std::regex_replace(std::back_inserter(__r), __s.begin(), __s.end(), __e,
                         __fmt.c_str(), __flags);
     return __r;
 }
@@ -6890,7 +6890,7 @@ regex_replace(const basic_string<_CharT, _ST, _SA>& __s,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     basic_string<_CharT, _ST, _SA> __r;
-    _VSTD::regex_replace(std::back_inserter(__r), __s.begin(), __s.end(), __e,
+    std::regex_replace(std::back_inserter(__r), __s.begin(), __s.end(), __e,
                         __fmt, __flags);
     return __r;
 }
@@ -6904,7 +6904,7 @@ regex_replace(const _CharT* __s,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     basic_string<_CharT> __r;
-    _VSTD::regex_replace(std::back_inserter(__r), __s,
+    std::regex_replace(std::back_inserter(__r), __s,
                         __s + char_traits<_CharT>::length(__s), __e,
                         __fmt.c_str(), __flags);
     return __r;
@@ -6919,7 +6919,7 @@ regex_replace(const _CharT* __s,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
     basic_string<_CharT> __r;
-    _VSTD::regex_replace(std::back_inserter(__r), __s,
+    std::regex_replace(std::back_inserter(__r), __s,
                         __s + char_traits<_CharT>::length(__s), __e,
                         __fmt, __flags);
     return __r;

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -233,7 +233,7 @@ protected:
         _LIBCPP_HIDE_FROM_ABI
         __scoped_allocator_storage(_OuterA2&& __outer_alloc,
                                    const _InnerAllocs& ...__inner_allocs) _NOEXCEPT
-            : outer_allocator_type(_VSTD::forward<_OuterA2>(__outer_alloc)),
+            : outer_allocator_type(std::forward<_OuterA2>(__outer_alloc)),
               __inner_(__inner_allocs...) {}
 
     template <class _OuterA2,
@@ -249,15 +249,15 @@ protected:
         _LIBCPP_HIDE_FROM_ABI
         __scoped_allocator_storage(
             __scoped_allocator_storage<_OuterA2, _InnerAllocs...>&& __other) _NOEXCEPT
-            : outer_allocator_type(_VSTD::move(__other.outer_allocator())),
-              __inner_(_VSTD::move(__other.inner_allocator())) {}
+            : outer_allocator_type(std::move(__other.outer_allocator())),
+              __inner_(std::move(__other.inner_allocator())) {}
 
     template <class _OuterA2,
               __enable_if_t<is_constructible<outer_allocator_type, _OuterA2>::value, int> = 0>
         _LIBCPP_HIDE_FROM_ABI
         __scoped_allocator_storage(_OuterA2&& __o,
                                    const inner_allocator_type& __i) _NOEXCEPT
-            : outer_allocator_type(_VSTD::forward<_OuterA2>(__o)),
+            : outer_allocator_type(std::forward<_OuterA2>(__o)),
               __inner_(__i)
         {
         }
@@ -305,7 +305,7 @@ protected:
               __enable_if_t<is_constructible<outer_allocator_type, _OuterA2>::value, int> = 0>
         _LIBCPP_HIDE_FROM_ABI
         __scoped_allocator_storage(_OuterA2&& __outer_alloc) _NOEXCEPT
-            : outer_allocator_type(_VSTD::forward<_OuterA2>(__outer_alloc)) {}
+            : outer_allocator_type(std::forward<_OuterA2>(__outer_alloc)) {}
 
     template <class _OuterA2,
               __enable_if_t<is_constructible<outer_allocator_type, const _OuterA2&>::value, int> = 0>
@@ -319,7 +319,7 @@ protected:
         _LIBCPP_HIDE_FROM_ABI
         __scoped_allocator_storage(
             __scoped_allocator_storage<_OuterA2>&& __other) _NOEXCEPT
-            : outer_allocator_type(_VSTD::move(__other.outer_allocator())) {}
+            : outer_allocator_type(std::move(__other.outer_allocator())) {}
 
     _LIBCPP_HIDE_FROM_ABI
     inner_allocator_type& inner_allocator() _NOEXCEPT
@@ -444,7 +444,7 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         scoped_allocator_adaptor(_OuterA2&& __outer_alloc,
                                  const _InnerAllocs& ...__inner_allocs) _NOEXCEPT
-            : base(_VSTD::forward<_OuterA2>(__outer_alloc), __inner_allocs...) {}
+            : base(std::forward<_OuterA2>(__outer_alloc), __inner_allocs...) {}
     // scoped_allocator_adaptor(const scoped_allocator_adaptor& __other) = default;
     template <class _OuterA2,
               __enable_if_t<is_constructible<outer_allocator_type, const _OuterA2&>::value, int> = 0>
@@ -457,7 +457,7 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         scoped_allocator_adaptor(
             scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>&& __other) _NOEXCEPT
-                : base(_VSTD::move(__other)) {}
+                : base(std::move(__other)) {}
 
     // scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
     // scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
@@ -511,7 +511,7 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         void construct(_Tp* __p, _Args&& ...__args)
             {__construct(__uses_alloc_ctor<_Tp, inner_allocator_type&, _Args...>(),
-                         __p, _VSTD::forward<_Args>(__args)...);}
+                         __p, std::forward<_Args>(__args)...);}
 
     template <class _T1, class _T2, class... _Args1, class... _Args2>
     _LIBCPP_HIDE_FROM_ABI void construct(pair<_T1, _T2>* __p, piecewise_construct_t,
@@ -524,14 +524,14 @@ public:
               typename __uses_alloc_ctor<
                   _T1, inner_allocator_type&, _Args1...
               >::type()
-            , _VSTD::move(__x)
+            , std::move(__x)
             , typename __make_tuple_indices<sizeof...(_Args1)>::type{}
           )
           , __transform_tuple(
               typename __uses_alloc_ctor<
                   _T2, inner_allocator_type&, _Args2...
               >::type()
-            , _VSTD::move(__y)
+            , std::move(__y)
             , typename __make_tuple_indices<sizeof...(_Args2)>::type{}
           )
         );
@@ -544,22 +544,22 @@ public:
     template <class _T1, class _T2, class _Up, class _Vp>
     _LIBCPP_HIDE_FROM_ABI void construct(pair<_T1, _T2>* __p, _Up&& __x, _Vp&& __y) {
         construct(__p, piecewise_construct,
-                  _VSTD::forward_as_tuple(_VSTD::forward<_Up>(__x)),
-                  _VSTD::forward_as_tuple(_VSTD::forward<_Vp>(__y)));
+                  std::forward_as_tuple(std::forward<_Up>(__x)),
+                  std::forward_as_tuple(std::forward<_Vp>(__y)));
     }
 
     template <class _T1, class _T2, class _Up, class _Vp>
     _LIBCPP_HIDE_FROM_ABI void construct(pair<_T1, _T2>* __p, const pair<_Up, _Vp>& __x) {
         construct(__p, piecewise_construct,
-                  _VSTD::forward_as_tuple(__x.first),
-                  _VSTD::forward_as_tuple(__x.second));
+                  std::forward_as_tuple(__x.first),
+                  std::forward_as_tuple(__x.second));
     }
 
     template <class _T1, class _T2, class _Up, class _Vp>
     _LIBCPP_HIDE_FROM_ABI void construct(pair<_T1, _T2>* __p, pair<_Up, _Vp>&& __x) {
         construct(__p, piecewise_construct,
-                  _VSTD::forward_as_tuple(_VSTD::forward<_Up>(__x.first)),
-                  _VSTD::forward_as_tuple(_VSTD::forward<_Vp>(__x.second)));
+                  std::forward_as_tuple(std::forward<_Up>(__x.first)),
+                  std::forward_as_tuple(std::forward<_Vp>(__x.second)));
     }
 #endif
 
@@ -584,7 +584,7 @@ private:
     _LIBCPP_HIDE_FROM_ABI
     scoped_allocator_adaptor(_OuterA2&& __o,
                              const inner_allocator_type& __i) _NOEXCEPT
-        : base(_VSTD::forward<_OuterA2>(__o), __i) {}
+        : base(std::forward<_OuterA2>(__o), __i) {}
 
     template <class _Tp, class... _Args>
         _LIBCPP_HIDE_FROM_ABI
@@ -595,7 +595,7 @@ private:
                 (
                     _OM()(outer_allocator()),
                     __p,
-                    _VSTD::forward<_Args>(__args)...
+                    std::forward<_Args>(__args)...
                 );
             }
 
@@ -608,7 +608,7 @@ private:
                 (
                     _OM()(outer_allocator()),
                     __p, allocator_arg, inner_allocator(),
-                    _VSTD::forward<_Args>(__args)...
+                    std::forward<_Args>(__args)...
                 );
             }
 
@@ -621,7 +621,7 @@ private:
                 (
                     _OM()(outer_allocator()),
                     __p,
-                    _VSTD::forward<_Args>(__args)...,
+                    std::forward<_Args>(__args)...,
                     inner_allocator()
                 );
             }
@@ -632,7 +632,7 @@ private:
     __transform_tuple(integral_constant<int, 0>, tuple<_Args...>&& __t,
                       __tuple_indices<_Idx...>)
     {
-        return _VSTD::forward_as_tuple(_VSTD::get<_Idx>(_VSTD::move(__t))...);
+        return std::forward_as_tuple(std::get<_Idx>(std::move(__t))...);
     }
 
     template <class ..._Args, size_t ..._Idx>
@@ -643,7 +643,7 @@ private:
     {
         using _Tup = tuple<allocator_arg_t, inner_allocator_type&, _Args&&...>;
         return _Tup(allocator_arg, inner_allocator(),
-                    _VSTD::get<_Idx>(_VSTD::move(__t))...);
+                    std::get<_Idx>(std::move(__t))...);
     }
 
     template <class ..._Args, size_t ..._Idx>
@@ -653,7 +653,7 @@ private:
                       __tuple_indices<_Idx...>)
     {
         using _Tup = tuple<_Args&&..., inner_allocator_type&>;
-        return _Tup(_VSTD::get<_Idx>(_VSTD::move(__t))..., inner_allocator());
+        return _Tup(std::get<_Idx>(std::move(__t))..., inner_allocator());
     }
 
     template <class...> friend class __scoped_allocator_storage;

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -591,8 +591,8 @@ public:
     typedef typename __base::difference_type       difference_type;
     typedef typename __base::const_iterator        iterator;
     typedef typename __base::const_iterator        const_iterator;
-    typedef _VSTD::reverse_iterator<iterator>       reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>       reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
 #if _LIBCPP_STD_VER >= 17
     typedef __set_node_handle<typename __base::__node, allocator_type> node_type;
@@ -682,7 +682,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     set(set&& __s)
         _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
-        : __tree_(_VSTD::move(__s.__tree_)) {}
+        : __tree_(std::move(__s.__tree_)) {}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
@@ -731,7 +731,7 @@ public:
     set& operator=(set&& __s)
         _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
         {
-            __tree_ = _VSTD::move(__s.__tree_);
+            __tree_ = std::move(__s.__tree_);
             return *this;
         }
 #endif // _LIBCPP_CXX03_LANG
@@ -784,11 +784,11 @@ public:
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         pair<iterator, bool> emplace(_Args&&... __args)
-            {return __tree_.__emplace_unique(_VSTD::forward<_Args>(__args)...);}
+            {return __tree_.__emplace_unique(std::forward<_Args>(__args)...);}
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator emplace_hint(const_iterator __p, _Args&&... __args)
-            {return __tree_.__emplace_hint_unique(__p, _VSTD::forward<_Args>(__args)...);}
+            {return __tree_.__emplace_hint_unique(__p, std::forward<_Args>(__args)...);}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
@@ -820,11 +820,11 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator,bool> insert(value_type&& __v)
-        {return __tree_.__insert_unique(_VSTD::move(__v));}
+        {return __tree_.__insert_unique(std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, value_type&& __v)
-        {return __tree_.__insert_unique(__p, _VSTD::move(__v));}
+        {return __tree_.__insert_unique(__p, std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     void insert(initializer_list<value_type> __il)
@@ -849,7 +849,7 @@ public:
         _LIBCPP_ASSERT_UNCATEGORIZED(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to set::insert()");
         return __tree_.template __node_handle_insert_unique<
-            node_type, insert_return_type>(_VSTD::move(__nh));
+            node_type, insert_return_type>(std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -857,7 +857,7 @@ public:
         _LIBCPP_ASSERT_UNCATEGORIZED(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to set::insert()");
         return __tree_.template __node_handle_insert_unique<node_type>(
-            __hint, _VSTD::move(__nh));
+            __hint, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -1052,13 +1052,13 @@ set(initializer_list<_Key>, _Allocator)
 
 template <class _Key, class _Compare, class _Allocator>
 set<_Key, _Compare, _Allocator>::set(set&& __s, const allocator_type& __a)
-    : __tree_(_VSTD::move(__s.__tree_), __a)
+    : __tree_(std::move(__s.__tree_), __a)
 {
     if (__a != __s.get_allocator())
     {
         const_iterator __e = cend();
         while (!__s.empty())
-            insert(__e, _VSTD::move(__s.__tree_.remove(__s.begin())->__value_));
+            insert(__e, std::move(__s.__tree_.remove(__s.begin())->__value_));
     }
 }
 
@@ -1070,7 +1070,7 @@ bool
 operator==(const set<_Key, _Compare, _Allocator>& __x,
            const set<_Key, _Compare, _Allocator>& __y)
 {
-    return __x.size() == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -1081,7 +1081,7 @@ bool
 operator< (const set<_Key, _Compare, _Allocator>& __x,
            const set<_Key, _Compare, _Allocator>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Key, class _Compare, class _Allocator>
@@ -1147,7 +1147,7 @@ template <class _Key, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI
     typename set<_Key, _Compare, _Allocator>::size_type
     erase_if(set<_Key, _Compare, _Allocator>& __c, _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -1185,8 +1185,8 @@ public:
     typedef typename __base::difference_type       difference_type;
     typedef typename __base::const_iterator        iterator;
     typedef typename __base::const_iterator        const_iterator;
-    typedef _VSTD::reverse_iterator<iterator>       reverse_iterator;
-    typedef _VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<iterator>       reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
 #if _LIBCPP_STD_VER >= 17
     typedef __set_node_handle<typename __base::__node, allocator_type> node_type;
@@ -1275,7 +1275,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     multiset(multiset&& __s)
         _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
-        : __tree_(_VSTD::move(__s.__tree_)) {}
+        : __tree_(std::move(__s.__tree_)) {}
 
     _LIBCPP_HIDE_FROM_ABI multiset(multiset&& __s, const allocator_type& __a);
 #endif // _LIBCPP_CXX03_LANG
@@ -1322,7 +1322,7 @@ public:
     multiset& operator=(multiset&& __s)
         _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
         {
-            __tree_ = _VSTD::move(__s.__tree_);
+            __tree_ = std::move(__s.__tree_);
             return *this;
         }
 #endif // _LIBCPP_CXX03_LANG
@@ -1375,11 +1375,11 @@ public:
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator emplace(_Args&&... __args)
-            {return __tree_.__emplace_multi(_VSTD::forward<_Args>(__args)...);}
+            {return __tree_.__emplace_multi(std::forward<_Args>(__args)...);}
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator emplace_hint(const_iterator __p, _Args&&... __args)
-            {return __tree_.__emplace_hint_multi(__p, _VSTD::forward<_Args>(__args)...);}
+            {return __tree_.__emplace_hint_multi(__p, std::forward<_Args>(__args)...);}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
@@ -1411,11 +1411,11 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(value_type&& __v)
-        {return __tree_.__insert_multi(_VSTD::move(__v));}
+        {return __tree_.__insert_multi(std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, value_type&& __v)
-        {return __tree_.__insert_multi(__p, _VSTD::move(__v));}
+        {return __tree_.__insert_multi(__p, std::move(__v));}
 
     _LIBCPP_HIDE_FROM_ABI
     void insert(initializer_list<value_type> __il)
@@ -1439,7 +1439,7 @@ public:
         _LIBCPP_ASSERT_UNCATEGORIZED(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to multiset::insert()");
         return __tree_.template __node_handle_insert_multi<node_type>(
-            _VSTD::move(__nh));
+            std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -1447,7 +1447,7 @@ public:
         _LIBCPP_ASSERT_UNCATEGORIZED(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to multiset::insert()");
         return __tree_.template __node_handle_insert_multi<node_type>(
-            __hint, _VSTD::move(__nh));
+            __hint, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -1643,13 +1643,13 @@ multiset(initializer_list<_Key>, _Allocator)
 
 template <class _Key, class _Compare, class _Allocator>
 multiset<_Key, _Compare, _Allocator>::multiset(multiset&& __s, const allocator_type& __a)
-    : __tree_(_VSTD::move(__s.__tree_), __a)
+    : __tree_(std::move(__s.__tree_), __a)
 {
     if (__a != __s.get_allocator())
     {
         const_iterator __e = cend();
         while (!__s.empty())
-            insert(__e, _VSTD::move(__s.__tree_.remove(__s.begin())->__value_));
+            insert(__e, std::move(__s.__tree_.remove(__s.begin())->__value_));
     }
 }
 
@@ -1661,7 +1661,7 @@ bool
 operator==(const multiset<_Key, _Compare, _Allocator>& __x,
            const multiset<_Key, _Compare, _Allocator>& __y)
 {
-    return __x.size() == __y.size() && _VSTD::equal(__x.begin(), __x.end(), __y.begin());
+    return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -1672,7 +1672,7 @@ bool
 operator< (const multiset<_Key, _Compare, _Allocator>& __x,
            const multiset<_Key, _Compare, _Allocator>& __y)
 {
-    return _VSTD::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
+    return std::lexicographical_compare(__x.begin(), __x.end(), __y.begin(), __y.end());
 }
 
 template <class _Key, class _Compare, class _Allocator>
@@ -1737,7 +1737,7 @@ template <class _Key, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI
     typename multiset<_Key, _Compare, _Allocator>::size_type
     erase_if(multiset<_Key, _Compare, _Allocator>& __c, _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -321,26 +321,26 @@ private:
 public:
   _LIBCPP_HIDE_FROM_ABI shared_lock() _NOEXCEPT : __m_(nullptr), __owns_(false) {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit shared_lock(mutex_type& __m) : __m_(_VSTD::addressof(__m)), __owns_(true) {
+  _LIBCPP_HIDE_FROM_ABI explicit shared_lock(mutex_type& __m) : __m_(std::addressof(__m)), __owns_(true) {
     __m_->lock_shared();
   }
 
   _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, defer_lock_t) _NOEXCEPT
-      : __m_(_VSTD::addressof(__m)),
+      : __m_(std::addressof(__m)),
         __owns_(false) {}
 
   _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, try_to_lock_t)
-      : __m_(_VSTD::addressof(__m)), __owns_(__m.try_lock_shared()) {}
+      : __m_(std::addressof(__m)), __owns_(__m.try_lock_shared()) {}
 
-  _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, adopt_lock_t) : __m_(_VSTD::addressof(__m)), __owns_(true) {}
+  _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, adopt_lock_t) : __m_(std::addressof(__m)), __owns_(true) {}
 
   template <class _Clock, class _Duration>
   _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, const chrono::time_point<_Clock, _Duration>& __abs_time)
-      : __m_(_VSTD::addressof(__m)), __owns_(__m.try_lock_shared_until(__abs_time)) {}
+      : __m_(std::addressof(__m)), __owns_(__m.try_lock_shared_until(__abs_time)) {}
 
   template <class _Rep, class _Period>
   _LIBCPP_HIDE_FROM_ABI shared_lock(mutex_type& __m, const chrono::duration<_Rep, _Period>& __rel_time)
-      : __m_(_VSTD::addressof(__m)), __owns_(__m.try_lock_shared_for(__rel_time)) {}
+      : __m_(std::addressof(__m)), __owns_(__m.try_lock_shared_for(__rel_time)) {}
 
   _LIBCPP_HIDE_FROM_ABI ~shared_lock() {
     if (__owns_)
@@ -377,8 +377,8 @@ public:
 
   // Setters
   _LIBCPP_HIDE_FROM_ABI void swap(shared_lock& __u) _NOEXCEPT {
-    _VSTD::swap(__m_, __u.__m_);
-    _VSTD::swap(__owns_, __u.__owns_);
+    std::swap(__m_, __u.__m_);
+    std::swap(__owns_, __u.__owns_);
   }
 
   _LIBCPP_HIDE_FROM_ABI mutex_type* release() _NOEXCEPT {

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -216,7 +216,7 @@ public:
 #else
     using iterator               = __wrap_iter<pointer>;
 #endif
-    using reverse_iterator       = _VSTD::reverse_iterator<iterator>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
 
     static constexpr size_type extent = _Extent;
 
@@ -230,14 +230,14 @@ public:
     template <__span_compatible_iterator<element_type> _It>
     _LIBCPP_HIDE_FROM_ABI
     constexpr explicit span(_It __first, size_type __count)
-        : __data_{_VSTD::to_address(__first)} {
+        : __data_{std::to_address(__first)} {
       (void)__count;
       _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(_Extent == __count, "size mismatch in span's constructor (iterator, len)");
     }
 
     template <__span_compatible_iterator<element_type> _It, __span_compatible_sentinel_for<_It> _End>
     _LIBCPP_HIDE_FROM_ABI
-    constexpr explicit span(_It __first, _End __last) : __data_{_VSTD::to_address(__first)} {
+    constexpr explicit span(_It __first, _End __last) : __data_{std::to_address(__first)} {
       // [span.cons]/10
       // Throws: When and what last - first throws.
       [[maybe_unused]] auto __dist = __last - __first;
@@ -403,7 +403,7 @@ public:
 #else
     using iterator               = __wrap_iter<pointer>;
 #endif
-    using reverse_iterator       = _VSTD::reverse_iterator<iterator>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
 
     static constexpr size_type extent = dynamic_extent;
 
@@ -416,11 +416,11 @@ public:
     template <__span_compatible_iterator<element_type> _It>
     _LIBCPP_HIDE_FROM_ABI
     constexpr span(_It __first, size_type __count)
-        : __data_{_VSTD::to_address(__first)}, __size_{__count} {}
+        : __data_{std::to_address(__first)}, __size_{__count} {}
 
     template <__span_compatible_iterator<element_type> _It, __span_compatible_sentinel_for<_It> _End>
     _LIBCPP_HIDE_FROM_ABI constexpr span(_It __first, _End __last)
-        : __data_(_VSTD::to_address(__first)), __size_(__last - __first) {
+        : __data_(std::to_address(__first)), __size_(__last - __first) {
         _LIBCPP_ASSERT_VALID_INPUT_RANGE(
             __last - __first >= 0, "invalid range in span's constructor (iterator, sentinel)");
     }

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -481,7 +481,7 @@ _LIBCPP_HIDE_FROM_ABI void basic_stringbuf<_CharT, _Traits, _Allocator>::__move_
         __eout = __rhs.epptr() - __p;
     }
     ptrdiff_t __hm = __rhs.__hm_ == nullptr ? -1 : __rhs.__hm_ - __p;
-    __str_ = _VSTD::move(__rhs.__str_);
+    __str_ = std::move(__rhs.__str_);
     __p = const_cast<char_type*>(__str_.data());
     if (__binp != -1)
         this->setg(__p + __binp, __p + __ninp, __p + __einp);
@@ -522,7 +522,7 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::operator=(basic_stringbuf&& __rhs)
         __eout = __rhs.epptr() - __p;
     }
     ptrdiff_t __hm = __rhs.__hm_ == nullptr ? -1 : __rhs.__hm_ - __p;
-    __str_ = _VSTD::move(__rhs.__str_);
+    __str_ = std::move(__rhs.__str_);
     __p = const_cast<char_type*>(__str_.data());
     if (__binp != -1)
         this->setg(__p + __binp, __p + __ninp, __p + __einp);
@@ -594,7 +594,7 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::swap(basic_stringbuf& __rhs)
         __leout = this->epptr() - __p;
     }
     ptrdiff_t __lhm = __hm_ == nullptr ? -1 : __hm_ - __p;
-    _VSTD::swap(__mode_, __rhs.__mode_);
+    std::swap(__mode_, __rhs.__mode_);
     __str_.swap(__rhs.__str_);
     __p = const_cast<char_type*>(__str_.data());
     if (__rbinp != -1)
@@ -762,7 +762,7 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::overflow(int_type __c)
             }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
         }
-        __hm_ = _VSTD::max(this->pptr() + 1, __hm_);
+        __hm_ = std::max(this->pptr() + 1, __hm_);
         if (__mode_ & ios_base::in)
         {
             char_type* __p = const_cast<char_type*>(__str_.data());
@@ -885,16 +885,16 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     basic_istringstream(basic_istringstream&& __rhs)
-        : basic_istream<_CharT, _Traits>(_VSTD::move(__rhs))
-        , __sb_(_VSTD::move(__rhs.__sb_))
+        : basic_istream<_CharT, _Traits>(std::move(__rhs))
+        , __sb_(std::move(__rhs.__sb_))
     {
         basic_istream<_CharT, _Traits>::set_rdbuf(&__sb_);
     }
 
     // [istringstream.assign] Assign and swap:
     basic_istringstream& operator=(basic_istringstream&& __rhs) {
-        basic_istream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-        __sb_ = _VSTD::move(__rhs.__sb_);
+        basic_istream<char_type, traits_type>::operator=(std::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
         return *this;
     }
     _LIBCPP_HIDE_FROM_ABI
@@ -1009,16 +1009,16 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     basic_ostringstream(basic_ostringstream&& __rhs)
-        : basic_ostream<_CharT, _Traits>(_VSTD::move(__rhs))
-        , __sb_(_VSTD::move(__rhs.__sb_))
+        : basic_ostream<_CharT, _Traits>(std::move(__rhs))
+        , __sb_(std::move(__rhs.__sb_))
     {
         basic_ostream<_CharT, _Traits>::set_rdbuf(&__sb_);
     }
 
     // [ostringstream.assign] Assign and swap:
     basic_ostringstream& operator=(basic_ostringstream&& __rhs) {
-        basic_ostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-        __sb_ = _VSTD::move(__rhs.__sb_);
+        basic_ostream<char_type, traits_type>::operator=(std::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
         return *this;
     }
 
@@ -1134,16 +1134,16 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     basic_stringstream(basic_stringstream&& __rhs)
-        : basic_iostream<_CharT, _Traits>(_VSTD::move(__rhs))
-        , __sb_(_VSTD::move(__rhs.__sb_))
+        : basic_iostream<_CharT, _Traits>(std::move(__rhs))
+        , __sb_(std::move(__rhs.__sb_))
     {
         basic_istream<_CharT, _Traits>::set_rdbuf(&__sb_);
     }
 
     // [stringstream.assign] Assign and swap:
     basic_stringstream& operator=(basic_stringstream&& __rhs) {
-        basic_iostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-        __sb_ = _VSTD::move(__rhs.__sb_);
+        basic_iostream<char_type, traits_type>::operator=(std::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
         return *this;
     }
     _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -183,15 +183,15 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     stack(stack&& __q)
         _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value)
-        : c(_VSTD::move(__q.c)) {}
+        : c(std::move(__q.c)) {}
 
     _LIBCPP_HIDE_FROM_ABI
     stack& operator=(stack&& __q)
         _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value)
-        {c = _VSTD::move(__q.c); return *this;}
+        {c = std::move(__q.c); return *this;}
 
     _LIBCPP_HIDE_FROM_ABI
-    explicit stack(container_type&& __c) : c(_VSTD::move(__c)) {}
+    explicit stack(container_type&& __c) : c(std::move(__c)) {}
 #endif // _LIBCPP_CXX03_LANG
 
     _LIBCPP_HIDE_FROM_ABI
@@ -217,12 +217,12 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         stack(container_type&& __c, const _Alloc& __a,
               __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-            : c(_VSTD::move(__c), __a) {}
+            : c(std::move(__c), __a) {}
     template <class _Alloc>
         _LIBCPP_HIDE_FROM_ABI
         stack(stack&& __s, const _Alloc& __a,
               __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-            : c(_VSTD::move(__s.c), __a) {}
+            : c(std::move(__s.c), __a) {}
 #endif // _LIBCPP_CXX03_LANG
 
 #if _LIBCPP_STD_VER >= 23
@@ -264,7 +264,7 @@ public:
     void push(const value_type& __v) {c.push_back(__v);}
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
-    void push(value_type&& __v) {c.push_back(_VSTD::move(__v));}
+    void push(value_type&& __v) {c.push_back(std::move(__v));}
 
 #if _LIBCPP_STD_VER >= 23
     template <_ContainerCompatibleRange<_Tp> _Range>
@@ -284,10 +284,10 @@ public:
         _LIBCPP_HIDE_FROM_ABI
 #if _LIBCPP_STD_VER >= 17
         decltype(auto) emplace(_Args&&... __args)
-        { return c.emplace_back(_VSTD::forward<_Args>(__args)...);}
+        { return c.emplace_back(std::forward<_Args>(__args)...);}
 #else
         void      emplace(_Args&&... __args)
-        {        c.emplace_back(_VSTD::forward<_Args>(__args)...);}
+        {        c.emplace_back(std::forward<_Args>(__args)...);}
 #endif
 #endif // _LIBCPP_CXX03_LANG
 
@@ -298,7 +298,7 @@ public:
     void swap(stack& __s)
         _NOEXCEPT_(__is_nothrow_swappable<container_type>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(c, __s.c);
     }
 

--- a/libcxx/include/stdexcept
+++ b/libcxx/include/stdexcept
@@ -79,7 +79,7 @@ class _LIBCPP_EXPORTED_FROM_ABI logic_error
 {
 #ifndef _LIBCPP_ABI_VCRUNTIME
 private:
-    _VSTD::__libcpp_refstring __imp_;
+    std::__libcpp_refstring __imp_;
 public:
     explicit logic_error(const string&);
     explicit logic_error(const char*);
@@ -92,7 +92,7 @@ public:
     const char* what() const _NOEXCEPT override;
 #else
 public:
-    explicit logic_error(const _VSTD::string&); // Symbol uses versioned std::string
+    explicit logic_error(const std::string&); // Symbol uses versioned std::string
     _LIBCPP_HIDE_FROM_ABI explicit logic_error(const char* __s) : exception(__s) {}
 #endif
 };
@@ -102,7 +102,7 @@ class _LIBCPP_EXPORTED_FROM_ABI runtime_error
 {
 #ifndef _LIBCPP_ABI_VCRUNTIME
 private:
-    _VSTD::__libcpp_refstring __imp_;
+    std::__libcpp_refstring __imp_;
 public:
     explicit runtime_error(const string&);
     explicit runtime_error(const char*);
@@ -115,7 +115,7 @@ public:
     const char* what() const _NOEXCEPT override;
 #else
 public:
-   explicit runtime_error(const _VSTD::string&); // Symbol uses versioned std::string
+   explicit runtime_error(const std::string&); // Symbol uses versioned std::string
    _LIBCPP_HIDE_FROM_ABI explicit runtime_error(const char* __s) : exception(__s) {}
 #endif // _LIBCPP_ABI_VCRUNTIME
 };

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -351,13 +351,13 @@ template <class _CharT, class _Traits>
 void
 basic_streambuf<_CharT, _Traits>::swap(basic_streambuf& __sb)
 {
-    _VSTD::swap(__loc_, __sb.__loc_);
-    _VSTD::swap(__binp_, __sb.__binp_);
-    _VSTD::swap(__ninp_, __sb.__ninp_);
-    _VSTD::swap(__einp_, __sb.__einp_);
-    _VSTD::swap(__bout_, __sb.__bout_);
-    _VSTD::swap(__nout_, __sb.__nout_);
-    _VSTD::swap(__eout_, __sb.__eout_);
+    std::swap(__loc_, __sb.__loc_);
+    std::swap(__binp_, __sb.__binp_);
+    std::swap(__ninp_, __sb.__ninp_);
+    std::swap(__einp_, __sb.__einp_);
+    std::swap(__bout_, __sb.__bout_);
+    std::swap(__nout_, __sb.__nout_);
+    std::swap(__eout_, __sb.__eout_);
 }
 
 template <class _CharT, class _Traits>
@@ -413,8 +413,8 @@ basic_streambuf<_CharT, _Traits>::xsgetn(char_type* __s, streamsize __n)
     {
         if (__ninp_ < __einp_)
         {
-            const streamsize __len = _VSTD::min(static_cast<streamsize>(INT_MAX),
-                                _VSTD::min(__einp_ - __ninp_, __n - __i));
+            const streamsize __len = std::min(static_cast<streamsize>(INT_MAX),
+                                std::min(__einp_ - __ninp_, __n - __i));
             traits_type::copy(__s, __ninp_, __len);
             __s +=  __len;
             __i +=  __len;
@@ -472,7 +472,7 @@ basic_streambuf<_CharT, _Traits>::xsputn(const char_type* __s, streamsize __n)
         }
         else
         {
-            streamsize __chunk_size = _VSTD::min(__eout_ - __nout_, __n - __i);
+            streamsize __chunk_size = std::min(__eout_ - __nout_, __n - __i);
             traits_type::copy(__nout_, __s, __chunk_size);
             __nout_ += __chunk_size;
             __s     += __chunk_size;

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -285,7 +285,7 @@ public:
     using const_iterator         = const_pointer; // See [string.view.iterators]
 #endif
     using iterator               = const_iterator;
-    using const_reverse_iterator = _VSTD::reverse_iterator<const_iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using reverse_iterator       = const_reverse_iterator;
     using size_type              = size_t;
     using difference_type        = ptrdiff_t;
@@ -324,7 +324,7 @@ public:
     template <contiguous_iterator _It, sized_sentinel_for<_It> _End>
       requires (is_same_v<iter_value_t<_It>, _CharT> && !is_convertible_v<_End, size_type>)
     constexpr _LIBCPP_HIDE_FROM_ABI basic_string_view(_It __begin, _End __end)
-       : __data_(_VSTD::to_address(__begin)), __size_(__end - __begin)
+       : __data_(std::to_address(__begin)), __size_(__end - __begin)
     {
       _LIBCPP_ASSERT_VALID_INPUT_RANGE((__end - __begin) >= 0,
                                        "std::string_view::string_view(iterator, sentinel) received invalid range");
@@ -340,7 +340,7 @@ public:
         is_same_v<ranges::range_value_t<_Range>, _CharT> &&
         !is_convertible_v<_Range, const _CharT*> &&
         (!requires(remove_cvref_t<_Range>& __d) {
-          __d.operator _VSTD::basic_string_view<_CharT, _Traits>();
+          __d.operator std::basic_string_view<_CharT, _Traits>();
         })
       )
     constexpr explicit _LIBCPP_HIDE_FROM_ABI
@@ -349,7 +349,7 @@ public:
 
     _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
     basic_string_view(const _CharT* __s)
-        : __data_(__s), __size_(_VSTD::__char_traits_length_checked<_Traits>(__s)) {}
+        : __data_(__s), __size_(std::__char_traits_length_checked<_Traits>(__s)) {}
 
 #if _LIBCPP_STD_VER >= 23
     basic_string_view(nullptr_t) = delete;
@@ -468,7 +468,7 @@ public:
     {
         if (__pos > size())
             __throw_out_of_range("string_view::copy");
-        size_type __rlen = _VSTD::min(__n, size() - __pos);
+        size_type __rlen = std::min(__n, size() - __pos);
         _Traits::copy(__s, data() + __pos, __rlen);
         return __rlen;
     }
@@ -478,12 +478,12 @@ public:
     {
         return __pos > size()
             ? (__throw_out_of_range("string_view::substr"), basic_string_view())
-            : basic_string_view(data() + __pos, _VSTD::min(__n, size() - __pos));
+            : basic_string_view(data() + __pos, std::min(__n, size() - __pos));
     }
 
     _LIBCPP_CONSTEXPR_SINCE_CXX14 int compare(basic_string_view __sv) const _NOEXCEPT
     {
-        size_type __rlen = _VSTD::min(size(), __sv.size());
+        size_type __rlen = std::min(size(), __sv.size());
         int __retval = _Traits::compare(data(), __sv.data(), __rlen);
         if (__retval == 0) // first __rlen chars matched
             __retval = size() == __sv.size() ? 0 : (size() < __sv.size() ? -1 : 1);

--- a/libcxx/include/strstream
+++ b/libcxx/include/strstream
@@ -257,8 +257,8 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     istrstream(istrstream&& __rhs)  // extension
-        : istream(_VSTD::move(static_cast<istream&>(__rhs))),
-          __sb_(_VSTD::move(__rhs.__sb_))
+        : istream(std::move(static_cast<istream&>(__rhs))),
+          __sb_(std::move(__rhs.__sb_))
     {
         istream::set_rdbuf(&__sb_);
     }
@@ -266,8 +266,8 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     istrstream& operator=(istrstream&& __rhs)
     {
-        __sb_ = _VSTD::move(__rhs.__sb_);
-        istream::operator=(_VSTD::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
+        istream::operator=(std::move(__rhs));
         return *this;
     }
 #endif // _LIBCPP_CXX03_LANG
@@ -300,14 +300,14 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     ostrstream(char* __s, int __n, ios_base::openmode __mode = ios_base::out)
         : ostream(&__sb_),
-          __sb_(__s, __n, __s + (__mode & ios::app ? _VSTD::strlen(__s) : 0))
+          __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0))
         {}
 
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     ostrstream(ostrstream&& __rhs)  // extension
-        : ostream(_VSTD::move(static_cast<ostream&>(__rhs))),
-          __sb_(_VSTD::move(__rhs.__sb_))
+        : ostream(std::move(static_cast<ostream&>(__rhs))),
+          __sb_(std::move(__rhs.__sb_))
     {
         ostream::set_rdbuf(&__sb_);
     }
@@ -315,8 +315,8 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     ostrstream& operator=(ostrstream&& __rhs)
     {
-        __sb_ = _VSTD::move(__rhs.__sb_);
-        ostream::operator=(_VSTD::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
+        ostream::operator=(std::move(__rhs));
         return *this;
     }
 #endif // _LIBCPP_CXX03_LANG
@@ -360,14 +360,14 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     strstream(char* __s, int __n, ios_base::openmode __mode = ios_base::in | ios_base::out)
         : iostream(&__sb_),
-          __sb_(__s, __n, __s + (__mode & ios::app ? _VSTD::strlen(__s) : 0))
+          __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0))
         {}
 
 #ifndef _LIBCPP_CXX03_LANG
     _LIBCPP_HIDE_FROM_ABI
     strstream(strstream&& __rhs)  // extension
-        : iostream(_VSTD::move(static_cast<iostream&>(__rhs))),
-          __sb_(_VSTD::move(__rhs.__sb_))
+        : iostream(std::move(static_cast<iostream&>(__rhs))),
+          __sb_(std::move(__rhs.__sb_))
     {
         iostream::set_rdbuf(&__sb_);
     }
@@ -375,8 +375,8 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     strstream& operator=(strstream&& __rhs)
     {
-        __sb_ = _VSTD::move(__rhs.__sb_);
-        iostream::operator=(_VSTD::move(__rhs));
+        __sb_ = std::move(__rhs.__sb_);
+        iostream::operator=(std::move(__rhs));
         return *this;
     }
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -358,28 +358,28 @@ public:
             >
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_((is_nothrow_constructible<_Hp, _Tp>::value))
-            : __value_(_VSTD::forward<_Tp>(__t))
+            : __value_(std::forward<_Tp>(__t))
         {static_assert(__can_bind_reference<_Tp&&>(),
        "Attempted construction of reference element binds to a temporary whose lifetime has ended");}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         explicit __tuple_leaf(integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
-            : __value_(_VSTD::forward<_Tp>(__t))
+            : __value_(std::forward<_Tp>(__t))
         {static_assert(__can_bind_reference<_Tp&&>(),
        "Attempted construction of reference element binds to a temporary whose lifetime has ended");}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         explicit __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
-            : __value_(allocator_arg_t(), __a, _VSTD::forward<_Tp>(__t))
+            : __value_(allocator_arg_t(), __a, std::forward<_Tp>(__t))
         {static_assert(!is_reference<_Hp>::value,
             "Attempted to uses-allocator construct a reference element in a tuple");}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         explicit __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
-            : __value_(_VSTD::forward<_Tp>(__t), __a)
+            : __value_(std::forward<_Tp>(__t), __a)
         {static_assert(!is_reference<_Hp>::value,
            "Attempted to uses-allocator construct a reference element in a tuple");}
 
@@ -389,13 +389,13 @@ public:
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     int swap(__tuple_leaf& __t) _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value)
     {
-        _VSTD::swap(*this, __t);
+        std::swap(*this, __t);
         return 0;
     }
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     int swap(const __tuple_leaf& __t) const _NOEXCEPT_(__is_nothrow_swappable<const __tuple_leaf>::value) {
-        _VSTD::swap(*this, __t);
+        std::swap(*this, __t);
         return 0;
     }
 
@@ -437,22 +437,22 @@ public:
             >
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_((is_nothrow_constructible<_Hp, _Tp>::value))
-            : _Hp(_VSTD::forward<_Tp>(__t)) {}
+            : _Hp(std::forward<_Tp>(__t)) {}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI constexpr
         explicit __tuple_leaf(integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
-            : _Hp(_VSTD::forward<_Tp>(__t)) {}
+            : _Hp(std::forward<_Tp>(__t)) {}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI constexpr
         explicit __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
-            : _Hp(allocator_arg_t(), __a, _VSTD::forward<_Tp>(__t)) {}
+            : _Hp(allocator_arg_t(), __a, std::forward<_Tp>(__t)) {}
 
     template <class _Tp, class _Alloc>
         _LIBCPP_HIDE_FROM_ABI constexpr
         explicit __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
-            : _Hp(_VSTD::forward<_Tp>(__t), __a) {}
+            : _Hp(std::forward<_Tp>(__t), __a) {}
 
     __tuple_leaf(__tuple_leaf const &) = default;
     __tuple_leaf(__tuple_leaf &&) = default;
@@ -461,13 +461,13 @@ public:
     int
     swap(__tuple_leaf& __t) _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value)
     {
-        _VSTD::swap(*this, __t);
+        std::swap(*this, __t);
         return 0;
     }
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     int swap(const __tuple_leaf& __rhs) const _NOEXCEPT_(__is_nothrow_swappable<const __tuple_leaf>::value) {
-        _VSTD::swap(*this, __rhs);
+        std::swap(*this, __rhs);
         return 0;
     }
 
@@ -508,7 +508,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
                      _Up&&... __u)
                      _NOEXCEPT_((__all<is_nothrow_constructible<_Tf, _Up>::value...>::value &&
                                  __all<is_nothrow_default_constructible<_Tl>::value...>::value)) :
-            __tuple_leaf<_Uf, _Tf>(_VSTD::forward<_Up>(__u))...,
+            __tuple_leaf<_Uf, _Tf>(std::forward<_Up>(__u))...,
             __tuple_leaf<_Ul, _Tl>()...
             {}
 
@@ -521,7 +521,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
                      __tuple_indices<_Ul...>, __tuple_types<_Tl...>,
                      _Up&&... __u) :
             __tuple_leaf<_Uf, _Tf>(__uses_alloc_ctor<_Tf, _Alloc, _Up>(), __a,
-            _VSTD::forward<_Up>(__u))...,
+            std::forward<_Up>(__u))...,
             __tuple_leaf<_Ul, _Tl>(__uses_alloc_ctor<_Tl, _Alloc>(), __a)...
             {}
 
@@ -531,8 +531,8 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
         _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
         __tuple_impl(_Tuple&& __t) _NOEXCEPT_((__all<is_nothrow_constructible<_Tp, typename tuple_element<_Indx,
                                        typename __make_tuple_types<_Tuple>::type>::type>::value...>::value))
-            : __tuple_leaf<_Indx, _Tp>(_VSTD::forward<typename tuple_element<_Indx,
-                                       typename __make_tuple_types<_Tuple>::type>::type>(_VSTD::get<_Indx>(__t)))...
+            : __tuple_leaf<_Indx, _Tp>(std::forward<typename tuple_element<_Indx,
+                                       typename __make_tuple_types<_Tuple>::type>::type>(std::get<_Indx>(__t)))...
             {}
 
     template <class _Alloc, class _Tuple,
@@ -542,8 +542,8 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
         __tuple_impl(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
             : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, typename tuple_element<_Indx,
                                        typename __make_tuple_types<_Tuple>::type>::type>(), __a,
-                                       _VSTD::forward<typename tuple_element<_Indx,
-                                       typename __make_tuple_types<_Tuple>::type>::type>(_VSTD::get<_Indx>(__t)))...
+                                       std::forward<typename tuple_element<_Indx,
+                                       typename __make_tuple_types<_Tuple>::type>::type>(std::get<_Indx>(__t)))...
             {}
 
     __tuple_impl(const __tuple_impl&) = default;
@@ -553,28 +553,28 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
     void swap(__tuple_impl& __t)
         _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value)
     {
-        _VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
+        std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
     }
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     void swap(const __tuple_impl& __t) const
         _NOEXCEPT_(__all<__is_nothrow_swappable<const _Tp>::value...>::value)
     {
-        _VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t))...);
+        std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t))...);
     }
 };
 
 template<class _Dest, class _Source, size_t ..._Np>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 void __memberwise_copy_assign(_Dest& __dest, _Source const& __source, __tuple_indices<_Np...>) {
-    _VSTD::__swallow(((_VSTD::get<_Np>(__dest) = _VSTD::get<_Np>(__source)), void(), 0)...);
+    std::__swallow(((std::get<_Np>(__dest) = std::get<_Np>(__source)), void(), 0)...);
 }
 
 template<class _Dest, class _Source, class ..._Up, size_t ..._Np>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 void __memberwise_forward_assign(_Dest& __dest, _Source&& __source, __tuple_types<_Up...>, __tuple_indices<_Np...>) {
-    _VSTD::__swallow(((
-        _VSTD::get<_Np>(__dest) = _VSTD::forward<_Up>(_VSTD::get<_Np>(__source))
+    std::__swallow(((
+        std::get<_Np>(__dest) = std::forward<_Up>(std::get<_Np>(__source))
     ), void(), 0)...);
 }
 
@@ -683,7 +683,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
                     typename __make_tuple_types<tuple, sizeof...(_Up)>::type(),
                     typename __make_tuple_indices<sizeof...(_Tp), sizeof...(_Up)>::type(),
                     typename __make_tuple_types<tuple, sizeof...(_Tp), sizeof...(_Up)>::type(),
-                    _VSTD::forward<_Up>(__u)...) {}
+                    std::forward<_Up>(__u)...) {}
 
     template <class _Alloc, class ..._Up, __enable_if_t<
         _And<
@@ -698,7 +698,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
                     typename __make_tuple_types<tuple, sizeof...(_Up)>::type(),
                     typename __make_tuple_indices<sizeof...(_Tp), sizeof...(_Up)>::type(),
                     typename __make_tuple_types<tuple, sizeof...(_Tp), sizeof...(_Up)>::type(),
-                    _VSTD::forward<_Up>(__u)...) {}
+                    std::forward<_Up>(__u)...) {}
 
     // Copy and move constructors (including the allocator_arg_t variants)
     tuple(const tuple&) = default;
@@ -717,7 +717,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
     , int> = 0>
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     tuple(allocator_arg_t, const _Alloc& __alloc, tuple&& __t)
-        : __base_(allocator_arg_t(), __alloc, _VSTD::move(__t))
+        : __base_(allocator_arg_t(), __alloc, std::move(__t))
     { }
 
     // tuple(const tuple<U...>&) constructors (including allocator_arg_t variants)
@@ -791,7 +791,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     explicit(_Not<_Lazy<_And, is_convertible<_Up, _Tp>...> >::value) tuple(tuple<_Up...>&& __t)
         _NOEXCEPT_((_And<is_nothrow_constructible<_Tp, _Up>...>::value))
-        : __base_(_VSTD::move(__t))
+        : __base_(std::move(__t))
     { }
 
     template <class _Alloc, class ..._Up, __enable_if_t<
@@ -801,7 +801,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
     , int> = 0>
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     explicit(_Not<_Lazy<_And, is_convertible<_Up, _Tp>...> >::value) tuple(allocator_arg_t, const _Alloc& __a, tuple<_Up...>&& __t)
-        : __base_(allocator_arg_t(), __a, _VSTD::move(__t))
+        : __base_(allocator_arg_t(), __a, std::move(__t))
     { }
 
 #if _LIBCPP_STD_VER >= 23
@@ -894,7 +894,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     explicit(_Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value) tuple(pair<_Up1, _Up2>&& __p)
         _NOEXCEPT_((_NothrowConstructibleFromPair<pair<_Up1, _Up2>&&>::value))
-        : __base_(_VSTD::move(__p))
+        : __base_(std::move(__p))
     { }
 
     template <class _Alloc, class _Up1, class _Up2, template<class...> class _And = _And, __enable_if_t<
@@ -904,7 +904,7 @@ _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")
     , int> = 0>
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
     explicit(_Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value) tuple(allocator_arg_t, const _Alloc& __a, pair<_Up1, _Up2>&& __p)
-        : __base_(allocator_arg_t(), __a, _VSTD::move(__p))
+        : __base_(allocator_arg_t(), __a, std::move(__p))
     { }
 
 #if _LIBCPP_STD_VER >= 23
@@ -931,7 +931,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(_If<_And<is_copy_assignable<_Tp>...>::value, tuple, __nat> const& __tuple)
         _NOEXCEPT_((_And<is_nothrow_copy_assignable<_Tp>...>::value))
     {
-        _VSTD::__memberwise_copy_assign(*this, __tuple,
+        std::__memberwise_copy_assign(*this, __tuple,
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
     }
@@ -959,7 +959,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(_If<_And<is_move_assignable<_Tp>...>::value, tuple, __nat>&& __tuple)
         _NOEXCEPT_((_And<is_nothrow_move_assignable<_Tp>...>::value))
     {
-        _VSTD::__memberwise_forward_assign(*this, _VSTD::move(__tuple),
+        std::__memberwise_forward_assign(*this, std::move(__tuple),
             __tuple_types<_Tp...>(),
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
@@ -975,7 +975,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(tuple<_Up...> const& __tuple)
         _NOEXCEPT_((_And<is_nothrow_assignable<_Tp&, _Up const&>...>::value))
     {
-        _VSTD::__memberwise_copy_assign(*this, __tuple,
+        std::__memberwise_copy_assign(*this, __tuple,
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
     }
@@ -990,7 +990,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(tuple<_Up...>&& __tuple)
         _NOEXCEPT_((_And<is_nothrow_assignable<_Tp&, _Up>...>::value))
     {
-        _VSTD::__memberwise_forward_assign(*this, _VSTD::move(__tuple),
+        std::__memberwise_forward_assign(*this, std::move(__tuple),
             __tuple_types<_Up...>(),
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
@@ -1068,8 +1068,8 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(pair<_Up1, _Up2> const& __pair)
         _NOEXCEPT_((_NothrowAssignFromPair<false, pair<_Up1, _Up2> const&>::value))
     {
-        _VSTD::get<0>(*this) = __pair.first;
-        _VSTD::get<1>(*this) = __pair.second;
+        std::get<0>(*this) = __pair.first;
+        std::get<1>(*this) = __pair.second;
         return *this;
     }
 
@@ -1080,8 +1080,8 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(pair<_Up1, _Up2>&& __pair)
         _NOEXCEPT_((_NothrowAssignFromPair<false, pair<_Up1, _Up2>&&>::value))
     {
-        _VSTD::get<0>(*this) = _VSTD::forward<_Up1>(__pair.first);
-        _VSTD::get<1>(*this) = _VSTD::forward<_Up2>(__pair.second);
+        std::get<0>(*this) = std::forward<_Up1>(__pair.first);
+        std::get<1>(*this) = std::forward<_Up2>(__pair.second);
         return *this;
     }
 
@@ -1096,7 +1096,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(array<_Up, _Np> const& __array)
         _NOEXCEPT_((_And<is_nothrow_assignable<_Tp&, _Up const&>...>::value))
     {
-        _VSTD::__memberwise_copy_assign(*this, __array,
+        std::__memberwise_copy_assign(*this, __array,
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
     }
@@ -1112,7 +1112,7 @@ _LIBCPP_DIAGNOSTIC_POP
     tuple& operator=(array<_Up, _Np>&& __array)
         _NOEXCEPT_((_And<is_nothrow_assignable<_Tp&, _Up>...>::value))
     {
-        _VSTD::__memberwise_forward_assign(*this, _VSTD::move(__array),
+        std::__memberwise_forward_assign(*this, std::move(__array),
             __tuple_types<_If<true, _Up, _Tp>...>(),
             typename __make_tuple_indices<sizeof...(_Tp)>::type());
         return *this;
@@ -1283,28 +1283,28 @@ template <class _T1, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _T1& get(tuple<_Args...>& __tup) noexcept
 {
-    return _VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
+    return std::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
 }
 
 template <class _T1, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _T1 const& get(tuple<_Args...> const& __tup) noexcept
 {
-    return _VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
+    return std::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
 }
 
 template <class _T1, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _T1&& get(tuple<_Args...>&& __tup) noexcept
 {
-    return _VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(_VSTD::move(__tup));
+    return std::get<__find_exactly_one_t<_T1, _Args...>::value>(std::move(__tup));
 }
 
 template <class _T1, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _T1 const&& get(tuple<_Args...> const&& __tup) noexcept
 {
-    return _VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(_VSTD::move(__tup));
+    return std::get<__find_exactly_one_t<_T1, _Args...>::value>(std::move(__tup));
 }
 
 #endif
@@ -1340,7 +1340,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 tuple<typename __unwrap_ref_decay<_Tp>::type...>
 make_tuple(_Tp&&... __t)
 {
-    return tuple<typename __unwrap_ref_decay<_Tp>::type...>(_VSTD::forward<_Tp>(__t)...);
+    return tuple<typename __unwrap_ref_decay<_Tp>::type...>(std::forward<_Tp>(__t)...);
 }
 
 template <class... _Tp>
@@ -1348,7 +1348,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 tuple<_Tp&&...>
 forward_as_tuple(_Tp&&... __t) _NOEXCEPT
 {
-    return tuple<_Tp&&...>(_VSTD::forward<_Tp>(__t)...);
+    return tuple<_Tp&&...>(std::forward<_Tp>(__t)...);
 }
 
 template <size_t _Ip>
@@ -1358,7 +1358,7 @@ struct __tuple_equal
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     bool operator()(const _Tp& __x, const _Up& __y)
     {
-        return __tuple_equal<_Ip - 1>()(__x, __y) && _VSTD::get<_Ip-1>(__x) == _VSTD::get<_Ip-1>(__y);
+        return __tuple_equal<_Ip - 1>()(__x, __y) && std::get<_Ip-1>(__x) == std::get<_Ip-1>(__y);
     }
 };
 
@@ -1391,7 +1391,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr
 auto
 __tuple_compare_three_way(const tuple<_Tp...>& __x, const tuple<_Up...>& __y, index_sequence<_Is...>) {
     common_comparison_category_t<__synth_three_way_result<_Tp, _Up>...> __result = strong_ordering::equal;
-    static_cast<void>(((__result = _VSTD::__synth_three_way(_VSTD::get<_Is>(__x), _VSTD::get<_Is>(__y)), __result != 0) || ...));
+    static_cast<void>(((__result = std::__synth_three_way(std::get<_Is>(__x), std::get<_Is>(__y)), __result != 0) || ...));
     return __result;
 }
 
@@ -1401,7 +1401,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr
 common_comparison_category_t<__synth_three_way_result<_Tp, _Up>...>
 operator<=>(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
 {
-    return _VSTD::__tuple_compare_three_way(__x, __y, index_sequence_for<_Tp...>{});
+    return std::__tuple_compare_three_way(__x, __y, index_sequence_for<_Tp...>{});
 }
 
 #else // _LIBCPP_STD_VER >= 20
@@ -1422,9 +1422,9 @@ struct __tuple_less
     bool operator()(const _Tp& __x, const _Up& __y)
     {
         const size_t __idx = tuple_size<_Tp>::value - _Ip;
-        if (_VSTD::get<__idx>(__x) < _VSTD::get<__idx>(__y))
+        if (std::get<__idx>(__x) < std::get<__idx>(__y))
             return true;
-        if (_VSTD::get<__idx>(__y) < _VSTD::get<__idx>(__x))
+        if (std::get<__idx>(__y) < std::get<__idx>(__x))
             return false;
         return __tuple_less<_Ip-1>()(__x, __y);
     }
@@ -1577,9 +1577,9 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
     operator()(tuple<_Types...> __t, _Tuple0&& __t0)
     {
         (void)__t; // avoid unused parameter warning on GCC when _I0 is empty
-        return _VSTD::forward_as_tuple(
-            _VSTD::forward<_Types>(_VSTD::get<_I0>(__t))...,
-            _VSTD::get<_J0>(_VSTD::forward<_Tuple0>(__t0))...);
+        return std::forward_as_tuple(
+            std::forward<_Types>(std::get<_I0>(__t))...,
+            std::get<_J0>(std::forward<_Tuple0>(__t0))...);
     }
 
     template <class _Tuple0, class _Tuple1, class ..._Tuples>
@@ -1593,10 +1593,10 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
         return __tuple_cat<tuple<_Types..., __apply_cv_t<_Tuple0, typename tuple_element<_J0, _T0>::type>&&...>,
                            typename __make_tuple_indices<sizeof...(_Types) + tuple_size<_T0>::value>::type,
                            typename __make_tuple_indices<tuple_size<_T1>::value>::type>()(
-            _VSTD::forward_as_tuple(
-                _VSTD::forward<_Types>(_VSTD::get<_I0>(__t))...,
-                _VSTD::get<_J0>(_VSTD::forward<_Tuple0>(__t0))...),
-            _VSTD::forward<_Tuple1>(__t1), _VSTD::forward<_Tuples>(__tpls)...);
+            std::forward_as_tuple(
+                std::forward<_Types>(std::get<_I0>(__t))...,
+                std::get<_J0>(std::forward<_Tuple0>(__t0))...),
+            std::forward<_Tuple1>(__t1), std::forward<_Tuples>(__tpls)...);
     }
 };
 
@@ -1608,8 +1608,8 @@ tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)
     typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple0> _T0;
     return __tuple_cat<tuple<>, __tuple_indices<>,
                   typename __make_tuple_indices<tuple_size<_T0>::value>::type>()
-                  (tuple<>(), _VSTD::forward<_Tuple0>(__t0),
-                                            _VSTD::forward<_Tuples>(__tpls)...);
+                  (tuple<>(), std::forward<_Tuple0>(__t0),
+                                            std::forward<_Tuples>(__tpls)...);
 }
 
 template <class ..._Tp, class _Alloc>
@@ -1622,8 +1622,8 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 pair<_T1, _T2>::pair(piecewise_construct_t,
                      tuple<_Args1...>& __first_args, tuple<_Args2...>& __second_args,
                      __tuple_indices<_I1...>, __tuple_indices<_I2...>)
-    :  first(_VSTD::forward<_Args1>(_VSTD::get<_I1>( __first_args))...),
-      second(_VSTD::forward<_Args2>(_VSTD::get<_I2>(__second_args))...)
+    :  first(std::forward<_Args1>(std::get<_I1>( __first_args))...),
+      second(std::forward<_Args2>(std::get<_I2>(__second_args))...)
 {
 }
 
@@ -1638,17 +1638,17 @@ inline _LIBCPP_HIDE_FROM_ABI
 constexpr decltype(auto) __apply_tuple_impl(_Fn && __f, _Tuple && __t,
                                             __tuple_indices<_Id...>)
 _LIBCPP_NOEXCEPT_RETURN(
-    _VSTD::__invoke(
-        _VSTD::forward<_Fn>(__f),
-        _VSTD::get<_Id>(_VSTD::forward<_Tuple>(__t))...)
+    std::__invoke(
+        std::forward<_Fn>(__f),
+        std::get<_Id>(std::forward<_Tuple>(__t))...)
 )
 
 template <class _Fn, class _Tuple>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr decltype(auto) apply(_Fn && __f, _Tuple && __t)
 _LIBCPP_NOEXCEPT_RETURN(
-    _VSTD::__apply_tuple_impl(
-        _VSTD::forward<_Fn>(__f), _VSTD::forward<_Tuple>(__t),
+    std::__apply_tuple_impl(
+        std::forward<_Fn>(__f), std::forward<_Tuple>(__t),
         typename __make_tuple_indices<tuple_size_v<remove_reference_t<_Tuple>>>::type{})
 )
 
@@ -1656,14 +1656,14 @@ template <class _Tp, class _Tuple, size_t... _Idx>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _Tp __make_from_tuple_impl(_Tuple&& __t, __tuple_indices<_Idx...>)
 _LIBCPP_NOEXCEPT_RETURN(
-    _Tp(_VSTD::get<_Idx>(_VSTD::forward<_Tuple>(__t))...)
+    _Tp(std::get<_Idx>(std::forward<_Tuple>(__t))...)
 )
 
 template <class _Tp, class _Tuple>
 inline _LIBCPP_HIDE_FROM_ABI
 constexpr _Tp make_from_tuple(_Tuple&& __t)
 _LIBCPP_NOEXCEPT_RETURN(
-    _VSTD::__make_from_tuple_impl<_Tp>(_VSTD::forward<_Tuple>(__t),
+    std::__make_from_tuple_impl<_Tp>(std::forward<_Tuple>(__t),
         typename __make_tuple_indices<tuple_size_v<remove_reference_t<_Tuple>>>::type{})
 )
 

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -659,7 +659,7 @@ public:
     void swap(__unordered_map_hasher& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(static_cast<_Hash&>(*this), static_cast<_Hash&>(__y));
     }
 };
@@ -695,7 +695,7 @@ public:
     void swap(__unordered_map_hasher& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(__hash_, __y.__hash_);
     }
 };
@@ -757,7 +757,7 @@ public:
     void swap(__unordered_map_equal& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(static_cast<_Pred&>(*this), static_cast<_Pred&>(__y));
     }
 };
@@ -808,7 +808,7 @@ public:
     void swap(__unordered_map_equal& __y)
         _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value)
     {
-        using _VSTD::swap;
+        using std::swap;
         swap(__pred_, __y.__pred_);
     }
 };
@@ -874,9 +874,9 @@ public:
     void operator()(pointer __p) _NOEXCEPT
     {
         if (__second_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__get_value().__get_value().second));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__get_value().__get_value().second));
         if (__first_constructed)
-            __alloc_traits::destroy(__na_, _VSTD::addressof(__p->__get_value().__get_value().first));
+            __alloc_traits::destroy(__na_, std::addressof(__p->__get_value().__get_value().first));
         if (__p)
             __alloc_traits::deallocate(__na_, __p, 1);
     }
@@ -900,7 +900,7 @@ public:
     value_type& __get_value()
     {
 #if _LIBCPP_STD_VER >= 17
-        return *_VSTD::launder(_VSTD::addressof(__cc_));
+        return *std::launder(std::addressof(__cc_));
 #else
         return __cc_;
 #endif
@@ -910,7 +910,7 @@ public:
     const value_type& __get_value() const
     {
 #if _LIBCPP_STD_VER >= 17
-        return *_VSTD::launder(_VSTD::addressof(__cc_));
+        return *std::launder(std::addressof(__cc_));
 #else
         return __cc_;
 #endif
@@ -928,8 +928,8 @@ public:
     {
         value_type& __v = __get_value();
         return __nc_rref_pair_type(
-            _VSTD::move(const_cast<key_type&>(__v.first)),
-            _VSTD::move(__v.second));
+            std::move(const_cast<key_type&>(__v.first)),
+            std::move(__v.second));
     }
 
     _LIBCPP_HIDE_FROM_ABI
@@ -952,7 +952,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI
     __hash_value_type& operator=(_ValueTp&& __v)
     {
-        __ref() = _VSTD::forward<_ValueTp>(__v);
+        __ref() = std::forward<_ValueTp>(__v);
         return *this;
     }
 
@@ -1263,7 +1263,7 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
         __table_ = __u.__table_;
 #else
-        if (this != _VSTD::addressof(__u)) {
+        if (this != std::addressof(__u)) {
             __table_.clear();
             __table_.hash_function() = __u.__table_.hash_function();
             __table_.key_eq() = __u.__table_.key_eq();
@@ -1335,36 +1335,36 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> insert(value_type&& __x)
-        {return __table_.__insert_unique(_VSTD::move(__x));}
+        {return __table_.__insert_unique(std::move(__x));}
 
     _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator, value_type&& __x) {
-        return __table_.__insert_unique(_VSTD::move(__x)).first;
+        return __table_.__insert_unique(std::move(__x)).first;
     }
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
         _LIBCPP_HIDE_FROM_ABI
         pair<iterator, bool> insert(_Pp&& __x)
-            {return __table_.__insert_unique(_VSTD::forward<_Pp>(__x));}
+            {return __table_.__insert_unique(std::forward<_Pp>(__x));}
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
         _LIBCPP_HIDE_FROM_ABI
         iterator insert(const_iterator, _Pp&& __x)
         {
-            return insert(_VSTD::forward<_Pp>(__x)).first;
+            return insert(std::forward<_Pp>(__x)).first;
         }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> emplace(_Args&&... __args) {
-        return __table_.__emplace_unique(_VSTD::forward<_Args>(__args)...);
+        return __table_.__emplace_unique(std::forward<_Args>(__args)...);
     }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator emplace_hint(const_iterator, _Args&&... __args) {
-        return __table_.__emplace_unique(_VSTD::forward<_Args>(__args)...).first;
+        return __table_.__emplace_unique(std::forward<_Args>(__args)...).first;
     }
 
 #endif // _LIBCPP_CXX03_LANG
@@ -1375,8 +1375,8 @@ public:
         pair<iterator, bool> try_emplace(const key_type& __k, _Args&&... __args)
     {
         return __table_.__emplace_unique_key_args(__k, piecewise_construct,
-            _VSTD::forward_as_tuple(__k),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...));
+            std::forward_as_tuple(__k),
+            std::forward_as_tuple(std::forward<_Args>(__args)...));
     }
 
     template <class... _Args>
@@ -1384,22 +1384,22 @@ public:
         pair<iterator, bool> try_emplace(key_type&& __k, _Args&&... __args)
     {
         return __table_.__emplace_unique_key_args(__k, piecewise_construct,
-            _VSTD::forward_as_tuple(_VSTD::move(__k)),
-            _VSTD::forward_as_tuple(_VSTD::forward<_Args>(__args)...));
+            std::forward_as_tuple(std::move(__k)),
+            std::forward_as_tuple(std::forward<_Args>(__args)...));
     }
 
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator try_emplace(const_iterator, const key_type& __k, _Args&&... __args)
     {
-        return try_emplace(__k, _VSTD::forward<_Args>(__args)...).first;
+        return try_emplace(__k, std::forward<_Args>(__args)...).first;
     }
 
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator try_emplace(const_iterator, key_type&& __k, _Args&&... __args)
     {
-        return try_emplace(_VSTD::move(__k), _VSTD::forward<_Args>(__args)...).first;
+        return try_emplace(std::move(__k), std::forward<_Args>(__args)...).first;
     }
 
     template <class _Vp>
@@ -1407,9 +1407,9 @@ public:
         pair<iterator, bool> insert_or_assign(const key_type& __k, _Vp&& __v)
     {
         pair<iterator, bool> __res = __table_.__emplace_unique_key_args(__k,
-            __k, _VSTD::forward<_Vp>(__v));
+            __k, std::forward<_Vp>(__v));
         if (!__res.second) {
-            __res.first->second = _VSTD::forward<_Vp>(__v);
+            __res.first->second = std::forward<_Vp>(__v);
         }
         return __res;
     }
@@ -1419,9 +1419,9 @@ public:
         pair<iterator, bool> insert_or_assign(key_type&& __k, _Vp&& __v)
     {
         pair<iterator, bool> __res = __table_.__emplace_unique_key_args(__k,
-            _VSTD::move(__k), _VSTD::forward<_Vp>(__v));
+            std::move(__k), std::forward<_Vp>(__v));
         if (!__res.second) {
-            __res.first->second = _VSTD::forward<_Vp>(__v);
+            __res.first->second = std::forward<_Vp>(__v);
         }
         return __res;
     }
@@ -1430,14 +1430,14 @@ public:
         _LIBCPP_HIDE_FROM_ABI
         iterator insert_or_assign(const_iterator, const key_type& __k, _Vp&& __v)
      {
-          return insert_or_assign(__k, _VSTD::forward<_Vp>(__v)).first;
+          return insert_or_assign(__k, std::forward<_Vp>(__v)).first;
      }
 
     template <class _Vp>
         _LIBCPP_HIDE_FROM_ABI
         iterator insert_or_assign(const_iterator, key_type&& __k, _Vp&& __v)
      {
-        return insert_or_assign(_VSTD::move(__k), _VSTD::forward<_Vp>(__v)).first;
+        return insert_or_assign(std::move(__k), std::forward<_Vp>(__v)).first;
      }
 #endif // _LIBCPP_STD_VER >= 17
 
@@ -1460,7 +1460,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_map::insert()");
         return __table_.template __node_handle_insert_unique<
-            node_type, insert_return_type>(_VSTD::move(__nh));
+            node_type, insert_return_type>(std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -1468,7 +1468,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_map::insert()");
         return __table_.template __node_handle_insert_unique<node_type>(
-            __hint.__i_, _VSTD::move(__nh));
+            __hint.__i_, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -1814,14 +1814,14 @@ inline
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(
         unordered_map&& __u)
     _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
-    : __table_(_VSTD::move(__u.__table_))
+    : __table_(std::move(__u.__table_))
 {
 }
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(
         unordered_map&& __u, const allocator_type& __a)
-    : __table_(_VSTD::move(__u.__table_), typename __table::allocator_type(__a))
+    : __table_(std::move(__u.__table_), typename __table::allocator_type(__a))
 {
     if (__a != __u.get_allocator())
     {
@@ -1866,7 +1866,7 @@ unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>&
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(unordered_map&& __u)
     _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
 {
-    __table_ = _VSTD::move(__u.__table_);
+    __table_ = std::move(__u.__table_);
     return *this;
 }
 
@@ -1900,8 +1900,8 @@ _Tp&
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](const key_type& __k)
 {
     return __table_.__emplace_unique_key_args(__k,
-        piecewise_construct, _VSTD::forward_as_tuple(__k),
-                             _VSTD::forward_as_tuple()).first->__get_value().second;
+        piecewise_construct, std::forward_as_tuple(__k),
+                             std::forward_as_tuple()).first->__get_value().second;
 }
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
@@ -1909,8 +1909,8 @@ _Tp&
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](key_type&& __k)
 {
     return __table_.__emplace_unique_key_args(__k,
-        piecewise_construct, _VSTD::forward_as_tuple(_VSTD::move(__k)),
-                             _VSTD::forward_as_tuple()).first->__get_value().second;
+        piecewise_construct, std::forward_as_tuple(std::move(__k)),
+                             std::forward_as_tuple()).first->__get_value().second;
 }
 #else // _LIBCPP_CXX03_LANG
 
@@ -1920,9 +1920,9 @@ unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::__construct_node_with_key(const 
 {
     __node_allocator& __na = __table_.__node_alloc();
     __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
-    __node_traits::construct(__na, _VSTD::addressof(__h->__get_value().__get_value().first), __k);
+    __node_traits::construct(__na, std::addressof(__h->__get_value().__get_value().first), __k);
     __h.get_deleter().__first_constructed = true;
-    __node_traits::construct(__na, _VSTD::addressof(__h->__get_value().__get_value().second));
+    __node_traits::construct(__na, std::addressof(__h->__get_value().__get_value().second));
     __h.get_deleter().__second_constructed = true;
     return __h;
 }
@@ -1979,7 +1979,7 @@ inline _LIBCPP_HIDE_FROM_ABI
     typename unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type
     erase_if(unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __c,
              _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -2179,7 +2179,7 @@ private:
 #ifndef _LIBCPP_CXX03_LANG
         __table_ = __u.__table_;
 #else
-        if (this != _VSTD::addressof(__u)) {
+        if (this != std::addressof(__u)) {
             __table_.clear();
             __table_.hash_function() = __u.__table_.hash_function();
             __table_.key_eq() = __u.__table_.key_eq();
@@ -2248,32 +2248,32 @@ private:
     void insert(initializer_list<value_type> __il)
         {insert(__il.begin(), __il.end());}
     _LIBCPP_HIDE_FROM_ABI
-    iterator insert(value_type&& __x) {return __table_.__insert_multi(_VSTD::move(__x));}
+    iterator insert(value_type&& __x) {return __table_.__insert_multi(std::move(__x));}
 
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, value_type&& __x)
-        {return __table_.__insert_multi(__p.__i_, _VSTD::move(__x));}
+        {return __table_.__insert_multi(__p.__i_, std::move(__x));}
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(_Pp&& __x)
-        {return __table_.__insert_multi(_VSTD::forward<_Pp>(__x));}
+        {return __table_.__insert_multi(std::forward<_Pp>(__x));}
 
     template <class _Pp,
               class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, _Pp&& __x)
-        {return __table_.__insert_multi(__p.__i_, _VSTD::forward<_Pp>(__x));}
+        {return __table_.__insert_multi(__p.__i_, std::forward<_Pp>(__x));}
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI iterator emplace(_Args&&... __args) {
-        return __table_.__emplace_multi(_VSTD::forward<_Args>(__args)...);
+        return __table_.__emplace_multi(std::forward<_Args>(__args)...);
     }
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI iterator emplace_hint(const_iterator __p, _Args&&... __args) {
-        return __table_.__emplace_hint_multi(__p.__i_, _VSTD::forward<_Args>(__args)...);
+        return __table_.__emplace_hint_multi(__p.__i_, std::forward<_Args>(__args)...);
     }
 #endif // _LIBCPP_CXX03_LANG
 
@@ -2297,7 +2297,7 @@ private:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_multimap::insert()");
         return __table_.template __node_handle_insert_multi<node_type>(
-            _VSTD::move(__nh));
+            std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -2305,7 +2305,7 @@ private:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_multimap::insert()");
         return __table_.template __node_handle_insert_multi<node_type>(
-            __hint.__i_, _VSTD::move(__nh));
+            __hint.__i_, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -2638,14 +2638,14 @@ inline
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(
         unordered_multimap&& __u)
     _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
-    : __table_(_VSTD::move(__u.__table_))
+    : __table_(std::move(__u.__table_))
 {
 }
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(
         unordered_multimap&& __u, const allocator_type& __a)
-    : __table_(_VSTD::move(__u.__table_), typename __table::allocator_type(__a))
+    : __table_(std::move(__u.__table_), typename __table::allocator_type(__a))
 {
     if (__a != __u.get_allocator())
     {
@@ -2691,7 +2691,7 @@ unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>&
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(unordered_multimap&& __u)
     _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
 {
-    __table_ = _VSTD::move(__u.__table_);
+    __table_ = std::move(__u.__table_);
     return *this;
 }
 
@@ -2737,7 +2737,7 @@ inline _LIBCPP_HIDE_FROM_ABI
     typename unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type
     erase_if(unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __c,
              _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -2755,9 +2755,9 @@ operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
     {
         _EqRng __xeq = __x.equal_range(__i->first);
         _EqRng __yeq = __y.equal_range(__i->first);
-        if (_VSTD::distance(__xeq.first, __xeq.second) !=
-            _VSTD::distance(__yeq.first, __yeq.second) ||
-                  !_VSTD::is_permutation(__xeq.first, __xeq.second, __yeq.first))
+        if (std::distance(__xeq.first, __xeq.second) !=
+            std::distance(__yeq.first, __yeq.second) ||
+                  !std::is_permutation(__xeq.first, __xeq.second, __yeq.first))
             return false;
         __i = __xeq.second;
     }

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -761,7 +761,7 @@ public:
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         pair<iterator, bool> emplace(_Args&&... __args)
-            {return __table_.__emplace_unique(_VSTD::forward<_Args>(__args)...);}
+            {return __table_.__emplace_unique(std::forward<_Args>(__args)...);}
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI
     iterator emplace_hint(const_iterator, _Args&&... __args) {
@@ -770,7 +770,7 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     pair<iterator, bool> insert(value_type&& __x)
-        {return __table_.__insert_unique(_VSTD::move(__x));}
+        {return __table_.__insert_unique(std::move(__x));}
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator, value_type&& __x) {
         return insert(std::move(__x)).first;
@@ -819,7 +819,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_set::insert()");
         return __table_.template __node_handle_insert_unique<
-            node_type, insert_return_type>(_VSTD::move(__nh));
+            node_type, insert_return_type>(std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __h, node_type&& __nh)
@@ -827,7 +827,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_set::insert()");
         return __table_.template __node_handle_insert_unique<node_type>(
-            __h, _VSTD::move(__nh));
+            __h, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(key_type const& __key)
@@ -1141,20 +1141,20 @@ inline
 unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(
         unordered_set&& __u)
     _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
-    : __table_(_VSTD::move(__u.__table_))
+    : __table_(std::move(__u.__table_))
 {
 }
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(
         unordered_set&& __u, const allocator_type& __a)
-    : __table_(_VSTD::move(__u.__table_), __a)
+    : __table_(std::move(__u.__table_), __a)
 {
     if (__a != __u.get_allocator())
     {
         iterator __i = __u.begin();
         while (__u.size() != 0)
-            __table_.__insert_unique(_VSTD::move(__u.__table_.remove(__i++)->__get_value()));
+            __table_.__insert_unique(std::move(__u.__table_.remove(__i++)->__get_value()));
     }
 }
 
@@ -1191,7 +1191,7 @@ unordered_set<_Value, _Hash, _Pred, _Alloc>&
 unordered_set<_Value, _Hash, _Pred, _Alloc>::operator=(unordered_set&& __u)
     _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
 {
-    __table_ = _VSTD::move(__u.__table_);
+    __table_ = std::move(__u.__table_);
     return *this;
 }
 
@@ -1235,7 +1235,7 @@ inline _LIBCPP_HIDE_FROM_ABI
     typename unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type
     erase_if(unordered_set<_Value, _Hash, _Pred, _Alloc>& __c,
              _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -1450,17 +1450,17 @@ public:
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator emplace(_Args&&... __args)
-            {return __table_.__emplace_multi(_VSTD::forward<_Args>(__args)...);}
+            {return __table_.__emplace_multi(std::forward<_Args>(__args)...);}
     template <class... _Args>
         _LIBCPP_HIDE_FROM_ABI
         iterator emplace_hint(const_iterator __p, _Args&&... __args)
-            {return __table_.__emplace_hint_multi(__p, _VSTD::forward<_Args>(__args)...);}
+            {return __table_.__emplace_hint_multi(__p, std::forward<_Args>(__args)...);}
 
     _LIBCPP_HIDE_FROM_ABI
-    iterator insert(value_type&& __x) {return __table_.__insert_multi(_VSTD::move(__x));}
+    iterator insert(value_type&& __x) {return __table_.__insert_multi(std::move(__x));}
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __p, value_type&& __x)
-        {return __table_.__insert_multi(__p, _VSTD::move(__x));}
+        {return __table_.__insert_multi(__p, std::move(__x));}
     _LIBCPP_HIDE_FROM_ABI
     void insert(initializer_list<value_type> __il)
         {insert(__il.begin(), __il.end());}
@@ -1494,7 +1494,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_multiset::insert()");
         return __table_.template __node_handle_insert_multi<node_type>(
-            _VSTD::move(__nh));
+            std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     iterator insert(const_iterator __hint, node_type&& __nh)
@@ -1502,7 +1502,7 @@ public:
         _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
             "node_type with incompatible allocator passed to unordered_multiset::insert()");
         return __table_.template __node_handle_insert_multi<node_type>(
-            __hint, _VSTD::move(__nh));
+            __hint, std::move(__nh));
     }
     _LIBCPP_HIDE_FROM_ABI
     node_type extract(const_iterator __position)
@@ -1826,20 +1826,20 @@ inline
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(
         unordered_multiset&& __u)
     _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
-    : __table_(_VSTD::move(__u.__table_))
+    : __table_(std::move(__u.__table_))
 {
 }
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(
         unordered_multiset&& __u, const allocator_type& __a)
-    : __table_(_VSTD::move(__u.__table_), __a)
+    : __table_(std::move(__u.__table_), __a)
 {
     if (__a != __u.get_allocator())
     {
         iterator __i = __u.begin();
         while (__u.size() != 0)
-            __table_.__insert_multi(_VSTD::move(__u.__table_.remove(__i++)->__get_value()));
+            __table_.__insert_multi(std::move(__u.__table_.remove(__i++)->__get_value()));
     }
 }
 
@@ -1877,7 +1877,7 @@ unordered_multiset<_Value, _Hash, _Pred, _Alloc>::operator=(
         unordered_multiset&& __u)
     _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
 {
-    __table_ = _VSTD::move(__u.__table_);
+    __table_ = std::move(__u.__table_);
     return *this;
 }
 
@@ -1921,7 +1921,7 @@ inline _LIBCPP_HIDE_FROM_ABI
     typename unordered_multiset<_Value, _Hash, _Pred, _Alloc>::size_type
     erase_if(unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __c,
              _Predicate __pred) {
-  return _VSTD::__libcpp_erase_if_container(__c, __pred);
+  return std::__libcpp_erase_if_container(__c, __pred);
 }
 #endif
 
@@ -1939,9 +1939,9 @@ operator==(const unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
     {
         _EqRng __xeq = __x.equal_range(*__i);
         _EqRng __yeq = __y.equal_range(*__i);
-        if (_VSTD::distance(__xeq.first, __xeq.second) !=
-            _VSTD::distance(__yeq.first, __yeq.second) ||
-                  !_VSTD::is_permutation(__xeq.first, __xeq.second, __yeq.first))
+        if (std::distance(__xeq.first, __xeq.second) !=
+            std::distance(__yeq.first, __yeq.second) ||
+                  !std::is_permutation(__xeq.first, __xeq.second, __yeq.first))
             return false;
         __i = __xeq.second;
     }

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -2674,9 +2674,9 @@ valarray<_Tp>::__assign_range(const value_type* __f, const value_type* __l)
         __clear(size());
         __begin_ = allocator<value_type>().allocate(__n);
         __end_ = __begin_ + __n;
-        _VSTD::uninitialized_copy(__f, __l, __begin_);
+        std::uninitialized_copy(__f, __l, __begin_);
     } else {
-        _VSTD::copy(__f, __l, __begin_);
+        std::copy(__f, __l, __begin_);
     }
     return *this;
 }
@@ -2685,7 +2685,7 @@ template <class _Tp>
 valarray<_Tp>&
 valarray<_Tp>::operator=(const valarray& __v)
 {
-    if (this != _VSTD::addressof(__v))
+    if (this != std::addressof(__v))
         return __assign_range(__v.__begin_, __v.__end_);
     return *this;
 }
@@ -2720,7 +2720,7 @@ inline
 valarray<_Tp>&
 valarray<_Tp>::operator=(const value_type& __x)
 {
-    _VSTD::fill(__begin_, __end_, __x);
+    std::fill(__begin_, __end_, __x);
     return *this;
 }
 
@@ -3178,8 +3178,8 @@ inline
 void
 valarray<_Tp>::swap(valarray& __v) _NOEXCEPT
 {
-    _VSTD::swap(__begin_, __v.__begin_);
-    _VSTD::swap(__end_, __v.__end_);
+    std::swap(__begin_, __v.__begin_);
+    std::swap(__end_, __v.__end_);
 }
 
 template <class _Tp>
@@ -3203,7 +3203,7 @@ valarray<_Tp>::min() const
 {
     if (__begin_ == __end_)
         return value_type();
-    return *_VSTD::min_element(__begin_, __end_);
+    return *std::min_element(__begin_, __end_);
 }
 
 template <class _Tp>
@@ -3213,7 +3213,7 @@ valarray<_Tp>::max() const
 {
     if (__begin_ == __end_)
         return value_type();
-    return *_VSTD::max_element(__begin_, __end_);
+    return *std::max_element(__begin_, __end_);
 }
 
 template <class _Tp>
@@ -3230,14 +3230,14 @@ valarray<_Tp>::shift(int __i) const
         value_type* __te;
         if (__i >= 0)
         {
-            __i = _VSTD::min(__i, static_cast<int>(__n));
+            __i = std::min(__i, static_cast<int>(__n));
             __sb = __begin_ + __i;
             __tb = __r.__begin_;
             __te = __r.__begin_ + (__n - __i);
         }
         else
         {
-            __i = _VSTD::min(-__i, static_cast<int>(__n));
+            __i = std::min(-__i, static_cast<int>(__n));
             __sb = __begin_;
             __tb = __r.__begin_ + __i;
             __te = __r.__begin_ + __n;

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -384,13 +384,13 @@ __as_variant(const variant<_Types...>& __vs) noexcept {
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI constexpr variant<_Types...>&&
 __as_variant(variant<_Types...>&& __vs) noexcept {
-  return _VSTD::move(__vs);
+  return std::move(__vs);
 }
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI constexpr const variant<_Types...>&&
 __as_variant(const variant<_Types...>&& __vs) noexcept {
-  return _VSTD::move(__vs);
+  return std::move(__vs);
 }
 
 namespace __find_detail {
@@ -482,13 +482,13 @@ struct __union {
   template <class _Vp>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto&& __get_alt(_Vp&& __v, in_place_index_t<0>) {
-    return _VSTD::forward<_Vp>(__v).__head;
+    return std::forward<_Vp>(__v).__head;
   }
 
   template <class _Vp, size_t _Ip>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto&& __get_alt(_Vp&& __v, in_place_index_t<_Ip>) {
-    return __get_alt(_VSTD::forward<_Vp>(__v).__tail, in_place_index<_Ip - 1>);
+    return __get_alt(std::forward<_Vp>(__v).__tail, in_place_index<_Ip - 1>);
   }
 };
 
@@ -496,7 +496,7 @@ struct __base {
   template <size_t _Ip, class _Vp>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto&& __get_alt(_Vp&& __v) {
-    return __union::__get_alt(_VSTD::forward<_Vp>(__v).__data,
+    return __union::__get_alt(std::forward<_Vp>(__v).__data,
                               in_place_index<_Ip>);
   }
 };
@@ -505,7 +505,7 @@ struct __variant {
   template <size_t _Ip, class _Vp>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto&& __get_alt(_Vp&& __v) {
-    return __base::__get_alt<_Ip>(_VSTD::forward<_Vp>(__v).__impl_);
+    return __base::__get_alt<_Ip>(std::forward<_Vp>(__v).__impl_);
   }
 };
 
@@ -520,9 +520,9 @@ struct __base {
   __visit_alt_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
     constexpr auto __fdiagonal =
         __make_fdiagonal<_Visitor&&,
-                         decltype(_VSTD::forward<_Vs>(__vs).__as_base())...>();
-    return __fdiagonal[__index](_VSTD::forward<_Visitor>(__visitor),
-                                _VSTD::forward<_Vs>(__vs).__as_base()...);
+                         decltype(std::forward<_Vs>(__vs).__as_base())...>();
+    return __fdiagonal[__index](std::forward<_Visitor>(__visitor),
+                                std::forward<_Vs>(__vs).__as_base()...);
   }
 
   template <class _Visitor, class... _Vs>
@@ -531,10 +531,10 @@ struct __base {
                                               _Vs&&... __vs) {
     constexpr auto __fmatrix =
         __make_fmatrix<_Visitor&&,
-                       decltype(_VSTD::forward<_Vs>(__vs).__as_base())...>();
+                       decltype(std::forward<_Vs>(__vs).__as_base())...>();
     return __at(__fmatrix, __vs.index()...)(
-        _VSTD::forward<_Visitor>(__visitor),
-        _VSTD::forward<_Vs>(__vs).__as_base()...);
+        std::forward<_Visitor>(__visitor),
+        std::forward<_Vs>(__vs).__as_base()...);
   }
 
 private:
@@ -561,7 +561,7 @@ private:
   static constexpr auto __make_farray(_Fs&&... __fs) {
     __std_visit_visitor_return_type_check<__remove_cvref_t<_Fs>...>();
     using __result = __farray<common_type_t<__remove_cvref_t<_Fs>...>, sizeof...(_Fs)>;
-    return __result{{_VSTD::forward<_Fs>(__fs)...}};
+    return __result{{std::forward<_Fs>(__fs)...}};
   }
 
   template <size_t... _Is>
@@ -569,7 +569,7 @@ private:
     template <class _Fp, class... _Vs>
     _LIBCPP_HIDE_FROM_ABI
     static constexpr decltype(auto) __dispatch(_Fp __f, _Vs... __vs) {
-        return _VSTD::__invoke(
+        return std::__invoke(
             static_cast<_Fp>(__f),
             __access::__base::__get_alt<_Is>(static_cast<_Vs>(__vs))...);
     }
@@ -631,8 +631,8 @@ struct __variant {
   static constexpr decltype(auto)
   __visit_alt_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
     return __base::__visit_alt_at(__index,
-                                  _VSTD::forward<_Visitor>(__visitor),
-                                  _VSTD::forward<_Vs>(__vs).__impl_...);
+                                  std::forward<_Visitor>(__visitor),
+                                  std::forward<_Vs>(__vs).__impl_...);
   }
 
   template <class _Visitor, class... _Vs>
@@ -640,8 +640,8 @@ struct __variant {
   static constexpr decltype(auto) __visit_alt(_Visitor&& __visitor,
                                               _Vs&&... __vs) {
     return __base::__visit_alt(
-        _VSTD::forward<_Visitor>(__visitor),
-        _VSTD::__as_variant(_VSTD::forward<_Vs>(__vs)).__impl_...);
+        std::forward<_Visitor>(__visitor),
+        std::__as_variant(std::forward<_Vs>(__vs)).__impl_...);
   }
 
   template <class _Visitor, class... _Vs>
@@ -650,8 +650,8 @@ struct __variant {
   __visit_value_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
     return __visit_alt_at(
         __index,
-        __make_value_visitor(_VSTD::forward<_Visitor>(__visitor)),
-        _VSTD::forward<_Vs>(__vs)...);
+        __make_value_visitor(std::forward<_Visitor>(__visitor)),
+        std::forward<_Vs>(__vs)...);
   }
 
   template <class _Visitor, class... _Vs>
@@ -659,8 +659,8 @@ struct __variant {
   static constexpr decltype(auto) __visit_value(_Visitor&& __visitor,
                                                 _Vs&&... __vs) {
     return __visit_alt(
-        __make_value_visitor(_VSTD::forward<_Visitor>(__visitor)),
-        _VSTD::forward<_Vs>(__vs)...);
+        __make_value_visitor(std::forward<_Visitor>(__visitor)),
+        std::forward<_Vs>(__vs)...);
   }
 
 #if _LIBCPP_STD_VER >= 20
@@ -669,8 +669,8 @@ struct __variant {
   static constexpr _Rp __visit_value(_Visitor&& __visitor,
                                      _Vs&&... __vs) {
     return __visit_alt(
-        __make_value_visitor<_Rp>(_VSTD::forward<_Visitor>(__visitor)),
-        _VSTD::forward<_Vs>(__vs)...);
+        __make_value_visitor<_Rp>(std::forward<_Visitor>(__visitor)),
+        std::forward<_Vs>(__vs)...);
   }
 #endif
 
@@ -688,9 +688,9 @@ private:
     constexpr decltype(auto) operator()(_Alts&&... __alts) const {
       __std_visit_exhaustive_visitor_check<
           _Visitor,
-          decltype((_VSTD::forward<_Alts>(__alts).__value))...>();
-      return _VSTD::__invoke(_VSTD::forward<_Visitor>(__visitor),
-                             _VSTD::forward<_Alts>(__alts).__value...);
+          decltype((std::forward<_Alts>(__alts).__value))...>();
+      return std::__invoke(std::forward<_Visitor>(__visitor),
+                             std::forward<_Alts>(__alts).__value...);
     }
     _Visitor&& __visitor;
   };
@@ -703,14 +703,14 @@ private:
     constexpr _Rp operator()(_Alts&&... __alts) const {
       __std_visit_exhaustive_visitor_check<
           _Visitor,
-          decltype((_VSTD::forward<_Alts>(__alts).__value))...>();
+          decltype((std::forward<_Alts>(__alts).__value))...>();
       if constexpr (is_void_v<_Rp>) {
-        _VSTD::__invoke(_VSTD::forward<_Visitor>(__visitor),
-                        _VSTD::forward<_Alts>(__alts).__value...);
+        std::__invoke(std::forward<_Visitor>(__visitor),
+                        std::forward<_Alts>(__alts).__value...);
       }
       else {
-        return _VSTD::__invoke(_VSTD::forward<_Visitor>(__visitor),
-                               _VSTD::forward<_Alts>(__alts).__value...);
+        return std::__invoke(std::forward<_Visitor>(__visitor),
+                               std::forward<_Alts>(__alts).__value...);
       }
     }
 
@@ -721,14 +721,14 @@ private:
   template <class _Visitor>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto __make_value_visitor(_Visitor&& __visitor) {
-    return __value_visitor<_Visitor>{_VSTD::forward<_Visitor>(__visitor)};
+    return __value_visitor<_Visitor>{std::forward<_Visitor>(__visitor)};
   }
 
 #if _LIBCPP_STD_VER >= 20
   template <class _Rp, class _Visitor>
   _LIBCPP_HIDE_FROM_ABI
   static constexpr auto __make_value_visitor(_Visitor&& __visitor) {
-    return __value_visitor_return_type<_Rp, _Visitor>{_VSTD::forward<_Visitor>(__visitor)};
+    return __value_visitor_return_type<_Rp, _Visitor>{std::forward<_Visitor>(__visitor)};
   }
 #endif
 };
@@ -742,7 +742,7 @@ struct _LIBCPP_TEMPLATE_VIS __alt {
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
   explicit constexpr __alt(in_place_t, _Args&&... __args)
-      : __value(_VSTD::forward<_Args>(__args)...) {}
+      : __value(std::forward<_Args>(__args)...) {}
 
   __value_type __value;
 };
@@ -766,12 +766,12 @@ union _LIBCPP_TEMPLATE_VIS __union<_DestructibleTrait, _Index> {};
     template <class... _Args>                                                  \
     _LIBCPP_HIDE_FROM_ABI                                                      \
     explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)         \
-        : __head(in_place, _VSTD::forward<_Args>(__args)...) {}                \
+        : __head(in_place, std::forward<_Args>(__args)...) {}                \
                                                                                \
     template <size_t _Ip, class... _Args>                                      \
     _LIBCPP_HIDE_FROM_ABI                                                      \
     explicit constexpr __union(in_place_index_t<_Ip>, _Args&&... __args)       \
-        : __tail(in_place_index<_Ip - 1>, _VSTD::forward<_Args>(__args)...) {} \
+        : __tail(in_place_index<_Ip - 1>, std::forward<_Args>(__args)...) {} \
                                                                                \
     __union(const __union&) = default;                                         \
     __union(__union&&) = default;                                              \
@@ -808,7 +808,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   explicit constexpr __base(in_place_index_t<_Ip>, _Args&&... __args)
       :
-        __data(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...),
+        __data(in_place_index<_Ip>, std::forward<_Args>(__args)...),
         __index(_Ip) {}
 
   _LIBCPP_HIDE_FROM_ABI
@@ -826,13 +826,13 @@ protected:
   constexpr auto&& __as_base() & { return *this; }
 
   _LIBCPP_HIDE_FROM_ABI
-  constexpr auto&& __as_base() && { return _VSTD::move(*this); }
+  constexpr auto&& __as_base() && { return std::move(*this); }
 
   _LIBCPP_HIDE_FROM_ABI
   constexpr auto&& __as_base() const & { return *this; }
 
   _LIBCPP_HIDE_FROM_ABI
-  constexpr auto&& __as_base() const && { return _VSTD::move(*this); }
+  constexpr auto&& __as_base() const && { return std::move(*this); }
 
   _LIBCPP_HIDE_FROM_ABI
   static constexpr size_t __size() { return sizeof...(_Types); }
@@ -909,8 +909,8 @@ protected:
   template <size_t _Ip, class _Tp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI
   static _Tp& __construct_alt(__alt<_Ip, _Tp>& __a, _Args&&... __args) {
-    ::new ((void*)_VSTD::addressof(__a))
-        __alt<_Ip, _Tp>(in_place, _VSTD::forward<_Args>(__args)...);
+    ::new ((void*)std::addressof(__a))
+        __alt<_Ip, _Tp>(in_place, std::forward<_Args>(__args)...);
     return __a.__value;
   }
 
@@ -924,9 +924,9 @@ protected:
           [](auto& __lhs_alt, auto&& __rhs_alt) {
             __construct_alt(
                 __lhs_alt,
-                _VSTD::forward<decltype(__rhs_alt)>(__rhs_alt).__value);
+                std::forward<decltype(__rhs_alt)>(__rhs_alt).__value);
           },
-          __lhs, _VSTD::forward<_Rhs>(__rhs));
+          __lhs, std::forward<_Rhs>(__rhs));
       __lhs.__index = __rhs.index();
     }
   }
@@ -963,7 +963,7 @@ _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
     __move_constructor(__move_constructor&& __that) noexcept(
         __all<is_nothrow_move_constructible_v<_Types>...>::value)
         : __move_constructor(__valueless_t{}) {
-      this->__generic_construct(*this, _VSTD::move(__that));
+      this->__generic_construct(*this, std::move(__that));
     });
 
 _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
@@ -1024,7 +1024,7 @@ public:
   auto& __emplace(_Args&&... __args) {
     this->__destroy();
     auto& __res = this->__construct_alt(__access::__base::__get_alt<_Ip>(*this),
-                          _VSTD::forward<_Args>(__args)...);
+                          std::forward<_Args>(__args)...);
     this->__index = _Ip;
     return __res;
   }
@@ -1034,18 +1034,18 @@ protected:
   _LIBCPP_HIDE_FROM_ABI
   void __assign_alt(__alt<_Ip, _Tp>& __a, _Arg&& __arg) {
     if (this->index() == _Ip) {
-      __a.__value = _VSTD::forward<_Arg>(__arg);
+      __a.__value = std::forward<_Arg>(__arg);
     } else {
       struct {
         _LIBCPP_HIDE_FROM_ABI void operator()(true_type) const {
-          __this->__emplace<_Ip>(_VSTD::forward<_Arg>(__arg));
+          __this->__emplace<_Ip>(std::forward<_Arg>(__arg));
         }
         _LIBCPP_HIDE_FROM_ABI void operator()(false_type) const {
-          __this->__emplace<_Ip>(_Tp(_VSTD::forward<_Arg>(__arg)));
+          __this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
         }
         __assignment* __this;
         _Arg&& __arg;
-      } __impl{this, _VSTD::forward<_Arg>(__arg)};
+      } __impl{this, std::forward<_Arg>(__arg)};
       __impl(bool_constant<is_nothrow_constructible_v<_Tp, _Arg> ||
                            !is_nothrow_move_constructible_v<_Tp>>{});
     }
@@ -1064,9 +1064,9 @@ protected:
           [this](auto& __this_alt, auto&& __that_alt) {
             this->__assign_alt(
                 __this_alt,
-                _VSTD::forward<decltype(__that_alt)>(__that_alt).__value);
+                std::forward<decltype(__that_alt)>(__that_alt).__value);
           },
-          *this, _VSTD::forward<_That>(__that));
+          *this, std::forward<_That>(__that));
     }
   }
 };
@@ -1102,7 +1102,7 @@ _LIBCPP_VARIANT_MOVE_ASSIGNMENT(
     __move_assignment& operator=(__move_assignment&& __that) noexcept(
         __all<(is_nothrow_move_constructible_v<_Types> &&
                is_nothrow_move_assignable_v<_Types>)...>::value) {
-      this->__generic_assign(_VSTD::move(__that));
+      this->__generic_assign(std::move(__that));
       return *this;
     });
 
@@ -1167,7 +1167,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   void __assign(_Arg&& __arg) {
     this->__assign_alt(__access::__base::__get_alt<_Ip>(*this),
-                       _VSTD::forward<_Arg>(__arg));
+                       std::forward<_Arg>(__arg));
   }
 
   inline _LIBCPP_HIDE_FROM_ABI
@@ -1178,30 +1178,30 @@ public:
       __visitation::__base::__visit_alt_at(
           this->index(),
           [](auto& __this_alt, auto& __that_alt) {
-            using _VSTD::swap;
+            using std::swap;
             swap(__this_alt.__value, __that_alt.__value);
           },
           *this,
           __that);
     } else {
       __impl* __lhs = this;
-      __impl* __rhs = _VSTD::addressof(__that);
+      __impl* __rhs = std::addressof(__that);
       if (__lhs->__move_nothrow() && !__rhs->__move_nothrow()) {
-        _VSTD::swap(__lhs, __rhs);
+        std::swap(__lhs, __rhs);
       }
-      __impl __tmp(_VSTD::move(*__rhs));
+      __impl __tmp(std::move(*__rhs));
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
       if constexpr (__all<is_nothrow_move_constructible_v<_Types>...>::value) {
-        this->__generic_construct(*__rhs, _VSTD::move(*__lhs));
+        this->__generic_construct(*__rhs, std::move(*__lhs));
       } else {
         // EXTENSION: When the move construction of `__lhs` into `__rhs` throws
         // and `__tmp` is nothrow move constructible then we move `__tmp` back
         // into `__rhs` and provide the strong exception safety guarantee.
         try {
-          this->__generic_construct(*__rhs, _VSTD::move(*__lhs));
+          this->__generic_construct(*__rhs, std::move(*__lhs));
         } catch (...) {
           if (__tmp.__move_nothrow()) {
-            this->__generic_construct(*__rhs, _VSTD::move(__tmp));
+            this->__generic_construct(*__rhs, std::move(__tmp));
           }
           throw;
         }
@@ -1209,9 +1209,9 @@ public:
 #else
       // this isn't consolidated with the `if constexpr` branch above due to
       // `throw` being ill-formed with exceptions disabled even when discarded.
-      this->__generic_construct(*__rhs, _VSTD::move(*__lhs));
+      this->__generic_construct(*__rhs, std::move(*__lhs));
 #endif
-      this->__generic_construct(*__lhs, _VSTD::move(__tmp));
+      this->__generic_construct(*__lhs, std::move(__tmp));
     }
   }
 
@@ -1344,7 +1344,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   constexpr variant(_Arg&& __arg) noexcept(
       is_nothrow_constructible_v<_Tp, _Arg>)
-      : __impl_(in_place_index<_Ip>, _VSTD::forward<_Arg>(__arg)) {}
+      : __impl_(in_place_index<_Ip>, std::forward<_Arg>(__arg)) {}
 
   template <size_t _Ip, class... _Args,
             class = enable_if_t<(_Ip < sizeof...(_Types)), int>,
@@ -1354,7 +1354,7 @@ public:
   explicit constexpr variant(
       in_place_index_t<_Ip>,
       _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __impl_(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...) {}
+      : __impl_(in_place_index<_Ip>, std::forward<_Args>(__args)...) {}
 
   template <
       size_t _Ip,
@@ -1370,7 +1370,7 @@ public:
       initializer_list<_Up> __il,
       _Args&&... __args) noexcept(
       is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
-      : __impl_(in_place_index<_Ip>, __il, _VSTD::forward<_Args>(__args)...) {}
+      : __impl_(in_place_index<_Ip>, __il, std::forward<_Args>(__args)...) {}
 
   template <
       class _Tp,
@@ -1381,7 +1381,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   explicit constexpr variant(in_place_type_t<_Tp>, _Args&&... __args) noexcept(
       is_nothrow_constructible_v<_Tp, _Args...>)
-      : __impl_(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...) {}
+      : __impl_(in_place_index<_Ip>, std::forward<_Args>(__args)...) {}
 
   template <
       class _Tp,
@@ -1397,7 +1397,7 @@ public:
       initializer_list<_Up> __il,
       _Args&&... __args) noexcept(
       is_nothrow_constructible_v<_Tp, initializer_list< _Up>&, _Args...>)
-      : __impl_(in_place_index<_Ip>, __il, _VSTD::forward<_Args>(__args)...) {}
+      : __impl_(in_place_index<_Ip>, __il, std::forward<_Args>(__args)...) {}
 
   _LIBCPP_HIDE_FROM_ABI ~variant() = default;
 
@@ -1416,7 +1416,7 @@ public:
   variant& operator=(_Arg&& __arg) noexcept(
       is_nothrow_assignable_v<_Tp&, _Arg> &&
       is_nothrow_constructible_v<_Tp, _Arg>) {
-    __impl_.template __assign<_Ip>(_VSTD::forward<_Arg>(__arg));
+    __impl_.template __assign<_Ip>(std::forward<_Arg>(__arg));
     return *this;
   }
 
@@ -1428,7 +1428,7 @@ public:
       enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   _Tp& emplace(_Args&&... __args) {
-    return __impl_.template __emplace<_Ip>(_VSTD::forward<_Args>(__args)...);
+    return __impl_.template __emplace<_Ip>(std::forward<_Args>(__args)...);
   }
 
   template <
@@ -1441,7 +1441,7 @@ public:
                   int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) {
-    return __impl_.template __emplace<_Ip>(__il, _VSTD::forward<_Args>(__args)...);
+    return __impl_.template __emplace<_Ip>(__il, std::forward<_Args>(__args)...);
   }
 
   template <
@@ -1452,7 +1452,7 @@ public:
       enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   _Tp& emplace(_Args&&... __args) {
-    return __impl_.template __emplace<_Ip>(_VSTD::forward<_Args>(__args)...);
+    return __impl_.template __emplace<_Ip>(std::forward<_Args>(__args)...);
   }
 
   template <
@@ -1465,7 +1465,7 @@ public:
                   int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) {
-    return __impl_.template __emplace<_Ip>(__il, _VSTD::forward<_Args>(__args)...);
+    return __impl_.template __emplace<_Ip>(__il, std::forward<_Args>(__args)...);
   }
 
   _LIBCPP_HIDE_FROM_ABI
@@ -1517,7 +1517,7 @@ constexpr auto&& __generic_get(_Vp&& __v) {
   if (!std::__holds_alternative<_Ip>(__v)) {
     __throw_bad_variant_access();
   }
-  return __variant::__get_alt<_Ip>(_VSTD::forward<_Vp>(__v)).__value;
+  return __variant::__get_alt<_Ip>(std::forward<_Vp>(__v)).__value;
 }
 
 template <size_t _Ip, class... _Types>
@@ -1537,7 +1537,7 @@ constexpr variant_alternative_t<_Ip, variant<_Types...>>&& get(
     variant<_Types...>&& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
-  return std::__generic_get<_Ip>(_VSTD::move(__v));
+  return std::__generic_get<_Ip>(std::move(__v));
 }
 
 template <size_t _Ip, class... _Types>
@@ -1557,7 +1557,7 @@ constexpr const variant_alternative_t<_Ip, variant<_Types...>>&& get(
     const variant<_Types...>&& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
-  return std::__generic_get<_Ip>(_VSTD::move(__v));
+  return std::__generic_get<_Ip>(std::move(__v));
 }
 
 template <class _Tp, class... _Types>
@@ -1565,7 +1565,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr _Tp& get(variant<_Types...>& __v) {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+  return std::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
@@ -1573,8 +1573,8 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr _Tp&& get(variant<_Types...>&& __v) {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(
-      _VSTD::move(__v));
+  return std::get<__find_exactly_one_t<_Tp, _Types...>::value>(
+      std::move(__v));
 }
 
 template <class _Tp, class... _Types>
@@ -1582,7 +1582,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr const _Tp& get(const variant<_Types...>& __v) {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+  return std::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
@@ -1590,8 +1590,8 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr const _Tp&& get(const variant<_Types...>&& __v) {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(
-      _VSTD::move(__v));
+  return std::get<__find_exactly_one_t<_Tp, _Types...>::value>(
+      std::move(__v));
 }
 
 template <size_t _Ip, class _Vp>
@@ -1599,7 +1599,7 @@ _LIBCPP_HIDE_FROM_ABI
 constexpr auto* __generic_get_if(_Vp* __v) noexcept {
   using __variant_detail::__access::__variant;
   return __v && std::__holds_alternative<_Ip>(*__v)
-             ? _VSTD::addressof(__variant::__get_alt<_Ip>(*__v).__value)
+             ? std::addressof(__variant::__get_alt<_Ip>(*__v).__value)
              : nullptr;
 }
 
@@ -1626,7 +1626,7 @@ _LIBCPP_HIDE_FROM_ABI
 constexpr add_pointer_t<_Tp>
 get_if(variant<_Types...>* __v) noexcept {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+  return std::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
@@ -1634,7 +1634,7 @@ _LIBCPP_HIDE_FROM_ABI
 constexpr add_pointer_t<const _Tp>
 get_if(const variant<_Types...>* __v) noexcept {
   static_assert(!is_void_v<_Tp>);
-  return _VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+  return std::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Operator>
@@ -1642,9 +1642,9 @@ struct __convert_to_bool {
   template <class _T1, class _T2>
   _LIBCPP_HIDE_FROM_ABI
   constexpr bool operator()(_T1 && __t1, _T2&& __t2) const {
-    static_assert(is_convertible<decltype(_Operator{}(_VSTD::forward<_T1>(__t1), _VSTD::forward<_T2>(__t2))), bool>::value,
+    static_assert(is_convertible<decltype(_Operator{}(std::forward<_T1>(__t1), std::forward<_T2>(__t2))), bool>::value,
         "the relational operator does not return a type which is implicitly convertible to bool");
-    return _Operator{}(_VSTD::forward<_T1>(__t1), _VSTD::forward<_T2>(__t2));
+    return _Operator{}(std::forward<_T1>(__t1), std::forward<_T2>(__t2));
   }
 };
 
@@ -1745,7 +1745,7 @@ _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr void __throw_if_valueless(_Vs&&... __vs) {
   const bool __valueless =
-      (... || _VSTD::__as_variant(__vs).valueless_by_exception());
+      (... || std::__as_variant(__vs).valueless_by_exception());
   if (__valueless) {
     __throw_bad_variant_access();
   }
@@ -1753,27 +1753,27 @@ constexpr void __throw_if_valueless(_Vs&&... __vs) {
 
 template <
     class _Visitor, class... _Vs,
-    typename = void_t<decltype(_VSTD::__as_variant(std::declval<_Vs>()))...> >
+    typename = void_t<decltype(std::__as_variant(std::declval<_Vs>()))...> >
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr decltype(auto) visit(_Visitor&& __visitor, _Vs&&... __vs) {
   using __variant_detail::__visitation::__variant;
-  _VSTD::__throw_if_valueless(_VSTD::forward<_Vs>(__vs)...);
-  return __variant::__visit_value(_VSTD::forward<_Visitor>(__visitor),
-                                  _VSTD::forward<_Vs>(__vs)...);
+  std::__throw_if_valueless(std::forward<_Vs>(__vs)...);
+  return __variant::__visit_value(std::forward<_Visitor>(__visitor),
+                                  std::forward<_Vs>(__vs)...);
 }
 
 #if _LIBCPP_STD_VER >= 20
 template <
     class _Rp, class _Visitor, class... _Vs,
-    typename = void_t<decltype(_VSTD::__as_variant(std::declval<_Vs>()))...> >
+    typename = void_t<decltype(std::__as_variant(std::declval<_Vs>()))...> >
 _LIBCPP_HIDE_FROM_ABI
 _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
 constexpr _Rp visit(_Visitor&& __visitor, _Vs&&... __vs) {
   using __variant_detail::__visitation::__variant;
-  _VSTD::__throw_if_valueless(_VSTD::forward<_Vs>(__vs)...);
-  return __variant::__visit_value<_Rp>(_VSTD::forward<_Visitor>(__visitor),
-                                       _VSTD::forward<_Vs>(__vs)...);
+  std::__throw_if_valueless(std::forward<_Vs>(__vs)...);
+  return __variant::__visit_value<_Rp>(std::forward<_Visitor>(__visitor),
+                                       std::forward<_Vs>(__vs)...);
 }
 #endif
 
@@ -1815,7 +1815,7 @@ template <size_t _Ip, class _Vp>
 _LIBCPP_HIDE_FROM_ABI
 constexpr auto&& __unchecked_get(_Vp&& __v) noexcept {
   using __variant_detail::__access::__variant;
-  return __variant::__get_alt<_Ip>(_VSTD::forward<_Vp>(__v)).__value;
+  return __variant::__get_alt<_Ip>(std::forward<_Vp>(__v)).__value;
 }
 
 template <class _Tp, class... _Types>

--- a/libcxx/src/chrono.cpp
+++ b/libcxx/src/chrono.cpp
@@ -94,8 +94,8 @@ public:
 static system_clock::time_point __libcpp_system_clock_now() {
   // FILETIME is in 100ns units
   using filetime_duration =
-      _VSTD::chrono::duration<__int64,
-                              _VSTD::ratio_multiply<_VSTD::ratio<100, 1>,
+      std::chrono::duration<__int64,
+                              std::ratio_multiply<std::ratio<100, 1>,
                                                     nanoseconds::period>>;
 
   // The Windows epoch is Jan 1 1601, the Unix epoch Jan 1 1970.

--- a/libcxx/src/include/to_chars_floating_point.h
+++ b/libcxx/src/include/to_chars_floating_point.h
@@ -37,7 +37,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace __itoa {
 inline constexpr char _Charconv_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
     'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
-static_assert(_VSTD::size(_Charconv_digits) == 36);
+static_assert(std::size(_Charconv_digits) == 36);
 } // __itoa
 
 // vvvvvvvvvv DERIVED FROM corecrt_internal_fltintrn.h vvvvvvvvvv
@@ -119,7 +119,7 @@ to_chars_result _Floating_to_chars_hex_precision(
     using _Traits    = _Floating_type_traits<_Floating>;
     using _Uint_type = typename _Traits::_Uint_type;
 
-    const _Uint_type _Uint_value    = _VSTD::bit_cast<_Uint_type>(_Value);
+    const _Uint_type _Uint_value    = std::bit_cast<_Uint_type>(_Value);
     const _Uint_type _Ieee_mantissa = _Uint_value & _Traits::_Denormal_mantissa_mask;
     const int32_t _Ieee_exponent    = static_cast<int32_t>(_Uint_value >> _Traits::_Exponent_shift);
 
@@ -307,7 +307,7 @@ to_chars_result _Floating_to_chars_hex_precision(
 
             if (_Number_of_bits_remaining == 0) {
                 // We've finished printing _Adjusted_mantissa, so all remaining hexits are '0'.
-                _VSTD::memset(_First, '0', static_cast<size_t>(_Precision));
+                std::memset(_First, '0', static_cast<size_t>(_Precision));
                 _First += _Precision;
                 break;
             }
@@ -330,7 +330,7 @@ to_chars_result _Floating_to_chars_hex_precision(
     *_First++ = _Sign_character;
 
     // We've already printed '-' if necessary, so uint32_t _Absolute_exponent avoids testing that again.
-    return _VSTD::to_chars(_First, _Last, _Absolute_exponent);
+    return std::to_chars(_First, _Last, _Absolute_exponent);
 }
 
 template <class _Floating>
@@ -347,7 +347,7 @@ to_chars_result _Floating_to_chars_hex_shortest(
     using _Traits    = _Floating_type_traits<_Floating>;
     using _Uint_type = typename _Traits::_Uint_type;
 
-    const _Uint_type _Uint_value = _VSTD::bit_cast<_Uint_type>(_Value);
+    const _Uint_type _Uint_value = std::bit_cast<_Uint_type>(_Value);
 
     if (_Uint_value == 0) { // zero detected; write "0p+0" and return
         // C11 7.21.6.1 "The fprintf function"/8: "If the value is zero, the exponent is zero."
@@ -359,7 +359,7 @@ to_chars_result _Floating_to_chars_hex_shortest(
             return {_Last, errc::value_too_large};
         }
 
-        _VSTD::memcpy(_First, _Str, _Len);
+        std::memcpy(_First, _Str, _Len);
 
         return {_First + _Len, errc{}};
     }
@@ -457,7 +457,7 @@ to_chars_result _Floating_to_chars_hex_shortest(
     }
 
     // We've already printed '-' if necessary, so static_cast<uint32_t> avoids testing that again.
-    return _VSTD::to_chars(_First, _Last, static_cast<uint32_t>(_Unbiased_exponent));
+    return std::to_chars(_First, _Last, static_cast<uint32_t>(_Unbiased_exponent));
 }
 
 // For general precision, we can use lookup tables to avoid performing trial formatting.
@@ -839,7 +839,7 @@ to_chars_result _Floating_to_chars_general_precision(
     using _Traits    = _Floating_type_traits<_Floating>;
     using _Uint_type = typename _Traits::_Uint_type;
 
-    const _Uint_type _Uint_value = _VSTD::bit_cast<_Uint_type>(_Value);
+    const _Uint_type _Uint_value = std::bit_cast<_Uint_type>(_Value);
 
     if (_Uint_value == 0) { // zero detected; write "0" and return; _Precision is irrelevant due to zero-trimming
         if (_First == _Last) {
@@ -890,7 +890,7 @@ to_chars_result _Floating_to_chars_general_precision(
         _Table_end   = _Table_begin + _Precision + 5;
     } else {
         _Table_begin = _Tables::_Ordinary_X_table;
-        _Table_end   = _Table_begin + _VSTD::min(_Precision, _Tables::_Max_P) + 5;
+        _Table_end   = _Table_begin + std::min(_Precision, _Tables::_Max_P) + 5;
     }
 
     // Profiling indicates that linear search is faster than binary search for small tables.
@@ -898,11 +898,11 @@ to_chars_result _Floating_to_chars_general_precision(
     const _Uint_type* const _Table_lower_bound = [=] {
         if constexpr (!_IsSame<_Floating, float>::value) {
             if (_Precision > 155) { // threshold determined via profiling
-                return _VSTD::lower_bound(_Table_begin, _Table_end, _Uint_value, less{});
+                return std::lower_bound(_Table_begin, _Table_end, _Uint_value, less{});
             }
         }
 
-        return _VSTD::find_if(_Table_begin, _Table_end, [=](const _Uint_type _Elem) { return _Uint_value <= _Elem; });
+        return std::find_if(_Table_begin, _Table_end, [=](const _Uint_type _Elem) { return _Uint_value <= _Elem; });
     }();
 
     const ptrdiff_t _Table_index     = _Table_lower_bound - _Table_begin;
@@ -937,17 +937,17 @@ to_chars_result _Floating_to_chars_general_precision(
     // Write into the local buffer.
     // Clamping _Effective_precision allows _Buffer to be as small as possible, and increases efficiency.
     if (_Use_fixed_notation) {
-        _Effective_precision = _VSTD::min(_Precision - (_Scientific_exponent_X + 1), _Max_fixed_precision);
+        _Effective_precision = std::min(_Precision - (_Scientific_exponent_X + 1), _Max_fixed_precision);
         const to_chars_result _Buf_result =
-            _Floating_to_chars_fixed_precision(_Buffer, _VSTD::end(_Buffer), _Value, _Effective_precision);
+            _Floating_to_chars_fixed_precision(_Buffer, std::end(_Buffer), _Value, _Effective_precision);
         _LIBCPP_ASSERT_UNCATEGORIZED(_Buf_result.ec == errc{}, "");
         _Significand_last = _Buf_result.ptr;
     } else {
-        _Effective_precision = _VSTD::min(_Precision - 1, _Max_scientific_precision);
+        _Effective_precision = std::min(_Precision - 1, _Max_scientific_precision);
         const to_chars_result _Buf_result =
-            _Floating_to_chars_scientific_precision(_Buffer, _VSTD::end(_Buffer), _Value, _Effective_precision);
+            _Floating_to_chars_scientific_precision(_Buffer, std::end(_Buffer), _Value, _Effective_precision);
         _LIBCPP_ASSERT_UNCATEGORIZED(_Buf_result.ec == errc{}, "");
-        _Significand_last = _VSTD::find(_Buffer, _Buf_result.ptr, 'e');
+        _Significand_last = std::find(_Buffer, _Buf_result.ptr, 'e');
         _Exponent_first   = _Significand_last;
         _Exponent_last    = _Buf_result.ptr;
     }
@@ -968,7 +968,7 @@ to_chars_result _Floating_to_chars_general_precision(
     if (_Last - _First < _Significand_distance) {
         return {_Last, errc::value_too_large};
     }
-    _VSTD::memcpy(_First, _Significand_first, static_cast<size_t>(_Significand_distance));
+    std::memcpy(_First, _Significand_first, static_cast<size_t>(_Significand_distance));
     _First += _Significand_distance;
 
     // Copy the exponent to the output range.
@@ -977,7 +977,7 @@ to_chars_result _Floating_to_chars_general_precision(
         if (_Last - _First < _Exponent_distance) {
             return {_Last, errc::value_too_large};
         }
-        _VSTD::memcpy(_First, _Exponent_first, static_cast<size_t>(_Exponent_distance));
+        std::memcpy(_First, _Exponent_first, static_cast<size_t>(_Exponent_distance));
         _First += _Exponent_distance;
     }
 
@@ -1002,7 +1002,7 @@ to_chars_result _Floating_to_chars(
     using _Traits    = _Floating_type_traits<_Floating>;
     using _Uint_type = typename _Traits::_Uint_type;
 
-    _Uint_type _Uint_value = _VSTD::bit_cast<_Uint_type>(_Value);
+    _Uint_type _Uint_value = std::bit_cast<_Uint_type>(_Value);
 
     const bool _Was_negative = (_Uint_value & _Traits::_Shifted_sign_mask) != 0;
 
@@ -1014,7 +1014,7 @@ to_chars_result _Floating_to_chars(
         *_First++ = '-';
 
         _Uint_value &= ~_Traits::_Shifted_sign_mask;
-        _Value = _VSTD::bit_cast<_Floating>(_Uint_value);
+        _Value = std::bit_cast<_Floating>(_Uint_value);
     }
 
     if ((_Uint_value & _Traits::_Shifted_exponent_mask) == _Traits::_Shifted_exponent_mask) {
@@ -1044,7 +1044,7 @@ to_chars_result _Floating_to_chars(
             return {_Last, errc::value_too_large};
         }
 
-        _VSTD::memcpy(_First, _Str, _Len);
+        std::memcpy(_First, _Str, _Len);
 
         return {_First + _Len, errc{}};
     }

--- a/libcxx/src/ios.cpp
+++ b/libcxx/src/ios.cpp
@@ -152,7 +152,7 @@ static size_t __ios_new_cap(size_t __req_size, size_t __current_cap)
 { // Precondition: __req_size > __current_cap
     const size_t mx = std::numeric_limits<size_t>::max() / sizeof(_Tp);
     if (__req_size < mx/2)
-        return _VSTD::max(2 * __current_cap, __req_size);
+        return std::max(2 * __current_cap, __req_size);
     else
         return mx;
 }
@@ -394,24 +394,24 @@ ios_base::move(ios_base& rhs)
 void
 ios_base::swap(ios_base& rhs) noexcept
 {
-    _VSTD::swap(__fmtflags_, rhs.__fmtflags_);
-    _VSTD::swap(__precision_, rhs.__precision_);
-    _VSTD::swap(__width_, rhs.__width_);
-    _VSTD::swap(__rdstate_, rhs.__rdstate_);
-    _VSTD::swap(__exceptions_, rhs.__exceptions_);
+    std::swap(__fmtflags_, rhs.__fmtflags_);
+    std::swap(__precision_, rhs.__precision_);
+    std::swap(__width_, rhs.__width_);
+    std::swap(__rdstate_, rhs.__rdstate_);
+    std::swap(__exceptions_, rhs.__exceptions_);
     locale& lhs_loc = *reinterpret_cast<locale*>(&__loc_);
     locale& rhs_loc = *reinterpret_cast<locale*>(&rhs.__loc_);
-    _VSTD::swap(lhs_loc, rhs_loc);
-    _VSTD::swap(__fn_, rhs.__fn_);
-    _VSTD::swap(__index_, rhs.__index_);
-    _VSTD::swap(__event_size_, rhs.__event_size_);
-    _VSTD::swap(__event_cap_, rhs.__event_cap_);
-    _VSTD::swap(__iarray_, rhs.__iarray_);
-    _VSTD::swap(__iarray_size_, rhs.__iarray_size_);
-    _VSTD::swap(__iarray_cap_, rhs.__iarray_cap_);
-    _VSTD::swap(__parray_, rhs.__parray_);
-    _VSTD::swap(__parray_size_, rhs.__parray_size_);
-    _VSTD::swap(__parray_cap_, rhs.__parray_cap_);
+    std::swap(lhs_loc, rhs_loc);
+    std::swap(__fn_, rhs.__fn_);
+    std::swap(__index_, rhs.__index_);
+    std::swap(__event_size_, rhs.__event_size_);
+    std::swap(__event_cap_, rhs.__event_cap_);
+    std::swap(__iarray_, rhs.__iarray_);
+    std::swap(__iarray_size_, rhs.__iarray_size_);
+    std::swap(__iarray_cap_, rhs.__iarray_cap_);
+    std::swap(__parray_, rhs.__parray_);
+    std::swap(__parray_size_, rhs.__parray_size_);
+    std::swap(__parray_cap_, rhs.__parray_cap_);
 }
 
 void

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -126,7 +126,7 @@ DoIOSInit::DoIOSInit()
     ostream* cerr_ptr = ::new(cerr) ostream(::new(__cerr) __stdoutbuf<char>(stderr, &mb_cerr));
                         ::new(clog) ostream(cerr_ptr->rdbuf());
     cin_ptr->tie(cout_ptr);
-    _VSTD::unitbuf(*cerr_ptr);
+    std::unitbuf(*cerr_ptr);
     cerr_ptr->tie(cout_ptr);
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
@@ -136,7 +136,7 @@ DoIOSInit::DoIOSInit()
                           ::new(wclog) wostream(wcerr_ptr->rdbuf());
 
     wcin_ptr->tie(wcout_ptr);
-    _VSTD::unitbuf(*wcerr_ptr);
+    std::unitbuf(*wcerr_ptr);
     wcerr_ptr->tie(wcout_ptr);
 #endif
 }

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -171,13 +171,13 @@ locale::__imp::__imp(size_t refs)
       name_("C")
 {
     facets_.clear();
-    install(&make<_VSTD::collate<char> >(1u));
+    install(&make<std::collate<char> >(1u));
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-    install(&make<_VSTD::collate<wchar_t> >(1u));
+    install(&make<std::collate<wchar_t> >(1u));
 #endif
-    install(&make<_VSTD::ctype<char> >(nullptr, false, 1u));
+    install(&make<std::ctype<char> >(nullptr, false, 1u));
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-    install(&make<_VSTD::ctype<wchar_t> >(1u));
+    install(&make<std::ctype<wchar_t> >(1u));
 #endif
     install(&make<codecvt<char, char, mbstate_t> >(1u));
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
@@ -225,9 +225,9 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
     install(&make<time_put<wchar_t> >(1u));
 #endif
-    install(&make<_VSTD::messages<char> >(1u));
+    install(&make<std::messages<char> >(1u));
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-    install(&make<_VSTD::messages<wchar_t> >(1u));
+    install(&make<std::messages<wchar_t> >(1u));
 #endif
 }
 
@@ -413,28 +413,28 @@ locale::__imp::__imp(const __imp& other, const __imp& one, locale::category c)
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
         if (c & locale::collate)
         {
-            install_from<_VSTD::collate<char> >(one);
+            install_from<std::collate<char> >(one);
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-            install_from<_VSTD::collate<wchar_t> >(one);
+            install_from<std::collate<wchar_t> >(one);
 #endif
         }
         if (c & locale::ctype)
         {
-            install_from<_VSTD::ctype<char> >(one);
+            install_from<std::ctype<char> >(one);
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-            install_from<_VSTD::ctype<wchar_t> >(one);
+            install_from<std::ctype<wchar_t> >(one);
 #endif
-            install_from<_VSTD::codecvt<char, char, mbstate_t> >(one);
+            install_from<std::codecvt<char, char, mbstate_t> >(one);
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-            install_from<_VSTD::codecvt<char16_t, char, mbstate_t> >(one);
-            install_from<_VSTD::codecvt<char32_t, char, mbstate_t> >(one);
+            install_from<std::codecvt<char16_t, char, mbstate_t> >(one);
+            install_from<std::codecvt<char32_t, char, mbstate_t> >(one);
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 #ifndef _LIBCPP_HAS_NO_CHAR8_T
-            install_from<_VSTD::codecvt<char16_t, char8_t, mbstate_t> >(one);
-            install_from<_VSTD::codecvt<char32_t, char8_t, mbstate_t> >(one);
+            install_from<std::codecvt<char16_t, char8_t, mbstate_t> >(one);
+            install_from<std::codecvt<char32_t, char8_t, mbstate_t> >(one);
 #endif
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-            install_from<_VSTD::codecvt<wchar_t, char, mbstate_t> >(one);
+            install_from<std::codecvt<wchar_t, char, mbstate_t> >(one);
 #endif
         }
         if (c & locale::monetary)
@@ -482,9 +482,9 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
         }
         if (c & locale::messages)
         {
-            install_from<_VSTD::messages<char> >(one);
+            install_from<std::messages<char> >(one);
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-            install_from<_VSTD::messages<wchar_t> >(one);
+            install_from<std::messages<wchar_t> >(one);
 #endif
         }
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS

--- a/libcxx/src/regex.cpp
+++ b/libcxx/src/regex.cpp
@@ -350,7 +350,7 @@ string
 __get_collation_name(const char* s)
 {
     const collationnames* i =
-            _VSTD::lower_bound(begin(collatenames), end(collatenames), s, use_strcmp());
+            std::lower_bound(begin(collatenames), end(collatenames), s, use_strcmp());
     string r;
     if (i != end(collatenames) && strcmp(s, i->elem_) == 0)
         r = char(i->char_);
@@ -361,7 +361,7 @@ regex_traits<char>::char_class_type
 __get_classname(const char* s, bool __icase)
 {
     const classnames* i =
-            _VSTD::lower_bound(begin(ClassNames), end(ClassNames), s, use_strcmp());
+            std::lower_bound(begin(ClassNames), end(ClassNames), s, use_strcmp());
     regex_traits<char>::char_class_type r = 0;
     if (i != end(ClassNames) && strcmp(s, i->elem_) == 0)
     {

--- a/libcxx/src/std_stream.h
+++ b/libcxx/src/std_stream.h
@@ -172,7 +172,7 @@ __stdinbuf<_CharT>::__getchar(bool __consume)
     }
 
     char __extbuf[__limit];
-    int __nread = _VSTD::max(1, __encoding_);
+    int __nread = std::max(1, __encoding_);
     for (int __i = 0; __i < __nread; ++__i)
     {
         int __c = getc(__file_);
@@ -191,7 +191,7 @@ __stdinbuf<_CharT>::__getchar(bool __consume)
                                &__1buf, &__1buf + 1, __inxt);
         switch (__r)
         {
-        case _VSTD::codecvt_base::ok:
+        case std::codecvt_base::ok:
             break;
         case codecvt_base::partial:
             *__st_ = __sv_st;
@@ -207,11 +207,11 @@ __stdinbuf<_CharT>::__getchar(bool __consume)
             break;
         case codecvt_base::error:
             return traits_type::eof();
-        case _VSTD::codecvt_base::noconv:
+        case std::codecvt_base::noconv:
             __1buf = static_cast<char_type>(__extbuf[0]);
             break;
         }
-    } while (__r == _VSTD::codecvt_base::partial);
+    } while (__r == std::codecvt_base::partial);
     if (!__consume)
     {
         for (int __i = __nread; __i > 0;)
@@ -251,9 +251,9 @@ __stdinbuf<_CharT>::pbackfail(int_type __c)
         switch (__cv_->out(*__st_, &__ci, &__ci + 1, __inxt,
                                   __extbuf, __extbuf + sizeof(__extbuf), __enxt))
         {
-        case _VSTD::codecvt_base::ok:
+        case std::codecvt_base::ok:
             break;
-        case _VSTD::codecvt_base::noconv:
+        case std::codecvt_base::noconv:
             __extbuf[0] = static_cast<char>(__last_consumed_);
             __enxt = __extbuf + 1;
             break;

--- a/libcxx/src/strstream.cpp
+++ b/libcxx/src/strstream.cpp
@@ -79,10 +79,10 @@ strstreambuf::~strstreambuf() {
 
 void strstreambuf::swap(strstreambuf& __rhs) {
   streambuf::swap(__rhs);
-  _VSTD::swap(__strmode_, __rhs.__strmode_);
-  _VSTD::swap(__alsize_, __rhs.__alsize_);
-  _VSTD::swap(__palloc_, __rhs.__palloc_);
-  _VSTD::swap(__pfree_, __rhs.__pfree_);
+  std::swap(__strmode_, __rhs.__strmode_);
+  std::swap(__alsize_, __rhs.__alsize_);
+  std::swap(__palloc_, __rhs.__palloc_);
+  std::swap(__pfree_, __rhs.__pfree_);
 }
 
 void strstreambuf::freeze(bool __freezefl) {
@@ -211,7 +211,7 @@ strstreambuf::pos_type strstreambuf::seekoff(off_type __off, ios_base::seekdir _
 
   char* newpos = eback() + newoff;
   if (pos_in)
-    setg(eback(), newpos, _VSTD::max(newpos, egptr()));
+    setg(eback(), newpos, std::max(newpos, egptr()));
   if (pos_out) {
     // min(pbase, newpos), newpos, epptr()
     __off = epptr() - newpos;
@@ -237,7 +237,7 @@ strstreambuf::pos_type strstreambuf::seekpos(pos_type __sp, ios_base::openmode _
 
   char* newpos = eback() + newoff;
   if (pos_in)
-    setg(eback(), newpos, _VSTD::max(newpos, egptr()));
+    setg(eback(), newpos, std::max(newpos, egptr()));
   if (pos_out) {
     // min(pbase, newpos), newpos, epptr()
     off_type temp = epptr() - newpos;

--- a/libcxx/src/support/win32/thread_win32.cpp
+++ b/libcxx/src/support/win32/thread_win32.cpp
@@ -115,7 +115,7 @@ int __libcpp_condvar_wait(__libcpp_condvar_t *__cv, __libcpp_mutex_t *__m)
 int __libcpp_condvar_timedwait(__libcpp_condvar_t *__cv, __libcpp_mutex_t *__m,
                                __libcpp_timespec_t *__ts)
 {
-  using namespace _VSTD::chrono;
+  using namespace std::chrono;
 
   auto duration = seconds(__ts->tv_sec) + nanoseconds(__ts->tv_nsec);
   auto abstime =

--- a/libcxx/src/vector.cpp
+++ b/libcxx/src/vector.cpp
@@ -22,11 +22,11 @@ struct __vector_base_common<true> {
 };
 
 void __vector_base_common<true>::__throw_length_error() const {
-  _VSTD::__throw_length_error("vector");
+  std::__throw_length_error("vector");
 }
 
 void __vector_base_common<true>::__throw_out_of_range() const {
-  _VSTD::__throw_out_of_range("vector");
+  std::__throw_out_of_range("vector");
 }
 
 #endif // _LIBCPP_ABI_DO_NOT_EXPORT_VECTOR_BASE_COMMON


### PR DESCRIPTION
As part of the upcoming clang-formatting of libc++, this patch performs the long desired removal of the _VSTD macro.

See https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all for the clang-format proposal.