### PR TITLE
[flang] Use `genOpenMPTerminator` to insert terminator

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -2150,13 +2150,7 @@ static void createBodyOfOp(
         firOpBuilder, eval.getNestedEvaluations());
 
   // Insert the terminator.
-  if constexpr (std::is_same_v<Op, mlir::omp::WsLoopOp> ||
-                std::is_same_v<Op, mlir::omp::SimdLoopOp>) {
-    mlir::ValueRange results;
-    firOpBuilder.create<mlir::omp::YieldOp>(loc, results);
-  } else {
-    firOpBuilder.create<mlir::omp::TerminatorOp>(loc);
-  }
+  Fortran::lower::genOpenMPTerminator(firOpBuilder, op.getOperation(), loc);
   // Reset the insert point to before the terminator.
   resetBeforeTerminator(firOpBuilder, storeOp, block);
 


### PR DESCRIPTION
The specific terminator operation depends on what operation it is inside of. The function `genOpenMPTerminator` performs these checks and selects the appropriate type of terminator.

Remove partial duplication of that code, and replace it with a function call. This makes `genOpenMPTerminator` be the sole source of OpenMP terminators.