### PR TITLE
[mlir][Pass] Move PassExecutionAction to Pass.h, NFC.

### DIFF
--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -36,9 +36,19 @@ using namespace mlir::detail;
 // PassExecutionAction
 //===----------------------------------------------------------------------===//
 
+PassExecutionAction::PassExecutionAction(ArrayRef<IRUnit> irUnits,
+                                         const Pass &pass)
+    : Base(irUnits), pass(pass) {}
+
 void PassExecutionAction::print(raw_ostream &os) const {
   os << llvm::formatv("`{0}` running `{1}` on Operation `{2}`", tag,
                       pass.getName(), getOp()->getName());
+}
+
+Operation *PassExecutionAction::getOp() const {
+  ArrayRef<IRUnit> irUnits = getContextIRUnits();
+  return irUnits.empty() ? nullptr
+                         : llvm::dyn_cast_if_present<Operation *>(irUnits[0]);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Pass/PassDetail.h
+++ b/mlir/lib/Pass/PassDetail.h
@@ -15,26 +15,6 @@
 #include "llvm/Support/FormatVariadic.h"
 
 namespace mlir {
-/// Encapsulate the "action" of executing a single pass, used for the MLIR
-/// tracing infrastructure.
-struct PassExecutionAction : public tracing::ActionImpl<PassExecutionAction> {
-  using Base = tracing::ActionImpl<PassExecutionAction>;
-  PassExecutionAction(ArrayRef<IRUnit> irUnits, const Pass &pass)
-      : Base(irUnits), pass(pass) {}
-  static constexpr StringLiteral tag = "pass-execution";
-  void print(raw_ostream &os) const override;
-  const Pass &getPass() const { return pass; }
-  Operation *getOp() const {
-    ArrayRef<IRUnit> irUnits = getContextIRUnits();
-    return irUnits.empty() ? nullptr
-                           : llvm::dyn_cast_if_present<Operation *>(irUnits[0]);
-  }
-
-public:
-  const Pass &pass;
-  Operation *op;
-};
-
 namespace detail {
 
 //===----------------------------------------------------------------------===//

--- a/mlir/unittests/Pass/CMakeLists.txt
+++ b/mlir/unittests/Pass/CMakeLists.txt
@@ -5,5 +5,6 @@ add_mlir_unittest(MLIRPassTests
 )
 target_link_libraries(MLIRPassTests
   PRIVATE
+  MLIRDebug
   MLIRFuncDialect
   MLIRPass)


### PR DESCRIPTION
This patch moves PassExecutionAction to Pass.h so that it can be used by the action framework to introspect and intercede in pass managers that might be set up opaquely. This provides for a very particular use case, which essentially involves being able to intercede in a PassManager and skip or apply individual passes. Because of this, this patch also adds a test for this use case to verify that it could in fact work.