### PR TITLE
Revert "[mlir][vector] Make `TransposeOpLowering` configurable (#73915)"

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/Transforms/VectorTransforms.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/VectorTransforms.h
@@ -59,16 +59,6 @@ struct VectorTransformsOptions {
     vectorTransferSplit = opt;
     return *this;
   }
-
-  /// Option to control if vector.transpose can lower to a vector.shape_cast.
-  /// TODO: ATM it's not possible to lower `vector.shape_cast` to SPIR-V
-  /// and hence the need for this opt-out. Once the missing support has been
-  /// added, this option can be removed.
-  bool useShapeCast = true;
-  VectorTransformsOptions &setUseShapeCast(bool opt = true) {
-    useShapeCast = opt;
-    return *this;
-  }
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
@@ -334,24 +334,22 @@ public:
       return rewriter.notifyMatchFailure(
           op, "Options specifies lowering to shuffle");
 
-    if (vectorTransformOptions.useShapeCast) {
-      // Replace:
-      //   vector.transpose %0, [1, 0] : vector<nx1x<eltty>> to
-      //                                 vector<1xnxelty>
-      // with:
-      //   vector.shape_cast %0 : vector<nx1x<eltty>> to vector<1xnxelty>
-      //
-      // Source with leading unit dim (inverse) is also replaced. Unit dim must
-      // be fixed. Non-unit can be scalable.
-      if (resType.getRank() == 2 &&
-          ((resType.getShape().front() == 1 &&
-            !resType.getScalableDims().front()) ||
-           (resType.getShape().back() == 1 &&
-            !resType.getScalableDims().back())) &&
-          transp == ArrayRef<int64_t>({1, 0})) {
-        rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, resType, input);
-        return success();
-      }
+    // Replace:
+    //   vector.transpose %0, [1, 0] : vector<nx1x<eltty>> to
+    //                                 vector<1xnxelty>
+    // with:
+    //   vector.shape_cast %0 : vector<nx1x<eltty>> to vector<1xnxelty>
+    //
+    // Source with leading unit dim (inverse) is also replaced. Unit dim must
+    // be fixed. Non-unit can be scalable.
+    if (resType.getRank() == 2 &&
+        ((resType.getShape().front() == 1 &&
+          !resType.getScalableDims().front()) ||
+         (resType.getShape().back() == 1 &&
+          !resType.getScalableDims().back())) &&
+        transp == ArrayRef<int64_t>({1, 0})) {
+      rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, resType, input);
+      return success();
     }
 
     if (inputType.isScalable())


### PR DESCRIPTION
Reverting a workaround intended specifically for SPRI-V. That workaround
emerged from this discussion:

  * https://github.com/llvm/llvm-project/pull/72105

AFAIK, it hasn't been required in practice. This is based on IREE
(https://github.com/openxla/iree), which has just bumped it's fork of LLVM
without using it (*).

(*) https://github.com/openxla/iree/commit/cef31e775e03ec83420e4a7b47a992242d8df37c

This reverts commit bbd2b08b95fe76bea138c1b03c1cd42ed3ee04df.
