### PR TITLE
[clang-format][NFC] Use `prog` in clang-format-diff.py

### DIFF
--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -38,7 +38,7 @@ else:
 
 def main():
     parser = argparse.ArgumentParser(
-        description=__doc__.format(clang_format_diff='%(prog)s'),
+        description=__doc__.format(clang_format_diff="%(prog)s"),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -37,9 +37,8 @@ else:
 
 
 def main():
-    basename = os.path.basename(sys.argv[0])
     parser = argparse.ArgumentParser(
-        description=__doc__.format(clang_format_diff=basename),
+        description=__doc__.format(clang_format_diff='%(prog)s'),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import, division, print_function
 
 import argparse
 import difflib
-import os
 import re
 import subprocess
 import sys


### PR DESCRIPTION
This is a minor improvement to #73491.