### PR TITLE
[mlir][LLVM] Add nsw and nuw flags

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -429,6 +429,29 @@ def DISubprogramFlags : I32BitEnumAttr<
 }
 
 //===----------------------------------------------------------------------===//
+// IntegerArithFlags
+//===----------------------------------------------------------------------===//
+
+def IAFnone : I32BitEnumAttrCaseNone<"none">;
+def IAFnsw  : I32BitEnumAttrCaseBit<"nsw", 0>;
+def IAFnuw  : I32BitEnumAttrCaseBit<"nuw", 1>;
+
+def IntegerArithFlags : I32BitEnumAttr<
+    "IntegerArithFlags",
+    "LLVM integer arithmetic flags",
+    [IAFnone, IAFnsw, IAFnuw]> {
+  let separator = ", ";
+  let cppNamespace = "::mlir::LLVM";
+  let genSpecializedAttr = 0;
+  let printBitEnumPrimaryGroups = 1;
+}
+
+def LLVM_IntegerArithFlagsAttr :
+    EnumAttr<LLVM_Dialect, IntegerArithFlags, "arith"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+//===----------------------------------------------------------------------===//
 // FastmathFlags
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -429,25 +429,25 @@ def DISubprogramFlags : I32BitEnumAttr<
 }
 
 //===----------------------------------------------------------------------===//
-// IntegerArithFlags
+// IntegerOverflowFlags
 //===----------------------------------------------------------------------===//
 
-def IAFnone : I32BitEnumAttrCaseNone<"none">;
-def IAFnsw  : I32BitEnumAttrCaseBit<"nsw", 0>;
-def IAFnuw  : I32BitEnumAttrCaseBit<"nuw", 1>;
+def IOFnone : I32BitEnumAttrCaseNone<"none">;
+def IOFnsw  : I32BitEnumAttrCaseBit<"nsw", 0>;
+def IOFnuw  : I32BitEnumAttrCaseBit<"nuw", 1>;
 
-def IntegerArithFlags : I32BitEnumAttr<
-    "IntegerArithFlags",
-    "LLVM integer arithmetic flags",
-    [IAFnone, IAFnsw, IAFnuw]> {
+def IntegerOverflowFlags : I32BitEnumAttr<
+    "IntegerOverflowFlags",
+    "LLVM integer overflow flags",
+    [IOFnone, IOFnsw, IOFnuw]> {
   let separator = ", ";
   let cppNamespace = "::mlir::LLVM";
   let genSpecializedAttr = 0;
   let printBitEnumPrimaryGroups = 1;
 }
 
-def LLVM_IntegerArithFlagsAttr :
-    EnumAttr<LLVM_Dialect, IntegerArithFlags, "arith"> {
+def LLVM_IntegerOverflowFlagsAttr :
+    EnumAttr<LLVM_Dialect, IntegerOverflowFlags, "overflow"> {
   let assemblyFormat = "`<` $value `>`";
 }
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -70,7 +70,7 @@ def IntegerOverflowFlagsInterface : OpInterface<"IntegerOverflowFlagsInterface">
     InterfaceMethod<
       /*desc=*/        "Returns whether the operation has the No Unsigned Wrap keyword",
       /*returnType=*/  "bool",
-      /*methodName=*/  "hasNuw",
+      /*methodName=*/  "hasNoUnsignedWrap",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
@@ -82,7 +82,7 @@ def IntegerOverflowFlagsInterface : OpInterface<"IntegerOverflowFlagsInterface">
     InterfaceMethod<
       /*desc=*/        "Returns whether the operation has the No Signed Wrap keyword",
       /*returnType=*/  "bool",
-      /*methodName=*/  "hasNsw",
+      /*methodName=*/  "hasNoSignedWrap",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -48,7 +48,7 @@ def FastmathFlagsInterface : OpInterface<"FastmathFlagsInterface"> {
   ];
 }
 
-def IntegerArithFlagsInterface : OpInterface<"IntegerArithFlagsInterface"> {
+def IntegerOverflowFlagsInterface : OpInterface<"IntegerOverflowFlagsInterface"> {
   let description = [{
     Access to op integer overflow flags.
   }];
@@ -57,14 +57,14 @@ def IntegerArithFlagsInterface : OpInterface<"IntegerArithFlagsInterface"> {
 
   let methods = [
     InterfaceMethod<
-      /*desc=*/        "Returns a IntegerArithFlagsAttr attribute for the operation",
-      /*returnType=*/  "IntegerArithFlagsAttr",
-      /*methodName=*/  "getArithAttr",
+      /*desc=*/        "Returns an IntegerOverflowFlagsAttr attribute for the operation",
+      /*returnType=*/  "IntegerOverflowFlagsAttr",
+      /*methodName=*/  "getOverflowAttr",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
-        return op.getArithFlagsAttr();
+        return op.getOverflowFlagsAttr();
       }]
       >,
     InterfaceMethod<
@@ -75,8 +75,8 @@ def IntegerArithFlagsInterface : OpInterface<"IntegerArithFlagsInterface"> {
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
-        IntegerArithFlags flags = op.getArithFlagsAttr().getValue();
-        return bitEnumContainsAll(flags, IntegerArithFlags::nuw);
+        IntegerOverflowFlags flags = op.getOverflowFlagsAttr().getValue();
+        return bitEnumContainsAll(flags, IntegerOverflowFlags::nuw);
       }]
       >,
     InterfaceMethod<
@@ -87,19 +87,19 @@ def IntegerArithFlagsInterface : OpInterface<"IntegerArithFlagsInterface"> {
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
-        IntegerArithFlags flags = op.getArithFlagsAttr().getValue();
-        return bitEnumContainsAll(flags, IntegerArithFlags::nsw);
+        IntegerOverflowFlags flags = op.getOverflowFlagsAttr().getValue();
+        return bitEnumContainsAll(flags, IntegerOverflowFlags::nsw);
       }]
       >,
     StaticInterfaceMethod<
-      /*desc=*/        [{Returns the name of the IntegerArithFlagsAttr attribute
+      /*desc=*/        [{Returns the name of the IntegerOveflowFlagsAttr attribute
                          for the operation}],
       /*returnType=*/  "StringRef",
-      /*methodName=*/  "getIntegerArithAttrName",
+      /*methodName=*/  "getIntegerOverflowAttrName",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
-        return "arithFlags";
+        return "overflowFlags";
       }]
       >
   ];

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -48,6 +48,63 @@ def FastmathFlagsInterface : OpInterface<"FastmathFlagsInterface"> {
   ];
 }
 
