### PR TITLE
[mlir][sparse] fix uninitialized dense tensor out in conv2d test

### DIFF
--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d.mlir
@@ -55,15 +55,15 @@ module {
 
   func.func @conv2d_CSR_dense_rotated(%arg0: tensor<8x8xi32, #CSR>,
                                       %arg1: tensor<3x3xi32>) -> tensor<6x6xi32> {
-    %s = tensor.empty() : tensor<6x6xi32>
+    %s = arith.constant dense<0> : tensor<6x6xi32>
     %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
-    iterator_types = ["parallel", "reduction", "reduction", "parallel"]}
-    ins(%arg0, %arg1 : tensor<8x8xi32, #CSR>, tensor<3x3xi32>)
-    outs(%s : tensor<6x6xi32>) attrs =  {sorted = true} {
-    ^bb0(%in: i32, %in_0: i32, %out: i32):
-      %1 = arith.muli %in, %in_0 : i32
-      %2 = arith.addi %out, %1 : i32
-      linalg.yield %2 : i32
+      iterator_types = ["parallel", "reduction", "reduction", "parallel"]}
+      ins(%arg0, %arg1 : tensor<8x8xi32, #CSR>, tensor<3x3xi32>)
+      outs(%s : tensor<6x6xi32>) attrs =  {sorted = true} {
+      ^bb0(%in: i32, %in_0: i32, %out: i32):
+        %1 = arith.muli %in, %in_0 : i32
+        %2 = arith.addi %out, %1 : i32
+        linalg.yield %2 : i32
     } -> tensor<6x6xi32>
     return %0 : tensor<6x6xi32>
   }


### PR DESCRIPTION
Note, tensor.empty may feed into SPARSE output (meaning it truly has no values yet), but for a DENSE output, it should always have an initial value. We ran a verifier over all our tests and this is the only remaining omission.