### PR TITLE
Debuginfod failed-server cache

### DIFF
--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -194,9 +194,9 @@ Error StreamedHTTPResponseHandler::handleBodyChunk(StringRef BodyChunk) {
   return Error::success();
 }
 
-// Make a file 'cache' to remember if a given server failed
-Expected<AddStreamFn> GetServerFailureCache(FileCache &Cache, uint &Task,
-                                            StringRef ServerUrl) {
+// Create a file cache entry to remember if a given server failed
+Expected<AddStreamFn> CheckServerFailure(FileCache &Cache, uint &Task,
+                                         StringRef ServerUrl) {
   SmallString<96> CachedServerFailurePath(ServerUrl);
   llvm::transform(CachedServerFailurePath, CachedServerFailurePath.begin(),
                   [&](char c) { return std::isalnum(c) ? c : '_'; });
@@ -204,9 +204,15 @@ Expected<AddStreamFn> GetServerFailureCache(FileCache &Cache, uint &Task,
   return Cache(Task, CachedServerFailurePath, "");
 }
 
-bool ShouldSkipServer(StringRef ServerID) { return true; }
-
-void RegisterFailedServer(StringRef ServerID) { return; }
+void RegisterFailedServer(AddStreamFn &ServerFailureFn, uint &Task) {
+  Expected<std::unique_ptr<CachedFileStream>> FileStreamOrError =
+      ServerFailureFn(Task, "");
+  if (!FileStreamOrError)
+    consumeError(FileStreamOrError.takeError());
+  else
+    // Create the server-failure file
+    *FileStreamOrError.get()->OS << "";
+}
 
 // An over-accepting simplification of the HTTP RFC 7230 spec.
 static bool isHeader(StringRef S) {
@@ -284,13 +290,13 @@ Expected<std::string> getCachedOrDownloadArtifact(
   Client.setTimeout(Timeout);
   for (StringRef ServerUrl : DebuginfodUrls) {
     // First, check to make sure we should keep asking this server.
-    Expected<AddStreamFn> ServerFailureCacheOrErr =
-        GetServerFailureCache(Cache, Task, ServerUrl);
-    if (!ServerFailureCacheOrErr)
-      return ServerFailureCacheOrErr.takeError();
-    AddStreamFn &ServerFailureCache = *ServerFailureCacheOrErr;
-    if (!ServerFailureCache)
-      // We found a 'server failure' file in cache which means
+    Expected<AddStreamFn> ServerFailureFnOrErr =
+        CheckServerFailure(Cache, Task, ServerUrl);
+    if (!ServerFailureFnOrErr)
+      return ServerFailureFnOrErr.takeError();
+    AddStreamFn &ServerFailureFn = *ServerFailureFnOrErr;
+    if (!ServerFailureFn)
+      // We found a 'server failure' file in the cache which means
       // this server has failed before: don't bother trying it again.
       continue;
 
@@ -306,14 +312,8 @@ Expected<std::string> getCachedOrDownloadArtifact(
       Request.Headers = getHeaders();
       Error Err = Client.perform(Request, Handler);
       if (Err) {
-        // Put a server-failuire marker in the cache so we don't keep trying it
-        Expected<std::unique_ptr<CachedFileStream>> FileStreamOrError =
-            ServerFailureCache(Task, "");
-        if (!FileStreamOrError)
-          consumeError(FileStreamOrError.takeError());
-        else
-          // Create the server-failure file
-          *FileStreamOrError.get()->OS << "";
+        // Put a server-failure marker in the cache so we don't keep trying it.
+        RegisterFailedServer(ServerFailureFn, Task);
         return std::move(Err);
       }
 


### PR DESCRIPTION
When using the Debuginfod library to pull symbols, a non-responding server is a major performance hit. I've added a "failed server" cache so that if a server has failed to respond, the library won't continue to query it. The performance hit is moderately catastrophic in my experience: 'target create /bin/ls' takes 45 seconds to fail on a system that's trying to talk to a server that is unreachable.

I'll be exposing more configuration settings for use of Debuginfod in the very near term, but for right now, this eliminates a pretty major negative user experience for folks on a Linux system sitting behind a proxy server, or in similar network-constrained situations.