### PR TITLE
[BPF][GlobalISel] add initial gisel support for BPF

### DIFF
--- a/llvm/lib/Target/BPF/BPF.h
+++ b/llvm/lib/Target/BPF/BPF.h
@@ -16,7 +16,10 @@
 #include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
+class BPFRegisterBankInfo;
+class BPFSubtarget;
 class BPFTargetMachine;
+class InstructionSelector;
 class PassRegistry;
 
 ModulePass *createBPFCheckAndAdjustIR();
@@ -26,6 +29,10 @@ FunctionPass *createBPFMISimplifyPatchablePass();
 FunctionPass *createBPFMIPeepholePass();
 FunctionPass *createBPFMIPreEmitPeepholePass();
 FunctionPass *createBPFMIPreEmitCheckingPass();
+
+InstructionSelector *createBPFInstructionSelector(const BPFTargetMachine &,
+                                                  const BPFSubtarget &,
+                                                  const BPFRegisterBankInfo &);
 
 void initializeBPFCheckAndAdjustIRPass(PassRegistry&);
 void initializeBPFDAGToDAGISelPass(PassRegistry &);

--- a/llvm/lib/Target/BPF/BPF.td
+++ b/llvm/lib/Target/BPF/BPF.td
@@ -11,6 +11,7 @@ include "llvm/Target/Target.td"
 include "BPFRegisterInfo.td"
 include "BPFCallingConv.td"
 include "BPFInstrInfo.td"
+include "GISel/BPFRegisterBanks.td"
 
 def BPFInstrInfo : InstrInfo;
 

--- a/llvm/lib/Target/BPF/BPFSubtarget.cpp
+++ b/llvm/lib/Target/BPF/BPFSubtarget.cpp
@@ -12,6 +12,10 @@
 
 #include "BPFSubtarget.h"
 #include "BPF.h"
+#include "BPFTargetMachine.h"
+#include "GISel/BPFCallLowering.h"
+#include "GISel/BPFLegalizerInfo.h"
+#include "GISel/BPFRegisterBankInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/TargetParser/Host.h"
 
@@ -95,4 +99,28 @@ BPFSubtarget::BPFSubtarget(const Triple &TT, const std::string &CPU,
       FrameLowering(initializeSubtargetDependencies(CPU, FS)),
       TLInfo(TM, *this) {
   IsLittleEndian = TT.isLittleEndian();
+
+  CallLoweringInfo.reset(new BPFCallLowering(*getTargetLowering()));
+  Legalizer.reset(new BPFLegalizerInfo(*this));
+  auto *RBI = new BPFRegisterBankInfo(*getRegisterInfo());
+  RegBankInfo.reset(RBI);
+
+  InstSelector.reset(createBPFInstructionSelector(
+      *static_cast<const BPFTargetMachine *>(&TM), *this, *RBI));
+}
+
+const CallLowering *BPFSubtarget::getCallLowering() const {
+  return CallLoweringInfo.get();
+}
+
+InstructionSelector *BPFSubtarget::getInstructionSelector() const {
+  return InstSelector.get();
+}
+
+const LegalizerInfo *BPFSubtarget::getLegalizerInfo() const {
+  return Legalizer.get();
+}
+
+const RegisterBankInfo *BPFSubtarget::getRegBankInfo() const {
+  return RegBankInfo.get();
 }

--- a/llvm/lib/Target/BPF/BPFSubtarget.h
+++ b/llvm/lib/Target/BPF/BPFSubtarget.h
@@ -16,7 +16,12 @@
 #include "BPFFrameLowering.h"
 #include "BPFISelLowering.h"
 #include "BPFInstrInfo.h"
+#include "BPFRegisterInfo.h"
 #include "BPFSelectionDAGInfo.h"
+#include "llvm/CodeGen/GlobalISel/CallLowering.h"
+#include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
+#include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
+#include "llvm/CodeGen/RegisterBankInfo.h"
 #include "llvm/CodeGen/SelectionDAGTargetInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
@@ -61,6 +66,11 @@ protected:
   // whether cpu v4 insns are enabled.
   bool HasLdsx, HasMovsx, HasBswap, HasSdivSmod, HasGotol, HasStoreImm;
 
+  std::unique_ptr<CallLowering> CallLoweringInfo;
+  std::unique_ptr<InstructionSelector> InstSelector;
+  std::unique_ptr<LegalizerInfo> Legalizer;
+  std::unique_ptr<RegisterBankInfo> RegBankInfo;
+
 public:
   // This constructor initializes the data members to match that
   // of the specified triple.
@@ -95,9 +105,14 @@ public:
   const BPFSelectionDAGInfo *getSelectionDAGInfo() const override {
     return &TSInfo;
   }
-  const TargetRegisterInfo *getRegisterInfo() const override {
+  const BPFRegisterInfo *getRegisterInfo() const override {
     return &InstrInfo.getRegisterInfo();
   }
+
+  const CallLowering *getCallLowering() const override;
+  InstructionSelector *getInstructionSelector() const override;
+  const LegalizerInfo *getLegalizerInfo() const override;
+  const RegisterBankInfo *getRegBankInfo() const override;
 };
 } // End llvm namespace
 

