### PR TITLE
[lldb] In-progress — All ValueObjectSP instances are now valid (non-null) but have an error state

### DIFF
--- a/lldb/include/lldb/Breakpoint/Watchpoint.h
+++ b/lldb/include/lldb/Breakpoint/Watchpoint.h
@@ -219,8 +219,8 @@ private:
   uint32_t m_ignore_count;      // Number of times to ignore this watchpoint
   std::string m_decl_str;       // Declaration information, if any.
   std::string m_watch_spec_str; // Spec for the watchpoint.
-  lldb::ValueObjectSP m_old_value_sp;
-  lldb::ValueObjectSP m_new_value_sp;
+  std::optional<lldb::ValueObjectSP> m_old_value_sp;
+  std::optional<lldb::ValueObjectSP> m_new_value_sp;
   CompilerType m_type;
   Status m_error; // An error object describing errors associated with this
                   // watchpoint.

--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -409,7 +409,7 @@ public:
       Stream &s,
       GetExpressionPathFormat = eGetExpressionPathFormatDereferencePointers);
 
-  lldb::ValueObjectSP GetValueForExpressionPath(
+  std::optional<lldb::ValueObjectSP> GetValueForExpressionPath(
       llvm::StringRef expression,
       ExpressionPathScanEndReason *reason_to_stop = nullptr,
       ExpressionPathEndResultType *final_value_type = nullptr,
@@ -465,22 +465,24 @@ public:
   /// Returns a unique id for this ValueObject.
   lldb::user_id_t GetID() const { return m_id.GetID(); }
 
-  virtual lldb::ValueObjectSP GetChildAtIndex(size_t idx,
-                                              bool can_create = true);
+  virtual std::optional<lldb::ValueObjectSP>
+  GetChildAtIndex(size_t idx, bool can_create = true);
 
-  // The method always creates missing children in the path, if necessary.
-  lldb::ValueObjectSP GetChildAtIndexPath(llvm::ArrayRef<size_t> idxs,
-                                          size_t *index_of_error = nullptr);
+  /// The method always creates missing children in the path, if necessary.
+  std::optional<lldb::ValueObjectSP>
+  GetChildAtIndexPath(llvm::ArrayRef<size_t> idxs,
+                      size_t *index_of_error = nullptr);
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetChildAtIndexPath(llvm::ArrayRef<std::pair<size_t, bool>> idxs,
                       size_t *index_of_error = nullptr);
 
-  // The method always creates missing children in the path, if necessary.
-  lldb::ValueObjectSP GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names);
+  /// The method always creates missing children in the path, if necessary.
+  std::optional<lldb::ValueObjectSP>
+  GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names);
 
-  virtual lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
-                                                     bool can_create = true);
+  virtual std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true);
 
   virtual size_t GetIndexOfChildWithName(llvm::StringRef name);
 
@@ -544,7 +546,12 @@ public:
 
   bool UpdateFormatsIfNeeded();
 
-  lldb::ValueObjectSP GetSP() { return m_manager->GetSharedPointer(this); }
+  lldb::ValueObjectSP GetSP() {
+    std::shared_ptr<ValueObject> shared_pointer =
+        m_manager->GetSharedPointer(this);
+    lldb::ValueObjectSP value_object_sp(std::move(shared_pointer));
+    return value_object_sp;
+  }
 
   /// Change the name of the current ValueObject. Should *not* be used from a
   /// synthetic child provider as it would change the name of the non synthetic
@@ -556,26 +563,28 @@ public:
 
   lldb::addr_t GetPointerValue(AddressType *address_type = nullptr);
 
-  lldb::ValueObjectSP GetSyntheticChild(ConstString key) const;
+  std::optional<lldb::ValueObjectSP> GetSyntheticChild(ConstString key) const;
 
-  lldb::ValueObjectSP GetSyntheticArrayMember(size_t index, bool can_create);
+  std::optional<lldb::ValueObjectSP> GetSyntheticArrayMember(size_t index,
+                                                             bool can_create);
 
-  lldb::ValueObjectSP GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
-                                                bool can_create);
+  std::optional<lldb::ValueObjectSP>
+  GetSyntheticBitFieldChild(uint32_t from, uint32_t to, bool can_create);
 
-  lldb::ValueObjectSP GetSyntheticExpressionPathChild(const char *expression,
-                                                      bool can_create);
+  std::optional<lldb::ValueObjectSP>
+  GetSyntheticExpressionPathChild(const char *expression, bool can_create);
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticChildAtOffset(uint32_t offset, const CompilerType &type,
                             bool can_create,
                             ConstString name_const_str = ConstString());
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticBase(uint32_t offset, const CompilerType &type, bool can_create,
                    ConstString name_const_str = ConstString());
 
-  virtual lldb::ValueObjectSP GetDynamicValue(lldb::DynamicValueType valueType);
+  virtual std::optional<lldb::ValueObjectSP>
+  GetDynamicValue(lldb::DynamicValueType valueType);
 
   lldb::DynamicValueType GetDynamicValueType();
 
@@ -583,7 +592,7 @@ public:
 
   virtual lldb::ValueObjectSP GetNonSyntheticValue() { return GetSP(); }
 
-  lldb::ValueObjectSP GetSyntheticValue();
+  std::optional<lldb::ValueObjectSP> GetSyntheticValue();
 
   virtual bool HasSyntheticValue();
 
@@ -595,7 +604,7 @@ public:
 
   virtual lldb::ValueObjectSP CreateConstantValue(ConstString name);
 
-  virtual lldb::ValueObjectSP Dereference(Status &error);
+  virtual lldb::ValueObjectSP Dereference();
 
   /// Creates a copy of the ValueObject with a new name and setting the current
   /// ValueObject as its parent. It should be used when we want to change the
@@ -603,7 +612,7 @@ public:
   /// (e.g. sythetic child provider).
   virtual lldb::ValueObjectSP Clone(ConstString new_name);
 
-  virtual lldb::ValueObjectSP AddressOf(Status &error);
+  virtual lldb::ValueObjectSP AddressOf();
 
   virtual lldb::addr_t GetLiveAddress() { return LLDB_INVALID_ADDRESS; }
 
@@ -614,11 +623,11 @@ public:
 
   virtual lldb::ValueObjectSP DoCast(const CompilerType &compiler_type);
 
-  virtual lldb::ValueObjectSP CastPointerType(const char *name,
-                                              CompilerType &ast_type);
+  virtual std::optional<lldb::ValueObjectSP>
+  CastPointerType(const char *name, CompilerType &ast_type);
 
