### PR TITLE
[AArch64][ELF][llvm-readobj] Support the GCS .note.gnu.property bit

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1693,6 +1693,7 @@ enum : unsigned {
 enum : unsigned {
   GNU_PROPERTY_AARCH64_FEATURE_1_BTI = 1 << 0,
   GNU_PROPERTY_AARCH64_FEATURE_1_PAC = 1 << 1,
+  GNU_PROPERTY_AARCH64_FEATURE_1_GCS = 1 << 2,
 };
 
 // x86 processor feature bits.

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
@@ -5,7 +5,7 @@
 // GNU: Displaying notes found in: .note.gnu.property
 // GNU-NEXT:   Owner                 Data size	Description
 // GNU-NEXT:   GNU                   0x00000010	NT_GNU_PROPERTY_TYPE_0 (property note)
-// GNU-NEXT:     Properties:    aarch64 feature: BTI, PAC
+// GNU-NEXT:     Properties:    aarch64 feature: BTI, PAC, GCS
 
 // LLVM:      Notes [
 // LLVM-NEXT:   NoteSection {
@@ -17,7 +17,7 @@
 // LLVM-NEXT:       Data size: 0x10
 // LLVM-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
 // LLVM-NEXT:       Property [
-// LLVM-NEXT:         aarch64 feature: BTI, PAC
+// LLVM-NEXT:         aarch64 feature: BTI, PAC, GCS
 // LLVM-NEXT:       ]
 // LLVM-NEXT:     }
 // LLVM-NEXT:   }
@@ -30,9 +30,9 @@
   .asciz "GNU"      /* Name */
   .p2align 3
 begin:
-  /* BTI and PAC property note */
+  /* BTI, PAC, and GCS property note */
   .long 0xc0000000  /* Type: GNU_PROPERTY_AARCH64_FEATURE_1_AND */
   .long 4           /* Data size */
-  .long 3           /* BTI and PAC */
+  .long 7           /* BTI, PAC, GCS */
   .p2align 3        /* Align to 8 byte for 64 bit */
 end:

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5129,6 +5129,7 @@ static std::string getGNUProperty(uint32_t Type, uint32_t DataSize,
     if (Type == GNU_PROPERTY_AARCH64_FEATURE_1_AND) {
       DumpBit(GNU_PROPERTY_AARCH64_FEATURE_1_BTI, "BTI");
       DumpBit(GNU_PROPERTY_AARCH64_FEATURE_1_PAC, "PAC");
+      DumpBit(GNU_PROPERTY_AARCH64_FEATURE_1_GCS, "GCS");
     } else {
       DumpBit(GNU_PROPERTY_X86_FEATURE_1_IBT, "IBT");
       DumpBit(GNU_PROPERTY_X86_FEATURE_1_SHSTK, "SHSTK");


### PR DESCRIPTION
This bit was added to the AArch64 ABI by https://github.com/ARM-software/abi-aa/pull/231.