### PR TITLE
[libc++][test] Drop unnecessary `typename` and `template` for `layout_meow::mapping`

### DIFF
--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.conversion.pass.cpp
@@ -52,7 +52,7 @@ int main(int, char**) {
     [[maybe_unused]] std::extents<char, D, 5> e(arg_exts);
     // but the product is not, so we can't use it for layout_left
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_left::template mapping<std::extents<char, D, 5>> m(arg); }()),
+        ([=] { std::layout_left::mapping<std::extents<char, D, 5>> m(arg); }()),
         "layout_left::mapping converting ctor: other.required_span_size() must be representable as index_type.");
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.ctor.extents.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.ctor.extents.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**) {
   {
     // the extents are representable but the product is not, so we can't use it for layout_left
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_left::template mapping<std::extents<char, D, 5>> m(std::extents<char, D, 5>(100)); }()),
+        ([=] { std::layout_left::mapping<std::extents<char, D, 5>> m(std::extents<char, D, 5>(100)); }()),
         "layout_left::mapping extents ctor: product of extents must be representable as index_type.");
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.index_operator.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.index_operator.pass.cpp
@@ -31,35 +31,35 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_left::template mapping<std::extents<unsigned char, 5>> m;
+    std::layout_left::mapping<std::extents<unsigned char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_left::mapping: out of bounds indexing");
   }
   {
-    std::layout_left::template mapping<std::extents<signed char, 5>> m;
+    std::layout_left::mapping<std::extents<signed char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_left::mapping: out of bounds indexing");
   }
   {
-    std::layout_left::template mapping<std::dextents<unsigned char, 1>> m(std::dextents<unsigned char, 1>(5));
+    std::layout_left::mapping<std::dextents<unsigned char, 1>> m(std::dextents<unsigned char, 1>(5));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_left::mapping: out of bounds indexing");
   }
   {
-    std::layout_left::template mapping<std::dextents<signed char, 1>> m(std::dextents<signed char, 1>(5));
+    std::layout_left::mapping<std::dextents<signed char, 1>> m(std::dextents<signed char, 1>(5));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_left::mapping: out of bounds indexing");
   }
   {
-    std::layout_left::template mapping<std::dextents<int, 3>> m(std::dextents<int, 3>(5, 7, 9));
+    std::layout_left::mapping<std::dextents<int, 3>> m(std::dextents<int, 3>(5, 7, 9));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(0, -1, 0), "layout_left::mapping: out of bounds indexing");
@@ -70,7 +70,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(m(5, 7, 9), "layout_left::mapping: out of bounds indexing");
   }
   {
-    std::layout_left::template mapping<std::dextents<unsigned, 3>> m(std::dextents<int, 3>(5, 7, 9));
+    std::layout_left::mapping<std::dextents<unsigned, 3>> m(std::dextents<int, 3>(5, 7, 9));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_left::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(0, -1, 0), "layout_left::mapping: out of bounds indexing");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.stride.pass.cpp
@@ -33,7 +33,7 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_left::template mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
+    std::layout_left::mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
 
     TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");
   }

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.conversion.pass.cpp
@@ -52,7 +52,7 @@ int main(int, char**) {
     [[maybe_unused]] std::extents<char, D, 5> e(arg_exts);
     // but the product is not, so we can't use it for layout_right
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_right::template mapping<std::extents<char, D, 5>> m(arg); }()),
+        ([=] { std::layout_right::mapping<std::extents<char, D, 5>> m(arg); }()),
         "layout_right::mapping converting ctor: other.required_span_size() must be representable as index_type.");
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.ctor.extents.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.ctor.extents.pass.cpp
@@ -31,7 +31,7 @@ int main(int, char**) {
   {
     // the extents are representable but the product is not, so we can't use it for layout_right
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_right::template mapping<std::extents<char, D, 5>> m(std::extents<char, D, 5>(100)); }()),
+        ([=] { std::layout_right::mapping<std::extents<char, D, 5>> m(std::extents<char, D, 5>(100)); }()),
         "layout_right::mapping extents ctor: product of extents must be representable as index_type.");
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.index_operator.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.index_operator.pass.cpp
@@ -31,35 +31,35 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_right::template mapping<std::extents<unsigned char, 5>> m;
+    std::layout_right::mapping<std::extents<unsigned char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_right::mapping: out of bounds indexing");
   }
   {
-    std::layout_right::template mapping<std::extents<signed char, 5>> m;
+    std::layout_right::mapping<std::extents<signed char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_right::mapping: out of bounds indexing");
   }
   {
-    std::layout_right::template mapping<std::dextents<unsigned char, 1>> m(std::dextents<unsigned char, 1>(5));
+    std::layout_right::mapping<std::dextents<unsigned char, 1>> m(std::dextents<unsigned char, 1>(5));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_right::mapping: out of bounds indexing");
   }
   {
-    std::layout_right::template mapping<std::dextents<signed char, 1>> m(std::dextents<signed char, 1>(5));
+    std::layout_right::mapping<std::dextents<signed char, 1>> m(std::dextents<signed char, 1>(5));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_right::mapping: out of bounds indexing");
   }
   {
-    std::layout_right::template mapping<std::dextents<int, 3>> m(std::dextents<int, 3>(5, 7, 9));
+    std::layout_right::mapping<std::dextents<int, 3>> m(std::dextents<int, 3>(5, 7, 9));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(0, -1, 0), "layout_right::mapping: out of bounds indexing");
@@ -70,7 +70,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(m(5, 7, 9), "layout_right::mapping: out of bounds indexing");
   }
   {
-    std::layout_right::template mapping<std::dextents<unsigned, 3>> m(std::dextents<int, 3>(5, 7, 9));
+    std::layout_right::mapping<std::dextents<unsigned, 3>> m(std::dextents<int, 3>(5, 7, 9));
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_right::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(0, -1, 0), "layout_right::mapping: out of bounds indexing");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.stride.pass.cpp
@@ -33,7 +33,7 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_right::template mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
+    std::layout_right::mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
 
     TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");
   }

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
@@ -73,9 +73,8 @@ int main(int, char**) {
   // all strides must be larger than zero
   {
     always_convertible_layout::mapping<std::dextents<int, 2>> offset_map(std::dextents<int, 2>{10, 10}, 100, -1);
-    TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
-        "layout_stride::mapping converting ctor: all strides must be greater than 0");
+    TEST_LIBCPP_ASSERT_FAILURE(([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
+                               "layout_stride::mapping converting ctor: all strides must be greater than 0");
   }
   // required_span_size not representable, while individual extents are
   {
@@ -105,9 +104,8 @@ int main(int, char**) {
   // base offset must be 0 (i.e. mapping(0,...,0)==0) for a strided layout with positive strides
   {
     always_convertible_layout::mapping<std::dextents<int, 2>> offset_map(std::dextents<int, 2>{10, 10}, 3);
-    TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
-        "layout_stride::mapping converting ctor: base offset of mapping must be zero.");
+    TEST_LIBCPP_ASSERT_FAILURE(([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
+                               "layout_stride::mapping converting ctor: base offset of mapping must be zero.");
   }
   return 0;
 }

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
@@ -74,7 +74,7 @@ int main(int, char**) {
   {
     always_convertible_layout::mapping<std::dextents<int, 2>> offset_map(std::dextents<int, 2>{10, 10}, 100, -1);
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::template mapping<std::extents<char, D, D>> m(offset_map); }()),
+        ([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
         "layout_stride::mapping converting ctor: all strides must be greater than 0");
   }
   // required_span_size not representable, while individual extents are
@@ -85,7 +85,7 @@ int main(int, char**) {
     [[maybe_unused]] std::extents<char, D, 5> e(arg_exts);
     // but the product is not, so we can't use it for layout_stride
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::template mapping<std::extents<char, D, 5>> m(arg); }()),
+        ([=] { std::layout_stride::mapping<std::extents<char, D, 5>> m(arg); }()),
         "layout_stride::mapping converting ctor: other.required_span_size() must be representable as index_type.");
   }
   // required_span_size not representable, while individual extents are, edge case
@@ -99,14 +99,14 @@ int main(int, char**) {
     [[maybe_unused]] std::extents<signed char, D, 10> e(arg_exts);
     // but the product is not, so we can't use it for layout_stride
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::template mapping<std::extents<signed char, D, 10>> m(arg); }()),
+        ([=] { std::layout_stride::mapping<std::extents<signed char, D, 10>> m(arg); }()),
         "layout_stride::mapping converting ctor: other.required_span_size() must be representable as index_type.");
   }
   // base offset must be 0 (i.e. mapping(0,...,0)==0) for a strided layout with positive strides
   {
     always_convertible_layout::mapping<std::dextents<int, 2>> offset_map(std::dextents<int, 2>{10, 10}, 3);
     TEST_LIBCPP_ASSERT_FAILURE(
-        ([=] { std::layout_stride::template mapping<std::extents<char, D, D>> m(offset_map); }()),
+        ([=] { std::layout_stride::mapping<std::extents<char, D, D>> m(offset_map); }()),
         "layout_stride::mapping converting ctor: base offset of mapping must be zero.");
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_array.non_unique.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_array.non_unique.pass.cpp
@@ -42,7 +42,7 @@ int main(int, char**) {
   {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5, 7>> m(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5, 7>> m(
               std::extents<unsigned, D, 5, 7>(20), std::array<unsigned, 3>{4, 1, 200});
         }()),
         "layout_stride::mapping ctor: the provided extents and strides lead to a non-unique mapping");
@@ -50,15 +50,15 @@ int main(int, char**) {
   // equal strides
   {
     // should work because one of the equal strides is associated with an extent of 1
-    [[maybe_unused]] std::layout_stride::template mapping<std::extents<unsigned, D, 5, 1>> m1(
+    [[maybe_unused]] std::layout_stride::mapping<std::extents<unsigned, D, 5, 1>> m1(
         std::extents<unsigned, D, 5, 1>(2), std::array<unsigned, 3>{5, 1, 5});
-    [[maybe_unused]] std::layout_stride::template mapping<std::extents<unsigned, D, 5, 2>> m2(
+    [[maybe_unused]] std::layout_stride::mapping<std::extents<unsigned, D, 5, 2>> m2(
         std::extents<unsigned, D, 5, 2>(1), std::array<unsigned, 3>{5, 1, 5});
 
     // will fail because neither of the equal strides is associated with an extent of 1
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5, 2>> m3(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5, 2>> m3(
               std::extents<unsigned, D, 5, 2>(2), std::array<unsigned, 3>{5, 1, 5});
         }()),
         "layout_stride::mapping ctor: the provided extents and strides lead to a non-unique mapping");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_array.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_array.pass.cpp
@@ -41,7 +41,7 @@ int main(int, char**) {
   // the extents are representable but the product with strides is not, so we can't use it for layout_stride
   TEST_LIBCPP_ASSERT_FAILURE(
       ([=] {
-        std::layout_stride::template mapping<std::extents<char, D, 5>> m(
+        std::layout_stride::mapping<std::extents<char, D, 5>> m(
             std::extents<char, D, 5>(20), std::array<int, 2>{20, 1});
       }()),
       "layout_stride::mapping ctor: required span size is not representable as index_type.");
@@ -50,7 +50,7 @@ int main(int, char**) {
   static_assert(static_cast<unsigned char>(257u) == 1);
   TEST_LIBCPP_ASSERT_FAILURE(
       ([=] {
-        std::layout_stride::template mapping<std::extents<unsigned char, D, 5>> m(
+        std::layout_stride::mapping<std::extents<unsigned char, D, 5>> m(
             std::extents<unsigned char, D, 5>(20), std::array<unsigned, 2>{257, 1});
       }()),
       "layout_stride::mapping ctor: required span size is not representable as index_type.");
@@ -58,14 +58,14 @@ int main(int, char**) {
   // negative strides are not allowed, check with unsigned index_type so we make sure we catch that
   TEST_LIBCPP_ASSERT_FAILURE(
       ([=] {
-        std::layout_stride::template mapping<std::extents<unsigned, D, 5>> m(
+        std::layout_stride::mapping<std::extents<unsigned, D, 5>> m(
             std::extents<unsigned, D, 5>(20), std::array<int, 2>{20, -1});
       }()),
       "layout_stride::mapping ctor: all strides must be greater than 0");
   // zero strides are not allowed, check with unsigned index_type so we make sure we catch that
   TEST_LIBCPP_ASSERT_FAILURE(
       ([=] {
-        std::layout_stride::template mapping<std::extents<unsigned, D, 5>> m(
+        std::layout_stride::mapping<std::extents<unsigned, D, 5>> m(
             std::extents<unsigned, D, 5>(20), std::array<unsigned, 2>{20, 0});
       }()),
       "layout_stride::mapping ctor: all strides must be greater than 0");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.non_unique.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.non_unique.pass.cpp
@@ -43,7 +43,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<unsigned, 3> strides{4, 1, 200};
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5, 7>> m(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5, 7>> m(
               std::extents<unsigned, D, 5, 7>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: the provided extents and strides lead to a non-unique mapping");
@@ -53,15 +53,15 @@ int main(int, char**) {
   {
     // should work because one of the equal strides is associated with an extent of 1
     std::array<unsigned, 3> strides{5, 1, 5};
-    [[maybe_unused]] std::layout_stride::template mapping<std::extents<unsigned, D, 5, 1>> m1(
+    [[maybe_unused]] std::layout_stride::mapping<std::extents<unsigned, D, 5, 1>> m1(
         std::extents<unsigned, D, 5, 1>(2), std::span(strides));
-    [[maybe_unused]] std::layout_stride::template mapping<std::extents<unsigned, D, 5, 2>> m2(
+    [[maybe_unused]] std::layout_stride::mapping<std::extents<unsigned, D, 5, 2>> m2(
         std::extents<unsigned, D, 5, 2>(1), std::span(strides));
 
     // will fail because neither of the equal strides is associated with an extent of 1
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5, 2>> m3(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5, 2>> m3(
               std::extents<unsigned, D, 5, 2>(2), std::span(strides));
         }()),
         "layout_stride::mapping ctor: the provided extents and strides lead to a non-unique mapping");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.pass.cpp
@@ -44,8 +44,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<int, 2> strides{20, 1};
-          std::layout_stride::mapping<std::extents<char, D, 5>> m(
-              std::extents<char, D, 5>(20), std::span(strides));
+          std::layout_stride::mapping<std::extents<char, D, 5>> m(std::extents<char, D, 5>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: required span size is not representable as index_type.");
 

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.ctor.extents_span.pass.cpp
@@ -44,7 +44,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<int, 2> strides{20, 1};
-          std::layout_stride::template mapping<std::extents<char, D, 5>> m(
+          std::layout_stride::mapping<std::extents<char, D, 5>> m(
               std::extents<char, D, 5>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: required span size is not representable as index_type.");
@@ -54,7 +54,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<unsigned, 2> strides{257, 1};
-          std::layout_stride::template mapping<std::extents<unsigned char, D, 5>> m(
+          std::layout_stride::mapping<std::extents<unsigned char, D, 5>> m(
               std::extents<unsigned char, D, 5>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: required span size is not representable as index_type.");
@@ -63,7 +63,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<int, 2> strides{20, -1};
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5>> m(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5>> m(
               std::extents<unsigned, D, 5>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: all strides must be greater than 0");
@@ -71,7 +71,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(
         ([=] {
           std::array<unsigned, 2> strides{20, 0};
-          std::layout_stride::template mapping<std::extents<unsigned, D, 5>> m(
+          std::layout_stride::mapping<std::extents<unsigned, D, 5>> m(
               std::extents<unsigned, D, 5>(20), std::span(strides));
         }()),
         "layout_stride::mapping ctor: all strides must be greater than 0");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.index_operator.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.index_operator.pass.cpp
@@ -31,21 +31,21 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_stride::template mapping<std::extents<unsigned char, 5>> m;
+    std::layout_stride::mapping<std::extents<unsigned char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_stride::mapping: out of bounds indexing");
   }
   {
-    std::layout_stride::template mapping<std::extents<signed char, 5>> m;
+    std::layout_stride::mapping<std::extents<signed char, 5>> m;
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(5), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_stride::mapping: out of bounds indexing");
   }
   {
-    std::layout_stride::template mapping<std::dextents<unsigned char, 1>> m(
+    std::layout_stride::mapping<std::dextents<unsigned char, 1>> m(
         std::dextents<unsigned char, 1>(5), std::array<int, 1>{1});
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_stride::mapping: out of bounds indexing");
@@ -53,7 +53,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_stride::mapping: out of bounds indexing");
   }
   {
-    std::layout_stride::template mapping<std::dextents<signed char, 1>> m(
+    std::layout_stride::mapping<std::dextents<signed char, 1>> m(
         std::dextents<signed char, 1>(5), std::array<int, 1>{1});
     TEST_LIBCPP_ASSERT_FAILURE(m(-1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-130), "layout_stride::mapping: out of bounds indexing");
@@ -61,7 +61,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(m(1000), "layout_stride::mapping: out of bounds indexing");
   }
   {
-    std::layout_stride::template mapping<std::dextents<int, 3>> m(
+    std::layout_stride::mapping<std::dextents<int, 3>> m(
         std::dextents<int, 3>(5, 7, 9), std::array<int, 3>{1, 10, 100});
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_stride::mapping: out of bounds indexing");
@@ -73,7 +73,7 @@ int main(int, char**) {
     TEST_LIBCPP_ASSERT_FAILURE(m(5, 7, 9), "layout_stride::mapping: out of bounds indexing");
   }
   {
-    std::layout_stride::template mapping<std::dextents<unsigned, 3>> m(
+    std::layout_stride::mapping<std::dextents<unsigned, 3>> m(
         std::dextents<int, 3>(5, 7, 9), std::array<int, 3>{1, 10, 100});
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, -1, -1), "layout_stride::mapping: out of bounds indexing");
     TEST_LIBCPP_ASSERT_FAILURE(m(-1, 0, 0), "layout_stride::mapping: out of bounds indexing");

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.stride.pass.cpp
@@ -27,7 +27,7 @@
 int main(int, char**) {
   // value out of range
   {
-    std::layout_stride::template mapping<std::dextents<int, 3>> m(
+    std::layout_stride::mapping<std::dextents<int, 3>> m(
         std::dextents<int, 3>(100, 100, 100), std::array<int, 3>{1, 100, 10000});
 
     TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");

--- a/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.conversion.pass.cpp
@@ -48,7 +48,7 @@
 int main(int, char**) {
   constexpr size_t D = std::dynamic_extent;
   std::array<float, 10> data;
-  typename layout_wrapping_integral<4>::template mapping<std::dextents<int, 2>> src_map(
+  layout_wrapping_integral<4>::mapping<std::dextents<int, 2>> src_map(
       std::dextents<int, 2>(5, 2), not_extents_constructible_tag());
   std::mdspan<float, std::dextents<int, 2>, layout_wrapping_integral<4>> arg(data.data(), src_map);
 

--- a/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
@@ -29,14 +29,14 @@ int main(int, char**) {
   std::array<float, 10> data;
   // make sure we are not failing because of using index_type instead of size_type
   {
-    typename layout_wrapping_integral<4>::template mapping<std::dextents<char, 2>> map(
+    layout_wrapping_integral<4>::mapping<std::dextents<char, 2>> map(
       std::dextents<char, 2>(100, 2), not_extents_constructible_tag());
     std::mdspan<float, std::dextents<char, 2>, layout_wrapping_integral<4>> mds(data.data(), map);
     assert(map.required_span_size() == char(8));
     assert((static_cast<unsigned char>(200) == mds.size()));
   }
   {
-    typename layout_wrapping_integral<4>::template mapping<std::dextents<char, 2>> map(
+    layout_wrapping_integral<4>::mapping<std::dextents<char, 2>> map(
       std::dextents<char, 2>(100, 3), not_extents_constructible_tag());
     std::mdspan<float, std::dextents<char, 2>, layout_wrapping_integral<4>> mds(data.data(), map);
     // sanity check

--- a/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
@@ -30,14 +30,14 @@ int main(int, char**) {
   // make sure we are not failing because of using index_type instead of size_type
   {
     layout_wrapping_integral<4>::mapping<std::dextents<char, 2>> map(
-      std::dextents<char, 2>(100, 2), not_extents_constructible_tag());
+        std::dextents<char, 2>(100, 2), not_extents_constructible_tag());
     std::mdspan<float, std::dextents<char, 2>, layout_wrapping_integral<4>> mds(data.data(), map);
     assert(map.required_span_size() == char(8));
     assert((static_cast<unsigned char>(200) == mds.size()));
   }
   {
     layout_wrapping_integral<4>::mapping<std::dextents<char, 2>> map(
-      std::dextents<char, 2>(100, 3), not_extents_constructible_tag());
+        std::dextents<char, 2>(100, 3), not_extents_constructible_tag());
     std::mdspan<float, std::dextents<char, 2>, layout_wrapping_integral<4>> mds(data.data(), map);
     // sanity check
     assert(map.required_span_size() == char(12));

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
@@ -64,9 +64,9 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using lr_mapping_t = typename std::layout_right::template mapping<std::extents<IdxT, Extents...>>;
+using lr_mapping_t = std::layout_right::mapping<std::extents<IdxT, Extents...>>;
 template <class IdxT, size_t... Extents>
-using ll_mapping_t = typename std::layout_left::template mapping<std::extents<IdxT, Extents...>>;
+using ll_mapping_t = std::layout_left::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_no_implicit_conversion() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_stride.pass.cpp
@@ -76,9 +76,9 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using ll_mapping_t = typename std::layout_left::template mapping<std::extents<IdxT, Extents...>>;
+using ll_mapping_t = std::layout_left::mapping<std::extents<IdxT, Extents...>>;
 template <class IdxT, size_t... Extents>
-using ls_mapping_t = typename std::layout_stride::template mapping<std::extents<IdxT, Extents...>>;
+using ls_mapping_t = std::layout_stride::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_rank_mismatch() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
@@ -71,7 +71,7 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using mapping_t = typename std::layout_left::template mapping<std::extents<IdxT, Extents...>>;
+using mapping_t = std::layout_left::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_no_implicit_conversion() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
@@ -35,7 +35,7 @@
 
 template <class E>
 constexpr void test_layout_mapping_left() {
-  using M = std::layout_left::template mapping<E>;
+  using M = std::layout_left::mapping<E>;
   assert(M::is_unique() == true);
   assert(M::is_exhaustive() == true);
   assert(M::is_strided() == true);

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
@@ -64,9 +64,9 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using lr_mapping_t = typename std::layout_right::template mapping<std::extents<IdxT, Extents...>>;
+using lr_mapping_t = std::layout_right::mapping<std::extents<IdxT, Extents...>>;
 template <class IdxT, size_t... Extents>
-using ll_mapping_t = typename std::layout_left::template mapping<std::extents<IdxT, Extents...>>;
+using ll_mapping_t = std::layout_left::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_no_implicit_conversion() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_stride.pass.cpp
@@ -76,9 +76,9 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using lr_mapping_t = typename std::layout_right::template mapping<std::extents<IdxT, Extents...>>;
+using lr_mapping_t = std::layout_right::mapping<std::extents<IdxT, Extents...>>;
 template <class IdxT, size_t... Extents>
-using ls_mapping_t = typename std::layout_stride::template mapping<std::extents<IdxT, Extents...>>;
+using ls_mapping_t = std::layout_stride::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_rank_mismatch() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
@@ -71,7 +71,7 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using mapping_t = typename std::layout_right::template mapping<std::extents<IdxT, Extents...>>;
+using mapping_t = std::layout_right::mapping<std::extents<IdxT, Extents...>>;
 
 constexpr void test_no_implicit_conversion() {
   constexpr size_t D = std::dynamic_extent;

--- a/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
@@ -35,7 +35,7 @@
 
 template <class E>
 constexpr void test_layout_mapping_right() {
-  using M = std::layout_right::template mapping<E>;
+  using M = std::layout_right::mapping<E>;
   assert(M::is_unique() == true);
   assert(M::is_exhaustive() == true);
   assert(M::is_strided() == true);

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/comparison.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/comparison.pass.cpp
@@ -142,7 +142,7 @@ constexpr void test_comparison_same_rank() {
 template <class OtherLayout, class E1, class E2, class... OtherArgs>
 constexpr void test_comparison_with(
     bool expect_equal, E1 e1, std::array<typename E1::index_type, E1::rank()> strides, E2 e2, OtherArgs... other_args) {
-  typename std::layout_stride::template mapping<E1> map(e1, strides);
+  std::layout_stride::mapping<E1> map(e1, strides);
   typename OtherLayout::template mapping<E2> other_map(e2, other_args...);
 
   assert((map == other_map) == expect_equal);

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
@@ -106,7 +106,7 @@ constexpr void test_conversion() {
 }
 
 template <class IdxT, size_t... Extents>
-using ToM = typename std::layout_stride::template mapping<std::extents<IdxT, Extents...>>;
+using ToM = std::layout_stride::mapping<std::extents<IdxT, Extents...>>;
 
 template <class FromL, class IdxT, size_t... Extents>
 using FromM = typename FromL::template mapping<std::extents<IdxT, Extents...>>;

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -27,24 +27,24 @@ constexpr bool test() {
   constexpr size_t D = std::dynamic_extent;
 
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int>(), std::array<unsigned, 0>())),
-                   std::layout_stride::template mapping<std::extents<int>>);
+                   std::layout_stride::mapping<std::extents<int>>);
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, 4>(), std::array<char, 1>{1})),
-                   std::layout_stride::template mapping<std::extents<int, 4>>);
+                   std::layout_stride::mapping<std::extents<int, 4>>);
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, D>(), std::array<char, 1>{1})),
-                   std::layout_stride::template mapping<std::extents<int, D>>);
+                   std::layout_stride::mapping<std::extents<int, D>>);
   ASSERT_SAME_TYPE(
       decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::array<int64_t, 2>{3, 100})),
-      std::layout_stride::template mapping<std::extents<unsigned, D, 3>>);
+      std::layout_stride::mapping<std::extents<unsigned, D, 3>>);
 
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int>(), std::span<unsigned, 0>())),
-                   std::layout_stride::template mapping<std::extents<int>>);
+                   std::layout_stride::mapping<std::extents<int>>);
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, 4>(), std::declval<std::span<char, 1>>())),
-                   std::layout_stride::template mapping<std::extents<int, 4>>);
+                   std::layout_stride::mapping<std::extents<int, 4>>);
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, D>(), std::declval<std::span<char, 1>>())),
-                   std::layout_stride::template mapping<std::extents<int, D>>);
+                   std::layout_stride::mapping<std::extents<int, D>>);
   ASSERT_SAME_TYPE(
       decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::declval<std::span<int64_t, 2>>())),
-      std::layout_stride::template mapping<std::extents<unsigned, D, 3>>);
+      std::layout_stride::mapping<std::extents<unsigned, D, 3>>);
   return true;
 }
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/is_exhaustive_corner_case.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/is_exhaustive_corner_case.pass.cpp
@@ -29,7 +29,7 @@
 template <class E>
 constexpr void
 test_layout_mapping_stride(E ext, std::array<typename E::index_type, E::rank()> strides, bool exhaustive) {
-  using M = std::layout_stride::template mapping<E>;
+  using M = std::layout_stride::mapping<E>;
   M m(ext, strides);
   assert(m.is_exhaustive() == exhaustive);
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
@@ -48,7 +48,7 @@
 template <class E>
 constexpr void
 test_layout_mapping_stride(E ext, std::array<typename E::index_type, E::rank()> strides, bool exhaustive) {
-  using M = std::layout_stride::template mapping<E>;
+  using M = std::layout_stride::mapping<E>;
   M m(ext, strides);
   const M c_m = m;
   assert(m.strides() == strides);

--- a/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -67,8 +67,8 @@ constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
 template <class H, class A>
 constexpr void mixin_layout(const H& handle, const A& acc) {
   // make sure we test a trivially assignable mapping
-  static_assert(std::is_trivially_assignable_v<typename std::layout_left::template mapping<std::extents<int>>,
-                                               const typename std::layout_left::template mapping<std::extents<int>>&>);
+  static_assert(std::is_trivially_assignable_v<std::layout_left::mapping<std::extents<int>>,
+                                               const std::layout_left::mapping<std::extents<int>>&>);
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially assignable mapping

--- a/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -73,8 +73,8 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially assignable mapping
   static_assert(!std::is_trivially_assignable_v<
-                typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
-                const typename layout_wrapping_integral<4>::template mapping<std::extents<int>>&>);
+                layout_wrapping_integral<4>::mapping<std::extents<int>>,
+                const layout_wrapping_integral<4>::mapping<std::extents<int>>&>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -72,9 +72,8 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially assignable mapping
-  static_assert(!std::is_trivially_assignable_v<
-                layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                const layout_wrapping_integral<4>::mapping<std::extents<int>>&>);
+  static_assert(!std::is_trivially_assignable_v< layout_wrapping_integral<4>::mapping<std::extents<int>>,
+                                                 const layout_wrapping_integral<4>::mapping<std::extents<int>>&>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -61,8 +61,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
-  static_assert(
-      !std::is_trivially_copyable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
+  static_assert(!std::is_trivially_copyable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -57,7 +57,7 @@ constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
 template <class H, class A>
 constexpr void mixin_layout(const H& handle, const A& acc) {
   // make sure we test a trivially copyable mapping
-  static_assert(std::is_trivially_copyable_v<typename std::layout_left::template mapping<std::extents<int>>>);
+  static_assert(std::is_trivially_copyable_v<std::layout_left::mapping<std::extents<int>>>);
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -62,7 +62,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
   static_assert(
-      !std::is_trivially_copyable_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>>);
+      !std::is_trivially_copyable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -74,8 +74,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   constexpr size_t D = std::dynamic_extent;
-  static_assert(!std::is_default_constructible_v<
-                layout_wrapping_integral<4>::mapping<std::extents<signed char, D>>>);
+  static_assert(!std::is_default_constructible_v< layout_wrapping_integral<4>::mapping<std::extents<signed char, D>>>);
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -75,7 +75,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   // Use weird layout, make sure it has the properties we want to test
   constexpr size_t D = std::dynamic_extent;
   static_assert(!std::is_default_constructible_v<
-                typename layout_wrapping_integral<4>::template mapping<std::extents<signed char, D>>>);
+                layout_wrapping_integral<4>::mapping<std::extents<signed char, D>>>);
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
@@ -119,15 +119,15 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents<true, ac>(handle, std::layout_right(), acc);
 
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
@@ -119,16 +119,14 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents<true, ac>(handle, std::layout_right(), acc);
 
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                        std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
@@ -83,16 +83,14 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                        std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
@@ -83,15 +83,15 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
@@ -106,15 +106,15 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
@@ -106,16 +106,14 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                        std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
@@ -93,7 +93,7 @@ constexpr void mixin_accessor() {
 }
 
 template <class E>
-using mapping_t = typename std::layout_right::template mapping<E>;
+using mapping_t = std::layout_right::mapping<E>;
 
 constexpr bool test() {
   mixin_accessor<int>();

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
@@ -87,7 +87,7 @@ constexpr void mixin_accessor() {
 }
 
 template <class E>
-using mapping_t = typename std::layout_right::template mapping<E>;
+using mapping_t = std::layout_right::mapping<E>;
 
 constexpr bool test() {
   mixin_accessor<int>();

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
@@ -119,15 +119,15 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents<true, ac>(handle, std::layout_right(), acc);
 
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<8>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          std::extents<int>>);
-  static_assert(!std::is_constructible_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>,
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
                                          const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
@@ -119,16 +119,14 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents<true, ac>(handle, std::layout_right(), acc);
 
   // Sanity check that this layouts mapping is constructible from extents (via its move constructor)
-  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                        std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<8>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<true, ac>(handle, layout_wrapping_integral<8>(), acc);
   // Sanity check that this layouts mapping is not constructible from extents
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         std::extents<int>>);
-  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>,
-                                         const std::extents<int>&>);
+  static_assert(!std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, std::extents<int>>);
+  static_assert(
+      !std::is_constructible_v<layout_wrapping_integral<4>::mapping<std::extents<int>>, const std::extents<int>&>);
   mixin_extents<false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -56,7 +56,7 @@ constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
 template <class H, class A>
 constexpr void mixin_layout(const H& handle, const A& acc) {
   // make sure we test a trivially copyable mapping
-  static_assert(std::is_trivially_move_constructible_v<typename std::layout_left::template mapping<std::extents<int>>>);
+  static_assert(std::is_trivially_move_constructible_v<std::layout_left::mapping<std::extents<int>>>);
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -60,8 +60,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
-  static_assert(!std::is_trivially_move_constructible_v<
-                layout_wrapping_integral<4>::mapping<std::extents<int>>>);
+  static_assert(!std::is_trivially_move_constructible_v< layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -61,7 +61,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
   static_assert(!std::is_trivially_move_constructible_v<
-                typename layout_wrapping_integral<4>::template mapping<std::extents<int>>>);
+                layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/mapping.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/mapping.verify.cpp
@@ -19,5 +19,5 @@
 
 void not_layout_policy() {
   // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: LayoutPolicy template parameter is invalid. A common mistake is to pass a layout mapping instead of a layout policy}}
-  [[maybe_unused]] std::mdspan<int, std::extents<int>, std::layout_left::template mapping<std::extents<int>>> m;
+  [[maybe_unused]] std::mdspan<int, std::extents<int>, std::layout_left::mapping<std::extents<int>>> m;
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -59,7 +59,7 @@ constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
 template <class H, class A>
 constexpr void mixin_layout(const H& handle, const A& acc) {
   // make sure we test a trivially copyable mapping
-  static_assert(std::is_trivially_move_assignable_v<typename std::layout_left::template mapping<std::extents<int>>>);
+  static_assert(std::is_trivially_move_assignable_v<std::layout_left::mapping<std::extents<int>>>);
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping

--- a/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -64,7 +64,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
   static_assert(
-      !std::is_trivially_move_assignable_v<typename layout_wrapping_integral<4>::template mapping<std::extents<int>>>);
+      !std::is_trivially_move_assignable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -63,8 +63,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   mixin_extents(handle, std::layout_left(), acc);
   mixin_extents(handle, std::layout_right(), acc);
   // make sure we test a not trivially copyable mapping
-  static_assert(
-      !std::is_trivially_move_assignable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
+  static_assert(!std::is_trivially_move_assignable_v<layout_wrapping_integral<4>::mapping<std::extents<int>>>);
   mixin_extents(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/swap.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/swap.pass.cpp
@@ -60,7 +60,7 @@ constexpr bool test() {
     test_swap(a, b);
   }
   {
-    layout_wrapping_integral<4>::template mapping<extents_t> map_a(extents_t(12), not_extents_constructible_tag()),
+    layout_wrapping_integral<4>::mapping<extents_t> map_a(extents_t(12), not_extents_constructible_tag()),
         map_b(extents_t(5), not_extents_constructible_tag());
     std::mdspan a(data_a, map_a);
     std::mdspan b(data_b, map_b);


### PR DESCRIPTION
This is a pure syntax cleanup, I don't need it for running libc++'s tests with MSVC's STL.

This is possible because `std::layout_meow` and `layout_wrapping_integral<1729>` aren't dependent types. We only need `typename` and `template` when reaching *into* a dependent type, like `typename OtherLayout::template mapping<E2>` or `typename layout_wrapping_integral<Wraps>::template mapping<Extents>`.

* Drop unnecessary `typename` and `template` disambiguators for `std::layout_meow::mapping`.
  + This is a pure regex replacement from `(?:typename )?std::layout_(left|right|stride)::template mapping` to `std::layout_$1::mapping`.
* Similarly for `layout_wrapping_integral`.
  + This is a pure regex replacement from `(?:typename )?(layout_wrapping_integral<\d+>)::template mapping` to `$1::mapping`.
