### PR TITLE
[mlir][Transforms][NFC] GreedyPatternRewriteDriver: Remove redundant worklist management code

### DIFF
--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -581,9 +581,6 @@ void GreedyPatternRewriteDriver::notifyOperationReplaced(
   });
   if (config.listener)
     config.listener->notifyOperationReplaced(op, replacement);
-  for (auto result : op->getResults())
-    for (auto *user : result.getUsers())
-      addToWorklist(user);
 }
 
 LogicalResult GreedyPatternRewriteDriver::notifyMatchFailure(


### PR DESCRIPTION
Do not add the previous users of replaced ops to the worklist during `notifyOperationReplaced`.

The previous users are modified inplace as part of `PatternRewriter::replaceOp`, which calls `PatternRewriter::replaceAllUsesWith`. The latter function updates all users with `updateRootInPlace`, which already puts all previous users of the replaced op on the worklist. No further worklist management work is needed in the `notifyOperationReplaced` callback.