### PR TITLE
[libc++][test] Use `TEST_MEOW_DIAGNOSTIC_IGNORED` instead of `ADDITIONAL_COMPILE_FLAGS`

### DIFF
--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
@@ -21,6 +21,11 @@
 //   constexpr borrowed_iterator_t<R>
 //     ranges::replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
 
+#include "test_macros.h"
+
+// MSVC warning C4244: 'argument': conversion from 'const _Ty2' to 'T', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4244)
+
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -18,15 +18,22 @@
 //   constexpr bool     // constexpr after c++17
 //   equal(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2);
 
+#include "test_macros.h"
+
 // We test the cartesian product, so we sometimes compare differently signed types
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
+// MSVC warning C4242: 'argument': conversion from 'int' to 'const _Ty', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'wchar_t' to 'const _Ty', possible loss of data
+// MSVC warning C4310: cast truncates constant value
+// MSVC warning C4389: '==': signed/unsigned mismatch
+TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244 4310 4389)
 
 #include <algorithm>
 #include <cassert>
 #include <functional>
 
 #include "test_iterators.h"
-#include "test_macros.h"
 #include "type_algorithms.h"
 
 template <class UnderlyingType, class Iter1>

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -64,9 +64,9 @@ struct Test {
 struct TestNarrowingEqualTo {
   template <class UnderlyingType>
   TEST_CONSTEXPR_CXX20 void operator()() {
-  TEST_DIAGNOSTIC_PUSH
-  // MSVC warning C4310: cast truncates constant value
-  TEST_MSVC_DIAGNOSTIC_IGNORED(4310)
+    TEST_DIAGNOSTIC_PUSH
+    // MSVC warning C4310: cast truncates constant value
+    TEST_MSVC_DIAGNOSTIC_IGNORED(4310)
 
     UnderlyingType a[] = {
         UnderlyingType(0x1000),
@@ -81,7 +81,7 @@ struct TestNarrowingEqualTo {
         UnderlyingType(0x1603),
         UnderlyingType(0x1604)};
 
-  TEST_DIAGNOSTIC_POP
+    TEST_DIAGNOSTIC_POP
 
     assert(std::equal(a, a + 5, b, std::equal_to<char>()));
 #if TEST_STD_VER >= 14

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -25,9 +25,8 @@ TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
 TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
 // MSVC warning C4242: 'argument': conversion from 'int' to 'const _Ty', possible loss of data
 // MSVC warning C4244: 'argument': conversion from 'wchar_t' to 'const _Ty', possible loss of data
-// MSVC warning C4310: cast truncates constant value
 // MSVC warning C4389: '==': signed/unsigned mismatch
-TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244 4310 4389)
+TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244 4389)
 
 #include <algorithm>
 #include <cassert>
@@ -65,6 +64,10 @@ struct Test {
 struct TestNarrowingEqualTo {
   template <class UnderlyingType>
   TEST_CONSTEXPR_CXX20 void operator()() {
+  TEST_DIAGNOSTIC_PUSH
+  // MSVC warning C4310: cast truncates constant value
+  TEST_MSVC_DIAGNOSTIC_IGNORED(4310)
+
     UnderlyingType a[] = {
         UnderlyingType(0x1000),
         UnderlyingType(0x1001),
@@ -77,6 +80,8 @@ struct TestNarrowingEqualTo {
         UnderlyingType(0x1602),
         UnderlyingType(0x1603),
         UnderlyingType(0x1604)};
+
+  TEST_DIAGNOSTIC_POP
 
     assert(std::equal(a, a + 5, b, std::equal_to<char>()));
 #if TEST_STD_VER >= 14

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
-
 // <algorithm>
 
 // template<InputIterator Iter, class T>
@@ -15,12 +13,18 @@
 //   constexpr Iter   // constexpr after C++17
 //   find(Iter first, Iter last, const T& value);
 
+#include "test_macros.h"
+
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
+// MSVC warning C4389: '==': signed/unsigned mismatch
+TEST_MSVC_DIAGNOSTIC_IGNORED(4389)
+
 #include <algorithm>
 #include <cassert>
 #include <vector>
 #include <type_traits>
 
-#include "test_macros.h"
 #include "test_iterators.h"
 #include "type_algorithms.h"
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -10,8 +10,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
-
 // template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
 //   requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
 //   constexpr I ranges::find(I first, S last, const T& value, Proj proj = {});
@@ -19,6 +17,14 @@
 //   requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
 //   constexpr borrowed_iterator_t<R>
 //     ranges::find(R&& r, const T& value, Proj proj = {});
+
+#include "test_macros.h"
+
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
+// MSVC warning C4242: 'argument': conversion from 'const _Ty' to 'ElementT', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'const _Ty' to 'ElementT', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
 
 #include <algorithm>
 #include <array>

--- a/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
@@ -56,15 +56,11 @@
 //    void notify_all() noexcept;
 //  };
 
-#include "test_macros.h"
-
-// MSVC warning C4197: 'volatile std::atomic<operator_hijacker>': top-level volatile in cast is ignored
-TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
-
 #include <atomic>
 #include <type_traits>
 
 #include "operator_hijacker.h"
+#include "test_macros.h"
 
 template <class T>
 void test() {
@@ -78,8 +74,14 @@ void test() {
 
   TEST_IGNORE_NODISCARD a.is_lock_free();
 
+  TEST_DIAGNOSTIC_PUSH
+  // MSVC warning C4197: 'volatile std::atomic<operator_hijacker>': top-level volatile in cast is ignored
+  TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
   TEST_IGNORE_NODISCARD T();
   TEST_IGNORE_NODISCARD T(v);
+
+  TEST_DIAGNOSTIC_POP
 
   TEST_IGNORE_NODISCARD a.load();
   TEST_IGNORE_NODISCARD static_cast<typename T::value_type>(a);

--- a/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
@@ -56,11 +56,15 @@
 //    void notify_all() noexcept;
 //  };
 
+#include "test_macros.h"
+
+// MSVC warning C4197: 'volatile std::atomic<operator_hijacker>': top-level volatile in cast is ignored
+TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
 #include <atomic>
 #include <type_traits>
 
 #include "operator_hijacker.h"
-#include "test_macros.h"
 
 template <class T>
 void test() {

--- a/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
@@ -78,11 +78,15 @@
 //    void notify_all() noexcept;
 //  };
 
+#include "test_macros.h"
+
+// MSVC warning C4197: 'volatile std::atomic<operator_hijacker *>': top-level volatile in cast is ignored
+TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
 #include <atomic>
 #include <type_traits>
 
 #include "operator_hijacker.h"
-#include "test_macros.h"
 
 template <class T>
 void test() {

--- a/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
@@ -78,15 +78,11 @@
 //    void notify_all() noexcept;
 //  };
 
-#include "test_macros.h"
-
-// MSVC warning C4197: 'volatile std::atomic<operator_hijacker *>': top-level volatile in cast is ignored
-TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
-
 #include <atomic>
 #include <type_traits>
 
 #include "operator_hijacker.h"
+#include "test_macros.h"
 
 template <class T>
 void test() {
@@ -102,8 +98,16 @@ void test() {
 
   a.store(v);
   a = v;
+
+  TEST_DIAGNOSTIC_PUSH
+  // MSVC warning C4197: 'volatile std::atomic<operator_hijacker *>': top-level volatile in cast is ignored
+  TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
   TEST_IGNORE_NODISCARD T();
   TEST_IGNORE_NODISCARD T(v);
+
+  TEST_DIAGNOSTIC_POP
+
   TEST_IGNORE_NODISCARD a.load();
   TEST_IGNORE_NODISCARD static_cast<typename T::value_type>(a);
   TEST_IGNORE_NODISCARD* a;

--- a/libcxx/test/std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp
@@ -8,14 +8,17 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// We voluntarily use std::default_initializable on types that have redundant
-// or ignored cv-qualifiers -- don't warn about it.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ignored-qualifiers
-
 // template<class T>
 //     concept default_initializable = constructible_from<T> &&
 //     requires { T{}; } &&
 //     is-default-initializable<T>;
+
+#include "test_macros.h"
+
+// We voluntarily use std::default_initializable on types that have redundant
+// or ignored cv-qualifiers -- don't warn about it.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wignored-qualifiers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wignored-qualifiers")
 
 #include <array>
 #include <concepts>
@@ -33,8 +36,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include "test_macros.h"
 
 struct Empty {};
 

--- a/libcxx/test/std/containers/associative/map/map.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.modifiers/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <map>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <map>
 
 #include "../../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   // Note: we want to use a pair with non-const elements for input (an assignable type is a lot more convenient) but

--- a/libcxx/test/std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <map>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <map>
 
 #include "../../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   // Note: we want to use a pair with non-const elements for input (an assignable type is a lot more convenient) but
@@ -38,4 +41,3 @@ int main(int, char**) {
 
   return 0;
 }
-

--- a/libcxx/test/std/containers/associative/multiset/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <set>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <set>
 
 #include "../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {

--- a/libcxx/test/std/containers/associative/set/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <set>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <set>
 
 #include "../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
@@ -10,8 +10,11 @@
 
 // template <size_t I, class T, size_t N> T& get(array<T, N>& a);
 
+#include "test_macros.h"
+
 // Prevent -Warray-bounds from issuing a diagnostic when testing with clang verify.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-array-bounds
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Warray-bounds")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Warray-bounds")
 
 #include <array>
 #include <cassert>

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <unordered_map>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <unordered_map>
 
 #include "../../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   // Note: we want to use a pair with non-const elements for input (an assignable type is a lot more convenient) but

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <unordered_map>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <unordered_map>
 
 #include "../../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   // Note: we want to use a pair with non-const elements for input (an assignable type is a lot more convenient) but
@@ -38,4 +41,3 @@ int main(int, char**) {
 
   return 0;
 }
-

--- a/libcxx/test/std/containers/unord/unord.multiset/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <set>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <unordered_set>
 
 #include "../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
@@ -34,4 +37,3 @@ int main(int, char**) {
 
   return 0;
 }
-

--- a/libcxx/test/std/containers/unord/unord.set/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/insert_range.pass.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
 
 // <set>
 
 // template<container-compatible-range<value_type> R>
 //   void insert_range(R&& rg); // C++23
 
+#include "test_macros.h"
+
+// Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wmissing-field-initializers")
+
 #include <unordered_set>
 
 #include "../../insert_range_maps_sets.h"
-#include "test_macros.h"
 
 int main(int, char**) {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -6,16 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
 
 // <mdspan>
+
+#include "test_macros.h"
+
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wctad-maybe-unsupported")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wctad-maybe-unsupported")
 
 #include <mdspan>
 #include <type_traits>
 #include <concepts>
 #include <cassert>
-
-#include "test_macros.h"
 
 // mdspan
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -35,12 +35,15 @@
 //   !is_convertible_v<const OtherLayoutPolicy::template mapping<OtherExtents>&, mapping_type>
 //   || !is_convertible_v<const OtherAccessor&, accessor_type>
 
+#include "test_macros.h"
+
+// MSVC warning C4244: 'initializing': conversion from '_Ty' to '_Ty', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4244)
+
 #include <mdspan>
 #include <type_traits>
 #include <concepts>
 #include <cassert>
-
-#include "test_macros.h"
 
 #include "../MinimalElementType.h"
 #include "../CustomTestLayouts.h"

--- a/libcxx/test/std/depr/depr.c.headers/setjmp_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/setjmp_h.compile.pass.cpp
@@ -11,9 +11,12 @@
 // Even though <setjmp.h> is not provided by libc++, we still test that
 // using it with libc++ on the search path will work.
 
-#include <setjmp.h>
-
 #include "test_macros.h"
+
+// MSVC warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable
+TEST_MSVC_DIAGNOSTIC_IGNORED(4611)
+
+#include <setjmp.h>
 
 jmp_buf jb;
 ASSERT_SAME_TYPE(void, decltype(longjmp(jb, 0)));

--- a/libcxx/test/std/depr/depr.numeric.limits.has.denorm/deprecated.verify.cpp
+++ b/libcxx/test/std/depr/depr.numeric.limits.has.denorm/deprecated.verify.cpp
@@ -8,7 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-value
+#include "test_macros.h"
+
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wunused-value")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wunused-value")
 
 #include <limits>
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp
@@ -29,6 +29,12 @@
 // - Let the library manage a buffer, without specifying any size. In this case, the library will use the default
 //   buffer size of 4096 bytes.
 
+#include "test_macros.h"
+
+// MSVC warning C4242: '+=': conversion from 'const _Ty' to 'size_t', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'std::streamsize' to 'size_t', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
+
 #include <cassert>
 #include <codecvt>
 #include <fstream>
@@ -40,7 +46,6 @@
 #include "../types.h"
 #include "assert_macros.h"
 #include "platform_support.h"
-#include "test_macros.h"
 
 template <class BufferPolicy>
 void test_read(BufferPolicy policy, const std::vector<std::streamsize>& payload_sizes) {

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp
@@ -29,6 +29,12 @@
 // - Let the library manage a buffer, without specifying any size. In this case, the library will use the default
 //   buffer size of 4096 bytes.
 
+#include "test_macros.h"
+
+// MSVC warning C4242: '+=': conversion from 'const _Ty' to 'size_t', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'std::streamsize' to 'size_t', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
+
 #include <cassert>
 #include <codecvt>
 #include <fstream>
@@ -40,7 +46,6 @@
 #include "../types.h"
 #include "assert_macros.h"
 #include "platform_support.h"
-#include "test_macros.h"
 
 template <class BufferPolicy>
 void test_write(BufferPolicy policy, const std::vector<std::streamsize>& payload_sizes) {

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
@@ -19,22 +19,22 @@
 // template <RandomAccessIterator Iter, class Distance>
 //   constexpr void advance(Iter& i, Distance n);
 
+#include "test_macros.h"
 
 // TODO: test_iterators.h includes <ranges>, and <ranges> includes <chrono> and <atomic>.
-// Lots of implementation headers under <__chrono/> and <atomic> has signed to unsigned conversion,
-// which will trigger the -Wsign-conversion warning.
-// Once those headers are fixed, enable the -Wsign-conversion for this test by removing
-// <TODO:Remove brackets> below
+// Lots of implementation headers under <__chrono/> and <atomic> have signed to unsigned
+// conversions, which will trigger the -Wsign-conversion warning.
+// Once those headers are fixed, uncomment the following lines:
 
 // Make sure we catch forced conversions to the difference_type if they happen.
-// ADDITIONAL_COMPILE_FLAGS<TODO:Remove brackets>: -Wsign-conversion
+// TEST_CLANG_DIAGNOSTIC_ERROR("-Wsign-conversion")
+// TEST_GCC_DIAGNOSTIC_ERROR("-Wsign-conversion")
 
 #include <iterator>
 #include <cassert>
 #include <cstddef>
 #include <type_traits>
 
-#include "test_macros.h"
 #include "test_iterators.h"
 
 template <class Distance, class It>

--- a/libcxx/test/std/language.support/support.runtime/csetjmp.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/csetjmp.pass.cpp
@@ -8,6 +8,11 @@
 
 // test <csetjmp>
 
+#include "test_macros.h"
+
+// MSVC warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable
+TEST_MSVC_DIAGNOSTIC_IGNORED(4611)
+
 #include <csetjmp>
 #include <cassert>
 #include <type_traits>

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp
@@ -14,6 +14,12 @@
 //            (forward_range<V> || tiny-range<Pattern>)
 // class lazy_split_view;
 
+#include "test_macros.h"
+
+// This is a compile-only test, so "inline function is not defined" warnings are irrelevant.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wundefined-inline")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wundefined-inline")
+
 #include <functional>
 #include <ranges>
 

--- a/libcxx/test/std/ranges/range.utility/range.utility.conv/to.pass.cpp
+++ b/libcxx/test/std/ranges/range.utility/range.utility.conv/to.pass.cpp
@@ -11,6 +11,11 @@
 // template<class C, input_range R, class... Args> requires (!view<C>)
 //   constexpr C to(R&& r, Args&&... args);     // Since C++23
 
+#include "test_macros.h"
+
+// MSVC warning C4244: 'argument': conversion from '_Ty' to 'int', possible loss of data
+TEST_MSVC_DIAGNOSTIC_IGNORED(4244)
+
 #include <ranges>
 
 #include <algorithm>
@@ -19,7 +24,6 @@
 #include <vector>
 #include "container.h"
 #include "test_iterators.h"
-#include "test_macros.h"
 #include "test_range.h"
 
 template <class Container, class Range, class... Args>

--- a/libcxx/test/std/strings/basic.string/string.cons/from_range_deduction.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/from_range_deduction.pass.cpp
@@ -9,8 +9,6 @@
 // <string>
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// To silence a GCC warning-turned-error re. `BadAlloc::value_type`.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-local-typedefs
 
 // template<ranges::input_range R,
 //          class Allocator = allocator<ranges::range_value_t<R>>>
@@ -20,6 +18,12 @@
 //
 // The deduction guide shall not participate in overload resolution if Allocator
 // is a type that does not qualify as an allocator (in addition to the `input_range` concept being satisfied by `R`).
+
+#include "test_macros.h"
+
+// To silence a GCC warning-turned-error re. `BadAlloc::value_type`.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wunused-local-typedefs")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wunused-local-typedefs")
 
 #include <array>
 #include <string>

--- a/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
+++ b/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
@@ -23,12 +23,8 @@
 //
 // void notify_all_at_thread_exit(condition_variable& cond, unique_lock<mutex> lk);
 
-#include "test_macros.h"
-
-// MSVC warning C4583: 'X::cv_': destructor is not implicitly called
-TEST_MSVC_DIAGNOSTIC_IGNORED(4583)
-
 #include "make_test_thread.h"
+#include "test_macros.h"
 
 #include <condition_variable>
 #include <cassert>
@@ -39,12 +35,18 @@ TEST_MSVC_DIAGNOSTIC_IGNORED(4583)
 
 int condition_variable_lock_skipped_counter = 0;
 
+TEST_DIAGNOSTIC_PUSH
+// MSVC warning C4583: 'X::cv_': destructor is not implicitly called
+TEST_MSVC_DIAGNOSTIC_IGNORED(4583)
+
 union X {
     X() : cv_() {}
     ~X() {}
     std::condition_variable cv_;
     unsigned char bytes_[sizeof(std::condition_variable)];
 };
+
+TEST_DIAGNOSTIC_POP
 
 void test()
 {

--- a/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
+++ b/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
@@ -23,8 +23,12 @@
 //
 // void notify_all_at_thread_exit(condition_variable& cond, unique_lock<mutex> lk);
 
-#include "make_test_thread.h"
 #include "test_macros.h"
+
+// MSVC warning C4583: 'X::cv_': destructor is not implicitly called
+TEST_MSVC_DIAGNOSTIC_IGNORED(4583)
+
+#include "make_test_thread.h"
 
 #include <condition_variable>
 #include <cassert>

--- a/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
@@ -10,9 +10,13 @@
 // UNSUPPORTED: libcpp-has-no-experimental-stop_token
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: availability-synchronization_library-missing
-// ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
 
 // jthread& operator=(jthread&&) noexcept;
+
+#include "test_macros.h"
+
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wself-move")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wself-move")
 
 #include <atomic>
 #include <cassert>
@@ -24,7 +28,6 @@
 #include <vector>
 
 #include "make_test_thread.h"
-#include "test_macros.h"
 
 static_assert(std::is_nothrow_move_assignable_v<std::jthread>);
 

--- a/libcxx/test/std/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
@@ -23,9 +23,10 @@
 
 // Ignore warnings about volatile in parameters being deprecated.
 // We know it is, but we still have to test it.
-#if defined(TEST_COMPILER_GCC)
-#   pragma GCC diagnostic ignored "-Wvolatile"
-#endif
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated-volatile")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wvolatile")
+// MSVC warning C5215: a function parameter with a volatile qualified type is deprecated in C++20
+TEST_MSVC_DIAGNOSTIC_IGNORED(5215)
 
 struct wat
 {
@@ -64,9 +65,6 @@ void test_result_of_imp()
     test_invoke_result<T, U>::call();
 #endif
 }
-
-// Do not warn on deprecated uses of 'volatile' below.
-_LIBCPP_SUPPRESS_DEPRECATED_PUSH
 
 int main(int, char**)
 {
@@ -184,5 +182,3 @@ int main(int, char**)
 
   return 0;
 }
-
-_LIBCPP_SUPPRESS_DEPRECATED_POP

--- a/libcxx/test/std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp
@@ -10,13 +10,16 @@
 
 // UNSUPPORTED: c++03, c++11
 
+#include "test_macros.h"
+
 // ignore deprecated volatile return types
-// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated-volatile")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wvolatile")
+// MSVC warning C5216: 'volatile int' a volatile qualified return type is deprecated in C++20
+TEST_MSVC_DIAGNOSTIC_IGNORED(5216)
 
 #include <type_traits>
 #include <utility>
-
-#include "test_macros.h"
 
 template <class T>
 std::add_const_t<T> add_const() {

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03
 
-// Self assignment post-conditions are tested.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
-
 // <memory>
 
 // unique_ptr
@@ -20,11 +17,16 @@
 // test move assignment.  Should only require a MoveConstructible deleter, or if
 //    deleter is a reference, not even that.
 
+#include "test_macros.h"
+
+// Self assignment post-conditions are tested.
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wself-move")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wself-move")
+
 #include <memory>
 #include <utility>
 #include <cassert>
 
-#include "test_macros.h"
 #include "deleter_types.h"
 #include "unique_ptr_test_helper.h"
 

--- a/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
@@ -14,14 +14,15 @@
 
 // Make sure that the implicitly-generated CTAD works.
 
+#include "test_macros.h"
+
 // We make sure that it is not ill-formed, however we still produce a warning for
 // this one because explicit construction from a variant using CTAD is ambiguous
-// (in the sense that the programer intent is not clear).
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
+// (in the sense that the programmer intent is not clear).
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wctad-maybe-unsupported")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wctad-maybe-unsupported")
 
 #include <variant>
-
-#include "test_macros.h"
 
 int main(int, char**) {
   // This is the motivating example from P0739R0

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -104,14 +104,4 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 
 #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
 
-#ifdef __clang__
-#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
-    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
-#  define _LIBCPP_SUPPRESS_DEPRECATED_POP _Pragma("GCC diagnostic pop")
-#else // ^^^ clang / MSVC vvv
-#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
-    __pragma(warning(push)) __pragma(warning(disable : 4996)) __pragma(warning(disable : 5215))
-#  define _LIBCPP_SUPPRESS_DEPRECATED_POP __pragma(warning(pop))
-#endif // __clang__
-
 #endif // SUPPORT_MSVC_STDLIB_FORCE_INCLUDE_H

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -411,24 +411,32 @@ inline void DoNotOptimize(Tp const& value) {
 #  define TEST_CLANG_DIAGNOSTIC_IGNORED(str) _Pragma(TEST_STRINGIZE(clang diagnostic ignored str))
 #  define TEST_GCC_DIAGNOSTIC_IGNORED(str)
 #  define TEST_MSVC_DIAGNOSTIC_IGNORED(num)
+#  define TEST_CLANG_DIAGNOSTIC_ERROR(str) _Pragma(TEST_STRINGIZE(clang diagnostic error str))
+#  define TEST_GCC_DIAGNOSTIC_ERROR(str)
 #elif defined(TEST_COMPILER_GCC)
 #  define TEST_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
 #  define TEST_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
 #  define TEST_CLANG_DIAGNOSTIC_IGNORED(str)
 #  define TEST_GCC_DIAGNOSTIC_IGNORED(str) _Pragma(TEST_STRINGIZE(GCC diagnostic ignored str))
 #  define TEST_MSVC_DIAGNOSTIC_IGNORED(num)
+#  define TEST_CLANG_DIAGNOSTIC_ERROR(str)
+#  define TEST_GCC_DIAGNOSTIC_ERROR(str) _Pragma(TEST_STRINGIZE(GCC diagnostic error str))
 #elif defined(TEST_COMPILER_MSVC)
 #  define TEST_DIAGNOSTIC_PUSH _Pragma("warning(push)")
 #  define TEST_DIAGNOSTIC_POP _Pragma("warning(pop)")
 #  define TEST_CLANG_DIAGNOSTIC_IGNORED(str)
 #  define TEST_GCC_DIAGNOSTIC_IGNORED(str)
 #  define TEST_MSVC_DIAGNOSTIC_IGNORED(num) _Pragma(TEST_STRINGIZE(warning(disable: num)))
+#  define TEST_CLANG_DIAGNOSTIC_ERROR(str)
+#  define TEST_GCC_DIAGNOSTIC_ERROR(str)
 #else
 #  define TEST_DIAGNOSTIC_PUSH
 #  define TEST_DIAGNOSTIC_POP
 #  define TEST_CLANG_DIAGNOSTIC_IGNORED(str)
 #  define TEST_GCC_DIAGNOSTIC_IGNORED(str)
 #  define TEST_MSVC_DIAGNOSTIC_IGNORED(num)
+#  define TEST_CLANG_DIAGNOSTIC_ERROR(str)
+#  define TEST_GCC_DIAGNOSTIC_ERROR(str)
 #endif
 
 #if __has_cpp_attribute(msvc::no_unique_address)

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -13,9 +13,11 @@ import shutil
 import subprocess
 import sys
 
-_isClang = lambda cfg: "__clang__" in compilerMacros(cfg) and "__apple_build_version__" not in compilerMacros(cfg)
+_isAnyClang = lambda cfg: "__clang__" in compilerMacros(cfg)
 _isAppleClang = lambda cfg: "__apple_build_version__" in compilerMacros(cfg)
-_isGCC = lambda cfg: "__GNUC__" in compilerMacros(cfg) and "__clang__" not in compilerMacros(cfg)
+_isAnyGCC = lambda cfg: "__GNUC__" in compilerMacros(cfg)
+_isClang = lambda cfg: _isAnyClang(cfg) and not _isAppleClang(cfg)
+_isGCC = lambda cfg: _isAnyGCC(cfg) and not _isAnyClang(cfg)
 _isMSVC = lambda cfg: "_MSC_VER" in compilerMacros(cfg)
 _msvcVersion = lambda cfg: (int(compilerMacros(cfg)["_MSC_VER"]) // 100, int(compilerMacros(cfg)["_MSC_VER"]) % 100)
 


### PR DESCRIPTION
Found while running libc++'s tests with MSVC's STL.

This is an alternative to my original PR #74974. @cpplearner suggested in https://github.com/llvm/llvm-project/pull/74974#issuecomment-1848928855 that we should follow the precedent of using these macros:

https://github.com/llvm/llvm-project/blob/59f3661bd22766e5d0dea391d4950605b249594a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.rel/three_way.pass.cpp#L19-L23

This PR does so throughout `libcxx/test/std`, converting existing Clang/GCC warning suppressions, and adding MSVC warning suppressions. (As usual, I'm not tooled up to work on `libcxx/test/libcxx`, so a followup PR should change that subdirectory if desired.)

Additional notes:

* Most suppressions are for the entire test, especially when test code triggers warnings in STL algorithms. This is why the usual pattern is to add or move `#include "test_macros.h"` to the top of the test, then ignore diagnostics. However, in a few cases, the MSVC warnings are very specific and I can locally suppress them with push/ignore/pop.
* In `test_macros.h`, I'm adding `TEST_MEOW_DIAGNOSTIC_ERROR` for `libcxx/test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp` to use someday. (Note that `diagnostic error` is intentional; `diagnostic warning` means "treat as a warning even under `-Werror`" as [GCC documents](https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html) and Clang follows.)
* I've also slightly improved the todo comment in `advance.pass.cpp`.
* I've fixed a comment typo in `libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp`.
* I've overhauled how `libcxx/test/std/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp` suppresses "deprecated volatile" warnings.
  + Don't use libc++-internal macros, which `msvc_stdlib_force_include.h` had to simulate.
  + Suppress the warnings in the entire test (as it was already doing for `TEST_COMPILER_GCC`), no need to push/pop.
  + The libc++-internal macro was ignoring the coarse-grained `-Wdeprecated` (plus `-Wdeprecated-declarations` which is irrelevant here, and omitted from `msvc_stdlib_force_include.h`'s simulation). Instead, we can ignore the fine-grained `-Wdeprecated-volatile` for Clang and `-Wvolatile` for GCC. (Interestingly, they both understand `-Wdeprecated`, but `-Wdeprecated-volatile` and `-Wvolatile` are mutually unintelligible, at least as of Clang 17.0.1 and GCC 13.2.)
  + Add a comment for what MSVC warning C5215 is.
  + We don't need to ignore MSVC warning C4996 about `result_of` being deprecated; we've already defined the finer-grained `_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS`.
* `libcxx/test/std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp` was specifying `// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile`. I'm splitting that into `TEST_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated-volatile")` and `TEST_GCC_DIAGNOSTIC_IGNORED("-Wvolatile")`. I'm not sure why GCC wasn't complaining earlier.
* Cleanup (NFC): Refactor how `features.py` defines `_isClang` and `_isGCC`.
  + I wanted to retain this improvement from #74974 even though the other changes have been dropped.