### PR TITLE
[clang-format] Fix parsing of `operator<() {}`

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -23,9 +23,6 @@
 
 namespace clang {
 namespace format {
-static bool isFunctionDeclarationName(bool IsCpp, const FormatToken &Current,
-                                      const AnnotatedLine &Line,
-                                      FormatToken *&ClosingParen);
 
 static bool mustBreakAfterAttributes(const FormatToken &Tok,
                                      const FormatStyle &Style) {
@@ -167,10 +164,8 @@ private:
                TT_OverloadedOperatorLParen))) {
         return false;
       }
-      FormatToken *ClosingParen = nullptr;
       if (Previous.Previous->is(tok::kw_operator) &&
-          isFunctionDeclarationName(Style.isCpp(), *Previous.Previous, Line,
-                                    ClosingParen)) {
+          CurrentToken->is(tok::l_paren)) {
         return false;
       }
     }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -23,6 +23,9 @@
 
 namespace clang {
 namespace format {
+static bool isFunctionDeclarationName(bool IsCpp, const FormatToken &Current,
+                                      const AnnotatedLine &Line,
+                                      FormatToken *&ClosingParen);
 
 static bool mustBreakAfterAttributes(const FormatToken &Tok,
                                      const FormatStyle &Style) {
@@ -162,6 +165,12 @@ private:
           (!Previous.Previous->MatchingParen ||
            Previous.Previous->MatchingParen->isNot(
                TT_OverloadedOperatorLParen))) {
+        return false;
+      }
+      FormatToken *ClosingParen = nullptr;
+      if (Previous.Previous->is(tok::kw_operator) &&
+          isFunctionDeclarationName(Style.isCpp(), *Previous.Previous, Line,
+                                    ClosingParen)) {
         return false;
       }
     }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -11727,13 +11727,6 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                "  void func(type &a) { a & member; }\n"
                "  anotherType &member;\n"
                "}");
-
-  Style.ReferenceAlignment = FormatStyle::RAS_Left;
-  verifyFormat("class Foo {\n"
-               "  void operator<(Foo&) {}\n"
-               "  Foo& f;\n"
-               "};",
-               Style);
 }
 
 TEST_F(FormatTest, UnderstandsAttributes) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -11727,6 +11727,13 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                "  void func(type &a) { a & member; }\n"
                "  anotherType &member;\n"
                "}");
+
+  Style.ReferenceAlignment = FormatStyle::RAS_Left;
+  verifyFormat("class Foo {\n"
+               "  void operator<(Foo&) {}\n"
+               "  Foo& f;\n"
+               "};",
+               Style);
 }
 
 TEST_F(FormatTest, UnderstandsAttributes) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -300,15 +300,15 @@ TEST_F(TokenAnnotatorTest, UnderstandsUsesOfStarAndAmp) {
   EXPECT_TOKEN(Tokens[3], tok::star, TT_PointerOrReference);
 
   Tokens = annotate("class Foo {\n"
-                    "void operator<(Foo&) {}\n"
-                    "Foo& f;\n"
+                    "  void operator<() {}\n"
+                    "  Foo &f;\n"
                     "};");
-  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 17u) << Tokens;
   EXPECT_TOKEN(Tokens[4], tok::kw_operator, TT_FunctionDeclarationName);
   EXPECT_TOKEN(Tokens[5], tok::less, TT_OverloadedOperator);
   EXPECT_TOKEN(Tokens[6], tok::l_paren, TT_OverloadedOperatorLParen);
-  EXPECT_TOKEN(Tokens[10], tok::l_brace, TT_FunctionLBrace);
-  EXPECT_TOKEN(Tokens[13], tok::amp, TT_PointerOrReference);
+  EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_FunctionLBrace);
+  EXPECT_TOKEN(Tokens[11], tok::amp, TT_PointerOrReference);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsUsesOfPlusAndMinus) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -298,6 +298,17 @@ TEST_F(TokenAnnotatorTest, UnderstandsUsesOfStarAndAmp) {
   ASSERT_EQ(Tokens.size(), 12u) << Tokens;
   EXPECT_TOKEN(Tokens[2], tok::identifier, TT_TypeName);
   EXPECT_TOKEN(Tokens[3], tok::star, TT_PointerOrReference);
+
+  Tokens = annotate("class Foo {\n"
+                    "void operator<(Foo&) {}\n"
+                    "Foo& f;\n"
+                    "};");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[4], tok::kw_operator, TT_FunctionDeclarationName);
+  EXPECT_TOKEN(Tokens[5], tok::less, TT_OverloadedOperator);
+  EXPECT_TOKEN(Tokens[6], tok::l_paren, TT_OverloadedOperatorLParen);
+  EXPECT_TOKEN(Tokens[10], tok::l_brace, TT_FunctionLBrace);
+  EXPECT_TOKEN(Tokens[13], tok::amp, TT_PointerOrReference);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsUsesOfPlusAndMinus) {


### PR DESCRIPTION
Fixes llvm/llvm-project#74876.

During the parsing of `operator<(Foo&) {}`, there was no handling for the operator<, so it called `consumeToken()` again, causing the `AnnotationParser::Scopes` to have one additional left brace each time it tried to parse it, leaving it unbalanced.
Because of this, in the following code:
```cpp
class Foo {
  void operator<(Foo&) {}
  Foo& f;
};
```
The `&` in the reference member, was being interpreted as `TT_BinaryOperator` instead of  `TT_PointerOrReference`.