### PR TITLE
[Workflow] remove unused import

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -12,7 +12,6 @@ import argparse
 import os
 import subprocess
 import sys
-from functools import cached_property
 
 import github
 from github import IssueComment, PullRequest


### PR DESCRIPTION
functools.cached_property is not used anymore, so drop the import statement.