### PR TITLE
[mlir:python] Fail immediately if importing an initializer module raises ImportError

### DIFF
--- a/mlir/python/mlir/_mlir_libs/__init__.py
+++ b/mlir/python/mlir/_mlir_libs/__init__.py
@@ -94,6 +94,7 @@ def _site_initialize():
                 "encountered otherwise and the MLIR Python API may not function."
             )
             logger.warning(message, exc_info=True)
+            return False
 
         logger.debug("Initializing MLIR with module: %s", module_name)
         if hasattr(m, "register_dialects"):


### PR DESCRIPTION
If ImportError is raised, _site_initialize will fail because 'm' will be an unbound local. Just return False in this case and fail fast.

@stellaraccident @makslevental 