### PR TITLE
 [clang][NFC] Refactor expected directives in C++ DRs 700-1999

### DIFF
--- a/clang/test/CXX/drs/dr11xx.cpp
+++ b/clang/test/CXX/drs/dr11xx.cpp
@@ -1,30 +1,30 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++2a %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected,cxx98 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2a %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
 
 namespace dr1111 { // dr1111: 3.2
 namespace example1 {
-template <typename> struct set;
+template <typename> struct set; // #dr1111-struct-set
 
 struct X {
-  template <typename T> void set(const T &value);
+  template <typename T> void set(const T &value); // #dr1111-func-set
 };
 void foo() {
   X x;
-#pragma clang diagnostic push
-#if __cplusplus < 201103L
-#pragma clang diagnostic ignored "-Wambiguous-member-template"
-#endif
+  // FIXME: should we backport C++11 behavior?
   x.set<double>(3.2);
-#pragma clang diagnostic pop
+  // cxx98-error@-1 {{lookup of 'set' in member access expression is ambiguous; using member of 'X'}}
+  //   cxx98-note@#dr1111-func-set {{lookup in the object type 'X' refers here}}
+  //   cxx98-note@#dr1111-struct-set {{lookup from the current scope refers here}}
 }
 
 struct Y {};
 void bar() {
   Y y;
-  y.set<double>(3.2); // expected-error {{no member named 'set' in 'dr1111::example1::Y'}}
+  y.set<double>(3.2);
+  // expected-error@-1 {{no member named 'set' in 'dr1111::example1::Y'}}
 }
 } // namespace example1
 
@@ -46,8 +46,10 @@ void baz() {
 
 namespace dr1113 { // dr1113: partial
   namespace named {
-    extern int a; // expected-note {{previous}}
-    static int a; // expected-error {{static declaration of 'a' follows non-static}}
+    extern int a; // #dr1113-a
+    static int a;
+    // expected-error@-1 {{static declaration of 'a' follows non-static}}
+    //   expected-note@#dr1113-a {{previous declaration is here}}
   }
   namespace {
     extern int a;

--- a/clang/test/CXX/drs/dr12xx.cpp
+++ b/clang/test/CXX/drs/dr12xx.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++20 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++23 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected,cxx98-14,cxx98 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected,cxx98-14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected,cxx98-14,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected,since-cxx17,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected,since-cxx17,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected,since-cxx17,since-cxx14,since-cxx11,since-cxx23 -fexceptions -fcxx-exceptions -pedantic-errors
 
 // dr1200: na
 
@@ -40,28 +40,33 @@ struct S {
   S* operator()();
   int N;
   int M;
-#if __cplusplus > 202002L
+#if __cplusplus >= 202302L
   template <typename T>
   static constexpr auto V = 0;
   void f(char);
   void f(int);
   void mem(S s) {
-    auto(s)()->M; //expected-warning {{expression result unused}}
-    auto(s)()->V<int>; //expected-warning {{expression result unused}}
+    auto(s)()->M;
+    // since-cxx23-warning@-1 {{expression result unused}}
+    auto(s)()->V<int>;
+    // since-cxx23-warning@-1 {{expression result unused}}
     auto(s)()->f(0);
   }
 #endif
 };
 void f(S s) {
   {
-#if __cplusplus > 202002L
-    auto(s)()->N; //expected-warning {{expression result unused}}
+#if __cplusplus >= 202302L
+    auto(s)()->N;
+    //since-cxx23-warning@-1 {{expression result unused}}
 #endif
     auto(s)()->M;
   }
   {
-    S(s)()->N; //expected-warning {{expression result unused}}
-    S(s)()->M; //expected-warning {{expression result unused}}
+    S(s)()->N;
+    // since-cxx11-warning@-1 {{expression result unused}}
+    S(s)()->M;
+    // since-cxx11-warning@-1 {{expression result unused}}
   }
 }
 
@@ -74,7 +79,8 @@ void g() {
     A a(B ()->C);
     A b(auto ()->C);
     static_assert(sizeof(B ()->C[1] == sizeof(int)), "");
-    sizeof(auto () -> C[1]); // expected-error{{function cannot return array type 'C[1]'}}
+    sizeof(auto () -> C[1]);
+    // since-cxx11-error@-1 {{function cannot return array type 'C[1]' (aka 'dr1223::BB[1]')}}
 }
 
 }
@@ -82,15 +88,18 @@ void g() {
 
 #if __cplusplus >= 201103L
 namespace dr1227 { // dr1227: 3.0
-template <class T> struct A { using X = typename T::X; }; // expected-error {{type 'int' cannot be used prior to '::' because it has no members}}
+template <class T> struct A { using X = typename T::X; };
+// since-cxx11-error@-1 {{type 'int' cannot be used prior to '::' because it has no members}}
+//   since-cxx11-note@#dr1227-g {{in instantiation of template class 'dr1227::A<int>' requested here}}
+//   since-cxx11-note@#dr1227-g-int {{while substituting explicitly-specified template arguments into function template 'g'}}
 template <class T> typename T::X f(typename A<T>::X);
 template <class T> void f(...) { }
-template <class T> auto g(typename A<T>::X) -> typename T::X; // expected-note {{in instantiation of template class 'dr1227::A<int>' requested here}}
+template <class T> auto g(typename A<T>::X) -> typename T::X; // #dr1227-g
 template <class T> void g(...) { }
 
 void h() {
   f<int>(0); // OK, substituting return type causes deduction to fail
-  g<int>(0); // expected-note {{while substituting explicitly-specified template arguments into function template 'g'}}
+  g<int>(0); // #dr1227-g-int
 }
 }
 #endif
@@ -109,15 +118,21 @@ struct Derived : Base {
 
 namespace dr1265 { // dr1265: 5
 #if __cplusplus >= 201103L
-  auto a = 0, b() -> int; // expected-error {{declaration with trailing return type must be the only declaration in its group}}
-  auto b() -> int, d = 0; // expected-error {{declaration with trailing return type must be the only declaration in its group}}
-  auto e() -> int, f() -> int; // expected-error {{declaration with trailing return type must be the only declaration in its group}}
+  auto a = 0, b() -> int;
+  // since-cxx11-error@-1 {{declaration with trailing return type must be the only declaration in its group}}
+  auto b() -> int, d = 0;
+  // since-cxx11-error@-1 {{declaration with trailing return type must be the only declaration in its group}}
+  auto e() -> int, f() -> int;
+  // since-cxx11-error@-1 {{declaration with trailing return type must be the only declaration in its group}}
 #endif
 
 #if __cplusplus >= 201402L
-  auto g(), h = 0; // expected-error {{function with deduced return type must be the only declaration in its group}}
-  auto i = 0, j(); // expected-error {{function with deduced return type must be the only declaration in its group}}
-  auto k(), l(); // expected-error {{function with deduced return type must be the only declaration in its group}}
+  auto g(), h = 0;
+  // since-cxx14-error@-1 {{function with deduced return type must be the only declaration in its group}}
+  auto i = 0, j();
+  // since-cxx14-error@-1 {{function with deduced return type must be the only declaration in its group}}
+  auto k(), l();
+  // since-cxx14-error@-1 {{function with deduced return type must be the only declaration in its group}}
 #endif
 }
 
@@ -130,16 +145,16 @@ namespace dr1295 { // dr1295: 4
 
   X x = {1};
 
-  unsigned const &r1 = static_cast<X &&>(x).bitfield; // expected-error 0-1{{C++11}}
-  unsigned const &r2 = static_cast<unsigned &&>(x.bitfield); // expected-error 0-1{{C++11}}
+  unsigned const &r1 = static_cast<X &&>(x).bitfield;
+  // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+  unsigned const &r2 = static_cast<unsigned &&>(x.bitfield);
+  // cxx98-error@-1 {{rvalue references are a C++11 extension}}
 
-  template<unsigned &r> struct Y {};
-  Y<x.bitfield> y;
-#if __cplusplus <= 201402L
-  // expected-error@-2 {{does not refer to any declaration}} expected-note@-3 {{here}}
-#else
-  // expected-error@-4 {{refers to subobject}}
-#endif
+  template<unsigned &r> struct Y {}; // #dr1295-Y
+  Y<x.bitfield> y; // #dr1295-y
+  // cxx98-14-error@-1 {{non-type template argument does not refer to any declaration}}
+  //   cxx98-14-note@#dr1295-Y {{template parameter is declared here}}
+  // since-cxx17-error@#dr1295-y {{non-type template argument refers to subobject 'x.bitfield'}}
 
 #if __cplusplus >= 201103L
   const unsigned other = 0;

--- a/clang/test/CXX/drs/dr13xx.cpp
+++ b/clang/test/CXX/drs/dr13xx.cpp
@@ -1,7 +1,10 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected,cxx98-14,cxx98 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected,cxx11-17,cxx11-14,cxx98-14,since-cxx11,cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected,cxx11-17,cxx11-14,since-cxx14,cxx98-14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected,cxx11-17,since-cxx14,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
 __extension__ typedef __SIZE_TYPE__ size_t;
 
@@ -15,10 +18,12 @@ namespace std {
 
 #if __cplusplus >= 201103L
 namespace dr1305 { // dr1305: 3.0
-struct Incomplete; // expected-note {{forward declaration of 'dr1305::Incomplete'}}
+struct Incomplete; // #dr1305-Incomplete
 struct Complete {};
 
-int incomplete = alignof(Incomplete(&)[]); // expected-error {{invalid application of 'alignof' to an incomplete type 'Incomplete'}}
+int incomplete = alignof(Incomplete(&)[]);
+// since-cxx11-error@-1 {{invalid application of 'alignof' to an incomplete type 'Incomplete'}}
+//   since-cxx11-note@#dr1305-Incomplete {{forward declaration of 'dr1305::Incomplete'}}
 int complete = alignof(Complete(&)[]);
 }
 #endif
@@ -36,9 +41,11 @@ void caller() {
 } // namespace dr1307
 
 namespace dr1310 { // dr1310: 5
-  struct S {} * sp = new S::S; // expected-error {{qualified reference to 'S' is a constructor name}}
+  struct S {} * sp = new S::S;
+  // expected-error@-1 {{qualified reference to 'S' is a constructor name rather than a type in this context}}
   void f() {
-    S::S(a); // expected-error {{qualified reference to 'S' is a constructor name}}
+    S::S(a);
+    // expected-error@-1 {{qualified reference to 'S' is a constructor name rather than a type in this context}}
   }
   struct T { int n; typedef int U; typedef T V; };
   int k = T().T::T::n;
@@ -64,39 +71,67 @@ namespace dr1310 { // dr1310: 5
   template<typename T> struct W : WBase<T> { typedef int X; int n; };
 
   void w_test() {
-    W<int>::W w1a; // expected-error {{qualified reference to 'W' is a constructor name}}
+    W<int>::W w1a;
+    // expected-error@-1 {{qualified reference to 'W' is a constructor name rather than a type in this context}}
     W<int>::W::X w1ax;
-    W<int>::W<int> w1b; // expected-error {{qualified reference to 'W' is a constructor name}}
+    W<int>::W<int> w1b;
+    // expected-error@-1 {{qualified reference to 'W' is a constructor name rather than a template name in this context}}
     W<int>::W<int>::X w1bx;
-    typename W<int>::W w2a; // expected-error {{qualified reference to 'W' is a constructor name}} expected-error 0-1{{outside of a template}}
-    typename W<int>::W::X w2ax; // expected-error 0-1{{outside of a template}}
-    typename W<int>::W<int> w2b; // expected-error {{qualified reference to 'W' is a constructor name}} expected-error 0-1{{outside of a template}}
-    typename W<int>::W<int>::X w2bx; // expected-error 0-1{{outside of a template}}
-    W<int>::template W<int> w3; // expected-error {{qualified reference to 'W' is a constructor name}} expected-error 0-1{{outside of a template}}
-    W<int>::template W<int>::X w3x; // expected-error 0-1{{outside of a template}}
-    typename W<int>::template W<int> w4; // expected-error {{qualified reference to 'W' is a constructor name}} expected-error 0-2{{outside of a template}}
-    typename W<int>::template W<int>::X w4x; // expected-error 0-2{{outside of a template}}
+    typename W<int>::W w2a;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a type in this context, despite preceding 'typename' keyword}}
+    // cxx98-error@-2 {{'typename' occurs outside of a template}}
+    typename W<int>::W::X w2ax;
+    // cxx98-error@-1 {{'typename' occurs outside of a template}}
+    typename W<int>::W<int> w2b;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'typename' keyword}}
+    // cxx98-error@-2 {{'typename' occurs outside of a template}}
+    typename W<int>::W<int>::X w2bx;
+    // cxx98-error@-1 {{'typename' occurs outside of a template}}
+    W<int>::template W<int> w3;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'template' keyword}}
+    // cxx98-error@-2 {{'template' keyword outside of a template}}
+    W<int>::template W<int>::X w3x;
+    // cxx98-error@-1 {{'template' keyword outside of a template}}
+    typename W<int>::template W<int> w4;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'template' keyword}}
+    // cxx98-error@-2 {{'template' keyword outside of a template}}
+    // cxx98-error@-3 {{'typename' occurs outside of a template}}
+    typename W<int>::template W<int>::X w4x;
+    // cxx98-error@-1 {{'template' keyword outside of a template}}
+    // cxx98-error@-2 {{'typename' occurs outside of a template}}
 
-    TT<W<int>::W> tt1; // expected-error {{qualified reference to 'W' is a constructor name}}
-    TTy<W<int>::W> tt1a; // expected-error {{qualified reference to 'W' is a constructor name}}
-    TT<W<int>::template W> tt2; // expected-error {{qualified reference to 'W' is a constructor name}} expected-error 0-1{{outside of a template}}
+    TT<W<int>::W> tt1;
+    // expected-error@-1 {{qualified reference to 'W' is a constructor name rather than a type in this context}}
+    TTy<W<int>::W> tt1a;
+    // expected-error@-1 {{qualified reference to 'W' is a constructor name rather than a type in this context}}
+    TT<W<int>::template W> tt2;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'template' keyword}}
+    // cxx98-error@-2 {{'template' keyword outside of a template}}
     TT<W<int>::WBase> tt3;
     TTy<W<int>::WBase> tt3a;
-    TT<W<int>::template WBase> tt4; // expected-error 0-1{{outside of a template}}
+    TT<W<int>::template WBase> tt4;
+    // cxx98-error@-1 {{'template' keyword outside of a template}}
 
     W<int> w;
     (void)w.W::W::n;
     (void)w.W<int>::W::n;
     (void)w.W<int>::W<int>::n;
