### PR TITLE
[lld][NFC] Silence -Wuninitialized GCC warnings.

### DIFF
--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -560,7 +560,7 @@ void Writer::createECCodeMap() {
   codeMap.clear();
 
   std::optional<chpe_range_type> lastType;
-  Chunk *first, *last;
+  Chunk *first = nullptr, *last = nullptr;
 
   auto closeRange = [&]() {
     if (lastType) {


### PR DESCRIPTION
A workaround for warnings reported in #69101. Use of those variables is guarded by lastType, so I don't think that they are actually used uninitialized and I don't see the warning on GCC 12.3.