### PR TITLE
[BOLT] Fix a wrong compiler option in test

### DIFF
--- a/bolt/test/runtime/AArch64/instrumentation-ind-call.c
+++ b/bolt/test/runtime/AArch64/instrumentation-ind-call.c
@@ -14,7 +14,7 @@ int main() {
 /*
 REQUIRES: system-linux,bolt-runtime
 
-RUN: %clang %cflags %s -o %t.exe -Wl,-q -nopie -fpie
+RUN: %clang %cflags %s -o %t.exe -Wl,-q -no-pie -fpie
 
 RUN: llvm-bolt %t.exe --instrument --instrumentation-file=%t.fdata \
 RUN:   -o %t.instrumented


### PR DESCRIPTION
-nopie is an option for OpenBSD, and other linux distribution might report an error like
`error: unsupported option '-nopie' for target 'aarch64-linux'`


using `-nopie` and `-fpie` together seems to be a mistake, so I changed -nopie to -pie in this patch.