### PR TITLE
[Analyzer][NFC] Remove redundant function call

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2567,6 +2567,9 @@ public:
   Tracker::Result handle(const Expr *E, const ExplodedNode *InputNode,
                          const ExplodedNode *RVNode,
                          TrackingOptions Opts) override {
+    assert(RVNode->getStmtForDiagnostics() == E &&
+           "RVNode must be the ExplodedNode for the tracked expression.");
+
     if (!E->isPRValue() || !RVNode)
       return {};
 

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2567,11 +2567,12 @@ public:
   Tracker::Result handle(const Expr *E, const ExplodedNode *InputNode,
                          const ExplodedNode *RVNode,
                          TrackingOptions Opts) override {
-    assert(RVNode->getStmtForDiagnostics() == E &&
-           "RVNode must be the ExplodedNode for the tracked expression.");
 
     if (!E->isPRValue() || !RVNode)
       return {};
+
+    assert(RVNode->getStmtForDiagnostics() == E &&
+           "RVNode must be the ExplodedNode for the tracked expression.");
 
     Tracker::Result CombinedResult;
     Tracker &Parent = getParentTracker();

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2565,21 +2565,17 @@ public:
   using ExpressionHandler::ExpressionHandler;
 
   Tracker::Result handle(const Expr *E, const ExplodedNode *InputNode,
-                         const ExplodedNode *ExprNode,
+                         const ExplodedNode *RVNode,
                          TrackingOptions Opts) override {
-    if (!E->isPRValue())
-      return {};
-
-    const ExplodedNode *RVNode = findNodeForExpression(ExprNode, E);
-    if (!RVNode)
+    if (!E->isPRValue() || !RVNode)
       return {};
 
     Tracker::Result CombinedResult;
     Tracker &Parent = getParentTracker();
 
-    const auto track = [&CombinedResult, &Parent, ExprNode,
+    const auto track = [&CombinedResult, &Parent, RVNode,
                         Opts](const Expr *Inner) {
-      CombinedResult.combineWith(Parent.track(Inner, ExprNode, Opts));
+      CombinedResult.combineWith(Parent.track(Inner, RVNode, Opts));
     };
 
     // FIXME: Initializer lists can appear in many different contexts


### PR DESCRIPTION
`PRValueHandler`'s handle function is only called from Tracker's track function. In `Tracker::track` the
`ExprNode` parameter passed to `PRValueHandler::handle` is already the `ExplodedNode` for the tracked expression. We do not need to calculate that again.