### PR TITLE
Align LLVM_EXTERNALIZE_DEBUGINFO_EXTENSION behaviour on Linux w/ Darwin

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2293,10 +2293,28 @@ function(llvm_externalize_debuginfo name)
       ${strip_command}
       )
   else()
+    if(LLVM_EXTERNALIZE_DEBUGINFO_EXTENSION)
+      set(file_ext ${LLVM_EXTERNALIZE_DEBUGINFO_EXTENSION})
+    else()
+      set(file_ext debug)
+    endif()
+    set(output_name "$<TARGET_FILE_NAME:${name}>.${file_ext}")
+    if(LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR)
+      set(output_path "${LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR}/${output_name}")
+      # If an output dir is specified, it must be manually mkdir'd on Linux,
+      # as that directory needs to exist before we can pipe to a file in it.
+      add_custom_command(TARGET ${name} POST_BUILD
+        WORKING_DIRECTORY ${LLVM_RUNTIME_OUTPUT_INTDIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR}
+        )
+    else()
+      set(output_path "${output_name}")
+    endif()
     add_custom_command(TARGET ${name} POST_BUILD
-      COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:${name}> $<TARGET_FILE:${name}>.debug
+      WORKING_DIRECTORY ${LLVM_RUNTIME_OUTPUT_INTDIR}
+      COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:${name}> ${output_path}
       ${strip_command} -R .gnu_debuglink
-      COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:${name}>.debug $<TARGET_FILE:${name}>
+      COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${output_path} $<TARGET_FILE:${name}>
       )
   endif()
 endfunction()

--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -649,8 +649,8 @@ enabled sub-projects. Nearly all of these variable names begin with
   -DLLVM_EXTERNAL_BAR_SOURCE_DIR=/src/bar``.
 
 **LLVM_EXTERNALIZE_DEBUGINFO**:BOOL
-  Generate dSYM files and strip executables and libraries (Darwin Only).
-  Defaults to OFF.
+  Generate dSYM files and strip executables and libraries. Defaults to OFF.
+  This option is not available on Windows.
 
 **LLVM_FORCE_USE_OLD_TOOLCHAIN**:BOOL
   If enabled, the compiler and standard library versions won't be checked. LLVM


### PR DESCRIPTION
Ported from D111740

Despite what it says in the documentation[1], LLVM_EXTERNALIZE_DEBUGINFO is not only for Darwin, and has been functional on Linux since 2017[2].

However, it is hardcoded to emit ${name}.debug in the same directory, whereas macOS allows overriding both the extension and the output dir.

This commit adds support for LLVM_EXTERNALIZE_DEBUGINFO_EXTENSION and LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR on Linux.

[1] https://www.llvm.org/docs/CMake.html#llvm-related-variables
[2] https://reviews.llvm.org/D28575