### PR TITLE
[SymbolFileDWARF][NFC] Remove duplicated code checking for type tags

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -130,11 +130,12 @@ public:
   }
 };
 
-bool IsTypeTag(llvm::dwarf::Tag Tag) {
+} // namespace
+
+bool IsStructOrClassTag(llvm::dwarf::Tag Tag) {
   return Tag == llvm::dwarf::Tag::DW_TAG_class_type ||
          Tag == llvm::dwarf::Tag::DW_TAG_structure_type;
 }
-} // namespace
 
 static PluginProperties &GetGlobalPluginProperties() {
   static PluginProperties g_settings;
@@ -2953,7 +2954,7 @@ TypeSP SymbolFileDWARF::FindCompleteObjCDefinitionTypeForDIE(
       type_name, must_be_implementation, [&](DWARFDIE type_die) {
         // Don't try and resolve the DIE we are looking for with the DIE
         // itself!
-        if (type_die == die || !IsTypeTag(type_die.Tag()))
+        if (type_die == die || !IsStructOrClassTag(type_die.Tag()))
           return true;
 
         if (must_be_implementation &&
@@ -3125,7 +3126,8 @@ SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die) {
       const dw_tag_t type_tag = type_die.Tag();
       // Resolve the type if both have the same tag or {class, struct} tags.
       const bool try_resolving_type =
-          type_tag == tag || (IsTypeTag(type_tag) && IsTypeTag(tag));
+          type_tag == tag ||
+          (IsStructOrClassTag(type_tag) && IsStructOrClassTag(tag));
 
       if (!try_resolving_type) {
         if (log) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -130,6 +130,10 @@ public:
   }
 };
 
+bool IsTypeTag(llvm::dwarf::Tag Tag) {
+  return Tag == llvm::dwarf::Tag::DW_TAG_class_type ||
+         Tag == llvm::dwarf::Tag::DW_TAG_structure_type;
+}
 } // namespace
 
 static PluginProperties &GetGlobalPluginProperties() {
@@ -2947,29 +2951,18 @@ TypeSP SymbolFileDWARF::FindCompleteObjCDefinitionTypeForDIE(
 
   m_index->GetCompleteObjCClass(
       type_name, must_be_implementation, [&](DWARFDIE type_die) {
-        bool try_resolving_type = false;
-
         // Don't try and resolve the DIE we are looking for with the DIE
         // itself!
-        if (type_die != die) {
-          switch (type_die.Tag()) {
-          case DW_TAG_class_type:
-          case DW_TAG_structure_type:
-            try_resolving_type = true;
-            break;
-          default:
-            break;
-          }
-        }
-        if (!try_resolving_type)
+        if (type_die == die || !IsTypeTag(type_die.Tag()))
           return true;
 
         if (must_be_implementation &&
-            type_die.Supports_DW_AT_APPLE_objc_complete_type())
-          try_resolving_type = type_die.GetAttributeValueAsUnsigned(
+            type_die.Supports_DW_AT_APPLE_objc_complete_type()) {
+          bool try_resolving_type = type_die.GetAttributeValueAsUnsigned(
               DW_AT_APPLE_objc_complete_type, 0);
-        if (!try_resolving_type)
-          return true;
+          if (!try_resolving_type)
+            return true;
+        }
 
         Type *resolved_type = ResolveType(type_die, false, true);
         if (!resolved_type || resolved_type == DIE_IS_BEING_PARSED)
@@ -3128,36 +3121,11 @@ SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die) {
       if (type_system &&
           !type_system->SupportsLanguage(GetLanguage(*type_die.GetCU())))
         return true;
-      bool try_resolving_type = false;
 
-      // Don't try and resolve the DIE we are looking for with the DIE
-      // itself!
       const dw_tag_t type_tag = type_die.Tag();
-      // Make sure the tags match
-      if (type_tag == tag) {
-        // The tags match, lets try resolving this type
-        try_resolving_type = true;
-      } else {
-        // The tags don't match, but we need to watch our for a forward
-        // declaration for a struct and ("struct foo") ends up being a
-        // class ("class foo { ... };") or vice versa.
-        switch (type_tag) {
-        case DW_TAG_class_type:
-          // We had a "class foo", see if we ended up with a "struct foo
-          // { ... };"
-          try_resolving_type = (tag == DW_TAG_structure_type);
-          break;
-        case DW_TAG_structure_type:
-          // We had a "struct foo", see if we ended up with a "class foo
-          // { ... };"
-          try_resolving_type = (tag == DW_TAG_class_type);
-          break;
-        default:
-          // Tags don't match, don't event try to resolve using this type
-          // whose name matches....
-          break;
-        }
-      }
+      // Resolve the type if both have the same tag or {class, struct} tags.
+      bool try_resolving_type =
+          type_tag == tag || (IsTypeTag(type_tag) && IsTypeTag(tag));
 
       if (!try_resolving_type) {
         if (log) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2958,7 +2958,7 @@ TypeSP SymbolFileDWARF::FindCompleteObjCDefinitionTypeForDIE(
 
         if (must_be_implementation &&
             type_die.Supports_DW_AT_APPLE_objc_complete_type()) {
-          bool try_resolving_type = type_die.GetAttributeValueAsUnsigned(
+          const bool try_resolving_type = type_die.GetAttributeValueAsUnsigned(
               DW_AT_APPLE_objc_complete_type, 0);
           if (!try_resolving_type)
             return true;
@@ -3124,7 +3124,7 @@ SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die) {
 
       const dw_tag_t type_tag = type_die.Tag();
       // Resolve the type if both have the same tag or {class, struct} tags.
-      bool try_resolving_type =
+      const bool try_resolving_type =
           type_tag == tag || (IsTypeTag(type_tag) && IsTypeTag(tag));
 
       if (!try_resolving_type) {


### PR DESCRIPTION
There was duplicated (and complex) code querying whether tags were type-like tags (i.e. class or struct); this has been factored out into a helper function.

There was also a comment about not comparing identical DIEs without ever performing that check; this comment has been removed. It was likely a result of copy paste from another function in this same file which actually does that check.