### PR TITLE
[X86][MC] Support Enc/Dec for EGPR for promoted VMX instructions

### DIFF
--- a/llvm/lib/Target/X86/X86InstrVMX.td
+++ b/llvm/lib/Target/X86/X86InstrVMX.td
@@ -23,6 +23,11 @@ def INVEPT64 : I<0x80, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
                "invept\t{$src2, $src1|$src1, $src2}", []>, T8PD,
                Requires<[In64BitMode]>;
 
+let CD8_Scale = 0 in
+def INVEPT64_EVEX : I<0xF0, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
+                      "invept\t{$src2, $src1|$src1, $src2}", []>,
+                    EVEX, T_MAP4XS, Requires<[In64BitMode]>;
+
 // 66 0F 38 81
 def INVVPID32 : I<0x81, MRMSrcMem, (outs), (ins GR32:$src1, i128mem:$src2),
                 "invvpid\t{$src2, $src1|$src1, $src2}", []>, T8PD,
@@ -30,6 +35,11 @@ def INVVPID32 : I<0x81, MRMSrcMem, (outs), (ins GR32:$src1, i128mem:$src2),
 def INVVPID64 : I<0x81, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
                 "invvpid\t{$src2, $src1|$src1, $src2}", []>, T8PD,
                 Requires<[In64BitMode]>;
+
+let CD8_Scale = 0 in
+def INVVPID64_EVEX : I<0xF1, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
+                       "invvpid\t{$src2, $src1|$src1, $src2}", []>,
+                     EVEX, T_MAP4XS, Requires<[In64BitMode]>;
 
 // 0F 01 C1
 def VMCALL : I<0x01, MRM_C1, (outs), (ins), "vmcall", []>, TB;

--- a/llvm/test/MC/Disassembler/X86/apx/invept.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/invept.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   invept	123(%r28,%r29,4), %r19
+# INTEL: invept	r19, xmmword ptr [r28 + 4*r29 + 123]
+0x62,0x8c,0x7a,0x08,0xf0,0x5c,0xac,0x7b

--- a/llvm/test/MC/Disassembler/X86/apx/invvpid.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/invvpid.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   invvpid	291(%r28,%r29,4), %r19
+# INTEL: invvpid	r19, xmmword ptr [r28 + 4*r29 + 291]
+0x62,0x8c,0x7a,0x08,0xf1,0x9c,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/X86/apx/invept-att.s
+++ b/llvm/test/MC/X86/apx/invept-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: invept	123(%r28,%r29,4), %r19
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf0,0x5c,0xac,0x7b]
+         invept	123(%r28,%r29,4), %r19

--- a/llvm/test/MC/X86/apx/invept-intel.s
+++ b/llvm/test/MC/X86/apx/invept-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: invept	r19, xmmword ptr [r28 + 4*r29 + 123]
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf0,0x5c,0xac,0x7b]
+         invept	r19, xmmword ptr [r28 + 4*r29 + 123]

--- a/llvm/test/MC/X86/apx/invvpid-att.s
+++ b/llvm/test/MC/X86/apx/invvpid-att.s
@@ -1,0 +1,9 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: invvpid	291(%r28,%r29,4), %r19
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf1,0x9c,0xac,0x23,0x01,0x00,0x00]
+         invvpid	291(%r28,%r29,4), %r19
+

--- a/llvm/test/MC/X86/apx/invvpid-intel.s
+++ b/llvm/test/MC/X86/apx/invvpid-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: invvpid	r19, xmmword ptr [r28 + 4*r29 + 291]
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf1,0x9c,0xac,0x23,0x01,0x00,0x00]
+         invvpid	r19, xmmword ptr [r28 + 4*r29 + 291]


### PR DESCRIPTION
R16-R31 was added into GPRs in https://github.com/llvm/llvm-project/pull/70958,
This patch supports the encoding/decoding for promoted VMX instructions in EVEX space.

RFC: https://discourse.llvm.org/t/rfc-design-for-apx-feature-egpr-and-ndd-support/73031/4