-  virtual lldb::ValueObjectSP CastPointerType(const char *name,
-                                              lldb::TypeSP &type_sp);
+  virtual std::optional<lldb::ValueObjectSP>
+  CastPointerType(const char *name, lldb::TypeSP &type_sp);
 
   /// If this object represents a C++ class with a vtable, return an object
   /// that represents the virtual function table. If the object isn't a class
@@ -650,18 +659,18 @@ public:
 
   void Dump(Stream &s, const DumpValueObjectOptions &options);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx,
                                   const EvaluateExpressionOptions &options);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromAddress(llvm::StringRef name, uint64_t address,
                                const ExecutionContext &exe_ctx,
                                CompilerType type);
@@ -670,7 +679,7 @@ public:
   CreateValueObjectFromData(llvm::StringRef name, const DataExtractor &data,
                             const ExecutionContext &exe_ctx, CompilerType type);
 
-  lldb::ValueObjectSP Persist();
+  std::optional<lldb::ValueObjectSP> Persist();
 
   /// Returns true if this is a char* or a char[] if it is a char* and
   /// check_pointer is true, it also checks that the pointer is valid.
@@ -882,7 +891,7 @@ protected:
 
   /// We have to hold onto a shared  pointer to this one because it is created
   /// as an independent ValueObjectConstResult, which isn't managed by us.
-  lldb::ValueObjectSP m_addr_of_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_addr_of_valobj_sp;
 
   lldb::Format m_format = lldb::eFormatDefault;
   lldb::Format m_last_format = lldb::eFormatDefault;
@@ -1006,7 +1015,7 @@ private:
     GetRoot()->DoUpdateChildrenAddressType(*this);
   }
 
-  lldb::ValueObjectSP GetValueForExpressionPath_Impl(
+  std::optional<lldb::ValueObjectSP> GetValueForExpressionPath_Impl(
       llvm::StringRef expression_cstr,
       ExpressionPathScanEndReason *reason_to_stop,
       ExpressionPathEndResultType *final_value_type,

--- a/lldb/include/lldb/Core/ValueObjectConstResult.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResult.h
@@ -77,16 +77,16 @@ public:
 
   void SetByteSize(size_t size);
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   lldb::addr_t GetAddressOf(bool scalar_is_load_address = true,
                             AddressType *address_type = nullptr) override;
@@ -101,7 +101,7 @@ public:
     m_impl.SetLiveAddress(addr, address_type);
   }
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetDynamicValue(lldb::DynamicValueType valueType) override;
 
   lldb::LanguageType GetPreferredDisplayLanguage() override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultCast.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultCast.h
@@ -33,7 +33,7 @@ public:
 
   ~ValueObjectConstResultCast() override;
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
@@ -42,11 +42,11 @@ public:
     return ValueObjectCast::GetCompilerType();
   }
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   size_t GetPointeeData(DataExtractor &data, uint32_t item_idx = 0,
                         uint32_t item_count = 1) override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultChild.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultChild.h
@@ -39,7 +39,7 @@ public:
 
   ~ValueObjectConstResultChild() override;
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
@@ -48,11 +48,11 @@ public:
     return ValueObjectChild::GetCompilerType();
   }
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   lldb::addr_t GetAddressOf(bool scalar_is_load_address = true,
                             AddressType *address_type = nullptr) override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultImpl.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultImpl.h
@@ -36,17 +36,17 @@ public:
 
   virtual ~ValueObjectConstResultImpl() = default;
 
-  lldb::ValueObjectSP Dereference(Status &error);
+  lldb::ValueObjectSP Dereference();
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index);
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetSyntheticChildAtOffset(uint32_t offset, const CompilerType &type,
                             bool can_create,
                             ConstString name_const_str = ConstString());
 
-  lldb::ValueObjectSP AddressOf(Status &error);
+  lldb::ValueObjectSP AddressOf();
 
   lldb::addr_t GetLiveAddress() { return m_live_address; }
 
@@ -68,7 +68,7 @@ private:
   ValueObject *m_impl_backend;
   lldb::addr_t m_live_address;
   AddressType m_live_address_type;
-  lldb::ValueObjectSP m_address_of_backend;
+  std::optional<lldb::ValueObjectSP> m_address_of_backend;
 
   ValueObjectConstResultImpl(const ValueObjectConstResultImpl &) = delete;
   const ValueObjectConstResultImpl &

--- a/lldb/include/lldb/Core/ValueObjectList.h
+++ b/lldb/include/lldb/Core/ValueObjectList.h
@@ -28,31 +28,34 @@ public:
 
   void Append(const ValueObjectList &valobj_list);
 
-  lldb::ValueObjectSP FindValueObjectByPointer(ValueObject *valobj);
+  std::optional<lldb::ValueObjectSP>
+  FindValueObjectByPointer(ValueObject *valobj);
 
   size_t GetSize() const;
 
   void Resize(size_t size);
 
-  lldb::ValueObjectSP GetValueObjectAtIndex(size_t idx);
+  std::optional<lldb::ValueObjectSP> GetValueObjectAtIndex(size_t idx);
 
-  lldb::ValueObjectSP RemoveValueObjectAtIndex(size_t idx);
+  std::optional<lldb::ValueObjectSP> RemoveValueObjectAtIndex(size_t idx);
 
   void SetValueObjectAtIndex(size_t idx, const lldb::ValueObjectSP &valobj_sp);
 
-  lldb::ValueObjectSP FindValueObjectByValueName(const char *name);
+  std::optional<lldb::ValueObjectSP>
+  FindValueObjectByValueName(const char *name);
 
-  lldb::ValueObjectSP FindValueObjectByUID(lldb::user_id_t uid);
+  std::optional<lldb::ValueObjectSP> FindValueObjectByUID(lldb::user_id_t uid);
 
   void Swap(ValueObjectList &value_object_list);
 
   void Clear() { m_value_objects.clear(); }
 
-  const std::vector<lldb::ValueObjectSP> &GetObjects() const {
+  const std::vector<std::optional<lldb::ValueObjectSP>> &GetObjects() const {
     return m_value_objects;
   }
+
 protected:
-  typedef std::vector<lldb::ValueObjectSP> collection;
+  typedef std::vector<std::optional<lldb::ValueObjectSP>> collection;
   // Classes that inherit from ValueObjectList can see and modify these
   collection m_value_objects;
 };

--- a/lldb/include/lldb/Core/ValueObjectRegister.h
+++ b/lldb/include/lldb/Core/ValueObjectRegister.h
@@ -52,8 +52,8 @@ public:
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
 
-  lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
-                                             bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true) override;
 
   size_t GetIndexOfChildWithName(llvm::StringRef name) override;
 

