### PR TITLE
[libc] fix -Wconversion in float_to_string.h

### DIFF
--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -548,7 +548,7 @@ public:
 
       val = POW10_SPLIT_2[p];
 #endif
-      const int32_t shift_amount = SHIFT_CONST + (-exponent - IDX_SIZE * idx);
+      const int32_t shift_amount = SHIFT_CONST + (-exponent - static_cast<int>(IDX_SIZE) * idx);
       uint32_t digits =
           internal::mul_shift_mod_1e9(mantissa, val, shift_amount);
       return digits;

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -548,7 +548,8 @@ public:
 
       val = POW10_SPLIT_2[p];
 #endif
-      const int32_t shift_amount = SHIFT_CONST + (-exponent - static_cast<int>(IDX_SIZE) * idx);
+      const int32_t shift_amount =
+          SHIFT_CONST + (-exponent - static_cast<int>(IDX_SIZE) * idx);
       uint32_t digits =
           internal::mul_shift_mod_1e9(mantissa, val, shift_amount);
       return digits;


### PR DESCRIPTION
Fixes:
libc/src/__support/float_to_string.h:551:48: error: conversion from ‘long
unsigned int’ to ‘int32_t’ {aka ‘int’} may change value [-Werror=conversion]
  551 |       const int32_t shift_amount = SHIFT_CONST + (-exponent - IDX_SIZE * idx);
      |                                    ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Observed in gcc fullbuilds.

IDX_SIZE is a size_t (aka 'long unsigned int'), but has the value 128, so the
expression is undergoing implicit promotion.

Link: https://lab.llvm.org/buildbot/#/builders/250/builds/14891
