### PR TITLE
[OpenACC] Add 'clause' parsing infrastructure plus a few clauses

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1358,11 +1358,9 @@ def err_acc_unexpected_directive
 def warn_pragma_acc_unimplemented
     : Warning<"OpenACC directives not yet implemented, pragma ignored">,
       InGroup<SourceUsesOpenACC>;
-def warn_pragma_acc_unimplemented_clause_parsing
-    : Warning<"OpenACC clause parsing not yet implemented">,
-      InGroup<SourceUsesOpenACC>;
 def err_acc_invalid_directive
     : Error<"invalid OpenACC directive %select{%1|'%1 %2'}0">;
+def err_acc_invalid_clause : Error<"invalid OpenACC clause %0">;
 def err_acc_missing_directive : Error<"expected OpenACC directive">;
 def err_acc_invalid_open_paren
     : Error<"expected clause-list or newline in OpenACC directive">;

--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -70,16 +70,27 @@ enum class OpenACCAtomicKind {
   Invalid,
 };
 
-// Represents the kind of an OpenACC clause.
+/// Represents the kind of an OpenACC clause.
 enum class OpenACCClauseKind {
+  // 'finalize' clause, allowed on 'exit data' directive.
   Finalize,
+  // 'if_present' clause, allowed on 'host_data' and 'update' directives.
   IfPresent,
+  // 'seq' clause, allowed on 'loop' and 'routine' directives.
   Seq,
+  // 'independent' clause, allowed on 'loop' directives.
   Independent,
+  // 'auto' clause, allowed on 'loop' directives.
   Auto,
+  // 'worker' clause, allowed on 'loop' and 'routine' directives.
   Worker,
+  // 'vector' clause, allowed on 'loop' and 'routine' directives. Takes no
+  // arguments for 'routine', so the 'loop' version is not yet implemented
+  // completely.
   Vector,
+  // 'nohost' clause, allowed on 'routine' directives.
   NoHost,
+  // Represents an invalid clause, for the purposes of parsing.
   Invalid,
 };
 } // namespace clang

--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -69,6 +69,19 @@ enum class OpenACCAtomicKind {
   Capture,
   Invalid,
 };
+
+// Represents the kind of an OpenACC clause.
+enum class OpenACCClauseKind {
+  Finalize,
+  IfPresent,
+  Seq,
+  Independent,
+  Auto,
+  Worker,
+  Vector,
+  NoHost,
+  Invalid,
+};
 } // namespace clang
 
 #endif // LLVM_CLANG_BASIC_OPENACCKINDS_H

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -69,6 +69,29 @@ OpenACCDirectiveKindEx getOpenACCDirectiveKind(Token Tok) {
       .Default(OpenACCDirectiveKindEx::Invalid);
 }
 