+def IntegerArithFlagsInterface : OpInterface<"IntegerArithFlagsInterface"> {
+  let description = [{
+    Access to op integer overflow flags.
+  }];
+
+  let cppNamespace = "::mlir::LLVM";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/        "Returns a IntegerArithFlagsAttr attribute for the operation",
+      /*returnType=*/  "IntegerArithFlagsAttr",
+      /*methodName=*/  "getArithAttr",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        return op.getArithFlagsAttr();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        "Returns whether the operation has the No Unsigned Wrap keyword",
+      /*returnType=*/  "bool",
+      /*methodName=*/  "hasNuw",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        IntegerArithFlags flags = op.getArithFlagsAttr().getValue();
+        return bitEnumContainsAll(flags, IntegerArithFlags::nuw);
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        "Returns whether the operation has the No Signed Wrap keyword",
+      /*returnType=*/  "bool",
+      /*methodName=*/  "hasNsw",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        IntegerArithFlags flags = op.getArithFlagsAttr().getValue();
+        return bitEnumContainsAll(flags, IntegerArithFlags::nsw);
+      }]
+      >,
+    StaticInterfaceMethod<
+      /*desc=*/        [{Returns the name of the IntegerArithFlagsAttr attribute
+                         for the operation}],
+      /*returnType=*/  "StringRef",
+      /*methodName=*/  "getIntegerArithAttrName",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        return "arithFlags";
+      }]
+      >
+  ];
+}
+
 def BranchWeightOpInterface : OpInterface<"BranchWeightOpInterface"> {
   let description = [{
     An interface for operations that can carry branch weights metadata. It

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -68,7 +68,7 @@ class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
     $res = op;
   }];
   let assemblyFormat = [{
-    $lhs `,` $rhs (`flags` ` ` $overflowFlags^)?
+    $lhs `,` $rhs (`overflow` $overflowFlags^)?
     custom<LLVMOpAttrs>(attr-dict) `:` type($res)
   }];
   string llvmBuilder =

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -55,7 +55,7 @@ class LLVM_IntArithmeticOp<string mnemonic, string instName,
     $res = $_builder.create<$_qualCppClassName>($_location, $lhs, $rhs);
   }];
 }
