### PR TITLE
Disable fail-fast for libc++ builders.

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: libcxx-runners-8-set
     continue-on-error: false
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config: [
           'generic-cxx03',
@@ -92,7 +92,7 @@ jobs:
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config: [
           'generic-cxx11',


### PR DESCRIPTION
It seems the fail fast just doesn't strike the right balance.
It wastes too many resources, especially if a build is killed because
the machine it was running on got preempted.

Instead, we should simply not run any future jobs if a failure has
occured, while letting the already running jobs finish.
