### PR TITLE
[X86][MC] Support Enc/Dec for EGPR for promoted INVPCID instruction

### DIFF
--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -679,6 +679,11 @@ def INVPCID32 : I<0x82, MRMSrcMem, (outs), (ins GR32:$src1, i128mem:$src2),
 def INVPCID64 : I<0x82, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
                   "invpcid\t{$src2, $src1|$src1, $src2}", []>, T8PD,
                   Requires<[In64BitMode, HasINVPCID]>;
+
+let CD8_Scale = 0 in
+def INVPCID64_EVEX : I<0xF2, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
+                       "invpcid\t{$src2, $src1|$src1, $src2}", []>,
+                     EVEX, T_MAP4XS, Requires<[In64BitMode, HasINVPCID]>;
 } // SchedRW
 
 let Predicates = [In64BitMode, HasINVPCID] in {

--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -680,10 +680,9 @@ def INVPCID64 : I<0x82, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
                   "invpcid\t{$src2, $src1|$src1, $src2}", []>, T8PD,
                   Requires<[In64BitMode, HasINVPCID]>;
 
-let CD8_Scale = 0 in
 def INVPCID64_EVEX : I<0xF2, MRMSrcMem, (outs), (ins GR64:$src1, i128mem:$src2),
                        "invpcid\t{$src2, $src1|$src1, $src2}", []>,
-                     EVEX, T_MAP4XS, Requires<[In64BitMode, HasINVPCID]>;
+                     EVEX_NoCD8, T_MAP4XS, Requires<[In64BitMode, HasINVPCID]>;
 } // SchedRW
 
 let Predicates = [In64BitMode, HasINVPCID] in {

--- a/llvm/lib/Target/X86/X86InstrUtils.td
+++ b/llvm/lib/Target/X86/X86InstrUtils.td
@@ -86,6 +86,7 @@ class EVEX_CD8<int esize, CD8VForm form> {
   int CD8_EltSize = !srl(esize, 3);
   bits<3> CD8_Form = form.Value;
 }
+class EVEX_NoCD8 : EVEX { bits<7> CD8_Scale = 0; }
 class XOP { Encoding OpEnc = EncXOP; }
 class XOP_4V : XOP { bit hasVEX_4V = 1; }
 class EVEX2VEXOverride<string VEXInstrName> {

--- a/llvm/test/MC/Disassembler/X86/apx/invpcid.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/invpcid.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   invpcid	291(%r28,%r29,4), %r19
+# INTEL: invpcid	r19, xmmword ptr [r28 + 4*r29 + 291]
+0x62,0x8c,0x7a,0x08,0xf2,0x9c,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/X86/apx/invpcid-att.s
+++ b/llvm/test/MC/X86/apx/invpcid-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: invpcid	291(%r28,%r29,4), %r19
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf2,0x9c,0xac,0x23,0x01,0x00,0x00]
+         invpcid	291(%r28,%r29,4), %r19

--- a/llvm/test/MC/X86/apx/invpcid-intel.s
+++ b/llvm/test/MC/X86/apx/invpcid-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: invpcid	r19, xmmword ptr [r28 + 4*r29 + 291]
+# CHECK: encoding: [0x62,0x8c,0x7a,0x08,0xf2,0x9c,0xac,0x23,0x01,0x00,0x00]
+         invpcid	r19, xmmword ptr [r28 + 4*r29 + 291]


### PR DESCRIPTION
R16-R31 was added into GPRs in https://github.com/llvm/llvm-project/pull/70958,
This patch supports the encoding/decoding for promoted INVPCID instruction in EVEX space.

RFC: https://discourse.llvm.org/t/rfc-design-for-apx-feature-egpr-and-ndd-support/73031/4