### PR TITLE
[IR] Use User::getHungOffOperands() in HungoffOperandTraits::op_begin/op_end(). NFC

### DIFF
--- a/llvm/include/llvm/IR/OperandTraits.h
+++ b/llvm/include/llvm/IR/OperandTraits.h
@@ -94,10 +94,10 @@ struct VariadicOperandTraits {
 template <unsigned MINARITY = 1>
 struct HungoffOperandTraits {
   static Use *op_begin(User* U) {
-    return U->getOperandList();
+    return U->getHungOffOperands();
   }
   static Use *op_end(User* U) {
-    return U->getOperandList() + U->getNumOperands();
+    return U->getHungOffOperands() + U->getNumOperands();
   }
   static unsigned operands(const User *U) {
     return U->getNumOperands();


### PR DESCRIPTION
User::getOperandList has to check the HasHungOffUses bit in Value to determine how the operand list is stored. If we're using HungoffOperandTraits we can assume how it is stored without checking the flag.

Noticed that the for loop in matchSimpleRecurrence was triggering loop unswitch when built with clang due to specializing based on how the operand list of the PHINode was stored.

This reduces the size of llc on my local Release+Asserts build by around 41K.