### PR TITLE
[libc++][test] `concat_macros.h`: Fix `TEST_HAS_NO_WIDE_CHARACTERS` syntax damage

### DIFF
--- a/libcxx/test/support/concat_macros.h
+++ b/libcxx/test/support/concat_macros.h
@@ -80,9 +80,9 @@ template <class InIt, class OutIt>
   requires(std::output_iterator<OutIt, const char&> &&
            (std::same_as<std::iter_value_t<InIt>, char16_t>
 #    ifndef TEST_HAS_NO_WIDE_CHARACTERS
-            || (std::same_as<std::iter_value_t<InIt>, wchar_t> && sizeof(wchar_t) == 2))
+            || (std::same_as<std::iter_value_t<InIt>, wchar_t> && sizeof(wchar_t) == 2)
 #    endif
-               )
+                ))
 OutIt test_transcode(InIt first, InIt last, OutIt out_it) {
   while (first != last) {
     char32_t value = *first++;
@@ -118,11 +118,11 @@ OutIt test_transcode(InIt first, InIt last, OutIt out_it) {
 
 template <class InIt, class OutIt>
   requires(std::output_iterator<OutIt, const char&> &&
-           (std::same_as<std::iter_value_t<InIt>, char32_t> ||
+           (std::same_as<std::iter_value_t<InIt>, char32_t>
 #    ifndef TEST_HAS_NO_WIDE_CHARACTERS
-            (std::same_as<std::iter_value_t<InIt>, wchar_t> && sizeof(wchar_t) == 4))
+            || (std::same_as<std::iter_value_t<InIt>, wchar_t> && sizeof(wchar_t) == 4)
 #    endif
-               )
+                ))
 OutIt test_transcode(InIt first, InIt last, OutIt out_it) {
   while (first != last) {
     char32_t value = *first++;


### PR DESCRIPTION
@mordante This was introduced by #73395 a couple of days ago.

This is causing PR checks to fail, [stage3 (generic-no-wide-characters, libcxx-runners-8-set, OFF)](https://github.com/llvm/llvm-project/actions/runs/7154839054/job/19484723909?pr=74254#logs):

```
In file included from /home/runner/_work/llvm-project/llvm-project/libcxx/test/std/utilities/format/format.tuple/format.functions.vformat.pass.cpp:29:
/home/runner/_work/llvm-project/llvm-project/libcxx/test/support/concat_macros.h:86:1: error: expected ')'
   86 | OutIt test_transcode(InIt first, InIt last, OutIt out_it) {
      | ^
/home/runner/_work/llvm-project/llvm-project/libcxx/test/support/concat_macros.h:80:11: note: to match this '('
   80 |   requires(std::output_iterator<OutIt, const char&> &&
      |           ^
/home/runner/_work/llvm-project/llvm-project/libcxx/test/std/utilities/format/format.tuple/format.functions.vformat.pass.cpp:63:2: error: expected unqualified-id
   63 | }
      |  ^
```
