### PR TITLE
[flang] Move OpenMP-related code from `FirConverter` to `OpenMPMixin`

### DIFF
--- a/flang/lib/Lower/ConverterMixin.h
+++ b/flang/lib/Lower/ConverterMixin.h
@@ -1,0 +1,28 @@
+//===-- ConverterMixin.h --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_CONVERTERMIXIN_H
+#define FORTRAN_LOWER_CONVERTERMIXIN_H
+
+namespace Fortran::lower {
+
+template <typename FirConverterT> class ConverterMixinBase {
+public:
+  FirConverterT *This() { return static_cast<FirConverterT *>(this); }
+  const FirConverterT *This() const {
+    return static_cast<const FirConverterT *>(this);
+  }
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_CONVERTERMIXIN_H

--- a/flang/lib/Lower/OpenMPMixin.h
+++ b/flang/lib/Lower/OpenMPMixin.h
@@ -1,0 +1,66 @@
+//===-- OpenMPMixin.h -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_OPENMPMIXIN_H
+#define FORTRAN_LOWER_OPENMPMIXIN_H
+
+#include "ConverterMixin.h"
+#include "flang/Parser/parse-tree.h"
+
+namespace fir {
+class FirOpBuilder;
+}
+
+namespace Fortran::semantics {
+class Symbol;
+}
+
+namespace Fortran::lower {
+
+class AbstractConverter;
+class LoweringBridge;
+class SymMap;
+
+namespace pft {
+class Evaluation;
+class Variable;
+} // namespace pft
+
+template <typename ConverterT>
+class OpenMPMixin : public ConverterMixinBase<ConverterT> {
+public:
+  void genFIR(const Fortran::parser::OpenMPConstruct &);
+  void genFIR(const Fortran::parser::OpenMPDeclarativeConstruct &);
+
+  void genFIR(const Fortran::parser::OmpEndLoopDirective &) {} // nop
+
+  void instantiateVariable(Fortran::lower::AbstractConverter &converter,
+                           const Fortran::lower::pft::Variable &var);
+  void finalize(const Fortran::semantics::Symbol *globalOmpRequiresSymbol);
+
+private:
+  // Shortcuts to call ConverterT:: functions. They can't be defined here
+  // because the definition of ConverterT is not available at this point.
+  Fortran::lower::LoweringBridge &getBridge();
+  fir::FirOpBuilder &getBuilder();
+  Fortran::lower::pft::Evaluation &getEval();
+  Fortran::lower::SymMap &getSymTable();
+
+private:
+  /// Whether a target region or declare target function/subroutine
+  /// intended for device offloading have been detected
+  bool ompDeviceCodeFound = false;
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_OPENMPMIXIN_H


### PR DESCRIPTION
This improves the separation of the generic Fortran lowering and the lowering of OpenMP constructs.

The mixin is intended to be derived from via CRTP:
```cpp
  class FirConverter : public OpenMPMixin<FirConverter> ...
```

The primary goal of the mixin is to implement `genFIR` functions that the derived converter can then call via
```cpp
  std::visit([this](auto &&s) { genFIR(s); });
```

The mixin is also expecting a handful of functions to be present in the derived class, most importantly `genFIR(Evaluation&)`, plus getter classes for the op builder, symbol table, etc.

The pre-existing PFT-lowering functionality is preserved.