--- a/lldb/include/lldb/Core/ValueObjectSyntheticFilter.h
+++ b/lldb/include/lldb/Core/ValueObjectSyntheticFilter.h
@@ -51,15 +51,15 @@ public:
 
   lldb::ValueType GetValueType() const override;
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx,
-                                      bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildAtIndex(size_t idx, bool can_create = true) override;
 
-  lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
-                                             bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true) override;
 
   size_t GetIndexOfChildWithName(llvm::StringRef name) override;
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetDynamicValue(lldb::DynamicValueType valueType) override;
 
   bool IsInScope() override;

--- a/lldb/include/lldb/Core/ValueObjectUpdater.h
+++ b/lldb/include/lldb/Core/ValueObjectUpdater.h
@@ -20,9 +20,9 @@ namespace lldb_private {
 /// process' stop ID and will update the user type when needed.
 class ValueObjectUpdater {
   /// The root value object is the static typed variable object.
-  lldb::ValueObjectSP m_root_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_root_valobj_sp;
   /// The user value object is the value object the user wants to see.
-  lldb::ValueObjectSP m_user_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_user_valobj_sp;
   /// The stop ID that m_user_valobj_sp is valid for.
   uint32_t m_stop_id = UINT32_MAX;
 
@@ -33,7 +33,7 @@ public:
   /// stop ID. If dynamic values are enabled, or if synthetic children are
   /// enabled, the value object that the user wants to see might change while
   /// debugging.
-  lldb::ValueObjectSP GetSP();
+  std::optional<lldb::ValueObjectSP> GetSP();
 
   lldb::ProcessSP GetProcessSP() const;
 };

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -45,7 +45,7 @@ public:
     return count <= max ? count : max;
   }
 
-  virtual lldb::ValueObjectSP GetChildAtIndex(size_t idx) = 0;
+  virtual std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) = 0;
 
   virtual size_t GetIndexOfChildWithName(ConstString name) = 0;
 
@@ -68,7 +68,7 @@ public:
   // if this function returns a non-null ValueObject, then the returned
   // ValueObject will stand for this ValueObject whenever a "value" request is
   // made to this ValueObject
-  virtual lldb::ValueObjectSP GetSyntheticValue() { return nullptr; }
+  virtual std::optional<lldb::ValueObjectSP> GetSyntheticValue() { return {}; }
 
   // if this function returns a non-empty ConstString, then clients are
   // expected to use the return as the name of the type of this ValueObject for
@@ -79,12 +79,12 @@ public:
   typedef std::unique_ptr<SyntheticChildrenFrontEnd> AutoPointer;
 
 protected:
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx);
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromAddress(llvm::StringRef name, uint64_t address,
                                const ExecutionContext &exe_ctx,
                                CompilerType type);
@@ -110,7 +110,9 @@ public:
 
   size_t CalculateNumChildren() override { return 0; }
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override { return nullptr; }
+  std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override {
+    return {};
+  }
 
   size_t GetIndexOfChildWithName(ConstString name) override {
     return UINT32_MAX;
@@ -120,7 +122,7 @@ public:
 
   bool MightHaveChildren() override { return false; }
 
-  lldb::ValueObjectSP GetSyntheticValue() override = 0;
+  std::optional<lldb::ValueObjectSP> GetSyntheticValue() override = 0;
 
 private:
   SyntheticValueProviderFrontEnd(const SyntheticValueProviderFrontEnd &) =
@@ -321,9 +323,9 @@ public:
 
     size_t CalculateNumChildren() override { return filter->GetCount(); }
 
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+    std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override {
       if (idx >= filter->GetCount())
-        return lldb::ValueObjectSP();
+        return {};
       return m_backend.GetSyntheticExpressionPathChild(
           filter->GetExpressionPathAtIndex(idx), true);
     }
@@ -425,7 +427,7 @@ public:
 
     size_t CalculateNumChildren(uint32_t max) override;
 
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+    std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override;
 
     bool Update() override;
 
@@ -433,7 +435,7 @@ public:
 
     size_t GetIndexOfChildWithName(ConstString name) override;
 
-    lldb::ValueObjectSP GetSyntheticValue() override;
+    std::optional<lldb::ValueObjectSP> GetSyntheticValue() override;
 
     ConstString GetSyntheticTypeName() override;
 

--- a/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
+++ b/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
@@ -101,7 +101,8 @@ protected:
 
   void PrintChildrenPostamble(bool print_dotdotdot);
 
-  lldb::ValueObjectSP GenerateChild(ValueObject *synth_valobj, size_t idx);
+  std::optional<lldb::ValueObjectSP> GenerateChild(ValueObject *synth_valobj,
+                                                   size_t idx);
 
   void PrintChild(lldb::ValueObjectSP child_sp,
                   const DumpValueObjectOptions::PointerDepth &curr_ptr_depth);

--- a/lldb/include/lldb/DataFormatters/VectorIterator.h
+++ b/lldb/include/lldb/DataFormatters/VectorIterator.h
@@ -26,7 +26,7 @@ public:
 
   size_t CalculateNumChildren() override;
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override;
 
   bool Update() override;
 

--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -266,7 +266,7 @@ public:
   static lldb::ExpressionResults
   Evaluate(ExecutionContext &exe_ctx, const EvaluateExpressionOptions &options,
            llvm::StringRef expr_cstr, llvm::StringRef expr_prefix,
-           lldb::ValueObjectSP &result_valobj_sp, Status &error,
+           std::optional<lldb::ValueObjectSP> result_valobj_sp, Status &error,
            std::string *fixed_expression = nullptr,
            ValueObject *ctx_obj = nullptr);
 

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -425,9 +425,9 @@ public:
     return 0;
   }
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetChildAtIndex(const StructuredData::ObjectSP &implementor, uint32_t idx) {
-    return lldb::ValueObjectSP();
+    return {};
   }
 
   virtual int
@@ -446,9 +446,9 @@ public:
     return true;
   }
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticValue(const StructuredData::ObjectSP &implementor) {
-    return nullptr;
+    return {};
   }
 
   virtual ConstString

--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -149,9 +149,9 @@ public:
   static lldb::BreakpointPreconditionSP
   GetExceptionPrecondition(lldb::LanguageType language, bool throw_bp);
 
