### PR TITLE
[llvm][NVPTX] Inform that 'DYNAMIC_STACKALLOC' is unsupported

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -639,6 +639,11 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
   setOperationAction(ISD::ConstantFP, MVT::f16, Legal);
   setOperationAction(ISD::ConstantFP, MVT::bf16, Legal);
 
+  // Lowering of DYNAMIC_STACKALLOC is unsupported.
+  // Custom lower to produce an error.
+  setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i32, Custom);
+  setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i64, Custom);
+
   // TRAP can be lowered to PTX trap
   setOperationAction(ISD::TRAP, MVT::Other, Legal);
 
@@ -2652,6 +2657,9 @@ NVPTXTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
   case ISD::SREM:
   case ISD::UREM:
     return LowerVectorArith(Op, DAG);
+  case ISD::DYNAMIC_STACKALLOC:
+    report_fatal_error(
+        "Dynamic stack allocation is yet unsupported by NVPTX backend.");
   default:
     llvm_unreachable("Custom lowering not defined for operation");
   }

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
@@ -513,6 +513,8 @@ public:
   SDValue LowerCall(CallLoweringInfo &CLI,
                     SmallVectorImpl<SDValue> &InVals) const override;
 
+  SDValue LowerDYNAMIC_STACKALLOC(SDValue Op, SelectionDAG &DAG) const;
+
   std::string
   getPrototype(const DataLayout &DL, Type *, const ArgListTy &,
                const SmallVectorImpl<ISD::OutputArg> &, MaybeAlign retAlignment,

--- a/llvm/test/CodeGen/NVPTX/dynamic_stackalloc.ll
+++ b/llvm/test/CodeGen/NVPTX/dynamic_stackalloc.ll
@@ -1,0 +1,10 @@
+; RUN: not llc -march=nvptx < %s 2>&1 | FileCheck %s
+; RUN: not llc -march=nvptx64 < %s 2>&1 | FileCheck %s
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: dynamic alloca unsupported by NVPTX backend
+
+define void @test_dynamic_stackalloc(i64 %n) {
+  %alloca = alloca i32, i64 %n
+  store volatile i32 0, ptr %alloca
+  ret void
+}


### PR DESCRIPTION
Catch unsupported path early up, and emit error with information.

Motivated by the following threads:
* https://discourse.llvm.org/t/nvptx-problems-with-dynamic-alloca/70745
* #64017