### PR TITLE
[lldb] Disable new TestLocationListLookup when clang version is <= 11

### DIFF
--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -43,6 +43,7 @@ class LocationListLookupTestCase(TestBase):
         self.build()
         self.check_local_vars(self.launch(), check_expr=False)
 
+    @skipIf(compiler="clang", compiler_version=["<=", "11.0"])
     @skipUnlessDarwin
     def test_loclist_expr(self):
         self.build()


### PR DESCRIPTION
The newly introduced LocationListLookupTestCase.test_loclist_expr test fails with older clangs.