### PR TITLE
[Clang][C++20] Implement constexpr std::bit_cast for bit-fields

### DIFF
--- a/clang/include/clang/Basic/DiagnosticASTKinds.td
+++ b/clang/include/clang/Basic/DiagnosticASTKinds.td
@@ -316,10 +316,14 @@ def note_constexpr_memcpy_unsupported : Note<
   "size to copy (%4) is not a multiple of size of element type %3 (%5)|"
   "source is not a contiguous array of at least %4 elements of type %3|"
   "destination is not a contiguous array of at least %4 elements of type %3}2">;
+def note_constexpr_bit_cast_bad_bits : Note<
+  "bit_cast source expression (type %5) does not produce a constant value for "
+  "%select{bit|byte}0 [%1] (of {%2%plural{0:|:..0}2}) which are required by "
+  "target type %4 %select{|(subobject %3)}6">;
 def note_constexpr_bit_cast_unsupported_type : Note<
   "constexpr bit cast involving type %0 is not yet supported">;
-def note_constexpr_bit_cast_unsupported_bitfield : Note<
-  "constexpr bit_cast involving bit-field is not yet supported">;
+def note_constexpr_bit_cast_invalid_decl : Note<
+  "bit_cast here %select{from|to}0 invalid declaration %0">;
 def note_constexpr_bit_cast_invalid_type : Note<
   "bit_cast %select{from|to}0 a %select{|type with a }1"
   "%select{union|pointer|member pointer|volatile|reference}2 "

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17219,6 +17219,13 @@ static bool ConvertAPValueToString(const APValue &V, QualType T,
     OS << "i)";
   } break;
 
+  case APValue::ValueKind::Array:
+  case APValue::ValueKind::Vector:
+  case APValue::ValueKind::Struct: {
+    llvm::raw_svector_ostream OS(Str);
+    V.printPretty(OS, Context, T);
+  } break;
+
   default:
     return false;
   }
@@ -17256,11 +17263,10 @@ static bool UsefulToPrintExpr(const Expr *E) {
 /// Try to print more useful information about a failed static_assert
 /// with expression \E
 void Sema::DiagnoseStaticAssertDetails(const Expr *E) {
-  if (const auto *Op = dyn_cast<BinaryOperator>(E);
-      Op && Op->getOpcode() != BO_LOr) {
-    const Expr *LHS = Op->getLHS()->IgnoreParenImpCasts();
-    const Expr *RHS = Op->getRHS()->IgnoreParenImpCasts();
-
+  const auto Diagnose = [&](const Expr *LHS, const Expr *RHS,
+                            const llvm::StringRef &OpStr) {
+    LHS = LHS->IgnoreParenImpCasts();
+    RHS = RHS->IgnoreParenImpCasts();
     // Ignore comparisons of boolean expressions with a boolean literal.
     if ((isa<CXXBoolLiteralExpr>(LHS) && RHS->getType()->isBooleanType()) ||
         (isa<CXXBoolLiteralExpr>(RHS) && LHS->getType()->isBooleanType()))
@@ -17287,10 +17293,19 @@ void Sema::DiagnoseStaticAssertDetails(const Expr *E) {
                                  DiagSide[I].ValueString, Context);
     }
     if (DiagSide[0].Print && DiagSide[1].Print) {
-      Diag(Op->getExprLoc(), diag::note_expr_evaluates_to)
-          << DiagSide[0].ValueString << Op->getOpcodeStr()
-          << DiagSide[1].ValueString << Op->getSourceRange();
+      Diag(E->getExprLoc(), diag::note_expr_evaluates_to)
+          << DiagSide[0].ValueString << OpStr << DiagSide[1].ValueString
+          << E->getSourceRange();
     }
+  };
+
+  if (const auto *Op = dyn_cast<BinaryOperator>(E);
+      Op && Op->getOpcode() != BO_LOr) {
+    Diagnose(Op->getLHS(), Op->getRHS(), Op->getOpcodeStr());
+  } else if (const auto *Op = dyn_cast<CXXOperatorCallExpr>(E);
+             Op && Op->isInfixBinaryOp()) {
+    Diagnose(Op->getArg(0), Op->getArg(1),
+             getOperatorSpelling(Op->getOperator()));
   }
 }
 

--- a/clang/test/CXX/class/class.compare/class.eq/p3.cpp
+++ b/clang/test/CXX/class/class.compare/class.eq/p3.cpp
@@ -6,11 +6,11 @@ struct A {
 };
 
 static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 3, 4, 5});
