### PR TITLE
Add a test for evicting unreachable modules from the global module cache

### DIFF
--- a/lldb/test/API/python_api/global_module_cache/Makefile
+++ b/lldb/test/API/python_api/global_module_cache/Makefile
@@ -1,0 +1,1 @@
+include Makefile.rules

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -12,7 +12,6 @@ import shutil
 from pathlib import Path
 import time
 
-
 class GlobalModuleCacheTestCase(TestBase):
     # NO_DEBUG_INFO_TESTCASE = True
 
@@ -49,7 +48,6 @@ class GlobalModuleCacheTestCase(TestBase):
     @expectedFailureAll
     def test_OneTargetTwoDebuggers(self):
         self.do_test(True, False)
-
 
     def do_test(self, one_target, one_debugger):
         # Make sure that if we have one target, and we run, then
@@ -137,7 +135,7 @@ class GlobalModuleCacheTestCase(TestBase):
             fail_msg = fail_msg + "\nError after MPD: " + error_after_mpd
         if fail_msg != "":
             self.fail(fail_msg)
-        
+
     def check_image_list_result(self, num_a_dot_out, num_main_dot_o):
         # Check the global module list, there should only be one a.out, and if we are
         # doing dwarf in .o file, there should only be one .o file.  This returns
@@ -161,12 +159,11 @@ class GlobalModuleCacheTestCase(TestBase):
                 found_a_dot_out += 1
             if "main.o" in line:
                 found_main_dot_o += 1
-
         
         if num_a_dot_out != found_a_dot_out:
             return f"Got {found_a_dot_out} number of a.out's, expected {num_a_dot_out}"
             
         if found_main_dot_o > 0 and num_main_dot_o != found_main_dot_o:
             return f"Got {found_main_dot_o} number of main.o's, expected {num_main_dot_o}"
-        
+
         return ""

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -1,0 +1,110 @@
+"""
+Test the use of the global module cache in lldb
+"""
+
+import lldb
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import os
+import shutil
+from pathlib import Path
+import time
+
+
+class GlobalModuleCacheTestCase(TestBase):
+    # NO_DEBUG_INFO_TESTCASE = True
+
+    def check_counter_var(self, thread, value):
+        frame = thread.frames[0]
+        var = frame.FindVariable("counter")
+        self.assertTrue(var.GetError().Success(), "Got counter variable")
+        self.assertEqual(var.GetValueAsUnsigned(), value, "This was one-print")
+
+    def copy_to_main(self, src, dst):
+        # We are relying on the source file being newer than the .o file from
+        # a previous build, so sleep a bit here to ensure that the touch is later.
+        time.sleep(2)
+        try:
+            shutil.copy(src, dst)
+        except:
+            self.fail(f"Could not copy {src} to {dst}")
+        Path(dst).touch()
+
+    # The rerun tests indicate rerunning on Windows doesn't really work, so
+    # this one won't either.
+    @skipIfWindows
+    def test_OneTargetOneDebugger(self):
+        # Make sure that if we have one target, and we run, then
+        # change the binary and rerun, the binary (and any .o files
+        # if using dwarf in .o file debugging) get removed from the
+        # shared module cache.  They are no longer reachable.
+        debug_style = self.getDebugInfo()
+
+        # Before we do anything, clear the global module cache so we don't
+        # see objects from other runs:
+        lldb.SBDebugger.MemoryPressureDetected()
+
+        # Set up the paths for our two versions of main.c:
+        main_c_path = os.path.join(self.getBuildDir(), "main.c")
+        one_print_path = os.path.join(self.getSourceDir(), "one-print.c")
+        two_print_path = os.path.join(self.getSourceDir(), "two-print.c")
+        main_filespec = lldb.SBFileSpec(main_c_path)
+
+        # First copy the one-print.c to main.c in the build folder and
+        # build our a.out from there:
+        self.copy_to_main(one_print_path, main_c_path)
+        self.build(dictionary={"C_SOURCES": main_c_path, "EXE": "a.out"})
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "return counter;", main_filespec
+        )
+
+        # Make sure we ran the version we intended here:
+        self.check_counter_var(thread, 1)
+        process.Kill()
+
+        # Now copy two-print.c over main.c, rebuild, and rerun:
+        # os.unlink(target.GetExecutable().fullpath)
+        self.copy_to_main(two_print_path, main_c_path)
+
+        self.build(dictionary={"C_SOURCES": main_c_path, "EXE": "a.out"})
+        error = lldb.SBError()
+        (_, process, thread, _) = lldbutil.run_to_breakpoint_do_run(self, target, bkpt)
+        # In two-print.c counter will be 2:
+        self.check_counter_var(thread, 2)
+
+        num_a_dot_out_entries = 1
+        # For dSYM's there will be two lines of output, one for the a.out and one
+        # for the dSYM.
+        if debug_style == "dsym":
+            num_a_dot_out_entries += 1
+
+        self.check_image_list_result(num_a_dot_out_entries, 1)
+
+    def check_image_list_result(self, num_a_dot_out, num_main_dot_o):
+        # Now look at the global module list, there should only be one a.out, and if we are
+        # doing dwarf in .o file, there should only be one .o file:
+        image_cmd_result = lldb.SBCommandReturnObject()
+        interp = self.dbg.GetCommandInterpreter()
+        interp.HandleCommand("image list -g", image_cmd_result)
+        image_list_str = image_cmd_result.GetOutput()
+        image_list = image_list_str.splitlines()
+        found_a_dot_out = 0
+        found_main_dot_o = 0
+
+        for line in image_list:
+            # FIXME: force this to be at the end of the string:
+            if "a.out" in line:
+                found_a_dot_out += 1
+            if "main.o" in line:
+                found_main_dot_o += 1
+
+        self.assertEqual(
+            num_a_dot_out, found_a_dot_out, "Got the right number of a.out's"
+        )
+        if found_main_dot_o > 0:
+            self.assertEqual(
+                num_main_dot_o, found_main_dot_o, "Got the right number of main.o's"
+            )

