### PR TITLE
[flang] Fix PPC and AARCH64 after #73301

### DIFF
--- a/flang/test/Semantics/kinds04_q10.f90
+++ b/flang/test/Semantics/kinds04_q10.f90
@@ -8,6 +8,7 @@
 ! This test is for x86_64, where exponent-letter 'q' is for
 ! 10-byte extended precision
 ! UNSUPPORTED: system-windows
+! REQUIRES: x86-registered-target
 
 subroutine s(var)
   real :: realvar1 = 4.0E6_4

--- a/flang/test/Semantics/real10-x86-01.f90
+++ b/flang/test/Semantics/real10-x86-01.f90
@@ -1,4 +1,5 @@
 ! RUN: %python %S/test_symbols.py %s %flang_fc1 -triple x86_64-unknown-linux-gnu
+! REQUIRES: x86-registered-target
 
  !DEF: /MainProgram1/rpdt DerivedType
  !DEF: /MainProgram1/rpdt/k TypeParam INTEGER(4)

--- a/flang/test/Semantics/real10-x86-02.f90
+++ b/flang/test/Semantics/real10-x86-02.f90
@@ -1,6 +1,7 @@
 ! RUN: %python %S/test_modfile.py %s %flang_fc1 -triple x86_64-unknown-linux-gnu
 ! Intrinsics SELECTED_INT_KIND, SELECTED_REAL_KIND, PRECISION, RANGE,
 ! RADIX, DIGITS
+! REQUIRES: x86-registered-target
 
 module m1
   ! REAL(KIND=10) handles 16 <= P < 19 (if available; ifort is KIND=16)


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/73301, all semantics tests using `triple XXX` options need to have a
`REQUIRED: XX-registered-target` since the llvm::TargetMachine is needed to get the llvm::DataLayout before semantics.

Fix three tests that lacked this.

Fixes:
https://lab.llvm.org/buildbot/#/builders/21/builds/87263 https://lab.llvm.org/buildbot/#/builders/268/builds/3841