### PR TITLE
[libc] Fix arm32 tests

### DIFF
--- a/libc/test/src/__support/memory_size_test.cpp
+++ b/libc/test/src/__support/memory_size_test.cpp
@@ -83,13 +83,13 @@ TEST(LlvmLibcMemSizeTest, AlignUp) {
 }
 
 TEST(LlvmLibcBlockBitTest, OffsetTo) {
-  ASSERT_EQ(SafeMemSize::offset_to(0, 512), 0UL);
-  ASSERT_EQ(SafeMemSize::offset_to(1, 512), 511UL);
-  ASSERT_EQ(SafeMemSize::offset_to(2, 512), 510UL);
-  ASSERT_EQ(SafeMemSize::offset_to(13, 1), 0UL);
-  ASSERT_EQ(SafeMemSize::offset_to(13, 4), 3UL);
+  ASSERT_EQ(SafeMemSize::offset_to(0, 512), size_t(0));
+  ASSERT_EQ(SafeMemSize::offset_to(1, 512), size_t(511));
+  ASSERT_EQ(SafeMemSize::offset_to(2, 512), size_t(510));
+  ASSERT_EQ(SafeMemSize::offset_to(13, 1), size_t(0));
+  ASSERT_EQ(SafeMemSize::offset_to(13, 4), size_t(3));
   for (unsigned int i = 0; i < 31; ++i) {
-    ASSERT_EQ((SafeMemSize::offset_to(i, 1u << i) + i) % (1u << i), 0UL);
+    ASSERT_EQ((SafeMemSize::offset_to(i, 1u << i) + i) % (1u << i), size_t(0));
   }
 }
 } // namespace internal

--- a/libc/test/src/__support/memory_size_test.cpp
+++ b/libc/test/src/__support/memory_size_test.cpp
@@ -75,7 +75,7 @@ TEST(LlvmLibcMemSizeTest, AlignUp) {
       auto safe_size = SafeMemSize{size};
       auto safe_aligned_size = safe_size.align_up(alignment);
       ASSERT_TRUE(safe_aligned_size.valid());
-      ASSERT_EQ(static_cast<size_t>(safe_aligned_size) % alignment, size_t{0});
+      ASSERT_EQ(static_cast<size_t>(safe_aligned_size) % alignment, size_t(0));
     }
   }
   auto max = SafeMemSize{SAFE_MEM_SIZE_TEST_LIMIT};


### PR DESCRIPTION
`ASSERT_EQ` requires that both operands have the same type but on arm32 `size_t` is `unsigned int` instead of `unsigned long`. Using `size_t` explicitely to avoid "conflicting types for parameter 'ValType"
