### PR TITLE
[LLVM][DWARF] Add compilation directory and dwo name to TU in dwo section

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -3478,6 +3478,12 @@ void DwarfDebug::addDwarfTypeUnitType(DwarfCompileUnit &CU,
   Ins.first->second = Signature;
 
   if (useSplitDwarf()) {
+    if (getDwarfVersion() >= 5) {
+      if (!CompilationDir.empty())
+        NewTU.addString(UnitDie, dwarf::DW_AT_comp_dir, CompilationDir);
+      NewTU.addString(UnitDie, dwarf::DW_AT_dwo_name,
+                      Asm->TM.Options.MCOptions.SplitDwarfFile);
+    }
     MCSection *Section =
         getDwarfVersion() <= 4
             ? Asm->getObjFileLowering().getDwarfTypesDWOSection()

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -3478,6 +3478,10 @@ void DwarfDebug::addDwarfTypeUnitType(DwarfCompileUnit &CU,
   Ins.first->second = Signature;
 
   if (useSplitDwarf()) {
+    // Although multiple type units can have the same signature, they are not
+    // guranteed to be bit identical. When LLDB uses .debug_names it needs to
+    // know from which CU a type unit came from. These two attrbutes help it to
+    // figure that out.
     if (getDwarfVersion() >= 5) {
       if (!CompilationDir.empty())
         NewTU.addString(UnitDie, dwarf::DW_AT_comp_dir, CompilationDir);

--- a/llvm/test/CodeGen/X86/dwarf-headers.ll
+++ b/llvm/test/CodeGen/X86/dwarf-headers.ll
@@ -75,14 +75,14 @@
 ; O-5: .debug_info contents:
 ; O-5: 0x00000000: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_skeleton, abbr_offset
 ; O-5-SAME:        DWO_id = 0xccd7e58ef8bf4aa6
-; O-5: 0x00000014: DW_TAG_skeleton_unit 
+; O-5: 0x00000014: DW_TAG_skeleton_unit
 ;
 ; DWO-5: .debug_info.dwo contents:
 ; DWO-5: 0x00000000: Type Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_type, abbr_offset
 ; DWO-5: 0x00000018: DW_TAG_type_unit
-; DWO-5: 0x00000033: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_compile, abbr_offset
+; DWO-5: 0x00000035: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_compile, abbr_offset
 ; DWO-5-SAME:        DWO_id = 0xccd7e58ef8bf4aa6
-; DWO-5: 0x00000047: DW_TAG_compile_unit
+; DWO-5: 0x00000049: DW_TAG_compile_unit
 
 
 ; ModuleID = 't.cpp'

--- a/llvm/test/DebugInfo/WebAssembly/dwarf-headers.ll
+++ b/llvm/test/DebugInfo/WebAssembly/dwarf-headers.ll
@@ -77,14 +77,14 @@
 ; O-5: .debug_info contents:
 ; O-5: 0x00000000: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_skeleton, abbr_offset
 ; O-5-SAME:        DWO_id = 0xccd7e58ef8bf4aa6
-; O-5: 0x00000014: DW_TAG_skeleton_unit 
+; O-5: 0x00000014: DW_TAG_skeleton_unit
 ;
 ; DWO-5: .debug_info.dwo contents:
 ; DWO-5: 0x00000000: Type Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_type, abbr_offset
 ; DWO-5: 0x00000018: DW_TAG_type_unit
-; DWO-5: 0x00000033: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_compile, abbr_offset
+; DWO-5: 0x00000035: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_split_compile, abbr_offset
 ; DWO-5-SAME:        DWO_id = 0xccd7e58ef8bf4aa6
-; DWO-5: 0x00000047: DW_TAG_compile_unit
+; DWO-5: 0x00000049: DW_TAG_compile_unit
 
 
 ; ModuleID = 't.cpp'

--- a/llvm/test/DebugInfo/X86/debug-names-types.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-types.ll
@@ -222,13 +222,12 @@
 ; CHECK-TYPE-NEXT:      DW_AT_high_pc
 ; CHECK-TYPE-NEXT:      DW_AT_addr_base
 
-; CHECK-TYPE: .debug_info.dwo contents
-; CHECK-TYPE:        DW_TAG_type_unit
-; CHECK-TYPE-NEXT:      DW_AT_language
-; CHECK-TYPE-NEXT:      DW_AT_comp_dir  ("/typeSmall")
-; CHECK-TYPE-NEXT:      DW_AT_dwo_name
+; CHECK-TYPE:           DW_TAG_type_unit
+; CHECK-TYPE-NOT:       DW_TAG
+; CHECK-TYPE:           DW_AT_comp_dir  ("/typeSmall")
+; CHECK-TYPE-NOT:       DW_TAG
+; CHECK-TYPE:           DW_AT_dwo_name
 ; CHECK-TYPE-SAME:        debug-names-types.ll.tmp.mainTypes.dwo
-; CHECK-TYPE-NEXT:      DW_AT_stmt_list
 
 ; ModuleID = 'main.cpp'
 source_filename = "main.cpp"

--- a/llvm/test/DebugInfo/X86/debug-names-types.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-types.ll
@@ -1,5 +1,6 @@
 ; UNSUPPORTED: system-windows
 ; This checks that .debug_names can be generated with monolithic, and split-dwarf, when -fdebug-type-sections is enabled.
+; It also checks that TU in .debug_info.dwo has correct DW_AT_comp_dir and DW_AT_dwo_name.
 ; Generated with: clang++ main.cpp   -g2 -gdwarf-5 -gpubnames -fdebug-types-section
 
 ; RUN: llc -mtriple=x86_64 -generate-type-units -dwarf-version=5 -filetype=obj %s -o %t
@@ -171,7 +172,7 @@
 ; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV1]]
 ; CHECK-SPLIT-NEXT:         Tag: DW_TAG_structure_type
 ; CHECK-SPLIT-NEXT:         DW_IDX_type_unit: 0x00
-; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x0000001f
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000021
 ; CHECK-SPLIT-NEXT:       }
 ; CHECK-SPLIT-NEXT:       Entry @ 0xae {
 ; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV]]
@@ -199,12 +200,35 @@
 ; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV4]]
 ; CHECK-SPLIT-NEXT:         Tag: DW_TAG_base_type
 ; CHECK-SPLIT-NEXT:         DW_IDX_type_unit: 0x00
-; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000034
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000036
 ; CHECK-SPLIT-NEXT:       }
 ; CHECK-SPLIT-NEXT:     }
 ; CHECK-SPLIT-NEXT:   ]
 ; CHECK-SPLIT-NEXT: }
 
+
+
+; RUN: llvm-dwarfdump -debug-info -r 0 %t > %tdebugInfo.txt
+; RUN: llvm-dwarfdump -debug-info -r 0 %t.mainTypes.dwo >> %tdebugInfo.txt
+; RUN: cat %tdebugInfo.txt | FileCheck %s --check-prefixes=CHECK-TYPE
+
+; CHECK-TYPE:         DW_TAG_skeleton_unit
+; CHECK-TYPE-NEXT:      DW_AT_stmt_list
+; CHECK-TYPE-NEXT:      DW_AT_str_offsets_base
+; CHECK-TYPE-NEXT:      DW_AT_comp_dir  ("/typeSmall")
+; CHECK-TYPE-NEXT:      DW_AT_dwo_name
+; CHECK-TYPE-SAME:        debug-names-types.ll.tmp.mainTypes.dwo
+; CHECK-TYPE-NEXT:      DW_AT_low_pc
+; CHECK-TYPE-NEXT:      DW_AT_high_pc
+; CHECK-TYPE-NEXT:      DW_AT_addr_base
+
+; CHECK-TYPE: .debug_info.dwo contents
+; CHECK-TYPE:        DW_TAG_type_unit
+; CHECK-TYPE-NEXT:      DW_AT_language
+; CHECK-TYPE-NEXT:      DW_AT_comp_dir  ("/typeSmall")
+; CHECK-TYPE-NEXT:      DW_AT_dwo_name
+; CHECK-TYPE-SAME:        debug-names-types.ll.tmp.mainTypes.dwo
+; CHECK-TYPE-NEXT:      DW_AT_stmt_list
 
 ; ModuleID = 'main.cpp'
 source_filename = "main.cpp"


### PR DESCRIPTION
This adds support to help LLDB when binary is built with split dwarf, has
.debug_names accelerator table and DWP file.
Final linked binary might have Type Units (TUs) with the same type signature in multiple
compilation units. Although the signature is the same, TUs are not guranted to
be bit identical. This is not a problem when they are in .o/.dwo files as LLDB
can find them by looking at the right one based on DW_AT_comp_dir/DW_AT_name in
skeleton CU. Once DWP is created, TUs are de-duplicated, and we need to know
from which CU remaining one came from.

This approach allows LLDB to figure it out, with minimal changes to the rest of
the tooling. As would have been the case if .debug-tu-index section in DWP was
modified.
