### PR TITLE
[clang-format] Fix operator overload inconsistency in `BreakAfterAttributes: Always`

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -583,26 +583,18 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
       return true;
   }
 
-  const auto WrapBeforeName = [&] {
-    // If the return type spans multiple lines, wrap before the function name.
-    if (Current.isNot(TT_FunctionDeclarationName) ||
-        State.Line->ReturnTypeWrapped) {
-      return false;
-    }
-    if (Previous.is(tok::kw_template) || Current.is(tok::kw_operator))
-      return false;
-    if (!CurrentState.BreakBeforeParameter)
-      return false;
-    // Don't break before a C# function when no break after return type.
-    return (!Style.isCSharp() ||
-            Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None) &&
-           // Don't always break between a JavaScript `function` and the
-           // function name.
-           !Style.isJavaScript();
-  };
-
-  if (WrapBeforeName())
+  if (Current.is(TT_FunctionDeclarationName) &&
+      !State.Line->ReturnTypeWrapped &&
+      // Don't break before a C# function when no break after return type.
+      (!Style.isCSharp() ||
+       Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None) &&
+      // Don't always break between a JavaScript `function` and the function
+      // name.
+      !Style.isJavaScript() && Previous.isNot(tok::kw_template) &&
+      CurrentState.BreakBeforeParameter) {
     return true;
+  }
+
   // The following could be precomputed as they do not depend on the state.
   // However, as they should take effect only if the UnwrappedLine does not fit
   // into the ColumnLimit, they are checked here in the ContinuationIndenter.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -594,7 +594,7 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
         !Style.isJavaScript()) ||
        (Current.is(tok::kw_operator) && Previous.isNot(tok::coloncolon))) &&
       Previous.isNot(tok::kw_template) && CurrentState.BreakBeforeParameter &&
-      (Style.isCpp() && Current.Tok.isNot(tok::kw_operator))) {
+      Current.Tok.isNot(tok::kw_operator)) {
     return true;
   }
 

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -593,7 +593,8 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
         // name.
         !Style.isJavaScript()) ||
        (Current.is(tok::kw_operator) && Previous.isNot(tok::coloncolon))) &&
-      Previous.isNot(tok::kw_template) && CurrentState.BreakBeforeParameter) {
+      Previous.isNot(tok::kw_template) && CurrentState.BreakBeforeParameter &&
+      (Style.isCpp() && Current.Tok.isNot(tok::kw_operator))) {
     return true;
   }
 

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -583,7 +583,7 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
       return true;
   }
 
-  const auto WrapBeforeName = [&]() {
+  const auto WrapBeforeName = [&] {
     // If the return type spans multiple lines, wrap before the function name.
     if (Current.isNot(TT_FunctionDeclarationName) ||
         State.Line->ReturnTypeWrapped) {
@@ -593,21 +593,16 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
       return false;
     if (!CurrentState.BreakBeforeParameter)
       return false;
-    return true;
+    // Don't break before a C# function when no break after return type.
+    return (!Style.isCSharp() ||
+            Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None) &&
+           // Don't always break between a JavaScript `function` and the
+           // function name.
+           !Style.isJavaScript();
   };
 
-  // Don't break before a C# function when no break after return type.
-  if (WrapBeforeName() &&
-      (!Style.isCSharp() ||
-       Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None)) {
+  if (WrapBeforeName())
     return true;
-  }
-
-  // Don't always break between a JavaScript `function` and the function
-  // name.
-  if (WrapBeforeName() && !Style.isJavaScript())
-    return true;
-
   // The following could be precomputed as they do not depend on the state.
   // However, as they should take effect only if the UnwrappedLine does not fit
   // into the ColumnLimit, they are checked here in the ContinuationIndenter.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -584,19 +584,22 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
   }
 
   // If the return type spans multiple lines, wrap before the function name.
-  if (((Current.is(TT_FunctionDeclarationName) &&
-        !State.Line->ReturnTypeWrapped &&
-        // Don't break before a C# function when no break after return type.
-        (!Style.isCSharp() ||
-         Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None) &&
-        // Don't always break between a JavaScript `function` and the function
-        // name.
-        !Style.isJavaScript()) ||
-       (Current.is(tok::kw_operator) && Previous.isNot(tok::coloncolon))) &&
-      Previous.isNot(tok::kw_template) && CurrentState.BreakBeforeParameter &&
-      Current.Tok.isNot(tok::kw_operator)) {
+  const bool WrapBeforeName =
+      Current.is(TT_FunctionDeclarationName) &&
+      !State.Line->ReturnTypeWrapped && Previous.isNot(tok::kw_template) &&
+      Current.isNot(tok::kw_operator) && CurrentState.BreakBeforeParameter;
+
+  // Don't break before a C# function when no break after return type.
+  if (WrapBeforeName &&
+      (!Style.isCSharp() ||
+       Style.AlwaysBreakAfterReturnType != FormatStyle::RTBS_None)) {
     return true;
   }
+
+  // Don't always break between a JavaScript `function` and the function
+  // name.
+  if (WrapBeforeName && !Style.isJavaScript())
+    return true;
 
   // The following could be precomputed as they do not depend on the state.
   // However, as they should take effect only if the UnwrappedLine does not fit

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26452,18 +26452,17 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "}",
                CtorDtorCode, Style);
 
-  Style.BreakBeforeBraces = FormatStyle::BS_Attach;
-  Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
   verifyFormat("struct Foo {\n"
                "  [[maybe_unused]]\n"
                "  void operator+();\n"
                "};\n"
                "[[nodiscard]]\n"
+               "Foo &operator-(Foo &);",
+               Style);
+
+  Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
+  verifyFormat("[[nodiscard]]\n"
                "Foo& operator-(Foo&);",
-               "struct Foo {\n"
-               "[[maybe_unused]] void operator+();\n"
-               "};\n"
-               "[[nodiscard]] Foo &operator-(Foo&);",
                Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26417,16 +26417,6 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "void g() {}",
                CtorDtorCode, Style);
 
-  Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
-  verifyNoChange("struct Foo {\n"
-                 "  [[maybe_unused]]\n"
-                 "  void operator+();\n"
-                 "};\n"
-                 "[[nodiscard]]\n"
-                 "Foo& operator-(Foo&);",
-                 Style);
-  Style.ReferenceAlignment = getLLVMStyle().ReferenceAlignment;
-
   Style.BreakBeforeBraces = FormatStyle::BS_Linux;
   verifyFormat("struct Foo {\n"
                "  [[deprecated]]\n"
@@ -26461,6 +26451,16 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "{\n"
                "}",
                CtorDtorCode, Style);
+
+  Style.BreakBeforeBraces = FormatStyle::BS_Attach;
+  Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
+  verifyNoChange("struct Foo {\n"
+                 "  [[maybe_unused]]\n"
+                 "  void operator+();\n"
+                 "};\n"
+                 "[[nodiscard]]\n"
+                 "Foo& operator-(Foo&);",
+                 Style);
 }
 
 TEST_F(FormatTest, InsertNewlineAtEOF) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26417,6 +26417,20 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "void g() {}",
                CtorDtorCode, Style);
 