-class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
+class LLVM_IntArithmeticOpWithOverflowFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnyInteger, mnemonic, instName,
     !listconcat([DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>], traits)> {
@@ -64,7 +64,7 @@ class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
   let arguments = !con(commonArgs, iofArg);
   string mlirBuilder = [{
     auto op = $_builder.create<$_qualCppClassName>($_location, $lhs, $rhs);
-    moduleImport.setIntegerFlagsAttr(inst, op);
+    moduleImport.setIntegerOverflowFlagsAttr(inst, op);
     $res = op;
   }];
   let assemblyFormat = [{
@@ -110,9 +110,11 @@ class LLVM_UnaryFloatArithmeticOp<Type type, string mnemonic,
 }
 
 // Integer binary operations.
-def LLVM_AddOp : LLVM_IntArithmeticOpWithFlag<"add", "Add", [Commutative]>;
-def LLVM_SubOp : LLVM_IntArithmeticOpWithFlag<"sub", "Sub", []>;
-def LLVM_MulOp : LLVM_IntArithmeticOpWithFlag<"mul", "Mul", [Commutative]>;
+def LLVM_AddOp : LLVM_IntArithmeticOpWithOverflowFlag<"add", "Add",
+    [Commutative]>;
+def LLVM_SubOp : LLVM_IntArithmeticOpWithOverflowFlag<"sub", "Sub", []>;
+def LLVM_MulOp : LLVM_IntArithmeticOpWithOverflowFlag<"mul", "Mul",
+    [Commutative]>;
 def LLVM_UDivOp : LLVM_IntArithmeticOp<"udiv", "UDiv">;
 def LLVM_SDivOp : LLVM_IntArithmeticOp<"sdiv", "SDiv">;
 def LLVM_URemOp : LLVM_IntArithmeticOp<"urem", "URem">;
@@ -122,7 +124,7 @@ def LLVM_OrOp : LLVM_IntArithmeticOp<"or", "Or"> {
   let hasFolder = 1;
 }
 def LLVM_XOrOp : LLVM_IntArithmeticOp<"xor", "Xor">;
-def LLVM_ShlOp : LLVM_IntArithmeticOpWithFlag<"shl", "Shl", []> {
+def LLVM_ShlOp : LLVM_IntArithmeticOpWithOverflowFlag<"shl", "Shl", []> {
   let hasFolder = 1;
 }
 def LLVM_LShrOp : LLVM_IntArithmeticOp<"lshr", "LShr">;

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -58,16 +58,16 @@ class LLVM_IntArithmeticOp<string mnemonic, string instName,
 class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnyInteger, mnemonic, instName,
-    !listconcat([DeclareOpInterfaceMethods<IntegerArithFlagsInterface>], traits)> {
-  dag iafArg = (
-    ins DefaultValuedAttr<LLVM_IntegerArithFlagsAttr, "{}">:$arithFlags);
-  let arguments = !con(commonArgs, iafArg);
+    !listconcat([DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>], traits)> {
+  dag iofArg = (
+    ins DefaultValuedAttr<LLVM_IntegerOverflowFlagsAttr, "{}">:$overflowFlags);
+  let arguments = !con(commonArgs, iofArg);
   string mlirBuilder = [{
     auto op = $_builder.create<$_qualCppClassName>($_location, $lhs, $rhs);
     moduleImport.setIntegerFlagsAttr(inst, op);
     $res = op;
   }];
-  let assemblyFormat = "$lhs `,` $rhs (`flags` ` ` $arithFlags^)? custom<LLVMOpAttrs>(attr-dict) `:` type($res)";
+  let assemblyFormat = "$lhs `,` $rhs (`flags` ` ` $overflowFlags^)? custom<LLVMOpAttrs>(attr-dict) `:` type($res)";
   string llvmBuilder = "$res = builder.Create" # instName # "($lhs, $rhs, /*Name=*/\"\", op.hasNuw(), op.hasNsw());";
 }
 class LLVM_FloatArithmeticOp<string mnemonic, string instName,

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -55,6 +55,21 @@ class LLVM_IntArithmeticOp<string mnemonic, string instName,
     $res = $_builder.create<$_qualCppClassName>($_location, $lhs, $rhs);
   }];
 }
+class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
+                                   list<Trait> traits = []> :
+    LLVM_ArithmeticOpBase<AnyInteger, mnemonic, instName,
+    !listconcat([DeclareOpInterfaceMethods<IntegerArithFlagsInterface>], traits)> {
+  dag iafArg = (
+    ins DefaultValuedAttr<LLVM_IntegerArithFlagsAttr, "{}">:$arithFlags);
+  let arguments = !con(commonArgs, iafArg);
+  string mlirBuilder = [{
+    auto op = $_builder.create<$_qualCppClassName>($_location, $lhs, $rhs);
+    moduleImport.setIntegerFlagsAttr(inst, op);
+    $res = op;
+  }];
+  let assemblyFormat = "$lhs `,` $rhs (`flags` ` ` $arithFlags^)? custom<LLVMOpAttrs>(attr-dict) `:` type($res)";
+  string llvmBuilder = "$res = builder.Create" # instName # "($lhs, $rhs, /*Name=*/\"\", op.hasNuw(), op.hasNsw());";
+}
 class LLVM_FloatArithmeticOp<string mnemonic, string instName,
                              list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<LLVM_AnyFloat, mnemonic, instName,
@@ -90,9 +105,9 @@ class LLVM_UnaryFloatArithmeticOp<Type type, string mnemonic,
 }
 
 // Integer binary operations.
