### PR TITLE
[Dexter] Set ShouldBuild=false for Visual Studio solutions

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -276,6 +276,13 @@ class VisualStudio(
             project.Properties, "ActiveConfiguration"
         ).Object
         ActiveConfiguration.DebugSettings.CommandArguments = cmdline_str
+        ConfigurationName = ActiveConfiguration.ConfigurationName
+        SolConfig = self._fetch_property(
+            self._interface.Solution.SolutionBuild.SolutionConfigurations,
+            ConfigurationName,
+        )
+        for Context in SolConfig.SolutionContexts:
+            Context.ShouldBuild = False
 
         self.context.logger.note("Launching VS debugger...")
         self._fn_go(False)


### PR DESCRIPTION
Since Dexter no longer intends to build any code, the ShouldBuild property in any Visual Studio project being run by Dexter should be false to ensure that a build step is never invoked by Dexter, whether the project has already been built or not.