### PR TITLE
[libc] Fix missing math_extras include

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -190,6 +190,7 @@ add_header_library(
   DEPENDS
     .bit
     .number_pair
+    .math_extras
     libc.src.__support.common
     libc.src.__support.CPP.type_traits
 )

--- a/libc/src/__support/integer_utils.h
+++ b/libc/src/__support/integer_utils.h
@@ -13,6 +13,7 @@
 #include "src/__support/common.h"
 
 #include "bit.h"
+#include "math_extras.h"
 #include "number_pair.h"
 
 #include <stdint.h>


### PR DESCRIPTION
The file integer_utils.h assumes it has access to the add_with_carry
function from math_extras.h, but did not have a direct include for that
file. This caused build errors on arm32 where the indirect include chain
was broken. This patch adds the missing include.
