### PR TITLE
[LLVM][DWARF] Fix uniquness of AccelTable Values

### DIFF
--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -120,6 +120,10 @@ public:
     return order() < Other.order();
   }
 
+  bool operator==(const AccelTableData &Other) const {
+    return order() == Other.order();
+  }
+
     // Subclasses should implement:
     // static uint32_t hash(StringRef Name);
 

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -59,7 +59,10 @@ void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {
                         return *A < *B;
                       });
     E.second.Values.erase(
-        std::unique(E.second.Values.begin(), E.second.Values.end()),
+        std::unique(E.second.Values.begin(), E.second.Values.end(),
+                    [](const AccelTableData *A, const AccelTableData *B) {
+                      return *A == *B;
+                    }),
         E.second.Values.end());
   }
 


### PR DESCRIPTION
The finalize function sorts by order, which is DieOffset. It then uses erase in
combination of std::unique to remove duplicates, but it doesn't specify
comparison function. So pointer addresses are used. Presumably it should also use
order() for compare?
