### PR TITLE
[compiler-rt] Fix linking a standalone libatomic for MinGW

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -38,6 +38,13 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     include(UseLibtool)
   endif()
   include(AddCompilerRT)
+
+  if(MINGW)
+    # Simplified version of what's set in cmake/config-ix.cmake; not including
+    # builtins, which are linked separately.
+    set(MINGW_LIBRARIES mingw32 moldname mingwex msvcrt advapi32 shell32
+                        user32 kernel32 mingw32 moldname mingwex msvcrt)
+   endif()
 endif()
 
 if (COMPILER_RT_STANDALONE_BUILD)
@@ -881,12 +888,14 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
   endif()
   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
     if(CAN_TARGET_${arch})
+      list(APPEND COMPILER_RT_LIBATOMIC_LINK_LIBS_${arch} clang_rt.builtins-${arch})
+      append_list_if(MINGW "${MINGW_LIBRARIES}" COMPILER_RT_LIBATOMIC_LINK_LIBS_${arch})
       add_compiler_rt_runtime(clang_rt.atomic
                               ${BUILTIN_TYPE}
                               ARCHS ${arch}
                               SOURCES atomic.c
                               LINK_FLAGS ${COMPILER_RT_LIBATOMIC_LINK_FLAGS}
-                              LINK_LIBS clang_rt.builtins-${arch}
+                              LINK_LIBS ${COMPILER_RT_LIBATOMIC_LINK_LIBS_${arch}}
                               PARENT_TARGET builtins-standalone-atomic)
     endif()
   endforeach()


### PR DESCRIPTION
Whenever linking with -nodefaultlibs for a MinGW target, we manually need to specify a bunch of libraries - listed in ${MINGW_LIBRARIES}; the same is already done for sanitizers and libunwind/libcxxabi/libcxx.

Practically speaking, linking with -nodefaultlibs but manually passing the libraries in ${MINGW_LIBRARIES} restores most of the libraries that are linked by default, except for the potential compiler builtins and unwind library; i.e. it has essentially the same effect as linking with "--unwindlib=none -rtlib=none", except that -rtlib doesn't accept such a value.

When building only compiler-rt/lib/builtins, not all of compiler-rt, ${MINGW_LIBRARIES} is unset - set it manually here for that case. This matches what is set in
compiler-rt/cmake/config-ix.cmake, except that the builtins (libgcc or compiler-rt builtins) is omitted; the only use within lib/buitlins is for the standalone libatomic, which explicitly already links against the just-built builtins.