### PR TITLE
[Clang][AST] Fix crash in APValue::LValueBase::getType when we have invalid decl

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -641,6 +641,10 @@ Bug Fixes in This Version
   Fixes (`#67317 <https://github.com/llvm/llvm-project/issues/67317>`_)
 - Clang now properly diagnoses use of stand-alone OpenMP directives after a
   label (including ``case`` or ``default`` labels).
+- Fix crash when dealing with ill-formed code where we were not handling invalid
+  redeclarations properly.
+  Fixes (`#69468 <https://github.com/llvm/llvm-project/issues/69468>`_)
+
 
   Before:
 

--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -70,11 +70,13 @@ QualType APValue::LValueBase::getType() const {
     // constexpr int *p = &arr[1]; // valid?
     //
     // For now, we take the most complete type we can find.
-    for (auto *Redecl = cast<ValueDecl>(D->getMostRecentDecl()); Redecl;
+    for (auto *Redecl = cast<ValueDecl>(D->getMostRecentDecl());
+         Redecl && !Redecl->isInvalidDecl();
          Redecl = cast_or_null<ValueDecl>(Redecl->getPreviousDecl())) {
       QualType T = Redecl->getType();
       if (!T->isIncompleteArrayType())
         return T;
+      D = Redecl;
     }
     return D->getType();
   }

--- a/clang/test/AST/gh69468.cpp
+++ b/clang/test/AST/gh69468.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -verify %s
+
+
+a[i] = b[i]; // expected-error {{use of undeclared identifier 'i'}} \
+             // expected-error {{a type specifier is required for all declarations}} \
+	     // expected-error {{use of undeclared identifier 'b'}} \
+	     // expected-error {{use of undeclared identifier 'i'}}
+extern char b[];
+extern char a[];
+
+void foo(int j) {
+  // This used to crash here
+  a[j] = b[j];
+}


### PR DESCRIPTION
In some cases when calling APValue::LValueBase::getType() when we have a ValueDecl in some cases we don't handle invalid decls. We iterating over redeclarations we reset the current decl to the current most recent decl and we check the next redeclaration to ensure it is not invalid.

Fixes: https://github.com/llvm/llvm-project/issues/69468