### PR TITLE
[Clang][ARM] support arm target attribute, and warning for bad typo

### DIFF
--- a/clang/lib/Basic/CMakeLists.txt
+++ b/clang/lib/Basic/CMakeLists.txt
@@ -134,5 +134,6 @@ add_clang_library(clangBasic
 
 target_link_libraries(clangBasic
   PRIVATE
+  clangAST
   ${LLVM_ATOMIC_LIB}
 )

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1085,13 +1085,17 @@ ParsedTargetAttr AArch64TargetInfo::parseTargetAttr(StringRef Features) const {
       FoundArch = true;
       std::pair<StringRef, StringRef> Split =
           Feature.split("=").second.trim().split("+");
+      if (Split.first == "")
+        continue;
       const std::optional<llvm::AArch64::ArchInfo> AI =
           llvm::AArch64::parseArch(Split.first);
 
       // Parse the architecture version, adding the required features to
       // Ret.Features.
-      if (!AI)
+      if (!AI) {
+        Ret.Features.push_back("+UNKNOWN");
         continue;
+      }
       Ret.Features.push_back(AI->ArchFeature.str());
       // Add any extra features, after the +
       SplitAndAddFeatures(Split.second, Ret.Features);

--- a/clang/lib/Basic/Targets/ARM.h
+++ b/clang/lib/Basic/Targets/ARM.h
@@ -134,6 +134,8 @@ public:
   initFeatureMap(llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags,
                  StringRef CPU,
                  const std::vector<std::string> &FeaturesVec) const override;
+  ParsedTargetAttr parseTargetAttr(StringRef Str) const override;
+  bool supportsTargetAttributeTune() const override { return false; }
 
   bool isValidFeatureName(StringRef Feature) const override {
     // We pass soft-float-abi in as a -target-feature, but the backend figures

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3462,6 +3462,9 @@ bool Sema::checkTargetAttr(SourceLocation LiteralLoc, StringRef AttrStr) {
 
   for (const auto &Feature : ParsedAttrs.Features) {
     auto CurFeature = StringRef(Feature).drop_front(); // remove + or -.
+    if (CurFeature == "UNKNOWN")
+      return Diag(LiteralLoc, diag::warn_unsupported_target_attribute)
+             << Unknown << None << AttrStr << Target;
     if (!Context.getTargetInfo().isValidFeatureName(CurFeature))
       return Diag(LiteralLoc, diag::warn_unsupported_target_attribute)
              << Unsupported << None << CurFeature << Target;

--- a/clang/test/CodeGen/arm-targetattr.c
+++ b/clang/test/CodeGen/arm-targetattr.c
@@ -1,0 +1,13 @@
+// REQUIRES: arm-registered-target
+// RUN: %clang -target arm-none-eabi -emit-llvm -S -o - %s | FileCheck %s
+
+// CHECK-LABEL: @v8() #0
+__attribute__((target("arch=armv8-a")))
+void v8() {}
+// CHECK-LABEL: @v8crc() #1
+__attribute__((target("arch=armv8-a+crc")))
+void v8crc() {}
+
+// CHECK: attributes #0 = { {{.*}} "target-features"="{{.*}}+armv8-a{{.*}}" }
+// CHECK: attributes #1 = { {{.*}} "target-features"="{{.*}}+armv8-a,+crc{{.*}}" }
+

--- a/clang/test/Frontend/arm-ignore-branch-protection-option.c
+++ b/clang/test/Frontend/arm-ignore-branch-protection-option.c
@@ -3,10 +3,10 @@
 /// Check warning for
 // RUN: %clang -target arm-arm-none-eabi -march=armv7-m -mbranch-protection=bti %s -S -emit-llvm -o - 2>&1 | FileCheck %s
 
-__attribute__((target("arch=cortex-m0"))) void f() {}
+__attribute__((target("cpu=cortex-m0"))) void f() {}
 
 // CHECK: warning: ignoring the 'branch-protection' attribute because the 'cortex-m0' architecture does not support it [-Wbranch-protection]
-// CHECK-NEXT: __attribute__((target("arch=cortex-m0"))) void f() {}
+// CHECK-NEXT: __attribute__((target("cpu=cortex-m0"))) void f() {}
 
 /// Check there are no branch protection function attributes
 

--- a/clang/test/Sema/arm-branch-protection-attr-warn.c
+++ b/clang/test/Sema/arm-branch-protection-attr-warn.c
@@ -1,16 +1,16 @@
 // RUN: %clang_cc1 -triple thumbv6m -verify -fsyntax-only %s
 
 // expected-warning@+1 {{unsupported 'branch-protection' in the 'target' attribute string; 'target' attribute ignored}}
-__attribute__((target("arch=cortex-m0,branch-protection=bti"))) void f1(void) {}
+__attribute__((target("cpu=cortex-m0,branch-protection=bti"))) void f1(void) {}
 
 // expected-warning@+1 {{unsupported 'branch-protection' in the 'target' attribute string; 'target' attribute ignored}}
-__attribute__((target("arch=cortex-m0,branch-protection=pac-ret"))) void f2(void) {}
+__attribute__((target("cpu=cortex-m0,branch-protection=pac-ret"))) void f2(void) {}
 
 // expected-warning@+1 {{unsupported 'branch-protection' in the 'target' attribute string; 'target' attribute ignored}}
-__attribute__((target("arch=cortex-m0,branch-protection=bti+pac-ret"))) void f3(void) {}
+__attribute__((target("cpu=cortex-m0,branch-protection=bti+pac-ret"))) void f3(void) {}
 
 // expected-warning@+1 {{unsupported 'branch-protection' in the 'target' attribute string; 'target' attribute ignored}}
-__attribute__((target("arch=cortex-m0,branch-protection=bti+pac-ret+leaf"))) void f4(void) {}
+__attribute__((target("cpu=cortex-m0,branch-protection=bti+pac-ret+leaf"))) void f4(void) {}
 
 // expected-warning@+1 {{unsupported 'branch-protection' in the 'target' attribute string; 'target' attribute ignored}}
-__attribute__((target("arch=cortex-a17,thumb,branch-protection=bti+pac-ret+leaf"))) void f5(void) {}
+__attribute__((target("cpu=cortex-a17,thumb,branch-protection=bti+pac-ret+leaf"))) void f5(void) {}

--- a/clang/test/Sema/arm-branch-protection.c
+++ b/clang/test/Sema/arm-branch-protection.c
@@ -2,22 +2,22 @@
 
 // expected-no-diagnostics
 // Armv8.1-M.Main
-__attribute__((target("arch=cortex-m55,branch-protection=bti"))) void f1(void) {}
-__attribute__((target("arch=cortex-m55,branch-protection=pac-ret"))) void f2(void) {}
-__attribute__((target("arch=cortex-m55,branch-protection=bti+pac-ret"))) void f3(void) {}
-__attribute__((target("arch=cortex-m55,branch-protection=bti+pac-ret+leaf"))) void f4(void) {}
+__attribute__((target("cpu=cortex-m55,branch-protection=bti"))) void f1(void) {}
+__attribute__((target("cpu=cortex-m55,branch-protection=pac-ret"))) void f2(void) {}
+__attribute__((target("cpu=cortex-m55,branch-protection=bti+pac-ret"))) void f3(void) {}
+__attribute__((target("cpu=cortex-m55,branch-protection=bti+pac-ret+leaf"))) void f4(void) {}
 // Armv8-M.Main
-__attribute__((target("arch=cortex-m33,branch-protection=bti"))) void f5(void) {}
-__attribute__((target("arch=cortex-m33,branch-protection=pac-ret"))) void f6(void) {}
-__attribute__((target("arch=cortex-m33,branch-protection=bti+pac-ret"))) void f7(void) {}
-__attribute__((target("arch=cortex-m33,branch-protection=bti+pac-ret+leaf"))) void f8(void) {}
+__attribute__((target("cpu=cortex-m33,branch-protection=bti"))) void f5(void) {}
+__attribute__((target("cpu=cortex-m33,branch-protection=pac-ret"))) void f6(void) {}
+__attribute__((target("cpu=cortex-m33,branch-protection=bti+pac-ret"))) void f7(void) {}
+__attribute__((target("cpu=cortex-m33,branch-protection=bti+pac-ret+leaf"))) void f8(void) {}
 // Armv7-M
-__attribute__((target("arch=cortex-m3,branch-protection=bti"))) void f9(void) {}
-__attribute__((target("arch=cortex-m3,branch-protection=pac-ret"))) void f10(void) {}
-__attribute__((target("arch=cortex-m3,branch-protection=bti+pac-ret"))) void f11(void) {}
-__attribute__((target("arch=cortex-m3,branch-protection=bti+pac-ret+leaf"))) void f12(void) {}
+__attribute__((target("cpu=cortex-m3,branch-protection=bti"))) void f9(void) {}
+__attribute__((target("cpu=cortex-m3,branch-protection=pac-ret"))) void f10(void) {}
+__attribute__((target("cpu=cortex-m3,branch-protection=bti+pac-ret"))) void f11(void) {}
+__attribute__((target("cpu=cortex-m3,branch-protection=bti+pac-ret+leaf"))) void f12(void) {}
 // Armv7E-M
-__attribute__((target("arch=cortex-m4,branch-protection=bti"))) void f13(void) {}
-__attribute__((target("arch=cortex-m4,branch-protection=pac-ret"))) void f14(void) {}
-__attribute__((target("arch=cortex-m4,branch-protection=bti+pac-ret"))) void f15(void) {}
-__attribute__((target("arch=cortex-m4,branch-protection=bti+pac-ret+leaf"))) void f16(void) {}
+__attribute__((target("cpu=cortex-m4,branch-protection=bti"))) void f13(void) {}
+__attribute__((target("cpu=cortex-m4,branch-protection=pac-ret"))) void f14(void) {}
+__attribute__((target("cpu=cortex-m4,branch-protection=bti+pac-ret"))) void f15(void) {}
+__attribute__((target("cpu=cortex-m4,branch-protection=bti+pac-ret+leaf"))) void f16(void) {}

--- a/clang/test/Sema/attr-target.c
+++ b/clang/test/Sema/attr-target.c
@@ -63,6 +63,14 @@ int __attribute__((target("tune=cortex-a710,tune=neoverse-n2"))) pear_tree(void)
 // no warning - branch-protection should work on aarch64
 int __attribute__((target("branch-protection=none"))) birch_tree(void) { return 5; }
 
+//expected-warning@+1 {{unknown 'arch=armv8-a-typo' in the 'target' attribute string; 'target' attribute ignored}}
+void __attribute__((target("arch=armv8-a-typo"))) typo_arch1(void) {}
+
+#elifdef __arm__
+
+//expected-warning@+1 {{unknown 'arch=armv8-b-typo' in the 'target' attribute string; 'target' attribute ignored}}
+void __attribute__((target("arch=armv8-b-typo"))) typo_arch2(void) {}
+
 #elifdef __powerpc__
 
 int __attribute__((target("float128,arch=pwr9"))) foo(void) { return 4; }


### PR DESCRIPTION
This adds support under ARM for the target("..") attributes like AArch64 https://reviews.llvm.org/D133848 .  And warning for bad typo for "arch=".