### PR TITLE
[libc++][test] Consistently use `TEST_SHORT_WCHAR`

### DIFF
--- a/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
@@ -515,7 +515,7 @@ static void test_ill_formed_utf8() {
 }
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-#  ifdef _LIBCPP_SHORT_WCHAR
+#  ifdef TEST_SHORT_WCHAR
 static void test_ill_formed_utf16() {
   using namespace std::literals;
 
@@ -543,7 +543,7 @@ static void test_ill_formed_utf16() {
               L"\xdbff"
               "a");
 }
-#  else // _LIBCPP_SHORT_WCHAR
+#  else // TEST_SHORT_WCHAR
 static void test_ill_formed_utf32() {
   using namespace std::literals;
 
@@ -552,7 +552,7 @@ static void test_ill_formed_utf32() {
   test_format(LR"("\x{ffffffff}")"sv, L"{:?}", L"\xffffffff"); // largest encoded code point
 }
 
-#  endif // _LIBCPP_SHORT_WCHAR
+#  endif // TEST_SHORT_WCHAR
 #endif   // TEST_HAS_NO_WIDE_CHARACTERS
 
 int main(int, char**) {
@@ -563,11 +563,11 @@ int main(int, char**) {
 
   test_ill_formed_utf8();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-#  ifdef _LIBCPP_SHORT_WCHAR
+#  ifdef TEST_SHORT_WCHAR
   test_ill_formed_utf16();
-#  else  // _LIBCPP_SHORT_WCHAR
+#  else  // TEST_SHORT_WCHAR
   test_ill_formed_utf32();
-#  endif // _LIBCPP_SHORT_WCHAR
+#  endif // TEST_SHORT_WCHAR
 #endif   // TEST_HAS_NO_WIDE_CHARACTERS
 
   return 0;

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -100,6 +100,8 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 #  define TEST_STD_VER 14
 #endif
 
+#define TEST_SHORT_WCHAR
+
 #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
 
 #ifdef __clang__


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

* In `escaped_output.unicode.pass.cpp`, replace `_LIBCPP_SHORT_WCHAR` with `TEST_SHORT_WCHAR`.
  + This was the only test that was directly using the `_LIBCPP` macro. `libcxx/test/support/test_macros.h` performs this mapping: https://github.com/llvm/llvm-project/blob/c60ac509399da5cba533b9b6cc5b983c59f7d7b3/libcxx/test/support/test_macros.h#L442-L444
* In `msvc_stdlib_force_include.h`, define `TEST_SHORT_WCHAR`.