--- a/lldb/test/API/python_api/global_module_cache/one-print.c
+++ b/lldb/test/API/python_api/global_module_cache/one-print.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 
-int
-main() {
+int main() {
   int counter = 0;
   printf("I only print one time: %d.\n", counter++);
   return counter;

--- a/lldb/test/API/python_api/global_module_cache/one-print.c
+++ b/lldb/test/API/python_api/global_module_cache/one-print.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int
+main() {
+  int counter = 0;
+  printf("I only print one time: %d.\n", counter++);
+  return counter;
+}

--- a/lldb/test/API/python_api/global_module_cache/two-print.c
+++ b/lldb/test/API/python_api/global_module_cache/two-print.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 
-int
-main() {
+int main() {
   int counter = 0;
   printf("I print one time: %d.\n", counter++);
   printf("I print two times: %d.\n", counter++);

--- a/lldb/test/API/python_api/global_module_cache/two-print.c
+++ b/lldb/test/API/python_api/global_module_cache/two-print.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int
+main() {
+  int counter = 0;
+  printf("I print one time: %d.\n", counter++);
+  printf("I print two times: %d.\n", counter++);
+  return counter;
+}


### PR DESCRIPTION
When you debug a binary and the change & rebuild and then rerun in lldb w/o quitting lldb, the Modules in the Global Module Cache for the old binary & .o files if used are now "unreachable".  Nothing in lldb is holding them alive, and they've already been unlinked.  lldb will properly discard them if there's not another Target referencing them.

However, this only works in simple cases at present.  If you have several Targets that reference the same modules, it's pretty easy to end up stranding Modules that are no longer reachable, and if you use a sequence of SBDebuggers unreachable modules can also get stranded.  If you run a long-lived lldb process and are iteratively developing on a large code base, lldb's memory gets filled with useless Modules.

This patch adds a test for the mode that currently works:

(lldb) target create foo
(lldb) run
<rebuild foo outside lldb>
(lldb) run

In that case, we do delete the unreachable Modules.

The next step will be to add tests for the cases where we fail to do this, then see how to safely/efficiently evict unreachable modules in those cases as well.