### PR TITLE
[libcxx] extends test range types to take a value-type

### DIFF
--- a/libcxx/test/std/ranges/range.adaptors/range.all/range.ref.view/borrowing.compile.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.all/range.ref.view/borrowing.compile.pass.cpp
@@ -15,6 +15,6 @@
 
 #include "test_range.h"
 
-static_assert(std::ranges::borrowed_range<std::ranges::ref_view<BorrowedRange>>);
+static_assert(std::ranges::borrowed_range<std::ranges::ref_view<BorrowedRange<>>>);
 static_assert(std::ranges::borrowed_range<std::ranges::ref_view<BorrowedView>>);
 static_assert(std::ranges::borrowed_range<std::ranges::ref_view<NonBorrowedView>>);

--- a/libcxx/test/support/test_range.h
+++ b/libcxx/test/support/test_range.h
@@ -22,55 +22,57 @@ struct sentinel {
   bool operator==(std::input_or_output_iterator auto const&) const;
 };
 
-template <template <class...> class I>
-requires std::input_or_output_iterator<I<int*> >
+template <template <class...> class I, class T = int>
+  requires std::input_or_output_iterator<I<T*> >
 struct test_range {
-  I<int*> begin();
-  I<int const*> begin() const;
+  I<T*> begin();
+  I<T const*> begin() const;
   sentinel end();
   sentinel end() const;
 };
 
-template <template <class...> class I>
-requires std::input_or_output_iterator<I<int*> >
+template <template <class...> class I, class T = int>
+  requires std::input_or_output_iterator<I<T*> >
 struct test_non_const_range {
-  I<int*> begin();
+  I<T*> begin();
   sentinel end();
 };
 
-template <template <class...> class I>
-requires std::input_or_output_iterator<I<int*> >
+template <template <class...> class I, class T = int>
+  requires std::input_or_output_iterator<I<T*> >
 struct test_common_range {
-  I<int*> begin();
-  I<int const*> begin() const;
-  I<int*> end();
-  I<int const*> end() const;
+  I<T*> begin();
+  I<T const*> begin() const;
+  I<T*> end();
+  I<T const*> end() const;
 };
 
-template <template <class...> class I>
-requires std::input_or_output_iterator<I<int*> >
+template <template <class...> class I, class T = int>
+  requires std::input_or_output_iterator<I<T*> >
 struct test_non_const_common_range {
-  I<int*> begin();
-  I<int*> end();
+  I<T*> begin();
+  I<T*> end();
 };
 
-template <template <class...> class I>
-requires std::input_or_output_iterator<I<int*> >
+template <template <class...> class I, class T = int>
+  requires std::input_or_output_iterator<I<T*> >
 struct test_view : std::ranges::view_base {
-  I<int*> begin();
-  I<int const*> begin() const;
+  I<T*> begin();
+  I<T const*> begin() const;
   sentinel end();
   sentinel end() const;
 };
 
+template <class T = int>
 struct BorrowedRange {
-  int *begin() const;
-  int *end() const;
+  T* begin() const;
+  T* end() const;
   BorrowedRange(BorrowedRange&&) = delete;
 };
-template<> inline constexpr bool std::ranges::enable_borrowed_range<BorrowedRange> = true;
-static_assert(!std::ranges::view<BorrowedRange>);
-static_assert(std::ranges::borrowed_range<BorrowedRange>);
+template <class T>
+inline constexpr bool std::ranges::enable_borrowed_range<BorrowedRange<T>> = true;
+static_assert(!std::ranges::view<BorrowedRange<>>);
+static_assert(std::ranges::borrowed_range<BorrowedRange<>>);
 
 using BorrowedView = std::ranges::empty_view<int>;
 static_assert(std::ranges::view<BorrowedView>);


### PR DESCRIPTION
This increases the types' versatility so that they're not restricted just to `int*`.