### PR TITLE
[libc++] tests with picolibc: handle stdin

### DIFF
--- a/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
+++ b/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
@@ -8,8 +8,6 @@
 
 // Make sure that the executor pipes standard input to the test-executable being run.
 
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // RUN: %{build}
 // RUN: echo "abc" | %{exec} %t.exe
 

--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
@@ -8,7 +8,11 @@
 
 // TODO: Investigate
 // UNSUPPORTED: LIBCXX-AIX-FIXME
-// XFAIL: LIBCXX-PICOLIBC-FIXME
+
+// QEMU does not detect EOF, when reading from stdin
+// "echo -n" suppresses any characters after the output and so the test hangs.
+// https://gitlab.com/qemu-project/qemu/-/issues/1963
+// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
 // This test hangs on Android devices that lack shell_v2, which was added in
 // Android N (API 24).


### PR DESCRIPTION
Add proper explanation for cin.sh.cpp fail.
The stdin-is-piped.sh.cpp used to fail with old qemu (4.2.0), but should pass now, as the qemu is updated now to 8.1.3 in CI.