### PR TITLE
[lldb-dap] Include [opt] in the frame name only if a custom frame format is not specified.

### DIFF
--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -803,9 +803,11 @@ llvm::json::Value CreateStackFrame(lldb::SBFrame &frame) {
     llvm::raw_string_ostream os(frame_name);
     os << llvm::format_hex(frame.GetPC(), 18);
   }
-  bool is_optimized = frame.GetFunction().GetIsOptimized();
-  if (is_optimized)
+
+  // We only include `[opt]` if a custom frame format is not specified.
+  if (!g_dap.frame_format && frame.GetFunction().GetIsOptimized())
     frame_name += " [opt]";
+
   EmplaceSafeString(object, "name", frame_name);
 
   auto source = CreateSource(frame);


### PR DESCRIPTION
Currently there's an include in which `[opt]` might be emitted twice if the frame format also asks for it. As a trivial fix, we should manually emit `[opt]` only if a custom frame format is not specified.