-  virtual lldb::ValueObjectSP GetExceptionObjectForThread(
-      lldb::ThreadSP thread_sp) {
-    return lldb::ValueObjectSP();
+  virtual std::optional<lldb::ValueObjectSP>
+  GetExceptionObjectForThread(lldb::ThreadSP thread_sp) {
+    return {};
   }
 
   virtual lldb::ThreadSP GetBacktraceThreadFromException(

--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -307,7 +307,7 @@ public:
   ///
   /// \return
   ///     A shared pointer to the ValueObject described by var_expr.
-  lldb::ValueObjectSP GetValueForVariableExpressionPath(
+  std::optional<lldb::ValueObjectSP> GetValueForVariableExpressionPath(
       llvm::StringRef var_expr, lldb::DynamicValueType use_dynamic,
       uint32_t options, lldb::VariableSP &var_sp, Status &error);
 
@@ -439,7 +439,7 @@ public:
   ///
   /// \return
   ///     A ValueObject for this variable.
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetValueObjectForFrameVariable(const lldb::VariableSP &variable_sp,
                                  lldb::DynamicValueType use_dynamic);
 
@@ -463,7 +463,7 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.  If valid, it has a valid ExpressionPath.
-  lldb::ValueObjectSP GuessValueForAddress(lldb::addr_t addr);
+  std::optional<lldb::ValueObjectSP> GuessValueForAddress(lldb::addr_t addr);
 
   /// Attempt to reconstruct the ValueObject for the address contained in a
   /// given register plus an offset.  The ExpressionPath should indicate how
@@ -477,8 +477,8 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.  If valid, it has a valid ExpressionPath.
-  lldb::ValueObjectSP GuessValueForRegisterAndOffset(ConstString reg,
-                                                     int64_t offset);
+  std::optional<lldb::ValueObjectSP>
+  GuessValueForRegisterAndOffset(ConstString reg, int64_t offset);
 
   /// Attempt to reconstruct the ValueObject for a variable with a given \a name
   /// from within the current StackFrame, within the current block. The search
@@ -491,7 +491,7 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.
-  lldb::ValueObjectSP FindVariable(ConstString name);
+  std::optional<lldb::ValueObjectSP> FindVariable(ConstString name);
 
   // lldb::ExecutionContextScope pure virtual functions
   lldb::TargetSP CalculateTarget() override;

--- a/lldb/include/lldb/Target/StackFrameRecognizer.h
+++ b/lldb/include/lldb/Target/StackFrameRecognizer.h
@@ -34,9 +34,7 @@ public:
   virtual lldb::ValueObjectListSP GetRecognizedArguments() {
     return m_arguments;
   }
-  virtual lldb::ValueObjectSP GetExceptionObject() {
-    return lldb::ValueObjectSP();
-  }
+  virtual std::optional<lldb::ValueObjectSP> GetExceptionObject() { return {}; }
   virtual lldb::StackFrameSP GetMostRelevantFrame() { return nullptr; };
   virtual ~RecognizedStackFrame() = default;
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1239,7 +1239,7 @@ public:
   // the execution context.
   lldb::ExpressionResults EvaluateExpression(
       llvm::StringRef expression, ExecutionContextScope *exe_scope,
-      lldb::ValueObjectSP &result_valobj_sp,
+      std::optional<lldb::ValueObjectSP> &result_valobj_sp,
       const EvaluateExpressionOptions &options = EvaluateExpressionOptions(),
       std::string *fixed_expression = nullptr, ValueObject *ctx_obj = nullptr);
 

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -414,7 +414,7 @@ public:
                                   bool broadcast = false);
 
   Status ReturnFromFrame(lldb::StackFrameSP frame_sp,
-                         lldb::ValueObjectSP return_value_sp,
+                         std::optional<lldb::ValueObjectSP> return_value_sp,
                          bool broadcast = false);
 
   Status JumpToLine(const FileSpec &file, uint32_t line,
@@ -1213,7 +1213,7 @@ public:
   ///     LLDB_INVALID_ADDRESS is returned if no token is available.
   virtual uint64_t GetExtendedBacktraceToken() { return LLDB_INVALID_ADDRESS; }
 
-  lldb::ValueObjectSP GetCurrentException();
+  std::optional<lldb::ValueObjectSP> GetCurrentException();
 
   lldb::ThreadSP GetCurrentExceptionBacktrace();
 

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -450,8 +450,8 @@ public:
   // (currently only ThreadPlanStepOut does this.) If so, the ReturnValueObject
   // can be retrieved from here.
 
-  virtual lldb::ValueObjectSP GetReturnValueObject() {
-    return lldb::ValueObjectSP();
+  virtual std::optional<lldb::ValueObjectSP> GetReturnValueObject() {
+    return {};
   }
 
   // If the thread plan managing the evaluation of a user expression lives

--- a/lldb/include/lldb/Target/ThreadPlanCallFunction.h
+++ b/lldb/include/lldb/Target/ThreadPlanCallFunction.h
@@ -59,7 +59,7 @@ public:
   // plan is complete, you can call "GetReturnValue()" to retrieve the value
   // that was extracted.
 
-  lldb::ValueObjectSP GetReturnValueObject() override {
+  std::optional<lldb::ValueObjectSP> GetReturnValueObject() override {
     return m_return_valobj_sp;
   }
 

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -9,7 +9,9 @@
 #ifndef LLDB_LLDB_FORWARD_H
 #define LLDB_LLDB_FORWARD_H
 
+#include <assert.h>
 #include <memory>
+#include <optional>
 
 // lldb forward declarations
 namespace lldb_private {
@@ -466,7 +468,23 @@ typedef std::shared_ptr<lldb_private::UnixSignals> UnixSignalsSP;
 typedef std::weak_ptr<lldb_private::UnixSignals> UnixSignalsWP;
 typedef std::shared_ptr<lldb_private::UnwindAssembly> UnwindAssemblySP;
 typedef std::shared_ptr<lldb_private::UnwindPlan> UnwindPlanSP;
-typedef std::shared_ptr<lldb_private::ValueObject> ValueObjectSP;
+class ValueObjectSP : public std::shared_ptr<lldb_private::ValueObject> {
+  ValueObjectSP() = delete;
+  operator bool() = delete;
+
+public:
+  ValueObjectSP(std::shared_ptr<lldb_private::ValueObject> &&pointer)
+      : std::shared_ptr<lldb_private::ValueObject>(std::move(pointer)) {
+    assert(pointer);
+  }
+
+  static std::optional<ValueObjectSP>
+  createFromSP(std::shared_ptr<lldb_private::ValueObject> &&pointer) {
+    if (!pointer)
+      return {};
+    return ValueObjectSP(std::move(pointer));
+  }
+};
 typedef std::shared_ptr<lldb_private::Value> ValueSP;
 typedef std::shared_ptr<lldb_private::Variable> VariableSP;
 typedef std::shared_ptr<lldb_private::VariableList> VariableListSP;

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -285,8 +285,6 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
   // We need to make sure the user sees any parse errors in their condition, so
   // we'll hook the constructor errors up to the debugger's Async I/O.
 
-  ValueObjectSP result_value_sp;
-
   EvaluateExpressionOptions options;
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
@@ -311,10 +309,10 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
       return false;
     }
 
-    result_value_sp = result_variable_sp->GetValueObject();
+    auto result_value_sp = result_variable_sp->GetValueObject();
 
     if (result_value_sp) {
-      ret = result_value_sp->IsLogicalTrue(error);
+      ret = result_value_sp.value()->IsLogicalTrue(error);
       if (log) {
         if (error.Success()) {
           LLDB_LOGF(log, "Condition successfully evaluated, result is %s.\n",

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -137,7 +137,7 @@ protected:
     Thread *thread = m_exe_ctx.GetThreadPtr();
     StackFrameSP frame_sp = thread->GetSelectedFrame(SelectMostRelevantFrame);
 
-    ValueObjectSP valobj_sp;
+    std::optional<lldb::ValueObjectSP> valobj_sp;
 
     if (m_options.address) {
       if (m_options.reg || m_options.offset) {
@@ -170,15 +170,15 @@ protected:
                      Stream &stream) -> bool {
       const ValueObject::GetExpressionPathFormat format = ValueObject::
           GetExpressionPathFormat::eGetExpressionPathFormatHonorPointers;
-      valobj_sp->GetExpressionPath(stream, format);
+      valobj_sp.value()->GetExpressionPath(stream, format);
       stream.PutCString(" =");
       return true;
     };
 
     DumpValueObjectOptions options;
     options.SetDeclPrintingHelper(helper);
-    ValueObjectPrinter printer(valobj_sp.get(), &result.GetOutputStream(),
-                               options);
+    ValueObjectPrinter printer(valobj_sp.value().get(),
+                               &result.GetOutputStream(), options);
     printer.PrintValueObject();
   }
 
@@ -544,7 +544,7 @@ protected:
       result.AppendError(error.AsCString());
 
     }
-    ValueObjectSP valobj_sp;
+    std::optional<ValueObjectSP> valobj_sp;
 
     TypeSummaryImplSP summary_format_sp;
     if (!m_option_variable.summary.IsCurrentValueEmpty())
@@ -606,7 +606,7 @@ protected:
                                                 show_module))
                       s.PutCString(": ");
                   }
-                  valobj_sp->Dump(result.GetOutputStream(), options);
+                  valobj_sp.value()->Dump(result.GetOutputStream(), options);
                 }
               }
             } else {
@@ -643,12 +643,12 @@ protected:
 
               options.SetFormat(format);
               options.SetVariableFormatDisplayLanguage(
-                  valobj_sp->GetPreferredDisplayLanguage());
+                  valobj_sp.value()->GetPreferredDisplayLanguage());
 
               Stream &output_stream = result.GetOutputStream();
               options.SetRootValueObjectName(
-                  valobj_sp->GetParent() ? entry.c_str() : nullptr);
-              valobj_sp->Dump(output_stream, options);
+                  valobj_sp.value()->GetParent() ? entry.c_str() : nullptr);
+              valobj_sp.value()->Dump(output_stream, options);
             } else {
               if (auto error_cstr = error.AsCString(nullptr))
                 result.AppendError(error_cstr);
@@ -679,10 +679,11 @@ protected:
             if (valobj_sp) {
               // When dumping all variables, don't print any variables that are
               // not in scope to avoid extra unneeded output
-              if (valobj_sp->IsInScope()) {
-                if (!valobj_sp->GetTargetSP()
+              if (valobj_sp.value()->IsInScope()) {
+                if (!valobj_sp.value()
+                         ->GetTargetSP()
                          ->GetDisplayRuntimeSupportValues() &&
-                    valobj_sp->IsRuntimeSupportValue())
+                    valobj_sp.value()->IsRuntimeSupportValue())
                   continue;
 
                 if (!scope_string.empty())
@@ -696,10 +697,10 @@ protected:
 
                 options.SetFormat(format);
                 options.SetVariableFormatDisplayLanguage(
-                    valobj_sp->GetPreferredDisplayLanguage());
+                    valobj_sp.value()->GetPreferredDisplayLanguage());
                 options.SetRootValueObjectName(
                     var_sp ? var_sp->GetName().AsCString() : nullptr);
-                valobj_sp->Dump(result.GetOutputStream(), options);
+                valobj_sp.value()->Dump(result.GetOutputStream(), options);
               }
             }
           }
