### PR TITLE
[OpenMP] Change check for OS to check for defined for a macro

### DIFF
--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -72,7 +72,7 @@ struct kmp_sys_timer {
   struct timespec start;
 };
 
-#if KMP_OS_SOLARIS
+#ifndef TIMEVAL_TO_TIMESPEC
 // Convert timeval to timespec.
 #define TIMEVAL_TO_TIMESPEC(tv, ts)                                            \
   do {                                                                         \


### PR DESCRIPTION
Check for the existence of the macro instead of checking for Solaris.
illumos has this macro in sys/time.h.

```
/export/home/brad/llvm-brad/openmp/runtime/src/z_Linux_util.cpp:77:9: warning: 'TIMEVAL_TO_TIMESPEC' macro redefined [-Wmacro-redefined]
   77 | #define TIMEVAL_TO_TIMESPEC(tv, ts)                                            \
      |         ^
/usr/include/sys/time.h:424:9: note: previous definition is here
  424 | #define TIMEVAL_TO_TIMESPEC(tv, ts) { \
      |         ^
```