### PR TITLE
TargetInstrInfo, TargetSchedule: fix non-NFC parts of 9468de4

### DIFF
--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -1462,7 +1462,7 @@ bool TargetInstrInfo::hasLowDefLatency(const TargetSchedModel &SchedModel,
   unsigned DefClass = DefMI.getDesc().getSchedClass();
   std::optional<unsigned> DefCycle =
       ItinData->getOperandCycle(DefClass, DefIdx);
-  return DefCycle <= 1U;
+  return DefCycle && DefCycle <= 1U;
 }
 
 bool TargetInstrInfo::isFunctionSafeToSplit(const MachineFunction &MF) const {

--- a/llvm/lib/CodeGen/TargetSchedule.cpp
+++ b/llvm/lib/CodeGen/TargetSchedule.cpp
@@ -178,7 +178,7 @@ unsigned TargetSchedModel::computeOperandLatency(
   const unsigned DefaultDefLatency = TII->defaultDefLatency(SchedModel, *DefMI);
 
   if (!hasInstrSchedModel() && !hasInstrItineraries())
-    return InstrLatency;
+    return DefaultDefLatency;
 
   if (hasInstrItineraries()) {
     std::optional<unsigned> OperLatency;

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -4836,7 +4836,7 @@ bool ARMBaseInstrInfo::hasLowDefLatency(const TargetSchedModel &SchedModel,
     unsigned DefClass = DefMI.getDesc().getSchedClass();
     std::optional<unsigned> DefCycle =
         ItinData->getOperandCycle(DefClass, DefIdx);
-    return DefCycle <= 2U;
+    return DefCycle && DefCycle <= 2U;
   }
   return false;
 }


### PR DESCRIPTION
Follow up on a post-commit review of 9468de4 (TargetInstrInfo: make getOperandLatency return optional (NFC)) by Bjorn Pettersson to fix a couple of things that are not NFC:

- `std::optional<T>::operator<=` returns true if the first operand is a std::nullopt and second operand is T. Fix a couple of places where we assumed it would return false.
- In TargetSchedule, computeInstrCost could take another codepath, returning InstrLatency instead of DefaultDefLatency. Fix one instance not accounting for this behavior.