### PR TITLE
Add missing dep on MLIRToLLVMIRTranslationRegistration to mlir-opt.

### DIFF
--- a/mlir/tools/mlir-opt/CMakeLists.txt
+++ b/mlir/tools/mlir-opt/CMakeLists.txt
@@ -66,6 +66,10 @@ set(LIBS
   MLIRTransformUtils
   MLIRSupport
   MLIRIR
+
+  # TODO: Remove when registerAllGPUToLLVMIRTranslations is no longer
+  # registered directly in mlir-opt.cpp.
+  MLIRToLLVMIRTranslationRegistration
   )
 
 # Exclude from libMLIR.so because this has static options intended for

--- a/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -274,6 +274,10 @@ int main(int argc, char **argv) {
   DialectRegistry registry;
   registerAllDialects(registry);
   registerAllExtensions(registry);
+
+  // TODO: Remove this and the corresponding MLIRToLLVMIRTranslationRegistration
+  // cmake dependency when a safe dialect interface registration mechanism is
+  // implemented, see D157703 (and corresponding note on the declaration).
   registerAllGPUToLLVMIRTranslations(registry);
 
 #ifdef MLIR_INCLUDE_TESTS


### PR DESCRIPTION
I was not able to fully triage why this just started failing on one of our bots as it seems that the use was added 4 months ago. I would assume that it was accidentally coming in transitively in some way as the dep was definitely missing.

For context, this started failing in [our byo_llvm](https://github.com/openxla/iree/blob/main/build_tools/llvm/byo_llvm.sh) build on a stock build of MLIR on top of an existing LLVM. We were getting:

```
ld.lld: error: undefined symbol: mlir::registerSPIRVDialectTranslation(mlir::DialectRegistry&)                                                        >>> referenced by mlir-opt.cpp
>>>               tools/mlir-opt/CMakeFiles/mlir-opt.dir/mlir-opt.cpp.o:(main)
```