### PR TITLE
[flang] Move `genCommonBlockMember` from OpenMP to ConvertVariable, NFC

### DIFF
--- a/flang/include/flang/Lower/ConvertVariable.h
+++ b/flang/include/flang/Lower/ConvertVariable.h
@@ -76,6 +76,7 @@ void defineCommonBlocks(
 /// of the COMMON block. As the offset from the symbol \p sym, generate the
 /// COMMON block member value (commonValue + offset) for the symbol.
 mlir::Value genCommonBlockMember(AbstractConverter &converter,
+                                 mlir::Location loc,
                                  const Fortran::semantics::Symbol &sym,
                                  mlir::Value commonValue);
 

--- a/flang/include/flang/Lower/ConvertVariable.h
+++ b/flang/include/flang/Lower/ConvertVariable.h
@@ -19,6 +19,7 @@
 
 #include "flang/Lower/Support/Utils.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Semantics/symbol.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
 
@@ -29,7 +30,12 @@ class GlobalOp;
 class FortranVariableFlagsAttr;
 } // namespace fir
 
-namespace Fortran ::lower {
+namespace Fortran {
+namespace semantics {
+class Scope;
+} // namespace semantics
+
+namespace lower {
 class AbstractConverter;
 class CallerInterface;
 class StatementContext;
@@ -65,6 +71,13 @@ void defineCommonBlocks(
     AbstractConverter &,
     const std::vector<std::pair<semantics::SymbolRef, std::size_t>>
         &commonBlocks);
+
+/// The COMMON block is a global structure. \p commonValue is the base address
+/// of the COMMON block. As the offset from the symbol \p sym, generate the
+/// COMMON block member value (commonValue + offset) for the symbol.
+mlir::Value genCommonBlockMember(AbstractConverter &converter,
+                                 const Fortran::semantics::Symbol &sym,
+                                 mlir::Value commonValue);
 
 /// Lower a symbol attributes given an optional storage \p and add it to the
 /// provided symbol map. If \preAlloc is not provided, a temporary storage will
@@ -138,5 +151,6 @@ void genDeclareSymbol(Fortran::lower::AbstractConverter &converter,
 /// Cray pointer symbol. Assert if the pointer symbol cannot be found.
 Fortran::semantics::SymbolRef getCrayPointer(Fortran::semantics::SymbolRef sym);
 
-} // namespace Fortran::lower
+} // namespace lower
+} // namespace Fortran
 #endif // FORTRAN_LOWER_CONVERT_VARIABLE_H

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -2025,7 +2025,7 @@ static void threadPrivatizeVars(Fortran::lower::AbstractConverter &converter,
         commonSyms.insert(common);
       }
       symThreadprivateValue = Fortran::lower::genCommonBlockMember(
-          converter, *sym, commonThreadprivateValue);
+          converter, currentLocation, *sym, commonThreadprivateValue);
     } else {
       symThreadprivateValue = genThreadprivateOp(*sym);
     }
@@ -3529,8 +3529,8 @@ void Fortran::lower::genThreadprivateOp(
             currentLocation, commonValue.getType(), commonValue);
     converter.bindSymbol(*common, commonThreadprivateValue);
     // Generate the threadprivate value for the common block member.
-    symThreadprivateValue =
-        genCommonBlockMember(converter, sym, commonThreadprivateValue);
+    symThreadprivateValue = genCommonBlockMember(converter, currentLocation,
+                                                 sym, commonThreadprivateValue);
   } else if (!var.isGlobal()) {
     // Non-global variable which can be in threadprivate directive must be one
     // variable in main program, and it has implicit SAVE attribute. Take it as

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -1959,31 +1959,6 @@ static mlir::Operation *getCompareFromReductionOp(mlir::Operation *reductionOp,
   return nullptr;
 }
 
-/// The COMMON block is a global structure. \p commonValue is the base address
-/// of the COMMON block. As the offset from the symbol \p sym, generate the
-/// COMMON block member value (commonValue + offset) for the symbol.
-/// FIXME: Share the code with `instantiateCommon` in ConvertVariable.cpp.
-static mlir::Value
-genCommonBlockMember(Fortran::lower::AbstractConverter &converter,
-                     const Fortran::semantics::Symbol &sym,
-                     mlir::Value commonValue) {
-  fir::FirOpBuilder &firOpBuilder = converter.getFirOpBuilder();
-  mlir::Location currentLocation = converter.getCurrentLocation();
-  mlir::IntegerType i8Ty = firOpBuilder.getIntegerType(8);
-  mlir::Type i8Ptr = firOpBuilder.getRefType(i8Ty);
-  mlir::Type seqTy = firOpBuilder.getRefType(firOpBuilder.getVarLenSeqTy(i8Ty));
-  mlir::Value base =
-      firOpBuilder.createConvert(currentLocation, seqTy, commonValue);
-  std::size_t byteOffset = sym.GetUltimate().offset();
-  mlir::Value offs = firOpBuilder.createIntegerConstant(
-      currentLocation, firOpBuilder.getIndexType(), byteOffset);
-  mlir::Value varAddr = firOpBuilder.create<fir::CoordinateOp>(
-      currentLocation, i8Ptr, base, mlir::ValueRange{offs});
-  mlir::Type symType = converter.genType(sym);
-  return firOpBuilder.createConvert(currentLocation,
-                                    firOpBuilder.getRefType(symType), varAddr);
-}
-
 // Get the extended value for \p val by extracting additional variable
 // information from \p base.
 static fir::ExtendedValue getExtendedValue(fir::ExtendedValue base,
@@ -2049,8 +2024,8 @@ static void threadPrivatizeVars(Fortran::lower::AbstractConverter &converter,
         converter.bindSymbol(*common, commonThreadprivateValue);
         commonSyms.insert(common);
       }
-      symThreadprivateValue =
-          genCommonBlockMember(converter, *sym, commonThreadprivateValue);
+      symThreadprivateValue = Fortran::lower::genCommonBlockMember(
+          converter, *sym, commonThreadprivateValue);
     } else {
       symThreadprivateValue = genThreadprivateOp(*sym);
     }


### PR DESCRIPTION
The function `genCommonBlockMember` is not specific to OpenMP, and it could very well be a common utility. Move it to ConvertVariable.cpp where it logically belongs.