### PR TITLE
[X86] Add ABI handling for __float128 to match with GCC

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -906,7 +906,7 @@ X86 Support
   * Support intrinsic of ``_uwrmsr``.
 - Support ISA of ``AVX10.1``.
 - ``-march=pantherlake`` and ``-march=clearwaterforest`` are now supported.
-- Added ABI handling for ``fp128``.
+- Added ABI handling for ``__float128``.
 
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -906,6 +906,7 @@ X86 Support
   * Support intrinsic of ``_uwrmsr``.
 - Support ISA of ``AVX10.1``.
 - ``-march=pantherlake`` and ``-march=clearwaterforest`` are now supported.
+- Added ABI handling for ``fp128``.
 
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -906,7 +906,7 @@ X86 Support
   * Support intrinsic of ``_uwrmsr``.
 - Support ISA of ``AVX10.1``.
 - ``-march=pantherlake`` and ``-march=clearwaterforest`` are now supported.
-- Added ABI handling for ``__float128``.
+- Added ABI handling for ``__float128`` to match with GCC.
 
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -1795,9 +1795,11 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase, Class &Lo,
     } else if (k >= BuiltinType::Bool && k <= BuiltinType::LongLong) {
       Current = Integer;
     } else if (k == BuiltinType::Float || k == BuiltinType::Double ||
-               k == BuiltinType::Float16 || k == BuiltinType::BFloat16 ||
-               k == BuiltinType::Float128) {
+               k == BuiltinType::Float16 || k == BuiltinType::BFloat16) {
       Current = SSE;
+    } else if (k == BuiltinType::Float128) {
+      Lo = SSE;
+      Hi = SSEUp;
     } else if (k == BuiltinType::LongDouble) {
       const llvm::fltSemantics *LDF = &getTarget().getLongDoubleFormat();
       if (LDF == &llvm::APFloat::IEEEquad()) {

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -1795,7 +1795,8 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase, Class &Lo,
     } else if (k >= BuiltinType::Bool && k <= BuiltinType::LongLong) {
       Current = Integer;
     } else if (k == BuiltinType::Float || k == BuiltinType::Double ||
-               k == BuiltinType::Float16 || k == BuiltinType::BFloat16) {
+               k == BuiltinType::Float16 || k == BuiltinType::BFloat16 ||
+               k == BuiltinType::Float128) {
       Current = SSE;
     } else if (k == BuiltinType::LongDouble) {
       const llvm::fltSemantics *LDF = &getTarget().getLongDoubleFormat();

--- a/clang/test/CodeGen/X86/fp128-abi.c
+++ b/clang/test/CodeGen/X86/fp128-abi.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-linux -emit-llvm  -target-feature +sse2 < %s | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm  -target-feature -sse2 < %s | FileCheck %s --check-prefixes=CHECK
 
 struct st1 {
   __float128 a;

--- a/clang/test/CodeGen/X86/fp128-abi.c
+++ b/clang/test/CodeGen/X86/fp128-abi.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm  -target-feature +sse2 < %s | FileCheck %s --check-prefixes=CHECK
+
+struct st1 {
+  __float128 a;
+};
+
+struct st1 h1(__float128 a) {
+  // CHECK: define{{.*}}fp128 @h1(fp128
+  struct st1 x;
+  x.a = a;
+  return x;
+}
+
+__float128 h2(struct st1 x) {
+  // CHECK: define{{.*}}fp128 @h2(fp128
+  return x.a;
+}
+
+struct st2 {
+  __float128 a;
+  int b;
+};
+
+struct st2 h3(__float128 a, int b) {
+  // CHECK: define{{.*}}void @h3(ptr {{.*}}sret(%struct.st2)
+  struct st2 x;
+  x.a = a;
+  x.b = b;
+  return x;
+}
+
+__float128 h4(struct st2 x) {
+  // CHECK: define{{.*}}fp128 @h4(ptr {{.*}}byval(%struct.st2)
+  return x.a;
+}


### PR DESCRIPTION
Fixes #74601