--- a/llvm/lib/Target/BPF/CMakeLists.txt
+++ b/llvm/lib/Target/BPF/CMakeLists.txt
@@ -11,10 +11,16 @@ tablegen(LLVM BPFGenInstrInfo.inc -gen-instr-info)
 tablegen(LLVM BPFGenMCCodeEmitter.inc -gen-emitter)
 tablegen(LLVM BPFGenRegisterInfo.inc -gen-register-info)
 tablegen(LLVM BPFGenSubtargetInfo.inc -gen-subtarget)
+tablegen(LLVM BPFGenGlobalISel.inc -gen-global-isel)
+tablegen(LLVM BPFGenRegisterBank.inc -gen-register-bank)
 
 add_public_tablegen_target(BPFCommonTableGen)
 
 add_llvm_target(BPFCodeGen
+  GISel/BPFCallLowering.cpp
+  GISel/BPFInstructionSelector.cpp
+  GISel/BPFRegisterBankInfo.cpp
+  GISel/BPFLegalizerInfo.cpp
   BPFAbstractMemberAccess.cpp
   BPFAdjustOpt.cpp
   BPFAsmPrinter.cpp
@@ -44,6 +50,7 @@ add_llvm_target(BPFCodeGen
   CodeGen
   CodeGenTypes
   Core
+  GlobalISel
   IPO
   MC
   Scalar

--- a/llvm/lib/Target/BPF/GISel/BPFCallLowering.cpp
+++ b/llvm/lib/Target/BPF/GISel/BPFCallLowering.cpp
@@ -1,0 +1,46 @@
+//===-- BPFCallLowering.cpp - Call lowering for GlobalISel ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the lowering of LLVM calls to machine code calls for
+/// GlobalISel.
+///
+//===----------------------------------------------------------------------===//
+
+#include "BPFCallLowering.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "bpf-call-lowering"
+
+using namespace llvm;
+
+BPFCallLowering::BPFCallLowering(const BPFTargetLowering &TLI)
+    : CallLowering(&TLI) {}
+
+bool BPFCallLowering::lowerReturn(MachineIRBuilder &MIRBuilder,
+                                  const Value *Val, ArrayRef<Register> VRegs,
+                                  FunctionLoweringInfo &FLI,
+                                  Register SwiftErrorVReg) const {
+  if (!VRegs.empty())
+    return false;
+  MIRBuilder.buildInstr(BPF::RET);
+  return true;
+}
+
+bool BPFCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
+                                           const Function &F,
+                                           ArrayRef<ArrayRef<Register>> VRegs,
+                                           FunctionLoweringInfo &FLI) const {
+  return VRegs.empty();
+}
+
+bool BPFCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
+                                CallLoweringInfo &Info) const {
+  return false;
+}

--- a/llvm/lib/Target/BPF/GISel/BPFCallLowering.h
+++ b/llvm/lib/Target/BPF/GISel/BPFCallLowering.h
@@ -1,0 +1,39 @@
+//===-- BPFCallLowering.h - Call lowering for GlobalISel --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file describes how to lower LLVM calls to machine code calls.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_GISEL_BPFCALLLOWERING_H
+#define LLVM_LIB_TARGET_BPF_GISEL_BPFCALLLOWERING_H
+
+#include "BPFISelLowering.h"
+#include "llvm/CodeGen/GlobalISel/CallLowering.h"
+#include "llvm/IR/CallingConv.h"
+
+namespace llvm {
+
+class BPFTargetLowering;
+
+class BPFCallLowering : public CallLowering {
+public:
+  BPFCallLowering(const BPFTargetLowering &TLI);
+  bool lowerReturn(MachineIRBuilder &MIRBuilder, const Value *Val,
+                   ArrayRef<Register> VRegs, FunctionLoweringInfo &FLI,
+                   Register SwiftErrorVReg) const override;
+  bool lowerFormalArguments(MachineIRBuilder &MIRBuilder, const Function &F,
+                            ArrayRef<ArrayRef<Register>> VRegs,
+                            FunctionLoweringInfo &FLI) const override;
+  bool lowerCall(MachineIRBuilder &MIRBuilder,
+                 CallLoweringInfo &Info) const override;
+};
+} // namespace llvm
+
+#endif

