### PR TITLE
[NVPTX] Custom lower integer<->bf16 conversions for sm_80

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
@@ -607,6 +607,9 @@ private:
   SDValue LowerFROUND32(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFROUND64(SDValue Op, SelectionDAG &DAG) const;
 
+  SDValue LowerINT_TO_FP(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFP_TO_INT(SDValue Op, SelectionDAG &DAG) const;
+
   SDValue LowerLOAD(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerLOADi1(SDValue Op, SelectionDAG &DAG) const;
 

--- a/llvm/test/CodeGen/NVPTX/bf16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16-instructions.ll
@@ -227,3 +227,106 @@ define <8 x float> @test_extload_bf16x8(ptr addrspace(3) noundef %arg) #0 {
   %res = fpext <8 x bfloat> %load to <8 x float>
   ret <8 x float> %res
 }
+
+; CHECK-LABEL: test_fptosi_i16(
+; CHECK:      ld.param.b16     [[A:%rs[0-9]+]], [test_fptosi_i16_param_0];
+; SM80:       cvt.f32.bf16     [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rzi.s16.f32  [[C:%rs[0-9]+]], [[B]];
+; SM80:       cvt.u32.u16      [[R:%r[0-9]+]], [[C]];
+; SM90:       cvt.rzi.s16.bf16 [[B:%rs[0-9]+]], [[A]];
+; SM90:       cvt.u32.u16      [[R:%r[0-9]+]], [[B]];
+; CHECK:      st.param.b32     [func_retval0+0], [[R]];
+; CHECK:      ret;
+define i16 @test_fptosi_i16(bfloat %a) {
+  %r = fptosi bfloat %a to i16
+  ret i16 %r
+}
+
+; CHECK-LABEL: test_fptoui_i16(
+; CHECK:      ld.param.b16     [[A:%rs[0-9]+]], [test_fptoui_i16_param_0];
+; SM80:       cvt.f32.bf16     [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rzi.u16.f32  [[C:%rs[0-9]+]], [[B]];
+; SM80:       cvt.u32.u16      [[R:%r[0-9]+]], [[C]];
+; SM90:       cvt.rzi.u16.bf16 [[B:%rs[0-9]+]], [[A]];
+; SM90:       cvt.u32.u16      [[R:%r[0-9]+]], [[B]];
+; CHECK:      st.param.b32     [func_retval0+0], [[R]];
+; CHECK:      ret;
+define i16 @test_fptoui_i16(bfloat %a) {
+  %r = fptoui bfloat %a to i16
+  ret i16 %r
+}
+
+; CHECK-LABEL: test_sitofp_i16(
+; CHECK:      ld.param.u16    [[A:%rs[0-9]+]], [test_sitofp_i16_param_0];
+; SM80:       cvt.rn.f32.s16  [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[B]];
+; SM90:       cvt.rn.bf16.s16 [[R:%rs[0-9]+]], [[A]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_sitofp_i16(i16 %a) {
+  %r = sitofp i16 %a to bfloat
+  ret bfloat %r
+}
+
+; CHECK-LABEL: test_uitofp_i8(
+; CHECK:      ld.param.u8 %rs1, [test_uitofp_i8_param_0];
+; SM80:       cvt.rn.f32.u16  [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[B]];
+; SM90:       cvt.rn.bf16.u16 [[R:%rs[0-9]+]], [[A]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_uitofp_i8(i8 %a) {
+  %r = uitofp i8 %a to bfloat
+  ret bfloat %r
+}
+
+; CHECK-LABEL: test_uitofp_i1(
+; CHECK:      ld.param.u8     [[A:%rs[0-9]+]], [test_uitofp_i1_param_0];
+; CHECK:      and.b16         [[B:%rs[0-9]+]], [[A]], 1;
+; CHECK:      setp.eq.b16     [[C:%p[0-9]+]], [[B]], 1;
+; CHECK:      selp.u32        [[D:%r[0-9]+]], 1, 0, [[C]];
+; SM80:       cvt.rn.f32.u32  [[E:%f[0-9]+]], [[D]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[E]];
+; SM90:       cvt.rn.bf16.u32 [[R:%rs[0-9]+]], [[D]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_uitofp_i1(i1 %a) {
+  %r = uitofp i1 %a to bfloat
+  ret bfloat %r
+}
+
+; CHECK-LABEL: test_uitofp_i16(
+; CHECK:      ld.param.u16    [[A:%rs[0-9]+]], [test_uitofp_i16_param_0];
+; SM80:       cvt.rn.f32.u16  [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[B]];
+; SM90:       cvt.rn.bf16.u16 [[R:%rs[0-9]+]], [[A]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_uitofp_i16(i16 %a) {
+  %r = uitofp i16 %a to bfloat
+  ret bfloat %r
+}
+
+; CHECK-LABEL: test_uitofp_i32(
+; CHECK:      ld.param.u32    [[A:%r[0-9]+]], [test_uitofp_i32_param_0];
+; SM80:       cvt.rn.f32.u32  [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[B]];
+; SM90:       cvt.rn.bf16.u32 [[R:%rs[0-9]+]], [[A]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_uitofp_i32(i32 %a) {
+  %r = uitofp i32 %a to bfloat
+  ret bfloat %r
+}
+
+; CHECK-LABEL: test_uitofp_i64(
+; CHECK:      ld.param.u64    [[A:%rd[0-9]+]], [test_uitofp_i64_param_0];
+; SM80:       cvt.rn.f32.u64  [[B:%f[0-9]+]], [[A]];
+; SM80:       cvt.rn.bf16.f32 [[R:%rs[0-9]+]], [[B]];
+; SM90:       cvt.rn.bf16.u64 [[R:%rs[0-9]+]], [[A]];
+; CHECK:      st.param.b16    [func_retval0+0], [[R]];
+; CHECK:      ret;
+define bfloat @test_uitofp_i64(i64 %a) {
+  %r = uitofp i64 %a to bfloat
+  ret bfloat %r
+}


### PR DESCRIPTION
sm_80 only has f32->bf16 conversions, the remaining integer conversions arrived with sm_90. Use a two-step conversion for sm_80.

There doesn't seem to be a way to express this promotion directly within the legalization framework, so fallback on Custom lowering.