### PR TITLE
[libc++][test] Cleanup `LIBCPP_ONLY(meow_assert(...))` to `LIBCPP_MEOW_ASSERT(...)`

### DIFF
--- a/libcxx/test/std/input.output/filesystems/class.path/path.member/path.assign/source.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.path/path.member/path.assign/source.pass.cpp
@@ -230,7 +230,7 @@ void RunStringMoveTest(const fs::path::value_type* Expect) {
   assert(p == Expect);
   {
     // Signature test
-    LIBCPP_ONLY(ASSERT_NOEXCEPT(p = std::move(ss)));
+    LIBCPP_ASSERT_NOEXCEPT(p = std::move(ss));
   }
 }
 

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
@@ -30,7 +30,7 @@ int main(int, char**) {
   typedef std::underlying_type<E>::type UT;
   static_assert(!std::is_convertible<E, UT>::value, "");
 
-  LIBCPP_ONLY(static_assert(std::is_same<UT, unsigned short>::value, "")); // Implementation detail
+  LIBCPP_STATIC_ASSERT(std::is_same<UT, unsigned short>::value, ""); // Implementation detail
 
   typedef check_bitmask_type<E, E::skip_existing, E::update_existing> BitmaskTester;
   assert(BitmaskTester::check());

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.directory_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.directory_options.pass.cpp
@@ -29,7 +29,7 @@ int main(int, char**) {
   // Check that E is a scoped enum by checking for conversions.
   typedef std::underlying_type<E>::type UT;
   static_assert(!std::is_convertible<E, UT>::value, "");
-  LIBCPP_ONLY(static_assert(std::is_same<UT, unsigned char>::value, ""));
+  LIBCPP_STATIC_ASSERT(std::is_same<UT, unsigned char>::value, "");
 
   typedef check_bitmask_type<E, E::follow_directory_symlink, E::skip_permission_denied> BitmaskTester;
   assert(BitmaskTester::check());

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.file_type.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.file_type.pass.cpp
@@ -29,7 +29,7 @@ int main(int, char**) {
   typedef std::underlying_type<E>::type UT;
   static_assert(!std::is_convertible<E, UT>::value, "");
 
-  LIBCPP_ONLY(static_assert(std::is_same<UT, signed char>::value, "")); // Implementation detail
+  LIBCPP_STATIC_ASSERT(std::is_same<UT, signed char>::value, ""); // Implementation detail
 
   // The standard doesn't specify the numeric values of the enum.
   LIBCPP_STATIC_ASSERT(

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.perm_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.perm_options.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**) {
   typedef std::underlying_type<E>::type UT;
   static_assert(!std::is_convertible<E, UT>::value, "");
 
-  LIBCPP_ONLY(static_assert(std::is_same<UT, unsigned char >::value, "")); // Implementation detail
+  LIBCPP_STATIC_ASSERT(std::is_same<UT, unsigned char >::value, ""); // Implementation detail
 
   typedef check_bitmask_type<E, E::replace, E::nofollow> BitmaskTester;
   assert(BitmaskTester::check());

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.perms.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.perms.pass.cpp
@@ -30,7 +30,7 @@ int main(int, char**) {
   typedef std::underlying_type<E>::type UT;
   static_assert(!std::is_convertible<E, UT>::value, "");
 
-  LIBCPP_ONLY(static_assert(std::is_same<UT, unsigned >::value, "")); // Implementation detail
+  LIBCPP_STATIC_ASSERT(std::is_same<UT, unsigned >::value, ""); // Implementation detail
 
   typedef check_bitmask_type<E, E::group_all, E::owner_all> BitmaskTester;
   assert(BitmaskTester::check());

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.absolute/absolute.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.absolute/absolute.pass.cpp
@@ -51,7 +51,7 @@ static void basic_test()
         assert(!ec);
         assert(ret.is_absolute());
         assert(PathEqIgnoreSep(ret, TC.expect));
-        LIBCPP_ONLY(assert(PathEq(ret, TC.expect)));
+        LIBCPP_ASSERT(PathEq(ret, TC.expect));
     }
 }
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.canonical/canonical.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.canonical/canonical.pass.cpp
@@ -104,7 +104,7 @@ static void test_exception_contains_paths()
     } catch (filesystem_error const& err) {
         assert(err.path1() == p);
         // libc++ provides the current path as the second path in the exception
-        LIBCPP_ONLY(assert(err.path2() == current_path()));
+        LIBCPP_ASSERT(err.path2() == current_path());
     }
     fs::current_path(static_env.Dir);
     try {
@@ -112,7 +112,7 @@ static void test_exception_contains_paths()
         assert(false);
     } catch (filesystem_error const& err) {
         assert(err.path1() == p);
-        LIBCPP_ONLY(assert(err.path2() == static_env.Dir));
+        LIBCPP_ASSERT(err.path2() == static_env.Dir);
     }
 #endif
 }

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.permissions/permissions.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.permissions/permissions.pass.cpp
@@ -40,7 +40,7 @@ static void test_signatures()
     ASSERT_NOT_NOEXCEPT(fs::permissions(p, pr));
     ASSERT_NOT_NOEXCEPT(fs::permissions(p, pr, opts));
     ASSERT_NOEXCEPT(fs::permissions(p, pr, ec));
-    LIBCPP_ONLY(ASSERT_NOT_NOEXCEPT(fs::permissions(p, pr, opts, ec)));
+    LIBCPP_ASSERT_NOT_NOEXCEPT(fs::permissions(p, pr, opts, ec));
 }
 
 static void test_error_reporting()

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.temp_dir_path/temp_directory_path.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.temp_dir_path/temp_directory_path.pass.cpp
@@ -95,7 +95,7 @@ static void basic_tests()
         PutEnv(TC.name, dne);
         ec = GetTestEC();
         ret = temp_directory_path(ec);
