### PR TITLE
[libc++] tests with picolibc: mark fenv tests as unsupported

### DIFF
--- a/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Floating point exceptions are required for the FE_... macros to be defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
+// REQUIRES: has-compolete-fenv
 
 // <fenv.h>
 

--- a/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Floating point exceptions are required for the FE_... macros to be defined.
-// REQUIRES: has-compolete-fenv
+// Picolibc does not define some of the floating point environment macros for
+// arm platforms without hardware floating point support.
+// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
 // <fenv.h>
 

--- a/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
+++ b/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Floating point exceptions are required for the FE_... macros to be defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
+// REQUIRES: has-compolete-fenv
 
 // <cfenv>
 

--- a/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
+++ b/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Floating point exceptions are required for the FE_... macros to be defined.
-// REQUIRES: has-compolete-fenv
+// Picolibc does not define some of the floating point environment macros for
+// arm platforms without hardware floating point support.
+// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
 // <cfenv>
 

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -224,35 +224,6 @@ DEFAULT_FEATURES = [
           """,
         ),
     ),
-    # Some platform do not provide complete floating point environment.
-    Feature(
-        name="has-compolete-fenv",
-        when=lambda cfg: sourceBuilds(
-            cfg,
-            """
-            #include <fenv.h>
-
-            #if !( \
-                defined FE_DIVBYZERO \
-                && defined FE_INEXACT \
-                && defined FE_INVALID \
-                && defined FE_INEXACT \
-                && defined FE_OVERFLOW \
-                && defined FE_UNDERFLOW \
-                && defined FE_ALL_EXCEPT \
-                && defined FE_DOWNWARD \
-                && defined FE_TONEAREST \
-                && defined FE_TOWARDZERO \
-                && defined FE_UPWARD \
-                && defined FE_DFL_ENV \
-                && defined FE_INEXACT)
-            #error Floating point environment not complete
-            #endif
-
-            int main(int, char**) { return 0; }
-          """,
-        ),
-    ),
     # Check for a Windows UCRT bug (fixed in UCRT/Windows 10.0.20348.0):
     # https://developercommunity.visualstudio.com/t/utf-8-locales-break-ctype-functions-for-wchar-type/1653678
     Feature(

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -224,6 +224,35 @@ DEFAULT_FEATURES = [
           """,
         ),
     ),
+    # Some platform do not provide complete floating point environment.
+    Feature(
+        name="has-compolete-fenv",
+        when=lambda cfg: sourceBuilds(
+            cfg,
+            """
+            #include <fenv.h>
+
+            #if !( \
+                defined FE_DIVBYZERO \
+                && defined FE_INEXACT \
+                && defined FE_INVALID \
+                && defined FE_INEXACT \
+                && defined FE_OVERFLOW \
+                && defined FE_UNDERFLOW \
+                && defined FE_ALL_EXCEPT \
+                && defined FE_DOWNWARD \
+                && defined FE_TONEAREST \
+                && defined FE_TOWARDZERO \
+                && defined FE_UPWARD \
+                && defined FE_DFL_ENV \
+                && defined FE_INEXACT)
+            #error Floating point environment not complete
+            #endif
+
+            int main(int, char**) { return 0; }
+          """,
+        ),
+    ),
     # Check for a Windows UCRT bug (fixed in UCRT/Windows 10.0.20348.0):
     # https://developercommunity.visualstudio.com/t/utf-8-locales-break-ctype-functions-for-wchar-type/1653678
     Feature(


### PR DESCRIPTION
The FE_* macros checked for in cfenv.pass.cpp are not required to be defined, if the relevant options are _not_ available. Picolibc happens not to provide these on some platforms.