### PR TITLE
[clang] Fix logic in APValue::LValueBase::getType()

### DIFF
--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -70,8 +70,10 @@ QualType APValue::LValueBase::getType() const {
     // constexpr int *p = &arr[1]; // valid?
     //
     // For now, we take the most complete type we can find.
-    for (auto *Redecl = cast<ValueDecl>(D->getMostRecentDecl()); Redecl;
+    for (auto *Redecl = cast<ValueDecl>(D->getMostRecentDecl());
+         Redecl && !Redecl->isInvalidDecl();
          Redecl = cast_or_null<ValueDecl>(Redecl->getPreviousDecl())) {
+      D = Redecl;
       QualType T = Redecl->getType();
       if (!T->isIncompleteArrayType())
         return T;


### PR DESCRIPTION
See #69468.