### PR TITLE
[Orc][examples] Fix lljit-with-remote-debugging test failure

### DIFF
--- a/llvm/test/Examples/OrcV2Examples/lljit-with-remote-debugging.test
+++ b/llvm/test/Examples/OrcV2Examples/lljit-with-remote-debugging.test
@@ -1,8 +1,7 @@
 # This test makes sure that the example builds and executes as expected.
 # Instructions for debugging can be found in LLJITWithRemoteDebugging.cpp
 
-# REQUIRES: default_triple
-# UNSUPPORTED: target=powerpc64{{.*}}
+# REQUIRES: target-x86_64
 
 # RUN: LLJITWithRemoteDebugging %p/Inputs/argc_sub1_elf.ll | FileCheck --check-prefix=CHECK0 %s
 # CHECK0: Parsing input IR code from: {{.*}}/Inputs/argc_sub1_elf.ll


### PR DESCRIPTION
Test lljit-with-remote-debugging fails on AArch64 because the
argc_sub1_elf.ll input file have a x86_64 target triple. Since there is
no way to set the target triple when invoking LLJITWithRemoteDebugging
let's require x86_64 target to be the default target.
