### PR TITLE
[NFC][VPlan] Simplify VPValue::removeUser

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -123,7 +123,7 @@ public:
   void removeUser(VPUser &User) {
     // The same user can be added multiple times, e.g. because the same VPValue
     // is used twice by the same VPUser. Remove a single one.
-    auto *I = llvm::find(Users, &User);
+    auto *I = find(Users, &User);
     if (I != Users.end())
       Users.erase(I);
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -121,18 +121,14 @@ public:
 
   /// Remove a single \p User from the list of users.
   void removeUser(VPUser &User) {
-    bool Found = false;
     // The same user can be added multiple times, e.g. because the same VPValue
     // is used twice by the same VPUser. Remove a single one.
-    erase_if(Users, [&User, &Found](VPUser *Other) {
-      if (Found)
-        return false;
-      if (Other == &User) {
-        Found = true;
-        return true;
+    for (const auto &U : Users) {
+      if (U == &User) {
+        Users.erase(&U);
+        return;
       }
-      return false;
-    });
+    }
   }
 
   typedef SmallVectorImpl<VPUser *>::iterator user_iterator;

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -123,12 +123,9 @@ public:
   void removeUser(VPUser &User) {
     // The same user can be added multiple times, e.g. because the same VPValue
     // is used twice by the same VPUser. Remove a single one.
-    for (const auto &U : Users) {
-      if (U == &User) {
-        Users.erase(&U);
-        return;
-      }
-    }
+    auto *I = llvm::find(Users, &User);
+    if (I != Users.end())
+      Users.erase(I);
   }
 
   typedef SmallVectorImpl<VPUser *>::iterator user_iterator;


### PR DESCRIPTION
I think we don't need to use lambda, and we can end the loop in advance like this.