-def LLVM_AddOp : LLVM_IntArithmeticOp<"add", "Add", [Commutative]>;
-def LLVM_SubOp : LLVM_IntArithmeticOp<"sub", "Sub">;
-def LLVM_MulOp : LLVM_IntArithmeticOp<"mul", "Mul", [Commutative]>;
+def LLVM_AddOp : LLVM_IntArithmeticOpWithFlag<"add", "Add", [Commutative]>;
+def LLVM_SubOp : LLVM_IntArithmeticOpWithFlag<"sub", "Sub", []>;
+def LLVM_MulOp : LLVM_IntArithmeticOpWithFlag<"mul", "Mul", [Commutative]>;
 def LLVM_UDivOp : LLVM_IntArithmeticOp<"udiv", "UDiv">;
 def LLVM_SDivOp : LLVM_IntArithmeticOp<"sdiv", "SDiv">;
 def LLVM_URemOp : LLVM_IntArithmeticOp<"urem", "URem">;
@@ -102,7 +117,7 @@ def LLVM_OrOp : LLVM_IntArithmeticOp<"or", "Or"> {
   let hasFolder = 1;
 }
 def LLVM_XOrOp : LLVM_IntArithmeticOp<"xor", "Xor">;
-def LLVM_ShlOp : LLVM_IntArithmeticOp<"shl", "Shl"> {
+def LLVM_ShlOp : LLVM_IntArithmeticOpWithFlag<"shl", "Shl", []> {
   let hasFolder = 1;
 }
 def LLVM_LShrOp : LLVM_IntArithmeticOp<"lshr", "LShr">;

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -67,8 +67,13 @@ class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
     moduleImport.setIntegerFlagsAttr(inst, op);
     $res = op;
   }];
-  let assemblyFormat = "$lhs `,` $rhs (`flags` ` ` $overflowFlags^)? custom<LLVMOpAttrs>(attr-dict) `:` type($res)";
-  string llvmBuilder = "$res = builder.Create" # instName # "($lhs, $rhs, /*Name=*/\"\", op.hasNoUnsignedWrap(), op.hasNoSignedWrap());";
+  let assemblyFormat = [{
+    $lhs `,` $rhs (`flags` ` ` $overflowFlags^)?
+    custom<LLVMOpAttrs>(attr-dict) `:` type($res)
+  }];
+  string llvmBuilder =
+    "$res = builder.Create" # instName #
+    "($lhs, $rhs, /*Name=*/\"\", op.hasNoUnsignedWrap(), op.hasNoSignedWrap());";
 }
 class LLVM_FloatArithmeticOp<string mnemonic, string instName,
                              list<Trait> traits = []> :

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -68,7 +68,7 @@ class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
     $res = op;
   }];
   let assemblyFormat = [{
-    $lhs `,` $rhs (`overflow` $overflowFlags^)?
+    $lhs `,` $rhs (`overflow` `` $overflowFlags^)?
     custom<LLVMOpAttrs>(attr-dict) `:` type($res)
   }];
   string llvmBuilder =

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -68,7 +68,7 @@ class LLVM_IntArithmeticOpWithFlag<string mnemonic, string instName,
     $res = op;
   }];
   let assemblyFormat = "$lhs `,` $rhs (`flags` ` ` $overflowFlags^)? custom<LLVMOpAttrs>(attr-dict) `:` type($res)";
-  string llvmBuilder = "$res = builder.Create" # instName # "($lhs, $rhs, /*Name=*/\"\", op.hasNuw(), op.hasNsw());";
+  string llvmBuilder = "$res = builder.Create" # instName # "($lhs, $rhs, /*Name=*/\"\", op.hasNoUnsignedWrap(), op.hasNoSignedWrap());";
 }
 class LLVM_FloatArithmeticOp<string mnemonic, string instName,
                              list<Trait> traits = []> :

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -172,9 +172,9 @@ public:
   /// attributes of LLVMFuncOp `funcOp`.
   void processFunctionAttributes(llvm::Function *func, LLVMFuncOp funcOp);
 
-  /// Sets the integer arithmetic flags (nsw/nuw) attribute for the imported
+  /// Sets the integer overflow flags (nsw/nuw) attribute for the imported
   /// operation `op` given the original instruction `inst`. Asserts if the
-  /// operation does not implement the integer arithmetic flag interface.
+  /// operation does not implement the integer overflow flag interface.
   void setIntegerFlagsAttr(llvm::Instruction *inst, Operation *op) const;
 
   /// Sets the fastmath flags attribute for the imported operation `op` given

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -172,6 +172,11 @@ public:
   /// attributes of LLVMFuncOp `funcOp`.
   void processFunctionAttributes(llvm::Function *func, LLVMFuncOp funcOp);
 
