### PR TITLE
[Cygwin] Cygwin general 2

### DIFF
--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -384,14 +384,6 @@ static bool shouldUseMmap(sys::fs::file_t FD,
   if ((FileSize & (PageSize -1)) == 0)
     return false;
 
-#if defined(__CYGWIN__)
-  // Don't try to map files that are exactly a multiple of the physical page size
-  // if we need a null terminator.
-  // FIXME: We should reorganize again getPageSize() on Win32.
-  if ((FileSize & (4096 - 1)) == 0)
-    return false;
-#endif
-
   return true;
 }
 

--- a/llvm/lib/Support/Process.cpp
+++ b/llvm/lib/Support/Process.cpp
@@ -102,6 +102,10 @@ bool Process::AreCoreFilesPrevented() { return coreFilesPrevented; }
     ::exit(RetCode);
 }
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+static unsigned computePageSize();
+#endif
+
 // Include the platform-specific parts of this class.
 #ifdef LLVM_ON_UNIX
 #include "Unix/Process.inc"
@@ -113,9 +117,7 @@ bool Process::AreCoreFilesPrevented() { return coreFilesPrevented; }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
-#endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
 // This function retrieves the page size using GetNativeSystemInfo() and is
 // present solely so it can be called once to initialize the self_process member
 // below.

--- a/llvm/lib/Support/Process.cpp
+++ b/llvm/lib/Support/Process.cpp
@@ -114,7 +114,6 @@ static unsigned computePageSize();
 #include "Windows/Process.inc"
 #endif
 
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 

--- a/llvm/lib/Support/Process.cpp
+++ b/llvm/lib/Support/Process.cpp
@@ -23,10 +23,6 @@
 #include <optional>
 #include <stdlib.h> // for _Exit
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
-#endif
-
 using namespace llvm;
 using namespace sys;
 
@@ -106,6 +102,19 @@ bool Process::AreCoreFilesPrevented() { return coreFilesPrevented; }
     ::exit(RetCode);
 }
 
+// Include the platform-specific parts of this class.
+#ifdef LLVM_ON_UNIX
+#include "Unix/Process.inc"
+#endif
+#ifdef _WIN32
+#include "Windows/Process.inc"
+#endif
+
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <windows.h>
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
 // This function retrieves the page size using GetNativeSystemInfo() and is
 // present solely so it can be called once to initialize the self_process member
@@ -119,12 +128,4 @@ static unsigned computePageSize() {
   // but dwAllocationGranularity.
   return static_cast<unsigned>(info.dwPageSize);
 }
-#endif
-
-// Include the platform-specific parts of this class.
-#ifdef LLVM_ON_UNIX
-#include "Unix/Process.inc"
-#endif
-#ifdef _WIN32
-#include "Windows/Process.inc"
 #endif

--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -78,7 +78,9 @@ Process::Pid Process::getProcessId() {
 // On Cygwin, getpagesize() returns 64k(AllocationGranularity) and
 // offset in mmap(3) should be aligned to the AllocationGranularity.
 Expected<unsigned> Process::getPageSize() {
-#if defined(HAVE_GETPAGESIZE)
+#if defined(__CYGWIN__)
+  static const int page_size = computePageSize();
+#elif defined(HAVE_GETPAGESIZE)
   static const int page_size = ::getpagesize();
 #elif defined(HAVE_SYSCONF)
   static long page_size = ::sysconf(_SC_PAGE_SIZE);

--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -50,19 +50,6 @@ Process::Pid Process::getProcessId() {
   return Pid(::GetCurrentProcessId());
 }
 
-// This function retrieves the page size using GetNativeSystemInfo() and is
-// present solely so it can be called once to initialize the self_process member
-// below.
-static unsigned computePageSize() {
-  // GetNativeSystemInfo() provides the physical page size which may differ
-  // from GetSystemInfo() in 32-bit applications running under WOW64.
-  SYSTEM_INFO info;
-  GetNativeSystemInfo(&info);
-  // FIXME: FileOffset in MapViewOfFile() should be aligned to not dwPageSize,
-  // but dwAllocationGranularity.
-  return static_cast<unsigned>(info.dwPageSize);
-}
-
 Expected<unsigned> Process::getPageSize() {
   static unsigned Ret = computePageSize();
   return Ret;


### PR DESCRIPTION
Override Cygwin's buggy getpagesize() to Win32 computePageSize().

I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git
