### PR TITLE
[flang][runtime] Support READ after WRITE w/o positioning

### DIFF
--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -140,6 +140,7 @@ private:
   Direction direction_{Direction::Output};
   bool impliedEndfile_{false}; // sequential/stream output has taken place
   bool beganReadingRecord_{false};
+  bool anyWriteSinceLastPositioning_{false};
   bool directAccessRecWasSet_{false}; // REC= appeared
   // Subtle: The beginning of the frame can't be allowed to advance
   // during a single list-directed READ due to the possibility of a


### PR DESCRIPTION
Most Fortran implementations support a READ statement after a WRITE without repositioning on a sequential unit; it implies on ENDFILE and then hits an EOF condition.

Fixes llvm-test-suite/Fortran/gfortran/regression/backspace_2.f.