### PR TITLE
[scudo] Add hooks to mark the range of realloc

### DIFF
--- a/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
+++ b/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
@@ -23,11 +23,10 @@ __attribute__((weak)) void __scudo_deallocate_hook(void *ptr);
 // `realloc` involves both deallocation and allocation but they are not reported
 // atomically. In one specific case which may keep taking a snapshot right in
 // the middle of `realloc` reporting the deallocation and allocation, it may
-// confuse the user by the missing memory from `realloc`. To alleviate that
-// case, define the two `realloc` hooks to get the knowledge of the bundled hook
-// calls. This hooks are optional and only used when you are pretty likely to
-// hit that specific case. Otherwise, the two general hooks above are pretty
-// sufficient for the most cases.
+// confuse the user by missing memory from `realloc`. To alleviate that case,
+// define the two `realloc` hooks to get the knowledge of the bundled hook
+// calls. These hooks are optional and should only be used when a hooks user
+// wants to track reallocs more closely.
 //
 // See more details in the comment of `realloc` in wrapper_c.inc.
 __attribute__((weak)) void

--- a/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
+++ b/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
@@ -20,6 +20,13 @@ __attribute__((weak)) const char *__scudo_default_options(void);
 __attribute__((weak)) void __scudo_allocate_hook(void *ptr, size_t size);
 __attribute__((weak)) void __scudo_deallocate_hook(void *ptr);
 
+// These hooks are used to mark the scope of doing realloc(). Note that the
+// allocation/deallocation are still reported through the hooks above, this is
+// only used when a hook user wants to know that the allocation/deallocation
+// operations are a single realloc operation.
+__attribute__((weak)) void __scudo_realloc_begin_hook(void *old_ptr);
+__attribute__((weak)) void __scudo_realloc_end_hook(void *old_ptr);
+
 void __scudo_print_stats(void);
 
 typedef void (*iterate_callback)(uintptr_t base, size_t size, void *arg);

--- a/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
@@ -90,7 +90,7 @@ __scudo_realloc_allocate_hook(void *OldPtr, void *NewPtr, size_t Size) {
   // Note that this is only used for testing. In general, only one pair of hooks
   // will be invoked in `realloc`. if __scudo_realloc_*_hook are not defined,
   // it'll call the general hooks only. To make the test easier, we call the
-  // general one here so that either case (wether __scudo_realloc_*_hook are
+  // general one here so that either case (whether __scudo_realloc_*_hook are
   // defined) will be verified without separating them into different tests.
   __scudo_allocate_hook(NewPtr, Size);
 }

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -38,30 +38,6 @@ static void reportReallocEnd(void *old_ptr) {
       __scudo_realloc_end_hook(old_ptr);
 }
 
