### PR TITLE
[libc++] tests with picolibc: Fix expected error message

### DIFF
--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-// XFAIL: LIBCXX-PICOLIBC-FIXME
 
 // <system_error>
 
@@ -48,6 +47,8 @@ int main(int, char**)
         // Exact message format varies by platform.
 #if defined(_AIX)
         LIBCPP_ASSERT(msg.rfind("Error -1 occurred", 0) == 0);
+#elif defined(_NEWLIB_VERSION)
+        LIBCPP_ASSERT(msg.empty());
 #else
         LIBCPP_ASSERT(msg.rfind("Unknown error", 0) == 0);
 #endif

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -13,7 +13,6 @@
 // const error_category& system_category();
 
 // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-// XFAIL: LIBCXX-PICOLIBC-FIXME
 
 #include <system_error>
 #include <cassert>
@@ -52,6 +51,8 @@ int main(int, char**)
             // Exact message format varies by platform.
 #if defined(_AIX)
             LIBCPP_ASSERT(msg.rfind("Error -1 occurred", 0) == 0);
+#elif defined(_NEWLIB_VERSION)
+            LIBCPP_ASSERT(msg.empty());
 #else
             LIBCPP_ASSERT(msg.rfind("Unknown error", 0) == 0);
 #endif


### PR DESCRIPTION
Newlib's strerror function returns an empty string for unknown errnum values as described in [1].

[1] https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/string/strerror.c;hb=HEAD