### PR TITLE
[libc] fix -Wshorten-64-to-32

### DIFF
--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -47,13 +47,13 @@ LIBC_INLINE constexpr size_t log2s(size_t value) {
 // Returns the first power of two preceding value or value if it is already a
 // power of two (or 0 when value is 0).
 LIBC_INLINE constexpr size_t le_power2(size_t value) {
-  return value == 0 ? value : 1ULL << log2s(value);
+  return value == 0 ? value : 1UL << log2s(value);
 }
 
 // Returns the first power of two following value or value if it is already a
 // power of two (or 0 when value is 0).
 LIBC_INLINE constexpr size_t ge_power2(size_t value) {
-  return is_power2_or_zero(value) ? value : 1ULL << (log2s(value) + 1);
+  return is_power2_or_zero(value) ? value : 1UL << (log2s(value) + 1);
 }
 
 // Returns the number of bytes to substract from ptr to get to the previous


### PR DESCRIPTION
32b arm failed when enabling -Werror:

```
libc/src/string/memory_utils/utils.h:50:36: error: implicit conversion loses
integer precision: 'unsigned long long' to 'size_t' (aka 'unsigned int')
[-Werror,-Wshorten-64-to-32]
  return value == 0 ? value : 1ULL << log2s(value);
  ~~~~~~                      ~~~~~^~~~~~~~~~~~~~~
libc/src/string/memory_utils/utils.h:56:50: error: implicit conversion loses
integer precision: 'unsigned long long' to 'size_t' (aka 'unsigned int')
[-Werror,-Wshorten-64-to-32]
  return is_power2_or_zero(value) ? value : 1ULL << (log2s(value) + 1);
  ~~~~~~                                    ~~~~~^~~~~~~~~~~~~~~~~~~~~
```

arm-linux-gnueabi is ILP32. size_t is an 'unsigned int' and 'long' is the same
bit width as `int`.

Use an unsigned long literal rather than an unsigned long long literal to avoid
the implicit promotion to unsigned long long which would then be truncated to
unsigned int, as hinted at by the warning.
