### PR TITLE
[mlir][vector] Fix invalid IR in `vector.print` lowering

### DIFF
--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -726,12 +726,14 @@ struct DecomposePrintOpConversion : public VectorToSCFPattern<vector::PrintOp> {
       auto targetVectorType = vectorType.cloneWith({}, legalIntTy);
       value = rewriter.create<vector::BitCastOp>(loc, signlessSourceVectorType,
                                                  value);
-      if (width == 1 || intTy.isUnsigned())
-        value = rewriter.create<arith::ExtUIOp>(loc, signlessTargetVectorType,
-                                                value);
-      else
-        value = rewriter.create<arith::ExtSIOp>(loc, signlessTargetVectorType,
-                                                value);
+      if (value.getType() != signlessTargetVectorType) {
+        if (width == 1 || intTy.isUnsigned())
+          value = rewriter.create<arith::ExtUIOp>(loc, signlessTargetVectorType,
+                                                  value);
+        else
+          value = rewriter.create<arith::ExtSIOp>(loc, signlessTargetVectorType,
+                                                  value);
+      }
       value = rewriter.create<vector::BitCastOp>(loc, targetVectorType, value);
       vectorType = targetVectorType;
     }


### PR DESCRIPTION
`DecomposePrintOpConversion` used to generate invalid op such as:
```
error: 'arith.extsi' op operand type 'vector<10xi32>' and result type 'vector<10xi32>' are cast incompatible
  vector.print %v9 : vector<10xi32>
```

This commit fixes tests such as `mlir/test/Integration/Dialect/Vector/CPU/test-reductions-i32.mlir` when verifying the IR after each pattern application (#74270).