### PR TITLE
[SPIR-V][NFC] Require asserts on 2 tests

### DIFF
--- a/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
@@ -2,6 +2,7 @@
 
 ; TODO(#60133): Requires updates following opaque pointer migration.
 ; XFAIL: *
+; REQUIRES: asserts
 
 ; CHECK: %[[#bool:]] = OpTypeBool
 ; CHECK: %[[#true:]] = OpConstantTrue %[[#bool]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/BuildNDRange_2.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/BuildNDRange_2.ll
@@ -22,6 +22,7 @@
 
 ; TODO(#60133): Requires updates following opaque pointer migration.
 ; XFAIL: *
+; REQUIRES: asserts
 
 ; CHECK-SPIRV-DAG:     %[[#LEN2_ID:]] = OpConstant %[[#]] 2
 ; CHECK-SPIRV-DAG:     %[[#LEN3_ID:]] = OpConstant %[[#]] 3


### PR DESCRIPTION
These tests currently fail on asserts, so adding a REQUIRES to make sure they're skipped on builds with asserts disabled.

Follow-up from #74849