### PR TITLE
[runtimes] Add missing test dependencies to check-all

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1259,6 +1259,7 @@ if( LLVM_INCLUDE_TESTS )
   add_custom_target(test-depends
       DEPENDS ${LLVM_ALL_LIT_DEPENDS} ${LLVM_ALL_ADDITIONAL_TEST_DEPENDS})
   set_target_properties(test-depends PROPERTIES FOLDER "Tests")
+  add_dependencies(check-all test-depends)
 endif()
 
 if (LLVM_INCLUDE_DOCS)


### PR DESCRIPTION
Re-apply 7f215b1380da49dccbf57da3040a40d25ed898f4, which was reverted in a9e3d232a520a17f098d4dc872c9591c565e7d36.

The orginal commit uncovered a bug that was fixed by 4701f776d0f22dc0ff80a7d33ef3ae031eac9c2f.

Fixes #58680