### PR TITLE
[ASan][X86] Mark asan_globals section large

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2144,7 +2144,7 @@ ModuleAddressSanitizer::CreateMetadataGlobal(Module &M, Constant *Initializer,
       M, Initializer->getType(), false, Linkage, Initializer,
       Twine("__asan_global_") + GlobalValue::dropLLVMManglingEscape(OriginalName));
   Metadata->setSection(getGlobalMetadataSection());
-  // Move metadata section out of the way for x86-64 ELF binaries to mitigate
+  // Place metadata in a large section for x86-64 ELF binaries to mitigate
   // relocation pressure.
   if (TargetTriple.getArch() == Triple::x86_64 &&
       TargetTriple.getObjectFormat() == Triple::ELF)

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2144,6 +2144,11 @@ ModuleAddressSanitizer::CreateMetadataGlobal(Module &M, Constant *Initializer,
       M, Initializer->getType(), false, Linkage, Initializer,
       Twine("__asan_global_") + GlobalValue::dropLLVMManglingEscape(OriginalName));
   Metadata->setSection(getGlobalMetadataSection());
+  // Move metadata section out of the way for x86-64 ELF binaries to mitigate
+  // relocation pressure.
+  if (TargetTriple.getArch() == Triple::x86_64 &&
+      TargetTriple.getObjectFormat() == Triple::ELF)
+    Metadata->setCodeModel(CodeModel::Large);
   return Metadata;
 }
 

--- a/llvm/test/Instrumentation/AddressSanitizer/global_metadata_code_model.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/global_metadata_code_model.ll
@@ -1,0 +1,10 @@
+; RUN: opt < %s -mtriple=x86_64-unknown-linux-gnu -passes=asan -S | FileCheck %s --check-prefix=LARGE
+; RUN: opt < %s -mtriple=aarch64-unknown-linux-gnu -passes=asan -S | FileCheck %s --check-prefix=NORMAL
+; RUN: opt < %s -mtriple=x86_64-pc-windows -passes=asan -S | FileCheck %s --check-prefix=NORMAL
+
+; check that asan globals metadata are emitted to a large section for x86-64 ELF
+
+; LARGE: @__asan_global_global = {{.*}}global {{.*}}, code_model "large"
+; NORMAL-NOT: code_model "large"
+
+@global = global i32 0, align 4

--- a/llvm/test/Instrumentation/AddressSanitizer/global_with_comdat.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/global_with_comdat.ll
@@ -102,8 +102,8 @@ target triple = "x86_64-unknown-linux-gnu"
 ;; Don't place the instrumented globals in a comdat when the unique module ID is empty.
 ; NOMODULEID:      @.str = internal constant { [4 x i8], [28 x i8] } { [4 x i8] c"str\00", [28 x i8] zeroinitializer }, align 32
 ; NOMODULEID:      @_ZL3buf = internal global { [4 x i8], [28 x i8] } zeroinitializer, align 32
-; NOMODULEID:      @__asan_global_.str = private global {{.*}}, section "asan_globals", !associated !0
-; NOMODULEID:      @__asan_global__ZL3buf = private global {{.*}}, section "asan_globals", !associated !1
+; NOMODULEID:      @__asan_global_.str = private global {{.*}}, section "asan_globals"{{.*}}, !associated !0
+; NOMODULEID:      @__asan_global__ZL3buf = private global {{.*}}, section "asan_globals"{{.*}}, !associated !1
 ; NOMODULEID:      @llvm.compiler.used = appending global [4 x ptr] [ptr @.str, ptr @_ZL3buf, ptr @__asan_global_.str, ptr @__asan_global__ZL3buf]
 
 ; NOMODULEID:      define internal void @asan.module_ctor() #[[#]] comdat {


### PR DESCRIPTION
We'd like to make the asan_globals section large to make it not
contribute to relocation pressure since there are no direct PC32
references to it.

Following #74498, we can do that by marking the code model for the
global explicitly large.

Without this change, asan_globals gets placed between .data and .bss.
With this change, it gets placed after .bss.
