### PR TITLE
[mlir][ArmSME] Remove `vector.print` legality from ArmSMEToSCF (NFC)

### DIFF
--- a/mlir/lib/Conversion/ArmSMEToSCF/ArmSMEToSCF.cpp
+++ b/mlir/lib/Conversion/ArmSMEToSCF/ArmSMEToSCF.cpp
@@ -484,12 +484,6 @@ struct ConvertArmSMEToSCFPass
     target.addLegalDialect<arm_sme::ArmSMEDialect, vector::VectorDialect,
                            arith::ArithDialect, scf::SCFDialect>();
     target.addIllegalOp<arm_sme::TileLoadOp, arm_sme::TileStoreOp>();
-    target.addDynamicallyLegalOp<vector::PrintOp>([](vector::PrintOp op) {
-      if (!op.getSource())
-        return true;
-      VectorType vectorType = dyn_cast<VectorType>(op.getPrintType());
-      return !vectorType || !arm_sme::isValidSMETileVectorType(vectorType);
-    });
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
       signalPassFailure();


### PR DESCRIPTION
This was moved to VectorToArmSME in #74063, so this is no longer needed.

VectorToArmSME uses a greedy rewriter, so a similar legality rule is not needed there.

See: https://github.com/llvm/llvm-project/blob/bbb8a0df7367068e1cf2fc54edd376beb976b430/mlir/lib/Conversion/VectorToArmSME/VectorToArmSMEPass.cpp#L35