### PR TITLE
[Github] Use three dot diff for darker in code format action

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -185,7 +185,7 @@ class DarkerFormatHelper(FormatHelper):
             "--check",
             "--diff",
             "-r",
-            f"{args.start_rev}..{args.end_rev}",
+            f"{args.start_rev}...{args.end_rev}",
         ] + py_files
         print(f"Running: {' '.join(darker_cmd)}")
         self.darker_cmd = darker_cmd


### PR DESCRIPTION
Using a two dot diff allows changes made in main after the merge base to show up in the formatting diff. Using a three dot diff fixes this and ensures that only changes made in the source branch (branch from the PR author) will get passed along to the formatter.

Without this, issues like #73873 occur.