### PR TITLE
[SPIR-V] Remove deleted functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -690,9 +690,7 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
     return getOpTypeArray(Ty->getArrayNumElements(), El, MIRBuilder, EmitIR);
   }
   if (auto SType = dyn_cast<StructType>(Ty)) {
-    if (SType->isOpaque())
-      return getOpTypeOpaque(SType, MIRBuilder);
-    return getOpTypeStruct(SType, MIRBuilder, EmitIR);
+    return getOpTypeOpaque(SType, MIRBuilder);
   }
   if (auto FType = dyn_cast<FunctionType>(Ty)) {
     SPIRVType *RetTy = findSPIRVType(FType->getReturnType(), MIRBuilder);
@@ -707,12 +705,7 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
     // At the moment, all opaque pointers correspond to i8 element type.
     // TODO: change the implementation once opaque pointers are supported
     // in the SPIR-V specification.
-    if (PType->isOpaque())
-      SpvElementType = getOrCreateSPIRVIntegerType(8, MIRBuilder);
-    else
-      SpvElementType =
-          findSPIRVType(PType->getNonOpaquePointerElementType(), MIRBuilder,
-                        SPIRV::AccessQualifier::ReadWrite, EmitIR);
+    SpvElementType = getOrCreateSPIRVIntegerType(8, MIRBuilder);
     auto SC = addressSpaceToStorageClass(PType->getAddressSpace());
     // Null pointer means we have a loop in type definitions, make and
     // return corresponding OpTypeForwardPointer.

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -326,10 +326,9 @@ std::string getOclOrSpirvBuiltinDemangledName(StringRef Name) {
 }
 
 const Type *getTypedPtrEltType(const Type *Ty) {
-  auto PType = dyn_cast<PointerType>(Ty);
-  if (!PType || PType->isOpaque())
-    return Ty;
-  return PType->getNonOpaquePointerElementType();
+  // TODO: This function requires updating following the opaque pointer
+  // migration.
+  return Ty;
 }
 
 bool hasBuiltinTypePrefix(StringRef Name) {


### PR DESCRIPTION
Remove references to functions that were deleted in #74521 which are causing SPIR-V backend build failures.