### PR TITLE
[lldb-dap] Introduce the new privateConfiguration setting

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -734,6 +734,7 @@ class DebugCommunication(object):
         commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
+        privateConfiguration=None,
     ):
         args_dict = {"program": program}
         if args:
@@ -779,6 +780,8 @@ class DebugCommunication(object):
             args_dict["customFrameFormat"] = customFrameFormat
         if customThreadFormat:
             args_dict["customThreadFormat"] = customThreadFormat
+        if privateConfiguration:
+            args_dict["privateConfiguration"] = privateConfiguration
 
         args_dict["enableAutoVariableSummaries"] = enableAutoVariableSummaries
         args_dict["enableSyntheticChildDebugging"] = enableSyntheticChildDebugging

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -357,6 +357,7 @@ class DAPTestCaseBase(TestBase):
         commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
+        privateConfiguration=None,
     ):
         """Sending launch request to dap"""
 
@@ -398,6 +399,7 @@ class DAPTestCaseBase(TestBase):
             commandEscapePrefix=commandEscapePrefix,
             customFrameFormat=customFrameFormat,
             customThreadFormat=customThreadFormat,
+            privateConfiguration=privateConfiguration,
         )
 
         if expectFailure:
@@ -437,6 +439,7 @@ class DAPTestCaseBase(TestBase):
         commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
