### PR TITLE
[clang] Skip tautological comparison if the comparison involves the 'size_t' type

### DIFF
--- a/clang/test/Sema/type-limit-compare.cpp
+++ b/clang/test/Sema/type-limit-compare.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 %s -fsyntax-only -Wtautological-type-limit-compare -verify
+
+// expected-no-diagnostics
+#if defined(_WIN32)
+typedef unsigned long long uint64_t;
+#else
+typedef unsigned long uint64_t;
+#endif
+
+namespace std {
+using size_t = decltype(sizeof(0));
+} // namespace std
+
+bool func(uint64_t Size) {
+  if (sizeof(std::size_t) < sizeof(uint64_t) &&
+     Size > (uint64_t)(__SIZE_MAX__))
+    return false;
+  return true;
+}
+


### PR DESCRIPTION
The issue with size_t comes when we are trying to add -Wtype-limits to -Wextra for GCC compatibility in review https://reviews.llvm.org/D142826.

Example of issue (false positive) -

$ cat clang/test/Sema/type-limit-compare.cpp
// RUN: %clang_cc1 %s -fsyntax-only -Wtautological-type-limit-compare -verify

namespace std {
using size_t = decltype(sizeof(0));
} // namespace std

bool func(uint64_t Size) {
  if (sizeof(std::size_t) < sizeof(uint64_t) &&
     Size > (uint64_t)(__SIZE_MAX__))
    return false;
  return true;
}

$ clang -c -Wtautological-type-limit-compare clang/test/Sema/type-limit-compare.cpp 
clang/test/Sema/type-limit-compare.cpp:16:11: warning: result of comparison 'uint64_t' (aka 'unsigned long') > 18446744073709551615 is always false [-Wtautological-type-limit-compare]
   16 |      Size > (uint64_t)(__SIZE_MAX__))
      |      ~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
 