### PR TITLE
[flang][driver] Rename `flang-new` as `flang`

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1948,7 +1948,7 @@ void Driver::PrintHelp(bool ShowHidden) const {
 
 void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   if (IsFlangMode()) {
-    OS << getClangToolFullVersion("flang-new") << '\n';
+    OS << getClangToolFullVersion("flang") << '\n';
   } else {
     // FIXME: The following handlers should use a callback mechanism, we don't
     // know what the client would like to do.

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -310,6 +310,9 @@ static const DriverSuffix *FindDriverSuffix(StringRef ProgName, size_t &Pos) {
       {"cl", "--driver-mode=cl"},
       {"++", "--driver-mode=g++"},
       {"flang", "--driver-mode=flang"},
+      // For backwards compatibility, we create a symlink for `flang` called
+      // `flang-new`. This will be removed in the future.
+      {"flang-new", "--driver-mode=flang"},
       {"clang-dxc", "--driver-mode=dxc"},
   };
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -768,14 +768,16 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   CmdArgs.push_back(Input.getFilename());
 
-  // TODO: Replace flang-new with flang once the new driver replaces the
-  // throwaway driver
-  const char *Exec = Args.MakeArgString(D.GetProgramPath("flang-new", TC));
+  // Get the name of this executable. The `getClangProgramPath` hook predates
+  // Flang, hence the name assumes that it's a Clang program. In practice, it
+  // can be any program (e.g. a Flang program) implemented in terms of
+  // `clangDriver`.
+  const char *Exec = D.getClangProgramPath();
   C.addCommand(std::make_unique<Command>(JA, *this,
                                          ResponseFileSupport::AtFileUTF8(),
                                          Exec, CmdArgs, Inputs, Output));
 }
 
-Flang::Flang(const ToolChain &TC) : Tool("flang-new", "flang frontend", TC) {}
+Flang::Flang(const ToolChain &TC) : Tool("flang", "flang frontend", TC) {}
 
 Flang::~Flang() {}

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -768,11 +768,7 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   CmdArgs.push_back(Input.getFilename());
 
-  // Get the name of this executable. The `getClangProgramPath` hook predates
-  // Flang, hence the name assumes that it's a Clang program. In practice, it
-  // can be any program (e.g. a Flang program) implemented in terms of
-  // `clangDriver`.
-  const char *Exec = D.getClangProgramPath();
+  const char *Exec = Args.MakeArgString(D.GetProgramPath("flang", TC));
   C.addCommand(std::make_unique<Command>(JA, *this,
                                          ResponseFileSupport::AtFileUTF8(),
                                          Exec, CmdArgs, Inputs, Output));

--- a/clang/test/Driver/flang/flang.f90
+++ b/clang/test/Driver/flang/flang.f90
@@ -13,7 +13,7 @@
 ! * (no type specified, resulting in an object file)
 
 ! All invocations should begin with flang -fc1, consume up to here.
-! ALL-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! ALL-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 
 ! Check that f90 files are not treated as "previously preprocessed"
 ! ... in --driver-mode=flang.

--- a/clang/test/Driver/flang/flang_ucase.F90
+++ b/clang/test/Driver/flang/flang_ucase.F90
@@ -13,7 +13,7 @@
 ! * (no type specified, resulting in an object file)
 
 ! All invocations should begin with flang -fc1, consume up to here.
-! ALL-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! ALL-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 
 ! Check that f90 files are not treated as "previously preprocessed"
 ! ... in --driver-mode=flang.

--- a/clang/test/Driver/flang/multiple-inputs-mixed.f90
+++ b/clang/test/Driver/flang/multiple-inputs-mixed.f90
@@ -1,7 +1,7 @@
 ! Check that flang can handle mixed C and fortran inputs.
 
 ! RUN: %clang --driver-mode=flang -### -fsyntax-only %S/Inputs/one.f90 %S/Inputs/other.c 2>&1 | FileCheck --check-prefixes=CHECK-SYNTAX-ONLY %s
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/one.f90"
 ! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}clang{{[^"/]*}}" "-cc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/other.c"

--- a/clang/test/Driver/flang/multiple-inputs.f90
+++ b/clang/test/Driver/flang/multiple-inputs.f90
@@ -1,7 +1,7 @@
 ! Check that flang driver can handle multiple inputs at once.
 
 ! RUN: %clang --driver-mode=flang -### -fsyntax-only %S/Inputs/one.f90 %S/Inputs/two.f90 2>&1 | FileCheck --check-prefixes=CHECK-SYNTAX-ONLY %s
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/one.f90"
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/two.f90"

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -18,6 +18,10 @@ There are two main drivers in Flang:
 * the compiler driver, `flang`
 * the frontend driver, `flang -fc1`
 
+**_NOTE:_** The driver binary used to be called `flang-new`. For backwards
+compatibility, there is a symlink called `flang-new` that points at `flang`.
+This will be removed in the future.
+
 The **compiler driver** will allow you to control all compilation phases (e.g.
 preprocessing, semantic checks, code-generation, code-optimisation, lowering
 and linking). For frontend specific tasks, the compiler driver creates a
@@ -200,11 +204,7 @@ words, `flang -fc1 <input-file>` is equivalent to `flang -fc1 -fsyntax-only
 
 ## The `flang-to-external-fc` script
 The `flang-to-external-fc` wrapper script for `flang` was introduced as a
-development tool and to facilitate testing. While code-generation is not
-available in Flang, you can use it as a drop-in replacement for other Fortran
-compilers in your build scripts.
-
-The `flang-to-external-fc` wrapper script will:
+development tool and to facilitate testing. In particular, it will:
 * use `flang` to unparse the input source file (i.e. it will run `flang -fc1
   -fdebug-unparse <input-file>`), and then
 * call a host Fortran compiler, e.g. `gfortran`, to compile the unparsed file.

--- a/flang/docs/ImplementingASemanticCheck.md
+++ b/flang/docs/ImplementingASemanticCheck.md
@@ -68,7 +68,7 @@ of the call to `intentOutFunc()`:
 
 I also used this program to produce a parse tree for the program using the command:
 ```bash
-  flang-new -fc1 -fdebug-dump-parse-tree testfun.f90
+  flang -fc1 -fdebug-dump-parse-tree testfun.f90
 ```
 
 Here's the relevant fragment of the parse tree produced by the compiler:
@@ -296,7 +296,7 @@ In `lib/Semantics/check-do.cpp`, I added an (almost empty) implementation:
 I then built the compiler with these changes and ran it on my test program.
 This time, I made sure to invoke semantic checking.  Here's the command I used:
 ```bash
-  flang-new -fc1 -fdebug-unparse-with-symbols testfun.f90
+  flang -fc1 -fdebug-unparse-with-symbols testfun.f90
 ```
 
 This produced the output:

--- a/flang/docs/Overview.md
+++ b/flang/docs/Overview.md
@@ -65,8 +65,8 @@ See [Preprocessing.md](Preprocessing.md).
 **Entry point:** `parser::Parsing::Prescan`
 
 **Commands:** 
- - `flang-new -fc1 -E src.f90` dumps the cooked character stream
- - `flang-new -fc1 -fdebug-dump-provenance src.f90` dumps provenance
+ - `flang -fc1 -E src.f90` dumps the cooked character stream
+ - `flang -fc1 -fdebug-dump-provenance src.f90` dumps provenance
    information
 
 ## Parsing
@@ -80,10 +80,10 @@ representing a syntactically correct program, rooted at the program unit.  See:
 **Entry point:** `parser::Parsing::Parse`
 
 **Commands:**
-  - `flang-new -fc1 -fdebug-dump-parse-tree-no-sema src.f90` dumps the parse tree
-  - `flang-new -fc1 -fdebug-unparse src.f90` converts the parse tree to normalized Fortran
-  - `flang-new -fc1 -fdebug-dump-parsing-log src.f90` runs an instrumented parse and dumps the log
-  - `flang-new -fc1 -fdebug-measure-parse-tree src.f90` measures the parse tree
+  - `flang -fc1 -fdebug-dump-parse-tree-no-sema src.f90` dumps the parse tree
+  - `flang -fc1 -fdebug-unparse src.f90` converts the parse tree to normalized Fortran
+  - `flang -fc1 -fdebug-dump-parsing-log src.f90` runs an instrumented parse and dumps the log
+  - `flang -fc1 -fdebug-measure-parse-tree src.f90` measures the parse tree
 
 ## Semantic processing
 

--- a/flang/examples/FlangOmpReport/FlangOmpReport.cpp
+++ b/flang/examples/FlangOmpReport/FlangOmpReport.cpp
@@ -9,7 +9,7 @@
 // all the OpenMP constructs and clauses and which line they're located on.
 //
 // The plugin may be invoked as:
-// ./bin/flang-new -fc1 -load lib/flangOmpReport.so -plugin flang-omp-report
+// ./bin/flang -fc1 -load lib/flangOmpReport.so -plugin flang-omp-report
 // -fopenmp
 //
 //===----------------------------------------------------------------------===//

--- a/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -152,8 +152,7 @@ bool executeCompilerInvocation(CompilerInstance *flang) {
   // Honor -help.
   if (flang->getFrontendOpts().showHelp) {
     clang::driver::getDriverOptTable().printHelp(
-        llvm::outs(), "flang-new -fc1 [options] file...",
-        "LLVM 'Flang' Compiler",
+        llvm::outs(), "flang -fc1 [options] file...", "LLVM 'Flang' Compiler",
         /*ShowHidden=*/false, /*ShowAllAliases=*/false,
         llvm::opt::Visibility(clang::driver::options::FC1Option));
     return true;

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -48,7 +48,7 @@ set(FLANG_TEST_PARAMS
   flang_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)
 
 set(FLANG_TEST_DEPENDS
-  flang-new
+  flang
   llvm-config
   FileCheck
   count

--- a/flang/test/Driver/compiler-options.f90
+++ b/flang/test/Driver/compiler-options.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -S -emit-llvm -flang-deprecated-no-hlfir -o - %s | FileCheck %s
 ! Test communication of COMPILER_OPTIONS from flang-new to flang-new -fc1.
-! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
+! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang{{(\.exe)?}} -S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/disable-ext-name-interop.f90
+++ b/flang/test/Driver/disable-ext-name-interop.f90
@@ -1,4 +1,4 @@
-! Test that we can disable the ExternalNameConversion pass in flang-new.
+! Test that we can disable the ExternalNameConversion pass in flang.
 
 ! RUN: %flang_fc1 -S %s -o - 2>&1 | FileCheck %s --check-prefix=EXTNAMES
 ! RUN: %flang_fc1 -S -mmlir -disable-external-name-interop %s -o - 2>&1 | FileCheck %s --check-prefix=INTNAMES

--- a/flang/test/Driver/driver-help-hidden.f90
+++ b/flang/test/Driver/driver-help-hidden.f90
@@ -1,17 +1,17 @@
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang --help-hidden 2>&1 | FileCheck %s
 ! RUN: not %flang  -help-hidden 2>&1 | FileCheck %s --check-prefix=ERROR-FLANG
 
 !----------------------------------------
-! FLANG FRONTEND DRIVER (flang-new -fc1)
+! FLANG FRONTEND DRIVER (flang -fc1)
 !----------------------------------------
 ! RUN: not %flang_fc1 --help-hidden 2>&1 | FileCheck %s --check-prefix=ERROR-FLANG-FC1
 ! RUN: not %flang_fc1  -help-hidden 2>&1 | FileCheck %s --check-prefix=ERROR-FLANG-FC1
 
-! CHECK:USAGE: flang-new
+! CHECK:USAGE: flang
 ! CHECK-EMPTY:
 ! CHECK-NEXT: DRIVER OPTIONS:
 ! CHECK-NEXT:  --driver-mode=<value> Set the driver mode to either 'gcc', 'g++', 'cpp', 'cl' or 'flang'

--- a/flang/test/Driver/driver-version.f90
+++ b/flang/test/Driver/driver-version.f90
@@ -4,12 +4,12 @@
 ! RUN: %flang_fc1 -version 2>&1 | FileCheck %s --check-prefix=VERSION-FC1
 ! RUN: not %flang_fc1 --version 2>&1 | FileCheck %s --check-prefix=ERROR-FC1
 
-! VERSION: flang-new version
+! VERSION: flang version
 ! VERSION-NEXT: Target:
 ! VERSION-NEXT: Thread model:
 ! VERSION-NEXT: InstalledDir:
 
-! ERROR: flang-new: error: unknown argument '--versions'; did you mean '--version'?
+! ERROR: flang-{{[0-9]+}}: error: unknown argument '--versions'; did you mean '--version'?
 
 ! VERSION-FC1: LLVM version
 

--- a/flang/test/Driver/driver-version.f90
+++ b/flang/test/Driver/driver-version.f90
@@ -9,7 +9,7 @@
 ! VERSION-NEXT: Thread model:
 ! VERSION-NEXT: InstalledDir:
 
-! ERROR: flang-{{[0-9]+}}: error: unknown argument '--versions'; did you mean '--version'?
+! ERROR: flang{{.*}}: error: unknown argument '--versions'; did you mean '--version'?
 
 ! VERSION-FC1: LLVM version
 

--- a/flang/test/Driver/escaped-backslash.f90
+++ b/flang/test/Driver/escaped-backslash.f90
@@ -1,14 +1,14 @@
 ! Ensure argument -fbackslash works as expected.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -E %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang -E -fbackslash -fno-backslash %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang -E -fbackslash %s  2>&1 | FileCheck %s --check-prefix=UNESCAPED
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang_fc1 -E -fbackslash -fno-backslash %s  2>&1 | FileCheck %s --check-prefix=ESCAPED

--- a/flang/test/Driver/fdefault.f90
+++ b/flang/test/Driver/fdefault.f90
@@ -2,25 +2,25 @@
 ! TODO: Add checks when actual codegen is possible for this family
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOOPTION
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=REAL8
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=DOUBLE8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOOPTION
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=REAL8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=DOUBLE8
 ! RUN: not %flang -fsyntax-only -fdefault-double-8 %s  2>&1 | FileCheck %s --check-prefix=ERROR
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOOPTION
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=REAL8
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=DOUBLE8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOOPTION
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=REAL8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=DOUBLE8
 ! RUN: not %flang_fc1 -fsyntax-only -fdefault-double-8 %s  2>&1 | FileCheck %s --check-prefix=ERROR
 
 ! NOOPTION: integer(4),parameter::real_kind=4_4

--- a/flang/test/Driver/flarge-sizes.f90
+++ b/flang/test/Driver/flarge-sizes.f90
@@ -2,20 +2,20 @@
 ! TODO: Add checks when actual codegen is possible.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOLARGE
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -flarge-sizes -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=LARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOLARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -flarge-sizes -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=LARGE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOLARGE
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -flarge-sizes -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=LARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOLARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -flarge-sizes -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=LARGE
 
 ! NOLARGE: real(4)::z(1_8:10_8)
 ! NOLARGE-NEXT: integer(4),parameter::size_kind=4_4

--- a/flang/test/Driver/frontend-forwarding.f90
+++ b/flang/test/Driver/frontend-forwarding.f90
@@ -1,5 +1,5 @@
-! Test that flang-new forwards Flang frontend
-! options to flang-new -fc1 as expected.
+! Test that flang forwards Flang frontend
+! options to flang -fc1 as expected.
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
 ! RUN:     -finput-charset=utf-8 \

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -4,7 +4,7 @@
 ! default one, causing a CHECKSUM error.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty --check-prefix=WITHOUT
 ! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=GIVEN

--- a/flang/test/Driver/lto-flags.f90
+++ b/flang/test/Driver/lto-flags.f90
@@ -30,7 +30,7 @@
 ! FULL-LTO: "-fc1"
 ! FULL-LTO-SAME: "-flto=full"
 
-! THIN-LTO-ALL: flang-new: warning: the option '-flto=thin' is a work in progress
+! THIN-LTO-ALL: flang-{{[0-9]+}}: warning: the option '-flto=thin' is a work in progress
 ! THIN-LTO-ALL: "-fc1"
 ! THIN-LTO-ALL-SAME: "-flto=thin"
 ! THIN-LTO-LINKER-PLUGIN: "-plugin-opt=thinlto"

--- a/flang/test/Driver/lto-flags.f90
+++ b/flang/test/Driver/lto-flags.f90
@@ -30,7 +30,7 @@
 ! FULL-LTO: "-fc1"
 ! FULL-LTO-SAME: "-flto=full"
 
-! THIN-LTO-ALL: flang-{{[0-9]+}}: warning: the option '-flto=thin' is a work in progress
+! THIN-LTO-ALL: warning: the option '-flto=thin' is a work in progress
 ! THIN-LTO-ALL: "-fc1"
 ! THIN-LTO-ALL-SAME: "-flto=thin"
 ! THIN-LTO-LINKER-PLUGIN: "-plugin-opt=thinlto"

--- a/flang/test/Driver/macro-def-undef.F90
+++ b/flang/test/Driver/macro-def-undef.F90
@@ -1,14 +1,14 @@
 ! Ensure arguments -D and -U work as expected.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -E -P %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 ! RUN: %flang -E -P -DX=A %s  2>&1 | FileCheck %s --check-prefix=DEFINED
 ! RUN: %flang -E -P -DX=A -UX %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E -P %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 ! RUN: %flang_fc1 -E -P -DX=A %s  2>&1 | FileCheck %s --check-prefix=DEFINED

--- a/flang/test/Driver/missing-input.f90
+++ b/flang/test/Driver/missing-input.f90
@@ -1,26 +1,26 @@
 ! Test the behaviour of the driver when input is missing or is invalid. Note
-! that with the compiler driver (flang-new), the input _has_ to be specified.
+! that with the compiler driver (flang), the input _has_ to be specified.
 ! Indeed, the driver decides what "job/command" to create based on the input
 ! file's extension. No input file means that it doesn't know what to do
-! (compile?  preprocess? link?). The frontend driver (flang-new -fc1) simply
+! (compile?  preprocess? link?). The frontend driver (flang -fc1) simply
 ! assumes that "no explicit input == read from stdin"
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: not %flang  2>&1 | FileCheck %s --check-prefix=FLANG-NO-FILE
 ! RUN: not %flang %t.f90 2>&1 | FileCheck %s --check-prefix=FLANG-NONEXISTENT-FILE
 
 !-----------------------------------------
-! FLANG FRONTEND DRIVER (flang-new -fc1)
+! FLANG FRONTEND DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 %t.f90 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-NONEXISTENT-FILE
 ! RUN: not %flang_fc1 %S 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-DIR
 
-! FLANG-NO-FILE: flang-new: error: no input files
+! FLANG-NO-FILE: flang-{{[0-9]+}}: error: no input files
 
-! FLANG-NONEXISTENT-FILE: flang-new: error: no such file or directory: {{.*}}
-! FLANG-NONEXISTENT-FILE: flang-new: error: no input files
+! FLANG-NONEXISTENT-FILE: error: no such file or directory: {{.*}}
+! FLANG-NONEXISTENT-FILE: error: no input files
 
 ! FLANG-FC1-NONEXISTENT-FILE: error: {{.*}} does not exist
 ! FLANG-FC1-DIR: error: {{.*}} is not a regular file

--- a/flang/test/Driver/missing-input.f90
+++ b/flang/test/Driver/missing-input.f90
@@ -17,7 +17,7 @@
 ! RUN: not %flang_fc1 %t.f90 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-NONEXISTENT-FILE
 ! RUN: not %flang_fc1 %S 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-DIR
 
-! FLANG-NO-FILE: flang-{{[0-9]+}}: error: no input files
+! FLANG-NO-FILE: flang{{.*}}: error: no input files
 
 ! FLANG-NONEXISTENT-FILE: error: no such file or directory: {{.*}}
 ! FLANG-NONEXISTENT-FILE: error: no input files

--- a/flang/test/Driver/multiple-input-files.f90
+++ b/flang/test/Driver/multiple-input-files.f90
@@ -39,7 +39,7 @@
 ! FLANG-NEXT:end program hello
 
 ! TEST 2: `-o` does not when multiple input files are present
-! ERROR: flang-new: error: cannot specify -o when generating multiple output files
+! ERROR: flang-{{[0-9]+}}: error: cannot specify -o when generating multiple output files
 
 ! TEST 3: The output file _was not_ specified - `flang_fc1` will process all
 ! input files and generate one output file for every input file.

--- a/flang/test/Driver/multiple-input-files.f90
+++ b/flang/test/Driver/multiple-input-files.f90
@@ -39,7 +39,7 @@
 ! FLANG-NEXT:end program hello
 
 ! TEST 2: `-o` does not when multiple input files are present
-! ERROR: flang-{{[0-9]+}}: error: cannot specify -o when generating multiple output files
+! ERROR: flang{{.*}}: error: cannot specify -o when generating multiple output files
 
 ! TEST 3: The output file _was not_ specified - `flang_fc1` will process all
 ! input files and generate one output file for every input file.

--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -1,6 +1,6 @@
-! Test that flang-new OpenMP and OpenMP offload related 
+! Test that flang-{{[0-9]+}} OpenMP and OpenMP offload related 
 ! commands forward or expand to the appropriate commands 
-! for flang-new -fc1 as expected. Assumes a gfx90a, aarch64,
+! for flang-{{[0-9]+}} -fc1 as expected. Assumes a gfx90a, aarch64,
 ! and sm_70 architecture, but doesn't require one to be 
 ! installed or compiled for, just testing the appropriate 
 ! generation of jobs are created with the correct 
@@ -8,8 +8,8 @@
 
 ! Test regular -fopenmp with no offload
 ! RUN: %flang -### -fopenmp %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP %s
-! CHECK-OPENMP: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
-! CHECK-OPENMP-NOT: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
+! CHECK-OPENMP-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Test regular -fopenmp with offload, and invocation filtering options
 ! RUN: %flang -S -### %s -o %t 2>&1 \
@@ -22,44 +22,44 @@
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST-AND-DEVICE
 
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-host-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST
 
-! OFFLOAD-HOST: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! OFFLOAD-HOST-NOT: "-triple" "amdgcn-amd-amdhsa"
 ! OFFLOAD-HOST-NOT: "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-device-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-DEVICE
 
-! OFFLOAD-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! Test regular -fopenmp with offload for basic fopenmp-is-target-device flag addition and correct fopenmp 
 ! RUN: %flang -### -fopenmp --offload-arch=gfx90a -fopenmp-targets=amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
-! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Testing appropriate flags are gnerated and appropriately assigned by the driver when offloading
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OPENMP-OFFLOAD-ARGS
-! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
 ! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}clang-offload-packager{{.*}}" {{.*}} "--image=file={{.*}}.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=openmp"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
 
 ! Test -fopenmp with offload for RTL Flag Options
 ! RUN: %flang -### %s -o %t 2>&1 \
@@ -72,7 +72,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-threads-oversubscription \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
-! CHECK-THREADS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
+! CHECK-THREADS-OVS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -84,7 +84,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-teams-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
-! CHECK-TEAMS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
+! CHECK-TEAMS-OVS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -96,7 +96,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-nested-parallelism  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
-! CHECK-NEST-PAR: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
+! CHECK-NEST-PAR: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -108,7 +108,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
-! CHECK-THREAD-STATE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
+! CHECK-THREAD-STATE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -120,7 +120,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
+! CHECK-TARGET-DEBUG: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -132,7 +132,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
+! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -148,7 +148,7 @@
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-RTL-ALL
-! CHECK-RTL-ALL: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
+! CHECK-RTL-ALL: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
 ! CHECK-RTL-ALL: {{.*}}.f90"
 
@@ -162,7 +162,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-version=45 \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
-! CHECK-OPENMP-VERSION: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
+! CHECK-OPENMP-VERSION: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
 
 ! Test diagnostic error when host IR file is non-existent 
 ! RUN: not %flang_fc1 %s -o %t 2>&1 -fopenmp -fopenmp-is-target-device \

--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -8,8 +8,8 @@
 
 ! Test regular -fopenmp with no offload
 ! RUN: %flang -### -fopenmp %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP %s
-! CHECK-OPENMP: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
-! CHECK-OPENMP-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP: "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
+! CHECK-OPENMP-NOT: "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Test regular -fopenmp with offload, and invocation filtering options
 ! RUN: %flang -S -### %s -o %t 2>&1 \
@@ -22,44 +22,44 @@
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST-AND-DEVICE
 
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE-NEXT:  "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-HOST-AND-DEVICE-NEXT:  "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-HOST-AND-DEVICE:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-host-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST
 
-! OFFLOAD-HOST: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! OFFLOAD-HOST-NOT: "-triple" "amdgcn-amd-amdhsa"
 ! OFFLOAD-HOST-NOT: "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-NOT:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-device-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-DEVICE
 
-! OFFLOAD-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE-NEXT:  "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-DEVICE-NEXT:  "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-DEVICE-NOT:  "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! Test regular -fopenmp with offload for basic fopenmp-is-target-device flag addition and correct fopenmp 
 ! RUN: %flang -### -fopenmp --offload-arch=gfx90a -fopenmp-targets=amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
-! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP-IS-TARGET-DEVICE:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Testing appropriate flags are gnerated and appropriately assigned by the driver when offloading
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OPENMP-OFFLOAD-ARGS
-! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS:  "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS-NEXT:  "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
 ! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}clang-offload-packager{{.*}}" {{.*}} "--image=file={{.*}}.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=openmp"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
+! OPENMP-OFFLOAD-ARGS-NEXT:  "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
 
 ! Test -fopenmp with offload for RTL Flag Options
 ! RUN: %flang -### %s -o %t 2>&1 \
@@ -72,7 +72,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-threads-oversubscription \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
-! CHECK-THREADS-OVS: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
+! CHECK-THREADS-OVS:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -84,7 +84,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-teams-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
-! CHECK-TEAMS-OVS: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
+! CHECK-TEAMS-OVS:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -96,7 +96,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-nested-parallelism  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
-! CHECK-NEST-PAR: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
+! CHECK-NEST-PAR:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -108,7 +108,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
-! CHECK-THREAD-STATE: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
+! CHECK-THREAD-STATE:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -120,7 +120,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
+! CHECK-TARGET-DEBUG:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -132,7 +132,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
+! CHECK-TARGET-DEBUG-EQ:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -148,7 +148,7 @@
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-RTL-ALL
-! CHECK-RTL-ALL: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
+! CHECK-RTL-ALL:  "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
 ! CHECK-RTL-ALL: {{.*}}.f90"
 
@@ -162,7 +162,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-version=45 \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
-! CHECK-OPENMP-VERSION: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
+! CHECK-OPENMP-VERSION:  "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
 
 ! Test diagnostic error when host IR file is non-existent 
 ! RUN: not %flang_fc1 %s -o %t 2>&1 -fopenmp -fopenmp-is-target-device \

--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -1,6 +1,6 @@
-! Test that flang-{{[0-9]+}} OpenMP and OpenMP offload related 
+! Test that flang OpenMP and OpenMP offload related 
 ! commands forward or expand to the appropriate commands 
-! for flang-{{[0-9]+}} -fc1 as expected. Assumes a gfx90a, aarch64,
+! for flang -fc1 as expected. Assumes a gfx90a, aarch64,
 ! and sm_70 architecture, but doesn't require one to be 
 ! installed or compiled for, just testing the appropriate 
 ! generation of jobs are created with the correct 
@@ -8,8 +8,8 @@
 
 ! Test regular -fopenmp with no offload
 ! RUN: %flang -### -fopenmp %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP %s
-! CHECK-OPENMP: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
-! CHECK-OPENMP-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
+! CHECK-OPENMP-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Test regular -fopenmp with offload, and invocation filtering options
 ! RUN: %flang -S -### %s -o %t 2>&1 \
@@ -22,44 +22,44 @@
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST-AND-DEVICE
 
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-host-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST
 
-! OFFLOAD-HOST: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! OFFLOAD-HOST-NOT: "-triple" "amdgcn-amd-amdhsa"
 ! OFFLOAD-HOST-NOT: "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-device-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-DEVICE
 
-! OFFLOAD-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! Test regular -fopenmp with offload for basic fopenmp-is-target-device flag addition and correct fopenmp 
 ! RUN: %flang -### -fopenmp --offload-arch=gfx90a -fopenmp-targets=amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
-! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Testing appropriate flags are gnerated and appropriately assigned by the driver when offloading
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OPENMP-OFFLOAD-ARGS
-! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-fopenmp" {{.*}} "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device" {{.*}}.f90"
 ! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}clang-offload-packager{{.*}}" {{.*}} "--image=file={{.*}}.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=openmp"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang{{.*}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
 
 ! Test -fopenmp with offload for RTL Flag Options
 ! RUN: %flang -### %s -o %t 2>&1 \
@@ -72,7 +72,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-threads-oversubscription \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
-! CHECK-THREADS-OVS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
+! CHECK-THREADS-OVS: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -84,7 +84,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-teams-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
-! CHECK-TEAMS-OVS: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
+! CHECK-TEAMS-OVS: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -96,7 +96,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-nested-parallelism  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
-! CHECK-NEST-PAR: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
+! CHECK-NEST-PAR: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -108,7 +108,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
-! CHECK-THREAD-STATE: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
+! CHECK-THREAD-STATE: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -120,7 +120,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
+! CHECK-TARGET-DEBUG: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -132,7 +132,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
+! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -148,7 +148,7 @@
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-RTL-ALL
-! CHECK-RTL-ALL: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
+! CHECK-RTL-ALL: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
 ! CHECK-RTL-ALL: {{.*}}.f90"
 
@@ -162,7 +162,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-version=45 \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
-! CHECK-OPENMP-VERSION: "{{[^"]*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
+! CHECK-OPENMP-VERSION: "{{[^"]*}}flang{{.*}}" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
 
 ! Test diagnostic error when host IR file is non-existent 
 ! RUN: not %flang_fc1 %s -o %t 2>&1 -fopenmp -fopenmp-is-target-device \

--- a/flang/test/Driver/predefined-macros-compiler-version.F90
+++ b/flang/test/Driver/predefined-macros-compiler-version.F90
@@ -1,12 +1,12 @@
 ! Check that the driver correctly defines macros with the compiler version
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --ignore-case
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --ignore-case
 

--- a/flang/test/Driver/std2018-wrong.f90
+++ b/flang/test/Driver/std2018-wrong.f90
@@ -1,7 +1,7 @@
 ! Ensure argument -std=f2018 works as expected.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 -std=90 %s  2>&1 | FileCheck %s --check-prefix=WRONG
 

--- a/flang/test/Driver/std2018.f90
+++ b/flang/test/Driver/std2018.f90
@@ -1,7 +1,7 @@
 ! Ensure argument -std=f2018 works as expected.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty --check-prefix=WITHOUT
 ! RUN: %flang_fc1 -fsyntax-only -std=f2018 %s  2>&1 | FileCheck %s --check-prefix=GIVEN

--- a/flang/test/Driver/supported-suffices/f03-suffix.f03
+++ b/flang/test/Driver/supported-suffices/f03-suffix.f03
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang{{.*}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f03
 end program f03

--- a/flang/test/Driver/supported-suffices/f03-suffix.f03
+++ b/flang/test/Driver/supported-suffices/f03-suffix.f03
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-new" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f03
 end program f03

--- a/flang/test/Driver/supported-suffices/f08-suffix.f08
+++ b/flang/test/Driver/supported-suffices/f08-suffix.f08
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang{{.*}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f08
 end program f08

--- a/flang/test/Driver/supported-suffices/f08-suffix.f08
+++ b/flang/test/Driver/supported-suffices/f08-suffix.f08
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-new" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f08
 end program f08

--- a/flang/test/Driver/use-module-error.f90
+++ b/flang/test/Driver/use-module-error.f90
@@ -1,14 +1,14 @@
 ! Ensure that multiple module directories are not allowed
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: not %flang -fsyntax-only -J %S/Inputs/module-dir -J %S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang -fsyntax-only -J %S/Inputs/module-dir -module-dir %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 -fsyntax-only -J %S/Inputs/module-dir -J %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang_fc1 -fsyntax-only -J %S/Inputs/module-dir -module-dir %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE

--- a/flang/test/Driver/use-module.f90
+++ b/flang/test/Driver/use-module.f90
@@ -1,7 +1,7 @@
 ! Checks that module search directories specified with `-J/-module-dir` and `-I` are handled correctly
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -fsyntax-only -I %S/Inputs -I %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
 ! RUN: %flang -fsyntax-only -I %S/Inputs -J %S/Inputs/module-dir %s 2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
@@ -16,7 +16,7 @@
 ! RUN: not %flang -fsyntax-only -module-dir %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=SINGLEINCLUDE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only -I %S/Inputs -I %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
 ! RUN: %flang_fc1 -fsyntax-only -I %S/Inputs -J %S/Inputs/module-dir %s 2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty

--- a/flang/test/Driver/version-loops.f90
+++ b/flang/test/Driver/version-loops.f90
@@ -1,5 +1,5 @@
-! Test that flang-{{[0-9]+}} forwards the -f{no-,}version-loops-for-stride 
-! options correctly to flang-{{[0-9]+}} -fc1 for different variants of optimisation
+! Test that flang forwards the -f{no-,}version-loops-for-stride 
+! options correctly to flang -fc1 for different variants of optimisation
 ! and explicit flags.
 
 ! RUN: %flang -### %s -o %t 2>&1   -O3 \
@@ -23,32 +23,32 @@
 ! RUN: %flang -### %s -o %t 2>&1 -O3 -fno-version-loops-for-stride \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-O3-no
 
-! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-SAME: "-fversion-loops-for-stride"
 ! CHECK-SAME: "-O3"
 
-! CHECK-O2: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-O2: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-O2-NOT: "-fversion-loops-for-stride"
 ! CHECK-O2-SAME: "-O2"  
 
-! CHECK-O2-with: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-O2-with: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-O2-with-SAME: "-fversion-loops-for-stride"
 ! CHECK-O2-with-SAME: "-O2"  
   
-! CHECK-O4: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-O4: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-O4-SAME: "-fversion-loops-for-stride"
 ! CHECK-O4-SAME: "-O3"
 
-! CHECK-Ofast: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-Ofast: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-Ofast-SAME: "-ffast-math"
 ! CHECK-Ofast-SAME: "-fversion-loops-for-stride"
 ! CHECK-Ofast-SAME: "-O3"
 
-! CHECK-Ofast-no: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-Ofast-no: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-Ofast-no-SAME: "-ffast-math"
 ! CHECK-Ofast-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-Ofast-no-SAME: "-O3"
 
-! CHECK-O3-no: "{{.*}}flang-{{[0-9]+}}" "-fc1"
+! CHECK-O3-no: "{{.*}}flang{{.*}}" "-fc1"
 ! CHECK-O3-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-O3-no-SAME: "-O3"

--- a/flang/test/Driver/version-loops.f90
+++ b/flang/test/Driver/version-loops.f90
@@ -1,5 +1,5 @@
-! Test that flang-new forwards the -f{no-,}version-loops-for-stride 
-! options correctly to flang-new -fc1 for different variants of optimisation
+! Test that flang-{{[0-9]+}} forwards the -f{no-,}version-loops-for-stride 
+! options correctly to flang-{{[0-9]+}} -fc1 for different variants of optimisation
 ! and explicit flags.
 
 ! RUN: %flang -### %s -o %t 2>&1   -O3 \
@@ -23,32 +23,32 @@
 ! RUN: %flang -### %s -o %t 2>&1 -O3 -fno-version-loops-for-stride \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-O3-no
 
-! CHECK: "{{.*}}flang-new" "-fc1"
+! CHECK: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-SAME: "-fversion-loops-for-stride"
 ! CHECK-SAME: "-O3"
 
-! CHECK-O2: "{{.*}}flang-new" "-fc1"
+! CHECK-O2: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-O2-NOT: "-fversion-loops-for-stride"
 ! CHECK-O2-SAME: "-O2"  
 
-! CHECK-O2-with: "{{.*}}flang-new" "-fc1"
+! CHECK-O2-with: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-O2-with-SAME: "-fversion-loops-for-stride"
 ! CHECK-O2-with-SAME: "-O2"  
   
-! CHECK-O4: "{{.*}}flang-new" "-fc1"
+! CHECK-O4: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-O4-SAME: "-fversion-loops-for-stride"
 ! CHECK-O4-SAME: "-O3"
 
-! CHECK-Ofast: "{{.*}}flang-new" "-fc1"
+! CHECK-Ofast: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-Ofast-SAME: "-ffast-math"
 ! CHECK-Ofast-SAME: "-fversion-loops-for-stride"
 ! CHECK-Ofast-SAME: "-O3"
 
-! CHECK-Ofast-no: "{{.*}}flang-new" "-fc1"
+! CHECK-Ofast-no: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-Ofast-no-SAME: "-ffast-math"
 ! CHECK-Ofast-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-Ofast-no-SAME: "-O3"
 
-! CHECK-O3-no: "{{.*}}flang-new" "-fc1"
+! CHECK-O3-no: "{{.*}}flang-{{[0-9]+}}" "-fc1"
 ! CHECK-O3-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-O3-no-SAME: "-O3"

--- a/flang/test/Driver/version-loops.f90
+++ b/flang/test/Driver/version-loops.f90
@@ -23,32 +23,32 @@
 ! RUN: %flang -### %s -o %t 2>&1 -O3 -fno-version-loops-for-stride \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-O3-no
 
-! CHECK: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK: "-fc1"
 ! CHECK-SAME: "-fversion-loops-for-stride"
 ! CHECK-SAME: "-O3"
 
-! CHECK-O2: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-O2: "-fc1"
 ! CHECK-O2-NOT: "-fversion-loops-for-stride"
 ! CHECK-O2-SAME: "-O2"  
 
-! CHECK-O2-with: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-O2-with: "-fc1"
 ! CHECK-O2-with-SAME: "-fversion-loops-for-stride"
 ! CHECK-O2-with-SAME: "-O2"  
   
-! CHECK-O4: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-O4: "-fc1"
 ! CHECK-O4-SAME: "-fversion-loops-for-stride"
 ! CHECK-O4-SAME: "-O3"
 
-! CHECK-Ofast: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-Ofast: "-fc1"
 ! CHECK-Ofast-SAME: "-ffast-math"
 ! CHECK-Ofast-SAME: "-fversion-loops-for-stride"
 ! CHECK-Ofast-SAME: "-O3"
 
-! CHECK-Ofast-no: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-Ofast-no: "-fc1"
 ! CHECK-Ofast-no-SAME: "-ffast-math"
 ! CHECK-Ofast-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-Ofast-no-SAME: "-O3"
 
-! CHECK-O3-no: "{{.*}}flang{{.*}}" "-fc1"
+! CHECK-O3-no: "-fc1"
 ! CHECK-O3-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-O3-no-SAME: "-O3"

--- a/flang/test/Lower/Intrinsics/command_argument_count.f90
+++ b/flang/test/Lower/Intrinsics/command_argument_count.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! bbc doesn't have a way to set the default kinds so we use flang-new driver
-! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64  %s
+! bbc doesn't have a way to set the default kinds so we use flang driver
+! RUN: %flang_fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64  %s
 
 ! CHECK-LABEL: argument_count_test
 subroutine argument_count_test()

--- a/flang/test/Lower/Intrinsics/exit.f90
+++ b/flang/test/Lower/Intrinsics/exit.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
-! bbc doesn't have a way to set the default kinds so we use flang-new driver
+! bbc doesn't have a way to set the default kinds so we use flang driver
 ! RUN: %flang_fc1 -fdefault-integer-8 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
 
 ! CHECK-LABEL: func @_QPexit_test1() {

--- a/flang/test/Lower/Intrinsics/ieee_is_normal.f90
+++ b/flang/test/Lower/Intrinsics/ieee_is_normal.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: flang -fc1 -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: ieee_is_normal_f16
 subroutine ieee_is_normal_f16(r)

--- a/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP allocate Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not %flang_fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 program main
   integer :: x, y

--- a/flang/test/Lower/OpenMP/Todo/omp-declare-reduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declare-reduction.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP declare reduction Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not %flang_fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 subroutine declare_red()
   integer :: my_var

--- a/flang/test/Lower/OpenMP/Todo/omp-declare-simd.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declare-simd.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP declare simd Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not %flang_fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 subroutine sub(x, y)
   real, intent(inout) :: x, y

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -121,10 +121,10 @@ if config.flang_standalone_build:
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.
 tools = [
-    ToolSubst("%flang", command=FindTool("flang-new"), unresolved="fatal"),
+    ToolSubst("%flang", command=FindTool("flang"), unresolved="fatal"),
     ToolSubst(
         "%flang_fc1",
-        command=FindTool("flang-new"),
+        command=FindTool("flang"),
         extra_args=["-fc1"],
         unresolved="fatal",
     ),

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -61,9 +61,9 @@ if (NOT CMAKE_CROSSCOMPILING)
 
     add_custom_command(OUTPUT ${base}.mod
       COMMAND ${CMAKE_COMMAND} -E make_directory ${FLANG_INTRINSIC_MODULES_DIR}
-      COMMAND flang-new -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
+      COMMAND flang -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
         ${FLANG_SOURCE_DIR}/module/${filename}.f90
-      DEPENDS flang-new ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
+      DEPENDS flang ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
     )
     add_custom_command(OUTPUT ${base}.f18.mod
       DEPENDS ${base}.mod
@@ -75,7 +75,7 @@ endif()
 
 add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})
 
-# This flang shell script will only work in a POSIX shell.
+# The flang-to-gfortan shell script will only work in a POSIX shell.
 if (NOT WIN32)
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/flang-to-external-fc.in

--- a/flang/tools/flang-driver/CMakeLists.txt
+++ b/flang/tools/flang-driver/CMakeLists.txt
@@ -11,7 +11,7 @@ set( LLVM_LINK_COMPONENTS
   TargetParser
 )
 
-add_flang_tool(flang-new
+add_flang_tool(flang
   driver.cpp
   fc1_main.cpp
 
@@ -24,23 +24,33 @@ add_flang_tool(flang-new
   Fortran_main
 )
 
-target_link_libraries(flang-new
+target_link_libraries(flang
   PRIVATE
   flangFrontend
   flangFrontendTool
 )
 
-clang_target_link_libraries(flang-new
+clang_target_link_libraries(flang
   PRIVATE
   clangDriver
   clangBasic
 )
 
-option(FLANG_PLUGIN_SUPPORT "Build Flang with plugin support." ON)
-
-# Enable support for plugins, which need access to symbols from flang-new
-if(FLANG_PLUGIN_SUPPORT)
-  export_executable_symbols_for_plugins(flang-new)
+if(WIN32 AND NOT CYGWIN)
+  # Prevent versioning if the buildhost is targeting for Win32.
+else()
+  set_target_properties(flang PROPERTIES VERSION ${FLANG_EXECUTABLE_VERSION})
 endif()
 
-install(TARGETS flang-new DESTINATION "${CMAKE_INSTALL_BINDIR}")
+option(FLANG_PLUGIN_SUPPORT "Build Flang with plugin support." ON)
+
+# Enable support for plugins, which need access to symbols from flang
+if(FLANG_PLUGIN_SUPPORT)
+  export_executable_symbols_for_plugins(flang)
+endif()
+
+install(TARGETS flang DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+# Keep "flang-new" as a symlink for backwards compatiblity. Remove once "flang"
+# is a widely adopted name.
+add_flang_symlink(flang-new flang)

--- a/flang/tools/flang-driver/driver.cpp
+++ b/flang/tools/flang-driver/driver.cpp
@@ -88,14 +88,15 @@ int main(int argc, const char **argv) {
   llvm::InitLLVM x(argc, argv);
   llvm::SmallVector<const char *, 256> args(argv, argv + argc);
 
-  clang::driver::ParsedClangName targetandMode("flang", "--driver-mode=flang");
+  clang::driver::ParsedClangName targetandMode =
+      clang::driver::ToolChain::getTargetAndModeFromProgramName(argv[0]);
   std::string driverPath = getExecutablePath(args[0]);
 
   llvm::BumpPtrAllocator a;
   llvm::StringSaver saver(a);
   ExpandResponseFiles(saver, args);
 
-  // Check if flang-new is in the frontend mode
+  // Check if flang is in the frontend mode
   auto firstArg = std::find_if(args.begin() + 1, args.end(),
                                [](const char *a) { return a != nullptr; });
   if (firstArg != args.end()) {
@@ -104,7 +105,7 @@ int main(int argc, const char **argv) {
                    << "Valid tools include '-fc1'.\n";
       return 1;
     }
-    // Call flang-new frontend
+    // Call flang frontend
     if (llvm::StringRef(args[1]).starts_with("-fc1")) {
       return executeFC1Tool(args);
     }


### PR DESCRIPTION
This patch renames `flang-new` as `flang`. Similarly to Clang, Flang's
driver executable will be called:

  * `flang-<MAJOR_VERSION>`

A symlink called `flang` pointing at `flang-<MAJOR_VERSION>` will be
created at build time. This is consistent with Clang.

For backwards compatibility, a symlink `flang-new` pointing to
`flang-<MAJOR_VERSION>` is also created. This will be removed in the
future.
