### PR TITLE
Attempt to use composite action for libc++ builders.

### DIFF
--- a/.github/actions/libcxx/run-buildbot/action.yaml
+++ b/.github/actions/libcxx/run-buildbot/action.yaml
@@ -1,0 +1,45 @@
+name: 'Configure the runtimes build'
+description: 'Match strings against paths in diff for origin/main and current SHA'
+
+inputs:
+  configuration:
+    description: 'the configuration to build'
+    required: true
+  cxx:
+    description: 'C++ compiler'
+    required: true
+  cc:
+    description: 'C compiler'
+    required: true
+  enable_clang_tidy:
+    description: 'enable clang-tidy'
+    required: false
+    default: 'OFF'
+  std_modules:
+    description: 'enable std modules'
+    required: false
+    default: 'OFF'
+
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: actions/checkout@v4
+    - name: ${{ inputs.config }}.${{ inputs.cxx }}
+      run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
+      env:
+        CC: ${{ inputs.cc }}
+        CXX: ${{ inputs.cxx }}
+        ENABLE_CLANG_TIDY: ${{ inputs.clang_tidy }}
+        ENABLE_STD_MODULES: ${{ inputs.std_modules }}
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ inputs.config }}-${{ matrix.cxx }}-results
+        path: |
+          **/test-results.xml
+          **/*.abilist
+          **/CMakeError.log
+          **/CMakeOutput.log
+          **/crash_diagnostics/*

--- a/.github/actions/libcxx/run-buildbot/action.yaml
+++ b/.github/actions/libcxx/run-buildbot/action.yaml
@@ -20,7 +20,6 @@ inputs:
     required: false
     default: 'OFF'
 
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/libcxx/run-buildbot/action.yaml
+++ b/.github/actions/libcxx/run-buildbot/action.yaml
@@ -1,5 +1,5 @@
-name: 'Configure the runtimes build'
-description: 'Match strings against paths in diff for origin/main and current SHA'
+name: 'Run Buildbot for libc++'
+description: 'Invoke the run-buildbot script with the specified parameters'
 
 inputs:
   configuration:
@@ -15,7 +15,7 @@ inputs:
     description: 'enable clang-tidy'
     required: false
     default: 'OFF'
-  std_modules:
+  enable_std_modules:
     description: 'enable std modules'
     required: false
     default: 'OFF'
@@ -23,20 +23,20 @@ inputs:
 
 runs:
   using: "composite"
-
   steps:
     - uses: actions/checkout@v4
-    - name: ${{ inputs.config }}.${{ inputs.cxx }}
-      run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
+    - name: ${{ inputs.configuration }}.${{ inputs.cxx }}
+      run: libcxx/utils/ci/run-buildbot ${{ inputs.configuration }}
+      shell: bash
       env:
         CC: ${{ inputs.cc }}
         CXX: ${{ inputs.cxx }}
-        ENABLE_CLANG_TIDY: ${{ inputs.clang_tidy }}
-        ENABLE_STD_MODULES: ${{ inputs.std_modules }}
+        ENABLE_CLANG_TIDY: ${{ inputs.enable_clang_tidy }}
+        ENABLE_STD_MODULES: ${{ inputs.enable_std_modules }}
     - uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: ${{ inputs.config }}-${{ matrix.cxx }}-results
+        name: ${{ inputs.configuration }}-${{ inputs.cxx }}-results
         path: |
           **/test-results.xml
           **/*.abilist

--- a/.github/workflows/libcxx-build-and-test-manual.yaml
+++ b/.github/workflows/libcxx-build-and-test-manual.yaml
@@ -1,0 +1,65 @@
+# This file defines a one-off single configuration CI job which can be manually triggered with the various
+# knobs and switches that are available in the pre-commit CI.
+#
+# The purpose of this workflow it to make reproducing non-tested configuration issues easier, and to allow
+# for testing of new configurations.
+name: Build and Test libc++
+on:
+  workflow_dispatch:
+    inputs:
+      configuration:
+        description: 'the configuration to build'
+        required: true
+      cxx:
+        description: 'C++ compiler'
+        required: true
+      cc:
+        description: 'C compiler'
+        required: true
+      enable_clang_tidy:
+        description: 'enable clang-tidy'
+        required: false
+        default: 'OFF'
+      std_modules:
+        description: 'enable std modules'
+        required: false
+        default: 'OFF'
+      runner:
+        description: 'runner to use'
+        required: false
+        default: 'libcxx-runners-8-set'
+
+permissions:
+  contents: read # Default everything to read-only
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.actor }}
+  cancel-in-progress: false
+
+
+env:
+  CMAKE: "/opt/bin/cmake"
+  # LLVM POST-BRANCH bump version
+  # LLVM POST-BRANCH add compiler test for ToT - 1, e.g. "Clang 17"
+  # LLVM RELEASE bump remove compiler ToT - 3, e.g. "Clang 15"
+  LLVM_HEAD_VERSION: "18"   # Used compiler, update POST-BRANCH.
+  LLVM_PREVIOUS_VERSION: "17"
+  LLVM_OLDEST_VERSION: "16"
+  GCC_STABLE_VERSION: "13"
+  LLVM_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer-18"
+  CLANG_CRASH_DIAGNOSTICS_DIR: "crash_diagnostics"
+
+
+jobs:
+  build-libcxx:
+    if: github.repository_owner == 'llvm'
+    runs-on: ${{ inputs.runner }}
+    steps:
+      # FIXME: Change to ./.github/actions/libcxx/run-buildbot
+      - uses: libcxx/actions/run-buildbot@main
+        with:
+          configuration: ${{ matrix.config }}
+          cc: ${{ inputs.cc }}
+          cxx: ${{ inputs.cxx }}
+          enable_clang_tidy: ${{ inputs.clang_tidy }}
+          enable_std_modules: ${{ inputs.std_modules }}

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -72,10 +72,10 @@ jobs:
       # FIXME: Change to ./.github/actions/libcxx/run-buildbot
       - uses: libcxx/actions/run-buildbot@main
         with:
-          config: ${{ matrix.config }}
+          configuration: ${{ matrix.config }}
           cc: ${{ matrix.cc }}
           cxx: ${{ matrix.cxx }}
-          clang_tidy: ${{ matrix.clang_tidy }}
+          enable_clang_tidy: ${{ matrix.clang_tidy }}
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-runners-8-set
@@ -108,12 +108,12 @@ jobs:
             cxx: 'clang++-17'
             clang_tidy: 'OFF'
     steps:
-      - uses: ./.github/actions/libcxx/run-buildbot
+      - uses: libcxx/actions/run-buildbot@main
         with:
-          config: ${{ matrix.config }}
+          configuration: ${{ matrix.config }}
           cc: ${{ matrix.cc }}
           cxx: ${{ matrix.cxx }}
-          clang_tidy: ${{ matrix.clang_tidy }}
+          enable_clang_tidy: ${{ matrix.clang_tidy }}
 
   stage3:
     if: github.repository_owner == 'llvm'
@@ -170,8 +170,8 @@ jobs:
     steps:
       - uses: libcxx/actions/run-buildbot@main
         with:
-          config: ${{ matrix.config }}
+          configuration: ${{ matrix.config }}
           cc: clang-18
           cxx: clang++-18
-          clang_tidy: "OFF"
-          std_modules: ${{ matrix.std_modules }}
+          enable_clang_tidy: "OFF"
+          enable_std_modules: ${{ matrix.std_modules }}

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -69,23 +69,13 @@ jobs:
             cxx: 'g++-13'
             clang_tidy: 'OFF'
     steps:
-      - uses: actions/checkout@v4
-      - name: ${{ matrix.config }}.${{ matrix.cxx }}
-        run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
-          ENABLE_CLANG_TIDY: ${{ matrix.clang_tidy }}
-      - uses: actions/upload-artifact@v3
-        if: always()
+      # FIXME: Change to ./.github/actions/libcxx/run-buildbot
+      - uses: libcxx/actions/run-buildbot@main
         with:
-          name: ${{ matrix.config }}-${{ matrix.cxx }}-results
-          path: |
-            **/test-results.xml
-            **/*.abilist
-            **/CMakeError.log
-            **/CMakeOutput.log
-            **/crash_diagnostics/*
+          config: ${{ matrix.config }}
+          cc: ${{ matrix.cc }}
+          cxx: ${{ matrix.cxx }}
+          clang_tidy: ${{ matrix.clang_tidy }}
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-runners-8-set
@@ -118,23 +108,13 @@ jobs:
             cxx: 'clang++-17'
             clang_tidy: 'OFF'
     steps:
-      - uses: actions/checkout@v4
-      - name: ${{ matrix.config }}
-        run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
-          ENABLE_CLANG_TIDY: ${{ matrix.clang_tidy }}
-      - uses: actions/upload-artifact@v3
-        if: always()  # Upload artifacts even if the build or test suite fails
+      - uses: ./.github/actions/libcxx/run-buildbot
         with:
-          name: ${{ matrix.config }}-results
-          path: |
-            **/test-results.xml
-            **/*.abilist
-            **/CMakeError.log
-            **/CMakeOutput.log
-            **/crash_diagnostics/*
+          config: ${{ matrix.config }}
+          cc: ${{ matrix.cc }}
+          cxx: ${{ matrix.cxx }}
+          clang_tidy: ${{ matrix.clang_tidy }}
+
   stage3:
     if: github.repository_owner == 'llvm'
     needs: [ stage1, stage2 ]
@@ -188,22 +168,10 @@ jobs:
           std_modules: 'OFF'
     runs-on: ${{ matrix.machine }}
     steps:
-      - uses: actions/checkout@v4
-      - name: ${{ matrix.config }}
-        run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
-        env:
-          CC: clang-18
-          CXX: clang++-18
-          ENABLE_CLANG_TIDY: "OFF"
-          ENABLE_STD_MODULES: ${{ matrix.std_modules }}
-      - uses: actions/upload-artifact@v3
-        if: always()
+      - uses: libcxx/actions/run-buildbot@main
         with:
-          name: ${{ matrix.config }}-results
-          path: |
-            **/test-results.xml
-            **/*.abilist
-            **/CMakeError.log
-            **/CMakeOutput.log
-            **/crash_diagnostics/*
-  
+          config: ${{ matrix.config }}
+          cc: clang-18
+          cxx: clang++-18
+          clang_tidy: "OFF"
+          std_modules: ${{ matrix.std_modules }}


### PR DESCRIPTION
This will allow us to refactor the single composite action rather
than every usage of it in the workflow when we want to make changes.

For the moment, the patch references an out-of-org action, this is
only temporary to demonstrate that it works.
