### PR TITLE
[clang][lex] Fix non-portability diagnostics with absolute path

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2466,15 +2466,21 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
         // The drive letter is optional for absolute paths on Windows, but
         // clang currently cannot process absolute paths in #include lines that
         // don't have a drive.
-        // If the first entry in Components is a directory separator,
-        // then the code at the bottom of this loop that keeps the original
-        // directory separator style copies it. If the second entry is
-        // a directory separator (the C:\ case), then that separator already
-        // got copied when the C: was processed and we want to skip that entry.
-        if (!(Component.size() == 1 && IsSep(Component[0])))
+        if (Component.size() == 1 && IsSep(Component[0])) {
+          // Note: Path always contains at least '<' or '"'.
+          if (Path.size() == 1) {
+            // If the first entry in Components is a directory separator,
+            // then the code at the bottom of this loop that keeps the original
+            // directory separator style copies it.
+          } else {
+            // If the second entry is a directory separator (the C:\ case),
+            // then that separator already got copied when the C: was processed
+            // and we want to skip that entry.
+            continue;
+          }
+        } else {
           Path.append(Component);
-        else if (!Path.empty())
-          continue;
+        }
 
         // Append the separator(s) the user used, or the close quote
         if (Path.size() > NameWithoriginalSlashes.size()) {

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2475,7 +2475,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
         // clang currently cannot process absolute paths in #include lines that
         // don't have a drive.
         if (Component.size() == 1 && IsSep(Component[0])) {
-          // Note: Path always contains at least '<' or '"'.
+          assert(!Path.empty() && "Path always contains at least '<' or quote");
           if (Path.size() == 1) {
             // If the first entry in Components is a directory separator,
             // then the code at the bottom of this loop that keeps the original

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2474,21 +2474,15 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
         // The drive letter is optional for absolute paths on Windows, but
         // clang currently cannot process absolute paths in #include lines that
         // don't have a drive.
-        if (Component.size() == 1 && IsSep(Component[0])) {
-          assert(!Path.empty() && "Path always contains at least '<' or quote");
-          if (Path.size() == 1) {
-            // If the first entry in Components is a directory separator,
-            // then the code at the bottom of this loop that keeps the original
-            // directory separator style copies it.
-          } else {
-            // If the second entry is a directory separator (the C:\ case),
-            // then that separator already got copied when the C: was processed
-            // and we want to skip that entry.
-            continue;
-          }
-        } else {
+        // If the first entry in Components is a directory separator,
+        // then the code at the bottom of this loop that keeps the original
+        // directory separator style copies it. If the second entry is
+        // a directory separator (the C:\ case), then that separator already
+        // got copied when the C: was processed and we want to skip that entry.
+        if (!(Component.size() == 1 && IsSep(Component[0])))
           Path.append(Component);
-        }
+        else if (Path.size() != 1)
+          continue;
 
         // Append the separator(s) the user used, or the close quote
         if (Path.size() > NameWithoriginalSlashes.size()) {

--- a/clang/test/Lexer/case-insensitive-include-absolute.c
+++ b/clang/test/Lexer/case-insensitive-include-absolute.c
@@ -1,8 +1,8 @@
 // REQUIRES: case-insensitive-filesystem
 
 // RUN: rm -rf %t && split-file %s %t
-// RUN: sed "s|DIR|%t|g" %t/tu.c.in > %t/tu.c
-// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DDIR=%t
+// RUN: sed "s|DIR|%/t|g" %t/tu.c.in > %t/tu.c
+// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DDIR=%/t
 
 //--- header.h
 //--- tu.c.in

--- a/clang/test/Lexer/case-insensitive-include-absolute.c
+++ b/clang/test/Lexer/case-insensitive-include-absolute.c
@@ -1,0 +1,13 @@
+// REQUIRES: case-insensitive-filesystem
+
+// RUN: rm -rf %t && split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/tu.c.in > %t/tu.c
+// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DPREFIX=%t
+
+//--- header.h
+//--- tu.c.in
+#import "DIR/Header.h"
+// CHECK:      tu.c:1:9: warning: non-portable path to file '"[[PREFIX]]/header.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+// CHECK-NEXT:    1 | #import "[[PREFIX]]/Header.h"
+// CHECK-NEXT:      |         ^~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT:      |         "[[PREFIX]]/header.h"

--- a/clang/test/Lexer/case-insensitive-include-absolute.c
+++ b/clang/test/Lexer/case-insensitive-include-absolute.c
@@ -1,13 +1,13 @@
 // REQUIRES: case-insensitive-filesystem
 
 // RUN: rm -rf %t && split-file %s %t
-// RUN: sed "s|DIR|%/t|g" %t/tu.c.in > %t/tu.c
-// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DPREFIX=%t
+// RUN: sed "s|DIR|%t|g" %t/tu.c.in > %t/tu.c
+// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DDIR=%t
 
 //--- header.h
 //--- tu.c.in
 #import "DIR/Header.h"
-// CHECK:      tu.c:1:9: warning: non-portable path to file '"[[PREFIX]]/header.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
-// CHECK-NEXT:    1 | #import "[[PREFIX]]/Header.h"
-// CHECK-NEXT:      |         ^~~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT:      |         "[[PREFIX]]/header.h"
+// CHECK:      tu.c:1:9: warning: non-portable path to file '"[[DIR]]/header.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+// CHECK-NEXT:    1 | #import "[[DIR]]/Header.h"
+// CHECK-NEXT:      |         ^~~~~~~~~~~~~~~~~~
+// CHECK-NEXT:      |         "[[DIR]]/header.h"


### PR DESCRIPTION
The existing code incorrectly assumes that `Path` can be empty. It can't, it always contains at least `<` or `"`. On Unix, this patch fixes an incorrect diagnostics that instead of `"/Users/blah"` suggested `"Userss/blah"`. In assert builds, this would outright crash.

rdar://91172342