-static void *reallocImpl(void *ptr, size_t size) {
-  // Given that the reporting of deallocation and allocation are not atomic, we
-  // always pretend the old pointer will be released so that the user doesn't
-  // need to worry about the false double-use case from the view of hooks.
-  //
-  // For example, assume that `realloc` releases the old pointer and allocates a
-  // new pointer. Before the reporting of both operations has been done, another
-  // thread may get the old pointer from `malloc`. It may be misinterpreted as
-  // double-use if it's not handled properly on the hook side.
-  reportDeallocation(ptr);
-  void *NewPtr = SCUDO_ALLOCATOR.reallocate(ptr, size, SCUDO_MALLOC_ALIGNMENT);
-  if (NewPtr != nullptr) {
-    // Note that even if NewPtr == ptr, the size has changed. We still need to
-    // report the new size.
-    reportAllocation(NewPtr, size);
-  } else {
-    // If `realloc` fails, the old pointer is not released. Report the old
-    // pointer as allocated back.
-    reportAllocation(ptr, SCUDO_ALLOCATOR.getAllocSize(ptr));
-  }
-
-  return NewPtr;
-}
-
 extern "C" {
 
 INTERFACE WEAK void *SCUDO_PREFIX(calloc)(size_t nmemb, size_t size) {
@@ -209,9 +185,29 @@ INTERFACE WEAK void *SCUDO_PREFIX(realloc)(void *ptr, size_t size) {
     return nullptr;
   }
 
+  // Mark the range of `SCUDO_ALLOCATOR.reallocate()` so that the hook user
+  // knows the deallocation/allocation are paired.
   reportReallocBegin(ptr);
 
-  void *NewPtr = reallocImpl(ptr, size);
+  // Given that the reporting of deallocation and allocation are not atomic, we
+  // always pretend the old pointer will be released so that the user doesn't
+  // need to worry about the false double-use case from the view of hooks.
+  //
+  // For example, assume that `realloc` releases the old pointer and allocates a
+  // new pointer. Before the reporting of both operations has been done, another
+  // thread may get the old pointer from `malloc`. It may be misinterpreted as
+  // double-use if it's not handled properly on the hook side.
+  reportDeallocation(ptr);
+  void *NewPtr = SCUDO_ALLOCATOR.reallocate(ptr, size, SCUDO_MALLOC_ALIGNMENT);
+  if (NewPtr != nullptr) {
+    // Note that even if NewPtr == ptr, the size has changed. We still need to
+    // report the new size.
+    reportAllocation(NewPtr, size);
+  } else {
+    // If `realloc` fails, the old pointer is not released. Report the old
+    // pointer as allocated back.
+    reportAllocation(ptr, SCUDO_ALLOCATOR.getAllocSize(ptr));
+  }
 
   reportReallocEnd(ptr);
 

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -28,10 +28,12 @@ static void reportDeallocation(void *ptr) {
       __scudo_deallocate_hook(ptr);
 }
 static void reportReallocAllocation(void *old_ptr, void *new_ptr, size_t size) {
+  DCHECK_NE(new_ptr, nullptr);
+
   if (SCUDO_ENABLE_HOOKS) {
     if (__scudo_realloc_allocate_hook)
       __scudo_realloc_allocate_hook(old_ptr, new_ptr, size);
-    else
+    else if (__scudo_allocate_hook)
       __scudo_allocate_hook(new_ptr, size);
   }
 }
@@ -39,7 +41,7 @@ static void reportReallocDeallocation(void *old_ptr) {
   if (SCUDO_ENABLE_HOOKS) {
     if (__scudo_realloc_deallocate_hook)
       __scudo_realloc_deallocate_hook(old_ptr);
-    else
+    else if (__scudo_deallocate_hook)
       __scudo_deallocate_hook(old_ptr);
   }
 }

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -27,6 +27,40 @@ static void reportDeallocation(void *ptr) {
     if (__scudo_deallocate_hook)
       __scudo_deallocate_hook(ptr);
 }
+static void reportReallocBegin(void *old_ptr) {
+  if (SCUDO_ENABLE_HOOKS)
+    if (__scudo_realloc_begin_hook)
+      __scudo_realloc_begin_hook(old_ptr);
+}
+static void reportReallocEnd(void *old_ptr) {
+  if (SCUDO_ENABLE_HOOKS)
+    if (__scudo_realloc_end_hook)
+      __scudo_realloc_end_hook(old_ptr);
+}
+
+static void *reallocImpl(void *ptr, size_t size) {
+  // Given that the reporting of deallocation and allocation are not atomic, we
+  // always pretend the old pointer will be released so that the user doesn't
+  // need to worry about the false double-use case from the view of hooks.
+  //
+  // For example, assume that `realloc` releases the old pointer and allocates a
+  // new pointer. Before the reporting of both operations has been done, another
+  // thread may get the old pointer from `malloc`. It may be misinterpreted as
+  // double-use if it's not handled properly on the hook side.
+  reportDeallocation(ptr);
+  void *NewPtr = SCUDO_ALLOCATOR.reallocate(ptr, size, SCUDO_MALLOC_ALIGNMENT);
+  if (NewPtr != nullptr) {
+    // Note that even if NewPtr == ptr, the size has changed. We still need to
+    // report the new size.
+    reportAllocation(NewPtr, size);
+  } else {
+    // If `realloc` fails, the old pointer is not released. Report the old
+    // pointer as allocated back.
+    reportAllocation(ptr, SCUDO_ALLOCATOR.getAllocSize(ptr));
+  }
+
+  return NewPtr;
+}
 
 extern "C" {
 
@@ -175,25 +209,11 @@ INTERFACE WEAK void *SCUDO_PREFIX(realloc)(void *ptr, size_t size) {
     return nullptr;
   }
 
-  // Given that the reporting of deallocation and allocation are not atomic, we
-  // always pretend the old pointer will be released so that the user doesn't
-  // need to worry about the false double-use case from the view of hooks.
-  //
-  // For example, assume that `realloc` releases the old pointer and allocates a
-  // new pointer. Before the reporting of both operations has been done, another
-  // thread may get the old pointer from `malloc`. It may be misinterpreted as
-  // double-use if it's not handled properly on the hook side.
-  reportDeallocation(ptr);
-  void *NewPtr = SCUDO_ALLOCATOR.reallocate(ptr, size, SCUDO_MALLOC_ALIGNMENT);
-  if (NewPtr != nullptr) {
-    // Note that even if NewPtr == ptr, the size has changed. We still need to
-    // report the new size.
-    reportAllocation(NewPtr, size);
-  } else {
-    // If `realloc` fails, the old pointer is not released. Report the old
-    // pointer as allocated back.
-    reportAllocation(ptr, SCUDO_ALLOCATOR.getAllocSize(ptr));
-  }
+  reportReallocBegin(ptr);
+
+  void *NewPtr = reallocImpl(ptr, size);
+
+  reportReallocEnd(ptr);
 
   return scudo::setErrnoOnNull(NewPtr);
 }

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -27,15 +27,21 @@ static void reportDeallocation(void *ptr) {
     if (__scudo_deallocate_hook)
       __scudo_deallocate_hook(ptr);
 }
-static void reportReallocBegin(void *old_ptr) {
-  if (SCUDO_ENABLE_HOOKS)
-    if (__scudo_realloc_begin_hook)
-      __scudo_realloc_begin_hook(old_ptr);
+static void reportReallocAllocation(void *old_ptr, void *new_ptr, size_t size) {
+  if (SCUDO_ENABLE_HOOKS) {
+    if (__scudo_realloc_allocate_hook)
+      __scudo_realloc_allocate_hook(old_ptr, new_ptr, size);
+    else
+      __scudo_allocate_hook(new_ptr, size);
+  }
 }
-static void reportReallocEnd(void *old_ptr) {
-  if (SCUDO_ENABLE_HOOKS)
-    if (__scudo_realloc_end_hook)
-      __scudo_realloc_end_hook(old_ptr);
+static void reportReallocDeallocation(void *old_ptr) {
+  if (SCUDO_ENABLE_HOOKS) {
+    if (__scudo_realloc_deallocate_hook)
+      __scudo_realloc_deallocate_hook(old_ptr);
+    else
+      __scudo_deallocate_hook(old_ptr);
+  }
 }
 
 extern "C" {
@@ -185,10 +191,6 @@ INTERFACE WEAK void *SCUDO_PREFIX(realloc)(void *ptr, size_t size) {
     return nullptr;
   }
 
-  // Mark the range of `SCUDO_ALLOCATOR.reallocate()` so that the hook user
-  // knows the deallocation/allocation are paired.
-  reportReallocBegin(ptr);
-
   // Given that the reporting of deallocation and allocation are not atomic, we
   // always pretend the old pointer will be released so that the user doesn't
   // need to worry about the false double-use case from the view of hooks.
@@ -197,19 +199,18 @@ INTERFACE WEAK void *SCUDO_PREFIX(realloc)(void *ptr, size_t size) {
   // new pointer. Before the reporting of both operations has been done, another
   // thread may get the old pointer from `malloc`. It may be misinterpreted as
   // double-use if it's not handled properly on the hook side.
-  reportDeallocation(ptr);
+  reportReallocDeallocation(ptr);
   void *NewPtr = SCUDO_ALLOCATOR.reallocate(ptr, size, SCUDO_MALLOC_ALIGNMENT);
   if (NewPtr != nullptr) {
     // Note that even if NewPtr == ptr, the size has changed. We still need to
     // report the new size.
-    reportAllocation(NewPtr, size);
+    reportReallocAllocation(/*OldPtr=*/ptr, NewPtr, size);
   } else {
     // If `realloc` fails, the old pointer is not released. Report the old
-    // pointer as allocated back.
-    reportAllocation(ptr, SCUDO_ALLOCATOR.getAllocSize(ptr));
+    // pointer as allocated again.
+    reportReallocAllocation(/*OldPtr=*/ptr, /*NewPtr=*/ptr,
+                            SCUDO_ALLOCATOR.getAllocSize(ptr));
   }
-
-  reportReallocEnd(ptr);
 
   return scudo::setErrnoOnNull(NewPtr);
 }


### PR DESCRIPTION
`realloc` may involve both allocation and deallocation. Given that the reporting the events is not atomic and which may lead the hook user to a false case that the double-use pattern happens. In general, this can be resolved on the hook side. To alleviate the task of handling it, we add two new hooks to mark the range so that the hook user can combine those calls together.