### PR TITLE
[libc++][NFC] Add a few clang-format annotations

### DIFF
--- a/libcxx/include/__availability
+++ b/libcxx/include/__availability
@@ -165,10 +165,12 @@
 #  define _LIBCPP_AVAILABILITY_BAD_ANY_CAST _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS
 
 // <filesystem>
+// clang-format off
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500) ||   \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 130000) || \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 130000) ||         \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 60000)
+// clang-format on
 #    define _LIBCPP_AVAILABILITY_HAS_FILESYSTEM_LIBRARY 0
 #  else
 #    define _LIBCPP_AVAILABILITY_HAS_FILESYSTEM_LIBRARY 1
@@ -178,6 +180,7 @@
         __attribute__((availability(ios,strict,introduced=13.0)))               \
         __attribute__((availability(tvos,strict,introduced=13.0)))              \
         __attribute__((availability(watchos,strict,introduced=6.0)))
+// clang-format off
 #   define _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY_PUSH                                 \
         _Pragma("clang attribute push(__attribute__((availability(macos,strict,introduced=10.15))), apply_to=any(function,record))") \
         _Pragma("clang attribute push(__attribute__((availability(ios,strict,introduced=13.0))), apply_to=any(function,record))")    \
@@ -188,12 +191,15 @@
         _Pragma("clang attribute pop")                                          \
         _Pragma("clang attribute pop")                                          \
         _Pragma("clang attribute pop")
+// clang-format on
 
 // std::to_chars(floating-point)
+// clang-format off
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300) ||   \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 160300) || \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 160300) ||         \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 90300)
+// clang-format on
 #    define _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT 0
 #  else
 #    define _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT 1
@@ -205,10 +211,12 @@
         __attribute__((availability(watchos,strict,introduced=9.3)))
 
     // c++20 synchronization library
+// clang-format off
 #   if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000) ||   \
        (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 140000) || \
        (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 140000) ||         \
        (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 70000)
+// clang-format on
 #    define _LIBCPP_AVAILABILITY_HAS_SYNC 0
 #  else
 #    define _LIBCPP_AVAILABILITY_HAS_SYNC 1
@@ -227,10 +235,12 @@
         __attribute__((unavailable))
 
 // std::pmr
+// clang-format off
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 140000) ||   \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 170000) || \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 170000) ||         \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 100000)
+// clang-format on
 #    define _LIBCPP_AVAILABILITY_HAS_PMR 0
 #  else
 #    define _LIBCPP_AVAILABILITY_HAS_PMR 1
@@ -252,10 +262,12 @@
 #  define _LIBCPP_AVAILABILITY_HAS_TZDB 0
 #  define _LIBCPP_AVAILABILITY_TZDB __attribute__((unavailable))
 
+// clang-format off
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 120000)   || \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 150000) || \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 150000)         || \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 80000)
+// clang-format on
 #    define _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1 0
 #  else
 #    define _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1 1

--- a/libcxx/include/__format/escaped_output_table.h
+++ b/libcxx/include/__format/escaped_output_table.h
@@ -75,6 +75,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 namespace __escaped_output_table {
+// clang-format off
 
 /// The entries of the characters to escape in format's debug string.
 ///
@@ -1029,6 +1030,7 @@ inline constexpr uint32_t __unallocated_region_lower_bound = 0x000323b0;
   return __code_point <= __upper_bound;
 }
 
+// clang-format on
 } // namespace __escaped_output_table
 
 #endif //_LIBCPP_STD_VER >= 23