+// Translate single-token string representations to the OpenCC Clause Kind.
+OpenACCClauseKind getOpenACCClauseKind(Token Tok) {
+  // auto is a keyword in some language modes, so make sure we parse it
+  // correctly.
+  if (Tok.is(tok::kw_auto))
+    return OpenACCClauseKind::Auto;
+
+  if (!Tok.is(tok::identifier))
+    return OpenACCClauseKind::Invalid;
+
+  return llvm::StringSwitch<OpenACCClauseKind>(
+      Tok.getIdentifierInfo()->getName())
+    .Case("finalize", OpenACCClauseKind::Finalize)
+    .Case("if_present", OpenACCClauseKind::IfPresent)
+    .Case("seq", OpenACCClauseKind::Seq)
+    .Case("independent", OpenACCClauseKind::Independent)
+    .Case("auto", OpenACCClauseKind::Auto)
+    .Case("worker", OpenACCClauseKind::Worker)
+    .Case("vector", OpenACCClauseKind::Vector)
+    .Case("nohost", OpenACCClauseKind::NoHost)
+    .Default(OpenACCClauseKind::Invalid);
+}
+
 // Since 'atomic' is effectively a compound directive, this will decode the
 // second part of the directive.
 OpenACCAtomicKind getOpenACCAtomicKind(Token Tok) {
@@ -164,6 +187,10 @@ ParseOpenACCEnterExitDataDirective(Parser &P, Token FirstTok,
     return OpenACCDirectiveKind::Invalid;
   }
 
+  // Consume the second name anyway, this way we can continue on without making
+  // this oddly look like a clause.
+  P.ConsumeAnyToken();
+
   if (!isOpenACCDirectiveKind(OpenACCDirectiveKind::Data, SecondTok)) {
     if (!SecondTok.is(tok::identifier))
       P.Diag(SecondTok, diag::err_expected) << tok::identifier;
@@ -173,8 +200,6 @@ ParseOpenACCEnterExitDataDirective(Parser &P, Token FirstTok,
           << SecondTok.getIdentifierInfo()->getName();
     return OpenACCDirectiveKind::Invalid;
   }
-
-  P.ConsumeToken();
 
   return ExtDirKind == OpenACCDirectiveKindEx::Enter
              ? OpenACCDirectiveKind::EnterData
@@ -208,6 +233,10 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   // introspect on the spelling before then.
   if (FirstTok.isNot(tok::identifier)) {
     P.Diag(FirstTok, diag::err_acc_missing_directive);
+
+    if (!FirstTok.isAnnotation())
+      P.ConsumeAnyToken();
+
     return OpenACCDirectiveKind::Invalid;
   }
 
@@ -262,12 +291,51 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   return DirKind;
 }
 
+bool ParseOpenACCClause(Parser &P) {
+  if (!P.getCurToken().isOneOf(tok::identifier, tok::kw_auto))
+    return P.Diag(P.getCurToken(), diag::err_expected) << tok::identifier;
+
+  OpenACCClauseKind Kind = getOpenACCClauseKind(P.getCurToken());
+
+  if (Kind == OpenACCClauseKind::Invalid)
+    return P.Diag(P.getCurToken(), diag::err_acc_invalid_clause)
+           << P.getCurToken().getIdentifierInfo();
+
+  // Consume the clause name.
+  P.ConsumeToken();
+
+  // FIXME: For future clauses, we need to handle parens/etc below.
+  return false;
+}
+
+// Skip until we see the end of pragma token, but don't consume it. This is us
+// just giving up on the rest of the pragma so we can continue executing. We
+// have to do this because 'SkipUntil' considers paren balancing, which isn't
+// what we want.
+void SkipUntilEndOfDirective(Parser &P) {
+  while(P.getCurToken().isNot(tok::annot_pragma_openacc_end))
+    P.ConsumeAnyToken();
+}
+
+// OpenACC 3.3, section 1.7:
+// To simplify the specification and convey appropriate constraint information,
+// a pqr-list is a comma-separated list of pdr items. The one exception is a
+// clause-list, which is a list of one or more clauses optionally separated by
+// commas.
 void ParseOpenACCClauseList(Parser &P) {
-  // FIXME: In the future, we'll start parsing the clauses here, but for now we
-  // haven't implemented that, so just emit the unimplemented diagnostic and
-  // fail reasonably.
-  if (P.getCurToken().isNot(tok::annot_pragma_openacc_end))
-    P.Diag(P.getCurToken(), diag::warn_pragma_acc_unimplemented_clause_parsing);
+  bool FirstClause = true;
+  while (P.getCurToken().isNot(tok::annot_pragma_openacc_end)) {
+    // Comma is optional in a clause-list.
+    if (!FirstClause && P.getCurToken().is(tok::comma))
+      P.ConsumeToken();
+    FirstClause = false;
+
+    // Recovering from a bad clause is really difficult, so we just give up on error.
+    if (ParseOpenACCClause(P)) {
+      SkipUntilEndOfDirective(P);
+      return;
+    }
+  }
 }
 
 } // namespace
@@ -499,7 +567,9 @@ void Parser::ParseOpenACCDirective() {
   ParseOpenACCClauseList(*this);
 
   Diag(getCurToken(), diag::warn_pragma_acc_unimplemented);
-  SkipUntil(tok::annot_pragma_openacc_end);
+  assert(Tok.is(tok::annot_pragma_openacc_end) &&
+         "Didn't parse all OpenACC Clauses");
+  ConsumeAnnotationToken();
 }
 
 // Parse OpenACC directive on a declaration.

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -80,16 +80,16 @@ OpenACCClauseKind getOpenACCClauseKind(Token Tok) {
     return OpenACCClauseKind::Invalid;
 
   return llvm::StringSwitch<OpenACCClauseKind>(
-      Tok.getIdentifierInfo()->getName())
-    .Case("finalize", OpenACCClauseKind::Finalize)
-    .Case("if_present", OpenACCClauseKind::IfPresent)
-    .Case("seq", OpenACCClauseKind::Seq)
-    .Case("independent", OpenACCClauseKind::Independent)
-    .Case("auto", OpenACCClauseKind::Auto)
-    .Case("worker", OpenACCClauseKind::Worker)
-    .Case("vector", OpenACCClauseKind::Vector)
-    .Case("nohost", OpenACCClauseKind::NoHost)
-    .Default(OpenACCClauseKind::Invalid);
+             Tok.getIdentifierInfo()->getName())
+      .Case("finalize", OpenACCClauseKind::Finalize)
+      .Case("if_present", OpenACCClauseKind::IfPresent)
+      .Case("seq", OpenACCClauseKind::Seq)
+      .Case("independent", OpenACCClauseKind::Independent)
+      .Case("auto", OpenACCClauseKind::Auto)
+      .Case("worker", OpenACCClauseKind::Worker)
+      .Case("vector", OpenACCClauseKind::Vector)
+      .Case("nohost", OpenACCClauseKind::NoHost)
+      .Default(OpenACCClauseKind::Invalid);
 }
 
 // Since 'atomic' is effectively a compound directive, this will decode the
