### PR TITLE
[Cygwin] Cygwin general 0

### DIFF
--- a/clang/lib/Headers/mm_malloc.h
+++ b/clang/lib/Headers/mm_malloc.h
@@ -12,7 +12,7 @@
 
 #include <stdlib.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <malloc.h>
 #else
 #ifndef __cplusplus
@@ -41,7 +41,7 @@ _mm_malloc(size_t __size, size_t __align) {
   void *__mallocedMemory;
 #if defined(__MINGW32__)
   __mallocedMemory = __mingw_aligned_malloc(__size, __align);
-#elif defined(_WIN32)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
   __mallocedMemory = _aligned_malloc(__size, __align);
 #else
   if (posix_memalign(&__mallocedMemory, __align, __size))
@@ -56,7 +56,7 @@ _mm_free(void *__p)
 {
 #if defined(__MINGW32__)
   __mingw_aligned_free(__p);
-#elif defined(_WIN32)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
   _aligned_free(__p);
 #else
   free(__p);

--- a/clang/tools/libclang/CIndexer.cpp
+++ b/clang/tools/libclang/CIndexer.cpp
@@ -27,12 +27,10 @@
 #include <mutex>
 
 #ifdef __CYGWIN__
-#include <cygwin/version.h>
 #include <sys/cygwin.h>
-#define _WIN32 1
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #elif defined(_AIX)
 #include <errno.h>
@@ -105,7 +103,7 @@ const std::string &CIndexer::getClangResourcesPath() {
   SmallString<128> LibClangPath;
 
   // Find the location where this library lives (libclang.dylib).
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
   MEMORY_BASIC_INFORMATION mbi;
   char path[MAX_PATH];
   VirtualQuery((void *)(uintptr_t)clang_createTranslationUnit, &mbi,
@@ -115,11 +113,7 @@ const std::string &CIndexer::getClangResourcesPath() {
 #ifdef __CYGWIN__
   char w32path[MAX_PATH];
   strcpy(w32path, path);
-#if CYGWIN_VERSION_API_MAJOR > 0 || CYGWIN_VERSION_API_MINOR >= 181
   cygwin_conv_path(CCP_WIN_A_TO_POSIX, w32path, path, MAX_PATH);
-#else
-  cygwin_conv_to_full_posix_path(w32path, path);
-#endif
 #endif
 
   LibClangPath += path;


### PR DESCRIPTION
Fix build error by Clang due to the conflict of CIndexer.cpp and mm_malloc.h. In mm_malloc.h, _WIN32 and __CYGWIN__ can't both be defined, but CIndexer.cpp define both.

In file included from /cygdrive/e/Note/Tool/llvm/clang/tools/libclang/CIndexer.cpp:35:
In file included from /usr/include/w32api/windows.h:69:
In file included from /usr/include/w32api/windef.h:9:
In file included from /usr/include/w32api/minwindef.h:163:
In file included from /usr/include/w32api/winnt.h:1658:
In file included from /cygdrive/d/cygwin64-packages/llvm/lib/clang/18/include/x86intrin.h:15:
In file included from /cygdrive/d/cygwin64-packages/llvm/lib/clang/18/include/immintrin.h:26:
In file included from /cygdrive/d/cygwin64-packages/llvm/lib/clang/18/include/xmmintrin.h:31:
/cygdrive/d/cygwin64-packages/llvm/lib/clang/18/include/mm_malloc.h:45:22: error: use of undeclared identifier '_aligned_malloc'; did you mean 'aligned_alloc'?
   45 |   __mallocedMemory = _aligned_malloc(__size, __align);
      |                      ^
/usr/include/stdlib.h:332:8: note: 'aligned_alloc' declared here
  332 | void *  aligned_alloc(size_t, size_t) __malloc_like __alloc_align(1)
      |         ^
[ 97%] Built target clangTidyModernizeModule


I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git
