### PR TITLE
[TextAPI] Add support to convert RecordSlices -> InterfaceFile

### DIFF
--- a/llvm/include/llvm/TextAPI/DylibReader.h
+++ b/llvm/include/llvm/TextAPI/DylibReader.h
@@ -38,6 +38,11 @@ struct ParseOption {
 /// \return List of record slices.
 Expected<Records> readFile(MemoryBufferRef Buffer, const ParseOption &Opt);
 
+/// Get TAPI file representation of binary dylib.
+///
+/// \param Buffer Data that points to dylib.
+Expected<std::unique_ptr<InterfaceFile>> get(MemoryBufferRef Buffer);
+
 } // namespace llvm::MachO::DylibReader
 
 #endif // LLVM_TEXTAPI_DYLIBREADER_H

--- a/llvm/include/llvm/TextAPI/Record.h
+++ b/llvm/include/llvm/TextAPI/Record.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TEXTAPI_RECORD_H
 #define LLVM_TEXTAPI_RECORD_H
 
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/TextAPI/Symbol.h"
@@ -50,7 +51,7 @@ class Record {
 public:
   Record() = default;
   Record(StringRef Name, RecordLinkage Linkage, SymbolFlags Flags)
-      : Name(Name), Linkage(Linkage), Flags(Flags) {}
+      : Name(Name), Linkage(Linkage), Flags(mergeFlags(Flags, Linkage)) {}
 
   bool isWeakDefined() const {
     return (Flags & SymbolFlags::WeakDefined) == SymbolFlags::WeakDefined;
@@ -79,6 +80,10 @@ public:
   bool isRexported() const { return Linkage == RecordLinkage::Rexported; }
 
   StringRef getName() const { return Name; }
+  SymbolFlags getFlags() const { return Flags; }
+
+private:
+  SymbolFlags mergeFlags(SymbolFlags Flags, RecordLinkage Linkage);
 
 protected:
   StringRef Name;
@@ -137,6 +142,7 @@ public:
 
   ObjCIVarRecord *addObjCIVar(StringRef IVar, RecordLinkage Linkage);
   ObjCIVarRecord *findObjCIVar(StringRef IVar) const;
+  std::vector<ObjCIVarRecord *> getObjCIVars() const;
 
 private:
   RecordMap<ObjCIVarRecord> IVars;
@@ -163,6 +169,7 @@ public:
 
   bool hasExceptionAttribute() const { return HasEHType; }
   bool addObjCCategory(ObjCCategoryRecord *Record);
+  std::vector<ObjCCategoryRecord *> getObjCCategories() const;
 
 private:
   bool HasEHType;

--- a/llvm/include/llvm/TextAPI/RecordVisitor.h
+++ b/llvm/include/llvm/TextAPI/RecordVisitor.h
@@ -1,0 +1,54 @@
+//===- llvm/TextAPI/RecordSlice.h - TAPI RecordSlice ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Defines the TAPI Record Visitor.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TEXTAPI_RECORDVISITOR_H
+#define LLVM_TEXTAPI_RECORDVISITOR_H
+
+#include "llvm/TextAPI/Record.h"
+#include "llvm/TextAPI/SymbolSet.h"
+
+namespace llvm {
+namespace MachO {
+
+/// Base class for any usage of traversing over collected Records.
+class RecordVisitor {
+public:
+  virtual ~RecordVisitor();
+
+  virtual void visitGlobal(const GlobalRecord &) = 0;
+  virtual void visitObjCInterface(const ObjCInterfaceRecord &);
+  virtual void visitObjCCategory(const ObjCCategoryRecord &);
+};
+
+/// Specialized RecordVisitor for collecting exported symbols
+/// and undefined symbols if RecordSlice being visited represents a
+/// flat-namespaced library.
+class SymbolConverter : public RecordVisitor {
+public:
+  SymbolConverter(SymbolSet *Symbols, const Target &T,
+                  const bool RecordUndefs = false)
+      : Symbols(Symbols), Targ(T), RecordUndefs(RecordUndefs) {}
+  void visitGlobal(const GlobalRecord &) override;
+  void visitObjCInterface(const ObjCInterfaceRecord &) override;
+  void visitObjCCategory(const ObjCCategoryRecord &) override;
+
+private:
+  void addIVars(const ArrayRef<ObjCIVarRecord *>, StringRef ContainerName);
+  SymbolSet *Symbols;
+  const Target Targ;
+  const bool RecordUndefs;
+};
+
+} // end namespace MachO.
+} // end namespace llvm.
+
+#endif // LLVM_TEXTAPI_RECORDVISITOR_H

--- a/llvm/include/llvm/TextAPI/RecordsSlice.h
+++ b/llvm/include/llvm/TextAPI/RecordsSlice.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_TEXTAPI_RECORDSLICE_H
 #define LLVM_TEXTAPI_RECORDSLICE_H
 
-#include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/TextAPI/InterfaceFile.h"
 #include "llvm/TextAPI/PackedVersion.h"
 #include "llvm/TextAPI/Record.h"
+#include "llvm/TextAPI/RecordVisitor.h"
 
 namespace llvm {
 namespace MachO {
@@ -133,6 +133,9 @@ public:
            Categories.empty();
   }
 
+  // Visit all records known to RecordsSlice.
+  void visit(RecordVisitor &V) const;
+
   struct BinaryAttrs {
     std::vector<StringRef> AllowableClients;
     std::vector<StringRef> RexportedLibraries;
@@ -174,6 +177,12 @@ private:
     R->Linkage = std::max(R->Linkage, L);
   }
 
+  /// Update set flags of requested record.
+  ///
+  /// \param R The global record to update.
+  /// \param F Flags to update to.
+  void updateFlags(GlobalRecord *R, SymbolFlags F) { R->Flags = F; }
+
   RecordMap<GlobalRecord> Globals;
   RecordMap<ObjCInterfaceRecord> Classes;
   RecordMap<ObjCCategoryRecord, std::pair<StringRef, StringRef>> Categories;
@@ -182,6 +191,7 @@ private:
 };
 
 using Records = llvm::SmallVector<std::shared_ptr<RecordsSlice>, 4>;
+std::unique_ptr<InterfaceFile> convertToInterfaceFile(const Records &Slices);
 
 } // namespace MachO
 } // namespace llvm

