### PR TITLE
[BPF] support indirect branch (callx) in AsmParser

### DIFF
--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -229,6 +229,7 @@ public:
     return StringSwitch<bool>(Name.lower())
         .Case("if", true)
         .Case("call", true)
+        .Case("callx", true)
         .Case("goto", true)
         .Case("gotol", true)
         .Case("*", true)

--- a/llvm/test/MC/BPF/callx.s
+++ b/llvm/test/MC/BPF/callx.s
@@ -1,0 +1,4 @@
+# RUN: llvm-mc -triple bpfel -show-encoding < %s | FileCheck %s
+
+# CHECK: callx r1                                # encoding: [0x8d,0x00,0x00,0x00,0x01,0x00,0x00,0x00]
+callx r1


### PR DESCRIPTION
Simply mark `callx` as a valid ID, so it can be recognized.

Previously this valid asm triggers an error:

    # clang local/callx.s -target bpf
    local/callx.s:8:2: error: invalid register/token name
            callx r1
            ^