### PR TITLE
[Orc][examples] Drop target triple from input for remote debugging test

### DIFF
--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/LLJITWithRemoteDebugging.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/LLJITWithRemoteDebugging.cpp
@@ -88,6 +88,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Host.h"
 
 #include "../ExampleModules.h"
 #include "RemoteJITUtils.h"
@@ -173,23 +174,14 @@ int main(int argc, char *argv[]) {
     TSMs.push_back(ExitOnErr(parseExampleModuleFromFile(Path)));
   }
 
-  StringRef TT;
+  std::string TT;
   StringRef MainModuleName;
   TSMs.front().withModuleDo([&MainModuleName, &TT](Module &M) {
     MainModuleName = M.getName();
     TT = M.getTargetTriple();
+    if (TT.empty())
+      TT = sys::getProcessTriple();
   });
-
-  for (const ThreadSafeModule &TSM : TSMs)
-    ExitOnErr(TSM.withModuleDo([TT, MainModuleName](Module &M) -> Error {
-      if (M.getTargetTriple() != TT)
-        return make_error<StringError>(
-            formatv("Different target triples in input files:\n"
-                    "  '{0}' in '{1}'\n  '{2}' in '{3}'",
-                    TT, MainModuleName, M.getTargetTriple(), M.getName()),
-            inconvertibleErrorCode());
-      return Error::success();
-    }));
 
   // Create a target machine that matches the input triple.
   JITTargetMachineBuilder JTMB((Triple(TT)));

--- a/llvm/test/Examples/OrcV2Examples/Inputs/argc_sub1_elf.ll
+++ b/llvm/test/Examples/OrcV2Examples/Inputs/argc_sub1_elf.ll
@@ -1,5 +1,4 @@
 ; ModuleID = 'argc_sub1.c'
-target triple = "x86_64-unknown-unknown-elf"
 
 define i32 @sub1(i32) !dbg !8 {
   call void @llvm.dbg.value(metadata i32 %0, metadata !13, metadata !DIExpression()), !dbg !14


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/74764 reported that the `lljit-with-remote-debugging` test fails on AArch64 hosts, because the input IR file states arch x86_64 explicitly. In order to drop the target triple we have to remove a check in the example implementation.