### PR TITLE
[flang][runtime]  Add a critical section for LookUpOrCreateAnonymous.

### DIFF
--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -20,6 +20,7 @@ namespace Fortran::runtime::io {
 // The per-unit data structures are created on demand so that Fortran I/O
 // should work without a Fortran main program.
 static Lock unitMapLock;
+static Lock createOpenLock;
 static UnitMap *unitMap{nullptr};
 static ExternalFileUnit *defaultInput{nullptr}; // unit 5
 static ExternalFileUnit *defaultOutput{nullptr}; // unit 6
@@ -52,6 +53,9 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreate(
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
     Direction dir, std::optional<bool> isUnformatted,
     const Terminator &terminator) {
+  // Make sure that the returned anonymous unit has been opened
+  // not just created in the unitmap.
+  CriticalSection critical{createOpenLock};
   bool exists{false};
   ExternalFileUnit *result{
       GetUnitMap().LookUpOrCreate(unit, terminator, exists)};

--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -54,7 +54,7 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
     Direction dir, std::optional<bool> isUnformatted,
     const Terminator &terminator) {
   // Make sure that the returned anonymous unit has been opened
-  // not just created in the unitmap.
+  // not just created in the unitMap.
   CriticalSection critical{createOpenLock};
   bool exists{false};
   ExternalFileUnit *result{


### PR DESCRIPTION
In parallel regions `LookUpOrCreateAnonymous` may return an anonymous unit that has not yet been opened, which may cause a runtime error.
This commit ensures that the returned anonymous unit has been opened.
For details see: https://github.com/llvm/llvm-project/issues/68856#issuecomment-1788632511

Fixes https://github.com/llvm/llvm-project/issues/68856

