### PR TITLE
[driver] Respect the mode the driver is in for autocomplete

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1991,12 +1991,7 @@ void Driver::HandleAutocompletions(StringRef PassedFlags) const {
   std::vector<std::string> SuggestedCompletions;
   std::vector<std::string> Flags;
 
-  llvm::opt::Visibility VisibilityMask(options::ClangOption);
-
-  // Make sure that Flang-only options don't pollute the Clang output
-  // TODO: Make sure that Clang-only options don't pollute Flang output
-  if (IsFlangMode())
-    VisibilityMask = llvm::opt::Visibility(options::FlangOption);
+  llvm::opt::Visibility VisibilityMask =  getOptionVisibilityMask();
 
   // Distinguish "--autocomplete=-someflag" and "--autocomplete=-someflag,"
   // because the latter indicates that the user put space before pushing tab


### PR DESCRIPTION
The previous code was always auto-completing options for the clang mode (except for flang which specifically overrode it.)  We have multiple other driver modes, and we appear to parse options based on those modes, so seemingly the obvious thing to do is auto-complete the options we'd accept?

Note: Advice on how to test this is very welcome.  I don't see any testing in tree for anything except clang, and I don't personally use this auto complete feature at all.