### PR TITLE
Make SANITIZER_MIN_OSX_VERSION a cache variable

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -461,11 +461,6 @@ if(APPLE)
     set(ORC_SUPPORTED_OS osx)
   endif()
 
-  # Note: In order to target x86_64h on OS X the minimum deployment target must
-  # be 10.8 or higher.
-  set(SANITIZER_MIN_OSX_VERSION "" CACHE STRING
-    "Minimum OS X version to target (e.g. 10.10) for sanitizers.")
-
   set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.10)
   set(DARWIN_osx_MIN_VER_FLAG "-mmacosx-version-min")
   if(NOT SANITIZER_MIN_OSX_VERSION)

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -463,25 +463,32 @@ if(APPLE)
 
   # Note: In order to target x86_64h on OS X the minimum deployment target must
   # be 10.8 or higher.
+  set(SANITIZER_MIN_OSX_VERSION "" CACHE STRING
+    "Minimum OS X version to target (e.g. 10.10) for sanitizers.")
+
   set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.10)
   set(DARWIN_osx_MIN_VER_FLAG "-mmacosx-version-min")
-  if(NOT SANITIZER_MIN_OSX_VERSION)
+  if(SANITIZER_MIN_OSX_VERSION STREQUAL "")
     string(REGEX MATCH "${DARWIN_osx_MIN_VER_FLAG}=([.0-9]+)"
            MACOSX_VERSION_MIN_FLAG "${CMAKE_CXX_FLAGS}")
     if(MACOSX_VERSION_MIN_FLAG)
-      set(SANITIZER_MIN_OSX_VERSION "${CMAKE_MATCH_1}")
+      set(MIN_OSX_VERSION "${CMAKE_MATCH_1}")
     elseif(CMAKE_OSX_DEPLOYMENT_TARGET)
-      set(SANITIZER_MIN_OSX_VERSION ${CMAKE_OSX_DEPLOYMENT_TARGET})
+      set(MIN_OSX_VERSION ${CMAKE_OSX_DEPLOYMENT_TARGET})
     else()
-      set(SANITIZER_MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
+      set(MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
     endif()
-    if(SANITIZER_MIN_OSX_VERSION VERSION_LESS "10.7")
+
+    if(MIN_OSX_VERSION VERSION_LESS "10.7")
       message(FATAL_ERROR "macOS deployment target '${SANITIZER_MIN_OSX_VERSION}' is too old.")
     endif()
-    if(SANITIZER_MIN_OSX_VERSION VERSION_GREATER ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
+    if(MIN_OSX_VERSION VERSION_GREATER ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
       message(WARNING "macOS deployment target '${SANITIZER_MIN_OSX_VERSION}' is too new, setting to '${DEFAULT_SANITIZER_MIN_OSX_VERSION}' instead.")
-      set(SANITIZER_MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
+      set(MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
     endif()
+
+    set(SANITIZER_MIN_OSX_VERSION "${MIN_OSX_VERSION}" CACHE STRING
+        "Minimum OS X version to target (e.g. 10.10) for sanitizers." FORCE)
   endif()
 
   # We're setting the flag manually for each target OS

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -484,9 +484,10 @@ if(APPLE)
       set(MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
     endif()
 
-    set(SANITIZER_MIN_OSX_VERSION "${MIN_OSX_VERSION}" CACHE STRING
-        "Minimum OS X version to target (e.g. 10.10) for sanitizers.")
   endif()
+
+  set(SANITIZER_MIN_OSX_VERSION "${MIN_OSX_VERSION}" CACHE STRING
+    "Minimum OS X version to target (e.g. 10.10) for sanitizers.")
 
   # We're setting the flag manually for each target OS
   set(CMAKE_OSX_DEPLOYMENT_TARGET "")

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -468,7 +468,7 @@ if(APPLE)
 
   set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.10)
   set(DARWIN_osx_MIN_VER_FLAG "-mmacosx-version-min")
-  if(SANITIZER_MIN_OSX_VERSION STREQUAL "")
+  if(NOT SANITIZER_MIN_OSX_VERSION)
     string(REGEX MATCH "${DARWIN_osx_MIN_VER_FLAG}=([.0-9]+)"
            MACOSX_VERSION_MIN_FLAG "${CMAKE_CXX_FLAGS}")
     if(MACOSX_VERSION_MIN_FLAG)
@@ -479,6 +479,8 @@ if(APPLE)
       set(MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
     endif()
 
+    # Note: In order to target x86_64h on OS X the minimum deployment target must
+    # be 10.8 or higher.
     if(MIN_OSX_VERSION VERSION_LESS "10.7")
       message(FATAL_ERROR "macOS deployment target '${SANITIZER_MIN_OSX_VERSION}' is too old.")
     endif()
@@ -488,7 +490,7 @@ if(APPLE)
     endif()
 
     set(SANITIZER_MIN_OSX_VERSION "${MIN_OSX_VERSION}" CACHE STRING
-        "Minimum OS X version to target (e.g. 10.10) for sanitizers." FORCE)
+        "Minimum OS X version to target (e.g. 10.10) for sanitizers.")
   endif()
 
   # We're setting the flag manually for each target OS


### PR DESCRIPTION
It is desirable to be able to configure the `-mmacosx-version-min` flag for the sanitizers, but this flag was never made a CACHE variable in cmake.

By doing this, it will allow developers to select different minimum versions, which results in different interceptors being enabled or disabled on their platforms. This version can now persist between cmake runs, so it can be remembered by cmake, and edited in the cache file.
