### PR TITLE
[LLD] [MinGW] Respect the -S/-s options when writing PDB files

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -297,6 +297,11 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     StringRef v = a->getValue();
     if (!v.empty())
       add("-pdb:" + v);
+    if (args.hasArg(OPT_strip_all)) {
+      add("-debug:nodwarf,nosymtab");
+    } else if (args.hasArg(OPT_strip_debug)) {
+      add("-debug:nodwarf,symtab");
+    }
   } else if (args.hasArg(OPT_strip_debug)) {
     add("-debug:symtab");
   } else if (!args.hasArg(OPT_strip_all)) {

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -138,11 +138,18 @@ STRIP-DEBUG-NOT: -debug:dwarf
 RUN: ld.lld -### -m i386pep foo.o -pdb out.pdb 2>&1 | FileCheck -check-prefix PDB %s
 RUN: ld.lld -### -m i386pep foo.o -pdb=out.pdb 2>&1 | FileCheck -check-prefix PDB %s
 PDB: -debug -pdb:out.pdb
-PDB-NOT: -debug:dwarf
+PDB-NOT: -debug:
 
 RUN: ld.lld -### -m i386pep foo.o -pdb= 2>&1 | FileCheck -check-prefix PDB-DEFAULT %s
 PDB-DEFAULT: -debug
 PDB-DEFAULT-NOT: -pdb:{{.*}}
+PDB-DEFAULT-NOT: -debug:
+
+RUN: ld.lld -### -m i386pep foo.o -pdb= -S 2>&1 | FileCheck -check-prefix PDB-NODWARF %s
+PDB-NODWARF: -debug -debug:nodwarf,symtab
+
+RUN: ld.lld -### -m i386pep foo.o -pdb= -s 2>&1 | FileCheck -check-prefix PDB-NODWARF-NOSYMTAB %s
+PDB-NODWARF-NOSYMTAB: -debug -debug:nodwarf,nosymtab
 
 RUN: ld.lld -### -m i386pep foo.o --large-address-aware 2>&1 | FileCheck -check-prefix LARGE-ADDRESS-AWARE %s
 LARGE-ADDRESS-AWARE: -largeaddressaware


### PR DESCRIPTION
This allows avoiding including some stray DWARF sections (e.g. from toolchain provided files), when writing a PDB file.

While that probably could be considered reasonable default behaviour, PDB writing and including DWARF sections are two entirely orthogonal concepts, and GNU ld (which can generate PDB files these days) does include DWARF unless -S/-s is passed, when creating a PDB.
