### PR TITLE
[flang] Add genEval to the AbstractConverter

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -280,6 +280,10 @@ public:
   // Miscellaneous
   //===--------------------------------------------------------------------===//
 
+  /// Generate IR for Evaluation \p eval.
+  virtual void genEval(pft::Evaluation &eval,
+                       bool unstructuredContext = true) = 0;
+
   /// Return options controlling lowering behavior.
   const Fortran::lower::LoweringOptions &getLoweringOptions() const {
     return loweringOptions;

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -840,7 +840,7 @@ public:
   }
 
   void genEval(Fortran::lower::pft::Evaluation &eval,
-               bool unstructuredContext) override {
+               bool unstructuredContext) override final {
     genFIR(eval, unstructuredContext);
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -839,6 +839,11 @@ public:
     }
   }
 
+  void genEval(Fortran::lower::pft::Evaluation &eval,
+               bool unstructuredContext) override {
+    genFIR(eval, unstructuredContext);
+  }
+
   //===--------------------------------------------------------------------===//
   // Utility methods
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
There was some discussion on discourse[1] about allowing call to FIR generation functions from other part of lowering belonging to OpenMP.

This solution exposes a simple `genEval` member function on the `AbstractConverter` so that IR generation for PFT Evaluation objects can be called from lowering outside of the FirConverter but not exposing it.

[1] https://discourse.llvm.org/t/openmp-lowering-from-pft-to-fir/75263