### PR TITLE
[lldb][test] TestLocationListLookup.py: skip expr check on unsupported platforms

### DIFF
--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -26,7 +26,8 @@ class LocationListLookupTestCase(TestBase):
         # make sure we can read out the local
         # variables (with both `frame var` and `expr`)
         for f in process.GetSelectedThread().frames:
-            if f.GetDisplayFunctionName().startswith("Foo::bar"):
+            frame_name = f.GetDisplayFunctionName()
+            if frame_name is not None and frame_name.startswith("Foo::bar"):
                 argv = f.GetValueForVariablePath("argv").GetChildAtIndex(0)
                 strm = lldb.SBStream()
                 argv.GetDescription(strm)
@@ -38,7 +39,6 @@ class LocationListLookupTestCase(TestBase):
 
     @skipIf(oslist=["linux"], archs=["arm"])
     @skipIfDarwin
-    @skipIfWindows  # GetDisplayFunctionName returns None
     def test_loclist_frame_var(self):
         self.build()
         self.check_local_vars(self.launch(), check_expr=False)

--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -38,7 +38,7 @@ class LocationListLookupTestCase(TestBase):
 
     @skipIf(oslist=["linux"], archs=["arm"])
     @skipIfDarwin
-    @skipIfWindows # GetDisplayFunctionName returns None
+    @skipIfWindows  # GetDisplayFunctionName returns None
     def test_loclist_frame_var(self):
         self.build()
         self.check_local_vars(self.launch(), check_expr=False)

--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -7,10 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class LocationListLookupTestCase(TestBase):
-    @skipIf(oslist=["linux"], archs=["arm"])
-    def test_loclist(self):
-        self.build()
-
+    def launch(self) -> lldb.SBProcess:
         exe = self.getBuildArtifact("a.out")
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
@@ -22,6 +19,9 @@ class LocationListLookupTestCase(TestBase):
         self.assertTrue(process.IsValid())
         self.assertTrue(process.is_stopped)
 
+        return process
+
+    def check_local_vars(self, process: lldb.SBProcess, check_expr: bool):
         # Find `bar` on the stack, then
         # make sure we can read out the local
         # variables (with both `frame var` and `expr`)
@@ -32,5 +32,17 @@ class LocationListLookupTestCase(TestBase):
                 argv.GetDescription(strm)
                 self.assertNotEqual(strm.GetData().find("a.out"), -1)
 
-                process.GetSelectedThread().SetSelectedFrame(f.idx)
-                self.expect_expr("this", result_type="Foo *")
+                if check_expr:
+                    process.GetSelectedThread().SetSelectedFrame(f.idx)
+                    self.expect_expr("this", result_type="Foo *")
+
+    @skipIf(oslist=["linux"], archs=["arm"])
+    @skipIfDarwin
+    def test_loclist_frame_var(self):
+        self.build()
+        self.check_local_vars(self.launch(), check_expr=False)
+
+    @skipUnlessDarwin
+    def test_loclist_expr(self):
+        self.build()
+        self.check_local_vars(self.launch(), check_expr=True)

--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -38,6 +38,7 @@ class LocationListLookupTestCase(TestBase):
 
     @skipIf(oslist=["linux"], archs=["arm"])
     @skipIfDarwin
+    @skipIfWindows # GetDisplayFunctionName returns None
     def test_loclist_frame_var(self):
         self.build()
         self.check_local_vars(self.launch(), check_expr=False)


### PR DESCRIPTION
The `expect_expr` check was introduced in https://github.com/llvm/llvm-project/pull/74772. It is failing on Linux and Windows, so skip this test to unblock the bots