### PR TITLE
[RFC][BPF] Add support for asm gotol_or_nop and nop_or_gotol insns

### DIFF
--- a/llvm/lib/Target/BPF/BPFRegisterInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFRegisterInfo.cpp
@@ -47,9 +47,17 @@ BitVector BPFRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   return Reserved;
 }
 
-static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
-{
+static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL,
+                     MachineBasicBlock& MBB) {
   if (Offset <= -BPFStackSizeOption) {
+    if (!DL)
+      /* try harder to get some debug loc */
+      for (auto &I : MBB)
+        if (I.getDebugLoc()) {
+          DL = I.getDebugLoc();
+          break;
+        }
+
     const Function &F = MF.getFunction();
     DiagnosticInfoUnsupported DiagStackSize(
         F,
@@ -73,14 +81,6 @@ bool BPFRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   MachineFunction &MF = *MBB.getParent();
   DebugLoc DL = MI.getDebugLoc();
 
-  if (!DL)
-    /* try harder to get some debug loc */
-    for (auto &I : MBB)
-      if (I.getDebugLoc()) {
-        DL = I.getDebugLoc();
-        break;
-      }
-
   while (!MI.getOperand(i).isFI()) {
     ++i;
     assert(i < MI.getNumOperands() && "Instr doesn't have FrameIndex operand!");
@@ -93,7 +93,7 @@ bool BPFRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   if (MI.getOpcode() == BPF::MOV_rr) {
     int Offset = MF.getFrameInfo().getObjectOffset(FrameIndex);
 
-    WarnSize(Offset, MF, DL);
+    WarnSize(Offset, MF, DL, MBB);
     MI.getOperand(i).ChangeToRegister(FrameReg, false);
     Register reg = MI.getOperand(i - 1).getReg();
     BuildMI(MBB, ++II, DL, TII.get(BPF::ADD_ri), reg)
@@ -108,7 +108,7 @@ bool BPFRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   if (!isInt<32>(Offset))
     llvm_unreachable("bug in frame offset");
 
-  WarnSize(Offset, MF, DL);
+  WarnSize(Offset, MF, DL, MBB);
 
   if (MI.getOpcode() == BPF::FI_ri) {
     // architecture does not really support FI_ri, replace it with


### PR DESCRIPTION
Two new insns are added to BPF instruction set:
  gotol_or_nop
    encoding: gotol encoding with src_reg = 1
  nop_or_gotol
    encoding: gotol encoding with src_reg = 3

Basically src_reg 'bit_0 == 1' means it is gotol_or_nop/nop_or_gotol insn. The src_reg 'bit_1' indicates the insn itself will be a 'goto' 'bit_1 == 0' or a 'nop' 'bit_1 == 1'.

Two insns intend to support kernel static key like transformation where the insn can be a nop or a ja.

The following is an example, where two labels,
static_key_loc_1 and static_key_loc_2, can be used to identify the location of a particular gotol_or_nop/nop_or_gotol location.

It is possible that user space could do
  static_key_enable("static_key_loc_1")
    libbpf can validate that the label "static_key_loc_1" indeed
      corresponds to a gotol_or_nop/nop_or_gotol insn and it
      can translated the 'static_key_enable("static_key_loc_1")'
      to something like bpf syscall command 'static_key_enable prog, insn offset 1'
      and kernel will do proper adjustment.
  the same for static_key_disable, static_key_enabled, etc.

```
$ cat t.c
int bar(void);
int foo1(int arg1)
{
        int a = arg1, b;

        asm volatile goto ("r0 = 0; \
                            static_key_loc_1: \
                            gotol_or_nop %l[label]; \
                            r2 = 2; \
                            r3 = 3; \
                           "::
                            : "r0", "r2", "r3"
                            :label);
        a = bar();
label:
        b = 20 * a;
        return b;
}
int foo2(int arg1)
{
        int a = arg1, b;

        asm volatile goto ("r0 = 0; \
                            static_key_loc_2: \
                            nop_or_gotol %l[label]; \
                            r2 = 2; \
                            r3 = 3; \
                           "::
                            : "r0", "r2", "r3"
                            :label);
        a = bar();
label:
        b = 20 * a;
        return b;
}
$ clang --target=bpf -O2 -g -c t.c
$ llvm-objdump -S t.o
t.o:    file format elf64-bpf

Disassembly of section .text:

0000000000000000 <foo1>:
;       asm volatile goto ("r0 = 0; \
       0:       b7 00 00 00 00 00 00 00 r0 = 0x0

0000000000000008 <static_key_loc_1>:
       1:       06 10 00 00 04 00 00 00 gotol_or_nop +0x4 <LBB0_2>
       2:       b7 02 00 00 02 00 00 00 r2 = 0x2
       3:       b7 03 00 00 03 00 00 00 r3 = 0x3
;       a = bar();
       4:       85 10 00 00 ff ff ff ff call -0x1
       5:       bf 01 00 00 00 00 00 00 r1 = r0

0000000000000030 <LBB0_2>:
;       b = 20 * a;
       6:       27 01 00 00 14 00 00 00 r1 *= 0x14
;       return b;
       7:       bf 10 00 00 00 00 00 00 r0 = r1
       8:       95 00 00 00 00 00 00 00 exit

0000000000000048 <foo2>:
;       asm volatile goto ("r0 = 0; \
       9:       b7 00 00 00 00 00 00 00 r0 = 0x0

0000000000000050 <static_key_loc_2>:
      10:       06 30 00 00 04 00 00 00 nop_or_gotol +0x4 <LBB1_2>
      11:       b7 02 00 00 02 00 00 00 r2 = 0x2
      12:       b7 03 00 00 03 00 00 00 r3 = 0x3
;       a = bar();
      13:       85 10 00 00 ff ff ff ff call -0x1
      14:       bf 01 00 00 00 00 00 00 r1 = r0

0000000000000078 <LBB1_2>:
;       b = 20 * a;
      15:       27 01 00 00 14 00 00 00 r1 *= 0x14
;       return b;
      16:       bf 10 00 00 00 00 00 00 r0 = r1
      17:       95 00 00 00 00 00 00 00 exit
```