### PR TITLE
[Cygwin] Cygwin macro

### DIFF
--- a/clang/lib/Basic/Targets/ARM.cpp
+++ b/clang/lib/Basic/Targets/ARM.cpp
@@ -1402,8 +1402,6 @@ void CygwinARMTargetInfo::getTargetDefines(const LangOptions &Opts,
   Builder.defineMacro("__CYGWIN__");
   Builder.defineMacro("__CYGWIN32__");
   DefineStd(Builder, "unix", Opts);
-  if (Opts.CPlusPlus)
-    Builder.defineMacro("_GNU_SOURCE");
 }
 
 DarwinARMTargetInfo::DarwinARMTargetInfo(const llvm::Triple &Triple,

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -508,8 +508,13 @@ void X86TargetInfo::getTargetDefines(const LangOptions &Opts,
   Builder.defineMacro("__GCC_ASM_FLAG_OUTPUTS__");
 
   std::string CodeModel = getTargetOpts().CodeModel;
-  if (CodeModel == "default")
-    CodeModel = "small";
+  if (CodeModel == "default") {
+    if (getTriple().isWindowsCygwinEnvironment() && getTriple().getArch() == llvm::Triple::x86_64) {
+      CodeModel = "medium";
+    } else {
+      CodeModel = "small";
+    }
+  }
   Builder.defineMacro("__code_model_" + CodeModel + "__");
 
   // Target identification.

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -509,7 +509,8 @@ void X86TargetInfo::getTargetDefines(const LangOptions &Opts,
 
   std::string CodeModel = getTargetOpts().CodeModel;
   if (CodeModel == "default") {
-    if (getTriple().isWindowsCygwinEnvironment() && getTriple().getArch() == llvm::Triple::x86_64) {
+    if (getTriple().isWindowsCygwinEnvironment() &&
+        getTriple().getArch() == llvm::Triple::x86_64) {
       CodeModel = "medium";
     } else {
       CodeModel = "small";

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -643,8 +643,6 @@ public:
     Builder.defineMacro("__CYGWIN32__");
     addCygMingDefines(Opts, Builder);
     DefineStd(Builder, "unix", Opts);
-    if (Opts.CPlusPlus)
-      Builder.defineMacro("_GNU_SOURCE");
   }
 };
 
@@ -916,8 +914,6 @@ public:
     Builder.defineMacro("__CYGWIN64__");
     addCygMingDefines(Opts, Builder);
     DefineStd(Builder, "unix", Opts);
-    if (Opts.CPlusPlus)
-      Builder.defineMacro("_GNU_SOURCE");
   }
 };
 


### PR DESCRIPTION
I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git
