### PR TITLE
[MC] Reduce size of MCLEBFragment (NFC)

### DIFF
--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -428,7 +428,7 @@ public:
   }
 };
 
-class MCLEBFragment final : public MCEncodedFragmentWithFixups<10, 1> {
+class MCLEBFragment final : public MCEncodedFragmentWithFixups<8, 0> {
   /// True if this is a sleb128, false if uleb128.
   bool IsSigned;
 
@@ -437,7 +437,7 @@ class MCLEBFragment final : public MCEncodedFragmentWithFixups<10, 1> {
 
 public:
   MCLEBFragment(const MCExpr &Value, bool IsSigned, MCSection *Sec = nullptr)
-      : MCEncodedFragmentWithFixups<10, 1>(FT_LEB, false, Sec),
+      : MCEncodedFragmentWithFixups<8, 0>(FT_LEB, false, Sec),
         IsSigned(IsSigned), Value(&Value) {
     getContents().push_back(0);
   }


### PR DESCRIPTION
This recovers more of the max-rss regression introduced by https://reviews.llvm.org/D157657.

Per http://llvm-compile-time-tracker.com/compare.php?from=dd32d26a37e22a3bce15ed8c21145b17ff5e1401&to=b4d4aba0dfbbe405f4da3494575434710f4ec9b9&stat=max-rss&linkStats=on this is an about 1.2% max-rss improvement for the LTO link stage with debuginfo.