--- a/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
+++ b/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
@@ -404,3 +404,13 @@ Expected<Records> DylibReader::readFile(MemoryBufferRef Buffer,
     return make_error<TextAPIError>(TextAPIErrorCode::EmptyResults);
   return Results;
 }
+
+Expected<std::unique_ptr<InterfaceFile>>
+DylibReader::get(MemoryBufferRef Buffer) {
+  ParseOption Options;
+  auto SlicesOrErr = readFile(Buffer, Options);
+  if (!SlicesOrErr)
+    return SlicesOrErr.takeError();
+
+  return convertToInterfaceFile(*SlicesOrErr);
+}

--- a/llvm/lib/TextAPI/CMakeLists.txt
+++ b/llvm/lib/TextAPI/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMTextAPI
   PackedVersion.cpp
   Platform.cpp
   RecordsSlice.cpp
+  RecordVisitor.cpp
   Symbol.cpp
   SymbolSet.cpp
   Target.cpp

--- a/llvm/lib/TextAPI/RecordVisitor.cpp
+++ b/llvm/lib/TextAPI/RecordVisitor.cpp
@@ -1,0 +1,65 @@
+//===- RecordVisitor.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Implements the TAPI Record Visitor.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/TextAPI/RecordVisitor.h"
+
+using namespace llvm;
+using namespace llvm::MachO;
+
+RecordVisitor::~RecordVisitor() {}
+void RecordVisitor::visitObjCInterface(const ObjCInterfaceRecord &) {}
+void RecordVisitor::visitObjCCategory(const ObjCCategoryRecord &) {}
+
+static bool shouldSkipRecord(const Record &R, const bool RecordUndefs) {
+  if (R.isExported())
+    return false;
+
+  // Skip non exported symbols unless for flat namespace libraries.
+  return !(RecordUndefs && R.isUndefined());
+}
+
+void SymbolConverter::visitGlobal(const GlobalRecord &GR) {
+  auto [SymName, SymKind] = parseSymbol(GR.getName(), GR.getFlags());
+  if (shouldSkipRecord(GR, RecordUndefs))
+    return;
+  Symbols->addGlobal(SymKind, SymName, GR.getFlags(), Targ);
+}
+
+void SymbolConverter::addIVars(const ArrayRef<ObjCIVarRecord *> IVars,
+                               StringRef ContainerName) {
+  for (auto *IV : IVars) {
+    if (shouldSkipRecord(*IV, RecordUndefs))
+      continue;
+    std::string Name =
+        ObjCIVarRecord::createScopedName(ContainerName, IV->getName());
+    Symbols->addGlobal(SymbolKind::ObjectiveCInstanceVariable, Name,
+                       IV->getFlags(), Targ);
+  }
+}
+
+void SymbolConverter::visitObjCInterface(const ObjCInterfaceRecord &ObjCR) {
+  if (!shouldSkipRecord(ObjCR, RecordUndefs)) {
+    Symbols->addGlobal(SymbolKind::ObjectiveCClass, ObjCR.getName(),
+                       ObjCR.getFlags(), Targ);
+    if (ObjCR.hasExceptionAttribute())
+      Symbols->addGlobal(SymbolKind::ObjectiveCClassEHType, ObjCR.getName(),
+                         ObjCR.getFlags(), Targ);
+  }
+
+  addIVars(ObjCR.getObjCIVars(), ObjCR.getName());
+  for (const auto *Cat : ObjCR.getObjCCategories())
+    addIVars(Cat->getObjCIVars(), ObjCR.getName());
+}
+
+void SymbolConverter::visitObjCCategory(const ObjCCategoryRecord &Cat) {
+  addIVars(Cat.getObjCIVars(), Cat.getName());
+}


### PR DESCRIPTION
Introduce RecordVisitor. This is used for different clients that want to extract information out of RecordSlice types.
The first and immediate use case is for serializing symbol information into TBD files.