### PR TITLE
[CMake] Make ELF library handling path default for libLLVM

### DIFF
--- a/llvm/tools/llvm-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-shlib/CMakeLists.txt
@@ -33,16 +33,9 @@ if(LLVM_BUILD_LLVM_DYLIB)
   add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${INSTALL_WITH_TOOLCHAIN} ${SOURCES})
 
   list(REMOVE_DUPLICATES LIB_NAMES)
-  if((MINGW) OR (HAIKU)
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "GNU")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "NetBSD")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "OpenBSD")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
-     OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "SunOS")) # FIXME: It should be "GNU ld for elf"
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(LIB_NAMES -Wl,-all_load ${LIB_NAMES})
+  else()
     configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/simple_version_script.map.in
     ${LLVM_LIBRARY_DIR}/tools/llvm-shlib/simple_version_script.map)
@@ -60,8 +53,6 @@ if(LLVM_BUILD_LLVM_DYLIB)
       # inside and outside libLLVM.so.
       target_link_options(LLVM PRIVATE LINKER:-Bsymbolic-functions)
     endif()
-  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    set(LIB_NAMES -Wl,-all_load ${LIB_NAMES})
   endif()
 
   target_link_libraries(LLVM PRIVATE ${LIB_NAMES})


### PR DESCRIPTION
Invert the logic and choose the ELF path by default as a fallback. Move check for Darwin to the top.