### PR TITLE
[OpenMP] Allow to specify what plugins to look for

### DIFF
--- a/openmp/libomptarget/CMakeLists.txt
+++ b/openmp/libomptarget/CMakeLists.txt
@@ -110,10 +110,6 @@ set(LIBOMPTARGET_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 message(STATUS "OpenMP tools dir in libomptarget: ${LIBOMP_OMP_TOOLS_INCLUDE_DIR}")
 include_directories(${LIBOMP_OMP_TOOLS_INCLUDE_DIR})
 
-# Build target agnostic offloading library.
-set(LIBOMPTARGET_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-add_subdirectory(${LIBOMPTARGET_SRC_DIR})
-
 # Definitions for testing, for reuse when testing libomptarget-nvptx.
 set(LIBOMPTARGET_OPENMP_HEADER_FOLDER "${LIBOMP_INCLUDE_DIR}" CACHE STRING
   "Path to folder containing omp.h")
@@ -128,6 +124,10 @@ set(LIBOMPTARGET_LLVM_LIBRARY_INTDIR "${LIBOMPTARGET_INTDIR}" CACHE STRING
 add_subdirectory(plugins-nextgen)
 add_subdirectory(DeviceRTL)
 add_subdirectory(tools)
+
+# Build target agnostic offloading library.
+set(LIBOMPTARGET_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_subdirectory(${LIBOMPTARGET_SRC_DIR})
 
 # Add tests.
 add_subdirectory(test)

--- a/openmp/libomptarget/src/CMakeLists.txt
+++ b/openmp/libomptarget/src/CMakeLists.txt
@@ -55,6 +55,27 @@ target_compile_definitions(omptarget PRIVATE
   DEBUG_PREFIX="omptarget"
 )
 
+macro(check_plugin_target target)
+if (TARGET omptarget.rtl.${target})
+	list(APPEND LIBOMPTARGET_PLUGINS_TO_LOAD ${target})
+endif()
+endmacro()
+
+set(LIBOMPTARGET_PLUGINS_TO_LOAD "" CACHE STRING
+  "Comma separated list of plugin names to look for at runtime")
+if (NOT LIBOMPTARGET_PLUGINS_TO_LOAD)
+	check_plugin_target(ppc64)
+	check_plugin_target(x86_64)
+	check_plugin_target(cuda)
+	check_plugin_target(aarch64)
+	check_plugin_target(amdgpu)
+endif()
+
+list(TRANSFORM LIBOMPTARGET_PLUGINS_TO_LOAD PREPEND "\"libomptarget.rtl.")
+list(TRANSFORM LIBOMPTARGET_PLUGINS_TO_LOAD APPEND "\"")
+list(JOIN LIBOMPTARGET_PLUGINS_TO_LOAD "," ENABLED_OFFLOAD_PLUGINS)
+target_compile_definitions(omptarget PRIVATE ENABLED_OFFLOAD_PLUGINS=${ENABLED_OFFLOAD_PLUGINS})
+
 # libomptarget.so needs to be aware of where the plugins live as they
 # are now separated in the build directory.
 set_target_properties(omptarget PROPERTIES

--- a/openmp/libomptarget/src/PluginManager.cpp
+++ b/openmp/libomptarget/src/PluginManager.cpp
@@ -23,11 +23,15 @@ PluginManager *PM;
 
 // List of all plugins that can support offloading.
 static const char *RTLNames[] = {
+#ifdef ENABLED_OFFLOAD_PLUGINS
+    ENABLED_OFFLOAD_PLUGINS
+#else
     /* PowerPC target       */ "libomptarget.rtl.ppc64",
     /* x86_64 target        */ "libomptarget.rtl.x86_64",
     /* CUDA target          */ "libomptarget.rtl.cuda",
     /* AArch64 target       */ "libomptarget.rtl.aarch64",
     /* AMDGPU target        */ "libomptarget.rtl.amdgpu",
+#endif
 };
 
 PluginAdaptorTy::PluginAdaptorTy(const std::string &Name) : Name(Name) {

--- a/openmp/libomptarget/src/PluginManager.cpp
+++ b/openmp/libomptarget/src/PluginManager.cpp
@@ -22,17 +22,7 @@ using namespace llvm::sys;
 PluginManager *PM;
 
 // List of all plugins that can support offloading.
-static const char *RTLNames[] = {
-#ifdef ENABLED_OFFLOAD_PLUGINS
-    ENABLED_OFFLOAD_PLUGINS
-#else
-    /* PowerPC target       */ "libomptarget.rtl.ppc64",
-    /* x86_64 target        */ "libomptarget.rtl.x86_64",
-    /* CUDA target          */ "libomptarget.rtl.cuda",
-    /* AArch64 target       */ "libomptarget.rtl.aarch64",
-    /* AMDGPU target        */ "libomptarget.rtl.amdgpu",
-#endif
-};
+static const char *RTLNames[] = {ENABLED_OFFLOAD_PLUGINS};
 
 PluginAdaptorTy::PluginAdaptorTy(const std::string &Name) : Name(Name) {
   DP("Attempting to load library '%s'...\n", Name.c_str());


### PR DESCRIPTION
By default we now only look for the plugins we build, but the user can overwrite that with `LIBOMPTARGET_PLUGINS_TO_LOAD="cuda,amdgpu,x86_64"`