### PR TITLE
[mlir][mesh] Add missing link lib that breaks shared libs build

### DIFF
--- a/mlir/lib/Dialect/Mesh/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Mesh/IR/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_dialect_library(MLIRMeshDialect
   MLIRArithDialect
   MLIRIR
   MLIRSupport
+  MLIRViewLikeInterface
 )


### PR DESCRIPTION
This fixes the build failure introduced by #73842.