### PR TITLE
[VFABI] Create FunctionType for vector functions

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -197,11 +197,10 @@ void getVectorVariantNames(const CallInst &CI,
                            SmallVectorImpl<std::string> &VariantMappings);
 
 /// Returns a pair of the vectorized FunctionType and the mask's position when
-/// there's one, otherwise -1. It rejects any non vectorized calls as this
-/// method should be called at a point where the Instruction \p I is already
-/// vectorized.
+/// there's one, otherwise -1.
 std::optional<std::pair<FunctionType *, int>>
-createFunctionType(const VFInfo &Info, const Instruction *I, const Module *M);
+createFunctionType(const VFInfo &Info, const FunctionType *ScalarFTy,
+                   Type *VecRetTy, const Module *M);
 } // end namespace VFABI
 
 /// The Vector Function Database.

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -196,10 +196,8 @@ static constexpr char const *MappingsAttrName = "vector-function-abi-variant";
 void getVectorVariantNames(const CallInst &CI,
                            SmallVectorImpl<std::string> &VariantMappings);
 
-/// Returns a vectorized FunctionType that was previously found in
-/// TargetLibraryInfo. It uses \p ScalarFTy for the types, and \p Info to get
-/// the vectorization factor and whether a particular parameter is indeed a
-/// vector, since some of them may be scalars.
+/// Constructs a FunctionType by applying vector function information to the
+/// type of a matching scalar function.
 FunctionType *createFunctionType(const VFInfo &Info,
                                  const FunctionType *ScalarFTy);
 } // end namespace VFABI

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -198,6 +198,11 @@ void getVectorVariantNames(const CallInst &CI,
 
 /// Constructs a FunctionType by applying vector function information to the
 /// type of a matching scalar function.
+/// \param Info gets the vectorization factor (VF) and the VFParamKind of the
+/// parameters.
+/// \param ScalarFTy gets the Type information of parameters, as it is not
+/// stored in \p Info.
+/// \returns a pointer to a newly created vector FunctionType
 FunctionType *createFunctionType(const VFInfo &Info,
                                  const FunctionType *ScalarFTy);
 } // end namespace VFABI

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -196,11 +196,12 @@ static constexpr char const *MappingsAttrName = "vector-function-abi-variant";
 void getVectorVariantNames(const CallInst &CI,
                            SmallVectorImpl<std::string> &VariantMappings);
 
-/// Returns a pair of the vectorized FunctionType and the mask's position when
-/// there's one, otherwise -1.
-std::optional<std::pair<FunctionType *, int>>
-createFunctionType(const VFInfo &Info, const FunctionType *ScalarFTy,
-                   Type *VecRetTy, const Module *M);
+/// Returns a vectorized FunctionType that was previously found in
+/// TargetLibraryInfo. It uses \p ScalarFTy for the types, and \p Info to get
+/// the vectorization factor and whether a particular parameter is indeed a
+/// vector, since some of them may be scalars.
+std::optional<FunctionType *> createFunctionType(const VFInfo &Info,
+                                                 const FunctionType *ScalarFTy);
 } // end namespace VFABI
 
 /// The Vector Function Database.

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -200,8 +200,8 @@ void getVectorVariantNames(const CallInst &CI,
 /// TargetLibraryInfo. It uses \p ScalarFTy for the types, and \p Info to get
 /// the vectorization factor and whether a particular parameter is indeed a
 /// vector, since some of them may be scalars.
-std::optional<FunctionType *> createFunctionType(const VFInfo &Info,
-                                                 const FunctionType *ScalarFTy);
+FunctionType *createFunctionType(const VFInfo &Info,
+                                 const FunctionType *ScalarFTy);
 } // end namespace VFABI
 
 /// The Vector Function Database.

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -195,6 +195,13 @@ static constexpr char const *MappingsAttrName = "vector-function-abi-variant";
 /// the presence of the attribute (see InjectTLIMappings).
 void getVectorVariantNames(const CallInst &CI,
                            SmallVectorImpl<std::string> &VariantMappings);
+
+/// Returns a pair of the vectorized FunctionType and the mask's position when
+/// there's one, otherwise -1. It rejects any non vectorized calls as this
+/// method should be called at a point where the Instruction \p I is already
+/// vectorized.
+std::optional<std::pair<FunctionType *, int>>
+createFunctionType(const VFInfo &Info, const Instruction *I, const Module *M);
 } // end namespace VFABI
 
 /// The Vector Function Database.