@@ -718,9 +719,10 @@ protected:
           for (auto &rec_value_sp : recognized_arg_list->GetObjects()) {
             options.SetFormat(m_option_format.GetFormat());
             options.SetVariableFormatDisplayLanguage(
-                rec_value_sp->GetPreferredDisplayLanguage());
-            options.SetRootValueObjectName(rec_value_sp->GetName().AsCString());
-            rec_value_sp->Dump(result.GetOutputStream(), options);
+                rec_value_sp.value()->GetPreferredDisplayLanguage());
+            options.SetRootValueObjectName(
+                rec_value_sp.value()->GetName().AsCString());
+            rec_value_sp.value()->Dump(result.GetOutputStream(), options);
           }
         }
       }

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -807,21 +807,14 @@ protected:
         name_strm.Printf("0x%" PRIx64, item_addr);
         ValueObjectSP valobj_sp(ValueObjectMemory::Create(
             exe_scope, name_strm.GetString(), address, compiler_type));
-        if (valobj_sp) {
-          Format format = m_format_options.GetFormat();
-          if (format != eFormatDefault)
-            valobj_sp->SetFormat(format);
+        Format format = m_format_options.GetFormat();
+        if (format != eFormatDefault)
+          valobj_sp->SetFormat(format);
 
-          DumpValueObjectOptions options(m_varobj_options.GetAsDumpOptions(
-              eLanguageRuntimeDescriptionDisplayVerbosityFull, format));
+        DumpValueObjectOptions options(m_varobj_options.GetAsDumpOptions(
+            eLanguageRuntimeDescriptionDisplayVerbosityFull, format));
 
-          valobj_sp->Dump(*output_stream_p, options);
-        } else {
-          result.AppendErrorWithFormat(
-              "failed to create a value object for: (%s) %s\n",
-              view_as_type_cstr, name_strm.GetData());
-          return;
-        }
+        valobj_sp->Dump(*output_stream_p, options);
       }
       return;
     }
