### PR TITLE
[llvm-exegesis]Allow clients to do their own snippet running error ha…

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
@@ -65,7 +65,7 @@ public:
                            unsigned NumRepetitions, unsigned LoopUnrollFactor,
                            const SnippetRepetitor &Repetitor) const;
 
-  Expected<Benchmark>
+  std::pair<Error, Benchmark>
   runConfiguration(RunnableConfiguration &&RC,
                    const std::optional<StringRef> &DumpFile) const;
 


### PR DESCRIPTION
…ndling.

Returns an error *and* a benchmark rather than an error *or* a benchmark. This allows users to have custom error handling while still being able to inspect the benchmark.

Apart from this small API change, this is an NFC.

This is an alternative to #74211.