### PR TITLE
[libc][NFC] Remove remaining specializations in FloatProperties

### DIFF
--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -90,13 +90,12 @@ template <typename T, size_t count> static constexpr T mask_trailing_ones() {
   return count == 0 ? 0 : ((~T(0)) >> (t_bits - count));
 }
 
-// Derives more properties from 'FPBaseProperties' above.
-// This class serves as a halfway point between 'FPBaseProperties' and
-// 'FPProperties' below.
+} // namespace internal
+
 template <FPType fp_type>
-struct FPCommonProperties : private FPBaseProperties<fp_type> {
+struct FPProperties : public internal::FPBaseProperties<fp_type> {
 private:
-  using UP = FPBaseProperties<fp_type>;
+  using UP = internal::FPBaseProperties<fp_type>;
   using UP::EXP_BITS;
   using UP::SIG_BITS;
   using UP::TOTAL_BITS;
@@ -123,15 +122,15 @@ private:
 
   // Masks
   LIBC_INLINE_VAR static constexpr UIntType SIG_MASK =
-      mask_trailing_ones<UIntType, SIG_BITS>() << SIG_MASK_SHIFT;
+      internal::mask_trailing_ones<UIntType, SIG_BITS>() << SIG_MASK_SHIFT;
   LIBC_INLINE_VAR static constexpr UIntType EXP_MASK =
-      mask_trailing_ones<UIntType, EXP_BITS>() << EXP_MASK_SHIFT;
+      internal::mask_trailing_ones<UIntType, EXP_BITS>() << EXP_MASK_SHIFT;
   // Trailing underscore on SIGN_MASK_ is temporary - it will be removed
   // once we can replace the public part below with the private one.
   LIBC_INLINE_VAR static constexpr UIntType SIGN_MASK_ =
-      mask_trailing_ones<UIntType, SIGN_BITS>() << SIGN_MASK_SHIFT;
+      internal::mask_trailing_ones<UIntType, SIGN_BITS>() << SIGN_MASK_SHIFT;
   LIBC_INLINE_VAR static constexpr UIntType FP_MASK =
-      mask_trailing_ones<UIntType, TOTAL_BITS>();
+      internal::mask_trailing_ones<UIntType, TOTAL_BITS>();
   static_assert((SIG_MASK & EXP_MASK & SIGN_MASK_) == 0, "masks disjoint");
   static_assert((SIG_MASK | EXP_MASK | SIGN_MASK_) == FP_MASK, "masks cover");
 
@@ -140,19 +139,19 @@ private:
   }
 
   LIBC_INLINE_VAR static constexpr UIntType QNAN_MASK =
-      UP::ENCODING == FPEncoding::X86_ExtendedPrecision
+      UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision
           ? bit_at(SIG_BITS - 1) | bit_at(SIG_BITS - 2) // 0b1100...
           : bit_at(SIG_BITS - 1);                       // 0b1000...
 
   LIBC_INLINE_VAR static constexpr UIntType SNAN_MASK =
-      UP::ENCODING == FPEncoding::X86_ExtendedPrecision
+      UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision
           ? bit_at(SIG_BITS - 1) | bit_at(SIG_BITS - 3) // 0b1010...
           : bit_at(SIG_BITS - 2);                       // 0b0100...
 
   // The number of bits after the decimal dot when the number if in normal form.
   LIBC_INLINE_VAR static constexpr int FRACTION_BITS =
-      UP::ENCODING == FPEncoding::X86_ExtendedPrecision ? SIG_BITS - 1
-                                                        : SIG_BITS;
+      UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision ? SIG_BITS - 1
+                                                                  : SIG_BITS;
 
 public:
   // Public facing API to keep the change local to this file.
@@ -163,7 +162,7 @@ public:
   LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_PRECISION =
       MANTISSA_WIDTH + 1;
   LIBC_INLINE_VAR static constexpr BitsType MANTISSA_MASK =
-      mask_trailing_ones<UIntType, MANTISSA_WIDTH>();
+      internal::mask_trailing_ones<UIntType, MANTISSA_WIDTH>();
   LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = EXP_BITS;
   LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_BIAS =
       static_cast<uint32_t>(EXP_BIAS);
@@ -175,29 +174,6 @@ public:
   //   QuietNaNMask & bits(x) != 0
   // Else, it is a signalling NAN.
   static constexpr BitsType QUIET_NAN_MASK = QNAN_MASK;
-};
-
-} // namespace internal
-
-template <FPType fp_type>
-struct FPProperties : public internal::FPCommonProperties<fp_type> {};
-
-// ----------------
-// Work In Progress
-// ----------------
-// The 'FPProperties' template specializations below are being slowly replaced
-// with properties from 'FPCommonProperties' above. Once specializations are
-// empty, 'FPProperties' declaration can be fully replace with
-// 'FPCommonProperties' implementation.
-
-// Properties for numbers represented in 80 bits long double on non-Windows x86
-// platforms.
-template <>
-struct FPProperties<FPType::X86_Binary80>
-    : public internal::FPCommonProperties<FPType::X86_Binary80> {
-  // The x86 80 bit float represents the leading digit of the mantissa
-  // explicitly. This is the mask for that bit.
-  static constexpr BitsType EXPLICIT_BIT_MASK = (BitsType(1) << MANTISSA_WIDTH);
 };
 
 //-----------------------------------------------------------------------------

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -68,7 +68,11 @@ template <> struct FPBits<long double> {
   }
 
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() const {
-    return bits & (FloatProp::MANTISSA_MASK | FloatProp::EXPLICIT_BIT_MASK);
+    // The x86 80 bit float represents the leading digit of the mantissa
+    // explicitly. This is the mask for that bit.
+    constexpr UIntType EXPLICIT_BIT_MASK =
+        (UIntType(1) << FloatProp::MANTISSA_WIDTH);
+    return bits & (FloatProp::MANTISSA_MASK | EXPLICIT_BIT_MASK);
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {


### PR DESCRIPTION
This patch sinks `EXPLICIT_BIT_MASK` into `get_explicit_mantissa` - the only function using it. Then it sinks the content of `FPCommonProperties` directly into `FPProperties`.
