### PR TITLE
[libc++][NFC] Use aliases instead of typedefs in std::array

### DIFF
--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -164,18 +164,18 @@ template <class _Tp, size_t _Size>
 struct _LIBCPP_TEMPLATE_VIS array
 {
     // types:
-    typedef array __self;
-    typedef _Tp                                   value_type;
-    typedef value_type&                           reference;
-    typedef const value_type&                     const_reference;
-    typedef value_type*                           iterator;
-    typedef const value_type*                     const_iterator;
-    typedef value_type*                           pointer;
-    typedef const value_type*                     const_pointer;
-    typedef size_t                                size_type;
-    typedef ptrdiff_t                             difference_type;
-    typedef std::reverse_iterator<iterator>       reverse_iterator;
-    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+    using __self                 = array;
+    using value_type             = _Tp;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using iterator               = value_type*;
+    using const_iterator         = const value_type*;
+    using pointer                = value_type*;
+    using const_pointer          = const value_type*;
+    using size_type              = size_t;
+    using difference_type        = ptrdiff_t;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     _Tp __elems_[_Size];
 


### PR DESCRIPTION
As requested in https://github.com/llvm/llvm-project/pull/74482.