### PR TITLE
[Profile] Disable continuous mode when reset to default.profraw due to malformed LLVM_PROFILE_FILE.

### DIFF
--- a/compiler-rt/lib/profile/InstrProfiling.h
+++ b/compiler-rt/lib/profile/InstrProfiling.h
@@ -55,6 +55,12 @@ int __llvm_profile_is_continuous_mode_enabled(void);
 void __llvm_profile_enable_continuous_mode(void);
 
 /*!
+ * \brief Enable continuous mode.
+ *
+ */
+void __llvm_profile_disable_continuous_mode(void);
+
+/*!
  * \brief Set the page size.
  *
  * This is a pre-requisite for enabling continuous mode. The buffer size

--- a/compiler-rt/lib/profile/InstrProfiling.h
+++ b/compiler-rt/lib/profile/InstrProfiling.h
@@ -55,7 +55,7 @@ int __llvm_profile_is_continuous_mode_enabled(void);
 void __llvm_profile_enable_continuous_mode(void);
 
 /*!
- * \brief Enable continuous mode.
+ * \brief Disable continuous mode.
  *
  */
 void __llvm_profile_disable_continuous_mode(void);

--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -33,6 +33,10 @@ COMPILER_RT_VISIBILITY void __llvm_profile_enable_continuous_mode(void) {
   ContinuouslySyncProfile = 1;
 }
 
+void __llvm_profile_disable_continuous_mode(void) {
+  ContinuouslySyncProfile = 0;
+}
+
 COMPILER_RT_VISIBILITY void __llvm_profile_set_page_size(unsigned PS) {
   PageSize = PS;
 }

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -711,7 +711,6 @@ static void resetFilenameToDefault(void) {
   memset(&lprofCurFilename, 0, sizeof(lprofCurFilename));
   lprofCurFilename.FilenamePat = DefaultProfileName;
   lprofCurFilename.PNS = PNS_default;
-  __llvm_profile_disable_continuous_mode();
 }
 
 static unsigned getMergePoolSize(const char *FilenamePat, int *I) {
@@ -807,6 +806,7 @@ static int parseFilenamePattern(const char *FilenamePat,
         if (__llvm_profile_is_continuous_mode_enabled()) {
           PROF_WARN("%%c specifier can only be specified once in %s.\n",
                     FilenamePat);
+          __llvm_profile_disable_continuous_mode();
           return -1;
         }
 #if defined(__APPLE__) || defined(__ELF__) || defined(_WIN32)

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -711,6 +711,7 @@ static void resetFilenameToDefault(void) {
   memset(&lprofCurFilename, 0, sizeof(lprofCurFilename));
   lprofCurFilename.FilenamePat = DefaultProfileName;
   lprofCurFilename.PNS = PNS_default;
+  __llvm_profile_disable_continuous_mode();
 }
 
 static unsigned getMergePoolSize(const char *FilenamePat, int *I) {

--- a/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
@@ -9,7 +9,7 @@
 // RUN: ls -l default.profraw | FileCheck %s
 
 // CHECK:     default.profraw
-// CEHCK-NOT: incorrect-profile-name.profraw
+// CHECK-NOT: incorrect-profile-name.profraw
 
 #include <stdio.h>
 int f() { return 0; }

--- a/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
@@ -1,0 +1,21 @@
+// REQUIRES: darwin || linux
+
+// Test when LLVM_PROFILE_FILE is set incorrectly, it should fall backs to use default.profraw without runtime error.
+
+// Create & cd into a temporary directory.
+// RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
+// RUN: %clang -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation=true -o %t.exe %s
+// RUN: env LLVM_PROFILE_FILE="incorrect-profile-name%m%c%c.profraw" %run %t.exe
+// RUN: ls -l default.profraw | FileCheck %s
+
+// CHECK:     default.profraw
+// CEHCK-NOT: incorrect-profile-name.profraw
+
+#include <stdio.h>
+int f() { return 0; }
+
+int main(int argc, char **argv) {
+  FILE* File = fopen("default.profraw", "w");
+  f();
+  return 0;
+}

--- a/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
@@ -15,7 +15,7 @@
 int f() { return 0; }
 
 int main(int argc, char **argv) {
-  FILE* File = fopen("default.profraw", "w");
+  FILE *File = fopen("default.profraw", "w");
   f();
   return 0;
 }

--- a/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
@@ -6,7 +6,7 @@
 // RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clang -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation=true -o %t.exe %s
 // RUN: env LLVM_PROFILE_FILE="incorrect-profile-name%m%c%c.profraw" %run %t.exe
-// RUN: ls -l default.profraw | FileCheck %s
+// RUN: ls -l | FileCheck %s
 
 // CHECK:     default.profraw
 // CHECK-NOT: incorrect-profile-name.profraw


### PR DESCRIPTION
When LLVM_PROFILE_FILE is set incorrectly (e.g. multiple %c) and it falls back to use `default.profraw` name, but continuous mode is still set. This might cause signal bus in the following scenario.

LLVM_PROFILE_FILE is set incorrectly (with "%c%c") for process A and B. Suppose A starts first and falls back to use `default.profraw` and mmaped its file content to memory.  Later B starts and also falls back to use `default.profraw`, but it will truncate the file because online merging is disable when reseting to `default.profraw`. When A tries to update counter via mmaped memory, signal bus will occur.

This fixes it by disabling continuous mode when reset to default.profraw. 