### PR TITLE
[libc++] Remove assumptions that std::array::iterator is a raw pointer

### DIFF
--- a/libcxx/include/__format/buffer.h
+++ b/libcxx/include/__format/buffer.h
@@ -130,8 +130,10 @@ public:
   /// A std::transform wrapper.
   ///
   /// Like @ref __copy it may need to do type conversion.
-  template <__fmt_char_type _InCharT, class _UnaryOperation>
-  _LIBCPP_HIDE_FROM_ABI void __transform(const _InCharT* __first, const _InCharT* __last, _UnaryOperation __operation) {
+  template <contiguous_iterator _Iterator,
+            class _UnaryOperation,
+            __fmt_char_type _InCharT = typename iterator_traits<_Iterator>::value_type>
+  _LIBCPP_HIDE_FROM_ABI void __transform(_Iterator __first, _Iterator __last, _UnaryOperation __operation) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__first <= __last, "not a valid range");
 
     size_t __n = static_cast<size_t>(__last - __first);
@@ -590,8 +592,10 @@ public:
     __size_ += __n;
   }
 
-  template <__fmt_char_type _InCharT, class _UnaryOperation>
-  _LIBCPP_HIDE_FROM_ABI void __transform(const _InCharT* __first, const _InCharT* __last, _UnaryOperation __operation) {
+  template <contiguous_iterator _Iterator,
+            class _UnaryOperation,
+            __fmt_char_type _InCharT = typename iterator_traits<_Iterator>::value_type>
+  _LIBCPP_HIDE_FROM_ABI void __transform(_Iterator __first, _Iterator __last, _UnaryOperation __operation) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__first <= __last, "not a valid range");
 
     size_t __n = static_cast<size_t>(__last - __first);

--- a/libcxx/include/__format/formatter_integral.h
+++ b/libcxx/include/__format/formatter_integral.h
@@ -21,6 +21,7 @@
 #include <__format/formatter_output.h>
 #include <__format/parser_std_format_spec.h>
 #include <__iterator/concepts.h>
+#include <__iterator/iterator_traits.h>
 #include <__memory/pointer_traits.h>
 #include <__system_error/errc.h>
 #include <__type_traits/make_unsigned.h>