-    (void)w.W<int>::template W<int>::n; // expected-error 0-1{{outside of a template}}
+    (void)w.W<int>::template W<int>::n;
+    // cxx98-error@-1 {{'template' keyword outside of a template}}
   }
 
   template<typename W>
   void wt_test() {
-    typename W::W w2a; // expected-error {{qualified reference to 'W' is a constructor name}}
-    typename W::template W<int> w4; // expected-error {{qualified reference to 'W' is a constructor name}}
-    TTy<typename W::W> tt2; // expected-error {{qualified reference to 'W' is a constructor name}}
-    TT<W::template W> tt3; // expected-error {{qualified reference to 'W' is a constructor name}}
+    typename W::W w2a;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a type in this context, despite preceding 'typename' keyword}}
+    //   cxx98-note@#dr1310-W-int {{in instantiation of function template specialization 'dr1310::wt_test<dr1310::W<int> >' requested here}}
+    //   since-cxx11-note@#dr1310-W-int {{in instantiation of function template specialization 'dr1310::wt_test<dr1310::W<int>>' requested here}}
+    typename W::template W<int> w4;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'template' keyword}}
+    TTy<typename W::W> tt2;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a type in this context, despite preceding 'typename' keyword}}
+    TT<W::template W> tt3;
+    // expected-error@-1 {{ISO C++ specifies that qualified reference to 'W' is a constructor name rather than a template name in this context, despite preceding 'template' keyword}}
   }
   template<typename W>
   void wt_test_good() {
@@ -111,18 +146,19 @@ namespace dr1310 { // dr1310: 5
     (void)w.template W<int>::W::n;
     (void)w.template W<int>::template W<int>::n;
   }
-  template void wt_test<W<int> >(); // expected-note {{instantiation of}}
+  template void wt_test<W<int> >(); // #dr1310-W-int
   template void wt_test_good<W<int> >();
 }
 
 namespace dr1315 { // dr1315: partial
   template <int I, int J> struct A {};
-  template <int I> // expected-note {{non-deducible template parameter 'I'}}
-    struct A<I + 5, I * 2> {}; // expected-error {{contains a template parameter that cannot be deduced}}
+  template <int I> struct A<I + 5, I * 2> {};
+  // expected-error@-1 {{class template partial specialization contains a template parameter that cannot be deduced; this partial specialization will never be used}}
+  //   expected-note@-2 {{non-deducible template parameter 'I'}}
   template <int I> struct A<I, I> {};
 
   template <int I, int J, int K> struct B;
-  template <int I, int K> struct B<I, I * 2, K> {}; // expected-note {{matches}}
+  template <int I, int K> struct B<I, I * 2, K> {}; // #dr1315-B-1
   B<1, 2, 3> b1;
 
   // Multiple declarations with the same dependent expression are equivalent
@@ -131,8 +167,11 @@ namespace dr1315 { // dr1315: partial
   B<1, 2, 2>::type b2;
 
   // Multiple declarations with differing dependent expressions are unordered.
-  template <int I, int K> struct B<I, I + 1, K> {}; // expected-note {{matches}}
-  B<1, 2, 4> b3; // expected-error {{ambiguous}}
+  template <int I, int K> struct B<I, I + 1, K> {}; // #dr1315-B-2
+  B<1, 2, 4> b3;
+  // expected-error@-1 {{ambiguous partial specializations of 'B<1, 2, 4>'}}
+  //   expected-note@#dr1315-B-1 {{partial specialization matches [with I = 1, K = 4]}}
+  //   expected-note@#dr1315-B-2 {{partial specialization matches [with I = 1, K = 4]}}
 
   // FIXME: Under dr1315, this is perhaps valid, but that is not clear: this
   // fails the "more specialized than the primary template" test because the
@@ -146,7 +185,9 @@ namespace dr1315 { // dr1315: partial
 namespace dr1330 { // dr1330: 4 c++11
   // exception-specifications are parsed in a context where the class is complete.
   struct A {
-    void f() throw(T) {} // expected-error 0-1{{C++17}} expected-note 0-1{{noexcept}}
+    void f() throw(T) {}
+    // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+    //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
     struct T {};
 
 #if __cplusplus >= 201103L
@@ -156,8 +197,12 @@ namespace dr1330 { // dr1330: 4 c++11
 #endif
   };
 
-  void (A::*af1)() throw(A::T) = &A::f; // expected-error 0-1{{C++17}} expected-note 0-1{{noexcept}}
-  void (A::*af2)() throw() = &A::f; // expected-error-re {{{{not superset|different exception spec}}}}
+  void (A::*af1)() throw(A::T) = &A::f;
+  // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+  //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
+  void (A::*af2)() throw() = &A::f;
+  // cxx98-14-error@-1 {{target exception specification is not superset of source}}
+  // since-cxx17-error@-2 {{cannot initialize a variable of type 'void (dr1330::A::*)() throw()' with an rvalue of type 'void (dr1330::A::*)() throw(T)': different exception specifications}}
 
 #if __cplusplus >= 201103L
   static_assert(noexcept(A().g()), "");
@@ -166,7 +211,9 @@ namespace dr1330 { // dr1330: 4 c++11
   // Likewise, they're instantiated separately from an enclosing class template.
   template<typename U>
   struct B {
-    void f() throw(T, typename U::type) {} // expected-error 0-1{{C++17}} expected-note 0-1{{noexcept}}
+    void f() throw(T, typename U::type) {}
+    // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+    //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
     struct T {};
 
 #if __cplusplus >= 201103L
@@ -183,9 +230,6 @@ namespace dr1330 { // dr1330: 4 c++11
     static const int value = true;
   };
 
-  void (B<P>::*bpf1)() throw(B<P>::T, int) = &B<P>::f; // expected-error 0-1{{C++17}} expected-note 0-1{{noexcept}}
-#if __cplusplus < 201103L
-  // expected-error@-2 {{not superset}}
   // FIXME: We only delay instantiation in C++11 onwards. In C++98, something
   // weird happens: instantiation of B<P> fails because it references T before
   // it's instantiated, but the diagnostic is suppressed in
@@ -193,20 +237,20 @@ namespace dr1330 { // dr1330: 4 c++11
   // obviously a bad way to react to this situation; we should still producing
   // the "T has not yet been instantiated" error here, rather than giving
   // confusing errors later on.
-#endif
-  void (B<P>::*bpf2)() throw(int) = &B<P>::f; // expected-error 0-1{{C++17}} expected-note 0-1{{noexcept}}
-#if __cplusplus <= 201402L
-  // expected-error@-2 {{not superset}}
-#else
-  // expected-warning@-4 {{not superset}}
-#endif
+  void (B<P>::*bpf1)() throw(B<P>::T, int) = &B<P>::f;
+  // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+  //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
+  // cxx98-error@-3 {{target exception specification is not superset of source}}
+
+  void (B<P>::*bpf2)() throw(int) = &B<P>::f;
+  // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+  //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
+  // cxx98-14-error@-3 {{target exception specification is not superset of source}}
+  // since-cxx17-warning@-4 {{target exception specification is not superset of source}}
   void (B<P>::*bpf3)() = &B<P>::f;
   void (B<P>::*bpf4)() throw() = &B<P>::f;
-#if __cplusplus <= 201402L
-  // expected-error@-2 {{not superset}}
-#else
-  // expected-error@-4 {{different exception specifications}}
-#endif
+  // cxx98-14-error@-1 {{target exception specification is not superset of source}}
+  // since-cxx17-error@-2 {{cannot initialize a variable of type 'void (B<P>::*)() throw()' with an rvalue of type 'void (dr1330::B<dr1330::P>::*)() throw(T, typename P::type)': different exception specifications}}
 
 #if __cplusplus >= 201103L
   static_assert(noexcept(B<P>().g()), "");
@@ -214,57 +258,64 @@ namespace dr1330 { // dr1330: 4 c++11
   static_assert(!noexcept(B<Q>().g()), "");
 #endif
 
-  template<typename T> int f() throw(typename T::error) { return 0; } // expected-error 1-4{{prior to '::'}} expected-note 0-1{{prior to '::'}} expected-note 0-1{{requested here}}
-#if __cplusplus > 201402L
-    // expected-error@-2 0-1{{C++17}} expected-note@-2 0-1{{noexcept}}
-#endif
+  template<typename T> int f() throw(typename T::error) { return 0; } // #dr1330-f
+  // expected-error@#dr1330-f {{type 'int' cannot be used prior to '::' because it has no members}}
+  //   cxx98-note@#dr1330-f-int {{in instantiation of function template specialization 'dr1330::f<int>' requested here}}
+  //   since-cxx11-note@#dr1330-f-int {{in instantiation of exception specification for 'f<int>' requested here}}
+  // cxx98-14-error@#dr1330-f {{type 'short' cannot be used prior to '::' because it has no members}}
+  //   cxx98-14-note@#dr1330-f-short {{in instantiation of function template specialization 'dr1330::f<short>' requested here}}
+  //   cxx11-14-note@#dr1330-f {{in instantiation of exception specification for 'f<short>' requested here}}
+  // since-cxx11-error@#dr1330-f {{type 'char' cannot be used prior to '::' because it has no members}}
+  //   since-cxx11-note@#dr1330-f-char {{in instantiation of exception specification for 'f<char>' requested here}}
+  // since-cxx11-error@#dr1330-f {{type 'float' cannot be used prior to '::' because it has no members}}
+  //   since-cxx11-note@#dr1330-f-float {{in instantiation of exception specification for 'f<float>' requested here}}
+  // since-cxx17-error@#dr1330-f {{ISO C++17 does not allow dynamic exception specifications}}
+  //   since-cxx17-note@#dr1330-f {{use 'noexcept(false)' instead}}
+
   // An exception-specification is needed even if the function is only used in
   // an unevaluated operand.
-  int f1 = sizeof(f<int>()); // expected-note {{instantiation of}}
+  int f1 = sizeof(f<int>()); // #dr1330-f-int
 #if __cplusplus >= 201103L
-  decltype(f<char>()) f2; // expected-note {{instantiation of}}
-  bool f3 = noexcept(f<float>()); // expected-note {{instantiation of}}
+  decltype(f<char>()) f2; // #dr1330-f-char
+  bool f3 = noexcept(f<float>()); /// #dr1330-f-float
 #endif
   // In C++17 onwards, substituting explicit template arguments into the
   // function type substitutes into the exception specification (because it's
   // part of the type). In earlier languages, we don't notice there's a problem
   // until we've already started to instantiate.
-  template int f<short>();
-#if __cplusplus >= 201703L
-  // expected-error@-2 {{does not refer to a function template}}
-#else
-  // expected-note@-4 {{instantiation of}}
-#endif
+  template int f<short>(); // #dr1330-f-short
+  // since-cxx17-error@-1 {{explicit instantiation of 'f' does not refer to a function template, variable template, member function, member class, or static data member}}
+  //   since-cxx17-note@#dr1330-f {{candidate template ignored: substitution failure [with T = short]: type 'short' cannot be used prior to '::' because it has no members}}
 
   template<typename T> struct C {
-    C() throw(typename T::type); // expected-error 1-2{{prior to '::'}}
-#if __cplusplus > 201402L
-    // expected-error@-2 0-1{{C++17}} expected-note@-2 0-1{{noexcept}}
-#endif
+    C() throw(typename T::type); // #dr1330-C
+    // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
+    //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
+    // cxx98-error@#dr1330-C {{type 'void' cannot be used prior to '::' because it has no members}}
+    //   cxx98-note@#dr1330-C-void {{in instantiation of template class 'dr1330::C<void>' requested here}}
+    // expected-error@#dr1330-C {{type 'int' cannot be used prior to '::' because it has no members}}
+    //   cxx98-note@#dr1330-C-int {{in instantiation of template class 'dr1330::C<int>' requested here}}
+    //   since-cxx11-note@#dr1330-C-int {{in instantiation of exception specification for 'C' requested here}}
+    //   since-cxx11-note@#dr1330-e {{in evaluation of exception specification for 'dr1330::E::E' needed here}}
   };
-  struct D : C<void> {}; // ok
-#if __cplusplus < 201103L
-  // expected-note@-2 {{instantiation of}}
-#endif
+  struct D : C<void> {}; // #dr1330-C-void
   void f(D &d) { d = d; } // ok
 
-  struct E : C<int> {}; // expected-note {{in instantiation of}}
-#if __cplusplus >= 201103L
-  E e; // expected-note {{needed here}}
-#endif
+  struct E : C<int> {}; // #dr1330-C-int
+  E e; // #dr1330-e
 }
 
 namespace dr1341 { // dr1341: sup P0683R1
 #if __cplusplus >= 202002L
 int a;
-const int b = 0; // #dr1341-b-decl
+const int b = 0; // #dr1341-b
 struct S {
   int x1 : 8 = 42;
   int x2 : 8 { 42 };
   int y1 : true ? 8 : a = 42;
   int y2 : true ? 8 : b = 42;
-  // expected-error@-1            {{cannot assign to variable 'b' with const-qualified type 'const int'}}
-  // expected-note@#dr1341-b-decl {{variable 'b' declared const here}}
+  // since-cxx20-error@-1 {{cannot assign to variable 'b' with const-qualified type 'const int'}}
+  //   since-cxx20-note@#dr1341-b {{variable 'b' declared const here}}
   int y3 : (true ? 8 : b) = 42;
   int z : 1 || new int { 0 };
 };
@@ -272,44 +323,66 @@ struct S {
 }
 
 namespace dr1346 { // dr1346: 3.5
-  auto a(1); // expected-error 0-1{{extension}}
-  auto b(1, 2); // expected-error {{multiple expressions}} expected-error 0-1{{extension}}
+  auto a(1);
+  // cxx98-error@-1 {{'auto' type specifier is a C++11 extension}}
+  auto b(1, 2);
+  // cxx98-error@-1 {{'auto' type specifier is a C++11 extension}}
+  // expected-error@-2 {{initializer for variable 'b' with type 'auto' contains multiple expressions}}
 #if __cplusplus >= 201103L
-  auto c({}); // expected-error {{parenthesized initializer list}}
-  auto d({1}); // expected-error {{parenthesized initializer list}}
-  auto e({1, 2}); // expected-error {{parenthesized initializer list}}
+  auto c({});
+  // since-cxx11-error@-1 {{cannot deduce type for variable 'c' with type 'auto' from parenthesized initializer list}}
+  auto d({1});
+  // since-cxx11-error@-1 {{cannot deduce type for variable 'd' with type 'auto' from parenthesized initializer list}}
+  auto e({1, 2});
+  // since-cxx11-error@-1 {{cannot deduce type for variable 'e' with type 'auto' from parenthesized initializer list}}
 #endif
-  template<typename...Ts> void f(Ts ...ts) { // expected-error 0-1{{extension}}
-    auto x(ts...); // expected-error {{empty}} expected-error 0-1{{extension}}
+  template<typename...Ts> void f(Ts ...ts) {
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+    auto x(ts...);
+    // cxx98-error@-1 {{'auto' type specifier is a C++11 extension}}
+    // expected-error@-2 {{initializer for variable 'x' with type 'auto' is empty}}
+    //   expected-note@#dr1346-f {{in instantiation of function template specialization 'dr1346::f<>' requested here}}
   }
-  template void f(); // expected-note {{instantiation}}
+  template void f(); // #dr1346-f
 
 #if __cplusplus >= 201103L
   void init_capture() {
-    [a(1)] {} (); // expected-error 0-1{{extension}}
-    [b(1, 2)] {} (); // expected-error {{multiple expressions}} expected-error 0-1{{extension}}
-#if __cplusplus >= 201103L
-    [c({})] {} (); // expected-error {{parenthesized initializer list}} expected-error 0-1{{extension}}
-    [d({1})] {} (); // expected-error {{parenthesized initializer list}} expected-error 0-1{{extension}}
-    [e({1, 2})] {} (); // expected-error {{parenthesized initializer list}} expected-error 0-1{{extension}}
-#endif
+    [a(1)] {} ();
+    // cxx11-error@-1 {{initialized lambda captures are a C++14 extension}}
+    [b(1, 2)] {} ();
+    // cxx11-error@-1 {{initialized lambda captures are a C++14 extension}}
+    // since-cxx11-error@-2 {{initializer for lambda capture 'b' contains multiple expressions}}
+    [c({})] {} ();
+    // cxx11-error@-1 {{initialized lambda captures are a C++14 extension}}
+    // since-cxx11-error@-2 {{cannot deduce type for lambda capture 'c' from parenthesized initializer list}}
+    [d({1})] {} ();
+    // cxx11-error@-1 {{initialized lambda captures are a C++14 extension}}
+    // since-cxx11-error@-2 {{cannot deduce type for lambda capture 'd' from parenthesized initializer list}}
+    [e({1, 2})] {} ();
+    // cxx11-error@-1 {{initialized lambda captures are a C++14 extension}}
+    // since-cxx11-error@-2 {{cannot deduce type for lambda capture 'e' from parenthesized initializer list}}
   }
 #endif
 }
 
 namespace dr1347 { // dr1347: 3.1
-  auto x = 5, *y = &x; // expected-error 0-1{{extension}}
-  auto z = y, *q = y; // expected-error {{'auto' deduced as 'int *' in declaration of 'z' and deduced as 'int' in declaration of 'q'}} expected-error 0-1{{extension}}
+  auto x = 5, *y = &x;
+  // cxx98-error@-1 {{'auto' type specifier is a C++11 extension}}
+  auto z = y, *q = y;
+  // cxx98-error@-1 {{'auto' type specifier is a C++11 extension}}
+  // expected-error@-2 {{'auto' deduced as 'int *' in declaration of 'z' and deduced as 'int' in declaration of 'q'}}
 #if __cplusplus >= 201103L
-  auto a = 5, b = {1, 2}; // expected-error {{'auto' deduced as 'int' in declaration of 'a' and deduced as 'std::initializer_list<int>' in declaration of 'b'}}
-  auto (*fp)(int) -> int, i = 0; // expected-error {{declaration with trailing return type must be the only declaration in its group}}
+  auto a = 5, b = {1, 2};
+  // since-cxx11-error@-1 {{'auto' deduced as 'int' in declaration of 'a' and deduced as 'std::initializer_list<int>' in declaration of 'b'}}
+  auto (*fp)(int) -> int, i = 0;
+  // since-cxx11-error@-1 {{declaration with trailing return type must be the only declaration in its group}}
 #endif
 }
 
 namespace dr1358 { // dr1358: 3.1
 #if __cplusplus >= 201103L
   struct Lit { constexpr operator int() const { return 0; } };
-  struct NonLit { NonLit(); operator int(); }; // expected-note 2{{no constexpr constructors}}
+  struct NonLit { NonLit(); operator int(); }; // #dr1358-NonLit
   struct NonConstexprConv { constexpr operator int() const; };
   struct Virt { virtual int f(int) const; };
 
@@ -336,8 +409,12 @@ namespace dr1358 { // dr1358: 3.1
   // But the corresponding non-template cases are rejected.
   struct B : Virt {
     int member;
-    constexpr B(NonLit u) : member(u) {} // expected-error {{not a literal type}}
-    constexpr NonLit f(NonLit u) const { return NonLit(); } // expected-error {{not a literal type}}
+    constexpr B(NonLit u) : member(u) {}
+    // since-cxx11-error@-1 {{constexpr constructor's 1st parameter type 'NonLit' is not a literal type}}
+    //   since-cxx11-note@#dr1358-NonLit {{'NonLit' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors}}
+    constexpr NonLit f(NonLit u) const { return NonLit(); }
+    // since-cxx11-error@-1 {{constexpr function's return type 'NonLit' is not a literal type}}
+    //   since-cxx11-note@#dr1358-NonLit {{'NonLit' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors}}
   };
 #endif
 }
@@ -345,65 +422,113 @@ namespace dr1358 { // dr1358: 3.1
 namespace dr1359 { // dr1359: 3.5
 #if __cplusplus >= 201103L
   union A { constexpr A() = default; };
-  union B { constexpr B() = default; int a; }; // expected-error {{not constexpr}} expected-note 2{{candidate}}
-  union C { constexpr C() = default; int a, b; }; // expected-error {{not constexpr}} expected-note 2{{candidate}}
-  struct X { constexpr X() = default; union {}; }; // expected-error {{does not declare anything}}
-  struct Y { constexpr Y() = default; union { int a; }; }; // expected-error {{not constexpr}} expected-note 2{{candidate}}
+  union B { constexpr B() = default; int a; }; // #dr1359-B
+  // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}}
+  union C { constexpr C() = default; int a, b; }; // #dr1359-C
+  // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}} 
+  struct X { constexpr X() = default; union {}; };
+  // since-cxx11-error@-1 {{declaration does not declare anything}}
+  struct Y { constexpr Y() = default; union { int a; }; }; // #dr1359-Y
+  // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}}
 
   constexpr A a = A();
-  constexpr B b = B(); // expected-error {{no matching}}
-  constexpr C c = C(); // expected-error {{no matching}}
+  constexpr B b = B();
+  // cxx11-17-error@-1 {{no matching constructor for initialization of 'B'}}
+  //   cxx11-17-note@#dr1359-B {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided}}
+  //   cxx11-17-note@#dr1359-B {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided}}
+  constexpr C c = C();
+  // cxx11-17-error@-1 {{no matching constructor for initialization of 'C'}}
+  //   cxx11-17-note@#dr1359-C {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided}}
+  //   cxx11-17-note@#dr1359-C {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided}}
   constexpr X x = X();
-  constexpr Y y = Y(); // expected-error {{no matching}}
+  constexpr Y y = Y();
+  // cxx11-17-error@-1 {{no matching constructor for initialization of 'Y'}}
+  //   cxx11-17-note@#dr1359-Y {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided}}
+  //   cxx11-17-note@#dr1359-Y {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided}}
 #endif
 }
 
 namespace dr1388 { // dr1388: 4
-  template<typename A, typename ...T> void f(T..., A); // expected-note 1+{{candidate}} expected-error 0-1{{C++11}}
-  template<typename ...T> void g(T..., int); // expected-note 1+{{candidate}} expected-error 0-1{{C++11}}
-  template<typename ...T, typename A> void h(T..., A); // expected-note 1+{{candidate}} expected-error 0-1{{C++11}}
+  template<typename A, typename ...T> void f(T..., A); // #dr1388-f
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  template<typename ...T> void g(T..., int); // #dr1388-g
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  template<typename ...T, typename A> void h(T..., A); // #dr1388-h
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
 
   void test_f() {
     f(0); // ok, trailing parameter pack deduced to empty
-    f(0, 0); // expected-error {{no matching}}
+    f(0, 0);
+    // expected-error@-1 {{no matching function for call to 'f'}}
+    //   expected-note@#dr1388-f {{candidate function [with A = int, T = <>] not viable: requires 1 argument, but 2 were provided}}
     f<int>(0);
-    f<int>(0, 0); // expected-error {{no matching}}
+    f<int>(0, 0);
+    // expected-error@-1 {{no matching function for call to 'f'}}
+    //   expected-note@#dr1388-f {{candidate function [with A = int, T = <>] not viable: requires 1 argument, but 2 were provided}}
     f<int, int>(0, 0);
-    f<int, int, int>(0, 0); // expected-error {{no matching}}
+    f<int, int, int>(0, 0);
+    // expected-error@-1 {{no matching function for call to 'f'}}
+    //   expected-note@#dr1388-f {{candidate function [with A = int, T = <int, int>] not viable: requires 3 arguments, but 2 were provided}}
 
     g(0);
-    g(0, 0); // expected-error {{no matching}}
+    g(0, 0);
+    // expected-error@-1 {{no matching function for call to 'g'}}
+    //   expected-note@#dr1388-g {{candidate function [with T = <>] not viable: requires 1 argument, but 2 were provided}}
     g<>(0);
-    g<int>(0); // expected-error {{no matching}}
+    g<int>(0);
+    // expected-error@-1 {{no matching function for call to 'g'}}
+    //   expected-note@#dr1388-g {{candidate function [with T = <int>] not viable: requires 2 arguments, but 1 was provided}}
     g<int>(0, 0);
 
     h(0);
-    h(0, 0); // expected-error {{no matching}}
+    h(0, 0);
+    // expected-error@-1 {{no matching function for call to 'h'}}
+    //   expected-note@#dr1388-h {{candidate function [with T = <>, A = int] not viable: requires 1 argument, but 2 were provided}}
     h<int>(0, 0);
-    h<int, int>(0, 0); // expected-error {{no matching}}
+    h<int, int>(0, 0);
+    // expected-error@-1 {{no matching function for call to 'h'}}
+    //   expected-note@#dr1388-h {{candidate template ignored: couldn't infer template argument 'A'}}
   }
 
   // A non-trailing parameter pack is still a non-deduced context, even though
   // we know exactly how many arguments correspond to it.
   template<typename T, typename U> struct pair {};
-  template<typename ...T> struct tuple { typedef char type; }; // expected-error 0-2{{C++11}}
-  template<typename ...T, typename ...U> void f_pair_1(pair<T, U>..., int); // expected-error 0-2{{C++11}} expected-note {{[with T = <int, long>]: deduced incomplete pack <(no value), (no value)> for template parameter 'U'}}
-  template<typename ...T, typename U> void f_pair_2(pair<T, char>..., U); // expected-error 0-2{{C++11}}
-  template<typename ...T, typename ...U> void f_pair_3(pair<T, U>..., tuple<U...>); // expected-error 0-2{{C++11}} expected-note {{deduced packs of different lengths for parameter 'U' (<(no value), (no value)> vs. <char>)}}
-  template<typename ...T> void f_pair_4(pair<T, char>..., T...); // expected-error 0-2{{C++11}} expected-note {{<int, long> vs. <int, long, const char *>}}
+  template<typename ...T> struct tuple { typedef char type; }; //
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  template<typename ...T, typename ...U> void f_pair_1(pair<T, U>..., int); // #dr1388-f-1
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  // cxx98-error@-2 {{variadic templates are a C++11 extension}}
+  template<typename ...T, typename U> void f_pair_2(pair<T, char>..., U);
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  template<typename ...T, typename ...U> void f_pair_3(pair<T, U>..., tuple<U...>); // #dr1388-f-3
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
+  // cxx98-error@-2 {{variadic templates are a C++11 extension}}
+  template<typename ...T> void f_pair_4(pair<T, char>..., T...); // #dr1388-f-4
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
   void g(pair<int, char> a, pair<long, char> b, tuple<char, char> c) {
-    f_pair_1<int, long>(a, b, 0); // expected-error {{no match}}
+    f_pair_1<int, long>(a, b, 0);
+    // expected-error@-1 {{no matching function for call to 'f_pair_1'}}
+    //   expected-note@#dr1388-f-1 {{candidate template ignored: substitution failure [with T = <int, long>]: deduced incomplete pack <(no value), (no value)> for template parameter 'U'}}
     f_pair_2<int, long>(a, b, 0);
     f_pair_3<int, long>(a, b, c);
-    f_pair_3<int, long>(a, b, tuple<char>()); // expected-error {{no match}}
+    f_pair_3<int, long>(a, b, tuple<char>());
+    // expected-error@-1 {{no matching function for call to 'f_pair_3'}}
+    //   expected-note@#dr1388-f-3 {{candidate template ignored: deduced packs of different lengths for parameter 'U' (<(no value), (no value)> vs. <char>)}}
     f_pair_4<int, long>(a, b, 0, 0L);
-    f_pair_4<int, long>(a, b, 0, 0L, "foo"); // expected-error {{no match}}
+    f_pair_4<int, long>(a, b, 0, 0L, "foo");
+    // expected-error@-1 {{no matching function for call to 'f_pair_4'}}
+    //   expected-note@#dr1388-f-4 {{candidate template ignored: deduced packs of different lengths for parameter 'T' (<int, long> vs. <int, long, const char *>)}}
   }
 }
 
 namespace dr1391 { // dr1391: partial
   struct A {}; struct B : A {};
-  template<typename T> struct C { C(int); typename T::error error; }; // expected-error 2{{'::'}}
+  template<typename T> struct C { C(int); typename T::error error; }; // #dr1391-C
+  // expected-error@#dr1391-C {{type 'int' cannot be used prior to '::' because it has no members}}
+  //   expected-note@#dr1391-b {{in instantiation of template class 'dr1391::C<int>' requested here}}
+  //   expected-note@#dr1391-b {{while substituting deduced template arguments into function template 'b' [with T = int]}}
+  // expected-error@#dr1391-C {{type 'double' cannot be used prior to '::' because it has no members}}
+  //   expected-note@#dr1391-c {{in instantiation of template class 'dr1391::C<double>' requested here}}
   template<typename T> struct D {};
 
   // No deduction is performed for parameters with no deducible template-parameters, therefore types do not need to match.
@@ -444,28 +569,36 @@ namespace dr1391 { // dr1391: partial
   void test_b() {
     b(0, 0); // ok, deduction fails prior to forming a conversion sequence and instantiating C<int>
     // FIXME: The "while substituting" note should point at the overload candidate.
-    b<int>(0, 0); // expected-note {{instantiation of}} expected-note {{while substituting}}
+    b<int>(0, 0); // #dr1391-b
   }
 
   template<typename T> struct Id { typedef T type; };
   template<typename T> void c(T, typename Id<C<T> >::type);
   void test_c() {
     // Implicit conversion sequences for dependent types are checked later.
-    c(0.0, 0); // expected-note {{instantiation of}}
+    c(0.0, 0); // #dr1391-c
   }
 
   namespace partial_ordering {
     // FIXME: Second template should be considered more specialized because non-dependent parameter is ignored.
-    template<typename T> int a(T, short) = delete; // expected-error 0-1{{extension}} expected-note {{candidate}}
-    template<typename T> int a(T*, char); // expected-note {{candidate}}
-    int test_a = a((int*)0, 0); // FIXME: expected-error {{ambiguous}}
+    template<typename T> int a(T, short) = delete; // #dr1391-a-short
+    // cxx98-error@-1 {{deleted function definitions are a C++11 extension}}
+    template<typename T> int a(T*, char); // #dr1391-a-char
+    int test_a = a((int*)0, 0);
+    // expected-error@-1 {{call to 'a' is ambiguous}} FIXME
+    //   expected-note@#dr1391-a-short {{candidate function [with T = int *] has been explicitly deleted}}
+    //   expected-note@#dr1391-a-char {{candidate function [with T = int]}}
 
     // FIXME: Second template should be considered more specialized:
     // deducing #1 from #2 ignores the second P/A pair, so deduction succeeds,
     // deducing #2 from #1 fails to deduce T, so deduction fails.
-    template<typename T> int b(T, int) = delete; // expected-error 0-1{{extension}} expected-note {{candidate}}
-    template<typename T, typename U> int b(T*, U); // expected-note {{candidate}}
-    int test_b = b((int*)0, 0); // FIXME: expected-error {{ambiguous}}
+    template<typename T> int b(T, int) = delete; // #dr1391-b-int
+    // cxx98-error@-1 {{deleted function definitions are a C++11 extension}}
+    template<typename T, typename U> int b(T*, U); // #dr1391-b-U
+    int test_b = b((int*)0, 0);
+    // expected-error@-1 {{call to 'b' is ambiguous}} FIXME
+    //   expected-note@#dr1391-b-int {{candidate function [with T = int *] has been explicitly deleted}}
+    //   expected-note@#dr1391-b-U {{candidate function [with T = int, U = int]}}
 
     // Unintended consequences: because partial ordering does not consider
     // explicit template arguments, and deduction from a non-dependent type
@@ -499,26 +632,26 @@ namespace dr1395 { // dr1395: 16
 
 namespace dr1397 { // dr1397: 3.2
 #if __cplusplus >= 201103L
-struct A {       // #dr1397-struct-A
-  void *p = A{}; // #dr1397-void-p
-#if __cplusplus == 201103L
-  // expected-error@#dr1397-struct-A {{default member initializer for 'p' needed within definition of enclosing class 'A' outside of member functions}}
-  // expected-note@#dr1397-void-p {{in evaluation of exception specification for 'dr1397::A::A' needed here}}
-  // expected-note@#dr1397-void-p {{default member initializer declared here}}
-#elif __cplusplus >= 201402L
-  // expected-error@#dr1397-void-p {{default member initializer for 'p' needed within definition of enclosing class 'A' outside of member functions}}
-  // expected-note@#dr1397-void-p {{default member initializer declared here}}
-#endif
+struct A {
+// cxx11-error@-1 {{default member initializer for 'p' needed within definition of enclosing class 'A' outside of member functions}}
+//   cxx11-note@#dr1397-p {{in evaluation of exception specification for 'dr1397::A::A' needed here}}
+//   cxx11-note@#dr1397-p {{default member initializer declared here}}
+  void *p = A{}; // #dr1397-p
+  // since-cxx14-error@-1 {{default member initializer for 'p' needed within definition of enclosing class 'A' outside of member functions}}
+  //   since-cxx14-note@-2 {{default member initializer declared here}}
   operator void*() const { return nullptr; }
 };
 #endif
 } // namespace dr1397
 
 namespace dr1399 { // dr1399: dup 1388
-  template<typename ...T> void f(T..., int, T...) {} // expected-note {{candidate}} expected-error 0-1{{C++11}}
+  template<typename ...T> void f(T..., int, T...) {} // #dr1399-f 
+  // cxx98-error@-1 {{variadic templates are a C++11 extension}}
   void g() {
     f(0);
     f<int>(0, 0, 0);
-    f(0, 0, 0); // expected-error {{no match}}
+    f(0, 0, 0);
+    // expected-error@-1 {{no matching function for call to 'f'}}
+    //   expected-note@#dr1399-f {{candidate template ignored: deduced packs of different lengths for parameter 'T' (<> vs. <int, int>)}}
   }
 }

--- a/clang/test/CXX/drs/dr14xx.cpp
+++ b/clang/test/CXX/drs/dr14xx.cpp
@@ -1,8 +1,10 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++2a %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected,cxx11-17,since-cxx11, -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected,cxx14-17,cxx11-17,since-cxx11,since-cxx14 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected,cxx14-17,cxx11-17,since-cxx11,since-cxx14 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected,since-cxx11,since-cxx14,since-cxx20 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected,since-cxx11,since-cxx14,since-cxx20 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c %s -verify=expected,since-cxx11,since-cxx14,since-cxx20 -fexceptions -fcxx-exceptions -pedantic-errors
 
 namespace dr1413 { // dr1413: 12
   template<int> struct Check {
@@ -15,24 +17,41 @@ namespace dr1413 { // dr1413: 12
     void d();
 
     void f() {
-      Check<true ? 0 : A::unknown_spec>::type *var1; // expected-error {{undeclared identifier 'var1'}}
-      Check<true ? 0 : a>::type *var2; // ok, variable declaration  expected-note 0+{{here}}
-      Check<true ? 0 : b>::type *var3; // expected-error {{undeclared identifier 'var3'}}
-      Check<true ? 0 : ((void)c, 0)>::type *var4; // expected-error {{undeclared identifier 'var4'}}
+      Check<true ? 0 : A::unknown_spec>::type *var1;
+      // expected-error@-1 {{use of undeclared identifier 'var1'}}
+
+      // ok, variable declaration
+      Check<true ? 0 : a>::type *var2; // #dr1413-var2
+      Check<true ? 0 : b>::type *var3;
+      // expected-error@-1 {{use of undeclared identifier 'var3'}}
+      //   expected-note@#dr1413-var2 {{'var2' declared here}}
+      Check<true ? 0 : ((void)c, 0)>::type *var4;
+      // expected-error@-1 {{use of undeclared identifier 'var4'}}
+      //   expected-note@#dr1413-var2 {{'var2' declared here}}
+
       // value-dependent because of the implied type-dependent 'this->', not because of 'd'
-      Check<true ? 0 : (d(), 0)>::type *var5; // expected-error {{undeclared identifier 'var5'}}
+      Check<true ? 0 : (d(), 0)>::type *var5;
+      // expected-error@-1 {{use of undeclared identifier 'var5'}}
+      //   expected-note@#dr1413-var2 {{'var2' declared here}}
+
       // value-dependent because of the value-dependent '&' operator, not because of 'A::d'
-      Check<true ? 0 : (&A::d(), 0)>::type *var5; // expected-error {{undeclared identifier 'var5'}}
+      Check<true ? 0 : (&A::d(), 0)>::type *var5;
+      // expected-error@-1 {{use of undeclared identifier 'var5'}}
+      //   expected-note@#dr1413-var2 {{'var2' declared here}}
     }
   };
 }
 
 namespace dr1423 { // dr1423: 11
 #if __cplusplus >= 201103L
-  bool b1 = nullptr; // expected-error {{cannot initialize}}
-  bool b2(nullptr); // expected-warning {{implicit conversion of nullptr constant to 'bool'}}
-  bool b3 = {nullptr}; // expected-error {{cannot initialize}}
-  bool b4{nullptr}; // expected-warning {{implicit conversion of nullptr constant to 'bool'}}
+  bool b1 = nullptr;
+  // since-cxx11-error@-1 {{cannot initialize a variable of type 'bool' with an rvalue of type 'std::nullptr_t'}}
+  bool b2(nullptr);
+  // since-cxx11-warning@-1 {{implicit conversion of nullptr constant to 'bool'}}
+  bool b3 = {nullptr};
+  // since-cxx11-error@-1 {{cannot initialize a variable of type 'bool' with an rvalue of type 'std::nullptr_t'}}
+  bool b4{nullptr};
+  // since-cxx11-warning@-1 {{implicit conversion of nullptr constant to 'bool'}}
 #endif
 }
 
@@ -62,7 +81,8 @@ namespace dr1432 { // dr1432: 16
 namespace dr1443 { // dr1443: yes
 struct A {
   int i;
-  A() { void foo(int=i); } // expected-error {{default argument references 'this'}}
+  A() { void foo(int=i); }
+  // expected-error@-1 {{default argument references 'this'}}
 };
 }
 
@@ -70,49 +90,54 @@ namespace dr1460 { // dr1460: 3.5
 #if __cplusplus >= 201103L
   namespace DRExample {
     union A {
-      union {}; // expected-error {{does not declare anything}}
-      union {}; // expected-error {{does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
       constexpr A() {}
     };
     constexpr A a = A();
 
     union B {
-      union {}; // expected-error {{does not declare anything}}
-      union {}; // expected-error {{does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
       constexpr B() = default;
     };
     constexpr B b = B();
 
     union C {
-      union {}; // expected-error {{does not declare anything}}
-      union {}; // expected-error {{does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
+      union {};
+      // expected-error@-1 {{declaration does not declare anything}}
     };
     constexpr C c = C();
-#if __cplusplus > 201103L
+#if __cplusplus >= 201403L
     constexpr void f() { C c; }
     static_assert((f(), true), "");
 #endif
   }
 
   union A {};
-  union B { int n; }; // expected-note 0+{{here}}
+  union B { int n; }; // #dr1460-B
   union C { int n = 0; };
-  struct D { union {}; }; // expected-error {{does not declare anything}}
-  struct E { union { int n; }; }; // expected-note 0+{{here}}
+  struct D { union {}; };
+  // expected-error@-1 {{declaration does not declare anything}}
+  struct E { union { int n; }; }; // #dr1460-E
   struct F { union { int n = 0; }; };
 
   struct X {
     friend constexpr A::A() noexcept;
     friend constexpr B::B() noexcept;
-#if __cplusplus <= 201703L
-    // expected-error@-2 {{follows non-constexpr declaration}}
-#endif
+    // cxx11-17-error@-1 {{constexpr declaration of 'B' follows non-constexpr declaration}}
+    //   cxx11-17-note@#dr1460-B {{previous declaration is here}}
     friend constexpr C::C() noexcept;
     friend constexpr D::D() noexcept;
     friend constexpr E::E() noexcept;
-#if __cplusplus <= 201703L
-    // expected-error@-2 {{follows non-constexpr declaration}}
-#endif
+    // cxx11-17-error@-1 {{constexpr declaration of 'E' follows non-constexpr declaration}}
+    //   cxx11-17-note@#dr1460-E {{previous declaration is here}}
     friend constexpr F::F() noexcept;
   };
 
@@ -128,79 +153,77 @@ namespace dr1460 { // dr1460: 3.5
   namespace Defaulted {
     union A { constexpr A() = default; };
     union B { int n; constexpr B() = default; };
-#if __cplusplus <= 201703L
-    // expected-error@-2 {{not constexpr}}
-#endif
+    // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}}
     union C { int n = 0; constexpr C() = default; };
-    struct D { union {}; constexpr D() = default; }; // expected-error {{does not declare anything}}
+    struct D { union {}; constexpr D() = default; };
+    // expected-error@-1 {{declaration does not declare anything}}
     struct E { union { int n; }; constexpr E() = default; };
-#if __cplusplus <= 201703L
-    // expected-error@-2 {{not constexpr}}
-#endif
+    // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}}
     struct F { union { int n = 0; }; constexpr F() = default; };
 
     struct G { union { int n = 0; }; union { int m; }; constexpr G() = default; };
-#if __cplusplus <= 201703L
-    // expected-error@-2 {{not constexpr}}
-#endif
+    // cxx11-17-error@-1 {{defaulted definition of default constructor is not constexpr}}
     struct H {
       union {
         int n = 0;
       };
-      union { // expected-note 0-2{{member not initialized}}
+      union { // #dr1460-H-union
         int m;
       };
       constexpr H() {}
-#if __cplusplus <= 201703L
-      // expected-error@-2 {{initialize all members}}
-#endif
+      // cxx11-17-error@-1 {{constexpr constructor that does not initialize all members is a C++20 extension}}
+      //   cxx11-17-note@#dr1460-H-union {{member not initialized by constructor}}
       constexpr H(bool) : m(1) {}
       constexpr H(char) : n(1) {}
-#if __cplusplus <= 201703L
-      // expected-error@-2 {{initialize all members}}
-#endif
+      // cxx11-17-error@-1 {{constexpr constructor that does not initialize all members is a C++20 extension}}
+      //   cxx11-17-note@#dr1460-H-union {{member not initialized by constructor}}
       constexpr H(double) : m(1), n(1) {}
     };
   }
 
-#if __cplusplus > 201103L
+#if __cplusplus >= 201403L
   template<typename T> constexpr bool check() {
-    T t;
-#if __cplusplus <= 201703L
-    // expected-note-re@-2 2{{non-constexpr constructor '{{[BE]}}'}}
-#endif
+    T t; // #dr1460-t
     return true;
   }
   static_assert(check<A>(), "");
-  static_assert(check<B>(), "");
-#if __cplusplus <= 201703L
-  // expected-error@-2 {{constant}} expected-note@-2 {{in call}}
-#endif
+  static_assert(check<B>(), ""); // #dr1460-check-B
+  // cxx14-17-error@-1 {{static assertion expression is not an integral constant expression}}
+  //   cxx14-17-note@#dr1460-t {{non-constexpr constructor 'B' cannot be used in a constant expression}}
+  //   cxx14-17-note@#dr1460-check-B {{in call to 'check<dr1460::B>()'}}
+  //   cxx14-17-note@#dr1460-B {{declared here}}
   static_assert(check<C>(), "");
   static_assert(check<D>(), "");
-  static_assert(check<E>(), "");
-#if __cplusplus <= 201703L
-  // expected-error@-2 {{constant}} expected-note@-2 {{in call}}
-#endif
+  static_assert(check<E>(), ""); // #dr1460-check-E
+  // cxx14-17-error@-1 {{static assertion expression is not an integral constant expression}}
+  //   cxx14-17-note@#dr1460-t {{non-constexpr constructor 'E' cannot be used in a constant expression}}
+  //   cxx14-17-note@#dr1460-check-E {{in call to 'check<dr1460::E>()'}}
+  //   cxx14-17-note@#dr1460-E {{declared here}}
   static_assert(check<F>(), "");
 #endif
 
   union G {
-    int a = 0; // expected-note {{previous initialization is here}}
-    int b = 0; // expected-error {{initializing multiple members of union}}
+    int a = 0; // #dr1460-G-a
+    int b = 0;
+    // expected-error@-1 {{initializing multiple members of union}}
+    //   expected-note@#dr1460-G-a {{previous initialization is here}}
   };
   union H {
     union {
-      int a = 0; // expected-note {{previous initialization is here}}
+      int a = 0; // #dr1460-H-a
     };
     union {
-      int b = 0; // expected-error {{initializing multiple members of union}}
+      int b = 0;
+      // expected-error@-1 {{initializing multiple members of union}}
+      //   expected-note@#dr1460-H-a {{previous initialization is here}}
     };
   };
   struct I {
     union {
-      int a = 0; // expected-note {{previous initialization is here}}
-      int b = 0; // expected-error {{initializing multiple members of union}}
+      int a = 0; // #dr1460-I-a
+      int b = 0;
+      // expected-error@-1 {{initializing multiple members of union}}
+      //   expected-note@#dr1460-I-a {{previous initialization is here}}
     };
   };
   struct J {
@@ -223,14 +246,24 @@ namespace dr1460 { // dr1460: 3.5
       constexpr B(const char*) {}
     };
     static_assert(B().a == 1, "");
-    static_assert(B().b == 2, ""); // expected-error {{constant}} expected-note {{read of}}
-    static_assert(B('x').a == 0, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(B().b == 2, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'b' of union with active member 'a' is not allowed in a constant expression}}
+    static_assert(B('x').a == 0, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'a' of union with active member 'b' is not allowed in a constant expression}}
     static_assert(B('x').b == 4, "");
-    static_assert(B(123).b == 2, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(B(123).b == 2, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'b' of union with active member 'c' is not allowed in a constant expression}}
     static_assert(B(123).c == 3, "");
-    static_assert(B("").a == 1, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(B("").a == 1, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'a' of union with active member 'b' is not allowed in a constant expression}}
     static_assert(B("").b == 2, "");
-    static_assert(B("").c == 3, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(B("").c == 3, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'c' of union with active member 'b' is not allowed in a constant expression}}
 
     struct C {
       union { int a, b = 2, c; };
@@ -243,31 +276,55 @@ namespace dr1460 { // dr1460: 3.5
     };
 
     static_assert(C().a == 1, "");
-    static_assert(C().b == 2, ""); // expected-error {{constant}} expected-note {{read of}}
-    static_assert(C().d == 4, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C().b == 2, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'b' of union with active member 'a' is not allowed in a constant expression}}
+    static_assert(C().d == 4, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'd' of union with active member 'e' is not allowed in a constant expression}}
     static_assert(C().e == 5, "");
 
-    static_assert(C('x').b == 2, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C('x').b == 2, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'b' of union with active member 'c' is not allowed in a constant expression}}
     static_assert(C('x').c == 3, "");
-    static_assert(C('x').d == 4, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C('x').d == 4, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'd' of union with active member 'e' is not allowed in a constant expression}}
     static_assert(C('x').e == 5, "");
 
     static_assert(C(1).b == 2, "");
-    static_assert(C(1).c == 3, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C(1).c == 3, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'c' of union with active member 'b' is not allowed in a constant expression}}
     static_assert(C(1).d == 4, "");
-    static_assert(C(1).e == 5, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C(1).e == 5, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'e' of union with active member 'd' is not allowed in a constant expression}}
 
     static_assert(C(1.f).b == 2, "");
-    static_assert(C(1.f).c == 3, ""); // expected-error {{constant}} expected-note {{read of}}
-    static_assert(C(1.f).e == 5, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C(1.f).c == 3, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'c' of union with active member 'b' is not allowed in a constant expression}}
+    static_assert(C(1.f).e == 5, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'e' of union with active member 'f' is not allowed in a constant expression}}
     static_assert(C(1.f).f == 6, "");
 
-    static_assert(C("").a == 1, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C("").a == 1, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'a' of union with active member 'b' is not allowed in a constant expression}}
     static_assert(C("").b == 2, "");
-    static_assert(C("").c == 3, ""); // expected-error {{constant}} expected-note {{read of}}
-    static_assert(C("").d == 4, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C("").c == 3, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'c' of union with active member 'b' is not allowed in a constant expression}}
+    static_assert(C("").d == 4, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'd' of union with active member 'e' is not allowed in a constant expression}}
     static_assert(C("").e == 5, "");
-    static_assert(C("").f == 6, ""); // expected-error {{constant}} expected-note {{read of}}
+    static_assert(C("").f == 6, "");
+    // expected-error@-1 {{static assertion expression is not an integral constant expression}}
+    //   expected-note@-2 {{read of member 'f' of union with active member 'e' is not allowed in a constant expression}}
 
     struct D;
     extern const D d;
@@ -315,8 +372,10 @@ namespace std {
     const _E* end()   const {return __begin_ + __size_;}
   };
 } // std
+#endif
 
 namespace dr1467 {  // dr1467: 3.7 c++11
+#if __cplusplus >= 201103L
   // Note that the change to [over.best.ics] was partially undone by DR2076;
   // the resulting rule is tested with the tests for that change.
 
@@ -382,9 +441,12 @@ namespace dr1467 {  // dr1467: 3.7 c++11
     X x;
     X x2{x};
 
-    void f1(int);                                  // expected-note {{candidate function}}
-    void f1(std::initializer_list<long>) = delete; // expected-note {{candidate function has been explicitly deleted}}
-    void g1() { f1({42}); }                        // expected-error {{call to deleted function 'f1'}}
+    void f1(int); // #dr1467-f1
+    void f1(std::initializer_list<long>) = delete; // #dr1467-f1-deleted
+    void g1() { f1({42}); }
+    // since-cxx11-error@-1 {{call to deleted function 'f1'}}
+    //   since-cxx11-note@#dr1467-f1 {{candidate function}}
+    //   since-cxx11-note@#dr1467-f1-deleted {{candidate function has been explicitly deleted}}
 
     template <class T, class U>
     struct Pair {
@@ -394,9 +456,12 @@ namespace dr1467 {  // dr1467: 3.7 c++11
       String(const char *);
     };
 
-    void f2(Pair<const char *, const char *>);       // expected-note {{candidate function}}
-    void f2(std::initializer_list<String>) = delete; // expected-note {{candidate function has been explicitly deleted}}
-    void g2() { f2({"foo", "bar"}); }                // expected-error {{call to deleted function 'f2'}}
+    void f2(Pair<const char *, const char *>); // #dr1467-f2
+    void f2(std::initializer_list<String>) = delete; // #dr1467-f2-deleted
+    void g2() { f2({"foo", "bar"}); }
+    // since-cxx11-error@-1 {{call to deleted function 'f2'}}
+    //   since-cxx11-note@#dr1467-f2 {{candidate function}}
+    //   since-cxx11-note@#dr1467-f2-deleted {{candidate function has been explicitly deleted}}
   } // dr_example
 
   namespace nonaggregate {
@@ -453,39 +518,89 @@ namespace dr1467 {  // dr1467: 3.7 c++11
   }
   } // namespace NonAmbiguous
 
-#if __cplusplus >= 201103L
   namespace StringLiterals {
   // When the array size is 4 the call will attempt to bind an lvalue to an
   // rvalue and fail. Therefore #2 will be called. (rsmith will bring this
   // issue to CWG)
-  void f(const char(&&)[4]);              // expected-note 2 {{expects an rvalue}} expected-note 3 {{no known conversion}}
-  void f(const char(&&)[5]) = delete;     // expected-note 2 {{candidate function has been explicitly deleted}} expected-note 3 {{no known conversion}}
-  void f(const wchar_t(&&)[4]);           // expected-note {{expects an rvalue}} expected-note 4 {{no known conversion}}
-  void f(const wchar_t(&&)[5]) = delete;  // expected-note {{candidate function has been explicitly deleted}} expected-note 4 {{no known conversion}}
+  void f(const char(&&)[4]);              // #dr1467-f-char-4
+  void f(const char(&&)[5]) = delete;     // #dr1467-f-char-5
+  void f(const wchar_t(&&)[4]);           // #dr1467-f-wchar-4
+  void f(const wchar_t(&&)[5]) = delete;  // #dr1467-f-wchar-5
 #if __cplusplus >= 202002L
-  void f2(const char8_t(&&)[4]);          // expected-note {{expects an rvalue}}
-  void f2(const char8_t(&&)[5]) = delete; // expected-note {{candidate function has been explicitly deleted}}
+  void f2(const char8_t(&&)[4]);          // #dr1467-f2-char8-4
+  void f2(const char8_t(&&)[5]) = delete; // #dr1467-f2-char8-5
 #endif
-  void f(const char16_t(&&)[4]);          // expected-note {{expects an rvalue}} expected-note 4 {{no known conversion}}
-  void f(const char16_t(&&)[5]) = delete; // expected-note {{candidate function has been explicitly deleted}} expected-note 4 {{no known conversion}}
-  void f(const char32_t(&&)[4]);          // expected-note {{expects an rvalue}} expected-note 4 {{no known conversion}}
-  void f(const char32_t(&&)[5]) = delete; // expected-note {{candidate function has been explicitly deleted}} expected-note 4 {{no known conversion}}
+  void f(const char16_t(&&)[4]);          // #dr1467-f-char16-4
+  void f(const char16_t(&&)[5]) = delete; // #dr1467-f-char16-5
+  void f(const char32_t(&&)[4]);          // #dr1467-f-char32-4
+  void f(const char32_t(&&)[5]) = delete; // #dr1467-f-char32-5
   void g() {
-    f({"abc"});       // expected-error {{call to deleted function 'f'}}
-    f({((("abc")))}); // expected-error {{call to deleted function 'f'}}
-    f({L"abc"});      // expected-error {{call to deleted function 'f'}}
+    f({"abc"});
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1467-f-char-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx11-note@#dr1467-f-char-4 {{candidate function not viable: expects an rvalue for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char32_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char32_t' for 1st argument}}
+    f({((("abc")))});
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1467-f-char-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx11-note@#dr1467-f-char-4 {{candidate function not viable: expects an rvalue for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-4 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char32_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-5 {{candidate function not viable: no known conversion from 'const char[4]' to 'const char32_t' for 1st argument}}
+    f({L"abc"});
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1467-f-wchar-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx11-note@#dr1467-f-char-4 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char-5 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-4 {{candidate function not viable: expects an rvalue for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-4 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-5 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-4 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char32_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-5 {{candidate function not viable: no known conversion from 'const wchar_t[4]' to 'const char32_t' for 1st argument}}
 #if __cplusplus >= 202002L
-    f2({u8"abc"});    // expected-error {{call to deleted function 'f2'}}
+    f2({u8"abc"});
+    // since-cxx20-error@-1 {{call to deleted function 'f2'}}
+    //   since-cxx20-note@#dr1467-f2-char8-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx20-note@#dr1467-f2-char8-4 {{candidate function not viable: expects an rvalue for 1st argument}}
 #endif
-    f({uR"(abc)"});   // expected-error {{call to deleted function 'f'}}
-    f({(UR"(abc)")}); // expected-error {{call to deleted function 'f'}}
+    f({uR"(abc)"});
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1467-f-char16-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx11-note@#dr1467-f-char-4 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char-5 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-4 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-5 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-4 {{candidate function not viable: expects an rvalue for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-4 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const char32_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-5 {{candidate function not viable: no known conversion from 'const char16_t[4]' to 'const char32_t' for 1st argument}}
+    f({(UR"(abc)")});
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1467-f-char32-5 {{candidate function has been explicitly deleted}}
+    //   since-cxx11-note@#dr1467-f-char-4 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char-5 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const char' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-4 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-wchar-5 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const wchar_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-4 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char16-5 {{candidate function not viable: no known conversion from 'const char32_t[4]' to 'const char16_t' for 1st argument}}
+    //   since-cxx11-note@#dr1467-f-char32-4 {{candidate function not viable: expects an rvalue for 1st argument}}
   }
   } // namespace StringLiterals
 #endif
 } // dr1467
 
 namespace dr1479 { // dr1479: 3.1
-  int operator"" _a(const char*, std::size_t = 0); // expected-error {{literal operator cannot have a default argument}}
+#if __cplusplus >= 201103L
+  int operator"" _a(const char*, std::size_t = 0);
+  // since-cxx11-error@-1 {{literal operator cannot have a default argument}}
+#endif
 }
 
 namespace dr1482 { // dr1482: 3.0
@@ -495,42 +610,59 @@ template <typename T> struct S {
   typedef char I;
 };
 enum E2 : S<E2>::I { e };
-// expected-error@-1 {{use of undeclared identifier 'E2'}}
+// since-cxx11-error@-1 {{use of undeclared identifier 'E2'}}
 #endif
 } // namespace dr1482
 
 namespace dr1490 {  // dr1490: 3.7 c++11
+#if __cplusplus >= 201103L
   // List-initialization from a string literal
 
-  char s[4]{"abc"};                   // Ok
-  std::initializer_list<char>{"abc"}; // expected-error {{expected unqualified-id}}}
+  char s[4]{"abc"}; // Ok
+  std::initializer_list<char>{"abc"};
+  // since-cxx11-error@-1 {{expected unqualified-id}}}
+#endif
 } // dr1490
 
 namespace dr1495 { // dr1495: 4
+#if __cplusplus >= 201103L
   // Deduction succeeds in both directions.
-  template<typename T, typename U> struct A {}; // expected-note {{template is declared here}}
-  template<typename T, typename U> struct A<U, T> {}; // expected-error {{class template partial specialization is not more specialized}}
+  template<typename T, typename U> struct A {}; // #dr1495-A
+  template<typename T, typename U> struct A<U, T> {};
+  // since-cxx11-error@-1 {{class template partial specialization is not more specialized than the primary template}}
+  //   since-cxx11-note@#dr1495-A {{template is declared here}}
 
   // Primary template is more specialized.
-  template<typename, typename...> struct B {}; // expected-note {{template is declared here}}
-  template<typename ...Ts> struct B<Ts...> {}; // expected-error {{not more specialized}}
+  template<typename, typename...> struct B {}; // #dr1495-B
+  template<typename ...Ts> struct B<Ts...> {};
+  // since-cxx11-error@-1 {{class template partial specialization is not more specialized than the primary template}}
+  //   since-cxx11-note@#dr1495-B {{template is declared here}}
 
   // Deduction fails in both directions.
-  template<int, typename, typename ...> struct C {}; // expected-note {{template is declared here}}
-  template<typename ...Ts> struct C<0, Ts...> {}; // expected-error {{not more specialized}}
+  template<int, typename, typename ...> struct C {}; // #dr1495-C
+  template<typename ...Ts> struct C<0, Ts...> {};
+  // since-cxx11-error@-1 {{class template partial specialization is not more specialized than the primary template}}
+  //   since-cxx11-note@#dr1495-C {{template is declared here}}
 
 #if __cplusplus >= 201402L
   // Deduction succeeds in both directions.
-  template<typename T, typename U> int a; // expected-note {{template is declared here}}
-  template<typename T, typename U> int a<U, T>; // expected-error {{variable template partial specialization is not more specialized}}
+  template<typename T, typename U> int a; // #dr1495-a
+  template<typename T, typename U> int a<U, T>;
+  // since-cxx14-error@-1 {{variable template partial specialization is not more specialized than the primary template}}
+  //   since-cxx14-note@#dr1495-a {{template is declared here}}
 
   // Primary template is more specialized.
-  template<typename, typename...> int b; // expected-note {{template is declared here}}
-  template<typename ...Ts> int b<Ts...>; // expected-error {{not more specialized}}
+  template<typename, typename...> int b; // #dr1495-b
+  template<typename ...Ts> int b<Ts...>;
+  // since-cxx14-error@-1 {{variable template partial specialization is not more specialized than the primary template}}
+  //   since-cxx14-note@#dr1495-b {{template is declared here}}
 
   // Deduction fails in both directions.
-  template<int, typename, typename ...> int c; // expected-note {{template is declared here}}
-  template<typename ...Ts> int c<0, Ts...>; // expected-error {{not more specialized}}
+  template<int, typename, typename ...> int c; // #dr1495-c
+  template<typename ...Ts> int c<0, Ts...>;
+  // since-cxx14-error@-1 {{variable template partial specialization is not more specialized than the primary template}}
+  //   since-cxx14-note@#dr1495-c {{template is declared here}}
+#endif
 #endif
 }
 
@@ -544,5 +676,3 @@ struct A {
 static_assert(__is_trivial(A), "");
 #endif
 }
-
-#endif

--- a/clang/test/CXX/drs/dr15xx.cpp
+++ b/clang/test/CXX/drs/dr15xx.cpp
@@ -1,13 +1,18 @@
 // RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify=expected,cxx14_17 -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify=expected,cxx17 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11,cxx11-14 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11,cxx11-14,cxx14-17 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11,since-cxx17 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx17 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx17 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx17 -fexceptions -fcxx-exceptions -pedantic-errors
 
 namespace dr1512 { // dr1512: 4
   void f(char *p) {
-    if (p > 0) {} // expected-error {{ordered comparison between pointer and zero}}
+    if (p > 0) {}
+    // expected-error@-1 {{ordered comparison between pointer and zero ('char *' and 'int')}}
 #if __cplusplus >= 201103L
-    if (p > nullptr) {} // expected-error {{invalid operands}}
+    if (p > nullptr) {}
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('char *' and 'std::nullptr_t')}}
 #endif
   }
   bool g(int **x, const int **y) {
@@ -28,10 +33,20 @@ namespace dr1512 { // dr1512: 4
   template<typename A, typename B, typename C> void composite_pointer_type_is_ord() {
     composite_pointer_type_is_base<A, B, C>();
 
-    typedef __typeof(val<A>() < val<B>()) cmp;  // cxx17-warning 2 {{ordered comparison of function pointers}}
-    typedef __typeof(val<A>() <= val<B>()) cmp; // cxx17-warning 2 {{ordered comparison of function pointers}}
-    typedef __typeof(val<A>() > val<B>()) cmp;  // cxx17-warning 2 {{ordered comparison of function pointers}}
-    typedef __typeof(val<A>() >= val<B>()) cmp; // cxx17-warning 2 {{ordered comparison of function pointers}}
+    typedef __typeof(val<A>() < val<B>()) cmp; // #dr1512-lt 
+    // since-cxx17-warning@#dr1512-lt {{ordered comparison of function pointers ('int (*)() noexcept' and 'int (*)()')}}
+    //   since-cxx17-note@#dr1512-noexcept-1st {{in instantiation of function template specialization 'dr1512::composite_pointer_type_is_ord<int (*)() noexcept, int (*)(), int (*)()>' requested here}}
+    // since-cxx17-warning@#dr1512-lt {{ordered comparison of function pointers ('int (*)()' and 'int (*)() noexcept')}}
+    //   since-cxx17-note@#dr1512-noexcept-2nd {{in instantiation of function template specialization 'dr1512::composite_pointer_type_is_ord<int (*)(), int (*)() noexcept, int (*)()>' requested here}}
+    typedef __typeof(val<A>() <= val<B>()) cmp;
+    // since-cxx17-warning@-1 {{ordered comparison of function pointers ('int (*)() noexcept' and 'int (*)()')}}
+    // since-cxx17-warning@-2 {{ordered comparison of function pointers ('int (*)()' and 'int (*)() noexcept')}}
+    typedef __typeof(val<A>() > val<B>()) cmp;
+    // since-cxx17-warning@-1 {{ordered comparison of function pointers ('int (*)() noexcept' and 'int (*)()')}}
+    // since-cxx17-warning@-2 {{ordered comparison of function pointers ('int (*)()' and 'int (*)() noexcept')}}
+    typedef __typeof(val<A>() >= val<B>()) cmp;
+    // since-cxx17-warning@-1 {{ordered comparison of function pointers ('int (*)() noexcept' and 'int (*)()')}}
+    // since-cxx17-warning@-2 {{ordered comparison of function pointers ('int (*)()' and 'int (*)() noexcept')}}
     typedef bool cmp;
   }
 
@@ -77,10 +92,11 @@ namespace dr1512 { // dr1512: 4
     composite_pointer_type_is_unord<const int *B::*, volatile int *A::*, const volatile int *const B::*>();
     no_composite_pointer_type<int (A::*)(), int (C::*)()>();
     no_composite_pointer_type<const int (A::*)(), volatile int (C::*)()>();
+    // since-cxx20-warning@-1 {{volatile-qualified return type 'volatile int' is deprecated}}
 
-#if __cplusplus > 201402
-    composite_pointer_type_is_ord<int (*)() noexcept, int (*)(), int (*)()>(); // expected-note {{requested here}}
-    composite_pointer_type_is_ord<int (*)(), int (*)() noexcept, int (*)()>(); // expected-note {{requested here}}
+#if __cplusplus >= 201703L
+    composite_pointer_type_is_ord<int (*)() noexcept, int (*)(), int (*)()>(); // #dr1512-noexcept-1st
+    composite_pointer_type_is_ord<int (*)(), int (*)() noexcept, int (*)()>(); // #dr1512-noexcept-2nd
     composite_pointer_type_is_unord<int (A::*)() noexcept, int (A::*)(), int (A::*)()>();
     composite_pointer_type_is_unord<int (A::*)(), int (A::*)() noexcept, int (A::*)()>();
     // FIXME: This looks like a standard defect; these should probably all have type 'int (B::*)()'.
@@ -113,24 +129,40 @@ namespace dr1512 { // dr1512: 4
   }
 
 #if __cplusplus >= 201103L
-  template<typename T> struct Wrap { operator T(); }; // expected-note 4{{converted to type 'std::nullptr_t'}} expected-note 4{{converted to type 'int *'}}
+  template<typename T> struct Wrap { operator T(); }; // #dr1512-Wrap
   void test_overload() {
     using nullptr_t = decltype(nullptr);
     void(Wrap<nullptr_t>() == Wrap<nullptr_t>());
     void(Wrap<nullptr_t>() != Wrap<nullptr_t>());
-    void(Wrap<nullptr_t>() < Wrap<nullptr_t>()); // expected-error {{invalid operands}}
-    void(Wrap<nullptr_t>() > Wrap<nullptr_t>()); // expected-error {{invalid operands}}
-    void(Wrap<nullptr_t>() <= Wrap<nullptr_t>()); // expected-error {{invalid operands}}
-    void(Wrap<nullptr_t>() >= Wrap<nullptr_t>()); // expected-error {{invalid operands}}
+    void(Wrap<nullptr_t>() < Wrap<nullptr_t>());
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>'))}}
+    void(Wrap<nullptr_t>() > Wrap<nullptr_t>());
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>'))}}
+    void(Wrap<nullptr_t>() <= Wrap<nullptr_t>());
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>'))}}
+    void(Wrap<nullptr_t>() >= Wrap<nullptr_t>());
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>'))}}
 
     // Under dr1213, this is ill-formed: we select the builtin operator<(int*, int*)
     // but then only convert as far as 'nullptr_t', which we then can't convert to 'int*'.
     void(Wrap<nullptr_t>() == Wrap<int*>());
     void(Wrap<nullptr_t>() != Wrap<int*>());
-    void(Wrap<nullptr_t>() < Wrap<int*>()); // expected-error {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<int *>')}}
-    void(Wrap<nullptr_t>() > Wrap<int*>()); // expected-error {{invalid operands}}
-    void(Wrap<nullptr_t>() <= Wrap<int*>()); // expected-error {{invalid operands}}
-    void(Wrap<nullptr_t>() >= Wrap<int*>()); // expected-error {{invalid operands}}
+    void(Wrap<nullptr_t>() < Wrap<int*>());
+    // since-cxx11-error@-1 {{invalid operands to binary expression ('Wrap<nullptr_t>' (aka 'Wrap<std::nullptr_t>') and 'Wrap<int *>')}}
+    //   since-cxx11-note@#dr1512-Wrap {{first operand was implicitly converted to type 'std::nullptr_t'}}
+    //   since-cxx11-note@#dr1512-Wrap {{second operand was implicitly converted to type 'int *'}}
+    void(Wrap<nullptr_t>() > Wrap<int*>());
+    // since-cxx11-error@-1 {{invalid operands}}
+    //   since-cxx11-note@#dr1512-Wrap {{first operand was implicitly converted to type 'std::nullptr_t'}}
+    //   since-cxx11-note@#dr1512-Wrap{{second operand was implicitly converted to type 'int *'}}
+    void(Wrap<nullptr_t>() <= Wrap<int*>());
+    // since-cxx11-error@-1 {{invalid operands}}
+    //   since-cxx11-note@#dr1512-Wrap {{first operand was implicitly converted to type 'std::nullptr_t'}}
+    //   since-cxx11-note@#dr1512-Wrap {{second operand was implicitly converted to type 'int *'}}
+    void(Wrap<nullptr_t>() >= Wrap<int*>());
+    // since-cxx11-error@-1 {{invalid operands}}
+    //   since-cxx11-note@#dr1512-Wrap {{first operand was implicitly converted to type 'std::nullptr_t'}}
+    //   since-cxx11-note@#dr1512-Wrap {{second operand was implicitly converted to type 'int *'}}
   }
 #endif
 }
@@ -138,8 +170,10 @@ namespace dr1512 { // dr1512: 4
 namespace dr1514 { // dr1514: 11
 #if __cplusplus >= 201103L
   struct S {
-    enum E : int {}; // expected-note {{previous}}
-    enum E : int {}; // expected-error {{redefinition}}
+    enum E : int {}; // #dr1514-E
+    enum E : int {};
+    // since-cxx11-error@-1 {{redefinition of 'E'}}
+    //   since-cxx11-note@#dr1514-E {{previous definition is here}}
   };
   S::E se; // OK, complete type, not zero-width bitfield.
 
@@ -149,88 +183,139 @@ namespace dr1514 { // dr1514: 11
 
 namespace dr1518 { // dr1518: 4
 #if __cplusplus >= 201103L
-struct Z0 { // expected-note 0+ {{candidate}}
-  explicit Z0() = default; // expected-note 0+ {{here}}
+struct Z0 { // #dr1518-Z0
+  explicit Z0() = default; // #dr1518-Z0-ctor
 };
-struct Z { // expected-note 0+ {{candidate}}
-  explicit Z(); // expected-note 0+ {{here}}
-  explicit Z(int); // expected-note {{not a candidate}}
-  explicit Z(int, int); // expected-note 0+ {{here}}
+struct Z { // #dr1518-Z
+  explicit Z(); // #dr1518-Z-ctor
+  explicit Z(int); // #dr1518-Z-int
+  explicit Z(int, int); // #dr1518-Z-int-int
 };
-template <class T> int Eat(T); // expected-note 0+ {{candidate}}
+template <class T> int Eat(T); // #dr1518-Eat
 Z0 a;
 Z0 b{};
-Z0 c = {}; // expected-error {{explicit in copy-initialization}}
-int i = Eat<Z0>({}); // expected-error {{no matching function for call to 'Eat'}}
+Z0 c = {};
+// since-cxx11-error@-1 {{chosen constructor is explicit in copy-initialization}}
+//   since-cxx11-note@#dr1518-Z0-ctor {{explicit constructor declared here}}
+int i = Eat<Z0>({});
+// since-cxx11-error@-1 {{no matching function for call to 'Eat'}}
+//   since-cxx11-note@#dr1518-Eat {{candidate function template not viable: cannot convert initializer list argument to 'Z0'}}
 
-Z c2 = {}; // expected-error {{explicit in copy-initialization}}
-int i2 = Eat<Z>({}); // expected-error {{no matching function for call to 'Eat'}}
-Z a1 = 1; // expected-error {{no viable conversion}}
+Z c2 = {};
+// since-cxx11-error@-1 {{chosen constructor is explicit in copy-initialization}}
+//   since-cxx11-note@#dr1518-Z-ctor {{explicit constructor declared here}}
+int i2 = Eat<Z>({});
+// since-cxx11-error@-1 {{no matching function for call to 'Eat'}}
+//   since-cxx11-note@#dr1518-Eat {{candidate function template not viable: cannot convert initializer list argument to 'Z'}}
+Z a1 = 1;
+// since-cxx11-error@-1 {{no viable conversion from 'int' to 'Z'}}
+//   since-cxx11-note@#dr1518-Z {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const Z &' for 1st argument}}
+//   since-cxx11-note@#dr1518-Z {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'Z &&' for 1st argument}}
+//   since-cxx11-note@#dr1518-Z-int {{explicit constructor is not a candidate}}
 Z a3 = Z(1);
 Z a2(1);
 Z *p = new Z(1);
 Z a4 = (Z)1;
 Z a5 = static_cast<Z>(1);
-Z a6 = {4, 3}; // expected-error {{explicit in copy-initialization}}
+Z a6 = {4, 3};
+// since-cxx11-error@-1 {{chosen constructor is explicit in copy-initialization}}
+//   since-cxx11-note@#dr1518-Z-int-int {{explicit constructor declared here}}
 
-struct UserProvidedBaseCtor { // expected-note 0+ {{candidate}}
+struct UserProvidedBaseCtor { // #dr1518-U
   UserProvidedBaseCtor() {}
 };
-struct DoesntInheritCtor : UserProvidedBaseCtor { // expected-note 0+ {{candidate}}
+struct DoesntInheritCtor : UserProvidedBaseCtor { // #dr1518-D-U
   int x;
 };
 DoesntInheritCtor I{{}, 42};
-#if __cplusplus <= 201402L
-// expected-error@-2 {{no matching constructor}}
-#endif
+// cxx11-14-error@-1 {{no matching constructor for initialization of 'DoesntInheritCtor'}}
+//   cxx11-14-note@#dr1518-D-U {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided}}
+//   cxx11-14-note@#dr1518-D-U {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided}}
+//   cxx11-14-note@#dr1518-D-U {{candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided}}
 
-struct BaseCtor { BaseCtor() = default; }; // expected-note 0+ {{candidate}}
-struct InheritsCtor : BaseCtor { // expected-note 1+ {{candidate}}
-  using BaseCtor::BaseCtor;      // expected-note 2 {{inherited here}}
+struct BaseCtor { BaseCtor() = default; }; // #dr1518-BC
+struct InheritsCtor : BaseCtor { // #dr1518-I
+  using BaseCtor::BaseCtor;      // #dr1518-I-using
   int x;
 };
-InheritsCtor II = {{}, 42}; // expected-error {{no matching constructor}}
+InheritsCtor II = {{}, 42};
+// since-cxx11-error@-1 {{no matching constructor for initialization of 'InheritsCtor'}}
+//   since-cxx11-note@#dr1518-BC {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided}}
+//   since-cxx11-note@#dr1518-I-using {{constructor from base class 'BaseCtor' inherited here}}
+//   since-cxx11-note@#dr1518-BC {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided}}
+//   since-cxx11-note@#dr1518-I-using {{constructor from base class 'BaseCtor' inherited here}}
+//   since-cxx11-note@#dr1518-I {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided}}
+//   since-cxx11-note@#dr1518-I {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided}}
+//   since-cxx11-note@#dr1518-I {{candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided}}
 
 namespace std_example {
   struct A {
-    explicit A() = default; // expected-note 2{{declared here}}
+    explicit A() = default; // #dr1518-A
   };
 
   struct B : A {
-    explicit B() = default; // expected-note 2{{declared here}}
+    explicit B() = default; // #dr1518-B
   };
 
   struct C {
-    explicit C(); // expected-note 2{{declared here}}
+    explicit C(); // #dr1518-C
   };
 
   struct D : A {
     C c;
-    explicit D() = default; // expected-note 2{{declared here}}
+    explicit D() = default; // #dr1518-D
   };
 
   template <typename T> void f() {
     T t; // ok
     T u{}; // ok
-    T v = {}; // expected-error 4{{explicit}}
+    T v = {}; // #dr1518-v
+    // since-cxx11-error@#dr1518-v {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-f-A {{in instantiation of function template specialization 'dr1518::std_example::f<dr1518::std_example::A>' requested here}}
+    //   since-cxx11-note@#dr1518-A {{explicit constructor declared here}}
+    // since-cxx11-error@#dr1518-v {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-f-B {{in instantiation of function template specialization 'dr1518::std_example::f<dr1518::std_example::B>' requested here}}
+    //   since-cxx11-note@#dr1518-B {{explicit constructor declared here}}
+    // since-cxx11-error@#dr1518-v {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-f-C {{in instantiation of function template specialization 'dr1518::std_example::f<dr1518::std_example::C>' requested here}}
+    //   since-cxx11-note@#dr1518-C {{explicit constructor declared here}}
+    // since-cxx11-error@#dr1518-v {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-f-D {{in instantiation of function template specialization 'dr1518::std_example::f<dr1518::std_example::D>' requested here}}
+    //   since-cxx11-note@#dr1518-D {{explicit constructor declared here}}
   }
   template <typename T> void g() {
-    void x(T t); // expected-note 4{{parameter}}
-    x({}); // expected-error 4{{explicit}}
+    void x(T t); // #dr1518-x
+    x({}); // #dr1518-x-call
+    // since-cxx11-error@#dr1518-x-call {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-g-A {{in instantiation of function template specialization 'dr1518::std_example::g<dr1518::std_example::A>' requested here}}
+    //   since-cxx11-note@#dr1518-A {{explicit constructor declared here}}
+    //   since-cxx11-note@#dr1518-x {{passing argument to parameter 't' here}}
+    // since-cxx11-error@#dr1518-x-call {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-g-B {{in instantiation of function template specialization 'dr1518::std_example::g<dr1518::std_example::B>' requested here}}
+    //   since-cxx11-note@#dr1518-B {{explicit constructor declared here}}
+    //   since-cxx11-note@#dr1518-x {{passing argument to parameter 't' here}}
+    // since-cxx11-error@#dr1518-x-call {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-g-C {{in instantiation of function template specialization 'dr1518::std_example::g<dr1518::std_example::C>' requested here}}
+    //   since-cxx11-note@#dr1518-C {{explicit constructor declared here}}
+    //   since-cxx11-note@#dr1518-x {{passing argument to parameter 't' here}}
+    // since-cxx11-error@#dr1518-x-call {{chosen constructor is explicit in copy-initialization}}
+    //   since-cxx11-note@#dr1518-g-D {{in instantiation of function template specialization 'dr1518::std_example::g<dr1518::std_example::D>' requested here}}
+    //   since-cxx11-note@#dr1518-D {{explicit constructor declared here}}
+    //   since-cxx11-note@#dr1518-x {{passing argument to parameter 't' here}}
   }
 
   void test() {
-    f<A>(); // expected-note {{instantiation of}}
-    f<B>(); // expected-note {{instantiation of}}
-    f<C>(); // expected-note {{instantiation of}}
-    f<D>(); // expected-note {{instantiation of}}
-    g<A>(); // expected-note {{instantiation of}}
-    g<B>(); // expected-note {{instantiation of}}
-    g<C>(); // expected-note {{instantiation of}}
-    g<D>(); // expected-note {{instantiation of}}
+    f<A>(); // #dr1518-f-A
+    f<B>(); // #dr1518-f-B
+    f<C>(); // #dr1518-f-C
+    f<D>(); // #dr1518-f-D
+    g<A>(); // #dr1518-g-A
+    g<B>(); // #dr1518-g-B
+    g<C>(); // #dr1518-g-C
+    g<D>(); // #dr1518-g-D
   }
 }
-#endif                      // __cplusplus >= 201103L
+#endif // __cplusplus >= 201103L
 }
 
 namespace dr1550 { // dr1550: 3.4
@@ -242,13 +327,16 @@ namespace dr1550 { // dr1550: 3.4
 namespace dr1558 { // dr1558: 12
 #if __cplusplus >= 201103L
   template<class T, class...> using first_of = T;
-  template<class T> first_of<void, typename T::type> f(int); // expected-note {{'int' cannot be used prior to '::'}}
-  template<class T> void f(...) = delete; // expected-note {{deleted}}
+  template<class T> first_of<void, typename T::type> f(int); // #dr1558-f 
+  template<class T> void f(...) = delete; // #dr1558-f-deleted
 
   struct X { typedef void type; };
   void test() {
     f<X>(0);
-    f<int>(0); // expected-error {{deleted}}
+    f<int>(0);
+    // since-cxx11-error@-1 {{call to deleted function 'f'}}
+    //   since-cxx11-note@#dr1558-f-deleted {{candidate function [with T = int] has been explicitly deleted}}
+    //   since-cxx11-note@#dr1558-f {{candidate template ignored: substitution failure [with T = int]: type 'int' cannot be used prior to '::' because it has no members}}
   }
 #endif
 }
@@ -283,17 +371,25 @@ namespace dr1573 { // dr1573: 3.9
   struct C { C(); constexpr C(int) {} };
   struct D : C { using C::C; };
   constexpr D d = D(0); // ok
-  struct E : C { using C::C; A a; }; // expected-note {{non-literal type}}
-  constexpr E e = E(0); // expected-error {{non-literal type}}
+  struct E : C { using C::C; A a; }; // #dr1573-E
+  constexpr E e = E(0);
+  // since-cxx11-error@-1 {{constexpr variable cannot have non-literal type 'const E'}}
+  //   since-cxx11-note@#dr1573-E {{'E' is not literal because it has data member 'a' of non-literal type 'A'}}
+
   // FIXME: This diagnostic is pretty bad; we should explain that the problem
   // is that F::c would be initialized by a non-constexpr constructor.
-  struct F : C { using C::C; C c; }; // expected-note {{here}}
-  constexpr F f = F(0); // expected-error {{constant expression}} expected-note {{constructor inherited from base class 'C'}}
+  struct F : C { using C::C; C c; }; // #dr1573-F
+  constexpr F f = F(0);
+  // since-cxx11-error@-1 {{constexpr variable 'f' must be initialized by a constant expression}}
+  //   since-cxx11-note@-2 {{constructor inherited from base class 'C' cannot be used in a constant expression; derived class cannot be implicitly initialized}}
+  //   since-cxx11-note@#dr1573-F {{declared here}}
 
   // inherited constructor is effectively deleted if the user-written constructor would be
   struct G { G(int); };
-  struct H : G { using G::G; G g; }; // expected-note {{constructor inherited by 'H' is implicitly deleted because field 'g' has no default constructor}}
-  H h(0); // expected-error {{constructor inherited by 'H' from base class 'G' is implicitly deleted}}
+  struct H : G { using G::G; G g; }; // #dr1573-H
+  H h(0);
+  // since-cxx11-error@-1 {{constructor inherited by 'H' from base class 'G' is implicitly deleted}}
+  //   since-cxx11-note@#dr1573-H {{constructor inherited by 'H' is implicitly deleted because field 'g' has no default constructor}}
 #endif
 }
 
@@ -336,13 +432,15 @@ namespace std {
   typedef basic_string<char> string;
 
 } // std
+#endif
 
 namespace dr1579 { // dr1579: 3.9
+#if __cplusplus >= 201103L
 template<class T>
 struct GenericMoveOnly {
   GenericMoveOnly();
-  template<class U> GenericMoveOnly(const GenericMoveOnly<U> &) = delete; // expected-note 5 {{marked deleted here}}
-  GenericMoveOnly(const int &) = delete; // expected-note 2 {{marked deleted here}}
+  template<class U> GenericMoveOnly(const GenericMoveOnly<U> &) = delete; // #dr1579-deleted-U
+  GenericMoveOnly(const int &) = delete; // #dr1579-deleted-int
   template<class U> GenericMoveOnly(GenericMoveOnly<U> &&);
   GenericMoveOnly(int &&);
 };
@@ -369,17 +467,29 @@ GenericMoveOnly<float> DR1579_Ineligible(int &AnInt,
   extern GenericMoveOnly<char> ExternMove;
 
   if (0)
-    return AnInt; // expected-error{{invokes a deleted function}}
+    return AnInt;
+    // since-cxx11-error@-1 {{conversion function from 'int' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-int {{'GenericMoveOnly' has been explicitly marked deleted here}}
   else if (0)
-    return GlobalMO; // expected-error{{invokes a deleted function}}
+    return GlobalMO;
+    // since-cxx11-error@-1 {{conversion function from 'GenericMoveOnly<char>' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-U {{'GenericMoveOnly<char>' has been explicitly marked deleted here}}
   else if (0)
-    return StaticMove; // expected-error{{invokes a deleted function}}
+    return StaticMove;
+    // since-cxx11-error@-1 {{conversion function from 'GenericMoveOnly<char>' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-U {{'GenericMoveOnly<char>' has been explicitly marked deleted here}}
   else if (0)
-    return ExternMove; // expected-error{{invokes a deleted function}}
+    return ExternMove;
+    // since-cxx11-error@-1 {{conversion function from 'GenericMoveOnly<char>' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-U {{'GenericMoveOnly<char>' has been explicitly marked deleted here}}
   else if (0)
-    return AnInt; // expected-error{{invokes a deleted function}}
+    return AnInt;
+    // since-cxx11-error@-1 {{conversion function from 'int' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-int {{'GenericMoveOnly' has been explicitly marked deleted here}}
   else
-    return CharMO; // expected-error{{invokes a deleted function}}
+    return CharMO;
+    // since-cxx11-error@-1 {{conversion function from 'GenericMoveOnly<char>' to 'GenericMoveOnly<float>' invokes a deleted function}}
+    //   since-cxx11-note@#dr1579-deleted-U {{'GenericMoveOnly<char>' has been explicitly marked deleted here}}
 }
 
 auto DR1579_lambda_valid = [](GenericMoveOnly<float> mo) ->
@@ -389,24 +499,34 @@ auto DR1579_lambda_valid = [](GenericMoveOnly<float> mo) ->
 
 auto DR1579_lambda_invalid = []() -> GenericMoveOnly<char> {
   static GenericMoveOnly<float> mo;
-  return mo; // expected-error{{invokes a deleted function}}
+  return mo;
+  // since-cxx11-error@-1 {{conversion function from 'GenericMoveOnly<float>' to 'GenericMoveOnly<char>' invokes a deleted function}}
+  //   since-cxx11-note@#dr1579-deleted-U {{'GenericMoveOnly<float>' has been explicitly marked deleted here}}
 };
+#endif
 } // end namespace dr1579
 
 namespace dr1584 {
+#if __cplusplus >= 201103L
   // Deducing function types from cv-qualified types
-  template<typename T> void f(const T *); // expected-note {{candidate template ignored}}
+  template<typename T> void f(const T *); // #dr1584-f
   template<typename T> void g(T *, const T * = 0);
-  template<typename T> void h(T *) { T::error; } // expected-error {{no members}}
+  template<typename T> void h(T *) { T::error; }
+  // since-cxx11-error@-1 {{type 'void ()' cannot be used prior to '::' because it has no members}}
+  //   since-cxx11-note@#dr1584-h {{in instantiation of function template specialization 'dr1584::h<void ()>' requested here}}
   template<typename T> void h(const T *);
   void i() {
-    f(&i); // expected-error {{no matching function}}
+    f(&i);
+    // since-cxx11-error@-1 {{no matching function for call to 'f'}}
+    //   since-cxx11-note@#dr1584-f {{candidate template ignored: could not match 'const T *' against 'void (*)()'}}
     g(&i);
-    h(&i); // expected-note {{here}}
+    h(&i); // #dr1584-h
   }
+#endif
 }
 
 namespace dr1589 {   // dr1589: 3.7 c++11
+#if __cplusplus >= 201103L
   // Ambiguous ranking of list-initialization sequences
 
   void f0(long, int=0);                 // Would makes selection of #0 ambiguous
@@ -425,25 +545,35 @@ namespace dr1589 {   // dr1589: 3.7 c++11
   void g2() { f2({"foo","bar"}); }              // chooses #4
 
   namespace with_error {
-    void f0(long);                        // #0
-    void f0(std::initializer_list<int>);  // #00     expected-note {{candidate function}}
-    void f0(std::initializer_list<int>, int = 0); // expected-note {{candidate function}}
-    void g0() { f0({1L}); }                 // expected-error{{call to 'f0' is ambiguous}}
+    void f0(long);
+    void f0(std::initializer_list<int>);          // #dr1589-f0-ilist
+    void f0(std::initializer_list<int>, int = 0); // #dr1589-f0-ilist-int
+    void g0() { f0({1L}); }
+    // since-cxx11-error@-1 {{call to 'f0' is ambiguous}}
+    //   since-cxx11-note@#dr1589-f0-ilist {{candidate function}}
+    //   since-cxx11-note@#dr1589-f0-ilist-int {{candidate function}}
 
-    void f1(int);                           // #1
-    void f1(std::initializer_list<long>);   // #2     expected-note {{candidate function}}
-    void f1(std::initializer_list<long>, int = 0); // expected-note {{candidate function}}
-    void g1() { f1({42}); }                 // expected-error{{call to 'f1' is ambiguous}}
+    void f1(int);
+    void f1(std::initializer_list<long>);          // #dr1589-f1-ilist
+    void f1(std::initializer_list<long>, int = 0); // #dr1589-f1-ilist-long
+    void g1() { f1({42}); }
+    // since-cxx11-error@-1 {{call to 'f1' is ambiguous}}
+    //   since-cxx11-note@#dr1589-f1-ilist {{candidate function}}
+    //   since-cxx11-note@#dr1589-f1-ilist-long {{candidate function}}
 
-    void f2(std::pair<const char*, const char*>); // #3
-    void f2(std::initializer_list<std::string>);  // #4      expected-note {{candidate function}}
-    void f2(std::initializer_list<std::string>, int = 0); // expected-note {{candidate function}}
-    void g2() { f2({"foo","bar"}); }        // expected-error{{call to 'f2' is ambiguous}}
+    void f2(std::pair<const char*, const char*>);
+    void f2(std::initializer_list<std::string>);          // #dr1589-f2-ilist
+    void f2(std::initializer_list<std::string>, int = 0); // #dr1589-f2-ilist-int
+    void g2() { f2({"foo","bar"}); }
+    // since-cxx11-error@-1 {{call to 'f2' is ambiguous}}
+    //   since-cxx11-note@#dr1589-f2-ilist {{candidate function}}
+    //   since-cxx11-note@#dr1589-f2-ilist-int {{candidate function}}
   }
-
+#endif
 } // dr1589
 
-namespace dr1591 {  //dr1591. Deducing array bound and element type from initializer list 
+namespace dr1591 {  //dr1591. Deducing array bound and element type from initializer list
+#if __cplusplus >= 201103L
   template<class T, int N> int h(T const(&)[N]);
   int X = h({1,2,3});              // T deduced to int, N deduced to 3
   
@@ -451,8 +581,10 @@ namespace dr1591 {  //dr1591. Deducing array bound and element type from initial
   int Y = j({42});                 // T deduced to int, array bound not considered
 
   struct Aggr { int i; int j; };
-  template<int N> int k(Aggr const(&)[N]); //expected-note{{not viable}}
-  int Y0 = k({1,2,3});              //expected-error{{no matching function}}
+  template<int N> int k(Aggr const(&)[N]); // #dr1591-k
+  int Y0 = k({1,2,3});
+  // since-cxx11-error@-1 {{no matching function for call to 'k'}}
+  //   since-cxx11-note@#dr1591-k {{candidate function [with N = 3] not viable: no known conversion from 'int' to 'const Aggr' for 1st argument}}
   int Z = k({{1},{2},{3}});        // OK, N deduced to 3
 
   template<int M, int N> int m(int const(&)[M][N]);
@@ -463,54 +595,64 @@ namespace dr1591 {  //dr1591. Deducing array bound and element type from initial
   
   
   namespace check_multi_dim_arrays {
-    template<class T, int N, int M, int O> int ***f(const T (&a)[N][M][O]); //expected-note{{deduced conflicting values}}
-    template<class T, int N, int M> int **f(const T (&a)[N][M]); //expected-note{{couldn't infer}}
+    template<class T, int N, int M, int O> int ***f(const T (&a)[N][M][O]); // #dr1591-f-3
+    template<class T, int N, int M> int **f(const T (&a)[N][M]); // #dr1591-f-2
    
-   template<class T, int N> int *f(const T (&a)[N]); //expected-note{{couldn't infer}}
+   template<class T, int N> int *f(const T (&a)[N]); // #dr1591-f-1
     int ***p3 = f({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12}  } });
-    int ***p33 = f({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12, 13}  } }); //expected-error{{no matching}}
+    int ***p33 = f({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12, 13}  } });
+    // since-cxx11-error@-1 {{no matching function for call to 'f'}}
+    //   since-cxx11-note@#dr1591-f-2 {{candidate template ignored: couldn't infer template argument 'T'}}
+    //   since-cxx11-note@#dr1591-f-1 {{candidate template ignored: couldn't infer template argument 'T'}}
+    //   since-cxx11-note@#dr1591-f-3 {{candidate template ignored: deduced conflicting values for parameter 'O' (2 vs. 3)}}
     int **p2 = f({  {1,2,3}, {3, 4, 5}  });
     int **p22 = f({  {1,2}, {3, 4}  });
     int *p1 = f({1, 2, 3});
   }
   namespace check_multi_dim_arrays_rref {
-    template<class T, int N, int M, int O> int ***f(T (&&a)[N][M][O]); //expected-note{{deduced conflicting values}}
-    template<class T, int N, int M> int **f(T (&&a)[N][M]); //expected-note{{couldn't infer}}
+    template<class T, int N, int M, int O> int ***g(T (&&a)[N][M][O]); // #dr1591-g-3
+    template<class T, int N, int M> int **g(T (&&a)[N][M]); // #dr1591-g-2
    
-    template<class T, int N> int *f(T (&&a)[N]); //expected-note{{couldn't infer}}
-    int ***p3 = f({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12}  } });
-    int ***p33 = f({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12, 13}  } }); //expected-error{{no matching}}
-    int **p2 = f({  {1,2,3}, {3, 4, 5}  });
-    int **p22 = f({  {1,2}, {3, 4}  });
-    int *p1 = f({1, 2, 3});
+    template<class T, int N> int *g(T (&&a)[N]); // #dr1591-g-1
+    int ***p3 = g({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12}  } });
+    int ***p33 = g({  {  {1,2}, {3, 4}  }, {  {5,6}, {7, 8}  }, {  {9,10}, {11, 12, 13}  } });
+    // since-cxx11-error@-1 {{no matching function for call to 'g'}}
+    //   since-cxx11-note@#dr1591-g-2 {{candidate template ignored: couldn't infer template argument 'T'}}
+    //   since-cxx11-note@#dr1591-g-1 {{candidate template ignored: couldn't infer template argument 'T'}}
+    //   since-cxx11-note@#dr1591-g-3 {{candidate template ignored: deduced conflicting values for parameter 'O' (2 vs. 3)}}
+    int **p2 = g({  {1,2,3}, {3, 4, 5}  });
+    int **p22 = g({  {1,2}, {3, 4}  });
+    int *p1 = g({1, 2, 3});
   }
   
   namespace check_arrays_of_init_list {
-    template<class T, int N> float *f(const std::initializer_list<T> (&)[N]);
-    template<class T, int N> double *f(const T(&)[N]);
-    double *p = f({1, 2, 3});
-    float *fp = f({{1}, {1, 2}, {1, 2, 3}});
+    template<class T, int N> float *h(const std::initializer_list<T> (&)[N]);
+    template<class T, int N> double *h(const T(&)[N]);
+    double *p = h({1, 2, 3});
+    float *fp = h({{1}, {1, 2}, {1, 2, 3}});
   }
   namespace core_reflector_28543 {
     
-    template<class T, int N> int *f(T (&&)[N]);  // #1
-    template<class T> char *f(std::initializer_list<T> &&);  //#2
-    template<class T, int N, int M> int **f(T (&&)[N][M]); //#3 expected-note{{candidate}}
-    template<class T, int N> char **f(std::initializer_list<T> (&&)[N]); //#4 expected-note{{candidate}}
+    template<class T, int N> int *i(T (&&)[N]);  // #1
+    template<class T> char *i(std::initializer_list<T> &&);  // #2
+    template<class T, int N, int M> int **i(T (&&)[N][M]); // #3 #dr1591-i-2
+    template<class T, int N> char **i(std::initializer_list<T> (&&)[N]); // #4 #dr1591-i-1
 
-    template<class T> short *f(T (&&)[2]);  //#5
+    template<class T> short *i(T (&&)[2]);  // #5
 
     template<class T> using Arr = T[];
      
-    char *pc = f({1, 2, 3}); // OK prefer #2 via 13.3.3.2 [over.ics.rank]
-    char *pc2 = f({1, 2}); // #2 also 
-    int *pi = f(Arr<int>{1, 2, 3}); // OK prefer #1
+    char *pc = i({1, 2, 3}); // OK prefer #2 via 13.3.3.2 [over.ics.rank]
+    char *pc2 = i({1, 2}); // #2 also 
+    int *pi = i(Arr<int>{1, 2, 3}); // OK prefer #1
 
-    void *pv1 = f({ {1, 2, 3}, {4, 5, 6} }); // expected-error{{ambiguous}} btw 3 & 4
-    char **pcc = f({ {1}, {2, 3} }); // OK #4
+    void *pv1 = i({ {1, 2, 3}, {4, 5, 6} }); // ambiguous btw 3 & 4
+    // since-cxx11-error@-1 {{call to 'i' is ambiguous}} 
+    //   since-cxx11-note@#dr1591-i-2 {{candidate function [with T = int, N = 2, M = 3]}}
+    //   since-cxx11-note@#dr1591-i-1 {{candidate function [with T = int, N = 2]}}
+    char **pcc = i({ {1}, {2, 3} }); // OK #4
 
-    short *ps = f(Arr<int>{1, 2});  // OK #5
+    short *ps = i(Arr<int>{1, 2});  // OK #5
   }
-} // dr1591
-
 #endif
+} // dr1591

--- a/clang/test/CXX/drs/dr16xx.cpp
+++ b/clang/test/CXX/drs/dr16xx.cpp
@@ -1,12 +1,14 @@
-// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++2a -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify=expected,cxx98-14,cxx98 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify=expected,cxx98-14,since-cxx11,cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx14,cxx98-14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx14,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify=expected,since-cxx14,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
-#if __cplusplus < 201103L
-// expected-error@+1 {{variadic macro}}
+#if __cplusplus == 199711L
 #define static_assert(...) __extension__ _Static_assert(__VA_ARGS__)
+// cxx98-error@-1 {{variadic macros are a C99 feature}}
 #endif
 
 #if __cplusplus >= 201103L
@@ -25,9 +27,7 @@ namespace std {
 
 namespace dr1601 { // dr1601: 10
 enum E : char { e };
-#if __cplusplus < 201103L
-    // expected-error@-2 {{enumeration types with a fixed underlying type are a C++11 extension}}
-#endif
+// cxx98-error@-1 {{enumeration types with a fixed underlying type are a C++11 extension}}
 void f(char);
 void f(int);
 void g() {
@@ -53,16 +53,20 @@ namespace dr1631 {  // dr1631: 3.7
   void f(int, A);
 
   void test() {
-    f({0}, {{1}}); // expected-warning {{braces around scalar init}}
+    f({0}, {{1}});
+    // since-cxx11-warning@-1 {{braces around scalar initializer}}
   }
 
   namespace with_error {
     void f(B, int);           // TODO: expected- note {{candidate function}}
-    void f(int, A);           // expected-note {{candidate function}}
-    void f(int, A, int = 0);  // expected-note {{candidate function}}
+    void f(int, A);           // #dr1631-f
+    void f(int, A, int = 0);  // #dr1631-f-int
     
     void test() {
-      f({0}, {{1}});        // expected-error{{call to 'f' is ambiguous}}
+      f({0}, {{1}});
+      // since-cxx11-error@-1 {{call to 'f' is ambiguous}}
+      //   since-cxx11-note@#dr1631-f {{candidate function}}
+      //   since-cxx11-note@#dr1631-f-int {{candidate function}}
     }
   }
 #endif
@@ -71,8 +75,8 @@ namespace dr1631 {  // dr1631: 3.7
 namespace dr1638 { // dr1638: 3.1
 #if __cplusplus >= 201103L
   template<typename T> struct A {
-    enum class E; // expected-note {{previous}}
-    enum class F : T; // expected-note 2{{previous}}
+    enum class E; // #dr1638-E
+    enum class F : T; // #dr1638-F
   };
 
   template<> enum class A<int>::E;
@@ -83,16 +87,27 @@ namespace dr1638 { // dr1638: 3.1
   template<> enum class A<short>::E : int;
   template<> enum class A<short>::E : int {};
 
-  template<> enum class A<short>::F; // expected-error {{different underlying type}}
-  template<> enum class A<char>::E : char; // expected-error {{different underlying type}}
-  template<> enum class A<char>::F : int; // expected-error {{different underlying type}}
+  template<> enum class A<short>::F;
+  // since-cxx11-error@-1 {{enumeration redeclared with different underlying type 'int' (was 'short')}}
+  //   since-cxx11-note@#dr1638-F {{previous declaration is here}}
+  template<> enum class A<char>::E : char;
+  // since-cxx11-error@-1 {{enumeration redeclared with different underlying type 'char' (was 'int')}}
+  //   since-cxx11-note@#dr1638-E {{previous declaration is here}}
+  template<> enum class A<char>::F : int;
+  // since-cxx11-error@-1 {{enumeration redeclared with different underlying type 'int' (was 'char')}}
+  //   since-cxx11-note@#dr1638-F {{previous declaration is here}}
 
-  enum class A<unsigned>::E; // expected-error {{template specialization requires 'template<>'}} expected-error {{nested name specifier}}
-  template enum class A<unsigned>::E; // expected-error {{enumerations cannot be explicitly instantiated}}
-  enum class A<unsigned>::E *e; // expected-error {{must use 'enum' not 'enum class'}}
+  enum class A<unsigned>::E;
+  // since-cxx11-error@-1 {{template specialization requires 'template<>'}}
+  // since-cxx11-error@-2 {{forward declaration of enum class cannot have a nested name specifier}}
+  template enum class A<unsigned>::E;
+  // since-cxx11-error@-1 {{enumerations cannot be explicitly instantiated}}
+  enum class A<unsigned>::E *e;
+  // since-cxx11-error@-1 {{reference to enumeration must use 'enum' not 'enum class'}}
 
   struct B {
-    friend enum class A<unsigned>::E; // expected-error {{must use 'enum' not 'enum class'}}
+    friend enum class A<unsigned>::E;
+    // since-cxx11-error@-1 {{reference to enumeration must use 'enum' not 'enum class'}}
   };
 #endif
 }
@@ -100,37 +115,50 @@ namespace dr1638 { // dr1638: 3.1
 namespace dr1645 { // dr1645: 3.9
 #if __cplusplus >= 201103L
   struct A {
-    constexpr A(int, float = 0); // expected-note {{candidate}}
-    explicit A(int, int = 0); // expected-note 2{{candidate}}
-    A(int, int, int = 0) = delete; // expected-note {{candidate}}
+    constexpr A(int, float = 0); // #dr1645-int-float
+    explicit A(int, int = 0); // #dr1645-int-int
+    A(int, int, int = 0) = delete; // #dr1645-int-int-int
   };
 
   struct B : A {
-    using A::A; // expected-note 4{{inherited here}}
+    using A::A; // #dr1645-using
   };
 
-  constexpr B a(0); // expected-error {{ambiguous}}
-  constexpr B b(0, 0); // expected-error {{ambiguous}}
+  constexpr B a(0);
+  // since-cxx11-error@-1 {{call to constructor of 'const B' is ambiguous}}
+  //   since-cxx11-note@#dr1645-int-float {{candidate inherited constructor}}
+  //   since-cxx11-note@#dr1645-using {{constructor from base class 'A' inherited here}}
+  //   since-cxx11-note@#dr1645-int-int {{candidate inherited constructor}}
+  //   since-cxx11-note@#dr1645-using {{constructor from base class 'A' inherited here}}
+  constexpr B b(0, 0);
+  // since-cxx11-error@-1 {{call to constructor of 'const B' is ambiguous}}
+  //   since-cxx11-note@#dr1645-int-int {{candidate inherited constructor}}
+  //   since-cxx11-note@#dr1645-using {{constructor from base class 'A' inherited here}}
+  //   since-cxx11-note@#dr1645-int-int-int {{candidate inherited constructor has been explicitly deleted}}
+  //   since-cxx11-note@#dr1645-using {{constructor from base class 'A' inherited here}}
 #endif
 }
 
 namespace dr1652 { // dr1652: 3.6
   int a, b;
-  int arr[&a + 1 == &b ? 1 : 2]; // expected-error 2{{variable length array}}
-                                 // expected-note@-1 {{points past the end}}
+  int arr[&a + 1 == &b ? 1 : 2];
+  // expected-error@-1 {{variable length arrays in C++ are a Clang extension}}
+  //   expected-note@-2 {{comparison against pointer '&a + 1' that points past the end of a complete object has unspecified value}}
+  // expected-error@-3 {{variable length array declaration not allowed at file scope}}
 }
 
 namespace dr1653 { // dr1653: 4 c++17
   void f(bool b) {
     ++b;
+    // cxx98-14-warning@-1 {{incrementing expression of type bool is deprecated and incompatible with C++17}}
+    // since-cxx17-error@-2 {{SO C++17 does not allow incrementing expression of type bool}}
     b++;
-#if __cplusplus <= 201402L
-    // expected-warning@-3 {{deprecated}} expected-warning@-2 {{deprecated}}
-#else
-    // expected-error@-5 {{incrementing expression of type bool}} expected-error@-4 {{incrementing expression of type bool}}
-#endif
-    --b; // expected-error {{cannot decrement expression of type bool}}
-    b--; // expected-error {{cannot decrement expression of type bool}}
+    // cxx98-14-warning@-1 {{incrementing expression of type bool is deprecated and incompatible with C++17}}
+    // since-cxx17-error@-2 {{SO C++17 does not allow incrementing expression of type bool}}
+    --b;
+    // expected-error@-1 {{cannot decrement expression of type bool}}
+    b--;
+    // expected-error@-1 {{cannot decrement expression of type bool}}
     b += 1; // ok
     b -= 1; // ok
   }
@@ -138,71 +166,88 @@ namespace dr1653 { // dr1653: 4 c++17
 
 namespace dr1658 { // dr1658: 5
   namespace DefCtor {
-    class A { A(); }; // expected-note 0-2{{here}}
-    class B { ~B(); }; // expected-note 0-2{{here}}
+    class A { A(); }; // #dr1658-A1
+    class B { ~B(); }; // #dr1658-B1
 
     // The stars align! An abstract class does not construct its virtual bases.
     struct C : virtual A { C(); virtual void foo() = 0; };
-    C::C() = default; // ok, not deleted, expected-error 0-1{{extension}}
+    C::C() = default; // ok, not deleted
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
     struct D : virtual B { D(); virtual void foo() = 0; };
-    D::D() = default; // ok, not deleted, expected-error 0-1{{extension}}
+    D::D() = default; // ok, not deleted
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
 
     // In all other cases, we are not so lucky.
-    struct E : A { E(); virtual void foo() = 0; };
-#if __cplusplus < 201103L
-    E::E() = default; // expected-error {{private default constructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    E::E() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible default constructor}}
-#endif
-    struct F : virtual A { F(); };
-#if __cplusplus < 201103L
-    F::F() = default; // expected-error {{private default constructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    F::F() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible default constructor}}
-#endif
+    struct E : A { E(); virtual void foo() = 0; }; // #dr1658-E1
+    E::E() = default; // #dr1658-E1-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}} 
+    // cxx98-error@-2 {{base class 'A' has private default constructor}}
+    //   cxx98-note@-3 {{in defaulted default constructor for 'dr1658::DefCtor::E' first required here}}
+    //   cxx98-note@#dr1658-A1 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-E1-ctor {{defaulting this default constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-E1 {{default constructor of 'E' is implicitly deleted because base class 'A' has an inaccessible default constructor}}
+    struct F : virtual A { F(); }; // #dr1658-F1
+    F::F() = default; // #dr1658-F1-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@-2 {{inherited virtual base class 'A' has private default constructor}} 
+    //   cxx98-note@-3 {{in defaulted default constructor for 'dr1658::DefCtor::F' first required here}}
+    //   cxx98-note@#dr1658-A1 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-F1-ctor {{defaulting this default constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-F1 {{default constructor of 'F' is implicitly deleted because base class 'A' has an inaccessible default constructor}}
 
-    struct G : B { G(); virtual void foo() = 0; };
-#if __cplusplus < 201103L
-    G::G() = default; // expected-error@-2 {{private destructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    G::G() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible destructor}}
-#endif
-    struct H : virtual B { H(); };
-#if __cplusplus < 201103L
-    H::H() = default; // expected-error@-2 {{private destructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    H::H() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible destructor}}
-#endif
+    struct G : B { G(); virtual void foo() = 0; }; // #dr1658-G1
+    G::G() = default; // #dr1658-G1-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@#dr1658-G1 {{base class 'B' has private destructor}}
+    //   cxx98-note@#dr1658-G1-ctor {{in defaulted default constructor for 'dr1658::DefCtor::G' first required here}}
+    //   cxx98-note@#dr1658-B1 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-G1-ctor {{defaulting this default constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-G1 {{default constructor of 'G' is implicitly deleted because base class 'B' has an inaccessible destructor}}
+    struct H : virtual B { H(); }; // #dr1658-H1
+    H::H() = default; // #dr1658-H1-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@#dr1658-H1 {{base class 'B' has private destructor}}
+    //   cxx98-note@#dr1658-H1-ctor {{in defaulted default constructor for 'dr1658::DefCtor::H' first required here}}
+    //   cxx98-note@#dr1658-B1 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-H1-ctor {{defaulting this default constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-H1 {{default constructor of 'H' is implicitly deleted because base class 'B' has an inaccessible destructor}}
   }
 
   namespace Dtor {
-    class B { ~B(); }; // expected-note 0-2{{here}}
+    class B { ~B(); }; // #dr1658-B2
 
     struct D : virtual B { ~D(); virtual void foo() = 0; };
-    D::~D() = default; // ok, not deleted, expected-error 0-1{{extension}}
+    D::~D() = default; // ok, not deleted
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
 
-    struct G : B { ~G(); virtual void foo() = 0; };
-#if __cplusplus < 201103L
-    G::~G() = default; // expected-error@-2 {{private destructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    G::~G() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible destructor}}
-#endif
-    struct H : virtual B { ~H(); };
-#if __cplusplus < 201103L
-    H::~H() = default; // expected-error@-2 {{private destructor}} expected-error {{extension}} expected-note {{here}}
-#else
-    H::~H() = default; // expected-error {{would delete}} expected-note@-4{{inaccessible destructor}}
-#endif
+    struct G : B { ~G(); virtual void foo() = 0; }; // #dr1658-G2
+    G::~G() = default; // #dr1658-G2-dtor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@#dr1658-G2 {{base class 'B' has private destructor}}
+    //   cxx98-note@#dr1658-G2-dtor {{in defaulted destructor for 'dr1658::Dtor::G' first required here}}
+    //   cxx98-note@#dr1658-B2 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-G2-dtor {{defaulting this destructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-G2 {{destructor of 'G' is implicitly deleted because base class 'B' has an inaccessible destructor}}
+    struct H : virtual B { ~H(); }; // #dr1658-H2
+    H::~H() = default; // #dr1658-H2-dtor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@#dr1658-H2 {{base class 'B' has private destructor}}
+    //   cxx98-note@#dr1658-H2-dtor {{in defaulted destructor for 'dr1658::Dtor::H' first required here}}
+    //   cxx98-note@#dr1658-B2 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-H2-dtor {{defaulting this destructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-H2 {{destructor of 'H' is implicitly deleted because base class 'B' has an inaccessible destructor}}
   }
 
   namespace MemInit {
-    struct A { A(int); }; // expected-note {{here}}
+    struct A { A(int); }; // #dr1658-A3
     struct B : virtual A {
       B() {}
       virtual void f() = 0;
     };
     struct C : virtual A {
-      C() {} // expected-error {{must explicitly initialize}}
+      C() {}
+      // expected-error@-1 {{constructor for 'dr1658::MemInit::C' must explicitly initialize the base class 'A' which does not have a default constructor}}
+      //   expected-note@#dr1658-A3 {{'dr1658::MemInit::A' declared here}}
     };
   }
 
@@ -220,28 +265,51 @@ namespace dr1658 { // dr1658: 5
   }
 
   namespace CopyCtor {
-    class A { A(const A&); A(A&&); }; // expected-note 0-4{{here}} expected-error 0-1{{extension}}
+    class A { A(const A&); A(A&&); }; // #dr1658-A5
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
 
-    struct C : virtual A { C(const C&); C(C&&); virtual void foo() = 0; }; // expected-error 0-1{{extension}}
-    C::C(const C&) = default; // expected-error 0-1{{extension}}
-    C::C(C&&) = default; // expected-error 0-2{{extension}}
+    struct C : virtual A { C(const C&); C(C&&); virtual void foo() = 0; };
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    C::C(const C&) = default;
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    C::C(C&&) = default;
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    // cxx98-error@-2 {{defaulted function definitions are a C++11 extension}}
 
-    struct E : A { E(const E&); E(E&&); virtual void foo() = 0; }; // expected-error 0-1{{extension}}
-#if __cplusplus < 201103L
-    E::E(const E&) = default; // expected-error {{private copy constructor}} expected-error {{extension}} expected-note {{here}}
-    E::E(E&&) = default; // expected-error {{private move constructor}} expected-error 2{{extension}} expected-note {{here}}
-#else
-    E::E(const E&) = default; // expected-error {{would delete}} expected-note@-5{{inaccessible copy constructor}}
-    E::E(E&&) = default; // expected-error {{would delete}} expected-note@-6{{inaccessible move constructor}}
-#endif
-    struct F : virtual A { F(const F&); F(F&&); }; // expected-error 0-1{{extension}}
-#if __cplusplus < 201103L
-    F::F(const F&) = default; // expected-error {{private copy constructor}} expected-error {{extension}} expected-note {{here}}
-    F::F(F&&) = default; // expected-error {{private move constructor}} expected-error 2{{extension}} expected-note {{here}}
-#else
-    F::F(const F&) = default; // expected-error {{would delete}} expected-note@-5{{inaccessible copy constructor}}
-    F::F(F&&) = default; // expected-error {{would delete}} expected-note@-6{{inaccessible move constructor}}
-#endif
+    struct E : A { E(const E&); E(E&&); virtual void foo() = 0; }; // #dr1658-E5
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    E::E(const E&) = default; // #dr1658-E5-copy-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@-2 {{base class 'A' has private copy constructor}}
+    //   cxx98-note@-3 {{in defaulted copy constructor for 'dr1658::CopyCtor::E' first required here}}
+    //   cxx98-note@#dr1658-A5 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-E5-copy-ctor {{defaulting this copy constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-E5 {{copy constructor of 'E' is implicitly deleted because base class 'A' has an inaccessible copy constructor}}
+    E::E(E&&) = default; // #dr1658-E5-move-ctor
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    // cxx98-error@-2 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@-3 {{base class 'A' has private move constructor}}
+    //   cxx98-note@-4 {{in defaulted move constructor for 'dr1658::CopyCtor::E' first required here}}
+    //   cxx98-note@#dr1658-A5 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-E5-move-ctor {{defaulting this move constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-E5 {{move constructor of 'E' is implicitly deleted because base class 'A' has an inaccessible move constructor}}
+    struct F : virtual A { F(const F&); F(F&&); }; // #dr1658-F5
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    F::F(const F&) = default; // #dr1658-F5-copy-ctor
+    // cxx98-error@-1 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@-2 {{inherited virtual base class 'A' has private copy constructor}}
+    //   cxx98-note@-3 {{in defaulted copy constructor for 'dr1658::CopyCtor::F' first required here}}
+    //   cxx98-note@#dr1658-A5 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-F5-copy-ctor {{defaulting this copy constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-F5 {{copy constructor of 'F' is implicitly deleted because base class 'A' has an inaccessible copy constructor}}
+    F::F(F&&) = default; // #dr1658-F5-move-ctor
+    // cxx98-error@-1 {{rvalue references are a C++11 extension}}
+    // cxx98-error@-2 {{defaulted function definitions are a C++11 extension}}
+    // cxx98-error@-3 {{inherited virtual base class 'A' has private move constructor}}
+    //   cxx98-note@-4 {{in defaulted move constructor for 'dr1658::CopyCtor::F' first required here}}
+    //   cxx98-note@#dr1658-A5 {{implicitly declared private here}}
+    // since-cxx11-error@#dr1658-F5-move-ctor {{defaulting this move constructor would delete it after its first declaration}}
+    //   since-cxx11-note@#dr1658-F5 {{move constructor of 'F' is implicitly deleted because base class 'A' has an inaccessible move constructor}}
   }
 
   // assignment case is superseded by dr2180
@@ -274,31 +342,38 @@ namespace dr1672 { // dr1672: 7
 
 namespace dr1684 { // dr1684: 3.6
 #if __cplusplus >= 201103L
-  struct NonLiteral { // expected-note {{because}}
+  struct NonLiteral { // #dr1684-struct
     NonLiteral();
-    constexpr int f() { return 0; } // expected-warning 0-1{{will not be implicitly 'const'}}
+    constexpr int f() { return 0; }
+    // cxx11-warning@-1 {{'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior}}
   };
   constexpr int f(NonLiteral &) { return 0; }
-  constexpr int f(NonLiteral) { return 0; } // expected-error {{not a literal type}}
+  constexpr int f(NonLiteral) { return 0; }
+  // since-cxx11-error@-1 {{constexpr function's 1st parameter type 'NonLiteral' is not a literal type}}
+  //   since-cxx11-note@#dr1684-struct {{'NonLiteral' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors}}
 #endif
 }
 
 namespace dr1687 { // dr1687: 7
   template<typename T> struct To {
-    operator T(); // expected-note 2{{first operand was implicitly converted to type 'int *'}}
-    // expected-note@-1 {{second operand was implicitly converted to type 'double'}}
-#if __cplusplus > 201703L
-    // expected-note@-3 2{{operand was implicitly converted to type 'dr1687::E}}
-#endif
+    operator T(); // #dr1687-op-T
   };
 
-  int *a = To<int*>() + 100.0; // expected-error {{invalid operands to binary expression ('To<int *>' and 'double')}}
-  int *b = To<int*>() + To<double>(); // expected-error {{invalid operands to binary expression ('To<int *>' and 'To<double>')}}
+  int *a = To<int*>() + 100.0;
+  // expected-error@-1 {{invalid operands to binary expression ('To<int *>' and 'double')}}
+  //   expected-note@#dr1687-op-T {{first operand was implicitly converted to type 'int *'}}
+  //   since-cxx20-note@#dr1687-op-T {{second operand was implicitly converted to type 'dr1687::E2'}}
+  int *b = To<int*>() + To<double>();
+  // expected-error@-1 {{invalid operands to binary expression ('To<int *>' and 'To<double>')}}
+  //   expected-note@#dr1687-op-T {{first operand was implicitly converted to type 'int *'}}
+  //   expected-note@#dr1687-op-T {{second operand was implicitly converted to type 'double'}}
 
-#if __cplusplus > 201703L
+#if __cplusplus >= 202002L
   enum E1 {};
   enum E2 {};
-  auto c = To<E1>() <=> To<E2>(); // expected-error {{invalid operands to binary expression ('To<E1>' and 'To<E2>')}}
+  auto c = To<E1>() <=> To<E2>();
+  // since-cxx20-error@-1 {{invalid operands to binary expression ('To<E1>' and 'To<E2>')}}
+  //   since-cxx20-note@#dr1687-op-T {{operand was implicitly converted to type 'dr1687::E}}
 #endif
 }
 
@@ -325,12 +400,14 @@ namespace dr1691 { // dr1691: 9
       void f(E);
     }
     enum M::E : int {};
-    void g(M::E); // expected-note {{declared here}}
+    void g(M::E); // #dr1691-g
   }
   void test() {
     N::M::E e;
     f(e); // ok
-    g(e); // expected-error {{use of undeclared}}
+    g(e);
+    // since-cxx11-error@-1 {{use of undeclared identifier 'g'; did you mean 'N::g'?}}
+    //   since-cxx11-note@#dr1691-g {{'N::g' declared here}}
   }
 #endif
 }
@@ -356,7 +433,9 @@ namespace dr1696 { // dr1696: 7
     extern struct A a;
     struct A {
       const A &x = { A{a, a} };
-      const A &y = { A{} }; // expected-error {{default member initializer for 'y' needed within definition of enclosing class 'A' outside of member functions}} expected-note {{here}}
+      const A &y = { A{} };
+      // since-cxx14-error@-1 {{default member initializer for 'y' needed within definition of enclosing class 'A' outside of member functions}}
+      //   since-cxx14-note@-2 {{default member initializer declared here}}
     };
     A a{a, a};
 #endif
@@ -365,16 +444,20 @@ namespace dr1696 { // dr1696: 7
   struct A { A(); ~A(); };
 #if __cplusplus >= 201103L
   struct B {
-    A &&a; // expected-note {{declared here}}
-    B() : a{} {} // expected-error {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+    A &&a; // #dr1696-a
+    B() : a{} {}
+    // since-cxx11-error@-1 {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+    //   since-cxx11-note@#dr1696-a {{reference member declared here}}
   } b;
 #endif
 
   struct C {
     C();
-    const A &a; // expected-note {{declared here}}
+    const A &a; // #dr1696-C-a
   };
-  C::C() : a(A()) {} // expected-error {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  C::C() : a(A()) {}
+  // expected-error@-1 {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   expected-note@#dr1696-C-a {{reference member declared here}}
 
 #if __cplusplus >= 201103L
   // This is OK in C++14 onwards, per DR1815, though we don't support that yet:
@@ -383,51 +466,62 @@ namespace dr1696 { // dr1696: 7
   //   D1 d1 = {A()};
   // ... which lifetime-extends the A temporary.
   struct D1 {
-#if __cplusplus < 201402L
-    // expected-error@-2 {{binds to a temporary}}
-#endif
-    const A &a = A(); // expected-note {{default member init}}
+  // cxx11-error@-1 {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   cxx11-note@#dr1696-d1 {{in implicit default constructor for 'dr1696::D1' first required here}}
+  //   cxx11-note@#dr1696-D1-a {{initializing field 'a' with default member initializer}}
+    const A &a = A(); // #dr1696-D1-a
   };
-  D1 d1 = {};
-#if __cplusplus < 201402L
-    // expected-note@-2 {{first required here}}
-#else
-    // expected-warning-re@-4 {{sorry, lifetime extension {{.*}} not supported}}
-#endif
+  D1 d1 = {}; // #dr1696-d1
+  // since-cxx14-warning@-1 {{sorry, lifetime extension of temporary created by aggregate initialization using default member initializer is not supported; lifetime of temporary will end at the end of the full-expression}}
+  //   since-cxx14-note@#dr1696-D1-a {{initializing field 'a' with default member initializer}}
 
   struct D2 {
-    const A &a = A(); // expected-note {{default member init}}
-    D2() {} // expected-error {{binds to a temporary}}
+    const A &a = A(); // #dr1696-D2-a
+    D2() {}
+    // since-cxx11-error@-1 {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+    //   since-cxx11-note@#dr1696-D2-a {{initializing field 'a' with default member initializer}}
   };
 
-  struct D3 { // expected-error {{binds to a temporary}}
-    const A &a = A(); // expected-note {{default member init}}
+  struct D3 {
+  // since-cxx11-error@-1 {{reference member 'a' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   since-cxx11-note@#dr1696-d3 {{in implicit default constructor for 'dr1696::D3' first required here}}
+  //   since-cxx11-note@#dr1696-D3-a {{initializing field 'a' with default member initializer}}
+    const A &a = A(); // #dr1696-D3-a
   };
-  D3 d3; // expected-note {{first required here}}
+  D3 d3; // #dr1696-d3
 
   struct haslist1 {
-    std::initializer_list<int> il; // expected-note {{'std::initializer_list' member}}
-    haslist1(int i) : il{i, 2, 3} {} // expected-error {{backing array for 'std::initializer_list' member 'il' is a temporary object}}
+    std::initializer_list<int> il; // #dr1696-il-1
+    haslist1(int i) : il{i, 2, 3} {}
+    // since-cxx11-error@-1 {{backing array for 'std::initializer_list' member 'il' is a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+    //   since-cxx11-note@#dr1696-il-1 {{'std::initializer_list' member declared here}}
   };
 
   struct haslist2 {
-    std::initializer_list<int> il; // expected-note {{'std::initializer_list' member}}
+    std::initializer_list<int> il; // #dr1696-il-2
     haslist2();
   };
-  haslist2::haslist2() : il{1, 2} {} // expected-error {{backing array for 'std::initializer_list' member 'il' is a temporary object}}
+  haslist2::haslist2() : il{1, 2} {}
+  // since-cxx11-error@-1 {{backing array for 'std::initializer_list' member 'il' is a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   since-cxx11-note@#dr1696-il-2 {{'std::initializer_list' member declared here}}
 
   struct haslist3 {
     std::initializer_list<int> il = {1, 2, 3};
   };
 
-  struct haslist4 { // expected-error {{backing array for 'std::initializer_list' member 'il' is a temporary object}}
-    std::initializer_list<int> il = {1, 2, 3}; // expected-note {{default member initializer}}
+  struct haslist4 {
+  // since-cxx11-error@-1 {{backing array for 'std::initializer_list' member 'il' is a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   since-cxx11-note@#dr1696-hl4 {{in implicit default constructor for 'dr1696::haslist4' first required here}}
+  //   since-cxx11-note@#dr1696-il-4 {{initializing field 'il' with default member initializer}}
+    std::initializer_list<int> il = {1, 2, 3}; // #dr1696-il-4
   };
-  haslist4 hl4; // expected-note {{in implicit default constructor}}
+  haslist4 hl4; // #dr1696-hl4
 
   struct haslist5 {
-    std::initializer_list<int> il = {1, 2, 3}; // expected-note {{default member initializer}}
-    haslist5() {} // expected-error {{backing array for 'std::initializer_list' member 'il' is a temporary object}}
+    std::initializer_list<int> il = {1, 2, 3}; // #dr1696-il-5
+    haslist5() {}
+    // since-cxx11-error@-1 {{backing array for 'std::initializer_list' member 'il' is a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+    //   since-cxx11-note@#dr1696-il-5 {{nitializing field 'il' with default member initializer}}
   };
 #endif
 }

--- a/clang/test/CXX/drs/dr18xx.cpp
+++ b/clang/test/CXX/drs/dr18xx.cpp
@@ -1,14 +1,14 @@
-// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify=expected,cxx98 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify=expected,cxx11-17,since-cxx11 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify=expected,cxx11-17,since-cxx11,since-cxx14 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify=expected,cxx11-17,since-cxx11,since-cxx14 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx14 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx14 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify=expected,since-cxx20,since-cxx11,since-cxx14 -fexceptions -Wno-deprecated-builtins -fcxx-exceptions -pedantic-errors
 
-#if __cplusplus < 201103L
-// expected-error@+1 {{variadic macro}}
+#if __cplusplus == 199711L
 #define static_assert(...) __extension__ _Static_assert(__VA_ARGS__)
+// cxx98-error@-1 {{variadic macros are a C99 feature}}
 #endif
 
 namespace dr1812 { // dr1812: no
@@ -16,7 +16,7 @@ namespace dr1812 { // dr1812: no
 #if __cplusplus >= 201103L
 template <typename T> struct A {
   using B = typename T::C<int>;
-  // expected-error@-1 {{use 'template' keyword to treat 'C' as a dependent template name}}
+  // since-cxx11-error@-1 {{use 'template' keyword to treat 'C' as a dependent template name}}
 };
 #endif
 } // namespace dr1812
@@ -54,11 +54,16 @@ namespace dr1814 { // dr1814: yes
 namespace dr1815 { // dr1815: no
 #if __cplusplus >= 201402L
   // FIXME: needs codegen test
-  struct A { int &&r = 0; }; // expected-note {{default member init}}
-  A a = {}; // FIXME expected-warning {{not supported}}
+  struct A { int &&r = 0; }; // #dr1815-A 
+  A a = {};
+  // since-cxx14-warning@-1 {{sorry, lifetime extension of temporary created by aggregate initialization using default member initializer is not supported; lifetime of temporary will end at the end of the full-expression}} FIXME
+  //   since-cxx14-note@#dr1815-A {{initializing field 'r' with default member initializer}}
 
-  struct B { int &&r = 0; }; // expected-error {{binds to a temporary}} expected-note {{default member init}}
-  B b; // expected-note {{here}}
+  struct B { int &&r = 0; }; // #dr1815-B
+  // since-cxx14-error@-1 {{reference member 'r' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
+  //   since-cxx14-note@#dr1815-B {{initializing field 'r' with default member initializer}}
+  //   since-cxx14-note@#dr1815-b {{in implicit default constructor for 'dr1815::B' first required here}}
+  B b; // #dr1815-b
 #endif
 }
 
@@ -80,9 +85,9 @@ struct A {
 
 namespace dr1822 { // dr1822: yes
 #if __cplusplus >= 201103L
-  int a;
+  double a;
   auto x = [] (int a) {
-#pragma clang __debug dump a // CHECK: ParmVarDecl
+    static_assert(__is_same(decltype(a), int), "should be resolved to lambda parameter");
   };
 #endif
 }
@@ -98,16 +103,22 @@ namespace dr1837 { // dr1837: 3.3
   };
 
   class Outer {
-    friend auto Other::q() -> decltype(this->p()) *; // expected-error {{invalid use of 'this'}}
+    friend auto Other::q() -> decltype(this->p()) *;
+    // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
     int g();
     int f() {
       extern void f(decltype(this->g()) *);
       struct Inner {
-        static_assert(Fish<decltype(this->g())>::value, ""); // expected-error {{invalid use of 'this'}}
-        enum { X = Fish<decltype(this->f())>::value }; // expected-error {{invalid use of 'this'}}
-        struct Inner2 : Fish<decltype(this->g())> { }; // expected-error {{invalid use of 'this'}}
-        friend void f(decltype(this->g()) *); // expected-error {{invalid use of 'this'}}
-        friend auto Other::q() -> decltype(this->p()) *; // expected-error {{invalid use of 'this'}}
+        static_assert(Fish<decltype(this->g())>::value, "");
+        // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
+        enum { X = Fish<decltype(this->f())>::value };
+        // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
+        struct Inner2 : Fish<decltype(this->g())> { };
+        // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
+        friend void f(decltype(this->g()) *);
+        // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
+        friend auto Other::q() -> decltype(this->p()) *;
+        // since-cxx11-error@-1 {{invalid use of 'this' outside of a non-static member function}}
       };
       return 0;
     }
@@ -135,19 +146,21 @@ namespace dr1872 { // dr1872: 9
 
   constexpr int x = A<X>().f();
   constexpr int y = A<Y>().f();
-#if __cplusplus <= 201703L
-  // expected-error@-2 {{constant expression}} expected-note@-2 {{call to virtual function}}
-#else
+  // cxx11-17-error@-1 {{constexpr variable 'y' must be initialized by a constant expression}}
+  //   cxx11-17-note@-2 {{cannot evaluate call to virtual function in a constant expression in C++ standards before C++20}}
+#if __cplusplus >= 202002L
   static_assert(y == 0);
 #endif
   // Note, this is invalid even though it would not use virtual dispatch.
   constexpr int y2 = A<Y>().A<Y>::f();
-#if __cplusplus <= 201703L
-  // expected-error@-2 {{constant expression}} expected-note@-2 {{call to virtual function}}
-#else
+  // cxx11-17-error@-1 {{constexpr variable 'y2' must be initialized by a constant expression}}
+  //   cxx11-17-note@-2 {{cannot evaluate call to virtual function in a constant expression in C++ standards before C++20}}
+#if __cplusplus >= 202002L
   static_assert(y == 0);
 #endif
-  constexpr int z = A<Z>().f(); // expected-error {{constant expression}} expected-note {{non-literal type}}
+  constexpr int z = A<Z>().f();
+  // since-cxx11-error@-1 {{constexpr variable 'z' must be initialized by a constant expression}}
+  //   since-cxx11-note@-2 {{non-literal type 'A<Z>' cannot be used in a constant expression}}
 #endif
 }
 
@@ -166,33 +179,38 @@ namespace dr1881 { // dr1881: 7
 void dr1891() { // dr1891: 4
 #if __cplusplus >= 201103L
   int n;
-  auto a = []{}; // expected-note 0-4{{}}
-  auto b = [=]{ return n; }; // expected-note 0-4{{}}
+  auto a = []{}; // #dr1891-a
+  auto b = [=]{ return n; }; // #dr1891-b
   typedef decltype(a) A;
   typedef decltype(b) B;
 
   static_assert(!__has_trivial_constructor(A), "");
-#if __cplusplus > 201703L
-  // expected-error@-2 {{failed}}
-#endif
+  // since-cxx20-error@-1 {{failed}}
   static_assert(!__has_trivial_constructor(B), "");
 
   // C++20 allows default construction for non-capturing lambdas (P0624R2).
   A x;
-#if __cplusplus <= 201703L
-  // expected-error@-2 {{no matching constructor}}
-#endif
-  B y; // expected-error {{no matching constructor}}
+  // cxx11-17-error@-1 {{no matching constructor for initialization of 'A' (aka '(lambda at}}
+  //   cxx11-17-note@#dr1891-a {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided}}
+  //   cxx11-17-note@#dr1891-a {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided}}
+  B y;
+  // since-cxx11-error@-1 {{no matching constructor for initialization of 'B' (aka '(lambda at}}
+  //   since-cxx11-note@#dr1891-b {{candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided}}
+  //   since-cxx11-note@#dr1891-b {{candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided}}
 
   // C++20 allows assignment for non-capturing lambdas (P0624R2).
   a = a;
+  // cxx11-17-error-re@-1 {{{{object of type '\(lambda at .+\)' cannot be assigned because its copy assignment operator is implicitly deleted}}}}
+  //   cxx11-17-note@#dr1891-a {{lambda expression begins here}}
   a = static_cast<A&&>(a);
-#if __cplusplus <= 201703L
-  // expected-error@-3 {{copy assignment operator is implicitly deleted}}
-  // expected-error@-3 {{copy assignment operator is implicitly deleted}}
-#endif
-  b = b; // expected-error {{copy assignment operator is implicitly deleted}}
-  b = static_cast<B&&>(b); // expected-error {{copy assignment operator is implicitly deleted}}
+  // cxx11-17-error-re@-1 {{{{object of type '\(lambda at .+\)' cannot be assigned because its copy assignment operator is implicitly deleted}}}}
+  //   cxx11-17-note@#dr1891-a {{lambda expression begins here}}
+  b = b;
+  // since-cxx11-error-re@-1 {{{{object of type '\(lambda at .+\)' cannot be assigned because its copy assignment operator is implicitly deleted}}}}
+  //   since-cxx11-note@#dr1891-b {{lambda expression begins here}}
+  b = static_cast<B&&>(b);
+  // since-cxx11-error-re@-1 {{{{object of type '\(lambda at .+\)' cannot be assigned because its copy assignment operator is implicitly deleted}}}}
+  //   since-cxx11-note@#dr1891-b {{lambda expression begins here}}
 #endif
 }
 

--- a/clang/test/CXX/drs/dr19xx.cpp
+++ b/clang/test/CXX/drs/dr19xx.cpp
@@ -1,41 +1,36 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++1z %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected,cxx98-11,cxx98 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected,cxx98-11,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c %s -verify=expected,since-cxx14,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
 namespace std { struct type_info; }
 
 namespace dr1902 { // dr1902: 3.7
   struct A {};
   struct B {
-    B(A);
-#if __cplusplus >= 201103L
-        // expected-note@-2 {{candidate}}
-#endif
-
-    B() = delete;
-#if __cplusplus < 201103L
-        // expected-error@-2 {{extension}}
-#endif
-
-    B(const B&) // expected-note {{deleted here}}
-#if __cplusplus >= 201103L
-        // expected-note@-2 {{candidate}}
-#else
-        // expected-error@+2 {{extension}}
-#endif
-        = delete;
-
+    B(A); // #dr1902-B-A
+    B() = delete; // #dr1902-B-ctor
+    // cxx98-error@-1 {{deleted function definitions are a C++11 extension}}
+    B(const B&) = delete; // #dr1902-B-copy-ctor
+    // cxx98-error@-1 {{deleted function definitions are a C++11 extension}}
     operator A();
   };
 
   extern B b1;
-  B b2(b1); // expected-error {{call to deleted}}
+  B b2(b1);
+  // expected-error@-1 {{call to deleted constructor of 'B'}}
+  //   expected-note@#dr1902-B-copy-ctor {{'B' has been explicitly marked deleted here}}
 
 #if __cplusplus >= 201103L
   // This is ambiguous, even though calling the B(const B&) constructor would
   // both directly and indirectly call a deleted function.
-  B b({}); // expected-error {{ambiguous}}
+  B b({});
+  // since-cxx11-error@-1 {{call to constructor of 'B' is ambiguous}}
+  //   since-cxx11-note@#dr1902-B-A {{candidate constructor}}
+  //   since-cxx11-note@#dr1902-B-copy-ctor {{candidate constructor has been explicitly deleted}}
 #endif
 }
 
@@ -66,16 +61,22 @@ namespace dr1903 {
 
 namespace dr1909 { // dr1909: 3.7
   struct A {
-    template<typename T> struct A {}; // expected-error {{member 'A' has the same name as its class}}
+    template<typename T> struct A {};
+    // expected-error@-1 {{member 'A' has the same name as its class}}
   };
   struct B {
-    template<typename T> void B() {} // expected-error {{constructor cannot have a return type}}
+    template<typename T> void B() {}
+    // expected-error@-1 {{constructor cannot have a return type}}
   };
   struct C {
-    template<typename T> static int C; // expected-error {{member 'C' has the same name as its class}} expected-error 0-1{{extension}}
+    template<typename T> static int C;
+    // expected-error@-1 {{member 'C' has the same name as its class}} 
+    // cxx98-11-error@-2 {{variable templates are a C++14 extension}}
   };
   struct D {
-    template<typename T> using D = int; // expected-error {{member 'D' has the same name as its class}} expected-error 0-1{{extension}}
+    template<typename T> using D = int;
+    // cxx98-error@-1 {{alias declarations are a C++11 extension}}
+    // expected-error@-2 {{member 'D' has the same name as its class}}
   };
 }
 
@@ -83,7 +84,8 @@ namespace dr1940 { // dr1940: 3.5
 #if __cplusplus >= 201103L
 static union {
   static_assert(true, "");  // ok
-  static_assert(false, ""); // expected-error {{static assertion failed}}
+  static_assert(false, "");
+  // since-cxx11-error@-1 {{static assertion failed}}
   int not_empty;
 };
 #endif
@@ -122,15 +124,18 @@ derived d2(42, 9);
 namespace dr1947 { // dr1947: 3.5
 #if __cplusplus >= 201402L
 unsigned o = 0'01;  // ok
-unsigned b = 0b'01; // expected-error {{invalid digit 'b' in octal constant}}
-unsigned x = 0x'01; // expected-error {{invalid suffix 'x'01' on integer constant}}
+unsigned b = 0b'01;
+// since-cxx14-error@-1 {{invalid digit 'b' in octal constant}}
+unsigned x = 0x'01;
+// since-cxx14-error@-1 {{invalid suffix 'x'01' on integer constant}}
 #endif
 }
 
 #if __cplusplus >= 201103L
 // dr1948: 3.5
 // FIXME: This diagnostic could be improved.
-void *operator new(__SIZE_TYPE__) noexcept { return nullptr; } // expected-error{{exception specification in declaration does not match previous declaration}}
+void *operator new(__SIZE_TYPE__) noexcept { return nullptr; }
+// since-cxx11-error@-1 {{exception specification in declaration does not match previous declaration}}
 #endif
 
 namespace dr1959 { // dr1959: 3.9
@@ -139,22 +144,31 @@ namespace dr1959 { // dr1959: 3.9
   struct c;
   struct a {
     a() = default;
-    a(const a &) = delete; // expected-note {{deleted}}
+    a(const a &) = delete; // #dr1959-copy-ctor
     a(const b &) = delete; // not inherited
-    a(c &&) = delete; // expected-note {{not viable}}
-    template<typename T> a(T) = delete; // expected-note {{would take its own class type by value}}
+    a(c &&) = delete; // #dr1959-move-ctor
+    template<typename T> a(T) = delete; // #dr1959-temp-ctor
   };
 
-  struct b : a { // expected-note {{cannot bind}} expected-note {{deleted because}}
-    using a::a; // expected-note 2{{inherited here}}
+  struct b : a { // #dr1959-b
+    using a::a; // #dr1959-using-a
   };
 
   a x;
   // FIXME: As a resolution to an open DR against P0136R0, we disallow
   // use of inherited constructors to construct from a single argument
   // where the base class is reference-related to the argument type.
-  b y = x; // expected-error {{no viable conversion}}
-  b z = z; // expected-error {{deleted}}
+  b y = x;
+  // since-cxx11-error@-1 {{no viable conversion from 'a' to 'b'}}
+  //   since-cxx11-note@#dr1959-move-ctor {{candidate inherited constructor not viable: no known conversion from 'a' to 'c &&' for 1st argument}}
+  //   since-cxx11-note@#dr1959-using-a {{constructor from base class 'a' inherited here}}
+  //   since-cxx11-note@#dr1959-b {{candidate constructor (the implicit copy constructor) not viable: cannot bind base class object of type 'a' to derived class reference 'const b &' for 1st argument}}
+  //   since-cxx11-note@#dr1959-temp-ctor {{candidate template ignored: instantiation would take its own class type by value}}
+  //   since-cxx11-note@#dr1959-using-a {{constructor from base class 'a' inherited here}}
+  b z = z;
+  // since-cxx11-error@-1 {{call to implicitly-deleted copy constructor of 'b'}}
+  //   since-cxx11-note@#dr1959-b {{copy constructor of 'b' is implicitly deleted because base class 'a' has a deleted copy constructor}}
+  //   since-cxx11-note@#dr1959-copy-ctor {{'a' has been explicitly marked deleted here}}
 
   struct c : a {
     using a::a;
@@ -191,16 +205,28 @@ using A::g;
 namespace dr1966 { // dr1966: 11
 #if __cplusplus >= 201103L
   struct A {
-    enum E : int {1}; // expected-error {{expected identifier}} (not bit-field)
+    enum E : int {1};
+    // since-cxx11-error@-1 {{expected identifier}} (not bit-field)
   };
-  auto *p1 = new enum E : int; // expected-error {{only permitted as a standalone declaration}}
-  auto *p2 = new enum F : int {}; // expected-error {{only permitted as a standalone declaration}}
-  auto *p3 = true ? new enum G : int {}; // expected-error {{forward reference}} expected-error {{incomplete}} expected-note {{declaration}}
-  auto h() -> enum E : int {}; // expected-error {{only permitted as a standalone declaration}}
+  auto *p1 = new enum E : int;
+  // since-cxx11-error@-1 {{non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration}}
+  auto *p2 = new enum F : int {};
+  // since-cxx11-error@-1 {{non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration}}
+  auto *p3 = true ? new enum G : int {};
+  // since-cxx11-error@-1 {{ISO C++ forbids forward references to 'enum' types}}
+  // since-cxx11-error@-2 {{allocation of incomplete type 'enum G'}}
+  //   since-cxx11-note@-3 {{forward declaration of 'dr1966::G'}}
+  auto h() -> enum E : int {};
+  // since-cxx11-error@-1 {{non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration}}
 
-  enum X : enum Y : int {} {}; // expected-error {{cannot be defined in a type specifier}}
+  enum X : enum Y : int {} {};
+  // since-cxx11-error@-1 {{'dr1966::Y' cannot be defined in a type specifier}}
   struct Q {
-    enum X : enum Y : int {} {}; // expected-error +{{}}
+    // FIXME: can we emit something nicer than that?
+    enum X : enum Y : int {} {};
+    // since-cxx11-error@-1 {{non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration; missing list of enumerators?}}
+    // since-cxx11-error@-2 {{non-integral type 'enum Y' is an invalid underlying type}}
+    // since-cxx11-error@-3 {{anonymous bit-field cannot have a default member initializer}}
   };
 #endif
 }

--- a/clang/test/CXX/drs/dr412.cpp
+++ b/clang/test/CXX/drs/dr412.cpp
@@ -1,7 +1,10 @@
 // RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT="throw()" -DBAD_ALLOC="throw(std::bad_alloc)"
 // RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
 // RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
-// RUN: %clang_cc1 -std=c++1z %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
+// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
+// RUN: %clang_cc1 -std=c++20 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
+// RUN: %clang_cc1 -std=c++23 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
+// RUN: %clang_cc1 -std=c++2c %s -verify -fexceptions -fcxx-exceptions -pedantic-errors -DNOEXCEPT=noexcept -DBAD_ALLOC=
 
 // dr412: 3.4
 // lwg404: yes
@@ -11,11 +14,17 @@
 __extension__ typedef __SIZE_TYPE__ size_t;
 namespace std { struct bad_alloc {}; }
 
-inline void* operator new(size_t) BAD_ALLOC; // expected-error {{cannot be declared 'inline'}}
-inline void* operator new[](size_t) BAD_ALLOC; // expected-error {{cannot be declared 'inline'}}
-inline void operator delete(void*) NOEXCEPT; // expected-error {{cannot be declared 'inline'}}
-inline void operator delete[](void*) NOEXCEPT; // expected-error {{cannot be declared 'inline'}}
+inline void* operator new(size_t) BAD_ALLOC;
+// expected-error@-1 {{replacement function 'operator new' cannot be declared 'inline'}}
+inline void* operator new[](size_t) BAD_ALLOC;
+// expected-error@-1 {{replacement function 'operator new[]' cannot be declared 'inline'}}
+inline void operator delete(void*) NOEXCEPT;
+// expected-error@-1 {{replacement function 'operator delete' cannot be declared 'inline'}}
+inline void operator delete[](void*) NOEXCEPT;
+// expected-error@-1 {{replacement function 'operator delete[]' cannot be declared 'inline'}}
 #ifdef __cpp_sized_deallocation
-inline void operator delete(void*, size_t) NOEXCEPT; // expected-error {{cannot be declared 'inline'}}
-inline void operator delete[](void*, size_t) NOEXCEPT; // expected-error {{cannot be declared 'inline'}}
+inline void operator delete(void*, size_t) NOEXCEPT;
+// expected-error@-1 {{replacement function 'operator delete' cannot be declared 'inline'}}
+inline void operator delete[](void*, size_t) NOEXCEPT;
+// expected-error@-1 {{replacement function 'operator delete[]' cannot be declared 'inline'}}
 #endif

--- a/clang/test/CXX/drs/dr8xx.cpp
+++ b/clang/test/CXX/drs/dr8xx.cpp
@@ -1,30 +1,27 @@
-// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify -fexceptions -fcxx-exceptions -pedantic-errors 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
+#if __cplusplus == 199711L
 // expected-no-diagnostics
+#endif
 
 namespace dr873 { // dr873: 3.0
 #if __cplusplus >= 201103L
 template <typename T> void f(T &&);
-template <> void f(int &) {}  // #1
-template <> void f(int &&) {} // #2
+template <> void f(int &) = delete;  // #dr873-lvalue-ref
+template <> void f(int &&) = delete; // #dr873-rvalue-ref
 void g(int i) {
-  f(i); // calls f<int&>(int&), i.e., #1
-#pragma clang __debug dump f(i)
-  //      CHECK: CallExpr {{.*}}
-  // CHECK-NEXT: |-ImplicitCastExpr {{.*}}
-  // CHECK-NEXT: | `-DeclRefExpr {{.*}} 'f' 'void (int &)' {{.*}}
-
-  f(0); // calls f<int>(int&&), i.e., #2
-#pragma clang __debug dump f(0)
-  //      CHECK: CallExpr {{.*}}
-  // CHECK-NEXT: |-ImplicitCastExpr {{.*}}
-  // CHECK-NEXT: | `-DeclRefExpr {{.*}} 'f' 'void (int &&)' {{.*}}
+  f(i); // calls f<int&>(int&)
+  // since-cxx11-error@-1 {{call to deleted function 'f'}}
+  //   since-cxx11-note@#dr873-lvalue-ref {{candidate function [with T = int &] has been implicitly deleted}}
+  f(0); // calls f<int>(int&&)
+  // since-cxx11-error@-1 {{call to deleted function 'f'}}
+  //   since-cxx11-note@#dr873-rvalue-ref {{candidate function [with T = int] has been implicitly deleted}}
 }
 #endif
 } // namespace dr873

--- a/clang/test/CXX/drs/dr9xx.cpp
+++ b/clang/test/CXX/drs/dr9xx.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -std=c++98 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++11 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++14 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++17 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++20 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: %clang_cc1 -std=c++23 %s -verify -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
 namespace std {
   __extension__ typedef __SIZE_TYPE__ size_t;
@@ -46,27 +46,31 @@ namespace dr948 { // dr948: 3.7
 namespace dr952 { // dr952: 2.8
 namespace example1 {
 struct A {
-  typedef int I; // #dr952-typedef-decl
+  typedef int I; // #dr952-I
 };
-struct B : private A { // #dr952-inheritance
+struct B : private A { // #dr952-B
 };
 struct C : B {
   void f() {
-    I i1; // expected-error {{private member}}
-    // expected-note@#dr952-inheritance {{constrained by private inheritance}}
-    // expected-note@#dr952-typedef-decl {{declared here}}
+    I i1;
+    // expected-error@-1 {{'I' is a private member of 'dr952::example1::A'}}
+    //   expected-note@#dr952-B {{constrained by private inheritance here}}
+    //   expected-note@#dr952-I {{member is declared here}}
   }
-  I i2; // expected-error {{private member}}
-  // expected-note@#dr952-inheritance {{constrained by private inheritance}}
-  // expected-note@#dr952-typedef-decl {{declared here}}
+  I i2;
+  // expected-error@-1 {{'I' is a private member of 'dr952::example1::A'}}
+  //   expected-note@#dr952-B {{constrained by private inheritance here}}
+  //   expected-note@#dr952-I {{member is declared here}}
   struct D {
-    I i3; // expected-error {{private member}}
-    // expected-note@#dr952-inheritance {{constrained by private inheritance}}
-    // expected-note@#dr952-typedef-decl {{declared here}}
+    I i3;
+    // expected-error@-1 {{'I' is a private member of 'dr952::example1::A'}}
+    //   expected-note@#dr952-B {{constrained by private inheritance here}}
+    //   expected-note@#dr952-I {{member is declared here}}
     void g() {
-      I i4; // expected-error {{private member}}
-      // expected-note@#dr952-inheritance {{constrained by private inheritance}}
-      // expected-note@#dr952-typedef-decl {{declared here}}
+      I i4;
+      // expected-error@-1 {{'I' is a private member of 'dr952::example1::A'}}
+      //   expected-note@#dr952-B {{constrained by private inheritance here}}
+      //   expected-note@#dr952-I {{member is declared here}}
     }
   };
 };
@@ -91,10 +95,10 @@ namespace dr974 { // dr974: yes
 }
 
 namespace dr977 { // dr977: yes
-enum E { e = E() };
+enum E { e = E() }; // #dr977-E
 #if !defined(_WIN32) || defined(__MINGW32__)
-// expected-error@-2 {{invalid use of incomplete type 'E'}}
-// expected-note@-3 {{definition of 'dr977::E' is not complete until the closing '}'}}
+// expected-error@#dr977-E {{invalid use of incomplete type 'E'}}
+//   expected-note@#dr977-E {{definition of 'dr977::E' is not complete until the closing '}'}}
 #endif
 #if __cplusplus >= 201103L
 enum E2 : int { e2 = E2() };
@@ -105,23 +109,29 @@ enum struct E4 : int { e = static_cast<int>(E4()) };
 
 namespace dr990 { // dr990: 3.5
 #if __cplusplus >= 201103L
-  struct A { // expected-note 2{{candidate}}
-    A(std::initializer_list<int>); // expected-note {{candidate}}
+  struct A { // #dr990-A
+    A(std::initializer_list<int>); // #dr990-A-init-list
   };
   struct B {
     A a;
   };
   B b1 { };
-  B b2 { 1 }; // expected-error {{no viable conversion from 'int' to 'A'}}
+  B b2 { 1 };
+  // since-cxx11-error@-1 {{no viable conversion from 'int' to 'A'}}
+  //   since-cxx11-note@#dr990-A {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const A &' for 1st argument}}
+  //   since-cxx11-note@#dr990-A {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'A &&' for 1st argument}}
+  //   since-cxx11-note@#dr990-A-init-list {{candidate constructor not viable: no known conversion from 'int' to 'std::initializer_list<int>' for 1st argument}}
   B b3 { { 1 } };
 
   struct C {
     C();
     C(int);
-    C(std::initializer_list<int>) = delete; // expected-note {{here}}
+    C(std::initializer_list<int>) = delete; // #dr990-deleted
   };
   C c1[3] { 1 }; // ok
-  C c2[3] { 1, {2} }; // expected-error {{call to deleted}}
+  C c2[3] { 1, {2} };
+  // since-cxx11-error@-1 {{call to deleted constructor of 'C'}}
+  //   since-cxx11-note@#dr990-deleted {{'C' has been explicitly marked deleted here}}
 
   struct D {
     D();


### PR DESCRIPTION
This patch continues the work started with ea5b1ef016d020c37f903d6c7d4f623be975dab8. See that commit and its corresponding PR for details.