### PR TITLE
Invalidate analyses after running Attributor in OpenMPOpt

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1159,8 +1159,8 @@ struct AnalysisGetter {
 
   /// Invalidates the analyses. Valid only when using the new pass manager.
   void invalidateAnalyses() {
-    if (FAM)
-      FAM->clear();
+    assert(FAM && "Can only be used from the new PM!");
+    FAM->clear();
   }
 
   AnalysisGetter(FunctionAnalysisManager &FAM, bool CachedOnly = false)

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1157,7 +1157,11 @@ struct AnalysisGetter {
     return nullptr;
   }
 
-  void invalidateAnalyses() { FAM->clear(); }
+  /// Invalidates the analyses. Valid only when using the new pass manager.
+  void invalidateAnalyses() {
+    if (FAM)
+      FAM->clear();
+  }
 
   AnalysisGetter(FunctionAnalysisManager &FAM, bool CachedOnly = false)
       : FAM(&FAM), CachedOnly(CachedOnly) {}
@@ -1288,6 +1292,7 @@ struct InformationCache {
     return AssumeOnlyValues.contains(&I);
   }
 
+  /// Invalidates the cached analyses.
   void invalidateAnalyses() { AG.invalidateAnalyses(); }
 
   /// Return the analysis result from a pass \p AP for function \p F.

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1157,6 +1157,10 @@ struct AnalysisGetter {
     return nullptr;
   }
 
+  void invalidate() {
+    FAM->clear();
+  }
+
   AnalysisGetter(FunctionAnalysisManager &FAM, bool CachedOnly = false)
       : FAM(&FAM), CachedOnly(CachedOnly) {}
   AnalysisGetter(Pass *P, bool CachedOnly = false)
@@ -1284,6 +1288,10 @@ struct InformationCache {
 
   bool isOnlyUsedByAssume(const Instruction &I) const {
     return AssumeOnlyValues.contains(&I);
+  }
+
+  void invalidate() {
+    AG.invalidate();
   }
 
   /// Return the analysis result from a pass \p AP for function \p F.

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1157,7 +1157,7 @@ struct AnalysisGetter {
     return nullptr;
   }
 
-  void invalidate() { FAM->clear(); }
+  void invalidateAnalyses() { FAM->clear(); }
 
   AnalysisGetter(FunctionAnalysisManager &FAM, bool CachedOnly = false)
       : FAM(&FAM), CachedOnly(CachedOnly) {}
@@ -1288,7 +1288,7 @@ struct InformationCache {
     return AssumeOnlyValues.contains(&I);
   }
 
-  void invalidate() { AG.invalidate(); }
+  void invalidateAnalyses() { AG.invalidateAnalyses(); }
 
   /// Return the analysis result from a pass \p AP for function \p F.
   template <typename AP>

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1292,7 +1292,8 @@ struct InformationCache {
     return AssumeOnlyValues.contains(&I);
   }
 
-  /// Invalidates the cached analyses.
+  /// Invalidates the cached analyses. Valid only when using the new pass
+  /// manager.
   void invalidateAnalyses() { AG.invalidateAnalyses(); }
 
   /// Return the analysis result from a pass \p AP for function \p F.

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1157,9 +1157,7 @@ struct AnalysisGetter {
     return nullptr;
   }
 
-  void invalidate() {
-    FAM->clear();
-  }
+  void invalidate() { FAM->clear(); }
 
   AnalysisGetter(FunctionAnalysisManager &FAM, bool CachedOnly = false)
       : FAM(&FAM), CachedOnly(CachedOnly) {}
@@ -1290,9 +1288,7 @@ struct InformationCache {
     return AssumeOnlyValues.contains(&I);
   }
 
-  void invalidate() {
-    AG.invalidate();
-  }
+  void invalidate() { AG.invalidate(); }
 
   /// Return the analysis result from a pass \p AP for function \p F.
   template <typename AP>

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -2054,7 +2054,7 @@ private:
                       << " functions, result: " << Changed << ".\n");
 
     if (Changed == ChangeStatus::CHANGED)
-      OMPInfoCache.invalidate();
+      OMPInfoCache.invalidateAnalyses();
 
     return Changed == ChangeStatus::CHANGED;
   }

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -2053,6 +2053,9 @@ private:
     LLVM_DEBUG(dbgs() << "[Attributor] Done with " << SCC.size()
                       << " functions, result: " << Changed << ".\n");
 
+    if (Changed == ChangeStatus::CHANGED)
+      OMPInfoCache.invalidate();
+
     return Changed == ChangeStatus::CHANGED;
   }
 


### PR DESCRIPTION
Using the LoopInfo from OMPInfoCache after the Attributor ran resulted in a crash due to it being in an invalid state.