--- a/llvm/lib/Analysis/VFABIDemangling.cpp
+++ b/llvm/lib/Analysis/VFABIDemangling.cpp
@@ -376,7 +376,7 @@ std::optional<VFInfo> VFABI::tryDemangleForVFABI(StringRef MangledName,
   // _ZGV<isa><mask><vlen><parameters>_<scalarname>.
   StringRef VectorName = MangledName;
 
-  // Parse the fixed size part of the manled name
+  // Parse the fixed size part of the mangled name
   if (!MangledName.consume_front("_ZGV"))
     return std::nullopt;
 

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1484,7 +1484,8 @@ FunctionType *VFABI::createFunctionType(const VFInfo &Info,
   // Create vector parameter types
   SmallVector<Type *, 8> VecTypes;
   ElementCount VF = Info.Shape.VF;
-  for (auto [Idx, VFParam] : enumerate(Info.Shape.Parameters)) {
+  int ScalarParamIndex = 0;
+  for (auto VFParam : Info.Shape.Parameters) {
     if (VFParam.ParamKind == VFParamKind::GlobalPredicate) {
       VectorType *MaskTy =
           VectorType::get(Type::getInt1Ty(ScalarFTy->getContext()), VF);
@@ -1492,7 +1493,7 @@ FunctionType *VFABI::createFunctionType(const VFInfo &Info,
       continue;
     }
 
-    Type *OperandTy = ScalarFTy->getParamType(Idx);
+    Type *OperandTy = ScalarFTy->getParamType(ScalarParamIndex++);
     if (VFParam.ParamKind == VFParamKind::Vector)
       OperandTy = VectorType::get(OperandTy, VF);
     VecTypes.push_back(OperandTy);

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1507,7 +1507,7 @@ VFABI::createFunctionType(const VFInfo &Info, const Instruction *I,
     VecParams.push_back(U->getType());
   }
 
-  // Append a mask and get its position.
+  // Get mask's position mask and append one if not present in the Instruction.
   int MaskPos = -1;
   if (Info.isMasked()) {
     auto OptMaskPos = Info.getParamIndexForOptionalMask();
@@ -1515,8 +1515,12 @@ VFABI::createFunctionType(const VFInfo &Info, const Instruction *I,
       return std::nullopt;
 
     MaskPos = OptMaskPos.value();
-    VectorType *MaskTy = VectorType::get(Type::getInt1Ty(M->getContext()), VF);
-    VecParams.insert(VecParams.begin() + MaskPos, MaskTy);
+    // append a mask only when it's missing
+    if (VecParams.size() == Info.Shape.Parameters.size() - 1) {
+      VectorType *MaskTy =
+          VectorType::get(Type::getInt1Ty(M->getContext()), VF);
+      VecParams.insert(VecParams.begin() + MaskPos, MaskTy);
+    }
   }
   FunctionType *VecFTy = FunctionType::get(I->getType(), VecParams, false);
   return std::make_pair(VecFTy, MaskPos);

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/VectorUtils.h"
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/InstIterator.h"
 #include "gtest/gtest.h"
 #include <optional>
@@ -397,7 +398,9 @@ TEST_F(VFABIParserTest, Align) {
   EXPECT_EQ(Parameters[0].Alignment, Align(2));
   EXPECT_EQ(ScalarName, "foo");
   EXPECT_EQ(VectorName, "vector_foo");
-
+  FunctionType *FTy =
+      FunctionType::get(Type::getVoidTy(Ctx), {Type::getInt32Ty(Ctx)}, false);
+  EXPECT_EQ(getFunctionType(), FTy);
   // Missing alignment value.
   EXPECT_FALSE(invokeParser("_ZGVsM2l2a_foo"));
   // Invalid alignment token "x".

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -126,12 +126,11 @@ protected:
 
     // Use VFInfo and the mock CallInst to create a FunctionType that will
     // include a mask when relevant.
-    auto OptVecFTyPos =
-        VFABI::createFunctionType(Info, ScalarFTy, VecRetTy, M.get());
-    if (!OptVecFTyPos)
+    auto OptVecFTy = VFABI::createFunctionType(Info, ScalarFTy);
+    if (!OptVecFTy)
       return false;
 
-    FunctionType *VecFTy = OptVecFTyPos->first;
+    FunctionType *VecFTy = *OptVecFTy;
     // Check that vectorized parameters' size match with VFInfo.
     // Both may include a mask.
     if ((VecFTy->getNumParams() != Info.Shape.Parameters.size()))

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -126,11 +126,10 @@ protected:
 
     // Use VFInfo and the mock CallInst to create a FunctionType that will
     // include a mask when relevant.
-    auto OptVecFTy = VFABI::createFunctionType(Info, ScalarFTy);
-    if (!OptVecFTy)
+    FunctionType *VecFTy = VFABI::createFunctionType(Info, ScalarFTy);
+    if (!VecFTy)
       return false;
 
-    FunctionType *VecFTy = *OptVecFTy;
     // Check that vectorized parameters' size match with VFInfo.
     // Both may include a mask.
     if ((VecFTy->getNumParams() != Info.Shape.Parameters.size()))


### PR DESCRIPTION
`createFunctionType` optionally returns a FunctionType and the mask's position when there's one. It requires VFInfo and an Instruction.

Add `checkFunctionType` in 'VectorFunctionABITest.cpp' tests to check that both the number and the type of vectorized parameters matches the created `FunctionType`.