### PR TITLE
[libc] Make BigInt bit_cast-able to compatible types

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -50,10 +50,10 @@ LIBC_INLINE constexpr void memcpy_inline(DstT *__restrict dst,
 // UB in the implementation.
 template <
     typename To, typename From,
-    typename = cpp::enable_if_t<sizeof(To) == sizeof(From)>,
-    typename = cpp::enable_if_t<cpp::is_trivially_constructible<To>::value>,
-    typename = cpp::enable_if_t<cpp::is_trivially_copyable<To>::value>,
-    typename = cpp::enable_if_t<cpp::is_trivially_copyable<From>::value>>
+    typename = cpp::enable_if_t<sizeof(To) == sizeof(From) &&
+                                cpp::is_trivially_constructible<To>::value &&
+                                cpp::is_trivially_copyable<To>::value &&
+                                cpp::is_trivially_copyable<From>::value>>
 LIBC_INLINE constexpr To bit_cast(const From &from) {
   MSAN_UNPOISON(&from, sizeof(From));
 #if LIBC_HAS_BUILTIN(__builtin_bit_cast)

--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -26,7 +26,7 @@ namespace LIBC_NAMESPACE::cpp {
 #endif
 
 // Performs a copy from 'src' to 'dst' of 'size' bytes.
-// The semantics is valid if 'src' and 'dst' are equal but undefined if the
+// The semantics are valid if 'src' and 'dst' are equal but undefined if the
 // regions defined by [src, src + size] and [dst, dst + size] overlap.
 template <size_t size, typename DstT, typename SrcT>
 LIBC_INLINE constexpr void memcpy_inline(DstT *__restrict dst,

--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -25,6 +25,27 @@ namespace LIBC_NAMESPACE::cpp {
 #define LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
 #endif
 
+// Performs a copy from 'src' to 'dst' of 'size' bytes.
+// The semantics is valid if 'src' and 'dst' are equal but undefined if the
+// regions defined by [src, src + size] and [dst, dst + size] overlap.
+template <size_t size, typename DstT, typename SrcT>
+LIBC_INLINE constexpr void memcpy_inline(DstT *__restrict dst,
+                                         const SrcT *__restrict src) {
+#ifdef LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
+  __builtin_memcpy(dst, src, size);
+#else
+  // `memcpy_inline` is instantiated several times with different value of the
+  // size parameter. This doesn't play well with GCC's Value Range Analysis that
+  // wrongly detects out of bounds accesses. We disable the 'array-bounds'
+  // warning for the purpose of this function.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  for (size_t i = 0; i < size; ++i)
+    static_cast<char *>(dst)[i] = static_cast<const char *>(src)[i];
+#pragma GCC diagnostic pop
+#endif
+}
+
 // This implementation of bit_cast requires trivially-constructible To, to avoid
 // UB in the implementation.
 template <
@@ -39,14 +60,7 @@ LIBC_INLINE constexpr To bit_cast(const From &from) {
   return __builtin_bit_cast(To, from);
 #else
   To to;
-  char *dst = reinterpret_cast<char *>(&to);
-  const char *src = reinterpret_cast<const char *>(&from);
-#if LIBC_HAS_BUILTIN(__builtin_memcpy_inline)
-  __builtin_memcpy_inline(dst, src, sizeof(To));
-#else
-  for (unsigned i = 0; i < sizeof(To); ++i)
-    dst[i] = src[i];
-#endif // LIBC_HAS_BUILTIN(__builtin_memcpy_inline)
+  memcpy_inline<sizeof(To)>(&to, &from);
   return to;
 #endif // LIBC_HAS_BUILTIN(__builtin_bit_cast)
 }

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -11,6 +11,7 @@
 
 #include "src/__support/CPP/bit.h"
 #include "src/__support/CPP/type_traits.h"
+#include "src/__support/UInt128.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 

--- a/libc/src/__support/UInt.h
+++ b/libc/src/__support/UInt.h
@@ -958,10 +958,24 @@ template <size_t Bits> struct is_custom_uint<UInt<Bits>> : cpp::true_type {};
 } // namespace internal
 
 // bit_cast to UInt
+// Note: The standard scheme for SFINAE selection is to have exactly one
+// function instanciation valid at a time. This is usually done by having a
+// predicate in one function and the negated predicate in the other one.
+// e.g.
+// template<typename = cpp::enable_if_t< is_custom_uint<To>::value == true> ...
+// template<typename = cpp::enable_if_t< is_custom_uint<To>::value == false> ...
+//
+// Unfortunately this would make the default 'cpp::bit_cast' aware of
+// 'is_custom_uint' (or any other customization). To prevent exposing all
+// customizations in the original function, we create a different function with
+// four 'typename's instead of three - otherwise it would be considered as a
+// redeclaration of the same function leading to "error: template parameter
+// redefines default argument".
 template <typename To, typename From,
-          typename = cpp::enable_if_t<internal::is_custom_uint<To>::value>,
-          typename = cpp::enable_if_t<sizeof(To) == sizeof(From)>,
-          typename = cpp::enable_if_t<cpp::is_trivially_copyable<From>::value>>
+          typename = cpp::enable_if_t<sizeof(To) == sizeof(From) &&
+                                      cpp::is_trivially_copyable<To>::value &&
+                                      cpp::is_trivially_copyable<From>::value>,
+          typename = cpp::enable_if_t<internal::is_custom_uint<To>::value>>
 LIBC_INLINE constexpr To bit_cast(const From &from) {
   To out;
   cpp::memcpy_inline<sizeof(out)>(out.val, &from);
@@ -971,10 +985,10 @@ LIBC_INLINE constexpr To bit_cast(const From &from) {
 // bit_cast from UInt
 template <
     typename To, size_t Bits,
-    typename = cpp::enable_if_t<sizeof(To) == sizeof(UInt<Bits>)>,
-    typename = cpp::enable_if_t<cpp::is_trivially_constructible<To>::value>,
-    typename = cpp::enable_if_t<cpp::is_trivially_copyable<To>::value>,
-    typename = cpp::enable_if_t<cpp::is_trivially_copyable<UInt<Bits>>::value>>
+    typename = cpp::enable_if_t<sizeof(To) == sizeof(UInt<Bits>) &&
+                                cpp::is_trivially_constructible<To>::value &&
+                                cpp::is_trivially_copyable<To>::value &&
+                                cpp::is_trivially_copyable<UInt<Bits>>::value>>
 LIBC_INLINE constexpr To bit_cast(const UInt<Bits> &from) {
   To out;
   cpp::memcpy_inline<sizeof(out)>(&out, from.val);

--- a/libc/src/__support/UInt.h
+++ b/libc/src/__support/UInt.h
@@ -30,7 +30,7 @@ template <size_t Bits, bool Signed> struct BigInt {
   static_assert(Bits > 0 && Bits % 64 == 0,
                 "Number of bits in BigInt should be a multiple of 64.");
   LIBC_INLINE_VAR static constexpr size_t WORDCOUNT = Bits / 64;
-  uint64_t val[WORDCOUNT]{};
+  cpp::array<uint64_t, WORDCOUNT> val{};
 
   LIBC_INLINE_VAR static constexpr uint64_t MASK32 = 0xFFFFFFFFu;
 
@@ -978,7 +978,8 @@ template <typename To, typename From,
           typename = cpp::enable_if_t<internal::is_custom_uint<To>::value>>
 LIBC_INLINE constexpr To bit_cast(const From &from) {
   To out;
-  cpp::memcpy_inline<sizeof(out)>(out.val, &from);
+  using Storage = decltype(out.val);
+  out.val = cpp::bit_cast<Storage>(from);
   return out;
 }
 
@@ -990,9 +991,7 @@ template <
                                 cpp::is_trivially_copyable<To>::value &&
                                 cpp::is_trivially_copyable<UInt<Bits>>::value>>
 LIBC_INLINE constexpr To bit_cast(const UInt<Bits> &from) {
-  To out;
-  cpp::memcpy_inline<sizeof(out)>(&out, from.val);
-  return out;
+  return cpp::bit_cast<To>(from.val);
 }
 
 } // namespace LIBC_NAMESPACE::cpp

--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -71,32 +71,9 @@ LIBC_INLINE bool is_disjoint(const void *p1, const void *p2, size_t size) {
   return sdiff >= 0 ? size <= udiff : size <= neg_udiff;
 }
 
-#if LIBC_HAS_BUILTIN(__builtin_memcpy_inline)
-#define LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
-#endif
-
 #if LIBC_HAS_BUILTIN(__builtin_memset_inline)
 #define LLVM_LIBC_HAS_BUILTIN_MEMSET_INLINE
 #endif
-
-// Performs a constant count copy.
-template <size_t Size>
-LIBC_INLINE void memcpy_inline(void *__restrict dst,
-                               const void *__restrict src) {
-#ifdef LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
-  __builtin_memcpy_inline(dst, src, Size);
-#else
-  // In memory functions `memcpy_inline` is instantiated several times with
-  // different value of the Size parameter. This doesn't play well with GCC's
-  // Value Range Analysis that wrongly detects out of bounds accesses. We
-  // disable the 'array-bounds' warning for the purpose of this function.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-  for (size_t i = 0; i < Size; ++i)
-    static_cast<char *>(dst)[i] = static_cast<const char *>(src)[i];
-#pragma GCC diagnostic pop
-#endif
-}
 
 using Ptr = cpp::byte *;        // Pointer to raw data.
 using CPtr = const cpp::byte *; // Const pointer to raw data.
@@ -204,13 +181,13 @@ LIBC_INLINE MemcmpReturnType cmp_neq_uint64_t(uint64_t a, uint64_t b) {
 // type.
 template <typename T> LIBC_INLINE T load(CPtr ptr) {
   T Out;
-  memcpy_inline<sizeof(T)>(&Out, ptr);
+  cpp::memcpy_inline<sizeof(T)>(&Out, ptr);
   return Out;
 }
 
 // Stores a value of type T in memory (possibly unaligned).
 template <typename T> LIBC_INLINE void store(Ptr ptr, T value) {
-  memcpy_inline<sizeof(T)>(ptr, &value);
+  cpp::memcpy_inline<sizeof(T)>(ptr, &value);
 }
 
 // On architectures that do not allow for unaligned access we perform several


### PR DESCRIPTION
This is a second take on #74837 to fix #74258