--- a/llvm/lib/Target/BPF/GISel/BPFInstructionSelector.cpp
+++ b/llvm/lib/Target/BPF/GISel/BPFInstructionSelector.cpp
@@ -1,0 +1,91 @@
+//===- BPFInstructionSelector.cpp --------------------------------*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file implements the targeting of the InstructionSelector class for BPF.
+//===----------------------------------------------------------------------===//
+
+#include "BPFInstrInfo.h"
+#include "BPFRegisterBankInfo.h"
+#include "BPFSubtarget.h"
+#include "BPFTargetMachine.h"
+#include "llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h"
+#include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/IR/IntrinsicsBPF.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "bpf-gisel"
+
+using namespace llvm;
+
+namespace {
+
+#define GET_GLOBALISEL_PREDICATE_BITSET
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_PREDICATE_BITSET
+
+class BPFInstructionSelector : public InstructionSelector {
+public:
+  BPFInstructionSelector(const BPFTargetMachine &TM, const BPFSubtarget &STI,
+                         const BPFRegisterBankInfo &RBI);
+
+  bool select(MachineInstr &I) override;
+  static const char *getName() { return DEBUG_TYPE; }
+
+private:
+  /// tblgen generated 'select' implementation that is used as the initial
+  /// selector for the patterns that do not require complex C++.
+  bool selectImpl(MachineInstr &I, CodeGenCoverage &CoverageInfo) const;
+
+  const BPFInstrInfo &TII;
+  const BPFRegisterInfo &TRI;
+  const BPFRegisterBankInfo &RBI;
+
+#define GET_GLOBALISEL_PREDICATES_DECL
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_PREDICATES_DECL
+
+#define GET_GLOBALISEL_TEMPORARIES_DECL
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_TEMPORARIES_DECL
+};
+
+} // namespace
+
+#define GET_GLOBALISEL_IMPL
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_IMPL
+
+BPFInstructionSelector::BPFInstructionSelector(const BPFTargetMachine &TM,
+                                               const BPFSubtarget &STI,
+                                               const BPFRegisterBankInfo &RBI)
+    : TII(*STI.getInstrInfo()), TRI(*STI.getRegisterInfo()), RBI(RBI),
+#define GET_GLOBALISEL_PREDICATES_INIT
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_PREDICATES_INIT
+#define GET_GLOBALISEL_TEMPORARIES_INIT
+#include "BPFGenGlobalISel.inc"
+#undef GET_GLOBALISEL_TEMPORARIES_INIT
+{
+}
+
+bool BPFInstructionSelector::select(MachineInstr &I) {
+  if (selectImpl(I, *CoverageInfo))
+    return true;
+  return false;
+}
+
+namespace llvm {
+InstructionSelector *
+createBPFInstructionSelector(const BPFTargetMachine &TM,
+                             const BPFSubtarget &Subtarget,
+                             const BPFRegisterBankInfo &RBI) {
+  return new BPFInstructionSelector(TM, Subtarget, RBI);
+}
+} // namespace llvm

--- a/llvm/lib/Target/BPF/GISel/BPFLegalizerInfo.cpp
+++ b/llvm/lib/Target/BPF/GISel/BPFLegalizerInfo.cpp
@@ -1,0 +1,22 @@
+//===- BPFLegalizerInfo.h ----------------------------------------*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file implements the targeting of the Machinelegalizer class for BPF
+//===----------------------------------------------------------------------===//
+
+#include "BPFLegalizerInfo.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "bpf-legalinfo"
+
+using namespace llvm;
+using namespace LegalizeActions;
+
+BPFLegalizerInfo::BPFLegalizerInfo(const BPFSubtarget &ST) {
+  getLegacyLegalizerInfo().computeTables();
+}

--- a/llvm/lib/Target/BPF/GISel/BPFLegalizerInfo.h
+++ b/llvm/lib/Target/BPF/GISel/BPFLegalizerInfo.h
@@ -1,0 +1,28 @@
+//===- BPFLegalizerInfo.h ----------------------------------------*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file declares the targeting of the Machinelegalizer class for BPF
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_GISEL_BPFMACHINELEGALIZER_H
+#define LLVM_LIB_TARGET_BPF_GISEL_BPFMACHINELEGALIZER_H
+
+#include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
+
+namespace llvm {
+
+class BPFSubtarget;
+
+/// This class provides the information for the BPF target legalizer for
+/// GlobalISel.
+class BPFLegalizerInfo : public LegalizerInfo {
+public:
+  BPFLegalizerInfo(const BPFSubtarget &ST);
+};
+} // namespace llvm
+#endif

