### PR TITLE
[mlir][arith] Overflow semantics in documentation for muli, subi, and addi

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -200,6 +200,12 @@ def Arith_AddIOp : Arith_TotalIntBinaryOp<"addi", [Commutative]> {
     a vector whose element type is integer, or a tensor of integers. It has no 
     standard attributes.
 
+    The operands are interpreted as unsigned bitvectors. The result is represented by 
+    a bitvector containing the mathematical value of the addition modulo 2^n, where 
+    `n` is the bitwidth. Because `arith` integers use a two's complement 
+    representation, this operation is applicable on both signed and unsigned 
+    integer operands.
+
     Example:
 
     ```mlir
@@ -276,6 +282,17 @@ def Arith_SubIOp : Arith_TotalIntBinaryOp<"subi"> {
   let summary = [{
     Integer subtraction operation.
   }];
+  let description = [{    
+    The `subi` operation takes two operands and returns one result, each of
+    these is required to be the same type. This type may be an integer scalar type, 
+    a vector whose element type is integer, or a tensor of integers. It has no 
+    standard attributes.
+
+    The operands are interpreted as unsigned bitvectors. The result is represented by a 
+    bitvector containing the mathematical value of the subtraction modulo 2^n, where `n` 
+    is the bitwidth. Because `arith` integers use a two's complement representation, this 
+    operation is applicable on both signed and unsigned integer operands.
+  }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -287,6 +304,17 @@ def Arith_SubIOp : Arith_TotalIntBinaryOp<"subi"> {
 def Arith_MulIOp : Arith_TotalIntBinaryOp<"muli", [Commutative]> {
   let summary = [{
     Integer multiplication operation.
+  }];
+  let description = [{
+    The `muli` operation takes two operands and returns one result, each of
+    these is required to be the same type. This type may be an integer scalar type, 
+    a vector whose element type is integer, or a tensor of integers. It has no 
+    standard attributes.
+
+    The operands are interpreted as unsigned bitvectors. The result is represented by a 
+    bitvector containing the mathematical value of the multiplication modulo 2^n, where `n` 
+    is the bitwidth. Because `arith` integers use a two's complement representation, this 
+    operation is applicable on both signed and unsigned integer operands.
   }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;

--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -195,16 +195,16 @@ def Arith_ConstantOp : Op<Arith_Dialect, "constant",
 def Arith_AddIOp : Arith_TotalIntBinaryOp<"addi", [Commutative]> {
   let summary = "integer addition operation";
   let description = [{
+    Performs N-bit addition on the operands. The operands are interpreted as 
+    unsigned bitvectors. The result is represented by a bitvector containing the 
+    mathematical value of the addition modulo 2^n, where `n` is the bitwidth. 
+    Because `arith` integers use a two's complement representation, this operation 
+    is applicable on both signed and unsigned integer operands.
+
     The `addi` operation takes two operands and returns one result, each of
     these is required to be the same type. This type may be an integer scalar type, 
     a vector whose element type is integer, or a tensor of integers. It has no 
     standard attributes.
-
-    The operands are interpreted as unsigned bitvectors. The result is represented by 
-    a bitvector containing the mathematical value of the addition modulo 2^n, where 
-    `n` is the bitwidth. Because `arith` integers use a two's complement 
-    representation, this operation is applicable on both signed and unsigned 
-    integer operands.
 
     Example:
 
@@ -236,7 +236,7 @@ def Arith_AddUIExtendedOp : Arith_Op<"addui_extended", [Pure, Commutative,
   let description = [{
     Performs (N+1)-bit addition on zero-extended operands. Returns two results:
     the N-bit sum (same type as both operands), and the overflow bit
-    (boolean-like), where`1` indicates unsigned addition overflow, while `0`
+    (boolean-like), where `1` indicates unsigned addition overflow, while `0`
     indicates no overflow.
 
     Example:
@@ -282,16 +282,17 @@ def Arith_SubIOp : Arith_TotalIntBinaryOp<"subi"> {
   let summary = [{
     Integer subtraction operation.
   }];
-  let description = [{    
+  let description = [{
+    Performs N-bit subtraction on the operands. The operands are interpreted as unsigned 
+    bitvectors. The result is represented by a bitvector containing the mathematical 
+    value of the subtraction modulo 2^n, where `n` is the bitwidth. Because `arith` 
+    integers use a two's complement representation, this operation is applicable on 
+    both signed and unsigned integer operands.
+
     The `subi` operation takes two operands and returns one result, each of
     these is required to be the same type. This type may be an integer scalar type, 
     a vector whose element type is integer, or a tensor of integers. It has no 
     standard attributes.
-
-    The operands are interpreted as unsigned bitvectors. The result is represented by a 
-    bitvector containing the mathematical value of the subtraction modulo 2^n, where `n` 
-    is the bitwidth. Because `arith` integers use a two's complement representation, this 
-    operation is applicable on both signed and unsigned integer operands.
   }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
@@ -306,15 +307,16 @@ def Arith_MulIOp : Arith_TotalIntBinaryOp<"muli", [Commutative]> {
     Integer multiplication operation.
   }];
   let description = [{
+    Performs N-bit multiplication on the operands. The operands are interpreted as 
+    unsigned bitvectors. The result is represented by a bitvector containing the 
+    mathematical value of the multiplication modulo 2^n, where `n` is the bitwidth. 
+    Because `arith` integers use a two's complement representation, this operation is 
+    applicable on both signed and unsigned integer operands.
+
     The `muli` operation takes two operands and returns one result, each of
     these is required to be the same type. This type may be an integer scalar type, 
     a vector whose element type is integer, or a tensor of integers. It has no 
-    standard attributes.
-
-    The operands are interpreted as unsigned bitvectors. The result is represented by a 
-    bitvector containing the mathematical value of the multiplication modulo 2^n, where `n` 
-    is the bitwidth. Because `arith` integers use a two's complement representation, this 
-    operation is applicable on both signed and unsigned integer operands.
+    standard attributes.    
   }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;


### PR DESCRIPTION
Following discussions from this RFC: https://discourse.llvm.org/t/rfc-integer-overflow-semantics

Adding the overflow semantics into the muli, subi and addi arith operations.