### PR TITLE
[Driver] Mark -arch as TargetSpecific

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -994,7 +994,7 @@ def all__load : Flag<["-"], "all_load">;
 def allowable__client : Separate<["-"], "allowable_client">;
 def ansi : Flag<["-", "--"], "ansi">, Group<CompileOnly_Group>;
 def arch__errors__fatal : Flag<["-"], "arch_errors_fatal">;
-def arch : Separate<["-"], "arch">, Flags<[NoXarchOption]>;
+def arch : Separate<["-"], "arch">, Flags<[NoXarchOption,TargetSpecific]>;
 def arch__only : Separate<["-"], "arch_only">;
 def autocomplete : Joined<["--"], "autocomplete=">;
 def bind__at__load : Flag<["-"], "bind_at_load">;

--- a/clang/test/Driver/arc-exceptions.m
+++ b/clang/test/Driver/arc-exceptions.m
@@ -1,5 +1,5 @@
-// RUN: %clang -### -x objective-c -arch x86_64 -fobjc-arc -fsyntax-only %s 2> %t.log
+// RUN: %clang -### -x objective-c --target=x86_64-apple-macos10.6 -fobjc-arc -fsyntax-only %s 2> %t.log
 // RUN: grep objective-c %t.log
 // RUN: not grep "fobjc-arc-exceptions" %t.log
-// RUN: %clang -### -x objective-c++ -arch x86_64 -fobjc-arc -fsyntax-only %s 2> %t.log
+// RUN: %clang -### -x objective-c++ --target=x86_64-apple-macos10.6 -fobjc-arc -fsyntax-only %s 2> %t.log
 // RUN: grep "fobjc-arc-exceptions" %t.log

--- a/clang/test/Driver/arm-arch-darwin.c
+++ b/clang/test/Driver/arm-arch-darwin.c
@@ -1,6 +1,7 @@
 // On Darwin, arch should override CPU for triple purposes
 // RUN: %clang -target armv7m-apple-darwin -arch armv7m -mcpu=cortex-m4 -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-V7M-DARWIN %s
 // CHECK-V7M-DARWIN: "-cc1"{{.*}} "-triple" "thumbv7m-{{.*}} "-target-cpu" "cortex-m4"
-// RUN: %clang -target armv7m -arch armv7m -mcpu=cortex-m4 -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-V7M-OVERRIDDEN %s
-// CHECK-V7M-OVERRIDDEN: "-cc1"{{.*}} "-triple" "thumbv7em-{{.*}} "-target-cpu" "cortex-m4"
 
+/// -arch is unsupported for non-Darwin targets.
+// RUN: not %clang --target=armv7m -arch armv7m -mcpu=cortex-m4 -### -c %s 2>&1 | FileCheck -check-prefix=ERR %s
+// ERR: unsupported option '-arch' for target 'armv7m'

--- a/clang/test/Frontend/darwin-eabi.c
+++ b/clang/test/Frontend/darwin-eabi.c
@@ -1,6 +1,6 @@
-// RUN: %clang -arch armv6m -dM -E %s | FileCheck %s
-// RUN: %clang -arch armv7m -dM -E %s | FileCheck %s
-// RUN: %clang -arch armv7em -dM -E %s | FileCheck %s
+// RUN: %clang --target=armv6m-apple-darwin -dM -E %s | FileCheck %s
+// RUN: %clang --target=armv7m-apple-darwin -dM -E %s | FileCheck %s
+// RUN: %clang --target=armv7em-apple-darwin -dM -E %s | FileCheck %s
 // RUN: %clang_cc1 -triple thumbv7m-apple-unknown-macho -dM -E %s | FileCheck %s
 
 // CHECK-NOT: __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__


### PR DESCRIPTION
`-arch` is a Darwin-specific option that is ignored for other targets
and not known by GCC.
```
% clang -arch arm64 -c a.c
clang: warning: argument unused during compilation: '-arch arm64' [-Wunused-command-line-argument]
```

We are utilizing TargetSpecific (from https://reviews.llvm.org/D151590)
to make more options lead to errors for unsupported targets.
