### PR TITLE
[clang] Fix '__cdecl' CC is not supported for this target

### DIFF
--- a/clang/test/SemaCXX/ms-constexpr-new.cpp
+++ b/clang/test/SemaCXX/ms-constexpr-new.cpp
@@ -4,7 +4,7 @@
 
 [[nodiscard]]
 [[msvc::constexpr]] // unsupported-warning {{unknown attribute 'constexpr' ignored}}
-inline void* __cdecl operator new(decltype(sizeof(void*)), void* p) noexcept { return p; }
+inline void* operator new(decltype(sizeof(void*)), void* p) noexcept { return p; }
 
 namespace std {
   constexpr int* construct_at(int* p, int v) {


### PR DESCRIPTION
Fixes regression introduced in b3e6ff331925dde24a4707452d657da0fdf7f588

    .---command stderr------------
    | error: 'supported-warning' diagnostics seen but not expected:
    |   File C:\buildbot\as-builder-1\x-armv7l\llvm-project\clang\test\SemaCXX\ms-constexpr-new.cpp Line 7: '__cdecl' calling convention is not supported for this target
    | 1 error generated.
    `-----------------------------