### PR TITLE
[flang][runtime] Clear last record in internal WRITE even if nothing …

### DIFF
--- a/flang/runtime/internal-unit.cpp
+++ b/flang/runtime/internal-unit.cpp
@@ -43,11 +43,9 @@ InternalDescriptorUnit<DIR>::InternalDescriptorUnit(
 
 template <Direction DIR> void InternalDescriptorUnit<DIR>::EndIoStatement() {
   if constexpr (DIR == Direction::Output) {
-    // Clear the remainder of the current record if anything was written
-    // to it, or if it is the only record.
+    // Clear the remainder of the current record.
     auto end{endfileRecordNumber.value_or(0)};
-    if (currentRecordNumber < end &&
-        (end == 2 || furthestPositionInRecord > 0)) {
+    if (currentRecordNumber < end) {
       BlankFillOutputRecord();
     }
   }


### PR DESCRIPTION
…was written

At the end of an internal output statement, The I/O runtime fills (the remainder of) the current record with blanks if it's the only record or if anything had been written to it.  This turns out to be wrong in the case of a format that ends with an explicit advance to the next record, which needs to be cleared even if nothing has been written.

Fixes llvm-test-suite/Fortran/gfortran/regression/arrayio_1.f90.