### PR TITLE
[PowerPC][CodeGen] Exploit STMW and LMW in 32-bit big-endian mode.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -2589,8 +2589,7 @@ bool PPCFrameLowering::spillCalleeSavedRegisters(
               MFI.getObjectAlign(FrameIdx));
           MIB.addMemOperand(MMO);
           FI->setHasSpills();
-          Register MergeEnd = PPC::R31;
-          for (unsigned I = MergeFrom.id(); I <= MergeEnd.id(); ++I)
+          for (unsigned I = MergeFrom.id(); I <= Register(PPC::R31).id(); ++I)
             MIB.addUse(Register(I), RegState::Implicit);
         } else
           TII.storeRegToStackSlot(MBB, MI, Reg, !IsLiveIn, I.getFrameIdx(), RC,

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2084,7 +2084,7 @@ def LFIWZX : XForm_25_memOp<31, 887, (outs f8rc:$RST), (ins (memrr $RA, $RB):$ad
 
 // Load Multiple
 let mayLoad = 1, mayStore = 0, hasSideEffects = 0 in
-def LMW : DForm_1<46, (outs gprc:$RST), (ins (memri $D, $RA):$src),
+def LMW : DForm_1<46, (outs gprc:$RST), (ins (memri $D, $RA):$src, variable_ops),
                   "lmw $RST, $src", IIC_LdStLMW, []>;
 
 //===----------------------------------------------------------------------===//
@@ -2239,7 +2239,7 @@ def : Pat<(pre_store f64:$rS, iPTR:$ptrreg, iPTR:$ptroff),
 
 // Store Multiple
 let mayStore = 1, mayLoad = 0, hasSideEffects = 0 in
-def STMW : DForm_1<47, (outs), (ins gprc:$RST, (memri $D, $RA):$dst),
+def STMW : DForm_1<47, (outs), (ins gprc:$RST, (memri $D, $RA):$dst, variable_ops),
                    "stmw $RST, $dst", IIC_LdStLMW, []>;
 
 def SYNC : XForm_24_sync<31, 598, (outs), (ins u2imm:$L),

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1673,8 +1673,10 @@ PPCRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
 
   // If the instruction is not present in ImmToIdxMap, then it has no immediate
   // form (and must be r+r).
+  // STMW and LMW only have immediate form.
   bool noImmForm = !MI.isInlineAsm() && OpC != TargetOpcode::STACKMAP &&
-                   OpC != TargetOpcode::PATCHPOINT && !ImmToIdxMap.count(OpC);
+                   OpC != TargetOpcode::PATCHPOINT && !ImmToIdxMap.count(OpC) &&
+                   OpC != PPC::STMW && OpC != PPC::LMW;
 
   // Now add the frame object offset to the offset from r1.
   int64_t Offset = MFI.getObjectOffset(FrameIndex);
@@ -1716,10 +1718,10 @@ PPCRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
                             isInt<16>(Offset);
   if (TII.isPrefixed(MI.getOpcode()))
     OffsetFitsMnemonic = isInt<34>(Offset);
-  if (!noImmForm && ((OffsetFitsMnemonic &&
-                      ((Offset % offsetMinAlign(MI)) == 0)) ||
-                     OpC == TargetOpcode::STACKMAP ||
-                     OpC == TargetOpcode::PATCHPOINT)) {
+  if (!noImmForm &&
+      ((OffsetFitsMnemonic && ((Offset % offsetMinAlign(MI)) == 0)) ||
+       OpC == TargetOpcode::STACKMAP || OpC == TargetOpcode::PATCHPOINT ||
+       OpC == PPC::STMW || OpC == PPC::LMW)) {
     MI.getOperand(OffsetOperandNo).ChangeToImmediate(Offset);
     return false;
   }

--- a/llvm/test/CodeGen/PowerPC/aix-stm-lm-merge.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-stm-lm-merge.ll
@@ -1,0 +1,16 @@
+; RUN: llc  -verify-machineinstrs -mtriple powerpc-ibm-aix-xcoff -mattr=-altivec \
+; RUN:      -mcpu=pwr4 --ppc-enable-load-store-multiple < %s | FileCheck %s
+
+target triple = "powerpc-ibm-aix7.2.0.0"
+
+define dso_local void @test_simple() #0 {
+entry:
+  call void asm sideeffect "nop", "~{r16},~{r17},~{r18},~{r19},~{r20},~{r21},~{r22},~{r23},~{r24},~{r25},~{r26},~{r27},~{r28},~{r29},~{r30},~{r31}"()
+  ret void
+}
+
+; CHECK:        stmw 16, -64(1)                         # 4-byte Folded Spill
+; CHECK-NEXT:   #APP
+; CHECK-NEXT:   nop
+; CHECK-NEXT:   #NO_APP
+; CHECK-NEXT:   lmw 16, -64(1)                          # 4-byte Folded Reload


### PR DESCRIPTION
This patch exploits the stmw and lmw instructions. Max to r13~r31 continuous store/load instructions can be merged to stmw/lmw, which saves code size.