-static_assert(A{1, 2, 3, 4, 5} == A{0, 2, 3, 4, 5}); // expected-error {{failed}}
-static_assert(A{1, 2, 3, 4, 5} == A{1, 0, 3, 4, 5}); // expected-error {{failed}}
-static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 0, 4, 5}); // expected-error {{failed}}
-static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 3, 0, 5}); // expected-error {{failed}}
-static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 3, 4, 0}); // expected-error {{failed}}
+static_assert(A{1, 2, 3, 4, 5} == A{0, 2, 3, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(A{1, 2, 3, 4, 5} == A{1, 0, 3, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 0, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 3, 0, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(A{1, 2, 3, 4, 5} == A{1, 2, 3, 4, 0}); // expected-error {{failed}} expected-note {{evaluates to}}
 
 struct B {
   int a, b[3], c;
@@ -18,8 +18,8 @@ struct B {
 };
 
 static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 3, 4, 5});
-static_assert(B{1, 2, 3, 4, 5} == B{0, 2, 3, 4, 5}); // expected-error {{failed}}
-static_assert(B{1, 2, 3, 4, 5} == B{1, 0, 3, 4, 5}); // expected-error {{failed}}
-static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 0, 4, 5}); // expected-error {{failed}}
-static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 3, 0, 5}); // expected-error {{failed}}
-static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 3, 4, 0}); // expected-error {{failed}}
+static_assert(B{1, 2, 3, 4, 5} == B{0, 2, 3, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(B{1, 2, 3, 4, 5} == B{1, 0, 3, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 0, 4, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 3, 0, 5}); // expected-error {{failed}} expected-note {{evaluates to}}
+static_assert(B{1, 2, 3, 4, 5} == B{1, 2, 3, 4, 0}); // expected-error {{failed}} expected-note {{evaluates to}}

--- a/clang/test/CXX/class/class.compare/class.rel/p2.cpp
+++ b/clang/test/CXX/class/class.compare/class.rel/p2.cpp
@@ -10,15 +10,15 @@ namespace Rel {
     friend bool operator>=(const A&, const A&) = default;
   };
   static_assert(A{0} < A{1});
-  static_assert(A{1} < A{1}); // expected-error {{failed}}
+  static_assert(A{1} < A{1}); // expected-error {{failed}} expected-note {{'{1} < {1}'}}
   static_assert(A{0} <= A{1});
   static_assert(A{1} <= A{1});
-  static_assert(A{2} <= A{1}); // expected-error {{failed}}
+  static_assert(A{2} <= A{1}); // expected-error {{failed}} expected-note {{'{2} <= {1}'}}
   static_assert(A{1} > A{0});
-  static_assert(A{1} > A{1}); // expected-error {{failed}}
+  static_assert(A{1} > A{1}); // expected-error {{failed}} expected-note {{'{1} > {1}'}}
   static_assert(A{1} >= A{0});
   static_assert(A{1} >= A{1});
-  static_assert(A{1} >= A{2}); // expected-error {{failed}}
+  static_assert(A{1} >= A{2}); // expected-error {{failed}} expected-note {{'{1} >= {2}'}}
 
   struct B {
     bool operator<=>(B) const = delete; // expected-note 4{{deleted here}} expected-note-re 8{{candidate {{.*}} deleted}}
@@ -49,7 +49,7 @@ namespace NotEqual {
     friend bool operator!=(const A&, const A&) = default;
   };
   static_assert(A{1} != A{2});
-  static_assert(A{1} != A{1}); // expected-error {{failed}}
+  static_assert(A{1} != A{1}); // expected-error {{failed}} expected-note {{'{1} != {1}'}}
 
   struct B {
     bool operator==(B) const = delete; // expected-note {{deleted here}} expected-note-re 2{{candidate {{.*}} deleted}}

--- a/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p9-2a.cpp
+++ b/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p9-2a.cpp
@@ -33,7 +33,7 @@ struct Y {};
 constexpr bool operator==(X x, Y) { return x.equal; }
 
 static_assert(X{true} == Y{});
-static_assert(X{false} == Y{}); // expected-error {{failed}}
+static_assert(X{false} == Y{}); // expected-error {{failed}} expected-note{{'{false} == {}'}}
 
 // x == y -> y == x
 static_assert(Y{} == X{true});

--- a/clang/test/SemaCXX/constexpr-builtin-bit-cast-bitint.cpp
+++ b/clang/test/SemaCXX/constexpr-builtin-bit-cast-bitint.cpp
@@ -1,0 +1,82 @@
+// RUN: %clang_cc1 -verify -std=c++2a -fsyntax-only -triple x86_64-apple-macosx10.14.0 %s
+// RUN: %clang_cc1 -verify -std=c++2a -fsyntax-only -triple x86_64-apple-macosx10.14.0 %s -fno-signed-char
+// RUN: %clang_cc1 -verify -std=c++2a -fsyntax-only -triple aarch64_be-linux-gnu %s
+
+// This is separate from constexpr-builtin-bit-cast.cpp because clangd17 seems to behave
+// poorly around __BitInt(N) types, and this isolates that unfortunate behavior to one file
+//
+// hopefully a future clangd will not crash or lose track of its syntax highlighting, at which
+// point the "bit_precise" namespace ought to be merged back into *bit-cast.cpp.
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#  define LITTLE_END 1
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#  define LITTLE_END 0
+#else
+#  error "huh?"
+#endif
+
+using uint8_t = unsigned char;
+
+template <class To, class From>
+constexpr To bit_cast(const From &from) {
+  static_assert(sizeof(To) == sizeof(From));
+  return __builtin_bit_cast(To, from);
+}
+
+namespace bit_precise {
+// ok so it's a little bit of a lie to say we don't support _BitInt in any casts; we do in fact
+// support casting _from_ a _BitInt(N), at least some of the time
+static_assert(bit_cast<uint8_t, _BitInt(8)>(0xff) == 0xff);
+template <int N> struct bytes { uint8_t b[N]; };
+static_assert(bit_cast<bytes<2>, _BitInt(12)>(0xff).b[(LITTLE_END ? 0 : /* fixme */ 0)] == 0xff);
+static_assert(bit_cast<bytes<4>, _BitInt(24)>(0xff).b[(LITTLE_END ? 0 : /* fixme */ 2)] == 0xff);
+
+enum byte : unsigned char {}; // not std::byte
+
+constexpr _BitInt(7) z = 0x7f;
+constexpr auto bad_cast = __builtin_bit_cast(byte, z); // expected-error {{constant expression}}
+// expected-note@-1 {{'bit_precise::byte' is invalid}}
+// expected-note@-2 {{byte [0]}}
+
+#if __clang_major__ > 17
+// This is #ifdef'd off to stop clangd from crashing every time I open this file in my editor
+// fixme? this crashes clang17 and before
+constexpr auto unsupported_cast = __builtin_bit_cast(uint8_t, z); // expected-error {{constant expression}}
+// expected-note@-1 {{subobject of type 'const uint8_t' (aka 'const unsigned char') is not initialized}}
+#endif
+
+// expected-note@+1 {{constexpr bit cast involving type '_BitInt(8)' is not yet supported}}
+constexpr auto _n = __builtin_bit_cast(_BitInt(8), (uint8_t)0xff); // expected-error {{constant expression}}
+
+// expected-note@+1 {{constexpr bit cast involving type '_BitInt(7)' is not yet supported}}
+constexpr auto _m = __builtin_bit_cast(_BitInt(7), (uint8_t)0xff); // expected-error {{constant expression}}
+
+// fixme: support _BitInt
+// struct bitints {
+//   _BitInt(2) x;
+//   signed _BitInt(4) y;
+// };
+//
+// constexpr auto bi = bit_cast<bitints, uint16_t>(0xff'ff);
+// static_assert(bi.x == 0x3);
+// static_assert(bi.y == -8);
+
+// fixme?: the syntax highlighting here is a little off (`signed` and `constexpr` both lose their "keyword" coloring)
+struct BF {
+  _BitInt(2) x : 2;
+  signed _BitInt(3) y : 2;
+    // expected-warning@+1 {{exceeds the width of its type}}
+  _BitInt(3) z : 4; // "oversized" bit field
+};
+
+// expected-note@+1 {{constexpr bit cast involving type '_BitInt(2)' is not yet supported}}
+constexpr auto bf = __builtin_bit_cast(BF, (uint8_t)0xff); // expected-error {{must be initialized by a constant expression}}
+
+// fixme: support _BitInt
+// constexpr auto bf = bit_cast<BF, uint8_t>(0xff);
+// static_assert(bf.x == 0x3);
+// static_assert(bf.y == -4); // or +4 ?
+// static_assert(bf.z == 0x7);
+
+} // namespace bit_precise

--- a/clang/test/SemaCXX/static-assert-cxx17.cpp
+++ b/clang/test/SemaCXX/static-assert-cxx17.cpp
@@ -94,7 +94,7 @@ void foo6() {
   // expected-error@-1{{static assertion failed due to requirement '(const X<int> *)nullptr'}}
   static_assert(static_cast<const X<typename T::T> *>(nullptr));
   // expected-error@-1{{static assertion failed due to requirement 'static_cast<const X<int> *>(nullptr)'}}
-  static_assert((const X<typename T::T>[]){} == nullptr);
+  static_assert((const X<typename T::T>[]){} == nullptr); // expected-note{{expression evaluates to '{} == nullptr'}}
   // expected-error@-1{{static assertion failed due to requirement '(const X<int>[0]){} == nullptr'}}
   static_assert(sizeof(X<decltype(X<typename T::T>().X<typename T::T>::~X())>) == 0);
   // expected-error@-1{{static assertion failed due to requirement 'sizeof(X<void>) == 0'}} \

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
@@ -216,15 +216,19 @@ namespace UnnamedBitfield {
   // uninitialized and it being zeroed. Those are not distinct states
   // according to [temp.type]p2.
   //
-  // FIXME: We shouldn't track a value for unnamed bit-fields, nor number
-  // them when computing field indexes.
+  // At namespace scope, multiple `using` declarations are valid (to avoid
+  // conflicts when #including), just in case they they "all refer to the same
+  // entity." This test makes use of that implicit constraint to ensure that
+  // the compiler does not "see" a difference between any of the `T`s below.
+  // cf. https://stackoverflow.com/a/31225016/151464
   template <A> struct X {};
   constexpr A a;
   using T = X<a>;
   using T = X<A{}>;
   using T = X<(A())>;
-  // Once we support bit-casts involving bit-fields, this should be valid too.
-  using T = X<__builtin_bit_cast(A, 0)>; // expected-error {{constant}} expected-note {{not yet supported}}
+  using T = X<__builtin_bit_cast(A, 0)>;
+  using T = X<__builtin_bit_cast(A, A{})>;
+  using T = X<__builtin_bit_cast(A, (unsigned char[4]){})>;
 }
 
 namespace Temporary {


### PR DESCRIPTION
After this commit, clang permits constructions like:
```c++
struct bits {
    unsigned char : 7;
    unsigned char flag : 1;
}

static_assert(std::bit_cast<bits>(0x80).flag); // succeeds on little-endian systems
```

A few notes for the reviewers:
- ~It's "stacked" on top of a change making `static_assert` print more complex expressions and binary operator call operands because that makes it a whole lot easier to debug, and it seems like there's a lot of overlap between folks working in both areas. I tried to open an actual "stacked" pair of PRs per the latest on #56636 , but I don't have the prerequisite permission to push to `users/sethp/...` and I'm not quite sure how to acquire it; if this doesn't work for you, just let me know what you'd prefer.~ Split out into #74852
- Overall, I feel pretty good about how the point-of-use side worked out (i.e. in `constexpr-builtin-bit-cast.cpp`); I'm especially happy that I worked out how to get the compiler to indicate which bits were indeterminate, because that really helped me learn and understand the way the structures were being laid out in memory (especially when paired with the "stacked" change).
- The implementation side is definitely a bit messier. I'm intending to continue "factoring around" the bit-field allocation logic (as mentioned in D62825), but I'm definitely not an expert in either LLVM or C++, so suggestions would be very welcome. ~~I also have an inkling that `APInt` is a better spelling of "fixed-width bit-buffer" than `SmallVector`, especially for this situation where we're (so far) exclusively mapping to/from `APInt`s.~~ I think this part at least worked out well in [2e0d3f8](https://github.com/llvm/llvm-project/pull/74775/commits/2e0d3f81e4f5b623bb476bfac0278cfc6d1bd4bc)
- As mentioned, I'm also relatively new to C++ (well, modern C++, used in anger; I don't think cutting my teeth on the language back when C++98 was the shiny new thing really helps). That said, I've got a fairly robust background in programming and computer architecture going back some 15 years. I mention that mostly because this seems like an area with more than a few subtleties, and I'm eager for your feedback on them, even if I'm not yet fluent in the C++ dialect. I did go through the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html) and did my best to observe its recommendations; while that document was very helpful, I know it's not likely to be complete!

To better inform the shape of work that I see as outstanding here, I was hoping to solicit your feedback on three specific points:
1. Sign extension; it seems the way the constant evaluator represents bit-fields is to use a full-width `APSInt`. That's convenient for a couple reasons (e.g. there's no need for "implicit" up/down-cast nodes in the expression tree), but it does mean that we've got to invent values for some bits that really aren't "part" of the bit-field. The least surprising way I found to do this was via sign-extension, but  that does lose track of information: for example, given `struct { signed : 1 ; signed : 31  } S`, `std::bit_cast<signed>(S)` doesn't work in a `constexpr` context, but `std::bit_cast<signed>(Ex.signed)` does. I'm not really sure what there is to be done about this one besides changing the evaluator to be bit-width-precise, which seems like a larger unit of work. It's also not really new to this change, but it's something that I noticed that seemed worth raising.
2. Error message(s); I like that the "bad bits" note indicates what ranges the evaluator was looking for and didn't find, but I'm hoping you can tell me how clearly it seems to present that. There's also the classic "first-failure recursive abort" problem that can make compilers feel so nit-picky; right now, "bad bits" only notifies about the first field the evaluator sees that it can't satisfy with a value, even if there are more such objects in the cast expression. It's also a bummer that it doesn't work for the "valid uninitialized holders" (`unsigned char`, `std::byte`). I think I can fix the former by computing the entire "mask" in one pass and then applying it in the next, so we can do a total validity check once (instead of once per field). I'm a little stumped about the latter, though, since it seems like it'd mostly just be false positives: is it possible to add some sort of "deferred" note that doesn't get emitted unless they try to use the uninitialized bytes somehow?
3. Future (type) completeness; Having the benefit of "beginners mind" here, I spent a bunch of time convincing myself that the evaluator was complete in terms of the types it currently handles. I believe it is, but if a future standard invents a new type of bit-field or a new, non-BuiltinType category of TriviallyCopyable bits, it looks to me like it'd be relatively easy to omit support for those in the bit_cast implementation. I wondered "How could we bring 'bit_cast' to the attention of an implementer working elsewhere in clang?", and took a wild swing at this in the test file. But tests are only one way to communicate this kind of thing, and I suppose the constant evaluator has plenty of other possible mismatch points between it and codegen. It seems to me that attempting to match 100% of the details by construction isn't possible, so I guess I'm curious what other strategies y'all have employed here?

Thanks for all the hard work y'all do! 