### PR TITLE
[libc][NFC] Simplify FloatProperties implementation

### DIFF
--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -72,8 +72,8 @@ template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
 };
 
 template <> struct FPBaseProperties<FPType::X86_Binary80> {
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 80;
   using UIntType = UInt128;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 80;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 64;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING =

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -40,7 +40,7 @@ enum class FPEncoding {
 template <FPType> struct FPBaseProperties {};
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary16> {
-  LIBC_INLINE_VAR static constexpr int FP_BITS = 16;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 16;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 10;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 5;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
@@ -48,7 +48,7 @@ template <> struct FPBaseProperties<FPType::IEEE754_Binary16> {
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary32> {
-  LIBC_INLINE_VAR static constexpr int FP_BITS = 32;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 32;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 23;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 8;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
@@ -56,7 +56,7 @@ template <> struct FPBaseProperties<FPType::IEEE754_Binary32> {
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary64> {
-  LIBC_INLINE_VAR static constexpr int FP_BITS = 64;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 64;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 52;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 11;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
@@ -64,7 +64,7 @@ template <> struct FPBaseProperties<FPType::IEEE754_Binary64> {
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
-  LIBC_INLINE_VAR static constexpr int FP_BITS = 128;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 128;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 112;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
@@ -72,7 +72,7 @@ template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
 };
 
 template <> struct FPBaseProperties<FPType::X86_Binary80> {
-  LIBC_INLINE_VAR static constexpr int FP_BITS = 80;
+  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 80;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 64;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING =
@@ -88,7 +88,7 @@ struct FPCommonProperties : private FPBaseProperties<fp_type> {
   using UP = FPBaseProperties<fp_type>;
   using BitsType = typename UP::UIntType;
 
-  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = UP::FP_BITS;
+  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = UP::TOTAL_BITS;
   LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_WIDTH = UP::SIG_BITS;
   LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = UP::EXP_BITS;
 

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOATPROPERTIES_H
 
 #include "src/__support/UInt128.h"
-#include "src/__support/macros/attributes.h"       // LIBC_INLINE
+#include "src/__support/macros/attributes.h" // LIBC_INLINE, LIBC_INLINE_VAR
 #include "src/__support/macros/properties/float.h" // LIBC_COMPILER_HAS_FLOAT128
 
 #include <stdint.h>
@@ -27,22 +27,98 @@ enum class FPType {
   X86_Binary80,
 };
 
+// For now 'FPEncoding', 'FPBaseProperties' and 'FPCommonProperties' are
+// implementation details.
+namespace internal {
+
+// The type of encoding for supported floating point types.
+enum class FPEncoding {
+  IEEE754,
+  X86_ExtendedPrecision,
+};
+
+template <FPType> struct FPBaseProperties {};
+
+template <> struct FPBaseProperties<FPType::IEEE754_Binary16> {
+  LIBC_INLINE_VAR static constexpr int FP_BITS = 16;
+  LIBC_INLINE_VAR static constexpr int SIG_BITS = 10;
+  LIBC_INLINE_VAR static constexpr int EXP_BITS = 5;
+  LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
+  using UIntType = uint16_t;
+};
+
+template <> struct FPBaseProperties<FPType::IEEE754_Binary32> {
+  LIBC_INLINE_VAR static constexpr int FP_BITS = 32;
+  LIBC_INLINE_VAR static constexpr int SIG_BITS = 23;
+  LIBC_INLINE_VAR static constexpr int EXP_BITS = 8;
+  LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
+  using UIntType = uint32_t;
+};
+
+template <> struct FPBaseProperties<FPType::IEEE754_Binary64> {
+  LIBC_INLINE_VAR static constexpr int FP_BITS = 64;
+  LIBC_INLINE_VAR static constexpr int SIG_BITS = 52;
+  LIBC_INLINE_VAR static constexpr int EXP_BITS = 11;
+  LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
+  using UIntType = uint64_t;
+};
+
+template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
+  LIBC_INLINE_VAR static constexpr int FP_BITS = 128;
+  LIBC_INLINE_VAR static constexpr int SIG_BITS = 112;
+  LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
+  LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
+  using UIntType = UInt128;
+};
+
+template <> struct FPBaseProperties<FPType::X86_Binary80> {
+  LIBC_INLINE_VAR static constexpr int FP_BITS = 80;
+  LIBC_INLINE_VAR static constexpr int SIG_BITS = 64;
+  LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
+  LIBC_INLINE_VAR static constexpr auto ENCODING =
+      FPEncoding::X86_ExtendedPrecision;
+  using UIntType = UInt128;
+};
+
+// Derives more properties from 'FPBaseProperties' above.
+// This class serves as a halfway point between 'FPBaseProperties' and
+// 'FPProperties' below.
+template <FPType fp_type>
+struct FPCommonProperties : private FPBaseProperties<fp_type> {
+  using UP = FPBaseProperties<fp_type>;
+  using BitsType = typename UP::UIntType;
+
+  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = UP::FP_BITS;
+  LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_WIDTH = UP::SIG_BITS;
+  LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = UP::EXP_BITS;
+
+  // The exponent bias. Always positive.
+  LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_BIAS =
+      (1U << (UP::EXP_BITS - 1U)) - 1U;
+  static_assert(EXPONENT_BIAS > 0);
+};
+
+} // namespace internal
+
 template <FPType> struct FPProperties {};
-template <> struct FPProperties<FPType::IEEE754_Binary32> {
-  typedef uint32_t BitsType;
 
-  static constexpr uint32_t BIT_WIDTH = sizeof(BitsType) * 8;
+// ----------------
+// Work In Progress
+// ----------------
+// The 'FPProperties' template specializations below are being slowly replaced
+// with properties from 'FPCommonProperties' above. Once specializations are
+// empty, 'FPProperties' declaration can be fully replace with
+// 'FPCommonProperties' implementation.
 
-  static constexpr uint32_t MANTISSA_WIDTH = 23;
+template <>
+struct FPProperties<FPType::IEEE754_Binary32>
+    : public internal::FPCommonProperties<FPType::IEEE754_Binary32> {
   // The mantissa precision includes the implicit bit.
   static constexpr uint32_t MANTISSA_PRECISION = MANTISSA_WIDTH + 1;
-  static constexpr uint32_t EXPONENT_WIDTH = 8;
   static constexpr BitsType MANTISSA_MASK = (BitsType(1) << MANTISSA_WIDTH) - 1;
   static constexpr BitsType SIGN_MASK = BitsType(1)
                                         << (EXPONENT_WIDTH + MANTISSA_WIDTH);
   static constexpr BitsType EXPONENT_MASK = ~(SIGN_MASK | MANTISSA_MASK);
-  static constexpr uint32_t EXPONENT_BIAS = 127;
-
   static constexpr BitsType EXP_MANT_MASK = MANTISSA_MASK + EXPONENT_MASK;
   static_assert(EXP_MANT_MASK == ~SIGN_MASK,
                 "Exponent and mantissa masks are not as expected.");
@@ -53,20 +129,14 @@ template <> struct FPProperties<FPType::IEEE754_Binary32> {
   static constexpr BitsType QUIET_NAN_MASK = 0x00400000U;
 };
 
-template <> struct FPProperties<FPType::IEEE754_Binary64> {
-  typedef uint64_t BitsType;
-
-  static constexpr uint32_t BIT_WIDTH = sizeof(BitsType) * 8;
-
-  static constexpr uint32_t MANTISSA_WIDTH = 52;
+template <>
+struct FPProperties<FPType::IEEE754_Binary64>
+    : public internal::FPCommonProperties<FPType::IEEE754_Binary64> {
   static constexpr uint32_t MANTISSA_PRECISION = MANTISSA_WIDTH + 1;
-  static constexpr uint32_t EXPONENT_WIDTH = 11;
   static constexpr BitsType MANTISSA_MASK = (BitsType(1) << MANTISSA_WIDTH) - 1;
   static constexpr BitsType SIGN_MASK = BitsType(1)
                                         << (EXPONENT_WIDTH + MANTISSA_WIDTH);
   static constexpr BitsType EXPONENT_MASK = ~(SIGN_MASK | MANTISSA_MASK);
-  static constexpr uint32_t EXPONENT_BIAS = 1023;
-
   static constexpr BitsType EXP_MANT_MASK = MANTISSA_MASK + EXPONENT_MASK;
   static_assert(EXP_MANT_MASK == ~SIGN_MASK,
                 "Exponent and mantissa masks are not as expected.");
@@ -79,27 +149,20 @@ template <> struct FPProperties<FPType::IEEE754_Binary64> {
 
 // Properties for numbers represented in 80 bits long double on non-Windows x86
 // platforms.
-template <> struct FPProperties<FPType::X86_Binary80> {
-  typedef UInt128 BitsType;
-
-  static constexpr uint32_t BIT_WIDTH = (sizeof(BitsType) * 8) - 48;
+template <>
+struct FPProperties<FPType::X86_Binary80>
+    : public internal::FPCommonProperties<FPType::X86_Binary80> {
   static constexpr BitsType FULL_WIDTH_MASK = ((BitsType(1) << BIT_WIDTH) - 1);
-
   static constexpr uint32_t MANTISSA_WIDTH = 63;
   static constexpr uint32_t MANTISSA_PRECISION = MANTISSA_WIDTH + 1;
-  static constexpr uint32_t EXPONENT_WIDTH = 15;
   static constexpr BitsType MANTISSA_MASK = (BitsType(1) << MANTISSA_WIDTH) - 1;
-
   // The x86 80 bit float represents the leading digit of the mantissa
   // explicitly. This is the mask for that bit.
   static constexpr BitsType EXPLICIT_BIT_MASK = (BitsType(1) << MANTISSA_WIDTH);
-
   static constexpr BitsType SIGN_MASK =
       BitsType(1) << (EXPONENT_WIDTH + MANTISSA_WIDTH + 1);
   static constexpr BitsType EXPONENT_MASK =
       ((BitsType(1) << EXPONENT_WIDTH) - 1) << (MANTISSA_WIDTH + 1);
-  static constexpr uint32_t EXPONENT_BIAS = 16383;
-
   static constexpr BitsType EXP_MANT_MASK =
       MANTISSA_MASK | EXPLICIT_BIT_MASK | EXPONENT_MASK;
   static_assert(EXP_MANT_MASK == (~SIGN_MASK & FULL_WIDTH_MASK),
@@ -114,20 +177,14 @@ template <> struct FPProperties<FPType::X86_Binary80> {
 
 // Properties for numbers represented in 128 bits long double on non x86
 // platform.
-template <> struct FPProperties<FPType::IEEE754_Binary128> {
-  typedef UInt128 BitsType;
-
-  static constexpr uint32_t BIT_WIDTH = sizeof(BitsType) << 3;
-
-  static constexpr uint32_t MANTISSA_WIDTH = 112;
+template <>
+struct FPProperties<FPType::IEEE754_Binary128>
+    : public internal::FPCommonProperties<FPType::IEEE754_Binary128> {
   static constexpr uint32_t MANTISSA_PRECISION = MANTISSA_WIDTH + 1;
-  static constexpr uint32_t EXPONENT_WIDTH = 15;
   static constexpr BitsType MANTISSA_MASK = (BitsType(1) << MANTISSA_WIDTH) - 1;
   static constexpr BitsType SIGN_MASK = BitsType(1)
                                         << (EXPONENT_WIDTH + MANTISSA_WIDTH);
   static constexpr BitsType EXPONENT_MASK = ~(SIGN_MASK | MANTISSA_MASK);
-  static constexpr uint32_t EXPONENT_BIAS = 16383;
-
   static constexpr BitsType EXP_MANT_MASK = MANTISSA_MASK | EXPONENT_MASK;
   static_assert(EXP_MANT_MASK == ~SIGN_MASK,
                 "Exponent and mantissa masks are not as expected.");

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -40,44 +40,44 @@ enum class FPEncoding {
 template <FPType> struct FPBaseProperties {};
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary16> {
+  using UIntType = uint16_t;
   LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 16;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 10;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 5;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
-  using UIntType = uint16_t;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary32> {
+  using UIntType = uint32_t;
   LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 32;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 23;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 8;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
-  using UIntType = uint32_t;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary64> {
+  using UIntType = uint64_t;
   LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 64;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 52;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 11;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
-  using UIntType = uint64_t;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
+  using UIntType = UInt128;
   LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 128;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 112;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
-  using UIntType = UInt128;
 };
 
 template <> struct FPBaseProperties<FPType::X86_Binary80> {
   LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 80;
+  using UIntType = UInt128;
   LIBC_INLINE_VAR static constexpr int SIG_BITS = 64;
   LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING =
       FPEncoding::X86_ExtendedPrecision;
-  using UIntType = UInt128;
 };
 
 // Derives more properties from 'FPBaseProperties' above.


### PR DESCRIPTION
Factor in common properties of `FloatProperties`.

This is a first patch of a series to simplify `FloatProperties` and `FPBits` implementations.
