### PR TITLE
[libc++abi] Fix test on Android

### DIFF
--- a/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
+++ b/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
@@ -1,5 +1,5 @@
 # RUN: %{cxx} %{flags} %s %{link_flags} -no-pie -o %t.exe
-# RUN: %t.exe
+# RUN: %{exec} %t.exe
 
 # REQUIRES: linux && target={{x86_64-.+}}
 # UNSUPPORTED: no-exceptions || android
@@ -82,7 +82,7 @@ GCC_except_table0:
 	.byte	155                             # @TType Encoding = indirect pcrel sdata4
 	.uleb128 .Lttbase0-.Lttbaseref0
 .Lttbaseref0:
-	.byte	11                              # Call site Encoding = udata4
+	.byte	11                              # Call site Encoding = sdata4
 	.uleb128 .Lcst_end0-.Lcst_begin0
 .Lcst_begin0:
 	.long .Lfunc_begin0-.Lfunc_begin0    # >> Call Site 1 <<

--- a/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
+++ b/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
@@ -2,7 +2,8 @@
 # RUN: %{exec} %t.exe
 
 # REQUIRES: linux && target={{x86_64-.+}}
-# UNSUPPORTED: no-exceptions || android
+# UNSUPPORTED: target={{.+-android.*}}
+# UNSUPPORTED: no-exceptions
 
 ## Check that libc++abi works correctly when LPStart address is explicitly set
 ## to zero.

--- a/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
+++ b/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
@@ -2,7 +2,7 @@
 # RUN: %t.exe
 
 # REQUIRES: linux && target={{x86_64-.+}}
-# UNSUPPORTED: no-exceptions
+# UNSUPPORTED: no-exceptions || android
 
 ## Check that libc++abi works correctly when LPStart address is explicitly set
 ## to zero.


### PR DESCRIPTION
Follow up to #72727. The added test could not be executed on Android.