@@ -52,6 +53,7 @@ namespace __formatter {
 //
 
 template <contiguous_iterator _Iterator>
+  requires same_as<char, iter_value_t<_Iterator>>
 _LIBCPP_HIDE_FROM_ABI inline _Iterator __insert_sign(_Iterator __buf, bool __negative, __format_spec::__sign __sign) {
   if (__negative)
     *__buf++ = '-';
@@ -153,6 +155,7 @@ _LIBCPP_HIDE_FROM_ABI auto __format_char(
 
 /** Wrapper around @ref to_chars, returning the output iterator. */
 template <contiguous_iterator _Iterator, integral _Tp>
+  requires same_as<char, iter_value_t<_Iterator>>
 _LIBCPP_HIDE_FROM_ABI _Iterator __to_buffer(_Iterator __first, _Iterator __last, _Tp __value, int __base) {
   // TODO FMT Evaluate code overhead due to not calling the internal function
   // directly. (Should be zero overhead.)
@@ -208,6 +211,7 @@ consteval size_t __buffer_size() noexcept
 }
 
 template <class _OutIt, contiguous_iterator _Iterator, class _CharT>
+  requires same_as<char, iter_value_t<_Iterator>>
 _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, _Iterator __begin, _Iterator __first,
                                                               _Iterator __last, string&& __grouping, _CharT __sep,
                                                               __format_spec::__parsed_specifications<_CharT> __specs) {
@@ -274,6 +278,7 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, _
 
 
 template <unsigned_integral _Tp, contiguous_iterator _Iterator, class _CharT, class _FormatContext>
+  requires same_as<char, iter_value_t<_Iterator>>
 _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator __format_integer(
     _Tp __value,
     _FormatContext& __ctx,

--- a/libcxx/include/__format/formatter_integral.h
+++ b/libcxx/include/__format/formatter_integral.h
@@ -20,6 +20,8 @@
 #include <__format/format_error.h>
 #include <__format/formatter_output.h>
 #include <__format/parser_std_format_spec.h>
+#include <__iterator/concepts.h>
+#include <__memory/pointer_traits.h>
 #include <__system_error/errc.h>
 #include <__type_traits/make_unsigned.h>
 #include <__utility/unreachable.h>
@@ -49,7 +51,8 @@ namespace __formatter {
 // Generic
 //
 
-_LIBCPP_HIDE_FROM_ABI inline char* __insert_sign(char* __buf, bool __negative, __format_spec::__sign __sign) {
+template <contiguous_iterator _Iterator>
+_LIBCPP_HIDE_FROM_ABI inline _Iterator __insert_sign(_Iterator __buf, bool __negative, __format_spec::__sign __sign) {
   if (__negative)
     *__buf++ = '-';
   else
@@ -148,14 +151,15 @@ _LIBCPP_HIDE_FROM_ABI auto __format_char(
 // Integer
 //
 
-/** Wrapper around @ref to_chars, returning the output pointer. */
-template <integral _Tp>
-_LIBCPP_HIDE_FROM_ABI char* __to_buffer(char* __first, char* __last, _Tp __value, int __base) {
+/** Wrapper around @ref to_chars, returning the output iterator. */
+template <contiguous_iterator _Iterator, integral _Tp>
+_LIBCPP_HIDE_FROM_ABI _Iterator __to_buffer(_Iterator __first, _Iterator __last, _Tp __value, int __base) {
   // TODO FMT Evaluate code overhead due to not calling the internal function
   // directly. (Should be zero overhead.)
-  to_chars_result __r = std::to_chars(__first, __last, __value, __base);
+  to_chars_result __r = std::to_chars(std::to_address(__first), std::to_address(__last), __value, __base);
   _LIBCPP_ASSERT_UNCATEGORIZED(__r.ec == errc(0), "Internal buffer too small");
-  return __r.ptr;
+  auto __diff = __r.ptr - std::to_address(__first);
+  return __first + __diff;
 }
 
 /**
@@ -203,9 +207,9 @@ consteval size_t __buffer_size() noexcept
        + 1;                          // Reserve space for the sign.
 }
 
-template <class _OutIt, class _CharT>
-_LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, const char* __begin, const char* __first,
-                                                              const char* __last, string&& __grouping, _CharT __sep,
+template <class _OutIt, contiguous_iterator _Iterator, class _CharT>
+_LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, _Iterator __begin, _Iterator __first,
+                                                              _Iterator __last, string&& __grouping, _CharT __sep,
                                                               __format_spec::__parsed_specifications<_CharT> __specs) {
   int __size = (__first - __begin) +    // [sign][prefix]
                (__last - __first) +     // data
@@ -269,22 +273,22 @@ _LIBCPP_HIDE_FROM_ABI _OutIt __write_using_decimal_separators(_OutIt __out_it, c
 
 
 
-template <unsigned_integral _Tp, class _CharT, class _FormatContext>
+template <unsigned_integral _Tp, contiguous_iterator _Iterator, class _CharT, class _FormatContext>
 _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator __format_integer(
     _Tp __value,
     _FormatContext& __ctx,
     __format_spec::__parsed_specifications<_CharT> __specs,
     bool __negative,
-    char* __begin,
-    char* __end,
+    _Iterator __begin,
+    _Iterator __end,
     const char* __prefix,
     int __base) {
-  char* __first = __formatter::__insert_sign(__begin, __negative, __specs.__std_.__sign_);
+  _Iterator __first = __formatter::__insert_sign(__begin, __negative, __specs.__std_.__sign_);
   if (__specs.__std_.__alternate_form_ && __prefix)
     while (*__prefix)
       *__first++ = *__prefix++;
 
-  char* __last = __formatter::__to_buffer(__first, __end, __value, __base);
+  _Iterator __last = __formatter::__to_buffer(__first, __end, __value, __base);
 
 #  ifndef _LIBCPP_HAS_NO_LOCALIZATION
   if (__specs.__std_.__locale_specific_form_) {

--- a/libcxx/test/libcxx/input.output/iostream.format/print.fun/transcoding.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/print.fun/transcoding.pass.cpp
@@ -8,6 +8,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
+// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=2000000
 
 // <print>
 
@@ -32,9 +33,9 @@ constexpr void test(std::basic_string_view<CharT> expected, std::string_view inp
   std::array<CharT, 1024> buffer;
   std::ranges::fill(buffer, CharT('*'));
 
-  CharT* out = std::__unicode::__transcode(input.begin(), input.end(), buffer.data());
+  auto out = std::__unicode::__transcode(input.begin(), input.end(), buffer.begin());
 
-  assert(std::basic_string_view<CharT>(buffer.data(), out) == expected);
+  assert(std::basic_string_view<CharT>(buffer.begin(), out) == expected);
 
   out = std::find_if(out, buffer.end(), [](CharT c) { return c != CharT('*'); });
   assert(out == buffer.end());

--- a/libcxx/test/std/algorithms/robust_against_proxy_iterators_lifetime_bugs.pass.cpp
+++ b/libcxx/test/std/algorithms/robust_against_proxy_iterators_lifetime_bugs.pass.cpp
@@ -547,24 +547,22 @@ class ConstexprIterator {
 
 #endif // TEST_STD_VER > 17
 
-template <class T, std::size_t N = 32>
+template <class T, std::size_t StorageSize = 32>
 class Input {
-  using Array = std::array<T, N>;
-
   std::size_t size_ = 0;
-  Array values_ = {};
+  T values_[StorageSize] = {};
 
 public:
-  template <std::size_t N2>
-  TEST_CONSTEXPR_CXX20 Input(std::array<T, N2> from) {
-    static_assert(N2 <= N, "");
+  template <std::size_t N>
+  TEST_CONSTEXPR_CXX20 Input(std::array<T, N> from) {
+    static_assert(N <= StorageSize, "");
 
     std::copy(from.begin(), from.end(), begin());
-    size_ = N2;
+    size_ = N;
   }
 
-  TEST_CONSTEXPR_CXX20 typename Array::iterator begin() { return values_.begin(); }
-  TEST_CONSTEXPR_CXX20 typename Array::iterator end() { return values_.begin() + size_; }
+  TEST_CONSTEXPR_CXX20 T* begin() { return values_; }
+  TEST_CONSTEXPR_CXX20 T* end() { return values_ + size_; }
   TEST_CONSTEXPR_CXX20 std::size_t size() const { return size_; }
 };
 

--- a/libcxx/test/std/containers/sequences/array/types.pass.cpp
+++ b/libcxx/test/std/containers/sequences/array/types.pass.cpp
@@ -54,8 +54,6 @@ int main(int, char**)
         typedef std::array<T, 10> C;
         static_assert((std::is_same<C::reference, T&>::value), "");
         static_assert((std::is_same<C::const_reference, const T&>::value), "");
-        LIBCPP_STATIC_ASSERT((std::is_same<C::iterator, T*>::value), "");
-        LIBCPP_STATIC_ASSERT((std::is_same<C::const_iterator, const T*>::value), "");
         test_iterators<C>();
         static_assert((std::is_same<C::pointer, T*>::value), "");
         static_assert((std::is_same<C::const_pointer, const T*>::value), "");
@@ -76,8 +74,6 @@ int main(int, char**)
         typedef std::array<T, 0> C;
         static_assert((std::is_same<C::reference, T&>::value), "");
         static_assert((std::is_same<C::const_reference, const T&>::value), "");
-        LIBCPP_STATIC_ASSERT((std::is_same<C::iterator, T*>::value), "");
-        LIBCPP_STATIC_ASSERT((std::is_same<C::const_iterator, const T*>::value), "");
         test_iterators<C>();
         static_assert((std::is_same<C::pointer, T*>::value), "");
         static_assert((std::is_same<C::const_pointer, const T*>::value), "");

--- a/libcxx/test/std/containers/views/views.span/span.cons/iterator_sentinel.pass.cpp
+++ b/libcxx/test/std/containers/views/views.span/span.cons/iterator_sentinel.pass.cpp
@@ -114,7 +114,10 @@ public:
   friend difference_type operator-(throw_operator_minus, throw_operator_minus) { throw 42; };
 
   friend bool operator==(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ == y.it_; }
-  friend auto operator<=>(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ <=> y.it_; }
+  friend bool operator<(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ < y.it_; }
+  friend bool operator>(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ > y.it_; }
+  friend bool operator<=(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ <= y.it_; }
+  friend bool operator>=(const throw_operator_minus& x, const throw_operator_minus& y) { return x.it_ >= y.it_; }
 };
 
 template <class It>

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp
@@ -61,7 +61,7 @@ void test(std::basic_string_view<CharT> fmt, ArithmeticT arg, std::basic_string<
 
   if (expected.empty()) {
     std::array<char, 128> buffer;
-    expected.append(buffer.begin(), std::to_chars(buffer.begin(), buffer.end(), arg).ptr);
+    expected.append(buffer.data(), std::to_chars(buffer.data(), buffer.data() + buffer.size(), arg).ptr);
   }
 
   assert(result == expected);
@@ -84,321 +84,401 @@ void test_termination_condition(StringT f, ArithmeticT arg, StringT expected = {
 
 template <class CharT, class ArithmeticT>
 void test_hex_lower_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::hex, 20'000).ptr;
-  test_termination_condition(STR(".20000a}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::hex, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000a}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000a}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::hex, 20'000).ptr;
-  test_termination_condition(STR(".20000La}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::hex, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000La}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000La}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_hex_upper_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::hex, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000A}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::hex, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000A}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000A}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::hex, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000LA}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::hex, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000LA}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000LA}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_scientific_lower_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::scientific, 20'000).ptr;
-  test_termination_condition(STR(".20000e}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::scientific, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000e}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000e}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::scientific, 20'000).ptr;
-  test_termination_condition(STR(".20000Le}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::scientific, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000Le}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000Le}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_scientific_upper_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::scientific, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000E}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::scientific, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000E}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000E}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::scientific, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000LE}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::scientific, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000LE}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000LE}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_fixed_lower_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::fixed, 20'000).ptr;
-  test_termination_condition(STR(".20000f}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000f}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000f}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::fixed, 20'000).ptr;
-  test_termination_condition(STR(".20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000Lf}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_fixed_upper_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::fixed, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000F}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000F}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000F}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::fixed, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000LF}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000LF}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000LF}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_general_lower_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::general, 20'000).ptr;
-  test_termination_condition(STR(".20000g}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::general, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000g}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000g}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::general, 20'000).ptr;
-  test_termination_condition(STR(".20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::general, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    test_termination_condition(STR(".20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000Lg}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 
 template <class CharT, class ArithmeticT>
 void test_general_upper_case_precision(ArithmeticT value) {
-  std::array<char, 25'000> buffer;
-  char* end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::general, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000G}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::general, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000G}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  std::size_t size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000G}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+
 #ifndef TEST_HAS_NO_LOCALIZATION
-  end = std::to_chars(buffer.begin(), buffer.end(), value, std::chars_format::general, 20'000).ptr;
-  std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
-  test_termination_condition(STR(".20000LG}"), value, std::basic_string<CharT>{buffer.begin(), end});
+  {
+    std::array<char, 25'000> buffer;
+    char* end_ptr = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::general, 20'000).ptr;
+    std::size_t size = end_ptr - buffer.data();
+    auto end = buffer.begin() + size;
+    std::transform(buffer.begin(), end, buffer.begin(), [](char c) { return std::toupper(c); });
+    test_termination_condition(STR(".20000LG}"), value, std::basic_string<CharT>{buffer.begin(), end});
 
-  size = buffer.end() - end;
-  std::fill_n(end, size, '#');
-  test_termination_condition(STR("#<25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - (size / 2), buffer.end());
-  test_termination_condition(STR("#^25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::rotate(buffer.begin(), buffer.end() - ((size + 1) / 2), buffer.end());
-  test_termination_condition(STR("#>25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
-  std::fill_n(buffer.begin(), size, '0');
-  if (std::signbit(value)) {
-    buffer[0] = '-';
-    buffer[size] = '0';
+    std::size_t unused = buffer.end() - end;
+    std::fill_n(end, unused, '#');
+    test_termination_condition(STR("#<25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - (unused / 2), buffer.end());
+    test_termination_condition(STR("#^25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::rotate(buffer.begin(), buffer.end() - ((unused + 1) / 2), buffer.end());
+    test_termination_condition(STR("#>25000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
+    std::fill_n(buffer.begin(), unused, '0');
+    if (std::signbit(value)) {
+      buffer[0] = '-';
+      buffer[unused] = '0';
+    }
+    test_termination_condition(STR("025000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
   }
-  test_termination_condition(STR("025000.20000LG}"), value, std::basic_string<CharT>{buffer.begin(), buffer.end()});
 #endif
 }
 

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -58,8 +58,8 @@ void test(StringT expected, StringViewT fmt, PointerT arg, std::size_t offset) {
     std::array<char, 128> buffer;
     buffer[0] = CharT('0');
     buffer[1] = CharT('x');
-    expected.append(buffer.begin(),
-                    std::to_chars(buffer.begin() + 2, buffer.end(), reinterpret_cast<std::uintptr_t>(arg), 16).ptr);
+    expected.append(buffer.data(),
+                    std::to_chars(buffer.data() + 2, buffer.data() + buffer.size(), reinterpret_cast<std::uintptr_t>(arg), 16).ptr);
   }
   assert(result == expected);
 }


### PR DESCRIPTION
This patch removes assumptions that std::array's iterators are raw pointers in the source code and in our test suite. While this is true right now, this doesn't have to be true and ion the future we might want to enable bounded iterators in std::array, which would require this change.

This is a pre-requisite for landing #74482