### PR TITLE
[libc] fix -Wtype-limits in wctob

### DIFF
--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -29,9 +29,14 @@ LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
   // The standard states that wint_t may either be an alias of wchar_t or
-  // an alias of an integer type, so we need to keep the c < 0 check.
+  // an alias of an integer type where different platforms define this type with
+  // different signedness, so we need to keep the c < 0 check, hence the
+  // pragmas.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
   if (c > 127 || c < 0)
     return cpp::nullopt;
+#pragma GCC diagnostic pop
   return static_cast<int>(c);
 }
 

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -25,8 +25,7 @@ namespace internal {
 // of a function call by inlining them.
 // ------------------------------------------------------
 
-template<typename W = wint_t>
-LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
+template <typename W = wint_t> LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
   if (c > 127)

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -28,15 +28,14 @@ namespace internal {
 LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
-  // The standard states that wint_t may either be an alias of wchar_t or
-  // an alias of an integer type where different platforms define this type with
-  // different signedness, so we need to keep the c < 0 check, hence the
-  // pragmas.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
-  if (c > 127 || c < 0)
+  if (c > 127)
     return cpp::nullopt;
-#pragma GCC diagnostic pop
+  // The standard states that wint_t may either be an alias of wchar_t or
+  // an alias of an integer type, different platforms define this type with
+  // different signedness, so we may need the c < 0 check.
+  if constexpr (cpp::is_signed_v<wint_t>)
+    if (c < 0)
+      return cpp::nullopt;
   return static_cast<int>(c);
 }
 

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -25,17 +25,15 @@ namespace internal {
 // of a function call by inlining them.
 // ------------------------------------------------------
 
-template <typename W = wint_t> LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
+LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
-  if (c > 127)
-    return cpp::nullopt;
   // The standard states that wint_t may either be an alias of wchar_t or
   // an alias of an integer type, different platforms define this type with
-  // different signedness, so we may need the c < 0 check.
-  if constexpr (cpp::is_signed_v<W>)
-    if (c < 0)
-      return cpp::nullopt;
+  // different signedness. This is equivalent to `(c > 127) || (c < 0)` but also
+  // works without -Wtype-limits warnings when `wint_t` is unsigned.
+  if ((c & ~127) != 0)
+    return cpp::nullopt;
   return static_cast<int>(c);
 }
 

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -25,6 +25,7 @@ namespace internal {
 // of a function call by inlining them.
 // ------------------------------------------------------
 
+template<typename W = wint_t>
 LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
@@ -33,7 +34,7 @@ LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // The standard states that wint_t may either be an alias of wchar_t or
   // an alias of an integer type, different platforms define this type with
   // different signedness, so we may need the c < 0 check.
-  if constexpr (cpp::is_signed_v<wint_t>)
+  if constexpr (cpp::is_signed_v<W>)
     if (c < 0)
       return cpp::nullopt;
   return static_cast<int>(c);


### PR DESCRIPTION
GCC warns:
```
libc/src/__support/wctype_utils.h:33:20: error: comparison of unsigned
expression in ‘< 0’ is always false [-Werror=type-limits]
   33 |   if (c > 127 || c < 0)
      |                  ~~^~~
```

Looking into the signedness of wint_t, it looks like depending on the platform,
__WINT_TYPE__ is defined to int or unsigned int depending on the platform.

Link: https://lab.llvm.org/buildbot/#/builders/250/builds/14891/steps/6/logs/stdio