+        privateConfiguration=None,
     ):
         """Build the default Makefile target, create the DAP debug adaptor,
         and launch the process.
@@ -470,4 +473,5 @@ class DAPTestCaseBase(TestBase):
             commandEscapePrefix=commandEscapePrefix,
             customFrameFormat=customFrameFormat,
             customThreadFormat=customThreadFormat,
+            privateConfiguration=privateConfiguration,
         )

--- a/lldb/test/API/tools/lldb-dap/privateConfiguration/Makefile
+++ b/lldb/test/API/tools/lldb-dap/privateConfiguration/Makefile
@@ -1,0 +1,2 @@
+CXX_SOURCES := main.cpp
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/privateConfiguration/TestDAP_privateConfiguration.py
+++ b/lldb/test/API/tools/lldb-dap/privateConfiguration/TestDAP_privateConfiguration.py
@@ -1,0 +1,77 @@
+"""
+Test lldb-dap stack trace response
+"""
+
+
+import os
+
+import dap_server
+import lldbdap_testcase
+from lldbsuite.test import lldbtest, lldbutil
+from lldbsuite.test.decorators import *
+
+
+class TestDAP_privateConfiguration(lldbdap_testcase.DAPTestCaseBase):
+    def do_test_initCommands(self, printMode, includeError=False):
+        """
+        Test the initCommands property of the privateConfiguration setting and
+        its various print modes.
+        """
+        commands = [
+            "settings set target.show-hex-variable-values-with-leading-zeroes false"
+        ]
+        if includeError:
+            commands.append(
+                "settings set target.show-hex-variable-values-with-leading-zeroes fooooo"
+            )
+
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(
+            program,
+            privateConfiguration={
+                "initCommands": {
+                    "commands": commands,
+                    "printMode": printMode,
+                }
+            },
+        )
+        full_output = self.collect_console(duration=1.0)
+        expected_output = """Running privateInitCommands:
+(lldb) settings set target.show-hex-variable-values-with-leading-zeroes false"""
+        expected_error_output = "error: invalid boolean string value: 'fooooo'"
+
+        if printMode == "always":
+            self.assertIn(expected_output, full_output)
+            if includeError:
+                self.assertIn(expected_error_output, full_output)
+        elif printMode == "never":
+            self.assertNotIn(expected_output, full_output)
+            if includeError:
+                self.assertNotIn(expected_error_output, full_output)
+        else:
+            if includeError:
+                self.assertIn(expected_output, full_output)
+                self.assertIn(expected_error_output, full_output)
+            else:
+                self.assertNotIn(expected_output, full_output)
+                self.assertNotIn(expected_error_output, full_output)
+
+    @skipIfWindows
+    @skipIfRemote
+    def test_initCommands_with_print_mode_always(self):
+        self.do_test_initCommands("always")
+
+    @skipIfWindows
+    @skipIfRemote
+    def test_initCommands_with_print_mode_never(self):
+        self.do_test_initCommands("never", includeError=True)
+
+    @skipIfWindows
+    @skipIfRemote
+    def test_initCommands_with_print_mode_onError_with_failure(self):
+        self.do_test_initCommands("onError", includeError=True)
+
+    @skipIfWindows
+    @skipIfRemote
+    def test_initCommands_with_print_mode_onError_no_actual_failures(self):
+        self.do_test_initCommands("onError", includeError=False)

--- a/lldb/test/API/tools/lldb-dap/privateConfiguration/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/privateConfiguration/main.cpp
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -11,11 +11,13 @@
 
 namespace lldb_dap {
 
-void RunLLDBCommands(llvm::StringRef prefix,
+bool RunLLDBCommands(llvm::StringRef prefix,
                      const llvm::ArrayRef<std::string> &commands,
                      llvm::raw_ostream &strm) {
   if (commands.empty())
-    return;
+    return true;
+  bool success = true;
+
   lldb::SBCommandInterpreter interp = g_dap.debugger.GetCommandInterpreter();
   if (!prefix.empty())
     strm << prefix << "\n";
@@ -32,17 +34,20 @@ void RunLLDBCommands(llvm::StringRef prefix,
     if (error_len) {
       const char *error = result.GetError();
       strm << error;
+      success = false;
     }
   }
+  return success;
 }
 
-std::string RunLLDBCommands(llvm::StringRef prefix,
-                            const llvm::ArrayRef<std::string> &commands) {
+std::pair<std::string, bool>
+RunLLDBCommands(llvm::StringRef prefix,
+                const llvm::ArrayRef<std::string> &commands) {
   std::string s;
   llvm::raw_string_ostream strm(s);
-  RunLLDBCommands(prefix, commands, strm);
+  bool success = RunLLDBCommands(prefix, commands, strm);
   strm.flush();
-  return s;
+  return {s, success};
 }
 
 bool ThreadHasStopReason(lldb::SBThread &thread) {

--- a/lldb/tools/lldb-dap/LLDBUtils.h
+++ b/lldb/tools/lldb-dap/LLDBUtils.h
@@ -33,7 +33,10 @@ namespace lldb_dap {
 /// \param[in] strm
 ///     The stream that will receive the prefix, prompt + command and
 ///     all command output.
-void RunLLDBCommands(llvm::StringRef prefix,
+///
+/// \return
+///     \b true if and only if all the commands executed successfully.
+bool RunLLDBCommands(llvm::StringRef prefix,
                      const llvm::ArrayRef<std::string> &commands,
                      llvm::raw_ostream &strm);
 
@@ -50,10 +53,12 @@ void RunLLDBCommands(llvm::StringRef prefix,
 ///     An array of LLDB commands to execute.
 ///
 /// \return
-///     A std::string that contains the prefix and all commands and
-///     command output
-std::string RunLLDBCommands(llvm::StringRef prefix,
-                            const llvm::ArrayRef<std::string> &commands);
+///     A \a std::string that contains the prefix and all commands and
+///     command output, along with a \a bool that signals whether the
+///     entire execution of commands succeeded or not.
+std::pair<std::string, bool>
+RunLLDBCommands(llvm::StringRef prefix,
+                const llvm::ArrayRef<std::string> &commands);
 
 /// Check if a thread has a stop reason.
 ///

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -265,6 +265,23 @@
 								"type": "string",
 								"description": "If non-empty, threads will have descriptions generated based on the provided format. See https://lldb.llvm.org/use/formatting.html for an explanation on format strings for threads. If the format string contains errors, an error message will be displayed on the Debug Console and the default thread names will be used. This might come with a performance cost because debug information might need to be processed to generate the description.",
 								"default": ""
+							},
+							"privateConfiguration": {
+								"description": "Additional settings that extensions that wrap `lldb-dap` can use to configure the debugger without interfering with the other settings, which are meant to be used directly by the end user.",
+								"properties": {
+									"initCommands": {
+										"properties": {
+											"commands": {
+												"type": "array",
+												"description": "Initialization commands executed upon debugger startup. It is executed before the public `initCommands` and its output can be controlled by the `printMode` property."
+											},
+											"printMode": {
+												"type": "string",
+												"description": "If \"always\", then the output of the private `initCommands` is always printed. If \"onError\", then the output is only printed if any of the commands fails. Otherwise, if \"never\", then the output is never printed. Defaults to \"onError\"."
+											}
+										}
+									}
+								}
 							}
 						}
 					},
@@ -369,6 +386,23 @@
 								"type": "string",
 								"description": "If non-empty, threads will have descriptions generated based on the provided format. See https://lldb.llvm.org/use/formatting.html for an explanation on format strings for threads. If the format string contains errors, an error message will be displayed on the Debug Console and the default thread names will be used. This might come with a performance cost because debug information might need to be processed to generate the description.",
 								"default": ""
+							},
+							"privateConfiguration": {
+								"description": "Additional settings that extensions that wrap `lldb-dap` can use to configure the debugger without interfering with the other settings, which are meant to be used directly by the end user.",
+								"properties": {
+									"initCommands": {
+										"properties": {
+											"commands": {
+												"type": "array",
+												"description": "Initialization commands executed upon debugger startup. It is executed before the public `initCommands` and its output can be controlled by the `printMode` property."
+											},
+											"printMode": {
+												"type": "string",
+												"description": "If \"always\", then the output of the private `initCommands` is always printed. If \"onError\", then the output is only printed if any of the commands fails. Otherwise, if \"never\", then the output is never printed. Defaults to \"onError\"."
+											}
+										}
+									}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
There are some typescript vscode extensions that are effectively wrappers of lldb-dap, and they commonly configure the debug adapter in particular ways using initCommands, among other settings. An unfortunate side effect is that, at least for initCommands, their output is printed on the Debug Console, which doesn't look clean and might confuse some users because.
As a way to improve the experience, I'm definining a new `privateConfiguration` setting, which can be used by adapter wrappers for private initialization. I'm starting with private initCommands, whose output can also be controlled via a `printMode` setting. By default, the output is only printed upon errors.
This setting helps distinguish things that the adapter wrapper does privately from what the user might want to do using public settings in JSON.
