### PR TITLE
[lldb] add support for thread names on Windows

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -7,19 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Host/HostNativeThreadBase.h"
-#include "lldb/Host/windows/HostThreadWindows.h"
-#include "lldb/Host/windows/windows.h"
-#include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/Unwind.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
-#include "lldb/Utility/State.h"
-#include "llvm/Support/ConvertUTF.h"
 
 #include "ProcessWindows.h"
-#include "ProcessWindowsLog.h"
 #include "TargetThreadWindows.h"
+#include "lldb/Host/windows/HostThreadWindows.h"
+#include <llvm/Support/ConvertUTF.h>
 
 #if defined(__x86_64__) || defined(_M_AMD64)
 #include "x64/RegisterContextWindows_x64.h"
@@ -182,26 +177,25 @@ Status TargetThreadWindows::DoResume() {
 
 const char *TargetThreadWindows::GetName() {
   Log *log = GetLog(LLDBLog::Thread);
-  HMODULE hModule = ::LoadLibraryW(L"Kernel32.dll");
-  if (hModule) {
-    auto GetThreadDescription =
-        reinterpret_cast<GetThreadDescriptionFunctionPtr>(
-            ::GetProcAddress(hModule, "GetThreadDescription"));
-    LLDB_LOGF(log, "GetProcAddress: %p",
-              reinterpret_cast<void *>(GetThreadDescription));
-    if (GetThreadDescription) {
-      PWSTR pszThreadName;
-      if (SUCCEEDED(GetThreadDescription(
-              m_host_thread.GetNativeThread().GetSystemHandle(),
-              &pszThreadName))) {
-        LLDB_LOGF(log, "GetThreadDescription: %ls", pszThreadName);
-        llvm::convertUTF16ToUTF8String(
-            llvm::ArrayRef(reinterpret_cast<char *>(pszThreadName),
-                           wcslen(pszThreadName) * sizeof(wchar_t)),
-            m_name);
-        ::LocalFree(pszThreadName);
-      }
-    }
+  static GetThreadDescriptionFunctionPtr GetThreadDescription = []() {
+    HMODULE hModule = ::LoadLibraryW(L"Kernel32.dll");
+    return hModule ? reinterpret_cast<GetThreadDescriptionFunctionPtr>(
+                         ::GetProcAddress(hModule, "GetThreadDescription"))
+                   : nullptr;
+  }();
+  LLDB_LOGF(log, "GetProcAddress: %p",
+            reinterpret_cast<void *>(GetThreadDescription));
+  if (!GetThreadDescription)
+    return m_name.c_str();
+  PWSTR pszThreadName;
+  if (SUCCEEDED(GetThreadDescription(
+          m_host_thread.GetNativeThread().GetSystemHandle(), &pszThreadName))) {
+    LLDB_LOGF(log, "GetThreadDescription: %ls", pszThreadName);
+    llvm::convertUTF16ToUTF8String(
+        llvm::ArrayRef(reinterpret_cast<char *>(pszThreadName),
+                       wcslen(pszThreadName) * sizeof(wchar_t)),
+        m_name);
+    ::LocalFree(pszThreadName);
   }
 
   return m_name.c_str();

--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
@@ -34,6 +34,7 @@ public:
   lldb::RegisterContextSP
   CreateRegisterContextForFrame(StackFrame *frame) override;
   bool CalculateStopInfo() override;
+  const char *GetName() override;
 
   Status DoResume();
 
@@ -42,6 +43,7 @@ public:
 private:
   lldb::RegisterContextSP m_thread_reg_ctx_sp;
   HostThread m_host_thread;
+  std::string m_name;
 };
 } // namespace lldb_private
 

--- a/lldb/unittests/Thread/CMakeLists.txt
+++ b/lldb/unittests/Thread/CMakeLists.txt
@@ -11,5 +11,7 @@ add_lldb_unittest(ThreadTests
       lldbInterpreter
       lldbBreakpoint
       lldbPluginPlatformLinux
+      lldbPluginPlatformWindows
+      lldbPluginProcessWindowsCommon
   )
 


### PR DESCRIPTION
This PR adds support for thread names in lldb on Windows.

```
(lldb) thr list
Process 2960 stopped
  thread #53: tid = 0x03a0, 0x00007ff84582db34 ntdll.dll`NtWaitForMultipleObjects + 20
  thread #29: tid = 0x04ec, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'SPUW.6'
  thread #89: tid = 0x057c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1000019] physics[main]'
  thread #3: tid = 0x0648, 0x00007ff843c2cafe combase.dll`InternalDoATClassCreate + 39518
  thread #93: tid = 0x0688, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x100501d] uMovie::StreamingThread'
  thread #1: tid = 0x087c, 0x00007ff842e7a104 win32u.dll`NtUserMsgWaitForMultipleObjectsEx + 20
  thread #96: tid = 0x0890, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1002020] HLE Video Decoder'
  thread #40: tid = 0x08e0, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Camera Thread'
  thread #78: tid = 0x0a04, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x100000e] _gcm_intr_thread'
  thread #44: tid = 0x0a48, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'RSX.W1'
  thread #90: tid = 0x0b24, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x100001a] physics[job]-000'
  thread #80: tid = 0x0c70, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1000010] Resource Loader'
  thread #26: tid = 0x0c78, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'SPUW.3'
  thread #47: tid = 0x0ec4, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'RSX.W4'
  thread #18: tid = 0x0fe8, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'NetStart Hack'
  thread #36: tid = 0x106c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'cellAudio Thread'
  thread #69: tid = 0x1090, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'SPU[0x3000400] xf_appli_CellSpursKernel3'
  thread #5: tid = 0x1094, 0x00007ff845830a74 ntdll.dll`NtWaitForWorkViaWorkerFactory + 20
  thread #65: tid = 0x1234, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1000008] xf_sound_SpursHdlr0'
  thread #9: tid = 0x12f8, 0x00007ff842e71224 win32u.dll`NtUserPostMessage + 20
  thread #60: tid = 0x13c4, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'SPU[0x0000200] xf_at3p_CellSpursKernel0'
  thread #46: tid = 0x1428, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'RSX.W3'
  thread #42: tid = 0x1470, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Overlay Input Thread'
  thread #91: tid = 0x1678, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x100001b] nativeFiber Thread'
  thread #85: tid = 0x1718, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1000015] snddrv_stream_preparing_thre'
  thread #13: tid = 0x19ac, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Tcp Over Udp Timeout Manager Thread'
  thread #31: tid = 0x1a00, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'CPU Profiler'
  thread #8: tid = 0x1a14, 0x00007ff84582d664 ntdll.dll`NtDelayExecution + 20
  thread #15: tid = 0x1b44, 0x00007ff84582d664 ntdll.dll`NtDelayExecution + 20, name = 'Network Thread'
  thread #39: tid = 0x1b68, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Gem Thread'
  thread #4: tid = 0x1b6c, 0x00007ff845830a74 ntdll.dll`NtWaitForWorkViaWorkerFactory + 20
  thread #79: tid = 0x2160, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x100000f] closeAsync'
  thread #14: tid = 0x2200, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'MediaList Thread'
  thread #70: tid = 0x228c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'SPU[0x4000400] xf_appli_CellSpursKernel4'
  thread #97: tid = 0x229c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1002021] _atxdec_adapter_decode_thr_f'
  thread #17: tid = 0x22b8, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Signaling Manager Thread'
  thread #11: tid = 0x232c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'Progress Dialog Server'
  thread #50: tid = 0x2360, 0x00007ff84582d8a4 ntdll.dll`NtYieldExecution + 20, name = 'rsx::thread'
  thread #59: tid = 0x254c, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU[0x1000004] xf_ms_SpursHdlr0'
  thread #49: tid = 0x2614, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'RSX.W6'
  thread #30: tid = 0x2618, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'PPU Syscall Usage Thread'
  thread #20: tid = 0x2640, 0x00007ff845830a14 ntdll.dll`NtWaitForAlertByThreadId + 20, name = 'LV2 Watchdog Thread'
```