@@ -1052,16 +1045,16 @@ protected:
       buffer.CopyData(str);
     } else if (m_memory_options.m_expr.OptionWasSet()) {
       StackFrame *frame = m_exe_ctx.GetFramePtr();
-      ValueObjectSP result_sp;
+      std::optional<lldb::ValueObjectSP> result_sp;
       if ((eExpressionCompleted ==
            process->GetTarget().EvaluateExpression(
                m_memory_options.m_expr.GetValueAs<llvm::StringRef>().value_or(
                    ""),
                frame, result_sp)) &&
           result_sp) {
-        uint64_t value = result_sp->GetValueAsUnsigned(0);
+        uint64_t value = result_sp.value()->GetValueAsUnsigned(0);
         std::optional<uint64_t> size =
-            result_sp->GetCompilerType().GetByteSize(nullptr);
+            result_sp.value()->GetCompilerType().GetByteSize(nullptr);
         if (!size)
           return;
         switch (*size) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -854,8 +854,7 @@ protected:
       ValueObjectSP valobj_sp(ValueObjectVariable::Create(
           exe_ctx.GetBestExecutionContextScope(), var_sp));
 
-      if (valobj_sp)
-        DumpValueObject(s, var_sp, valobj_sp, var_sp->GetName().GetCString());
+      DumpValueObject(s, var_sp, valobj_sp, var_sp->GetName().GetCString());
     }
   }
 
@@ -897,14 +896,14 @@ protected:
           for (uint32_t global_idx = 0; global_idx < matches; ++global_idx) {
             VariableSP var_sp(variable_list.GetVariableAtIndex(global_idx));
             if (var_sp) {
-              ValueObjectSP valobj_sp(
+              std::optional<ValueObjectSP> valobj_sp(
                   valobj_list.GetValueObjectAtIndex(global_idx));
               if (!valobj_sp)
                 valobj_sp = ValueObjectVariable::Create(
                     m_exe_ctx.GetBestExecutionContextScope(), var_sp);
 
               if (valobj_sp)
-                DumpValueObject(s, var_sp, valobj_sp,
+                DumpValueObject(s, var_sp, valobj_sp.value(),
                                 use_var_name ? var_sp->GetName().GetCString()
                                              : arg.c_str());
             }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1422,10 +1422,8 @@ public:
     }
 
     Stream &strm = result.GetOutputStream();
-    ValueObjectSP exception_object_sp = thread_sp->GetCurrentException();
-    if (exception_object_sp) {
-      exception_object_sp->Dump(strm);
-    }
+    if (auto exception_object_sp = thread_sp->GetCurrentException())
+      exception_object_sp.value()->Dump(strm);
 
     ThreadSP exception_thread_sp = thread_sp->GetCurrentExceptionBacktrace();
     if (exception_thread_sp && exception_thread_sp->IsValid()) {
@@ -1476,10 +1474,7 @@ public:
       return false;
     }
     ValueObjectSP exception_object_sp = thread_sp->GetSiginfoValue();
-    if (exception_object_sp)
-      exception_object_sp->Dump(strm);
-    else
-      strm.Printf("(no siginfo)\n");
+    exception_object_sp->Dump(strm);
     strm.PutChar('\n');
 
     return true;
@@ -1601,7 +1596,7 @@ protected:
       return;
     }
 
-    ValueObjectSP return_valobj_sp;
+    std::optional<ValueObjectSP> return_valobj_sp;
 
     StackFrameSP frame_sp = m_exe_ctx.GetFrameSP();
     uint32_t frame_idx = frame_sp->GetFrameIndex();
@@ -1625,7 +1620,7 @@ protected:
         if (return_valobj_sp)
           result.AppendErrorWithFormat(
               "Error evaluating result expression: %s",
-              return_valobj_sp->GetError().AsCString());
+              return_valobj_sp.value()->GetError().AsCString());
         else
           result.AppendErrorWithFormat(
               "Unknown error evaluating result expression.");

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2855,28 +2855,30 @@ protected:
 
     StackFrameSP frame_sp =
         thread->GetSelectedFrame(DoNoSelectMostRelevantFrame);