--- a/llvm/lib/Target/BPF/GISel/BPFRegisterBankInfo.cpp
+++ b/llvm/lib/Target/BPF/GISel/BPFRegisterBankInfo.cpp
@@ -1,0 +1,25 @@
+//===- BPFRegisterBankInfo.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file implements the targeting of the RegisterBankInfo class for BPF
+//===----------------------------------------------------------------------===//
+
+#include "BPFRegisterBankInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "bpf-reg-bank-info"
+
+#define GET_TARGET_REGBANK_IMPL
+#include "BPFGenRegisterBank.inc"
+
+using namespace llvm;
+
+BPFRegisterBankInfo::BPFRegisterBankInfo(const TargetRegisterInfo &TRI)
+    : BPFGenRegisterBankInfo() {}

--- a/llvm/lib/Target/BPF/GISel/BPFRegisterBankInfo.h
+++ b/llvm/lib/Target/BPF/GISel/BPFRegisterBankInfo.h
@@ -1,0 +1,39 @@
+//===-- BPFRegisterBankInfo.h -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the targeting of the RegisterBankInfo class for BPF.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_GISEL_BPFREGISTERBANKINFO_H
+#define LLVM_LIB_TARGET_BPF_GISEL_BPFREGISTERBANKINFO_H
+
+#include "MCTargetDesc/BPFMCTargetDesc.h"
+#include "llvm/CodeGen/RegisterBankInfo.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+
+#define GET_REGBANK_DECLARATIONS
+#include "BPFGenRegisterBank.inc"
+
+namespace llvm {
+class TargetRegisterInfo;
+
+class BPFGenRegisterBankInfo : public RegisterBankInfo {
+protected:
+#define GET_TARGET_REGBANK_CLASS
+#include "BPFGenRegisterBank.inc"
+};
+
+class BPFRegisterBankInfo final : public BPFGenRegisterBankInfo {
+public:
+  BPFRegisterBankInfo(const TargetRegisterInfo &TRI);
+};
+} // namespace llvm
+
+#endif

--- a/llvm/lib/Target/BPF/GISel/BPFRegisterBanks.td
+++ b/llvm/lib/Target/BPF/GISel/BPFRegisterBanks.td
@@ -1,0 +1,15 @@
+//===-- BPFRegisterBanks.td - Describe the BPF Banks -------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Define the BPF register banks used for GlobalISel.
+///
+//===----------------------------------------------------------------------===//
+
+/// General Purpose Registers
+def GPRRegBank : RegisterBank<"GPRB", [GPR]>;

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCTargetDesc.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCTargetDesc.h
@@ -30,8 +30,7 @@ class MCSubtargetInfo;
 class MCTargetOptions;
 class Target;
 
-MCCodeEmitter *createBPFMCCodeEmitter(const MCInstrInfo &MCII,
-                                      MCContext &Ctx);
+MCCodeEmitter *createBPFMCCodeEmitter(const MCInstrInfo &MCII, MCContext &Ctx);
 MCCodeEmitter *createBPFbeMCCodeEmitter(const MCInstrInfo &MCII,
                                         MCContext &Ctx);
 
@@ -43,7 +42,7 @@ MCAsmBackend *createBPFbeAsmBackend(const Target &T, const MCSubtargetInfo &STI,
                                     const MCTargetOptions &Options);
 
 std::unique_ptr<MCObjectTargetWriter> createBPFELFObjectWriter(uint8_t OSABI);
-}
+} // namespace llvm
 
 // Defines symbolic names for BPF registers.  This defines a mapping from
 // register name to register number.

--- a/llvm/test/CodeGen/BPF/GlobalISel/ir-translator-ret.ll
+++ b/llvm/test/CodeGen/BPF/GlobalISel/ir-translator-ret.ll
@@ -1,0 +1,7 @@
+; RUN: llc -mtriple=bpfel -global-isel -verify-machineinstrs -stop-after=irtranslator < %s | FileCheck %s
+
+; CHECK: name: f
+; CHECK: RET
+define void @f() {
+  ret void
+}


### PR DESCRIPTION
This adds initial codegen support for BPF backend.

Only implemented ir-translator for "RET" (but not support isel).

Depends on: #74998