### PR TITLE
[AArch64][PAC] Expand blend(reg, imm) operation in aarch64-pauth pass

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1581,6 +1581,9 @@ def PAUTH_PROLOGUE : Pseudo<(outs), (ins), []>, Sched<[]>;
 def PAUTH_EPILOGUE : Pseudo<(outs), (ins), []>, Sched<[]>;
 }
 
+def PAUTH_BLEND : Pseudo<(outs GPR64:$disc),
+                         (ins GPR64:$addr_disc, i32imm:$int_disc), []>, Sched<[]>;
+
 // These pointer authentication instructions require armv8.3a
 let Predicates = [HasPAuth] in {
 
@@ -9317,12 +9320,10 @@ let Predicates = [HasMOPS, HasMTE], Defs = [NZCV], Size = 12, mayLoad = 0, maySt
 //-----------------------------------------------------------------------------
 // v8.3 Pointer Authentication late patterns
 
-let Predicates = [HasPAuth] in {
 def : Pat<(int_ptrauth_blend GPR64:$Rd, imm64_0_65535:$imm),
-          (MOVKXi GPR64:$Rd, (trunc_imm imm64_0_65535:$imm), 48)>;
+          (PAUTH_BLEND GPR64:$Rd, (trunc_imm imm64_0_65535:$imm))>;
 def : Pat<(int_ptrauth_blend GPR64:$Rd, GPR64:$Rn),
           (BFMXri GPR64:$Rd, GPR64:$Rn, 16, 15)>;
-}
 
 //-----------------------------------------------------------------------------
 

--- a/llvm/test/CodeGen/AArch64/ptrauth-pseudo-instructions.mir
+++ b/llvm/test/CodeGen/AArch64/ptrauth-pseudo-instructions.mir
@@ -1,0 +1,27 @@
+# RUN: llc -mtriple=aarch64--- -run-pass=aarch64-ptrauth -verify-machineinstrs %s -o - | FileCheck %s
+
+# Test the corner cases that cannot be reliably tested using LLVM IR as input.
+
+--- |
+  define i64 @blend_untied(i64 %unused, i64 %ptr_arg) {
+    ret i64 0
+  }
+...
+---
+# Check that the input register is copied to the output one, if not tied.
+
+name:            blend_untied
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr, $x0, $x1
+    $x0 = PAUTH_BLEND $x1, 42
+    RET undef $lr
+
+# CHECK:       liveins: $lr, $x0, $x1
+# CHECK-NEXT:    {{^ +$}}
+# CHECK-NEXT:    $x0 = ORRXrs $xzr, $x1, 0
+# CHECK-NEXT:    $x0 = MOVKXi $x0, 42, 48
+# CHECK-NEXT:    RET undef $lr
+
+...


### PR DESCRIPTION
In preparation for implementing code generation for more @llvm.ptrauth.* intrinsics, move the expansion of blend(register, small integer) variant of @llvm.ptrauth.blend to the AArch64PointerAuth pass, where most other PAuth-related code generation takes place.