### PR TITLE
[Clang] Allow the use of consecutive brackets as an extension in C++03

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -815,8 +815,8 @@ def err_unexpected_template_in_destructor_name : Error<
   "'template' keyword not permitted in destructor name">;
 def err_unexpected_template_after_using : Error<
   "'template' keyword not permitted after 'using' keyword">;
-def err_two_right_angle_brackets_need_space : Error<
-  "a space is required between consecutive right angle brackets (use '> >')">;
+def err_two_right_angle_brackets_need_space : ExtWarn<
+  "two consecutive right angle brackets without a space is a C++11 extension">, InGroup<CXX11>;
 def err_right_angle_bracket_equal_needs_space : Error<
   "a space is required between a right angle bracket and an equals sign "
   "(use '> =')">;

--- a/clang/test/CXX/temp/temp.param/p15.cpp
+++ b/clang/test/CXX/temp/temp.param/p15.cpp
@@ -3,10 +3,10 @@ template<typename T> struct X;
 template<int I> struct Y;
 
 X<X<int> > *x1;
-X<X<int>> *x2; // expected-error{{a space is required between consecutive right angle brackets (use '> >')}}
+X<X<int>> *x2; // expected-warning{{two consecutive right angle brackets without a space is a C++11 extension}}
 
-X<X<X<X<int>> // expected-error{{a space is required between consecutive right angle brackets (use '> >')}}
-    >> *x3;   // expected-error{{a space is required between consecutive right angle brackets (use '> >')}}
+X<X<X<X<int>> // expected-warning{{two consecutive right angle brackets without a space is a C++11 extension}}
+    >> *x3;   // expected-warning{{two consecutive right angle brackets without a space is a C++11 extension}}
 
 Y<(1 >> 2)> *y1;
 Y<1 >> 2> *y2; // expected-warning{{use of right-shift operator ('>>') in template argument will require parentheses in C++11}}

--- a/clang/test/FixIt/fixit.cpp
+++ b/clang/test/FixIt/fixit.cpp
@@ -296,10 +296,10 @@ namespace greatergreater {
   void g() {
     int p = 0;
     (void)(t<int>==p); // expected-error {{use '> ='}}
-    (void)(t<int>>=p); // expected-error {{use '> >'}}
+    (void)(t<int>>=p); // expected-warning {{consecutive right angle brackets}}
 #if __cplusplus < 201103L
-    (void)(t<S<int>>>=p); // expected-error {{use '> >'}}
-    (Shr)t<S<int>>>>=p; // expected-error {{use '> >'}}
+    (void)(t<S<int>>>=p); // expected-warning {{consecutive right angle brackets}}
+    (Shr)t<S<int>>>>=p; // expected-warning {{consecutive right angle brackets}}
 #endif
 
     // FIXME: We correct this to 't<int> > >= p;' not 't<int> >>= p;'

--- a/clang/test/Misc/diag-greatergreater.cpp
+++ b/clang/test/Misc/diag-greatergreater.cpp
@@ -23,7 +23,7 @@ template<int> int V;
 // Here, we split the >>= token into a > followed by a >=.
 // Then we split the >= token into a > followed by an =,
 // which we merge with the other = to form an ==.
-// CHECK:      error: a space is required
+// CHECK:      warning: two consecutive right angle brackets
 // CHECK-NEXT: int k = V<C<int>>==0;
 // CHECK-NEXT:                ^~{{$}}
 // CHECK-NEXT:                > >{{$}}

--- a/clang/test/Parser/cxx-template-argument.cpp
+++ b/clang/test/Parser/cxx-template-argument.cpp
@@ -20,7 +20,7 @@ S<bool(2 > 1)> s;
 namespace greatergreater {
   template<typename T> struct S { S(); S(T); };
   void f(S<int>=0); // expected-error {{a space is required between a right angle bracket and an equals sign (use '> =')}}
-  void f(S<S<int>>=S<int>()); // expected-error {{use '> >'}} expected-error {{use '> ='}}
+  void f(S<S<int>>=S<int>()); // expected-warning {{two consecutive right angle brackets}} expected-error {{use '> ='}}
   template<typename T> void t();
   struct R {
     friend void operator==(void (*)(), R) {}
@@ -28,12 +28,12 @@ namespace greatergreater {
   };
   void g() {
     (void)(&t<int>==R()); // expected-error {{use '> ='}}
-    (void)(&t<int>>=R()); // expected-error {{use '> >'}}
+    (void)(&t<int>>=R()); // expected-warning {{two consecutive right angle brackets}}
     (void)(&t<S<int>>>=R());
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
-    (void)(&t<S<int>>==R()); // expected-error {{use '> >'}} expected-error {{use '> ='}}
+    (void)(&t<S<int>>==R()); // expected-warning {{two consecutive right angle brackets}} expected-error {{use '> ='}}
   }
 }
 
@@ -83,14 +83,14 @@ namespace pr16225add {
   template<class T1, typename T2> struct foo5 :
     UnknownBase<T1,T2,ABC<T2,T1>> // expected-error {{no template named 'UnknownBase'}}
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
   { };
 
   template<class T1, typename T2> struct foo6 :
     UnknownBase<T1,ABC<T2,T1>>, // expected-error {{no template named 'UnknownBase'}}
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
     Known<T1>  // expected-error {{too few template arguments for class template 'Known'}}
   { };
@@ -102,21 +102,21 @@ namespace pr16225add {
   template<class T1, typename T2> struct foo8 :
     UnknownBase<X<int,int>,X<int,int>> // expected-error {{no template named 'UnknownBase'}}
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
   { };
 
   template<class T1, typename T2> struct foo9 :
     UnknownBase<Known<int,int>,X<int,int>> // expected-error {{no template named 'UnknownBase'}}
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
   { };
 
   template<class T1, typename T2> struct foo10 :
     UnknownBase<Known<int,int>,X<int,X<int,int>>> // expected-error {{no template named 'UnknownBase'}}
 #if __cplusplus <= 199711L
-    // expected-error@-2 {{use '> >'}}
+    // expected-warning@-2 {{two consecutive right angle brackets}}
 #endif
   { };
 


### PR DESCRIPTION
This implements https://discourse.llvm.org/t/rfc-c-03-extension-allow-consecutive-in-template-code-for-known-bad-code/75626.