### PR TITLE
[Flang] remove assert using femode_t from AIX

### DIFF
--- a/flang/runtime/exceptions.cpp
+++ b/flang/runtime/exceptions.cpp
@@ -77,12 +77,8 @@ std::int32_t RTNAME(MapException)(int32_t except) {
 
 // Verify that the size of ieee_modes_type and ieee_status_type objects from
 // intrinsic module file __fortran_ieee_exceptions.f90 are large enough to
-// hold femode_t and fenv_t objects, respectively.
-#if !defined(_WIN32) && !defined(_AIX)
-static_assert(
-    sizeof(femode_t) <= sizeof(int) * _FORTRAN_RUNTIME_IEEE_FEMODE_T_EXTENT,
-    "increase ieee_modes_type size");
-#endif
+// hold fenv_t object.
+// TODO: consider femode_t object size comparison once its more mature.
 static_assert(
     sizeof(fenv_t) <= sizeof(int) * _FORTRAN_RUNTIME_IEEE_FENV_T_EXTENT,
     "increase ieee_status_type size");

--- a/flang/runtime/exceptions.cpp
+++ b/flang/runtime/exceptions.cpp
@@ -78,7 +78,7 @@ std::int32_t RTNAME(MapException)(int32_t except) {
 // Verify that the size of ieee_modes_type and ieee_status_type objects from
 // intrinsic module file __fortran_ieee_exceptions.f90 are large enough to
 // hold femode_t and fenv_t objects, respectively.
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_AIX)
 static_assert(
     sizeof(femode_t) <= sizeof(int) * _FORTRAN_RUNTIME_IEEE_FEMODE_T_EXTENT,
     "increase ieee_modes_type size");


### PR DESCRIPTION
AIX does not have `femode_t` in `<cfenv>` header, removing the assert to fix build failures