### PR TITLE
[GitHub] Try a workaround to get the new contributor greeting to work

### DIFF
--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -20,12 +20,19 @@ jobs:
     permissions:
       pull-requests: write
     # Only comment on PRs that have been opened for the first time, by someone
-    # new to LLVM or to GitHub as a whole.
+    # new to LLVM or to GitHub as a whole. Ideally we'd look for FIRST_TIMER
+    # or FIRST_TIME_CONTRIBUTOR, but this does not appear to work. Instead check
+    # that we do not have any of the other author associations.
+    # See https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
+    # for all the possible values.
     if: >-
       (github.repository == 'llvm/llvm-project') &&
       (github.event.action == 'opened') &&
-      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-       github.event.pull_request.author_association == 'FIRST_TIMER')
+      (github.event.pull_request.author_association != 'COLLABORATOR') &&
+      (github.event.pull_request.author_association != 'CONTRIBUTOR') &&
+      (github.event.pull_request.author_association != 'MANNEQUIN') &&
+      (github.event.pull_request.author_association != 'MEMBER') &&
+      (github.event.pull_request.author_association != 'OWNER')
     steps:
       - name: Setup Automation Script
         run: |
@@ -33,6 +40,14 @@ jobs:
           curl -O -L --fail https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/requirements.txt
           chmod a+x github-automation.py
           pip install -r requirements.txt
+
+      # Will be removed shortly, just gathering info to report to Github that
+      # this is not working as expected.
+      - name: Dump Author Association
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          echo "$AUTHOR_ASSOCIATION"
 
       - name: Greet Author
         run: |


### PR DESCRIPTION
For reasons unknown, the FIRST_TIMER and FIRST_TIME_CONTRIBUTOR states don't come through on new user PRs, I have opened https://github.com/orgs/community/discussions/78038 to see if that's my mistake or GitHub's.

In the meantime, a possible workaround is to check that we have none of the other states. If there's some bug that means the first time associations aren't available in workflows, maybe the association will be "NONE".

Also added a debug step to print that association so I can add it to the linked report. I will remove this as soon as I have 1 example PR.