### PR TITLE
[Clang][Parser] Fix crash of clang when using C++ constructs like :: in C code

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -685,9 +685,11 @@ Bug Fixes in This Version
   (`#65568 <https://github.com/llvm/llvm-project/issues/65568>`_)
 - Fix an issue where clang doesn't respect detault template arguments that
   are added in a later redeclaration for CTAD.
-  Fixes (#69987 <https://github.com/llvm/llvm-project/issues/69987>`_)
+  Fixes (`#69987 <https://github.com/llvm/llvm-project/issues/69987>`_)
 - Fix an issue where CTAD fails for explicit type conversion.
-  Fixes (#64347 <https://github.com/llvm/llvm-project/issues/64347>`_)
+  Fixes (`#64347 <https://github.com/llvm/llvm-project/issues/64347>`_)
+- Fix crash when using C++ only tokens like ``::`` in C compiler clang.
+  Fixes (`#73559 <https://github.com/llvm/llvm-project/issues/73559>`_)
 
 
 Bug Fixes to Compiler Builtins

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3483,7 +3483,8 @@ void Parser::ParseDeclarationSpecifiers(
 
     case tok::coloncolon: // ::foo::bar
       // C++ scope specifier.  Annotate and loop, or bail out on error.
-      if (TryAnnotateCXXScopeToken(EnteringContext)) {
+      if (getLangOpts().CPlusPlus &&
+          TryAnnotateCXXScopeToken(EnteringContext)) {
         if (!DS.hasTypeSpecifier())
           DS.SetTypeSpecError();
         goto DoneWithDeclSpec;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2679,6 +2679,8 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
                                        ParsedAttributes &AccessAttrs,
                                        const ParsedTemplateInfo &TemplateInfo,
                                        ParsingDeclRAIIObject *TemplateDiags) {
+  assert(getLangOpts().CPlusPlus &&
+         "ParseCXXClassMemberDeclaration should only be called in C++ mode");
   if (Tok.is(tok::at)) {
     if (getLangOpts().ObjC && NextToken().isObjCAtKeyword(tok::objc_defs))
       Diag(Tok, diag::err_at_defs_cxx);

--- a/clang/test/Parser/cxx-in-c.c
+++ b/clang/test/Parser/cxx-in-c.c
@@ -3,3 +3,6 @@
 // PR9137
 void f0(int x) : {}; // expected-error{{expected function body after function declarator}}
 void f1(int x) try {}; // expected-error{{expected function body after function declarator}}
+
+// GH73559
+::; // expected-error{{expected identifier or '('}}


### PR DESCRIPTION
As stated in this issue, https://github.com/llvm/llvm-project/issues/73559, clang (C version of clang, not C++) crashes when C++ components are parsed.

Even a file which only contains a double-colon "::" leads to this kind of crash.

The reason for this behavior is that TryAnnotateCXXScopeToken() of the clang parser assumes to be executed in C++ mode only. 

But in 2 places in the code, there was no guard to ensure this function is only called in C++ mode. When it is called nonetheless, the aforementioned error is created.