### PR TITLE
[sanitizer_common] Fix potential null dereference in dlopen interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -6327,7 +6327,7 @@ INTERCEPTOR(void*, dlopen, const char *filename, int flag) {
       VPrintf(1, "dlopen interceptor: DladdrSelfFName: %p %s\n",
               (void *)SelfFName, SelfFName);
 
-      if (internal_strcmp(SelfFName, filename) == 0) {
+      if (SelfFName && internal_strcmp(SelfFName, filename) == 0) {
         // It's possible they copied the string from dladdr, so
         // we do a string comparison rather than pointer comparison.
         VPrintf(1, "dlopen interceptor: replacing %s because it matches %s\n",


### PR DESCRIPTION
The test_only_replace_dlopen_main_program flag
(introduced in https://github.com/llvm/llvm-project/commit/0be4c6b9483594494051e8f1f67afc2b516270ca)
will cause internal_strcmp to dereference NULL if DlAddrSelfFName()
returns NULL (which happens in very rare cases). This patch adds a
null pointer check.
