### PR TITLE
[Bazel] Define BUILTIN_THREAD_POINTER where appropriate on x86-64 linux

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -86,18 +86,24 @@ os_defines = select({
     "//conditions:default": linux_defines,
 })
 
+# HAVE_BUILTIN_THREAD_POINTER is true for on Linux (outside of ppc64) for
+# all recent toolchains. Add it here by default on Linux as we can't perform a
+# configure time check.
+builtin_thread_pointer = select({
+    "@bazel_tools//src/conditions:linux_ppc64le": [],
+    "@bazel_tools//src/conditions:linux": ["HAVE_BUILTIN_THREAD_POINTER"],
+    "//conditions:default": [],
+})
+
 # TODO: We should split out host vs. target here.
-llvm_config_defines = os_defines + select({
+llvm_config_defines = os_defines + builtin_thread_pointer + select({
     "@bazel_tools//src/conditions:windows": native_arch_defines("X86", "x86_64-pc-win32"),
     "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
     "@bazel_tools//src/conditions:darwin_x86_64": native_arch_defines("X86", "x86_64-unknown-darwin"),
     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
-    # HAVE_BUILTIN_THREAD_POINTER is true for on x86-64 Linux for all recent
-    # toolchains. Add it here by default as we can't perfomr a configure time
-    # check.
-    "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu") + ["HAVE_BUILTIN_THREAD_POINTER"],
+    "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
 }) + [
     "LLVM_VERSION_MAJOR={}".format(LLVM_VERSION_MAJOR),
     "LLVM_VERSION_MINOR={}".format(LLVM_VERSION_MINOR),

--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -94,7 +94,7 @@ llvm_config_defines = os_defines + select({
     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
-    "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
+    "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu") + ["HAVE_BUILTIN_THREAD_POINTER"],
 }) + [
     "LLVM_VERSION_MAJOR={}".format(LLVM_VERSION_MAJOR),
     "LLVM_VERSION_MINOR={}".format(LLVM_VERSION_MINOR),

--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -94,6 +94,9 @@ llvm_config_defines = os_defines + select({
     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
     "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
+    # HAVE_BUILTIN_THREAD_POINTER is true for on x86-64 Linux for all recent
+    # toolchains. Add it here by default as we can't perfomr a configure time
+    # check.
     "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu") + ["HAVE_BUILTIN_THREAD_POINTER"],
 }) + [
     "LLVM_VERSION_MAJOR={}".format(LLVM_VERSION_MAJOR),


### PR DESCRIPTION
This patch defines BUILTIN_THREAD_POINTER in config.bzl when appropriate on x86-64 linux only. This is needed to build exegesis properly as certain functionality breaks if this is not enabled. This option is only supported on relatively recent compiler versions, but given most people using the bazel build are using very recent toolchains, this shouldn't be an issue.