+  Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
+  constexpr StringRef OperatorOverloadCode(
+      "struct Foo {\n"
+      "[[maybe_unused]] void operator+();\n"
+      "};\n"
+      "[[nodiscard]] Foo& operator-(Foo&);");
+  verifyFormat("struct Foo {\n"
+               "  [[maybe_unused]]\n"
+               "  void operator+();\n"
+               "};\n"
+               "[[nodiscard]]\n"
+               "Foo& operator-(Foo&);",
+               OperatorOverloadCode, Style);
+
   Style.BreakBeforeBraces = FormatStyle::BS_Linux;
   verifyFormat("struct Foo {\n"
                "  [[deprecated]]\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26454,12 +26454,17 @@ TEST_F(FormatTest, BreakAfterAttributes) {
 
   Style.BreakBeforeBraces = FormatStyle::BS_Attach;
   Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
-  verifyNoChange("struct Foo {\n"
+  verifyFormat("struct Foo {\n"
                  "  [[maybe_unused]]\n"
                  "  void operator+();\n"
                  "};\n"
                  "[[nodiscard]]\n"
                  "Foo& operator-(Foo&);",
+
+                 "struct Foo {\n"
+                 "[[maybe_unused]] void operator+();\n"
+                 "};\n"
+                 "[[nodiscard]] Foo &operator-(Foo&);",
                  Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26455,17 +26455,16 @@ TEST_F(FormatTest, BreakAfterAttributes) {
   Style.BreakBeforeBraces = FormatStyle::BS_Attach;
   Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
   verifyFormat("struct Foo {\n"
-                 "  [[maybe_unused]]\n"
-                 "  void operator+();\n"
-                 "};\n"
-                 "[[nodiscard]]\n"
-                 "Foo& operator-(Foo&);",
-
-                 "struct Foo {\n"
-                 "[[maybe_unused]] void operator+();\n"
-                 "};\n"
-                 "[[nodiscard]] Foo &operator-(Foo&);",
-                 Style);
+               "  [[maybe_unused]]\n"
+               "  void operator+();\n"
+               "};\n"
+               "[[nodiscard]]\n"
+               "Foo& operator-(Foo&);",
+               "struct Foo {\n"
+               "[[maybe_unused]] void operator+();\n"
+               "};\n"
+               "[[nodiscard]] Foo &operator-(Foo&);",
+               Style);
 }
 
 TEST_F(FormatTest, InsertNewlineAtEOF) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26418,18 +26418,14 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                CtorDtorCode, Style);
 
   Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
-  constexpr StringRef OperatorOverloadCode(
-      "struct Foo {\n"
-      "[[maybe_unused]] void operator+();\n"
-      "};\n"
-      "[[nodiscard]] Foo& operator-(Foo&);");
-  verifyFormat("struct Foo {\n"
-               "  [[maybe_unused]]\n"
-               "  void operator+();\n"
-               "};\n"
-               "[[nodiscard]]\n"
-               "Foo& operator-(Foo&);",
-               OperatorOverloadCode, Style);
+  verifyNoChange("struct Foo {\n"
+                 "  [[maybe_unused]]\n"
+                 "  void operator+();\n"
+                 "};\n"
+                 "[[nodiscard]]\n"
+                 "Foo& operator-(Foo&);",
+                 Style);
+  Style.ReferenceAlignment = getLLVMStyle().ReferenceAlignment;
 
   Style.BreakBeforeBraces = FormatStyle::BS_Linux;
   verifyFormat("struct Foo {\n"


### PR DESCRIPTION
Fixes llvm/llvm-project#74901