### PR TITLE
[NFC][CLANG] Fix static analyzer bugs about unnecessary object copies with auto keyword

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -876,7 +876,7 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
           << PluginFN << toString(PassPlugin.takeError());
     }
   }
-  for (auto PassCallback : CodeGenOpts.PassBuilderCallbacks)
+  for (const auto &PassCallback : CodeGenOpts.PassBuilderCallbacks)
     PassCallback(PB);
 #define HANDLE_EXTENSION(Ext)                                                  \
   get##Ext##PluginInfo().RegisterPassBuilderCallbacks(PB);


### PR DESCRIPTION
Reported by Static Analyzer Tool:

In ​EmitAssemblyHelper::​RunOptimizationPipeline(): Using the auto keyword without an & causes the copy of an object of type function.

 /// List of pass builder callbacks ("CodeGenOptions.h").
  std::vector<std::function<void(llvm::PassBuilder &)>> PassBuilderCallbacks;
