### PR TITLE
[SystemZ][z/OS] Fix build errors on z/OS in the Unix .inc files

### DIFF
--- a/llvm/include/llvm/Support/SystemZ/zOSSupport.h
+++ b/llvm/include/llvm/Support/SystemZ/zOSSupport.h
@@ -19,7 +19,7 @@
 
 // z/OS Unix System Services does not have strsignal() support, so the
 // strsignal() function is implemented here.
-static inline char *strsignal(int sig) {
+inline char *strsignal(int sig) {
   static char msg[256];
   sprintf(msg, "%d", sig);
   return msg;
@@ -27,8 +27,8 @@ static inline char *strsignal(int sig) {
 
 // z/OS Unix System Services does not have wait4() support, so the wait4
 // function is implemented here.
-static inline pid_t wait4(pid_t pid, int *wstatus, int options,
-                          struct rusage *rusage) {
+inline pid_t wait4(pid_t pid, int *wstatus, int options,
+                   struct rusage *rusage) {
   pid_t Result = waitpid(pid, wstatus, options);
   int GetrusageRC = getrusage(RUSAGE_CHILDREN, rusage);
   assert(!GetrusageRC && "Must have valid measure of the resources!");

--- a/llvm/include/llvm/Support/SystemZ/zOSSupport.h
+++ b/llvm/include/llvm/Support/SystemZ/zOSSupport.h
@@ -1,0 +1,39 @@
+//===- zOSSupport.h - Common z/OS Include File ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines z/OS implementations for common functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_ZOSSUPPORT_H
+#define LLVM_SUPPORT_ZOSSUPPORT_H
+
+#ifdef __MVS__
+#include <sys/resource.h>
+#include <sys/wait.h>
+
+// z/OS Unix System Services does not have strsignal() support, so the
+// strsignal() function is implemented here.
+static inline char *strsignal(int sig) {
+  static char msg[256];
+  sprintf(msg, "%d", sig);
+  return msg;
+}
+
+// z/OS Unix System Services does not have wait4() support, so the wait4
+// function is implemented here.
+static inline pid_t wait4(pid_t pid, int *wstatus, int options,
+                          struct rusage *rusage) {
+  pid_t Result = waitpid(pid, wstatus, options);
+  int GetrusageRC = getrusage(RUSAGE_CHILDREN, rusage);
+  assert(!GetrusageRC && "Must have valid measure of the resources!");
+  return Result;
+}
+
+#endif
+#endif

--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -62,7 +62,7 @@ getRUsageTimes() {
   ::getrusage(RUSAGE_SELF, &RU);
   return {toDuration(RU.ru_utime), toDuration(RU.ru_stime)};
 #else
-#ifndef __MVS__  // Exclude for MVS in case -pedantic is used
+#ifndef __MVS__ // Exclude for MVS in case -pedantic is used
 #warning Cannot get usage times on this platform
 #endif
   return {std::chrono::microseconds::zero(), std::chrono::microseconds::zero()};
@@ -119,7 +119,7 @@ size_t Process::GetMallocUsage() {
     return EndOfMemory - StartOfMemory;
   return 0;
 #else
-#ifndef __MVS__  // Exclude for MVS in case -pedantic is used
+#ifndef __MVS__ // Exclude for MVS in case -pedantic is used
 #warning Cannot get malloc info on this platform
 #endif
   return 0;

--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -62,7 +62,9 @@ getRUsageTimes() {
   ::getrusage(RUSAGE_SELF, &RU);
   return {toDuration(RU.ru_utime), toDuration(RU.ru_stime)};
 #else
+#ifndef __MVS__  // Exclude for MVS in case -pedantic is used
 #warning Cannot get usage times on this platform
+#endif
   return {std::chrono::microseconds::zero(), std::chrono::microseconds::zero()};
 #endif
 }
@@ -117,7 +119,9 @@ size_t Process::GetMallocUsage() {
     return EndOfMemory - StartOfMemory;
   return 0;
 #else
+#ifndef __MVS__  // Exclude for MVS in case -pedantic is used
 #warning Cannot get malloc info on this platform
+#endif
   return 0;
 #endif
 }

--- a/llvm/lib/Support/Unix/Program.inc
+++ b/llvm/lib/Support/Unix/Program.inc
@@ -25,6 +25,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/SystemZ/zOSSupport.h"
 #include "llvm/Support/raw_ostream.h"
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
@@ -466,7 +467,7 @@ ProcessInfo llvm::sys::Wait(const ProcessInfo &PI,
     std::chrono::microseconds UserT = toDuration(Info.ru_utime);
     std::chrono::microseconds KernelT = toDuration(Info.ru_stime);
     uint64_t PeakMemory = 0;
-#ifndef __HAIKU__
+#if !defined(__HAIKU__) && !defined(__MVS__)
     PeakMemory = static_cast<uint64_t>(Info.ru_maxrss);
 #endif
     *ProcStat = ProcessStatistics{UserT + KernelT, UserT, PeakMemory};


### PR DESCRIPTION
This patch resolves the following errors on z/OS:

error: no member named 'wait4' in the global namespace
error: no member named 'ru_maxrss' in 'rusage'
error: use of undeclared identifier 'strsignal'
error: Cannot get usage times on this platform
error: Cannot get malloc info on this platform