### PR TITLE
[libc][NFC] Fix mixed up biased/unbiased exponent

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -59,13 +59,13 @@ template <typename T> struct FPBits {
     return bits & FloatProp::MANTISSA_MASK;
   }
 
-  LIBC_INLINE constexpr void set_unbiased_exponent(UIntType expVal) {
+  LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
     expVal = (expVal << (FloatProp::MANTISSA_WIDTH)) & FloatProp::EXPONENT_MASK;
     bits &= ~(FloatProp::EXPONENT_MASK);
     bits |= expVal;
   }
 
-  LIBC_INLINE constexpr uint16_t get_unbiased_exponent() const {
+  LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
     return uint16_t((bits & FloatProp::EXPONENT_MASK) >>
                     (FloatProp::MANTISSA_WIDTH));
   }
@@ -73,7 +73,7 @@ template <typename T> struct FPBits {
   // The function return mantissa with the implicit bit set iff the current
   // value is a valid normal number.
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() {
-    return ((get_unbiased_exponent() > 0 && !is_inf_or_nan())
+    return ((get_biased_exponent() > 0 && !is_inf_or_nan())
                 ? (FloatProp::MANTISSA_MASK + 1)
                 : 0) |
            (FloatProp::MANTISSA_MASK & bits);
@@ -126,7 +126,7 @@ template <typename T> struct FPBits {
   LIBC_INLINE constexpr UIntType uintval() const { return bits; }
 
   LIBC_INLINE constexpr int get_exponent() const {
-    return int(get_unbiased_exponent()) - EXPONENT_BIAS;
+    return int(get_biased_exponent()) - EXPONENT_BIAS;
   }
 
   // If the number is subnormal, the exponent is treated as if it were the
@@ -136,13 +136,13 @@ template <typename T> struct FPBits {
   // will give a slightly incorrect result. Additionally, zero has an exponent
   // of zero, and that should actually be treated as zero.
   LIBC_INLINE constexpr int get_explicit_exponent() const {
-    const int unbiased_exp = int(get_unbiased_exponent());
+    const int biased_exp = int(get_biased_exponent());
     if (is_zero()) {
       return 0;
-    } else if (unbiased_exp == 0) {
+    } else if (biased_exp == 0) {
       return 1 - EXPONENT_BIAS;
     } else {
-      return unbiased_exp - EXPONENT_BIAS;
+      return biased_exp - EXPONENT_BIAS;
     }
   }
 
@@ -228,7 +228,7 @@ template <typename T> struct FPBits {
     if (LIBC_LIKELY(ep >= 0)) {
       // Implicit number bit will be removed by mask
       result.set_mantissa(number);
-      result.set_unbiased_exponent(ep + 1);
+      result.set_biased_exponent(ep + 1);
     } else {
       result.set_mantissa(number >> -ep);
     }
@@ -236,10 +236,10 @@ template <typename T> struct FPBits {
   }
 
   LIBC_INLINE static constexpr FPBits<T>
-  create_value(bool sign, UIntType unbiased_exp, UIntType mantissa) {
+  create_value(bool sign, UIntType biased_exp, UIntType mantissa) {
     FPBits<T> result;
     result.set_sign(sign);
-    result.set_unbiased_exponent(unbiased_exp);
+    result.set_biased_exponent(biased_exp);
     result.set_mantissa(mantissa);
     return result;
   }

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -120,8 +120,8 @@ LIBC_INLINE T hypot(T x, T y) {
     return y;
   }
 
-  uint16_t x_exp = x_bits.get_unbiased_exponent();
-  uint16_t y_exp = y_bits.get_unbiased_exponent();
+  uint16_t x_exp = x_bits.get_biased_exponent();
+  uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
   if ((exp_diff >= MantissaWidth<T>::VALUE + 2) || (x == 0) || (y == 0)) {

--- a/libc/src/__support/FPUtil/NormalFloat.h
+++ b/libc/src/__support/FPUtil/NormalFloat.h
@@ -111,7 +111,7 @@ template <typename T> struct NormalFloat {
         const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
         const UIntType shift_out_value = mantissa & shift_out_mask;
         const UIntType halfway_value = UIntType(1) << (shift - 1);
-        result.set_unbiased_exponent(0);
+        result.set_biased_exponent(0);
         result.set_mantissa(mantissa >> shift);
         UIntType new_mantissa = result.get_mantissa();
         if (shift_out_value > halfway_value) {
@@ -126,14 +126,14 @@ template <typename T> struct NormalFloat {
         // mantissa was all ones (0b111..11). For such a case, we will carry
         // the overflow into the exponent.
         if (new_mantissa == ONE)
-          result.set_unbiased_exponent(1);
+          result.set_biased_exponent(1);
         return T(result);
       } else {
         return T(result);
       }
     }
 
-    result.set_unbiased_exponent(exponent + FPBits<T>::EXPONENT_BIAS);
+    result.set_biased_exponent(exponent + FPBits<T>::EXPONENT_BIAS);
     result.set_mantissa(mantissa);
     return T(result);
   }
@@ -151,12 +151,12 @@ private:
     }
 
     // Normalize subnormal numbers.
-    if (bits.get_unbiased_exponent() == 0) {
+    if (bits.get_biased_exponent() == 0) {
       unsigned shift = evaluate_normalization_shift(bits.get_mantissa());
       mantissa = UIntType(bits.get_mantissa()) << shift;
       exponent = 1 - FPBits<T>::EXPONENT_BIAS - shift;
     } else {
-      exponent = bits.get_unbiased_exponent() - FPBits<T>::EXPONENT_BIAS;
+      exponent = bits.get_biased_exponent() - FPBits<T>::EXPONENT_BIAS;
       mantissa = ONE | bits.get_mantissa();
     }
   }
@@ -184,7 +184,7 @@ NormalFloat<long double>::init_from_bits(FPBits<long double> bits) {
     return;
   }
 
-  if (bits.get_unbiased_exponent() == 0) {
+  if (bits.get_biased_exponent() == 0) {
     if (bits.get_implicit_bit() == 0) {
       // Since we ignore zero value, the mantissa in this case is non-zero.
       int normalization_shift =
@@ -201,7 +201,7 @@ NormalFloat<long double>::init_from_bits(FPBits<long double> bits) {
       exponent = 0;
       mantissa = 0;
     } else {
-      exponent = bits.get_unbiased_exponent() - 16383;
+      exponent = bits.get_biased_exponent() - 16383;
       mantissa = ONE | bits.get_mantissa();
     }
   }
@@ -228,7 +228,7 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
       const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
       const UIntType shift_out_value = mantissa & shift_out_mask;
       const UIntType halfway_value = UIntType(1) << (shift - 1);
-      result.set_unbiased_exponent(0);
+      result.set_biased_exponent(0);
       result.set_mantissa(mantissa >> shift);
       UIntType new_mantissa = result.get_mantissa();
       if (shift_out_value > halfway_value) {
@@ -243,7 +243,7 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
       // mantissa was all ones (0b111..11). For such a case, we will carry
       // the overflow into the exponent and set the implicit bit to 1.
       if (new_mantissa == ONE) {
-        result.set_unbiased_exponent(1);
+        result.set_biased_exponent(1);
         result.set_implicit_bit(1);
       } else {
         result.set_implicit_bit(0);
@@ -254,7 +254,7 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
     }
   }
 
-  result.set_unbiased_exponent(biased_exponent);
+  result.set_biased_exponent(biased_exponent);
   result.set_mantissa(mantissa);
   result.set_implicit_bit(1);
   return static_cast<long double>(result);

--- a/libc/src/__support/FPUtil/fpbits_str.h
+++ b/libc/src/__support/FPUtil/fpbits_str.h
@@ -53,7 +53,7 @@ template <typename T> LIBC_INLINE cpp::string str(fputil::FPBits<T> x) {
   s += sign_char(x.get_sign());
 
   s += ", E: ";
-  const details::ZeroPaddedHexFmt<uint16_t> exponent(x.get_unbiased_exponent());
+  const details::ZeroPaddedHexFmt<uint16_t> exponent(x.get_biased_exponent());
   s += exponent.view();
 
   if constexpr (cpp::is_same_v<T, long double> &&

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -58,7 +58,7 @@ template <> LIBC_INLINE float fma<float>(float x, float y, float z) {
     // bit of sum, so that the sticky bits used when rounding sum to float are
     // correct (when it matters).
     fputil::FPBits<double> t(
-        (bit_prod.get_unbiased_exponent() >= bitz.get_unbiased_exponent())
+        (bit_prod.get_biased_exponent() >= bitz.get_biased_exponent())
             ? ((double(bit_sum) - double(bit_prod)) - double(bitz))
             : ((double(bit_sum) - double(bitz)) - double(bit_prod)));
 
@@ -106,15 +106,15 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
   int z_exp = 0;
 
   // Normalize denormal inputs.
-  if (LIBC_UNLIKELY(FPBits(x).get_unbiased_exponent() == 0)) {
+  if (LIBC_UNLIKELY(FPBits(x).get_biased_exponent() == 0)) {
     x_exp -= 52;
     x *= 0x1.0p+52;
   }
-  if (LIBC_UNLIKELY(FPBits(y).get_unbiased_exponent() == 0)) {
+  if (LIBC_UNLIKELY(FPBits(y).get_biased_exponent() == 0)) {
     y_exp -= 52;
     y *= 0x1.0p+52;
   }
-  if (LIBC_UNLIKELY(FPBits(z).get_unbiased_exponent() == 0)) {
+  if (LIBC_UNLIKELY(FPBits(z).get_biased_exponent() == 0)) {
     z_exp -= 52;
     z *= 0x1.0p+52;
   }
@@ -124,9 +124,9 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
   bool y_sign = y_bits.get_sign();
   bool z_sign = z_bits.get_sign();
   bool prod_sign = x_sign != y_sign;
-  x_exp += x_bits.get_unbiased_exponent();
-  y_exp += y_bits.get_unbiased_exponent();
-  z_exp += z_bits.get_unbiased_exponent();
+  x_exp += x_bits.get_biased_exponent();
+  y_exp += y_bits.get_biased_exponent();
+  z_exp += z_bits.get_biased_exponent();
 
   if (LIBC_UNLIKELY(x_exp == FPBits::MAX_EXPONENT ||
                     y_exp == FPBits::MAX_EXPONENT ||

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -233,8 +233,8 @@ private:
       return FPB(FPB::zero()); // |x|=|y| return 0.0
     }
 
-    int e_x = sx.get_unbiased_exponent();
-    int e_y = sy.get_unbiased_exponent();
+    int e_x = sx.get_biased_exponent();
+    int e_y = sy.get_biased_exponent();
 
     // Most common case where |y| is "very normal" and |x/y| < 2^EXPONENT_WIDTH
     if (LIBC_LIKELY(e_y > int(FPB::FloatProp::MANTISSA_WIDTH) &&

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -97,7 +97,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       UIntType x_mant = bits.get_mantissa();
 
       // Step 1a: Normalize denormal input and append hidden bit to the mantissa
-      if (bits.get_unbiased_exponent() == 0) {
+      if (bits.get_biased_exponent() == 0) {
         ++x_exp; // let x_exp be the correct exponent of ONE bit.
         internal::normalize<T>(x_exp, x_mant);
       } else {

--- a/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
+++ b/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
@@ -65,7 +65,7 @@ LIBC_INLINE long double sqrt(long double x) {
     // Step 1a: Normalize denormal input
     if (bits.get_implicit_bit()) {
       x_mant |= ONE;
-    } else if (bits.get_unbiased_exponent() == 0) {
+    } else if (bits.get_biased_exponent() == 0) {
       normalize(x_exp, x_mant);
     }
 
@@ -128,7 +128,7 @@ LIBC_INLINE long double sqrt(long double x) {
 
     // Extract output
     FPBits<long double> out(0.0L);
-    out.set_unbiased_exponent(x_exp);
+    out.set_biased_exponent(x_exp);
     out.set_implicit_bit(1);
     out.set_mantissa((y & (ONE - 1)));
 

--- a/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
+++ b/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
@@ -39,8 +39,8 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
 
   // Convert pseudo subnormal number to normal number.
   if (from_bits.get_implicit_bit() == 1 &&
-      from_bits.get_unbiased_exponent() == 0) {
-    from_bits.set_unbiased_exponent(1);
+      from_bits.get_biased_exponent() == 0) {
+    from_bits.set_biased_exponent(1);
   }
 
   using UIntType = FPBits::UIntType;
@@ -59,7 +59,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         // Incrementing exponent might overflow the value to infinity,
         // which is what is expected. Since NaNs are handling separately,
         // it will never overflow "beyond" infinity.
-        from_bits.set_unbiased_exponent(from_bits.get_unbiased_exponent() + 1);
+        from_bits.set_biased_exponent(from_bits.get_biased_exponent() + 1);
         if (from_bits.is_inf())
           raise_except_if_required(FE_OVERFLOW | FE_INEXACT);
         return from_bits;
@@ -75,7 +75,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         from_bits.set_mantissa(MANTISSA_MASK);
         // from == 0 is handled separately so decrementing the exponent will not
         // lead to underflow.
-        from_bits.set_unbiased_exponent(from_bits.get_unbiased_exponent() - 1);
+        from_bits.set_biased_exponent(from_bits.get_biased_exponent() - 1);
         return from_bits;
       } else {
         --int_val;
@@ -94,7 +94,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         from_bits.set_mantissa(MANTISSA_MASK);
         // from == 0 is handled separately so decrementing the exponent will not
         // lead to underflow.
-        from_bits.set_unbiased_exponent(from_bits.get_unbiased_exponent() - 1);
+        from_bits.set_biased_exponent(from_bits.get_biased_exponent() - 1);
         return from_bits;
       } else {
         --int_val;
@@ -107,7 +107,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         // Incrementing exponent might overflow the value to infinity,
         // which is what is expected. Since NaNs are handling separately,
         // it will never overflow "beyond" infinity.
-        from_bits.set_unbiased_exponent(from_bits.get_unbiased_exponent() + 1);
+        from_bits.set_biased_exponent(from_bits.get_biased_exponent() + 1);
         if (from_bits.is_inf())
           raise_except_if_required(FE_OVERFLOW | FE_INEXACT);
         return from_bits;

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -92,7 +92,7 @@ template <class T> LIBC_INLINE void set_implicit_bit(fputil::FPBits<T> &) {
 template <>
 LIBC_INLINE void
 set_implicit_bit<long double>(fputil::FPBits<long double> &result) {
-  result.set_implicit_bit(result.get_unbiased_exponent() != 0);
+  result.set_implicit_bit(result.get_biased_exponent() != 0);
 }
 #endif
 
@@ -643,7 +643,7 @@ clinger_fast_path(ExpandedFloat<T> init_num,
 
   ExpandedFloat<T> output;
   output.mantissa = result.get_mantissa();
-  output.exponent = result.get_unbiased_exponent();
+  output.exponent = result.get_biased_exponent();
   return output;
 }
 
@@ -1164,7 +1164,7 @@ LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
     }
     seen_digit = parse_result.parsed_len != 0;
     result.set_mantissa(parse_result.value.mantissa);
-    result.set_unbiased_exponent(parse_result.value.exponent);
+    result.set_biased_exponent(parse_result.value.exponent);
     index += parse_result.parsed_len;
     error = parse_result.error;
   } else if (tolower(src[index]) == 'n') { // NaN

--- a/libc/src/math/generic/expf.cpp
+++ b/libc/src/math/generic/expf.cpp
@@ -37,7 +37,7 @@ LLVM_LIBC_FUNCTION(float, expf, (float x)) {
   // When |x| >= 89, |x| < 2^-25, or x is nan
   if (LIBC_UNLIKELY(x_abs >= 0x42b2'0000U || x_abs <= 0x3280'0000U)) {
     // |x| < 2^-25
-    if (xbits.get_unbiased_exponent() <= 101) {
+    if (xbits.get_biased_exponent() <= 101) {
       return 1.0f + x;
     }
 

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -285,7 +285,7 @@ LIBC_INLINE static double log2_eval(double x) {
       (LOG_P1_SIZE - 1);
 
   bs.bits &= FPB::FloatProp::MANTISSA_MASK >> LOG_P1_BITS;
-  bs.set_unbiased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
   // Taylor series for log(2,1+x)
@@ -316,7 +316,7 @@ LIBC_INLINE static double log_eval(double x) {
 
   // Set bs to (1 + (mx - p1*2^(-7))
   bs.bits &= FPB::FloatProp::MANTISSA_MASK >> 7;
-  bs.set_unbiased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
 

--- a/libc/src/math/generic/hypotf.cpp
+++ b/libc/src/math/generic/hypotf.cpp
@@ -19,8 +19,8 @@ LLVM_LIBC_FUNCTION(float, hypotf, (float x, float y)) {
 
   FPBits x_bits(x), y_bits(y);
 
-  uint16_t x_exp = x_bits.get_unbiased_exponent();
-  uint16_t y_exp = y_bits.get_unbiased_exponent();
+  uint16_t x_exp = x_bits.get_biased_exponent();
+  uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
   if (exp_diff >= fputil::MantissaWidth<float>::VALUE + 2) {

--- a/libc/src/math/generic/log10f.cpp
+++ b/libc/src/math/generic/log10f.cpp
@@ -187,7 +187,7 @@ LLVM_LIBC_FUNCTION(float, log10f, (float x)) {
   // Extract 7 leading fractional bits of the mantissa
   int index = (x_u >> 16) & 0x7F;
   // Set bits to 1.m
-  xbits.set_unbiased_exponent(0x7F);
+  xbits.set_biased_exponent(0x7F);
 
   float u = static_cast<float>(xbits);
   double v;

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -880,7 +880,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
 
   fputil::DoubleDouble x_dd{0.0, 0.0};
 
-  uint16_t x_exp = xbits.get_unbiased_exponent();
+  uint16_t x_exp = xbits.get_biased_exponent();
 
   if (x_exp >= EXPONENT_BIAS) {
     // |x| >= 1
@@ -909,7 +909,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
     }
   } else {
     // |x| < 1
-    if (LIBC_UNLIKELY(xbits.get_unbiased_exponent() <
+    if (LIBC_UNLIKELY(xbits.get_biased_exponent() <
                       EXPONENT_BIAS - MANTISSA_WIDTH - 1)) {
       // Quick return when |x| < 2^-53.
       // Since log(1 + x) = x - x^2/2 + x^3/3 - ...,

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -60,7 +60,7 @@ LIBC_INLINE float log(double x) {
       xbits.get_mantissa() >> 45); // fputil::MantissaWidth<double>::VALUE - 7
 
   // Set bits to 1.m
-  xbits.set_unbiased_exponent(0x3FF);
+  xbits.set_biased_exponent(0x3FF);
   FPBits f = xbits;
 
   // Clear the lowest 45 bits.

--- a/libc/src/math/generic/log2f.cpp
+++ b/libc/src/math/generic/log2f.cpp
@@ -87,10 +87,10 @@ LLVM_LIBC_FUNCTION(float, log2f, (float x)) {
     m -= 23;
   }
 
-  m += xbits.get_unbiased_exponent();
+  m += xbits.get_biased_exponent();
   int index = xbits.get_mantissa() >> 16;
   // Set bits to 1.m
-  xbits.set_unbiased_exponent(0x7F);
+  xbits.set_biased_exponent(0x7F);
 
   float u = static_cast<float>(xbits);
   double v;

--- a/libc/src/math/generic/logf.cpp
+++ b/libc/src/math/generic/logf.cpp
@@ -135,7 +135,7 @@ LLVM_LIBC_FUNCTION(float, logf, (float x)) {
   // rounding mode.
   if (LIBC_UNLIKELY((x_u & 0x007f'ffffU) == 0))
     return static_cast<float>(
-        static_cast<double>(m + xbits.get_unbiased_exponent()) * LOG_2);
+        static_cast<double>(m + xbits.get_biased_exponent()) * LOG_2);
 #endif // LIBC_TARGET_CPU_HAS_FMA
 
   uint32_t mant = xbits.get_mantissa();
@@ -146,7 +146,7 @@ LLVM_LIBC_FUNCTION(float, logf, (float x)) {
   m += static_cast<int>((x_u + (1 << 16)) >> 23);
 
   // Set bits to 1.m
-  xbits.set_unbiased_exponent(0x7F);
+  xbits.set_biased_exponent(0x7F);
 
   float u = static_cast<float>(xbits);
   double v;

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -410,8 +410,8 @@ LIBC_INLINE bool is_integer(float x) {
 
 LIBC_INLINE bool larger_exponent(double a, double b) {
   using DoubleBits = typename fputil::FPBits<double>;
-  return DoubleBits(a).get_unbiased_exponent() >=
-         DoubleBits(b).get_unbiased_exponent();
+  return DoubleBits(a).get_biased_exponent() >=
+         DoubleBits(b).get_biased_exponent();
 }
 
 // Calculate 2^(y * log2(x)) in double-double precision.

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -24,7 +24,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits zero(0.0f);
   EXPECT_EQ(zero.get_sign(), false);
-  EXPECT_EQ(zero.get_unbiased_exponent(), static_cast<uint16_t>(0));
+  EXPECT_EQ(zero.get_biased_exponent(), static_cast<uint16_t>(0));
   EXPECT_EQ(zero.get_mantissa(), static_cast<uint32_t>(0));
   EXPECT_EQ(zero.uintval(), static_cast<uint32_t>(0x00000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(zero).c_str(),
@@ -32,7 +32,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits negzero(-0.0f);
   EXPECT_EQ(negzero.get_sign(), true);
-  EXPECT_EQ(negzero.get_unbiased_exponent(), static_cast<uint16_t>(0));
+  EXPECT_EQ(negzero.get_biased_exponent(), static_cast<uint16_t>(0));
   EXPECT_EQ(negzero.get_mantissa(), static_cast<uint32_t>(0));
   EXPECT_EQ(negzero.uintval(), static_cast<uint32_t>(0x80000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negzero).c_str(),
@@ -40,7 +40,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits one(1.0f);
   EXPECT_EQ(one.get_sign(), false);
-  EXPECT_EQ(one.get_unbiased_exponent(), static_cast<uint16_t>(0x7F));
+  EXPECT_EQ(one.get_biased_exponent(), static_cast<uint16_t>(0x7F));
   EXPECT_EQ(one.get_mantissa(), static_cast<uint32_t>(0));
   EXPECT_EQ(one.uintval(), static_cast<uint32_t>(0x3F800000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(one).c_str(),
@@ -48,7 +48,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits negone(-1.0f);
   EXPECT_EQ(negone.get_sign(), true);
-  EXPECT_EQ(negone.get_unbiased_exponent(), static_cast<uint16_t>(0x7F));
+  EXPECT_EQ(negone.get_biased_exponent(), static_cast<uint16_t>(0x7F));
   EXPECT_EQ(negone.get_mantissa(), static_cast<uint32_t>(0));
   EXPECT_EQ(negone.uintval(), static_cast<uint32_t>(0xBF800000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negone).c_str(),
@@ -56,7 +56,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits num(1.125f);
   EXPECT_EQ(num.get_sign(), false);
-  EXPECT_EQ(num.get_unbiased_exponent(), static_cast<uint16_t>(0x7F));
+  EXPECT_EQ(num.get_biased_exponent(), static_cast<uint16_t>(0x7F));
   EXPECT_EQ(num.get_mantissa(), static_cast<uint32_t>(0x00100000));
   EXPECT_EQ(num.uintval(), static_cast<uint32_t>(0x3F900000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(num).c_str(),
@@ -64,7 +64,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
 
   FloatBits negnum(-1.125f);
   EXPECT_EQ(negnum.get_sign(), true);
-  EXPECT_EQ(negnum.get_unbiased_exponent(), static_cast<uint16_t>(0x7F));
+  EXPECT_EQ(negnum.get_biased_exponent(), static_cast<uint16_t>(0x7F));
   EXPECT_EQ(negnum.get_mantissa(), static_cast<uint32_t>(0x00100000));
   EXPECT_EQ(negnum.uintval(), static_cast<uint32_t>(0xBF900000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),
@@ -84,7 +84,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits zero(0.0);
   EXPECT_EQ(zero.get_sign(), false);
-  EXPECT_EQ(zero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(zero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(zero.get_mantissa(), static_cast<uint64_t>(0x0000000000000000));
   EXPECT_EQ(zero.uintval(), static_cast<uint64_t>(0x0000000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(zero).c_str(),
@@ -92,7 +92,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits negzero(-0.0);
   EXPECT_EQ(negzero.get_sign(), true);
-  EXPECT_EQ(negzero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(negzero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(negzero.get_mantissa(), static_cast<uint64_t>(0x0000000000000000));
   EXPECT_EQ(negzero.uintval(), static_cast<uint64_t>(0x8000000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negzero).c_str(),
@@ -100,7 +100,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits one(1.0);
   EXPECT_EQ(one.get_sign(), false);
-  EXPECT_EQ(one.get_unbiased_exponent(), static_cast<uint16_t>(0x03FF));
+  EXPECT_EQ(one.get_biased_exponent(), static_cast<uint16_t>(0x03FF));
   EXPECT_EQ(one.get_mantissa(), static_cast<uint64_t>(0x0000000000000000));
   EXPECT_EQ(one.uintval(), static_cast<uint64_t>(0x3FF0000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(one).c_str(),
@@ -108,7 +108,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits negone(-1.0);
   EXPECT_EQ(negone.get_sign(), true);
-  EXPECT_EQ(negone.get_unbiased_exponent(), static_cast<uint16_t>(0x03FF));
+  EXPECT_EQ(negone.get_biased_exponent(), static_cast<uint16_t>(0x03FF));
   EXPECT_EQ(negone.get_mantissa(), static_cast<uint64_t>(0x0000000000000000));
   EXPECT_EQ(negone.uintval(), static_cast<uint64_t>(0xBFF0000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negone).c_str(),
@@ -116,7 +116,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits num(1.125);
   EXPECT_EQ(num.get_sign(), false);
-  EXPECT_EQ(num.get_unbiased_exponent(), static_cast<uint16_t>(0x03FF));
+  EXPECT_EQ(num.get_biased_exponent(), static_cast<uint16_t>(0x03FF));
   EXPECT_EQ(num.get_mantissa(), static_cast<uint64_t>(0x0002000000000000));
   EXPECT_EQ(num.uintval(), static_cast<uint64_t>(0x3FF2000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(num).c_str(),
@@ -124,7 +124,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
 
   DoubleBits negnum(-1.125);
   EXPECT_EQ(negnum.get_sign(), true);
-  EXPECT_EQ(negnum.get_unbiased_exponent(), static_cast<uint16_t>(0x03FF));
+  EXPECT_EQ(negnum.get_biased_exponent(), static_cast<uint16_t>(0x03FF));
   EXPECT_EQ(negnum.get_mantissa(), static_cast<uint64_t>(0x0002000000000000));
   EXPECT_EQ(negnum.uintval(), static_cast<uint64_t>(0xBFF2000000000000));
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),
@@ -150,7 +150,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits zero(0.0l);
   EXPECT_EQ(zero.get_sign(), false);
-  EXPECT_EQ(zero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(zero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(zero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                      << 64);
   EXPECT_EQ(zero.uintval(), static_cast<UInt128>(0x0000000000000000) << 64);
@@ -161,7 +161,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits negzero(-0.0l);
   EXPECT_EQ(negzero.get_sign(), true);
-  EXPECT_EQ(negzero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(negzero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(negzero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                         << 64);
   EXPECT_EQ(negzero.uintval(), static_cast<UInt128>(0x1) << 79);
@@ -172,7 +172,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits one(1.0l);
   EXPECT_EQ(one.get_sign(), false);
-  EXPECT_EQ(one.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(one.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(one.get_mantissa(), static_cast<UInt128>(0x0000000000000000) << 64);
   EXPECT_EQ(one.uintval(), static_cast<UInt128>(0x3FFF8) << 60);
   EXPECT_STREQ(
@@ -182,7 +182,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits negone(-1.0l);
   EXPECT_EQ(negone.get_sign(), true);
-  EXPECT_EQ(negone.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negone.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negone.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                        << 64);
   EXPECT_EQ(negone.uintval(), static_cast<UInt128>(0xBFFF8) << 60);
@@ -193,7 +193,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits num(1.125l);
   EXPECT_EQ(num.get_sign(), false);
-  EXPECT_EQ(num.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(num.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(num.get_mantissa(), static_cast<UInt128>(0x1) << 60);
   EXPECT_EQ(num.uintval(), static_cast<UInt128>(0x3FFF9) << 60);
   EXPECT_STREQ(
@@ -203,7 +203,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
 
   LongDoubleBits negnum(-1.125l);
   EXPECT_EQ(negnum.get_sign(), true);
-  EXPECT_EQ(negnum.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negnum.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negnum.get_mantissa(), static_cast<UInt128>(0x1) << 60);
   EXPECT_EQ(negnum.uintval(), static_cast<UInt128>(0xBFFF9) << 60);
   EXPECT_STREQ(
@@ -230,7 +230,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits zero(0.0l);
   EXPECT_EQ(zero.get_sign(), false);
-  EXPECT_EQ(zero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(zero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(zero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                      << 64);
   EXPECT_EQ(zero.uintval(), static_cast<UInt128>(0x0000000000000000) << 64);
@@ -240,7 +240,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits negzero(-0.0l);
   EXPECT_EQ(negzero.get_sign(), true);
-  EXPECT_EQ(negzero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(negzero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(negzero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                         << 64);
   EXPECT_EQ(negzero.uintval(), static_cast<UInt128>(0x1) << 127);
@@ -250,7 +250,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits one(1.0l);
   EXPECT_EQ(one.get_sign(), false);
-  EXPECT_EQ(one.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(one.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(one.get_mantissa(), static_cast<UInt128>(0x0000000000000000) << 64);
   EXPECT_EQ(one.uintval(), static_cast<UInt128>(0x3FFF) << 112);
   EXPECT_STREQ(LIBC_NAMESPACE::str(one).c_str(),
@@ -259,7 +259,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits negone(-1.0l);
   EXPECT_EQ(negone.get_sign(), true);
-  EXPECT_EQ(negone.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negone.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negone.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                        << 64);
   EXPECT_EQ(negone.uintval(), static_cast<UInt128>(0xBFFF) << 112);
@@ -269,7 +269,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits num(1.125l);
   EXPECT_EQ(num.get_sign(), false);
-  EXPECT_EQ(num.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(num.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(num.get_mantissa(), static_cast<UInt128>(0x2) << 108);
   EXPECT_EQ(num.uintval(), static_cast<UInt128>(0x3FFF2) << 108);
   EXPECT_STREQ(LIBC_NAMESPACE::str(num).c_str(),
@@ -278,7 +278,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
 
   LongDoubleBits negnum(-1.125l);
   EXPECT_EQ(negnum.get_sign(), true);
-  EXPECT_EQ(negnum.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negnum.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negnum.get_mantissa(), static_cast<UInt128>(0x2) << 108);
   EXPECT_EQ(negnum.uintval(), static_cast<UInt128>(0xBFFF2) << 108);
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),
@@ -303,7 +303,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits zero(Float128Bits::zero());
   EXPECT_EQ(zero.get_sign(), false);
-  EXPECT_EQ(zero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(zero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(zero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                      << 64);
   EXPECT_EQ(zero.uintval(), static_cast<UInt128>(0x0000000000000000) << 64);
@@ -313,7 +313,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits negzero(Float128Bits::neg_zero());
   EXPECT_EQ(negzero.get_sign(), true);
-  EXPECT_EQ(negzero.get_unbiased_exponent(), static_cast<uint16_t>(0x0000));
+  EXPECT_EQ(negzero.get_biased_exponent(), static_cast<uint16_t>(0x0000));
   EXPECT_EQ(negzero.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                         << 64);
   EXPECT_EQ(negzero.uintval(), static_cast<UInt128>(0x1) << 127);
@@ -323,7 +323,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits one(float128(1.0));
   EXPECT_EQ(one.get_sign(), false);
-  EXPECT_EQ(one.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(one.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(one.get_mantissa(), static_cast<UInt128>(0x0000000000000000) << 64);
   EXPECT_EQ(one.uintval(), static_cast<UInt128>(0x3FFF) << 112);
   EXPECT_STREQ(LIBC_NAMESPACE::str(one).c_str(),
@@ -332,7 +332,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits negone(float128(-1.0));
   EXPECT_EQ(negone.get_sign(), true);
-  EXPECT_EQ(negone.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negone.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negone.get_mantissa(), static_cast<UInt128>(0x0000000000000000)
                                        << 64);
   EXPECT_EQ(negone.uintval(), static_cast<UInt128>(0xBFFF) << 112);
@@ -342,7 +342,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits num(float128(1.125));
   EXPECT_EQ(num.get_sign(), false);
-  EXPECT_EQ(num.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(num.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(num.get_mantissa(), static_cast<UInt128>(0x2) << 108);
   EXPECT_EQ(num.uintval(), static_cast<UInt128>(0x3FFF2) << 108);
   EXPECT_STREQ(LIBC_NAMESPACE::str(num).c_str(),
@@ -351,7 +351,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
 
   Float128Bits negnum(float128(-1.125));
   EXPECT_EQ(negnum.get_sign(), true);
-  EXPECT_EQ(negnum.get_unbiased_exponent(), static_cast<uint16_t>(0x3FFF));
+  EXPECT_EQ(negnum.get_biased_exponent(), static_cast<uint16_t>(0x3FFF));
   EXPECT_EQ(negnum.get_mantissa(), static_cast<UInt128>(0x2) << 108);
   EXPECT_EQ(negnum.uintval(), static_cast<UInt128>(0xBFFF2) << 108);
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -132,7 +132,7 @@ public:
     FPBits result_bits(result);
     ASSERT_FALSE(result_bits.is_zero());
     // Verify that the result is indeed subnormal.
-    ASSERT_EQ(result_bits.get_unbiased_exponent(), uint16_t(0));
+    ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
     result = func(x, -FPBits::MAX_EXPONENT - int(MANTISSA_WIDTH) - 5);

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -162,30 +162,28 @@ public:
     result = func(x, 0);
     FPBits x_bits = FPBits(x);
     FPBits result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
 
     x = -x;
 
     result = func(x, 0);
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
   }
 };

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -126,7 +126,7 @@ public:
     // We start with 1.0 so that the implicit bit for x86 long doubles
     // is set.
     FPBits bits(F(1.0));
-    bits.set_unbiased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
+    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
     bits.set_sign(1);
     bits.set_mantissa(0);
 
@@ -190,7 +190,7 @@ public:
     // We start with 1.0 so that the implicit bit for x86 long doubles
     // is set.
     FPBits bits(F(1.0));
-    bits.set_unbiased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
+    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
     bits.set_sign(1);
     bits.set_mantissa(UIntType(0x1)
                       << (LIBC_NAMESPACE::fputil::MantissaWidth<F>::VALUE - 1));

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -132,7 +132,7 @@ public:
     FPBits result_bits(result);
     ASSERT_FALSE(result_bits.is_zero());
     // Verify that the result is indeed subnormal.
-    ASSERT_EQ(result_bits.get_unbiased_exponent(), uint16_t(0));
+    ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
     result = func(x, -FPBits::MAX_EXPONENT - int(MANTISSA_WIDTH) - 5);

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -173,30 +173,28 @@ public:
     result = func(x, 0);
     FPBits x_bits = FPBits(x);
     FPBits result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
 
     x = -x;
 
     result = func(x, 0);
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
   }
 };

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -187,30 +187,28 @@ public:
     result = func(x, 0);
     FPBits x_bits = FPBits(x);
     FPBits result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, 33.0);
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
 
     x = -x;
 
     result = func(x, 0);
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              uint16_t(x_bits.get_unbiased_exponent() - 1));
+    ASSERT_EQ(result_bits.get_biased_exponent(),
+              uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
               (UIntType(1) << MantissaWidth::VALUE) - 1);
 
     result = func(x, -33.0);
     result_bits = FPBits(result);
-    ASSERT_EQ(result_bits.get_unbiased_exponent(),
-              x_bits.get_unbiased_exponent());
+    ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
     ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
   }
 };

--- a/libc/test/utils/FPUtil/x86_long_double_test.cpp
+++ b/libc/test/utils/FPUtil/x86_long_double_test.cpp
@@ -22,7 +22,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
   constexpr uint32_t COUNT = 100'000;
 
   FPBits bits(0.0l);
-  bits.set_unbiased_exponent(FPBits::MAX_EXPONENT);
+  bits.set_biased_exponent(FPBits::MAX_EXPONENT);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent has the max value and the implicit bit is 0,
     // then the number is a NaN for all values of mantissa.
@@ -43,7 +43,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
     ASSERT_TRUE(bits.is_nan());
   }
 
-  bits.set_unbiased_exponent(1);
+  bits.set_biased_exponent(1);
   bits.set_implicit_bit(0);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent is non-zero and also not max, and the implicit bit is 0,
@@ -54,7 +54,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
     ASSERT_TRUE(bits.is_nan());
   }
 
-  bits.set_unbiased_exponent(1);
+  bits.set_biased_exponent(1);
   bits.set_implicit_bit(1);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent is non-zero and also not max, and the implicit bit is 1,
@@ -65,7 +65,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
     ASSERT_FALSE(bits.is_nan());
   }
 
-  bits.set_unbiased_exponent(0);
+  bits.set_biased_exponent(0);
   bits.set_implicit_bit(1);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent is zero, then the number is a valid but denormal value.
@@ -75,7 +75,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
     ASSERT_FALSE(bits.is_nan());
   }
 
-  bits.set_unbiased_exponent(0);
+  bits.set_biased_exponent(0);
   bits.set_implicit_bit(0);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent is zero, then the number is a valid but denormal value.

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -458,9 +458,9 @@ public:
     int thisExponent = fputil::FPBits<T>(thisAsT).get_exponent();
     int inputExponent = fputil::FPBits<T>(input).get_exponent();
     // Adjust the exponents for denormal numbers.
-    if (fputil::FPBits<T>(thisAsT).get_unbiased_exponent() == 0)
+    if (fputil::FPBits<T>(thisAsT).get_biased_exponent() == 0)
       ++thisExponent;
-    if (fputil::FPBits<T>(input).get_unbiased_exponent() == 0)
+    if (fputil::FPBits<T>(input).get_biased_exponent() == 0)
       ++inputExponent;
 
     if (thisAsT * input < 0 || thisExponent == inputExponent) {
@@ -483,9 +483,9 @@ public:
     int minExponent = fputil::FPBits<T>(min).get_exponent();
     int maxExponent = fputil::FPBits<T>(max).get_exponent();
     // Adjust the exponents for denormal numbers.
-    if (fputil::FPBits<T>(min).get_unbiased_exponent() == 0)
+    if (fputil::FPBits<T>(min).get_biased_exponent() == 0)
       ++minExponent;
-    if (fputil::FPBits<T>(max).get_unbiased_exponent() == 0)
+    if (fputil::FPBits<T>(max).get_biased_exponent() == 0)
       ++maxExponent;
 
     MPFRNumber minMPFR(min);


### PR DESCRIPTION
According to [wikipedia](https://en.wikipedia.org/wiki/Exponent_bias) the "biased exponent" is the encoded form that is always positive whereas the unbiased form is the actual "real" exponent that can be positive or negative.
`FPBits` seems to be using `unbiased_exponent` to describe the encoded form (unsigned). This patch simply use `biased` instead of `unbiased`.
