### PR TITLE
[libc] fix HashTable warnings and build problems

### DIFF
--- a/libc/src/__support/HashTable/bitmask.h
+++ b/libc/src/__support/HashTable/bitmask.h
@@ -73,7 +73,7 @@ template <class BitMask> struct IteratableBitMaskAdaptor : public BitMask {
     return *this;
   }
   LIBC_INLINE IteratableBitMaskAdaptor begin() { return *this; }
-  LIBC_INLINE IteratableBitMaskAdaptor end() { return {0}; }
+  LIBC_INLINE IteratableBitMaskAdaptor end() { return {{0}}; }
   LIBC_INLINE bool operator==(const IteratableBitMaskAdaptor &other) {
     return this->word == other.word;
   }

--- a/libc/src/__support/HashTable/bitmask.h
+++ b/libc/src/__support/HashTable/bitmask.h
@@ -73,7 +73,7 @@ template <class BitMask> struct IteratableBitMaskAdaptor : public BitMask {
     return *this;
   }
   LIBC_INLINE IteratableBitMaskAdaptor begin() { return *this; }
-  LIBC_INLINE IteratableBitMaskAdaptor end() { return {{0}}; }
+  LIBC_INLINE IteratableBitMaskAdaptor end() { return {BitMask{0}}; }
   LIBC_INLINE bool operator==(const IteratableBitMaskAdaptor &other) {
     return this->word == other.word;
   }

--- a/libc/src/__support/HashTable/generic/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/generic/bitmask_impl.inc
@@ -98,7 +98,7 @@ struct Group {
     auto cmp = data ^ repeat_byte(byte);
     auto result = LIBC_NAMESPACE::Endian::to_little_endian(
         (cmp - repeat_byte(0x01)) & ~cmp & repeat_byte(0x80));
-    return {{result}};
+    return {BitMask{result}};
   }
 
   // Find out the lanes equal to EMPTY or DELETE (highest bit set) and

--- a/libc/src/__support/HashTable/generic/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/generic/bitmask_impl.inc
@@ -98,7 +98,7 @@ struct Group {
     auto cmp = data ^ repeat_byte(byte);
     auto result = LIBC_NAMESPACE::Endian::to_little_endian(
         (cmp - repeat_byte(0x01)) & ~cmp & repeat_byte(0x80));
-    return {result};
+    return {{result}};
   }
 
   // Find out the lanes equal to EMPTY or DELETE (highest bit set) and

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -181,4 +181,12 @@ add_subdirectory(File)
 add_subdirectory(RPC)
 add_subdirectory(OSUtil)
 add_subdirectory(FPUtil)
-add_subdirectory(HashTable)
+
+list(FIND TARGET_ENTRYPOINT_NAME_LIST hsearch hsearch_index)
+list(FIND TARGET_ENTRYPOINT_NAME_LIST hsearch_r hsearch_r_index)
+
+if (${hsearch_index} EQUAL -1 AND ${hsearch_r_index} EQUAL -1)
+  message(STATUS "Skipping HashTable tests since hsearch and hsearch_r are not built.")
+else()
+  add_subdirectory(HashTable)
+endif()

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -181,12 +181,4 @@ add_subdirectory(File)
 add_subdirectory(RPC)
 add_subdirectory(OSUtil)
 add_subdirectory(FPUtil)
-
-list(FIND TARGET_ENTRYPOINT_NAME_LIST hsearch hsearch_index)
-list(FIND TARGET_ENTRYPOINT_NAME_LIST hsearch_r hsearch_r_index)
-
-if (${hsearch_index} EQUAL -1 AND ${hsearch_r_index} EQUAL -1)
-  message(STATUS "Skipping HashTable tests since hsearch and hsearch_r are not built.")
-else()
-  add_subdirectory(HashTable)
-endif()
+add_subdirectory(HashTable)

--- a/libc/test/src/__support/HashTable/CMakeLists.txt
+++ b/libc/test/src/__support/HashTable/CMakeLists.txt
@@ -6,6 +6,7 @@ add_libc_test(
     bitmask_test.cpp
   DEPENDS
     libc.src.__support.HashTable.bitmask
+    libc.src.search.hsearch
 )
 
 add_libc_test(
@@ -18,6 +19,7 @@ add_libc_test(
     libc.src.__support.HashTable.randomness
     libc.src.__support.HashTable.table
     libc.src.__support.common
+    libc.src.search.hsearch
   UNIT_TEST_ONLY
 )
 
@@ -30,4 +32,5 @@ add_libc_test(
   DEPENDS
     libc.src.__support.HashTable.bitmask
     libc.src.stdlib.rand
+    libc.src.search.hsearch
 )


### PR DESCRIPTION
According to https://lab.llvm.org/buildbot/#/builders/163/builds/48002, the generic build on HashTable fails with two major issues with `werror`:
1. warnings on `error: suggest braces around initialization of subobject`.
2. `__support/HashTable` tests are built regardless of its entrypoints`

This PR attempts to fix such issues.