### PR TITLE
[LLD] [COFF] Parse all /debug: options, like /opt:

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1616,37 +1616,48 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
 
   // Handle /debug
   bool shouldCreatePDB = false;
-  if (auto *arg = args.getLastArg(OPT_debug, OPT_debug_opt)) {
-    std::string s;
+  for (auto *arg : args.filtered(OPT_debug, OPT_debug_opt)) {
+    std::string str;
     if (arg->getOption().getID() == OPT_debug)
-      s = "full";
+      str = "full";
     else
-      s = StringRef(arg->getValue()).lower();
-    if (s == "fastlink") {
-      warn("/debug:fastlink unsupported; using /debug:full");
-      s = "full";
-    }
-    if (s == "none") {
-    } else if (s == "full" || s == "ghash" || s == "noghash") {
-      config->debug = true;
-      config->incremental = true;
-      config->includeDwarfChunks = true;
-      if (s == "full" || s == "ghash")
-        config->debugGHashes = true;
-      shouldCreatePDB = true;
-      doGC = false;
-    } else if (s == "dwarf") {
-      config->debug = true;
-      config->incremental = true;
-      config->includeDwarfChunks = true;
-      config->writeSymtab = true;
-      config->warnLongSectionNames = false;
-      doGC = false;
-    } else if (s == "symtab") {
-      config->writeSymtab = true;
-      doGC = false;
-    } else {
-      error("/debug: unknown option: " + s);
+      str = StringRef(arg->getValue()).lower();
+    SmallVector<StringRef, 1> vec;
+    StringRef(str).split(vec, ',');
+    for (StringRef s : vec) {
+      if (s == "fastlink") {
+        warn("/debug:fastlink unsupported; using /debug:full");
+        s = "full";
+      }
+      if (s == "none") {
+        config->debug = false;
+        config->incremental = false;
+        config->includeDwarfChunks = false;
+        config->debugGHashes = false;
+        config->writeSymtab = false;
+        shouldCreatePDB = false;
+        doGC = true;
+      } else if (s == "full" || s == "ghash" || s == "noghash") {
+        config->debug = true;
+        config->incremental = true;
+        config->includeDwarfChunks = true;
+        if (s == "full" || s == "ghash")
+          config->debugGHashes = true;
+        shouldCreatePDB = true;
+        doGC = false;
+      } else if (s == "dwarf") {
+        config->debug = true;
+        config->incremental = true;
+        config->includeDwarfChunks = true;
+        config->writeSymtab = true;
+        config->warnLongSectionNames = false;
+        doGC = false;
+      } else if (s == "symtab") {
+        config->writeSymtab = true;
+        doGC = false;
+      } else {
+        error("/debug: unknown option: " + s);
+      }
     }
   }
 

--- a/lld/test/COFF/debug-dwarf.test
+++ b/lld/test/COFF/debug-dwarf.test
@@ -17,3 +17,11 @@
 # RUN: rm -f %t.pdb
 # RUN: lld-link /debug:dwarf /pdb:%t.pdb /entry:main /out:%t.exe %p/Inputs/ret42.obj
 # RUN: not ls %t.pdb
+
+# Check that /debug /debug:dwarf or /debug:full,dwarf creates %t.pdb.
+# RUN: rm -f %t.pdb
+# RUN: lld-link /debug /debug:dwarf /entry:main /out:%t.exe %p/Inputs/ret42.obj
+# RUN: ls %t.pdb
+# RUN: rm -f %t.pdb
+# RUN: lld-link /debug:full,dwarf /entry:main /out:%t.exe %p/Inputs/ret42.obj
+# RUN: ls %t.pdb

--- a/lld/test/COFF/symtab.test
+++ b/lld/test/COFF/symtab.test
@@ -5,6 +5,8 @@
 # RUN: llvm-readobj --symbols %t.exe | FileCheck %s
 # RUN: lld-link /debug:symtab /opt:noref /out:%t.exe /entry:main %t.obj %p/Inputs/std64.lib
 # RUN: llvm-readobj --symbols %t.exe | FileCheck %s
+# RUN: lld-link /debug:full,symtab /opt:noref /out:%t.exe /entry:main %t.obj %p/Inputs/std64.lib
+# RUN: llvm-readobj --symbols %t.exe | FileCheck %s
 
 # RUN: lld-link /debug /out:%t.exe /entry:main %t.obj %p/Inputs/std64.lib
 # RUN: llvm-readobj --symbols %t.exe | FileCheck -check-prefix=NO %s


### PR DESCRIPTION
Most option handling is like it was before; the last /debug: option takes effect.

However, the options /debug:dwarf or /debug:symtab don't reset all flags into the specific behaviour they chose before - e.g. if an earlier option enables writing a PDB, a later /debug:dwarf or /debug:symtab doesn't disable that. This allows combining these options with options for controlling PDB writing, for finetuning what is done.
