### PR TITLE
[SampleProfile] Add option to limit number of (indirect) call target and inlined callsites when reading a Sample Profile

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -782,8 +782,8 @@ public:
   }
 
   SampleRecord &getOrCreateBodySample(uint32_t LineOffset,
-                                      uint32_t Discriminator,
-                                      uint64_t Num, uint64_t Weight = 1) {
+                                      uint32_t Discriminator, uint64_t Num,
+                                      uint64_t Weight = 1) {
     SampleRecord &Sample = BodySamples[LineLocation(LineOffset, Discriminator)];
     Sample.addSamples(Num, Weight);
     return Sample;
@@ -991,7 +991,7 @@ public:
       FunctionSamplesMap &FunctionSamples = CallsiteSample.second;
       if (ProfileInlineCallsiteMax < FunctionSamples.size()) {
         auto It = llvm::map_range(FunctionSamples,
-                                  [](FunctionSamplesMap::value_type &V){
+                                  [](FunctionSamplesMap::value_type &V) {
                                     return V.second.getTotalSamples();
                                   });
         std::vector<uint64_t> TotalSamples(It.begin(), It.end());

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -494,6 +494,10 @@ public:
 
   void setModule(const Module *Mod) { M = Mod; }
 
+  void setProfileCallTargetMax(size_t N) { ProfileCallTargetMax = N; }
+
+  void setProfileInlineCallsiteMax(size_t N) { ProfileInlineCallsiteMax = N; }
+
 protected:
   /// Map every function to its associated profile.
   ///
@@ -552,6 +556,16 @@ protected:
   /// Whether the profile uses MD5 for Sample Contexts and function names. This
   /// can be one-way overriden by the user to force use MD5.
   bool ProfileIsMD5 = false;
+
+  /// Number of call targets to keep in a sample record. Only those with highest
+  /// count are kept. 0 = unlimited.
+  /// Same as ProfileCallTargetMax option from SampleProfile.cpp.
+  uint32_t ProfileCallTargetMax = 0;
+
+  /// Number of inlined callsites to keep in a line location. Only those with
+  /// highest count are kept. 0 = unlimited.
+  /// Same as ProfileInlineCallsiteMax option from SampleProfile.cpp.
+  uint32_t ProfileInlineCallsiteMax = 0;
 };
 
 class SampleProfileReaderText : public SampleProfileReader {

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -409,7 +409,7 @@ std::error_code SampleProfileReaderText::readImpl() {
       }
       case LineType::BodyProfile: {
         FunctionSamples &FProfile = *InlineStack.back();
-        if (ProfileCallTargetMax != 0)  {
+        if (ProfileCallTargetMax != 0) {
           std::multimap<uint64_t, FunctionId> CallTargets;
           for (const auto &CallTarget : TargetCountMap) {
             CallTargets.emplace(CallTarget.second, CallTarget.first);
@@ -423,10 +423,10 @@ std::error_code SampleProfileReaderText::readImpl() {
           }
         } else {
           for (const auto &name_count : TargetCountMap) {
-            MergeResult(Result, FProfile.addCalledTargetSamples(
-                                    LineOffset, Discriminator,
-                                    FunctionId(name_count.first),
-                                    name_count.second));
+            MergeResult(Result,
+                        FProfile.addCalledTargetSamples(
+                            LineOffset, Discriminator,
+                            FunctionId(name_count.first), name_count.second));
           }
         }
         MergeResult(Result, FProfile.addBodySamples(LineOffset, Discriminator,
@@ -624,9 +624,8 @@ SampleProfileReaderBinary::readProfile(FunctionSamples &FProfile) {
     // Here we handle FS discriminators:
     uint32_t DiscriminatorVal = (*Discriminator) & getDiscriminatorMask();
 
-    SampleRecord &Sample =
-        FProfile.getOrCreateBodySample(*LineOffset, DiscriminatorVal,
-                                       *NumSamples);
+    SampleRecord &Sample = FProfile.getOrCreateBodySample(
+        *LineOffset, DiscriminatorVal, *NumSamples);
 
     if (ProfileCallTargetMax != 0) {
       // ProfileCallTargetMax is only used by SampleProfile.cpp at compilation,
@@ -647,7 +646,7 @@ SampleProfileReaderBinary::readProfile(FunctionSamples &FProfile) {
           CallTargets.erase(CallTargets.begin());
       }
 
-      for (auto & CallTarget : CallTargets) {
+      for (auto &CallTarget : CallTargets) {
         Sample.addCalledTarget(CallTarget.second, CallTarget.first);
       }
     } else {

--- a/llvm/lib/Transforms/IPO/SampleProfile.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfile.cpp
@@ -213,6 +213,16 @@ cl::opt<int> ProfileInlineLimitMax(
     cl::desc("The upper bound of size growth limit for "
              "proirity-based sample profile loader inlining."));
 
+static cl::opt<uint32_t> ProfileCallTargetMax(
+    "sample-profile-call-target-max", cl::Hidden, cl::init(3),
+    cl::desc("In a sample record, only keep top N frequent indirect call "
+             "targets at the same location."));
+
+static cl::opt<uint32_t> ProfileInlineCallsiteMax(
+    "sample-profile-inline-callsite-max", cl::Hidden, cl::init(3),
+    cl::desc("In an inlined callsite map, only keep top N frequently inlined "
+             "callsites at the same location."));
+
 cl::opt<int> SampleHotCallSiteThreshold(
     "sample-profile-hot-inline-threshold", cl::Hidden, cl::init(3000),
     cl::desc("Hot callsite threshold for proirity-based sample profile loader "
@@ -2015,6 +2025,8 @@ bool SampleProfileLoader::doInitialization(Module &M,
   // set module before reading the profile so reader may be able to only
   // read the function profiles which are used by the current module.
   Reader->setModule(&M);
+  Reader->setProfileCallTargetMax(ProfileCallTargetMax);
+  Reader->setProfileInlineCallsiteMax(ProfileInlineCallsiteMax);
   if (std::error_code EC = Reader->read()) {
     std::string Msg = "profile reading failed: " + EC.message();
     Ctx.diagnose(DiagnosticInfoSampleProfile(Filename, Msg));

--- a/llvm/test/tools/llvm-profdata/Inputs/sample-max-callsite.proftext
+++ b/llvm/test/tools/llvm-profdata/Inputs/sample-max-callsite.proftext
@@ -1,0 +1,20 @@
+main:184019:0
+ 4: 534
+ 4.2: 534
+ 5: 1075
+ 5.1: 1075
+ 6: 2080
+ 7: 534 _Z3bazi:1
+ 9: 2064 _Z3bari:1471 _Z3fooi:631 _Z3gooi:123 _Z3hooi:999
+ 10: inline1:1000
+  1: 1000
+  2: 1001 func1:10 func2:30 func3:20
+ 10: inline2:2000
+  1: 2000
+  3: inlineinline1:3
+  3: inlineinline2:2
+  3: inlineinline3:1
+ 10: inline3:45
+ 10.1: inline4:1
+_Z3bari:20301:1437
+ 1: 1437

--- a/llvm/test/tools/llvm-profdata/sample-max-callsite.test
+++ b/llvm/test/tools/llvm-profdata/sample-max-callsite.test
@@ -1,0 +1,124 @@
+# Test options sample-profile-call-target-max and
+# sample-profile-inline-callsite-max in llvm-profdata. Same options are
+# available in clang when compiling using a sample profile.
+
+RUN: llvm-profdata merge -text -sample -sample-profile-call-target-max=3 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW30
+RUN: llvm-profdata merge -text -sample -sample-profile-call-target-max=2 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW20
+RUN: llvm-profdata merge -text -sample -sample-profile-inline-callsite-max=2 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW02
+RUN: llvm-profdata merge -text -sample -sample-profile-inline-callsite-max=1 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW01
+RUN: llvm-profdata merge -text -sample -sample-profile-call-target-max=1 -sample-profile-inline-callsite-max=1 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW11
+
+RUN: llvm-profdata merge -text -sample -sample-profile-call-target-max=0 -sample-profile-inline-callsite-max=0 %p/Inputs/sample-max-callsite.proftext | FileCheck %s --check-prefix=SHOW
+RUN: llvm-profdata merge -text -sample -sample-profile-call-target-max=999 -sample-profile-inline-callsite-max=999 %p/Inputs/sample-max-callsite.proftext  | FileCheck %s --check-prefix=SHOW
+
+SHOW30: main:184019:0
+SHOW30-NEXT:  4: 534
+SHOW30-NEXT:  4.2: 534
+SHOW30-NEXT:  5: 1075
+SHOW30-NEXT:  5.1: 1075
+SHOW30-NEXT:  6: 2080
+SHOW30-NEXT:  7: 534 _Z3bazi:1
+SHOW30-NEXT:  9: 2064 _Z3bari:1471 _Z3hooi:999 _Z3fooi:631
+SHOW30-NEXT:  10: inline1:1000
+SHOW30-NEXT:   1: 1000
+SHOW30-NEXT:   2: 1001 func2:30 func3:20 func1:10
+SHOW30-NEXT:  10: inline2:2000
+SHOW30-NEXT:   1: 2000
+SHOW30-NEXT:   3: inlineinline1:3
+SHOW30-NEXT:   3: inlineinline2:2
+SHOW30-NEXT:   3: inlineinline3:1
+SHOW30-NEXT:  10: inline3:45
+SHOW30-NEXT:  10.1: inline4:1
+SHOW30-NEXT: _Z3bari:20301:1437
+SHOW30-NEXT:  1: 1437
+
+SHOW20: main:184019:0
+SHOW20-NEXT:  4: 534
+SHOW20-NEXT:  4.2: 534
+SHOW20-NEXT:  5: 1075
+SHOW20-NEXT:  5.1: 1075
+SHOW20-NEXT:  6: 2080
+SHOW20-NEXT:  7: 534 _Z3bazi:1
+SHOW20-NEXT:  9: 2064 _Z3bari:1471 _Z3hooi:999
+SHOW20-NEXT:  10: inline1:1000
+SHOW20-NEXT:   1: 1000
+SHOW20-NEXT:   2: 1001 func2:30 func3:20
+SHOW20-NEXT:  10: inline2:2000
+SHOW20-NEXT:   1: 2000
+SHOW20-NEXT:   3: inlineinline1:3
+SHOW20-NEXT:   3: inlineinline2:2
+SHOW20-NEXT:   3: inlineinline3:1
+SHOW20-NEXT:  10: inline3:45
+SHOW20-NEXT:  10.1: inline4:1
+SHOW20-NEXT: _Z3bari:20301:1437
+SHOW20-NEXT:  1: 1437
+
+SHOW02: main:184019:0
+SHOW02-NEXT:  4: 534
+SHOW02-NEXT:  4.2: 534
+SHOW02-NEXT:  5: 1075
+SHOW02-NEXT:  5.1: 1075
+SHOW02-NEXT:  6: 2080
+SHOW02-NEXT:  7: 534 _Z3bazi:1
+SHOW02-NEXT:  9: 2064 _Z3bari:1471 _Z3hooi:999 _Z3fooi:631 _Z3gooi:123
+SHOW02-NEXT:  10: inline1:1000
+SHOW02-NEXT:   1: 1000
+SHOW02-NEXT:   2: 1001 func2:30 func3:20 func1:10
+SHOW02-NEXT:  10: inline2:2000
+SHOW02-NEXT:   1: 2000
+SHOW02-NEXT:   3: inlineinline1:3
+SHOW02-NEXT:   3: inlineinline2:2
+SHOW02-NEXT:  10.1: inline4:1
+SHOW02-NEXT: _Z3bari:20301:1437
+SHOW02-NEXT:  1: 1437
+
+SHOW01: main:184019:0
+SHOW01-NEXT:  4: 534
+SHOW01-NEXT:  4.2: 534
+SHOW01-NEXT:  5: 1075
+SHOW01-NEXT:  5.1: 1075
+SHOW01-NEXT:  6: 2080
+SHOW01-NEXT:  7: 534 _Z3bazi:1
+SHOW01-NEXT:  9: 2064 _Z3bari:1471 _Z3hooi:999 _Z3fooi:631 _Z3gooi:123
+SHOW01-NEXT:  10: inline2:2000
+SHOW01-NEXT:   1: 2000
+SHOW01-NEXT:   3: inlineinline1:3
+SHOW01-NEXT:  10.1: inline4:1
+SHOW01-NEXT: _Z3bari:20301:1437
+SHOW01-NEXT:  1: 1437
+
+SHOW11: main:184019:0
+SHOW11-NEXT:  4: 534
+SHOW11-NEXT:  4.2: 534
+SHOW11-NEXT:  5: 1075
+SHOW11-NEXT:  5.1: 1075
+SHOW11-NEXT:  6: 2080
+SHOW11-NEXT:  7: 534 _Z3bazi:1
+SHOW11-NEXT:  9: 2064 _Z3bari:1471
+SHOW11-NEXT:  10: inline2:2000
+SHOW11-NEXT:   1: 2000
+SHOW11-NEXT:   3: inlineinline1:3
+SHOW11-NEXT:  10.1: inline4:1
+SHOW11-NEXT: _Z3bari:20301:1437
+SHOW11-NEXT:  1: 1437
+
+SHOW: main:184019:0
+SHOW-NEXT:  4: 534
+SHOW-NEXT:  4.2: 534
+SHOW-NEXT:  5: 1075
+SHOW-NEXT:  5.1: 1075
+SHOW-NEXT:  6: 2080
+SHOW-NEXT:  7: 534 _Z3bazi:1
+SHOW-NEXT:  9: 2064 _Z3bari:1471 _Z3hooi:999 _Z3fooi:631 _Z3gooi:123
+SHOW-NEXT:  10: inline1:1000
+SHOW-NEXT:   1: 1000
+SHOW-NEXT:   2: 1001 func2:30 func3:20 func1:10
+SHOW-NEXT:  10: inline2:2000
+SHOW-NEXT:   1: 2000
+SHOW-NEXT:   3: inlineinline1:3
+SHOW-NEXT:   3: inlineinline2:2
+SHOW-NEXT:   3: inlineinline3:1
+SHOW-NEXT:  10: inline3:45
+SHOW-NEXT:  10.1: inline4:1
+SHOW-NEXT: _Z3bari:20301:1437
+SHOW-NEXT:  1: 1437

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -175,6 +175,14 @@ cl::opt<bool> CompressAllSections(
     cl::sub(MergeSubcommand),
     cl::desc("Compress all sections when writing the profile (only "
              "meaningful for -extbinary)"));
+cl::opt<uint32_t> ProfileCallTargetMax(
+    "sample-profile-call-target-max", cl::Hidden, cl::init(0),
+    cl::desc("While reading a profile, in a sample record, only keep top N "
+             "frequent indirect call targets at the same location."));
+cl::opt<uint32_t> ProfileInlineCallsiteMax(
+    "sample-profile-inline-callsite-max", cl::Hidden, cl::init(0),
+    cl::desc("While reading a profile, in an inlined callsite map, only keep "
+             "top N frequently inlined callsites at the same location."));
 cl::opt<bool> SampleMergeColdContext(
     "sample-merge-cold-context", cl::init(false), cl::Hidden,
     cl::sub(MergeSubcommand),
@@ -1377,6 +1385,8 @@ static void mergeSampleProfile(const WeightedFileVector &Inputs,
     // merged profile map.
     Readers.push_back(std::move(ReaderOrErr.get()));
     const auto Reader = Readers.back().get();
+    Reader->setProfileCallTargetMax(ProfileCallTargetMax);
+    Reader->setProfileInlineCallsiteMax(ProfileInlineCallsiteMax);
     if (std::error_code EC = Reader->read()) {
       warnOrExitGivenError(FailMode, EC, Input.Filename);
       Readers.pop_back();


### PR DESCRIPTION
Add option to limit number of (indirect) call target and inlined callsites when reading a Sample Profile

Sample profile generated in production environment can contain entries with a huge amount of indirect call targets or inlined callsites due to usages like Listener pattern, CRTP, etc. This will cause a combinatorial blow up when constructing the call graph from the profile for inlining, slowing down the compilation time by 10+ times.

Since we actually don't inline indirect call for more than a few call targets, a limit is added to sample profile parsing so that it will only keep the top N indirect call targets or inlined callsites, ranking by sample count. Lowest is dropped first.

Use -sample-profile-call-target-max and
-sample-profile-inline-callsite-max to control the max number to kept, default is 3.

This option also works on llvm-profdata merge, but it only controls the input reader, not the output after merging multiple profiles