@@ -313,7 +313,7 @@ bool ParseOpenACCClause(Parser &P) {
 // have to do this because 'SkipUntil' considers paren balancing, which isn't
 // what we want.
 void SkipUntilEndOfDirective(Parser &P) {
-  while(P.getCurToken().isNot(tok::annot_pragma_openacc_end))
+  while (P.getCurToken().isNot(tok::annot_pragma_openacc_end))
     P.ConsumeAnyToken();
 }
 
@@ -330,7 +330,8 @@ void ParseOpenACCClauseList(Parser &P) {
       P.ConsumeToken();
     FirstClause = false;
 
-    // Recovering from a bad clause is really difficult, so we just give up on error.
+    // Recovering from a bad clause is really difficult, so we just give up on
+    // error.
     if (ParseOpenACCClause(P)) {
       SkipUntilEndOfDirective(P);
       return;

--- a/clang/test/ParserOpenACC/parse-cache-construct.c
+++ b/clang/test/ParserOpenACC/parse-cache-construct.c
@@ -14,7 +14,7 @@ void func() {
 
   for (int i = 0; i < 10; ++i) {
     // expected-error@+3{{expected '('}}
-    // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+    // expected-error@+2{{invalid OpenACC clause 'clause'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache clause list
   }
@@ -25,7 +25,7 @@ void func() {
   }
 
   for (int i = 0; i < 10; ++i) {
-    // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+    // expected-error@+2{{invalid OpenACC clause 'clause'}}
     // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
     #pragma acc cache() clause-list
   }

--- a/clang/test/ParserOpenACC/parse-clauses.c
+++ b/clang/test/ParserOpenACC/parse-clauses.c
@@ -1,0 +1,64 @@
+// RUN: %clang_cc1 %s -verify -fopenacc -std=c99
+// RUNX: %clang_cc1 %s -verify -fopenacc
+// RUNX: %clang_cc1 %s -verify -fopenacc -x c++
+
+void func() {
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc enter data finalize
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc enter data finalize finalize
+
+  // expected-error@+2{{invalid OpenACC clause 'invalid'}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc enter data finalize invalid
+
+  // expected-error@+2{{invalid OpenACC clause 'invalid'}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc enter data finalize invalid invalid finalize
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc enter data seq finalize
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc host_data if_present
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc host_data if_present, if_present
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc loop seq independent auto
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc loop seq, independent auto
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc loop seq independent, auto
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc kernels loop seq independent auto
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc serial loop seq, independent auto
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc parallel loop seq independent, auto
+
+
+  // expected-error@+2{{expected identifier}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc loop , seq
+
+  // expected-error@+2{{expected identifier}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc loop seq,
+
+}
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc routine worker, vector, seq, nohost
+void bar();
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc routine(bar) worker, vector, seq, nohost

--- a/clang/test/ParserOpenACC/parse-constructs.c
+++ b/clang/test/ParserOpenACC/parse-constructs.c
@@ -7,14 +7,13 @@ void func() {
 #pragma acc
   for(;;){}
 
-  // expected-error@+4{{expected OpenACC directive}}
-  // expected-error@+3{{expected clause-list or newline in OpenACC directive}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+3{{expected OpenACC directive}}
+  // expected-error@+2{{invalid OpenACC clause 'whatever'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc(whatever) routine
 
   // expected-error@+3{{expected OpenACC directive}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'routine'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc) routine
 
@@ -23,12 +22,12 @@ void func() {
 #pragma acc invalid
   for(;;){}
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel clause list
   for(;;){}
   // expected-error@+3{{expected clause-list or newline in OpenACC directive}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel() clause list
   for(;;){}
@@ -38,33 +37,31 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel( clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc serial clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc kernels clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc data clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc enter data clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc exit data clause list
   for(;;){}
-  // expected-error@+3{{invalid OpenACC directive 'enter invalid'}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC directive 'enter invalid'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc enter invalid
   for(;;){}
-  // expected-error@+3{{invalid OpenACC directive 'exit invalid'}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC directive 'exit invalid'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc exit invalid
   for(;;){}
@@ -72,24 +69,23 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc enter
   for(;;){}
-  // expected-error@+3{{expected identifier}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{expected identifier}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc exit }
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc host_data clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc loop clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'invalid'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel invalid clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel loop clause list
   for(;;){}
@@ -97,14 +93,14 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel loop
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc serial loop clause list
   for(;;){}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc serial loop
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc kernels loop clause list
   for(;;){}
@@ -116,48 +112,48 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic
   i = j;
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'garbage'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic garbage
   i = j;
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'garbage'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic garbage clause list
   i = j;
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic read
   i = j;
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic write clause list
   i = i + j;
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic update clause list
   i++;
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic capture clause list
   i = j++;
 
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc declare clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc init clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc shutdown clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc set clause list
   for(;;){}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc update clause list
   for(;;){}
@@ -166,7 +162,7 @@ void func() {
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine
 void routine_func();
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'clause'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine clause list
 void routine_func();
@@ -175,13 +171,13 @@ void routine_func();
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine (func_name)
 // expected-error@+3{{use of undeclared identifier 'func_name'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'clause'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine (func_name) clause list
 
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine (routine_func)
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'clause'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc routine (routine_func) clause list
 

--- a/clang/test/ParserOpenACC/parse-wait-construct.c
+++ b/clang/test/ParserOpenACC/parse-wait-construct.c
@@ -6,7 +6,7 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait clause-list
 
@@ -18,7 +18,7 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait ()
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait () clause-list
 
@@ -33,7 +33,7 @@ void func() {
   #pragma acc wait (devnum:)
 
   // expected-error@+3{{expected expression}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (devnum:) clause-list
 
@@ -48,7 +48,7 @@ void func() {
   #pragma acc wait (devnum: i + j)
 
   // expected-error@+3{{expected ':'}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (devnum: i + j) clause-list
 
@@ -60,7 +60,7 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (queues:)
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (queues:) clause-list
 
@@ -72,7 +72,7 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (devnum: i + j:queues:)
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (devnum: i + j:queues:) clause-list
 
@@ -87,7 +87,7 @@ void func() {
   #pragma acc wait (queues:devnum: i + j)
 
   // expected-error@+3{{use of undeclared identifier 'devnum'}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait (queues:devnum: i + j) clause-list
 
@@ -98,7 +98,7 @@ void func() {
 
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(i, j, 1+1, 3.3)
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(i, j, 1+1, 3.3) clause-list
 
@@ -113,7 +113,7 @@ void func() {
   #pragma acc wait(,)
 
   // expected-error@+3{{expected expression}}
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(,) clause-list
 
@@ -131,7 +131,7 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(queues:i, j, 1+1, 3.3)
 
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(queues:i, j, 1+1, 3.3) clause-list
 
@@ -141,7 +141,7 @@ void func() {
   #pragma acc wait(devnum:3:i, j, 1+1, 3.3
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(devnum:3:i, j, 1+1, 3.3)
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(devnum:3:i, j, 1+1, 3.3) clause-list
 
@@ -151,7 +151,7 @@ void func() {
   #pragma acc wait(devnum:3:queues:i, j, 1+1, 3.3
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(devnum:3:queues:i, j, 1+1, 3.3)
-  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC clause 'clause'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
   #pragma acc wait(devnum:3:queues:i, j, 1+1, 3.3) clause-list
 }

--- a/clang/test/ParserOpenACC/unimplemented.c
+++ b/clang/test/ParserOpenACC/unimplemented.c
@@ -2,7 +2,7 @@
 
 // Parser::ParseExternalDeclaration
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
 int foo;
@@ -10,7 +10,7 @@ int foo;
 struct S {
 // Parser::ParseStructUnionBody
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
   int foo;
@@ -19,7 +19,7 @@ struct S {
 void func() {
 // Parser::ParseStmtOrDeclarationAfterAttributes
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
   while(0) {}

--- a/clang/test/ParserOpenACC/unimplemented.cpp
+++ b/clang/test/ParserOpenACC/unimplemented.cpp
@@ -2,7 +2,7 @@
 
 // Parser::ParseExternalDeclaration
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
 int foo;
@@ -10,7 +10,7 @@ int foo;
 struct S {
 // Parser::ParseCXXClassMemberDeclarationWithPragmas
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
   int foo;
@@ -19,7 +19,7 @@ struct S {
 void func() {
 // Parser::ParseStmtOrDeclarationAfterAttributes
 // expected-error@+3{{invalid OpenACC directive 'havent'}}
-// expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+// expected-error@+2{{invalid OpenACC clause 'implemented'}}
 // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc havent implemented
   while(false) {}


### PR DESCRIPTION
As we've now finished parsing the constructs, we're moving onto implementing 'clause' parsing.  While some are complicated and require their own patch, the handful added here are simple to parse (that is,
    they are a single identifier).

This patch adds the infrastructure to parse these and a clause-list in its entirety. This adds some complication to how we are diagnosing parsing errors elsewhere, so a few changes were made to better recover from errors.