### PR TITLE
[NFC][CLANG] Fix static analyzer bugs about large copy by values

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1488,7 +1488,7 @@ static bool hasUnsupportedSpecifiers(const VarDecl *VD,
 // returned by this function is the last location of the last token.
 static SourceRange getSourceRangeToTokenEnd(const Decl *D,
                                             const SourceManager &SM,
-                                            LangOptions LangOpts) {
+                                            const LangOptions &LangOpts) {
   SourceLocation Begin = D->getBeginLoc();
   SourceLocation
     End = // `D->getEndLoc` should always return the starting location of the

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -110,7 +110,7 @@ void ModuleDepCollector::addOutputPaths(CowCompilerInvocation &CI,
 }
 
 static CowCompilerInvocation
-makeCommonInvocationForModuleBuild(const CompilerInvocation &CI) {
+makeCommonInvocationForModuleBuild(CompilerInvocation CI) {
   CI.resetNonModularOptions();
   CI.clearImplicitModuleBuildOptions();
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -110,7 +110,7 @@ void ModuleDepCollector::addOutputPaths(CowCompilerInvocation &CI,
 }
 
 static CowCompilerInvocation
-makeCommonInvocationForModuleBuild(CompilerInvocation CI) {
+makeCommonInvocationForModuleBuild(const CompilerInvocation &CI) {
   CI.resetNonModularOptions();
   CI.clearImplicitModuleBuildOptions();
 


### PR DESCRIPTION
Reported by Static Analyzer tool:

In getSourceRangeToTokenEnd(clang::Decl const *, clang::SourceManager const &, clang::LangOptions): A very large function call parameter exceeding the high threshold is passed by value

   pass_by_value: Passing parameter LangOpts of type clang::LangOptions (size 1784 bytes) by value, which exceeds the high threshold of 512 bytes

