### PR TITLE
[RISCV] Set DebugLoc of epilogue

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -681,6 +681,7 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
                                           const TargetRegisterClass *RC,
                                           const TargetRegisterInfo *TRI,
                                           Register VReg) const {
+  const DebugLoc &DL = MBB.findDebugLoc(I);
   MachineFunction *MF = MBB.getParent();
   MachineFrameInfo &MFI = MF->getFrameInfo();
 
@@ -741,7 +742,7 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
         MemoryLocation::UnknownSize, MFI.getObjectAlign(FI));
 
     MFI.setStackID(FI, TargetStackID::ScalableVector);
-    BuildMI(MBB, I, DebugLoc(), get(Opcode), DstReg)
+    BuildMI(MBB, I, DL, get(Opcode), DstReg)
         .addFrameIndex(FI)
         .addMemOperand(MMO);
   } else {
@@ -749,7 +750,7 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
         MachinePointerInfo::getFixedStack(*MF, FI), MachineMemOperand::MOLoad,
         MFI.getObjectSize(FI), MFI.getObjectAlign(FI));
 
-    BuildMI(MBB, I, DebugLoc(), get(Opcode), DstReg)
+    BuildMI(MBB, I, DL, get(Opcode), DstReg)
         .addFrameIndex(FI)
         .addImm(0)
         .addMemOperand(MMO);

--- a/llvm/test/CodeGen/RISCV/debug-loc.ll
+++ b/llvm/test/CodeGen/RISCV/debug-loc.ll
@@ -1,0 +1,46 @@
+; RUN: llc -mtriple=riscv64 < %s | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64-unknown-linux-gnu"
+
+define void @foo() #0 !dbg !3 {
+; CHECK-LABEL: foo:
+; CHECK: .Lfunc_begin0:
+; CHECK-NEXT: 	.file	1 "test.c"
+; CHECK-NEXT: 	.loc	1 5 0                           # test.c:5:0
+; CHECK-NEXT: 	.cfi_startproc
+; CHECK-NEXT: # %bb.0:                                # %entry
+; CHECK-NEXT: 	addi	sp, sp, -16
+; CHECK-NEXT: 	.cfi_def_cfa_offset 16
+; CHECK-NEXT: 	sd	ra, 8(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT: 	sd	s0, 0(sp)                       # 8-byte Folded Spill
+; CHECK-NEXT: 	.cfi_offset ra, -8
+; CHECK-NEXT: 	.cfi_offset s0, -16
+; CHECK-NEXT: 	addi	s0, sp, 16
+; CHECK-NEXT: 	.cfi_def_cfa s0, 0
+; CHECK-NEXT: .Ltmp0:
+; CHECK-NEXT: 	.loc	1 6 4 prologue_end              # test.c:6:4
+; CHECK-NEXT: 	sw	zero, 0(zero)
+; CHECK-NEXT: 	ld	ra, 8(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT: 	ld	s0, 0(sp)                       # 8-byte Folded Reload
+; CHECK-NEXT: 	.loc	1 7 1 epilogue_begin # test.c:7:1
+; CHECK-NEXT: 	addi	sp, sp, 16
+; CHECK-NEXT: 	ret
+entry:
+  store i32 0, ptr null, align 4, !dbg !6
+  ret void, !dbg !7
+}
+
+attributes #0 = { "frame-pointer"="all" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.c", directory: "")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 5, type: !4, scopeLine: 5, unit: !0)
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = !DILocation(line: 6, column: 4, scope: !3)
+!7 = !DILocation(line: 7, column: 1, scope: !3)

--- a/llvm/test/CodeGen/RISCV/debug-loc.ll
+++ b/llvm/test/CodeGen/RISCV/debug-loc.ll
@@ -21,9 +21,10 @@ define void @foo() #0 !dbg !3 {
 ; CHECK-NEXT: .Ltmp0:
 ; CHECK-NEXT: 	.loc	1 6 4 prologue_end              # test.c:6:4
 ; CHECK-NEXT: 	sw	zero, 0(zero)
+; CHECK-NEXT: 	.loc	1 7 1                           # test.c:7:1
 ; CHECK-NEXT: 	ld	ra, 8(sp)                       # 8-byte Folded Reload
 ; CHECK-NEXT: 	ld	s0, 0(sp)                       # 8-byte Folded Reload
-; CHECK-NEXT: 	.loc	1 7 1 epilogue_begin # test.c:7:1
+; CHECK-NEXT: 	.loc	1 7 1 epilogue_begin is_stmt 0  # test.c:7:1
 ; CHECK-NEXT: 	addi	sp, sp, 16
 ; CHECK-NEXT: 	ret
 entry:


### PR DESCRIPTION
There is a problem I found when discussing at
https://discourse.llvm.org/t/llvm-generates-wrong-dwarf-line-table-to-gdb/75454/10:
if we set a breakpoint to the end of a function, the debugger will
stop at the place after restoring registers, not before it, which
is a wrong behavior I think.

There are two problems here actually:

1. Instructions for restoring registers don't have debug line info
  as we just set it to `DebugLoc()`.
2. We can't recognize the right epilogue beginning `epilogue_begin`.
  This is a feature introduced by https://reviews.llvm.org/D133376.
  In short, the epilogue beginning will be the first instruction
  with flag `FrameDestroy`. The problem for RISCV target is that
  we only set `FrameDestroy` flag for stack pointer recovering
  instructions(IIUC).

This PR fixes the first problem and the fix is to use the `DebugLoc`
getting from the insert point `I` like other in-tree targets.

As for second problem, I don't have a fix now and I think it may
be hard to fix, so I will leave it there.

A test is added to show the change, please see the topmost commit.