+  /// Sets the integer arithmetic flags (nsw/nuw) attribute for the imported
+  /// operation `op` given the original instruction `inst`. Asserts if the
+  /// operation does not implement the integer arithmetic flag interface.
+  void setIntegerFlagsAttr(llvm::Instruction *inst, Operation *op) const;
+
   /// Sets the fastmath flags attribute for the imported operation `op` given
   /// the original instruction `inst`. Asserts if the operation does not
   /// implement the fastmath interface.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -175,7 +175,8 @@ public:
   /// Sets the integer overflow flags (nsw/nuw) attribute for the imported
   /// operation `op` given the original instruction `inst`. Asserts if the
   /// operation does not implement the integer overflow flag interface.
-  void setIntegerFlagsAttr(llvm::Instruction *inst, Operation *op) const;
+  void setIntegerOverflowFlagsAttr(llvm::Instruction *inst,
+                                   Operation *op) const;
 
   /// Sets the fastmath flags attribute for the imported operation `op` given
   /// the original instruction `inst`. Asserts if the operation does not

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -69,12 +69,13 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
+  auto filteredAttrs = processFMFAttr(attrs.getValue());
   if (auto iface = dyn_cast<IntegerOverflowFlagsInterface>(op))
     printer.printOptionalAttrDict(
-        processFMFAttr(attrs.getValue()),
+        filteredAttrs,
         /*elidedAttrs=*/{iface.getIntegerOverflowAttrName()});
   else
-    printer.printOptionalAttrDict(processFMFAttr(attrs.getValue()));
+    printer.printOptionalAttrDict(filteredAttrs);
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -62,10 +62,10 @@ static auto processFMFAttr(ArrayRef<NamedAttribute> attrs) {
   return filteredAttrs;
 }
 
-static auto processIntArithAttr(ArrayRef<NamedAttribute> attrs) {
+static auto processIntOverflowAttr(ArrayRef<NamedAttribute> attrs) {
   SmallVector<NamedAttribute, 8> filteredAttrs(
       llvm::make_filter_range(attrs, [&](NamedAttribute attr) {
-        return attr.getName() != "arithFlags";
+        return attr.getName() != "overflowFlags";
       }));
   return filteredAttrs;
 }
@@ -78,7 +78,7 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
   printer.printOptionalAttrDict(
-      processFMFAttr(processIntArithAttr(attrs.getValue())));
+      processFMFAttr(processIntOverflowAttr(attrs.getValue())));
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -69,8 +69,12 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
-  printer.printOptionalAttrDict(processFMFAttr(attrs.getValue()),
-                                /*elidedAttrs=*/{"overflowFlags"});
+  if (auto iface = dyn_cast<IntegerOverflowFlagsInterface>(op))
+    printer.printOptionalAttrDict(
+        processFMFAttr(attrs.getValue()),
+        /*elidedAttrs=*/{iface.getIntegerOverflowAttrName()});
+  else
+    printer.printOptionalAttrDict(processFMFAttr(attrs.getValue()));
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -62,6 +62,14 @@ static auto processFMFAttr(ArrayRef<NamedAttribute> attrs) {
   return filteredAttrs;
 }
 
+static auto processIntArithAttr(ArrayRef<NamedAttribute> attrs) {
+  SmallVector<NamedAttribute, 8> filteredAttrs(
+      llvm::make_filter_range(attrs, [&](NamedAttribute attr) {
+        return attr.getName() != "arithFlags";
+      }));
+  return filteredAttrs;
+}
+
 static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
                                     NamedAttrList &result) {
   return parser.parseOptionalAttrDict(result);
@@ -69,7 +77,8 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
-  printer.printOptionalAttrDict(processFMFAttr(attrs.getValue()));
+  printer.printOptionalAttrDict(
+      processFMFAttr(processIntArithAttr(attrs.getValue())));
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -62,14 +62,6 @@ static auto processFMFAttr(ArrayRef<NamedAttribute> attrs) {
   return filteredAttrs;
 }
 
-static auto processIntOverflowAttr(ArrayRef<NamedAttribute> attrs) {
-  SmallVector<NamedAttribute, 8> filteredAttrs(
-      llvm::make_filter_range(attrs, [&](NamedAttribute attr) {
-        return attr.getName() != "overflowFlags";
-      }));
-  return filteredAttrs;
-}
-
 static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
                                     NamedAttrList &result) {
   return parser.parseOptionalAttrDict(result);
@@ -77,8 +69,8 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
-  printer.printOptionalAttrDict(
-      processFMFAttr(processIntOverflowAttr(attrs.getValue())));
+  printer.printOptionalAttrDict(processFMFAttr(attrs.getValue()),
+                                /*elidedAttrs=*/{"overflowFlags"});
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -619,6 +619,19 @@ void ModuleImport::setNonDebugMetadataAttrs(llvm::Instruction *inst,
   }
 }
 
