### PR TITLE
[NFC][Clang] Fix Static Code Analysis Concerns with copy without assign

### DIFF
--- a/clang/utils/TableGen/SveEmitter.cpp
+++ b/clang/utils/TableGen/SveEmitter.cpp
@@ -90,6 +90,8 @@ public:
     NumVectors = NumV;
   }
 
+  SVEType &operator=(const SVEType &) = delete;
+
   bool isPointer() const { return Pointer; }
   bool isVoidPointer() const { return Pointer && Void; }
   bool isSigned() const { return Signed; }


### PR DESCRIPTION
This patch adds missing assignment operator to the class which has user-defined copy constructor.