### PR TITLE
[NFC] Replace CallInst with FunctionType in VFABI, VFShape API

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -94,24 +94,24 @@ struct VFShape {
     assert(hasValidParameterList() && "Invalid parameter list");
   }
 
-  // Retrieve the VFShape that can be used to map a (scalar) function to itself,
-  // with VF = 1.
-  static VFShape getScalarShape(const CallInst &CI) {
-    return VFShape::get(CI, ElementCount::getFixed(1),
+  /// Retrieve the VFShape that can be used to map a scalar function to itself,
+  /// with VF = 1.
+  static VFShape getScalarShape(const FunctionType *FTy) {
+    return VFShape::get(FTy, ElementCount::getFixed(1),
                         /*HasGlobalPredicate*/ false);
   }
 
-  // Retrieve the basic vectorization shape of the function, where all
-  // parameters are mapped to VFParamKind::Vector with \p EC
-  // lanes. Specifies whether the function has a Global Predicate
-  // argument via \p HasGlobalPred.
-  static VFShape get(const CallInst &CI, ElementCount EC, bool HasGlobalPred) {
+  /// Retrieve the basic vectorization shape of the function, where all
+  /// parameters are mapped to VFParamKind::Vector with \p EC lanes. Specifies
+  /// whether the function has a Global Predicate argument via \p HasGlobalPred.
+  static VFShape get(const FunctionType *FTy, ElementCount EC,
+                     bool HasGlobalPred) {
     SmallVector<VFParameter, 8> Parameters;
-    for (unsigned I = 0; I < CI.arg_size(); ++I)
+    for (unsigned I = 0; I < FTy->getNumParams(); ++I)
       Parameters.push_back(VFParameter({I, VFParamKind::Vector}));
     if (HasGlobalPred)
       Parameters.push_back(
-          VFParameter({CI.arg_size(), VFParamKind::GlobalPredicate}));
+          VFParameter({FTy->getNumParams(), VFParamKind::GlobalPredicate}));
 
     return {EC, Parameters};
   }
@@ -174,13 +174,13 @@ static constexpr char const *_LLVM_Scalarize_ = "_LLVM_Scalarize_";
 ///
 /// \param MangledName -> input string in the format
 /// _ZGV<isa><mask><vlen><parameters>_<scalarname>[(<redirection>)].
-/// \param CI -> A call to the scalar function which we're trying to find
+/// \param FTy -> FunctionType of the scalar function which we're trying to find
 /// a vectorized variant for. This is required to determine the vectorization
 /// factor for scalable vectors, since the mangled name doesn't encode that;
 /// it needs to be derived from the widest element types of vector arguments
 /// or return values.
 std::optional<VFInfo> tryDemangleForVFABI(StringRef MangledName,
-                                          const CallInst &CI);
+                                          const FunctionType *FTy);
 
 /// Retrieve the `VFParamKind` from a string token.
 VFParamKind getVFParamKindFromString(const StringRef Token);
@@ -227,7 +227,7 @@ class VFDatabase {
       return;
     for (const auto &MangledName : ListOfStrings) {
       const std::optional<VFInfo> Shape =
-          VFABI::tryDemangleForVFABI(MangledName, CI);
+          VFABI::tryDemangleForVFABI(MangledName, CI.getFunctionType());
       // A match is found via scalar and vector names, and also by
       // ensuring that the variant described in the attribute has a
       // corresponding definition or declaration of the vector
@@ -276,7 +276,7 @@ public:
   /// @{
   /// Retrieve the Function with VFShape \p Shape.
   Function *getVectorizedFunction(const VFShape &Shape) const {
-    if (Shape == VFShape::getScalarShape(CI))
+    if (Shape == VFShape::getScalarShape(CI.getFunctionType()))
       return CI.getCalledFunction();
 
     for (const auto &Info : ScalarToVectorMappings)

--- a/llvm/lib/Analysis/VFABIDemangling.cpp
+++ b/llvm/lib/Analysis/VFABIDemangling.cpp
@@ -369,7 +369,7 @@ getScalableECFromSignature(const FunctionType *Signature, const VFISAKind ISA,
 // Format of the ABI name:
 // _ZGV<isa><mask><vlen><parameters>_<scalarname>[(<redirection>)]
 std::optional<VFInfo> VFABI::tryDemangleForVFABI(StringRef MangledName,
-                                                 const CallInst &CI) {
+                                                 const FunctionType *FTy) {
   const StringRef OriginalName = MangledName;
   // Assume there is no custom name <redirection>, and therefore the
   // vector name consists of
@@ -434,7 +434,7 @@ std::optional<VFInfo> VFABI::tryDemangleForVFABI(StringRef MangledName,
   // demangled parameter types and the scalar function signature.
   std::optional<ElementCount> EC;
   if (ParsedVF.second) {
-    EC = getScalableECFromSignature(CI.getFunctionType(), ISA, Parameters);
+    EC = getScalableECFromSignature(FTy, ISA, Parameters);
     if (!EC)
       return std::nullopt;
   } else

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1466,7 +1466,8 @@ void VFABI::getVectorVariantNames(
   S.split(ListAttr, ",");
 
   for (const auto &S : SetVector<StringRef>(ListAttr.begin(), ListAttr.end())) {
-    std::optional<VFInfo> Info = VFABI::tryDemangleForVFABI(S, CI);
+    std::optional<VFInfo> Info =
+        VFABI::tryDemangleForVFABI(S, CI.getFunctionType());
     if (Info && CI.getModule()->getFunction(Info->VectorName)) {
       LLVM_DEBUG(dbgs() << "VFABI: Adding mapping '" << S << "' for " << CI
                         << "\n");

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -346,7 +346,8 @@ void VFABI::setVectorVariantNames(CallInst *CI,
 #ifndef NDEBUG
   for (const std::string &VariantMapping : VariantMappings) {
     LLVM_DEBUG(dbgs() << "VFABI: adding mapping '" << VariantMapping << "'\n");
-    std::optional<VFInfo> VI = VFABI::tryDemangleForVFABI(VariantMapping, *CI);
+    std::optional<VFInfo> VI =
+        VFABI::tryDemangleForVFABI(VariantMapping, CI->getFunctionType());
     assert(VI && "Cannot add an invalid VFABI name.");
     assert(M->getNamedValue(VI->VectorName) &&
            "Cannot add variant to attribute: "

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -5466,7 +5466,8 @@ BoUpSLP::TreeEntry::EntryState BoUpSLP::getScalarsVectorizationState(
     Intrinsic::ID ID = getVectorIntrinsicIDForCall(CI, TLI);
 
     VFShape Shape = VFShape::get(
-        *CI, ElementCount::getFixed(static_cast<unsigned int>(VL.size())),
+        CI->getFunctionType(),
+        ElementCount::getFixed(static_cast<unsigned int>(VL.size())),
         false /*HasGlobalPred*/);
     Function *VecFunc = VFDatabase(*CI).getVectorizedFunction(Shape);
 
@@ -6461,9 +6462,10 @@ getVectorCallCosts(CallInst *CI, FixedVectorType *VecTy,
   auto IntrinsicCost =
     TTI->getIntrinsicInstrCost(CostAttrs, TTI::TCK_RecipThroughput);
 
-  auto Shape = VFShape::get(*CI, ElementCount::getFixed(static_cast<unsigned>(
-                                     VecTy->getNumElements())),
-                            false /*HasGlobalPred*/);
+  auto Shape = VFShape::get(
+      CI->getFunctionType(),
+      ElementCount::getFixed(static_cast<unsigned>(VecTy->getNumElements())),
+      false /*HasGlobalPred*/);
   Function *VecFunc = VFDatabase(*CI).getVectorizedFunction(Shape);
   auto LibCost = IntrinsicCost;
   if (!CI->isNoBuiltin() && VecFunc) {
@@ -11643,8 +11645,9 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E, bool PostponedPHIs) {
       Function *CF;
       if (!UseIntrinsic) {
         VFShape Shape =
-            VFShape::get(*CI, ElementCount::getFixed(static_cast<unsigned>(
-                                  VecTy->getNumElements())),
+            VFShape::get(CI->getFunctionType(),
+                         ElementCount::getFixed(
+                             static_cast<unsigned>(VecTy->getNumElements())),
                          false /*HasGlobalPred*/);
         CF = VFDatabase(*CI).getVectorizedFunction(Shape);
       } else {

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6462,10 +6462,9 @@ getVectorCallCosts(CallInst *CI, FixedVectorType *VecTy,
   auto IntrinsicCost =
     TTI->getIntrinsicInstrCost(CostAttrs, TTI::TCK_RecipThroughput);
 
-  auto Shape = VFShape::get(
-      CI->getFunctionType(),
-      ElementCount::getFixed(static_cast<unsigned>(VecTy->getNumElements())),
-      false /*HasGlobalPred*/);
+  auto Shape = VFShape::get(CI->getFunctionType(),
+                            ElementCount::getFixed(VecTy->getNumElements()),
+                            false /*HasGlobalPred*/);
   Function *VecFunc = VFDatabase(*CI).getVectorizedFunction(Shape);
   auto LibCost = IntrinsicCost;
   if (!CI->isNoBuiltin() && VecFunc) {

--- a/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
+++ b/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
@@ -31,14 +31,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   if (!MangledName.empty() && MangledName.find_first_of(0) == StringRef::npos) {
     FunctionType *FTy =
         FunctionType::get(Type::getVoidTy(M->getContext()), false);
-    FunctionCallee F = M->getOrInsertFunction(MangledName, FTy);
-    // Fake the arguments to the CallInst.
-    SmallVector<Value *> Args;
-    for (Type *ParamTy : FTy->params()) {
-      Args.push_back(Constant::getNullValue(ParamTy));
-    }
-    std::unique_ptr<CallInst> CI(CallInst::Create(F, Args));
-    const auto Info = VFABI::tryDemangleForVFABI(MangledName, *(CI.get()));
+    const auto Info = VFABI::tryDemangleForVFABI(MangledName, FTy);
 
     // Do not optimize away the return value. Inspired by
     // https://github.com/google/benchmark/blob/main/include/benchmark/benchmark.h#L307-L345

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -82,7 +82,8 @@ protected:
       Args.push_back(Constant::getNullValue(ParamTy->getScalarType()));
     }
     std::unique_ptr<CallInst> CI(CallInst::Create(F, Args));
-    const auto OptInfo = VFABI::tryDemangleForVFABI(MangledName, *(CI.get()));
+    const auto OptInfo =
+        VFABI::tryDemangleForVFABI(MangledName, CI->getFunctionType());
     if (OptInfo) {
       Info = *OptInfo;
       return true;

--- a/llvm/unittests/Analysis/VectorUtilsTest.cpp
+++ b/llvm/unittests/Analysis/VectorUtilsTest.cpp
@@ -580,7 +580,7 @@ protected:
   SmallVector<VFParameter, 8> &ExpectedParams = Expected.Parameters;
 
   void buildShape(ElementCount VF, bool HasGlobalPred) {
-    Shape = VFShape::get(*CI, VF, HasGlobalPred);
+    Shape = VFShape::get(CI->getFunctionType(), VF, HasGlobalPred);
   }
 
   bool validParams(ArrayRef<VFParameter> Parameters) {
@@ -619,11 +619,11 @@ TEST_F(VFShapeAPITest, API_buildVFShape) {
 
 TEST_F(VFShapeAPITest, API_getScalarShape) {
   buildShape(/*VF*/ ElementCount::getFixed(1), /*HasGlobalPred*/ false);
-  EXPECT_EQ(VFShape::getScalarShape(*CI), Shape);
+  EXPECT_EQ(VFShape::getScalarShape(CI->getFunctionType()), Shape);
 }
 
 TEST_F(VFShapeAPITest, API_getVectorizedFunction) {
-  VFShape ScalarShape = VFShape::getScalarShape(*CI);
+  VFShape ScalarShape = VFShape::getScalarShape(CI->getFunctionType());
   EXPECT_EQ(VFDatabase(*CI).getVectorizedFunction(ScalarShape),
             M->getFunction("g"));
 


### PR DESCRIPTION
This minor simplification was applied to VFShape::getScalarShape, VFShape::get, and VFABI::tryDemangleForVFABI methods.