--- a/libcxx/include/__format/extended_grapheme_cluster_table.h
+++ b/libcxx/include/__format/extended_grapheme_cluster_table.h
@@ -124,6 +124,7 @@ enum class __property : uint8_t {
 /// this approach uses less space for the data and is about 4% faster in the
 /// following benchmark.
 /// libcxx/benchmarks/std_format_spec_string_unicode.bench.cpp
+// clang-format off
 inline constexpr uint32_t __entries[1496] = {
     0x00000091,
     0x00005005,
@@ -1621,6 +1622,7 @@ inline constexpr uint32_t __entries[1496] = {
     0x707787f1,
     0x707b87f1,
     0x707f80f1};
+// clang-format on
 
 /// Returns the extended grapheme cluster bondary property of a code point.
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr __property __get_property(const char32_t __code_point) noexcept {

--- a/libcxx/include/__iterator/iter_swap.h
+++ b/libcxx/include/__iterator/iter_swap.h
@@ -77,14 +77,14 @@ namespace __iter_swap {
     }
 
     template <class _T1, class _T2>
-      requires (!__unqualified_iter_swap<_T1, _T2> &&
-                !__readable_swappable<_T1, _T2>) &&
-               indirectly_movable_storable<_T1, _T2> &&
+      requires (!__unqualified_iter_swap<_T1, _T2> && //
+                !__readable_swappable<_T1, _T2>) && //
+               indirectly_movable_storable<_T1, _T2> && //
                indirectly_movable_storable<_T2, _T1>
     _LIBCPP_HIDE_FROM_ABI
     constexpr void operator()(_T1&& __x, _T2&& __y) const
-      noexcept(noexcept(iter_value_t<_T2>(ranges::iter_move(__y))) &&
-               noexcept(*__y = ranges::iter_move(__x)) &&
+      noexcept(noexcept(iter_value_t<_T2>(ranges::iter_move(__y))) && //
+               noexcept(*__y = ranges::iter_move(__x)) && //
                noexcept(*_VSTD::forward<_T1>(__x) = std::declval<iter_value_t<_T2>>()))
     {
       iter_value_t<_T2> __old(ranges::iter_move(__y));

--- a/libcxx/include/__string/extern_template_lists.h
+++ b/libcxx/include/__string/extern_template_lists.h
@@ -15,6 +15,8 @@
 #  pragma GCC system_header
 #endif
 
+// clang-format off
+
 // We maintain 2 ABI lists:
 // - _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST
 // - _LIBCPP_STRING_UNSTABLE_EXTERN_TEMPLATE_LIST
@@ -126,5 +128,6 @@
   _Func(_LIBCPP_EXPORTED_FROM_ABI void basic_string<_CharType>::resize(size_type, value_type)) \
   _Func(_LIBCPP_EXPORTED_FROM_ABI basic_string<_CharType>& basic_string<_CharType>::insert(size_type, basic_string const&, size_type, size_type))
 
+// clang-format on
 
 #endif // _LIBCPP___STRING_EXTERN_TEMPLATE_LISTS_H

--- a/libcxx/include/__utility/integer_sequence.h
+++ b/libcxx/include/__utility/integer_sequence.h
@@ -51,6 +51,7 @@ template<typename _Tp, _Tp ..._Np, size_t ..._Extra> struct __repeat<__integer_s
 template<size_t _Np> struct __parity;
 template<size_t _Np> struct __make : __parity<_Np % 8>::template __pmake<_Np> {};
 
+// clang-format off
 template<> struct __make<0> { typedef __integer_sequence<size_t> type; };
 template<> struct __make<1> { typedef __integer_sequence<size_t, 0> type; };
 template<> struct __make<2> { typedef __integer_sequence<size_t, 0, 1> type; };
@@ -68,6 +69,7 @@ template<> struct __parity<4> { template<size_t _Np> struct __pmake : __repeat<t
 template<> struct __parity<5> { template<size_t _Np> struct __pmake : __repeat<typename __make<_Np / 8>::type, _Np - 5, _Np - 4, _Np - 3, _Np - 2, _Np - 1> {}; };
 template<> struct __parity<6> { template<size_t _Np> struct __pmake : __repeat<typename __make<_Np / 8>::type, _Np - 6, _Np - 5, _Np - 4, _Np - 3, _Np - 2, _Np - 1> {}; };
 template<> struct __parity<7> { template<size_t _Np> struct __pmake : __repeat<typename __make<_Np / 8>::type, _Np - 7, _Np - 6, _Np - 5, _Np - 4, _Np - 3, _Np - 2, _Np - 1> {}; };
+// clang-format on
 
 } // namespace detail
 

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_BITSET
 #define _LIBCPP_BITSET
 
+// clang-format off
+
 /*
     bitset synopsis
 
@@ -121,6 +123,8 @@ template <size_t N> struct hash<std::bitset<N>>;
 }  // std
 
 */
+
+// clang-format on
 
 #include <__algorithm/count.h>
 #include <__algorithm/fill.h>

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_CHRONO
 #define _LIBCPP_CHRONO
 
+// clang-format off
+
 /*
     chrono synopsis
 
@@ -795,6 +797,8 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 
 }  // std
 */
+
+// clang-format on
 
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__chrono/calendar.h>

--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_MEMORY
 #define _LIBCPP_MEMORY
 
+// clang-format off
+
 /*
     memory synopsis
 
@@ -913,6 +915,8 @@ template<size_t N, class T>
 }  // std
 
 */
+
+// clang-format on
 
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__config>

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -182,12 +182,12 @@ struct __is_std_span<span<_Tp, _Sz>> : true_type {};
 
 template <class _Range, class _ElementType>
 concept __span_compatible_range =
-  ranges::contiguous_range<_Range> &&
-  ranges::sized_range<_Range> &&
-  (ranges::borrowed_range<_Range> || is_const_v<_ElementType>) &&
-  !__is_std_span<remove_cvref_t<_Range>>::value  &&
-  !__is_std_array<remove_cvref_t<_Range>>::value &&
-  !is_array_v<remove_cvref_t<_Range>> &&
+  ranges::contiguous_range<_Range> && //
+  ranges::sized_range<_Range> && //
+  (ranges::borrowed_range<_Range> || is_const_v<_ElementType>) && //
+  !__is_std_span<remove_cvref_t<_Range>>::value  && //
+  !__is_std_array<remove_cvref_t<_Range>>::value && //
+  !is_array_v<remove_cvref_t<_Range>> && //
   is_convertible_v<remove_reference_t<ranges::range_reference_t<_Range>>(*)[], _ElementType(*)[]>;
 
 template <class _From, class _To>

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_SSTREAM
 #define _LIBCPP_SSTREAM
 
+// clang-format off
+
 /*
     sstream synopsis [sstream.syn]
 
@@ -265,6 +267,8 @@ typedef basic_stringstream<wchar_t> wstringstream;
 }  // std
 
 */
+
+// clang-format on
 
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__availability>

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_STRING
 #define _LIBCPP_STRING
 
+// clang-format off
+
 /*
     string synopsis
 
@@ -563,6 +565,8 @@ basic_string<char32_t> operator""s( const char32_t *str, size_t len );          
 }  // std
 
 */
+
+// clang-format on
 
 #include <__algorithm/max.h>
 #include <__algorithm/min.h>

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_STRING_VIEW
 #define _LIBCPP_STRING_VIEW
 
+// clang-format off
+
 /*
 
     string_view synopsis
@@ -199,8 +201,9 @@ namespace std {
 
 }  // namespace std
 
-
 */
+
+// clang-format on
 
 #include <__algorithm/min.h>
 #include <__assert> // all public C++ headers provide the assertion handler

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_TUPLE
 #define _LIBCPP_TUPLE
 
+// clang-format off
+
 /*
     tuple synopsis
 
@@ -200,6 +202,8 @@ template <class... Types>
 }  // std
 
 */
+
+// clang-format on
 
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__compare/common_comparison_category.h>

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_UNORDERED_SET
 #define _LIBCPP_UNORDERED_SET
 
+// clang-format off
+
 /*
 
     unordered_set synopsis
@@ -526,6 +528,8 @@ template <class Value, class Hash, class Pred, class Alloc>
 }  // std
 
 */
+
+// clang-format on
 
 #include <__algorithm/is_permutation.h>
 #include <__assert> // all public C++ headers provide the assertion handler

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -10,6 +10,8 @@
 #ifndef _LIBCPP_VECTOR
 #define _LIBCPP_VECTOR
 
+// clang-format off
+
 /*
     vector synopsis
 
@@ -300,6 +302,8 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 }  // std
 
 */
+
+// clang-format on
 
 #include <__algorithm/copy.h>
 #include <__algorithm/equal.h>

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -1058,6 +1058,7 @@ extern "C" const int ** __ctype_toupper_loc();
 const ctype<char>::mask*
 ctype<char>::classic_table() noexcept
 {
+  // clang-format off
     static constexpr const ctype<char>::mask builtin_table[table_size] = {
         cntrl,                          cntrl,
         cntrl,                          cntrl,
@@ -1132,6 +1133,7 @@ ctype<char>::classic_table() noexcept
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
+  // clang-format on
     return builtin_table;
 }
 #else

--- a/libcxx/utils/generate_escaped_output_table.py
+++ b/libcxx/utils/generate_escaped_output_table.py
@@ -231,7 +231,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 namespace __escaped_output_table {{
+// clang-format off
 {content}
+// clang-format on
 }} // namespace __escaped_output_table
 
 #endif //_LIBCPP_STD_VER >= 23

--- a/libcxx/utils/generate_extended_grapheme_cluster_table.py
+++ b/libcxx/utils/generate_extended_grapheme_cluster_table.py
@@ -112,8 +112,10 @@ DATA_ARRAY_TEMPLATE = """
 /// this approach uses less space for the data and is about 4% faster in the
 /// following benchmark.
 /// libcxx/benchmarks/std_format_spec_string_unicode.bench.cpp
+// clang-format off
 inline constexpr uint32_t __entries[{size}] = {{
 {entries}}};
+// clang-format on
 
 /// Returns the extended grapheme cluster bondary property of a code point.
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr __property __get_property(const char32_t __code_point) noexcept {{


### PR DESCRIPTION
This is in preparation for clang-formatting the whole code base. These annotations are required either to avoid clang-format bugs or because the manually formatted code is significantly more readable than the clang-formatted alternative. All in all, it seems like very few annotations are required, which means that clang-format is doing a very good job in most cases.