### PR TITLE
[pseudo] lib Grammar.cpp

### DIFF
--- a/clang-tools-extra/pseudo/lib/grammar/Grammar.cpp
+++ b/clang-tools-extra/pseudo/lib/grammar/Grammar.cpp
@@ -172,9 +172,10 @@ std::vector<llvm::DenseSet<SymbolID>> followSets(const Grammar &G) {
   return FollowSets;
 }
 
+static auto TerminalNames = new std::string[NumTerminals];
+
 static llvm::ArrayRef<std::string> getTerminalNames() {
-  static const auto &TerminalNames = []() {
-    auto TerminalNames = new std::string[NumTerminals];
+  static const auto &TerminalNames1 = []() {
 #define PUNCTUATOR(Tok, Spelling) TerminalNames[tok::Tok] = Spelling;
 #define KEYWORD(Keyword, Condition)                                            \
   TerminalNames[tok::kw_##Keyword] = llvm::StringRef(#Keyword).upper();
@@ -182,7 +183,7 @@ static llvm::ArrayRef<std::string> getTerminalNames() {
 #include "clang/Basic/TokenKinds.def"
     return llvm::ArrayRef(TerminalNames, NumTerminals);
   }();
-  return TerminalNames;
+  return TerminalNames1;
 }
 GrammarTable::GrammarTable() : Terminals(getTerminalNames()) {}
 


### PR DESCRIPTION


[  7%] Generating nonterminal symbol file for cxx grammar...
[  7%] Generating bnf string file for cxx grammar...
cd /cygdrive/e/Note/Tool/llvm-release-build/tools/clang/tools/extra/pseudo/include && ../../../../../../bin/clang-pseudo-gen.exe --grammar /cygdrive/e/Note/Tool/llvm/clang-tools-extra/pseudo/include/../lib/cxx/cxx.bnf --emit-symbol-list -o /cygdrive/e/Note/Tool/llvm-release-build/tools/clang/tools/extra/pseudo/include/CXXSymbols.inc
cd /cygdrive/e/Note/Tool/llvm-release-build/tools/clang/tools/extra/pseudo/include && ../../../../../../bin/clang-pseudo-gen.exe --grammar /cygdrive/e/Note/Tool/llvm/clang-tools-extra/pseudo/include/../lib/cxx/cxx.bnf --emit-grammar-content -o /cygdrive/e/Note/Tool/llvm-release-build/tools/clang/tools/extra/pseudo/include/CXXBNF.inc
make[2]: *** [tools/clang/tools/extra/pseudo/include/CMakeFiles/cxx_gen.dir/build.make:75: tools/clang/tools/extra/pseudo/include/CXXBNF.inc] Aborted
make[2]: *** Deleting file 'tools/clang/tools/extra/pseudo/include/CXXBNF.inc'
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [tools/clang/tools/extra/pseudo/include/CMakeFiles/cxx_gen.dir/build.make:80: tools/clang/tools/extra/pseudo/include/CXXSymbols.inc] Aborted
make[2]: *** Deleting file 'tools/clang/tools/extra/pseudo/include/CXXSymbols.inc'
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make[1]: *** [CMakeFiles/Makefile2:46834: tools/clang/tools/extra/pseudo/include/CMakeFiles/cxx_gen.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
[  7%] Built target LLVMDebugInfoCodeView
