### PR TITLE
[libc] [riscv] support build with `scudo` on `riscv64`

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -268,18 +268,27 @@ if(LLVM_LIBC_INCLUDE_SCUDO)
   set(SCUDO_DEPS "")
 
   include(${LIBC_SOURCE_DIR}/../compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake)
-  if(NOT (LIBC_TARGET_ARCHITECTURE IN_LIST ALL_SCUDO_STANDALONE_SUPPORTED_ARCH))
-    message(FATAL_ERROR "Architecture ${LIBC_TARGET_ARCHITECTURE} is not supported by SCUDO. 
+  
+  # scudo distinguishes riscv32 and riscv64, so we need to translate the architecture
+  set(LIBC_TARGET_ARCHITECTURE_FOR_SCUDO ${LIBC_TARGET_ARCHITECTURE})
+  if(LIBC_TARGET_ARCHITECTURE_IS_RISCV64)
+    set(LIBC_TARGET_ARCHITECTURE_FOR_SCUDO riscv64)
+  elseif(LIBC_TARGET_ARCHITECTURE_IS_RISCV32)
+    set(LIBC_TARGET_ARCHITECTURE_FOR_SCUDO riscv32)
+  endif()
+
+  if(NOT (LIBC_TARGET_ARCHITECTURE_FOR_SCUDO IN_LIST ALL_SCUDO_STANDALONE_SUPPORTED_ARCH))
+    message(FATAL_ERROR "Architecture ${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO} is not supported by SCUDO. 
       Either disable LLVM_LIBC_INCLUDE_SCUDO or change your target architecture.")
   endif()
 
-  list(APPEND SCUDO_DEPS RTScudoStandalone.${LIBC_TARGET_ARCHITECTURE}
-      RTScudoStandaloneCWrappers.${LIBC_TARGET_ARCHITECTURE})
+  list(APPEND SCUDO_DEPS RTScudoStandalone.${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO}
+      RTScudoStandaloneCWrappers.${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO})
 
   list(APPEND SCUDO_DEPS
-    RTGwpAsan.${LIBC_TARGET_ARCHITECTURE}
-    RTGwpAsanBacktraceLibc.${LIBC_TARGET_ARCHITECTURE}
-    RTGwpAsanSegvHandler.${LIBC_TARGET_ARCHITECTURE}
+    RTGwpAsan.${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO}
+    RTGwpAsanBacktraceLibc.${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO}
+    RTGwpAsanSegvHandler.${LIBC_TARGET_ARCHITECTURE_FOR_SCUDO}
     )
   
   add_entrypoint_external(


### PR DESCRIPTION
This patch fixes cmake configuration when building with LLVM_LIBC_INCLUDE_SCUDO. In libc, LIBC_TARGET_ARCHITECTURE is renamed from `riscv64` to `riscv`. However, `compiler-rt`, hence `scudo`, distinguishes `riscv32` and `riscv64` in the support list. As a result, we need to translate the architecture name accordingly.