### PR TITLE
LoopVectorize/test: fix opt invocations with -march (NFC)

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/Hexagon/maximum-vf-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/Hexagon/maximum-vf-crash.ll
@@ -1,4 +1,4 @@
-; RUN: opt -march=hexagon -hexagon-autohvx -passes=loop-vectorize -S < %s 2>&1 | FileCheck %s
+; RUN: opt -mtriple=hexagon -hexagon-autohvx -passes=loop-vectorize -S < %s 2>&1 | FileCheck %s
 
 ; Check that we don't crash.
 
@@ -6,7 +6,6 @@
 ; CHECK: vector.body
 
 target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
-target triple = "hexagon"
 
 ; Function Attrs: optsize
 define i32 @f() #0 {

--- a/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
+++ b/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
@@ -1,4 +1,4 @@
-; RUN: opt -march=hexagon -passes=loop-vectorize -hexagon-autohvx -debug-only=loop-vectorize -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt -mtriple=hexagon -passes=loop-vectorize -hexagon-autohvx -debug-only=loop-vectorize -disable-output < %s 2>&1 | FileCheck %s
 ; REQUIRES: asserts
 
 ; Check that TTI::getMinimumVF works. The calculated MaxVF was based on the
@@ -6,7 +6,6 @@
 ; CHECK: LV: Overriding calculated MaxVF({{[0-9]+}}) with target's minimum: 64
 
 target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
-target triple = "hexagon"
 
 %s.0 = type { ptr, i32, i32, i32, i32 }
 


### PR DESCRIPTION
opt accepts the -march command-line argument, but this argument only makes sense in conjunction with -mtriple. Fix a couple of tests under LoopVectorize that invoke opt with -march but without -mtriple, to avoid confusing users.