-    ValueObjectSP result_valobj_sp;
+    std::optional<ValueObjectSP> result_valobj_sp;
     EvaluateExpressionOptions options;
     lldb::ExpressionResults expr_result = target_sp->EvaluateExpression(
         command, frame_sp.get(), result_valobj_sp, options);
     if (expr_result == eExpressionCompleted && result_valobj_sp) {
       result_valobj_sp =
-          result_valobj_sp->GetQualifiedRepresentationIfAvailable(
+          result_valobj_sp.value()->GetQualifiedRepresentationIfAvailable(
               target_sp->GetPreferDynamicValue(),
               target_sp->GetEnableSyntheticValue());
       typename FormatterType::SharedPointer formatter_sp =
-          m_discovery_function(*result_valobj_sp);
+          m_discovery_function(*result_valobj_sp.value());
       if (formatter_sp) {
         std::string description(formatter_sp->GetDescription());
         result.GetOutputStream()
             << m_formatter_name << " applied to ("
-            << result_valobj_sp->GetDisplayTypeName().AsCString("<unknown>")
+            << result_valobj_sp.value()->GetDisplayTypeName().AsCString(
+                   "<unknown>")
             << ") " << command << " is: " << description << "\n";
         result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
       } else {
         result.GetOutputStream()
             << "no " << m_formatter_name << " applies to ("
-            << result_valobj_sp->GetDisplayTypeName().AsCString("<unknown>")
+            << result_valobj_sp.value()->GetDisplayTypeName().AsCString(
+                   "<unknown>")
             << ") " << command << "\n";
         result.SetStatus(lldb::eReturnStatusSuccessFinishNoResult);
       }

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -608,8 +608,8 @@ static bool DumpRegister(Stream &s, StackFrame *frame, RegisterKind reg_kind,
   return false;
 }
 
-static ValueObjectSP ExpandIndexedExpression(ValueObject *valobj, size_t index,
-                                             bool deref_pointer) {
+static std::optional<ValueObjectSP>
+ExpandIndexedExpression(ValueObject *valobj, size_t index, bool deref_pointer) {
   Log *log = GetLog(LLDBLog::DataFormatters);
   std::string name_to_deref = llvm::formatv("[{0}]", index);
   LLDB_LOG(log, "[ExpandIndexedExpression] name to deref: {0}", name_to_deref);
@@ -619,7 +619,7 @@ static ValueObjectSP ExpandIndexedExpression(ValueObject *valobj, size_t index,
   ValueObject::ExpressionPathAftermath what_next =
       (deref_pointer ? ValueObject::eExpressionPathAftermathDereference
                      : ValueObject::eExpressionPathAftermathNothing);
-  ValueObjectSP item = valobj->GetValueForExpressionPath(
+  std::optional<ValueObjectSP> item = valobj->GetValueForExpressionPath(
       name_to_deref, &reason_to_stop, &final_value_type, options, &what_next);
   if (!item) {
     LLDB_LOGF(log,
@@ -690,8 +690,9 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
     custom_format = entry.fmt;
     val_obj_display = (ValueObject::ValueObjectRepresentationStyle)entry.number;
     if (!valobj->IsSynthetic()) {
-      valobj = valobj->GetSyntheticValue().get();
-      if (valobj == nullptr)
+      if (std::optional<ValueObjectSP> temp = valobj->GetSyntheticValue())
+        valobj = temp.value().get();
+      else
         return false;
     }
     break;
@@ -756,7 +757,7 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
         valobj
             ->GetValueForExpressionPath(expr_path.c_str(), &reason_to_stop,
                                         &final_value_type, options, &what_next)
-            .get();
+            ->get();
 
     if (!target) {
       LLDB_LOGF(log,
@@ -789,13 +790,13 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
     // I have not deref-ed yet, let's do it
     // this happens when we are not going through
     // GetValueForVariableExpressionPath to get to the target ValueObject
-    Status error;
-    target = target->Dereference(error).get();
-    if (error.Fail()) {
+    ValueObjectSP temp = target->Dereference();
+    if (temp->GetError().Fail()) {
       LLDB_LOGF(log, "[Debugger::FormatPrompt] ERROR: %s\n",
-                error.AsCString("unknown"));
+                temp->GetError().AsCString("unknown"));
       return false;
     }
+    target = temp.get();
     do_deref_pointer = false;
   }
 
@@ -933,7 +934,7 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
 
     bool success = true;
     for (int64_t index = index_lower; index <= index_higher; ++index) {
-      ValueObject *item = ExpandIndexedExpression(target, index, false).get();
+      ValueObject *item = ExpandIndexedExpression(target, index, false)->get();
 
       if (!item) {
         LLDB_LOGF(log,
@@ -1343,10 +1344,10 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
       if (thread) {
         StopInfoSP stop_info_sp = thread->GetStopInfo();
         if (stop_info_sp && stop_info_sp->IsValid()) {
-          ValueObjectSP return_valobj_sp =
+          std::optional<ValueObjectSP> return_valobj_sp =
               StopInfo::GetReturnValueObject(stop_info_sp);
           if (return_valobj_sp) {
-            return_valobj_sp->Dump(s);
+            return_valobj_sp.value()->Dump(s);
             return true;
           }
         }
@@ -1363,7 +1364,7 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
           ExpressionVariableSP expression_var_sp =
               StopInfo::GetExpressionVariable(stop_info_sp);
           if (expression_var_sp && expression_var_sp->GetValueObject()) {
-            expression_var_sp->GetValueObject()->Dump(s);
+            expression_var_sp->GetValueObject().value()->Dump(s);
             return true;
           }
         }

--- a/lldb/source/Core/ValueObjectConstResult.cpp
+++ b/lldb/source/Core/ValueObjectConstResult.cpp
@@ -244,19 +244,21 @@ bool ValueObjectConstResult::IsInScope() {
   return true;
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResult::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::GetSyntheticChildAtOffset(
-    uint32_t offset, const CompilerType &type, bool can_create,
-    ConstString name_const_str) {
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResult::GetSyntheticChildAtOffset(uint32_t offset,
+                                                  const CompilerType &type,
+                                                  bool can_create,
+                                                  ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResult::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 lldb::addr_t ValueObjectConstResult::GetAddressOf(bool scalar_is_load_address,
@@ -276,7 +278,7 @@ size_t ValueObjectConstResult::GetPointeeData(DataExtractor &data,
   return m_impl.GetPointeeData(data, item_idx, item_count);
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObjectConstResult::GetDynamicValue(lldb::DynamicValueType use_dynamic) {
   // Always recalculate dynamic values for const results as the memory that
   // they might point to might have changed at any time.
@@ -290,7 +292,7 @@ ValueObjectConstResult::GetDynamicValue(lldb::DynamicValueType use_dynamic) {
     if (m_dynamic_value && m_dynamic_value->GetError().Success())
       return m_dynamic_value->GetSP();
   }
-  return ValueObjectSP();
+  return {};
 }
 
 lldb::ValueObjectSP

--- a/lldb/source/Core/ValueObjectConstResultCast.cpp
+++ b/lldb/source/Core/ValueObjectConstResultCast.cpp
@@ -29,19 +29,20 @@ ValueObjectConstResultCast::ValueObjectConstResultCast(
 
 ValueObjectConstResultCast::~ValueObjectConstResultCast() = default;
 
-lldb::ValueObjectSP ValueObjectConstResultCast::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResultCast::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResultCast::GetSyntheticChildAtOffset(
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResultCast::GetSyntheticChildAtOffset(
     uint32_t offset, const CompilerType &type, bool can_create,
     ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResultCast::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResultCast::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 ValueObject *ValueObjectConstResultCast::CreateChildAtIndex(

--- a/lldb/source/Core/ValueObjectConstResultChild.cpp
+++ b/lldb/source/Core/ValueObjectConstResultChild.cpp
@@ -36,19 +36,20 @@ ValueObjectConstResultChild::ValueObjectConstResultChild(
 
 ValueObjectConstResultChild::~ValueObjectConstResultChild() = default;
 
-lldb::ValueObjectSP ValueObjectConstResultChild::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResultChild::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResultChild::GetSyntheticChildAtOffset(
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResultChild::GetSyntheticChildAtOffset(
     uint32_t offset, const CompilerType &type, bool can_create,
     ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResultChild::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResultChild::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 lldb::addr_t ValueObjectConstResultChild::GetAddressOf(

--- a/lldb/source/Core/ValueObjectRegister.cpp
+++ b/lldb/source/Core/ValueObjectRegister.cpp
@@ -127,7 +127,7 @@ ValueObject *ValueObjectRegisterSet::CreateChildAtIndex(
   return valobj;
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObjectRegisterSet::GetChildMemberWithName(llvm::StringRef name,
                                                bool can_create) {
   ValueObject *valobj = nullptr;
@@ -139,7 +139,7 @@ ValueObjectRegisterSet::GetChildMemberWithName(llvm::StringRef name,
   if (valobj)
     return valobj->GetSP();
   else
-    return ValueObjectSP();
+    return {};
 }
 
 size_t ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -115,23 +115,25 @@ std::string CXXSyntheticChildren::GetDescription() {
   return std::string(sstr.GetString());
 }
 
-lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromExpression(
+std::optional<lldb::ValueObjectSP>
+SyntheticChildrenFrontEnd::CreateValueObjectFromExpression(
     llvm::StringRef name, llvm::StringRef expression,
     const ExecutionContext &exe_ctx) {
-  ValueObjectSP valobj_sp(
+  std::optional<ValueObjectSP> valobj_sp(
       ValueObject::CreateValueObjectFromExpression(name, expression, exe_ctx));
   if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+    valobj_sp.value()->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
-lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromAddress(
+std::optional<lldb::ValueObjectSP>
+SyntheticChildrenFrontEnd::CreateValueObjectFromAddress(
     llvm::StringRef name, uint64_t address, const ExecutionContext &exe_ctx,
     CompilerType type) {
-  ValueObjectSP valobj_sp(
+  std::optional<ValueObjectSP> valobj_sp(
       ValueObject::CreateValueObjectFromAddress(name, address, exe_ctx, type));
   if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+    valobj_sp.value()->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
@@ -140,8 +142,7 @@ lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromData(
     const ExecutionContext &exe_ctx, CompilerType type) {
   ValueObjectSP valobj_sp(
       ValueObject::CreateValueObjectFromData(name, data, exe_ctx, type));
-  if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+  valobj_sp->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
@@ -166,10 +167,10 @@ ScriptedSyntheticChildren::FrontEnd::FrontEnd(std::string pclass,
 
 ScriptedSyntheticChildren::FrontEnd::~FrontEnd() = default;
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ScriptedSyntheticChildren::FrontEnd::GetChildAtIndex(size_t idx) {
   if (!m_wrapper_sp || !m_interpreter)
-    return lldb::ValueObjectSP();
+    return {};
 
   return m_interpreter->GetChildAtIndex(m_wrapper_sp, idx);
 }
@@ -212,9 +213,10 @@ size_t ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(
                                                 name.GetCString());
 }
 
-lldb::ValueObjectSP ScriptedSyntheticChildren::FrontEnd::GetSyntheticValue() {
+std::optional<ValueObjectSP>
+ScriptedSyntheticChildren::FrontEnd::GetSyntheticValue() {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return nullptr;
+    return {};
 
   return m_interpreter->GetSyntheticValue(m_wrapper_sp);
 }

--- a/lldb/source/Expression/ExpressionVariable.cpp
+++ b/lldb/source/Expression/ExpressionVariable.cpp
@@ -20,14 +20,18 @@ char ExpressionVariable::ID;
 ExpressionVariable::ExpressionVariable() : m_flags(0) {}
 
 uint8_t *ExpressionVariable::GetValueBytes() {
-  std::optional<uint64_t> byte_size = m_frozen_sp->GetByteSize();
+  if (!m_frozen_sp)
+    return nullptr;
+
+  std::optional<uint64_t> byte_size = m_frozen_sp.value()->GetByteSize();
   if (byte_size && *byte_size) {
-    if (m_frozen_sp->GetDataExtractor().GetByteSize() < *byte_size) {
-      m_frozen_sp->GetValue().ResizeData(*byte_size);
-      m_frozen_sp->GetValue().GetData(m_frozen_sp->GetDataExtractor());
+    if (m_frozen_sp.value()->GetDataExtractor().GetByteSize() < *byte_size) {
+      m_frozen_sp.value()->GetValue().ResizeData(*byte_size);
+      m_frozen_sp.value()->GetValue().GetData(
+          m_frozen_sp.value()->GetDataExtractor());
     }
     return const_cast<uint8_t *>(
-        m_frozen_sp->GetDataExtractor().GetDataStart());
+        m_frozen_sp.value()->GetDataExtractor().GetDataStart());
   }
   return nullptr;
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2656,7 +2656,7 @@ Target *Target::GetTargetFromContexts(const ExecutionContext *exe_ctx_ptr,
 
 ExpressionResults Target::EvaluateExpression(
     llvm::StringRef expr, ExecutionContextScope *exe_scope,
-    lldb::ValueObjectSP &result_valobj_sp,
+    std::optional<lldb::ValueObjectSP> &result_valobj_sp,
     const EvaluateExpressionOptions &options, std::string *fixed_expression,
     ValueObject *ctx_obj) {
   result_valobj_sp.reset();


### PR DESCRIPTION
### Purpose
For now, we'd like to get people's thought's on the goal, design, and scope of this PR by reviewing these preliminary changes.

I recommend focussing (or starting) on these files:
* `ValueObject.h`
* `ValueObject.cpp`


### Goal
Every `ValueObjectSP` will have an actual value and will never be equal to `nullptr`.


### Design
To force each `ValueObjectSP` to contain _something_, we're considering changing the type from a typedef…
```cpp
typedef std::shared_ptr<lldb_private::ValueObject> ValueObjectSP;

```

to this subclass:
```cpp
class ValueObjectSP : public std::shared_ptr<lldb_private::ValueObject> {
  ValueObjectSP() = delete;
  operator bool() = delete;

public:
  ValueObjectSP(std::shared_ptr<lldb_private::ValueObject> &&pointer)
      : std::shared_ptr<lldb_private::ValueObject>(std::move(pointer)) {
    assert(pointer);
  }
};
```

This class removes the default constructor to force each `ValueObjectSP` to point to a real `ValueObject` instance. It also removes `operator bool()` because no instance will ever equal `nullptr`. 


### Change Patterns
The bulk of the changes into one of these two camps:
1. For methods that have a `Status &error` parameter **and** return an `ValueObjectSP`, the return value *becomes* the container for the error state, which eliminate the need for a parameter.
* This means that callers of these methods need to check the return value's error state.
  * `return_value->GetError.Success()`
  * `return_value->GetError.Fail()`

2. For all other methods that return a `ValueObjectSP` but don't have a `Status &` parameter, they now return `std::optional<ValueObjectSP>`.
* This changes a fair amount of code in these ways:
  * Code which had been using the `std::shared_ptr` Boolean operator now uses the `std::optional` Boolean operator.
  * Nearby code has to call the optional's `value()` method to get the shared pointer inside.
  * Methods with lines that return `ValueObjectSP()` now return `{}`, which creates an optional with nothing in it.

Again, I recommend focussing (or starting) on these files:
* `ValueObject.h`
* `ValueObject.cpp`


### Remaining work
This is very much a work-in-progress for a proof of concept, which means:
* It doesn't compile (yet)
* So far I've modified 53 files
* I estimate another 100-250 more files need to change based on the ninja build progress indicator.

The remaining changes will just be more of the same but now's a good time to take a look at this sample to get a sense of the magnitude and trajectory of the remaining changes.