+void ModuleImport::setIntegerFlagsAttr(llvm::Instruction *inst,
+                                       Operation *op) const {
+  IntegerArithFlagsInterface iface = cast<IntegerArithFlagsInterface>(op);
+
+  IntegerArithFlags value = {};
+  value = bitEnumSet(value, IntegerArithFlags::nsw, inst->hasNoSignedWrap());
+  value = bitEnumSet(value, IntegerArithFlags::nuw, inst->hasNoUnsignedWrap());
+
+  IntegerArithFlagsAttr attr =
+      IntegerArithFlagsAttr::get(op->getContext(), value);
+  iface->setAttr(iface.getIntegerArithAttrName(), attr);
+}
+
 void ModuleImport::setFastmathFlagsAttr(llvm::Instruction *inst,
                                         Operation *op) const {
   auto iface = cast<FastmathFlagsInterface>(op);

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -619,8 +619,8 @@ void ModuleImport::setNonDebugMetadataAttrs(llvm::Instruction *inst,
   }
 }
 
-void ModuleImport::setIntegerFlagsAttr(llvm::Instruction *inst,
-                                       Operation *op) const {
+void ModuleImport::setIntegerOverflowFlagsAttr(llvm::Instruction *inst,
+                                               Operation *op) const {
   auto iface = cast<IntegerOverflowFlagsInterface>(op);
 
   IntegerOverflowFlags value = {};

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -621,15 +621,16 @@ void ModuleImport::setNonDebugMetadataAttrs(llvm::Instruction *inst,
 
 void ModuleImport::setIntegerFlagsAttr(llvm::Instruction *inst,
                                        Operation *op) const {
-  IntegerArithFlagsInterface iface = cast<IntegerArithFlagsInterface>(op);
+  auto iface = cast<IntegerOverflowFlagsInterface>(op);
 
-  IntegerArithFlags value = {};
-  value = bitEnumSet(value, IntegerArithFlags::nsw, inst->hasNoSignedWrap());
-  value = bitEnumSet(value, IntegerArithFlags::nuw, inst->hasNoUnsignedWrap());
+  IntegerOverflowFlags value = {};
+  value = bitEnumSet(value, IntegerOverflowFlags::nsw, inst->hasNoSignedWrap());
+  value =
+      bitEnumSet(value, IntegerOverflowFlags::nuw, inst->hasNoUnsignedWrap());
 
-  IntegerArithFlagsAttr attr =
-      IntegerArithFlagsAttr::get(op->getContext(), value);
-  iface->setAttr(iface.getIntegerArithAttrName(), attr);
+  auto attr =
+      IntegerOverflowFlagsAttr::get(op->getContext(), value);
+  iface->setAttr(iface.getIntegerOverflowAttrName(), attr);
 }
 
 void ModuleImport::setFastmathFlagsAttr(llvm::Instruction *inst,

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -628,8 +628,7 @@ void ModuleImport::setIntegerFlagsAttr(llvm::Instruction *inst,
   value =
       bitEnumSet(value, IntegerOverflowFlags::nuw, inst->hasNoUnsignedWrap());
 
-  auto attr =
-      IntegerOverflowFlagsAttr::get(op->getContext(), value);
+  auto attr = IntegerOverflowFlagsAttr::get(op->getContext(), value);
   iface->setAttr(iface.getIntegerOverflowAttrName(), attr);
 }
 

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -35,14 +35,14 @@ func.func @ops(%arg0: i32, %arg1: f32,
   %typecheck_vptrcmp = llvm.add %vptrcmp, %vptrcmp : vector<2 x i1>
 
 // Integer arithmetic flags
-// CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] flags <nsw> : i32
-// CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] flags <nuw> : i32
-// CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] flags <nsw, nuw> : i32
-// CHECK: {{.*}} = llvm.shl %[[I32]], %[[I32]] flags <nsw, nuw> : i32
-  %add_flag = llvm.add %arg0, %arg0 flags <nsw> : i32
-  %sub_flag = llvm.sub %arg0, %arg0 flags <nuw> : i32
-  %mul_flag = llvm.mul %arg0, %arg0 flags <nsw, nuw> : i32
-  %shl_flag = llvm.shl %arg0, %arg0 flags <nuw, nsw> : i32
+// CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] overflow <nsw> : i32
+// CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] overflow <nuw> : i32
+// CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] overflow <nsw, nuw> : i32
+// CHECK: {{.*}} = llvm.shl %[[I32]], %[[I32]] overflow <nsw, nuw> : i32
+  %add_flag = llvm.add %arg0, %arg0 overflow <nsw> : i32
+  %sub_flag = llvm.sub %arg0, %arg0 overflow <nuw> : i32
+  %mul_flag = llvm.mul %arg0, %arg0 overflow <nsw, nuw> : i32
+  %shl_flag = llvm.shl %arg0, %arg0 overflow <nuw, nsw> : i32
 
 // Floating point binary operations.
 //

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -34,6 +34,16 @@ func.func @ops(%arg0: i32, %arg1: f32,
   %vptrcmp = llvm.icmp "ne" %arg5, %arg5 : !llvm.vec<2 x ptr>
   %typecheck_vptrcmp = llvm.add %vptrcmp, %vptrcmp : vector<2 x i1>
 
+// Integer arithmetic flags
+// CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] flags <nsw> : i32
+// CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] flags <nuw> : i32
+// CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] flags <nsw, nuw> : i32
+// CHECK: {{.*}} = llvm.shl %[[I32]], %[[I32]] flags <nsw, nuw> : i32
+  %add_flag = llvm.add %arg0, %arg0 flags <nsw> : i32
+  %sub_flag = llvm.sub %arg0, %arg0 flags <nuw> : i32
+  %mul_flag = llvm.mul %arg0, %arg0 flags <nsw, nuw> : i32
+  %shl_flag = llvm.shl %arg0, %arg0 flags <nuw, nsw> : i32
+
 // Floating point binary operations.
 //
 // CHECK: {{.*}} = llvm.fadd %[[FLOAT]], %[[FLOAT]] : f32

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -34,7 +34,7 @@ func.func @ops(%arg0: i32, %arg1: f32,
   %vptrcmp = llvm.icmp "ne" %arg5, %arg5 : !llvm.vec<2 x ptr>
   %typecheck_vptrcmp = llvm.add %vptrcmp, %vptrcmp : vector<2 x i1>
 
-// Integer arithmetic flags
+// Integer overflow flags
 // CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] overflow<nsw> : i32
 // CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] overflow<nuw> : i32
 // CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] overflow<nsw, nuw> : i32

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -35,14 +35,14 @@ func.func @ops(%arg0: i32, %arg1: f32,
   %typecheck_vptrcmp = llvm.add %vptrcmp, %vptrcmp : vector<2 x i1>
 
 // Integer arithmetic flags
-// CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] overflow <nsw> : i32
-// CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] overflow <nuw> : i32
-// CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] overflow <nsw, nuw> : i32
-// CHECK: {{.*}} = llvm.shl %[[I32]], %[[I32]] overflow <nsw, nuw> : i32
-  %add_flag = llvm.add %arg0, %arg0 overflow <nsw> : i32
-  %sub_flag = llvm.sub %arg0, %arg0 overflow <nuw> : i32
-  %mul_flag = llvm.mul %arg0, %arg0 overflow <nsw, nuw> : i32
-  %shl_flag = llvm.shl %arg0, %arg0 overflow <nuw, nsw> : i32
+// CHECK: {{.*}} = llvm.add %[[I32]], %[[I32]] overflow<nsw> : i32
+// CHECK: {{.*}} = llvm.sub %[[I32]], %[[I32]] overflow<nuw> : i32
+// CHECK: {{.*}} = llvm.mul %[[I32]], %[[I32]] overflow<nsw, nuw> : i32
+// CHECK: {{.*}} = llvm.shl %[[I32]], %[[I32]] overflow<nsw, nuw> : i32
+  %add_flag = llvm.add %arg0, %arg0 overflow<nsw> : i32
+  %sub_flag = llvm.sub %arg0, %arg0 overflow<nuw> : i32
+  %mul_flag = llvm.mul %arg0, %arg0 overflow<nsw, nuw> : i32
+  %shl_flag = llvm.shl %arg0, %arg0 overflow<nuw, nsw> : i32
 
 // Floating point binary operations.
 //

--- a/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
+++ b/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
@@ -2,13 +2,13 @@
 
 ; CHECK-LABEL: @intflag_inst
 define void @intflag_inst(i64 %arg1, i64 %arg2) {
-  ; CHECK: llvm.add %{{.*}}, %{{.*}} flags <nsw> : i64
+  ; CHECK: llvm.add %{{.*}}, %{{.*}} overflow <nsw> : i64
   %1 = add nsw i64 %arg1, %arg2
-  ; CHECK: llvm.sub %{{.*}}, %{{.*}} flags <nuw> : i64
+  ; CHECK: llvm.sub %{{.*}}, %{{.*}} overflow <nuw> : i64
   %2 = sub nuw i64 %arg1, %arg2
-  ; CHECK: llvm.mul %{{.*}}, %{{.*}} flags <nsw, nuw> : i64
+  ; CHECK: llvm.mul %{{.*}}, %{{.*}} overflow <nsw, nuw> : i64
   %3 = mul nsw nuw i64 %arg1, %arg2
-  ; CHECK: llvm.shl %{{.*}}, %{{.*}} flags <nsw, nuw> : i64
+  ; CHECK: llvm.shl %{{.*}}, %{{.*}} overflow <nsw, nuw> : i64
   %4 = shl nuw nsw i64 %arg1, %arg2
   ret void
 }

--- a/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
+++ b/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
@@ -2,13 +2,13 @@
 
 ; CHECK-LABEL: @intflag_inst
 define void @intflag_inst(i64 %arg1, i64 %arg2) {
-  ; CHECK: llvm.add %{{.*}}, %{{.*}} overflow <nsw> : i64
+  ; CHECK: llvm.add %{{.*}}, %{{.*}} overflow<nsw> : i64
   %1 = add nsw i64 %arg1, %arg2
-  ; CHECK: llvm.sub %{{.*}}, %{{.*}} overflow <nuw> : i64
+  ; CHECK: llvm.sub %{{.*}}, %{{.*}} overflow<nuw> : i64
   %2 = sub nuw i64 %arg1, %arg2
-  ; CHECK: llvm.mul %{{.*}}, %{{.*}} overflow <nsw, nuw> : i64
+  ; CHECK: llvm.mul %{{.*}}, %{{.*}} overflow<nsw, nuw> : i64
   %3 = mul nsw nuw i64 %arg1, %arg2
-  ; CHECK: llvm.shl %{{.*}}, %{{.*}} overflow <nsw, nuw> : i64
+  ; CHECK: llvm.shl %{{.*}}, %{{.*}} overflow<nsw, nuw> : i64
   %4 = shl nuw nsw i64 %arg1, %arg2
   ret void
 }

--- a/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
+++ b/mlir/test/Target/LLVMIR/Import/nsw_nuw.ll
@@ -1,0 +1,14 @@
+; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
+
+; CHECK-LABEL: @intflag_inst
+define void @intflag_inst(i64 %arg1, i64 %arg2) {
+  ; CHECK: llvm.add %{{.*}}, %{{.*}} flags <nsw> : i64
+  %1 = add nsw i64 %arg1, %arg2
+  ; CHECK: llvm.sub %{{.*}}, %{{.*}} flags <nuw> : i64
+  %2 = sub nuw i64 %arg1, %arg2
+  ; CHECK: llvm.mul %{{.*}}, %{{.*}} flags <nsw, nuw> : i64
+  %3 = mul nsw nuw i64 %arg1, %arg2
+  ; CHECK: llvm.shl %{{.*}}, %{{.*}} flags <nsw, nuw> : i64
+  %4 = shl nuw nsw i64 %arg1, %arg2
+  ret void
+}

--- a/mlir/test/Target/LLVMIR/nsw_nuw.mlir
+++ b/mlir/test/Target/LLVMIR/nsw_nuw.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// CHECK-LABEL: define void @intflags_func
+llvm.func @intflags_func(%arg0: i64, %arg1: i64) {
+  // CHECK: %{{.*}} = add nsw i64 %{{.*}}, %{{.*}}
+  %0 = llvm.add %arg0, %arg1 flags <nsw> : i64
+  // CHECK: %{{.*}} = sub nuw i64 %{{.*}}, %{{.*}}
+  %1 = llvm.sub %arg0, %arg1 flags <nuw> : i64
+  // CHECK: %{{.*}} = mul nuw nsw i64 %{{.*}}, %{{.*}}
+  %2 = llvm.mul %arg0, %arg1 flags <nsw, nuw> : i64
+  // CHECK: %{{.*}} = shl nuw nsw i64 %{{.*}}, %{{.*}}
+  %3 = llvm.shl %arg0, %arg1 flags <nsw, nuw> : i64
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/nsw_nuw.mlir
+++ b/mlir/test/Target/LLVMIR/nsw_nuw.mlir
@@ -3,12 +3,12 @@
 // CHECK-LABEL: define void @intflags_func
 llvm.func @intflags_func(%arg0: i64, %arg1: i64) {
   // CHECK: %{{.*}} = add nsw i64 %{{.*}}, %{{.*}}
-  %0 = llvm.add %arg0, %arg1 flags <nsw> : i64
+  %0 = llvm.add %arg0, %arg1 overflow <nsw> : i64
   // CHECK: %{{.*}} = sub nuw i64 %{{.*}}, %{{.*}}
-  %1 = llvm.sub %arg0, %arg1 flags <nuw> : i64
+  %1 = llvm.sub %arg0, %arg1 overflow <nuw> : i64
   // CHECK: %{{.*}} = mul nuw nsw i64 %{{.*}}, %{{.*}}
-  %2 = llvm.mul %arg0, %arg1 flags <nsw, nuw> : i64
+  %2 = llvm.mul %arg0, %arg1 overflow <nsw, nuw> : i64
   // CHECK: %{{.*}} = shl nuw nsw i64 %{{.*}}, %{{.*}}
-  %3 = llvm.shl %arg0, %arg1 flags <nsw, nuw> : i64
+  %3 = llvm.shl %arg0, %arg1 overflow <nsw, nuw> : i64
   llvm.return
 }


### PR DESCRIPTION
The implementation of these are modeled after the existing fastmath flags for floating point arithmetic.