### PR TITLE
Fix test.

### DIFF
--- a/openmp/libomptarget/test/offloading/target_map_for_member_data.cpp
+++ b/openmp/libomptarget/test/offloading/target_map_for_member_data.cpp
@@ -2,6 +2,8 @@
 // RUN: %libomptarget-compilexx-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
 // clang-format on
 
+// REQUIRES: libomptarget-debug
+
 struct DataTy {
   float a;
   float b[3];


### PR DESCRIPTION
Just add
// REQUIRES: libomptarget-debug

So that test will not run with release compiler.

