### PR TITLE
[Cygwin] Cygwin X86ISelLowering.cpp 

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -18329,6 +18329,7 @@ unsigned X86TargetLowering::getGlobalWrapperKind(
 
   // The following OpFlags under RIP-rel PIC use RIP.
   if (Subtarget.isPICStyleRIPRel() &&
+      !(Subtarget.isTargetWindowsCygwin() && Subtarget.is64Bit()) &&
       (OpFlags == X86II::MO_NO_FLAG || OpFlags == X86II::MO_COFFSTUB ||
        OpFlags == X86II::MO_DLLIMPORT))
     return X86ISD::WrapperRIP;


### PR DESCRIPTION
Fix the regression caused by commit c04a05d898982614a2df80d928b97ed4f8c49b60 2023-08-14, that, in Cygwin, Clang can't bootstrap.

Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
make[1]: *** [CMakeFiles/Makefile2:11572: include/llvm/TargetParser/CMakeFiles/RISCVTargetParserTableGen.dir/all] Error 2
Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
make[2]: *** [include/llvm/IR/CMakeFiles/intrinsics_gen.dir/build.make:311: include/llvm/IR/IntrinsicImpl.inc] Error 127
Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
make[2]: *** [include/llvm/IR/CMakeFiles/intrinsics_gen.dir/build.make:237: include/llvm/IR/IntrinsicEnums.inc] Error 127
make[2]: *** [include/llvm/Frontend/OpenACC/CMakeFiles/acc_gen.dir/build.make:172: include/llvm/Frontend/OpenACC/ACC.inc] Error 127
make[2]: *** [include/llvm/Frontend/OpenMP/CMakeFiles/omp_gen.dir/build.make:121: include/llvm/Frontend/OpenMP/OMP.h.inc] Error 127
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:11520: include/llvm/Frontend/OpenACC/CMakeFiles/acc_gen.dir/all] Error 2
make[2]: *** [include/llvm/IR/CMakeFiles/intrinsics_gen.dir/build.make:459: include/llvm/IR/IntrinsicsAMDGPU.h] Error 127
Cygwin runtime failure: /cygdrive/e/Note/Tool/llvm-release-build/bin/llvm-min-tblgen.exe: Invalid relocation.  Offset 0x7837bccad at address 0x7ff7902c1077 doesn't fit into 32 bits
make[2]: *** [include/llvm/Frontend/OpenMP/CMakeFiles/omp_gen.dir/build.make:172: include/llvm/Frontend/OpenMP/OMP.inc] Error 127
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make[2]: *** [include/llvm/IR/CMakeFiles/intrinsics_gen.dir/build.make:385: include/llvm/IR/IntrinsicsAArch64.h] Error 127
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make[1]: *** [CMakeFiles/Makefile2:11546: include/llvm/Frontend/OpenMP/CMakeFiles/omp_gen.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:11468: include/llvm/IR/CMakeFiles/intrinsics_gen.dir/all] Error 2
[  9%] Linking CXX executable ../../bin/FileCheck.exe


I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git
