### PR TITLE
[llvm-c] Add support for setting/getting new disjoint flag on or instructions

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -200,8 +200,9 @@ Changes to the C API
   The option structure exposes an additional setting (i.e., the target ABI) and
   provides default values for unspecified settings.
 
-* Added ``LLVMGetNNeg`` and ``LLVMSetNNeg`` for setting/getting the new nneg flag
-  on zext instructions
+* Added ``LLVMGetNNeg`` and ``LLVMSetNNeg`` for getting/setting the new nneg flag
+  on zext instructions, and ``LLVMGetIsDisjoint`` and ``LLVMSetIsDisjoint``
+  for getting/setting the new disjoint flag on or instructions.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3986,13 +3986,13 @@ LLVMBool LLVMGetNNeg(LLVMValueRef NonNegInst);
 void LLVMSetNNeg(LLVMValueRef NonNegInst, LLVMBool IsNonNeg);
 
 /**
- * Gets if the instruction has the disjoint flag set
- * Only valid for or instructions
+ * Gets whether the instruction has the disjoint flag set.
+ * Only valid for or instructions.
  */
 LLVMBool LLVMGetIsDisjoint(LLVMValueRef Inst);
 /**
- * Sets the disjoint flag for the instruction
- * Only valid for or instructions
+ * Sets the disjoint flag for the instruction.
+ * Only valid for or instructions.
  */
 void LLVMSetIsDisjoint(LLVMValueRef Inst, LLVMBool IsDisjoint);
 

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3985,6 +3985,17 @@ LLVMBool LLVMGetNNeg(LLVMValueRef NonNegInst);
  */
 void LLVMSetNNeg(LLVMValueRef NonNegInst, LLVMBool IsNonNeg);
 
+/**
+ * Gets if the instruction has the disjoint flag set
+ * Only valid for or instructions
+ */
+LLVMBool LLVMGetIsDisjoint(LLVMValueRef Inst);
+/**
+ * Sets the disjoint flag for the instruction
+ * Only valid for or instructions
+ */
+void LLVMSetIsDisjoint(LLVMValueRef Inst, LLVMBool IsDisjoint);
+
 /* Memory */
 LLVMValueRef LLVMBuildMalloc(LLVMBuilderRef, LLVMTypeRef Ty, const char *Name);
 LLVMValueRef LLVMBuildArrayMalloc(LLVMBuilderRef, LLVMTypeRef Ty,

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3464,6 +3464,16 @@ void LLVMSetNNeg(LLVMValueRef NonNegInst, LLVMBool IsNonNeg) {
   cast<Instruction>(P)->setNonNeg(IsNonNeg);
 }
 
+LLVMBool LLVMGetIsDisjoint(LLVMValueRef Inst) {
+  Value *P = unwrap<Value>(Inst);
+  return cast<PossiblyDisjointInst>(P)->isDisjoint();
+}
+
+void LLVMSetIsDisjoint(LLVMValueRef Inst, LLVMBool IsDisjoint) {
+  Value *P = unwrap<Value>(Inst);
+  cast<PossiblyDisjointInst>(P)->setIsDisjoint(IsDisjoint);
+}
+
 /*--.. Memory ..............................................................--*/
 
 LLVMValueRef LLVMBuildMalloc(LLVMBuilderRef B, LLVMTypeRef Ty,

--- a/llvm/test/Bindings/llvm-c/echo.ll
+++ b/llvm/test/Bindings/llvm-c/echo.ll
@@ -92,7 +92,8 @@ define i32 @iops(i32 %a, i32 %b) {
   %23 = ashr exact i32 %22, %14
   %24 = zext i32 %23 to i64
   %25 = zext nneg i32 %23 to i64
-  ret i32 %23
+  %26 = or disjoint i32 %23, %a
+  ret i32 %26
 }
 
 define i32 @call() {

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -656,7 +656,9 @@ struct FunCloner {
       case LLVMOr: {
         LLVMValueRef LHS = CloneValue(LLVMGetOperand(Src, 0));
         LLVMValueRef RHS = CloneValue(LLVMGetOperand(Src, 1));
+        LLVMBool IsDisjoint = LLVMGetIsDisjoint(Src);
         Dst = LLVMBuildOr(Builder, LHS, RHS, Name);
+        LLVMSetIsDisjoint(Dst, IsDisjoint);
         break;
       }
       case LLVMXor: {


### PR DESCRIPTION
Follows #73952 doing the same thing for the nneg flag on zext (i.e., exposing support in the C API).