### PR TITLE
[SPIR-V] Partial revert of d40eb0a

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -690,7 +690,9 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
     return getOpTypeArray(Ty->getArrayNumElements(), El, MIRBuilder, EmitIR);
   }
   if (auto SType = dyn_cast<StructType>(Ty)) {
-    return getOpTypeOpaque(SType, MIRBuilder);
+    if (SType->isOpaque())
+      return getOpTypeOpaque(SType, MIRBuilder);
+    return getOpTypeStruct(SType, MIRBuilder, EmitIR);
   }
   if (auto FType = dyn_cast<FunctionType>(Ty)) {
     SPIRVType *RetTy = findSPIRVType(FType->getReturnType(), MIRBuilder);


### PR DESCRIPTION
This part of the #74660 patch was incorrect and shouldn't have been changed since this usage of `isOpaque()` is not one of `PointerType`'s functions.