### PR TITLE
[libc][NFC] Make EXPONENT_BIAS int32_t

### DIFF
--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -163,8 +163,7 @@ public:
   LIBC_INLINE_VAR static constexpr BitsType MANTISSA_MASK =
       mask_trailing_ones<UIntType, MANTISSA_WIDTH>();
   LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = EXP_BITS;
-  LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_BIAS =
-      static_cast<uint32_t>(EXP_BIAS);
+  LIBC_INLINE_VAR static constexpr int32_t EXPONENT_BIAS = EXP_BIAS;
   LIBC_INLINE_VAR static constexpr BitsType SIGN_MASK = SIGN_MASK_;
   LIBC_INLINE_VAR static constexpr BitsType EXPONENT_MASK = EXP_MASK;
   LIBC_INLINE_VAR static constexpr BitsType EXP_MANT_MASK = EXP_MASK | SIG_MASK;

--- a/libc/src/__support/detailed_powers_of_ten.h
+++ b/libc/src/__support/detailed_powers_of_ten.h
@@ -29,8 +29,9 @@ constexpr int32_t DETAILED_POWERS_OF_TEN_MIN_EXP_10 = -348;
 constexpr int32_t DETAILED_POWERS_OF_TEN_MAX_EXP_10 = 347;
 
 // This rescales the base 10 exponent by a factor of log(10)/log(2).
-LIBC_INLINE int64_t exp10_to_exp2(int64_t exp10) {
-  return (217706 * exp10) >> 16;
+LIBC_INLINE int32_t exp10_to_exp2(int32_t exp10) {
+  // Valid if exp10 < 646 456 636.
+  return static_cast<int32_t>((217706 * static_cast<int64_t>(exp10)) >> 16);
 }
 
 static constexpr uint64_t DETAILED_POWERS_OF_TEN[696][2] = {

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -389,22 +389,24 @@ static constexpr DoubleDouble LOG2_R2_DD[] = {
 LIBC_INLINE bool is_odd_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
-  int x_e = static_cast<int>((x_u & FloatProp::EXPONENT_MASK) >>
-                             FloatProp::MANTISSA_WIDTH);
-  int lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
-  constexpr int UNIT_EXPONENT =
-      static_cast<int>(FloatProp::EXPONENT_BIAS + FloatProp::MANTISSA_WIDTH);
+  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
+                                     FloatProp::MANTISSA_WIDTH);
+  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
+  constexpr int32_t UNIT_EXPONENT =
+      FloatProp::EXPONENT_BIAS +
+      static_cast<int32_t>(FloatProp::MANTISSA_WIDTH);
   return (x_e + lsb == UNIT_EXPONENT);
 }
 
 LIBC_INLINE bool is_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
-  int x_e = static_cast<int>((x_u & FloatProp::EXPONENT_MASK) >>
-                             FloatProp::MANTISSA_WIDTH);
-  int lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
-  constexpr int UNIT_EXPONENT =
-      static_cast<int>(FloatProp::EXPONENT_BIAS + FloatProp::MANTISSA_WIDTH);
+  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
+                                     FloatProp::MANTISSA_WIDTH);
+  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
+  constexpr int32_t UNIT_EXPONENT =
+      FloatProp::EXPONENT_BIAS +
+      static_cast<int32_t>(FloatProp::MANTISSA_WIDTH);
   return (x_e + lsb >= UNIT_EXPONENT);
 }
 


### PR DESCRIPTION
`EXPONENT_BIAS` is almost always used with signed arithmetic. Making it an `int32_t` from the start reduces the chances to run into implementation defined behavior (cast from unsigned to signed is implementation-defined until C++20).

https://en.cppreference.com/w/cpp/language/implicit_conversion#:~:text=If%20the%20destination%20type%20is%20signed,arithmetic%20overflow%2C%20which%20is%20undefined).