-        LIBCPP_ONLY(assert(ErrorIs(ec, expect_errc)));
+        LIBCPP_ASSERT(ErrorIs(ec, expect_errc));
         assert(ec != GetTestEC());
         assert(ec);
         assert(ret == "");
@@ -104,7 +104,7 @@ static void basic_tests()
         PutEnv(TC.name, file);
         ec = GetTestEC();
         ret = temp_directory_path(ec);
-        LIBCPP_ONLY(assert(ErrorIs(ec, expect_errc)));
+        LIBCPP_ASSERT(ErrorIs(ec, expect_errc));
         assert(ec != GetTestEC());
         assert(ec);
         assert(ret == "");


### PR DESCRIPTION
This is a syntax cleanup, not needed for running libc++'s tests with MSVC's STL.

While changing `libcxx/test/std/input.output/filesystems/fs.enum/enum.path.format.pass.cpp` in #74965, I noticed that libc++'s tests almost always use the special-purpose macros for "this is a libc++-specific `static_assert` etc." defined by:

https://github.com/llvm/llvm-project/blob/b85f1f9b182234ba366d78ae2174a149e44d08c1/libcxx/test/support/test_macros.h#L240-L253

However, there were a very small number of occurrences that were using the general-purpose `LIBCPP_ONLY` macro when they could have been using the special-purpose macros. I believe that they should be cleaned up, to make it easier to search for usage, and to make it clearer when the full power of `LIBCPP_ONLY` is necessary.

This is a pure regex replacement from `LIBCPP_ONLY\((assert|static_assert|ASSERT_NOEXCEPT|ASSERT_NOT_NOEXCEPT)\((.*)\)\);` to `LIBCPP_\U$1($2);` using the power of [VSCode's case changing in regex replace](https://code.visualstudio.com/docs/editor/codebasics#_case-changing-in-regex-replace).

To avoid merge conflicts, this isn't changing the line in `libcxx/test/std/input.output/filesystems/fs.enum/enum.path.format.pass.cpp` that #74965 is already changing to use `LIBCPP_STATIC_ASSERT`.