### PR TITLE
[libc][NFC] Implement `FPBits` in terms of `FloatProperties` to reduce clutter

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -36,71 +36,74 @@ template <typename T> struct ExponentWidth {
 // floating numbers. On x86 platforms however, the 'long double' type maps to
 // an x87 floating point format. This format is an IEEE 754 extension format.
 // It is handled as an explicit specialization of this class.
-template <typename T> struct FPBits {
+template <typename T> struct FPBits : private FloatProperties<T> {
   static_assert(cpp::is_floating_point_v<T>,
                 "FPBits instantiated with invalid type.");
+  using typename FloatProperties<T>::UIntType;
+  using FloatProperties<T>::BIT_WIDTH;
+  using FloatProperties<T>::EXP_MANT_MASK;
+  using FloatProperties<T>::EXPONENT_MASK;
+  using FloatProperties<T>::EXPONENT_BIAS;
+  using FloatProperties<T>::EXPONENT_WIDTH;
+  using FloatProperties<T>::MANTISSA_MASK;
+  using FloatProperties<T>::MANTISSA_WIDTH;
+  using FloatProperties<T>::QUIET_NAN_MASK;
+  using FloatProperties<T>::SIGN_MASK;
 
   // Reinterpreting bits as an integer value and interpreting the bits of an
   // integer value as a floating point value is used in tests. So, a convenient
   // type is provided for such reinterpretations.
-  using FloatProp = FloatProperties<T>;
-  using UIntType = typename FloatProp::UIntType;
-
   UIntType bits;
 
   LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
-    mantVal &= (FloatProp::MANTISSA_MASK);
-    bits &= ~(FloatProp::MANTISSA_MASK);
+    mantVal &= MANTISSA_MASK;
+    bits &= ~MANTISSA_MASK;
     bits |= mantVal;
   }
 
   LIBC_INLINE constexpr UIntType get_mantissa() const {
-    return bits & FloatProp::MANTISSA_MASK;
+    return bits & MANTISSA_MASK;
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal = (expVal << (FloatProp::MANTISSA_WIDTH)) & FloatProp::EXPONENT_MASK;
-    bits &= ~(FloatProp::EXPONENT_MASK);
+    expVal = (expVal << MANTISSA_WIDTH) & EXPONENT_MASK;
+    bits &= ~EXPONENT_MASK;
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & FloatProp::EXPONENT_MASK) >>
-                    (FloatProp::MANTISSA_WIDTH));
+    return uint16_t((bits & EXPONENT_MASK) >> MANTISSA_WIDTH);
   }
 
   // The function return mantissa with the implicit bit set iff the current
   // value is a valid normal number.
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() {
     return ((get_biased_exponent() > 0 && !is_inf_or_nan())
-                ? (FloatProp::MANTISSA_MASK + 1)
+                ? (MANTISSA_MASK + 1)
                 : 0) |
-           (FloatProp::MANTISSA_MASK & bits);
+           (MANTISSA_MASK & bits);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {
-    bits |= FloatProp::SIGN_MASK;
+    bits |= SIGN_MASK;
     if (!signVal)
-      bits -= FloatProp::SIGN_MASK;
+      bits -= SIGN_MASK;
   }
 
   LIBC_INLINE constexpr bool get_sign() const {
-    return (bits & FloatProp::SIGN_MASK) != 0;
+    return (bits & SIGN_MASK) != 0;
   }
 
   static_assert(sizeof(T) == sizeof(UIntType),
                 "Data type and integral representation have different sizes.");
 
-  static constexpr int EXPONENT_BIAS = (1 << (ExponentWidth<T>::VALUE - 1)) - 1;
-  static constexpr int MAX_EXPONENT = (1 << ExponentWidth<T>::VALUE) - 1;
+  static constexpr int MAX_EXPONENT = (1 << EXPONENT_WIDTH) - 1;
 
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
-  static constexpr UIntType MAX_SUBNORMAL =
-      (UIntType(1) << MantissaWidth<T>::VALUE) - 1;
-  static constexpr UIntType MIN_NORMAL =
-      (UIntType(1) << MantissaWidth<T>::VALUE);
+  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << MANTISSA_WIDTH) - 1;
+  static constexpr UIntType MIN_NORMAL = (UIntType(1) << MANTISSA_WIDTH);
   static constexpr UIntType MAX_NORMAL =
-      ((UIntType(MAX_EXPONENT) - 1) << MantissaWidth<T>::VALUE) | MAX_SUBNORMAL;
+      ((UIntType(MAX_EXPONENT) - 1) << MANTISSA_WIDTH) | MAX_SUBNORMAL;
 
   // We don't want accidental type promotions/conversions, so we require exact
   // type match.
@@ -151,32 +154,29 @@ template <typename T> struct FPBits {
   }
 
   LIBC_INLINE constexpr bool is_inf() const {
-    return (bits & FloatProp::EXP_MANT_MASK) == FloatProp::EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) == EXPONENT_MASK;
   }
 
   LIBC_INLINE constexpr bool is_nan() const {
-    return (bits & FloatProp::EXP_MANT_MASK) > FloatProp::EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) > EXPONENT_MASK;
   }
 
   LIBC_INLINE constexpr bool is_quiet_nan() const {
-    return (bits & FloatProp::EXP_MANT_MASK) ==
-           (FloatProp::EXPONENT_MASK | FloatProp::QUIET_NAN_MASK);
+    return (bits & EXP_MANT_MASK) == (EXPONENT_MASK | QUIET_NAN_MASK);
   }
 
   LIBC_INLINE constexpr bool is_inf_or_nan() const {
-    return (bits & FloatProp::EXPONENT_MASK) == FloatProp::EXPONENT_MASK;
+    return (bits & EXPONENT_MASK) == EXPONENT_MASK;
   }
 
   LIBC_INLINE static constexpr T zero(bool sign = false) {
-    return FPBits(sign ? FloatProp::SIGN_MASK : UIntType(0)).get_val();
+    return FPBits(sign ? SIGN_MASK : UIntType(0)).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_zero() { return zero(true); }
 
   LIBC_INLINE static constexpr T inf(bool sign = false) {
-    return FPBits((sign ? FloatProp::SIGN_MASK : UIntType(0)) |
-                  FloatProp::EXPONENT_MASK)
-        .get_val();
+    return FPBits((sign ? SIGN_MASK : UIntType(0)) | EXPONENT_MASK).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_inf() { return inf(true); }
@@ -204,7 +204,7 @@ template <typename T> struct FPBits {
   }
 
   LIBC_INLINE static constexpr T build_quiet_nan(UIntType v) {
-    return build_nan(FloatProp::QUIET_NAN_MASK | v);
+    return build_nan(QUIET_NAN_MASK | v);
   }
 
   // The function convert integer number and unbiased exponent to proper float
@@ -220,7 +220,7 @@ template <typename T> struct FPBits {
   LIBC_INLINE static constexpr FPBits<T> make_value(UIntType number, int ep) {
     FPBits<T> result;
     // offset: +1 for sign, but -1 for implicit first bit
-    int lz = cpp::countl_zero(number) - FloatProp::EXPONENT_WIDTH;
+    int lz = cpp::countl_zero(number) - EXPONENT_WIDTH;
     number <<= lz;
     ep -= lz;
 

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -104,14 +104,14 @@ template <> struct DoubleLength<uint64_t> {
 //
 template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T hypot(T x, T y) {
-  using FPBits_t = FPBits<T>;
-  using UIntType = typename FPBits<T>::UIntType;
+  using FPBits = FPBits<T>;
+  using UIntType = typename FPBits::UIntType;
   using DUIntType = typename DoubleLength<UIntType>::Type;
 
-  FPBits_t x_bits(x), y_bits(y);
+  FPBits x_bits(x), y_bits(y);
 
   if (x_bits.is_inf() || y_bits.is_inf()) {
-    return T(FPBits_t::inf());
+    return T(FPBits::inf());
   }
   if (x_bits.is_nan()) {
     return x;
@@ -193,11 +193,11 @@ LIBC_INLINE T hypot(T x, T y) {
       sticky_bits = sticky_bits || ((sum & 0x3U) != 0);
       sum >>= 2;
       ++out_exp;
-      if (out_exp >= FPBits_t::MAX_EXPONENT) {
+      if (out_exp >= FPBits::MAX_EXPONENT) {
         if (int round_mode = quick_get_round();
             round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
-          return T(FPBits_t::inf());
-        return T(FPBits_t(FPBits_t::MAX_NORMAL));
+          return T(FPBits::inf());
+        return T(FPBits(FPBits::MAX_NORMAL));
       }
     } else {
       // For denormal result, we simply move the leading bit of the result to
@@ -251,10 +251,10 @@ LIBC_INLINE T hypot(T x, T y) {
   if (y_new >= (ONE >> 1)) {
     y_new -= ONE >> 1;
     ++out_exp;
-    if (out_exp >= FPBits_t::MAX_EXPONENT) {
+    if (out_exp >= FPBits::MAX_EXPONENT) {
       if (round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
-        return T(FPBits_t::inf());
-      return T(FPBits_t(FPBits_t::MAX_NORMAL));
+        return T(FPBits::inf());
+      return T(FPBits(FPBits::MAX_NORMAL));
     }
   }
 

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -123,9 +123,9 @@ template <typename T> struct FModExceptionalInputHandler {
                 "FModCStandardWrapper instantiated with invalid type.");
 
   LIBC_INLINE static bool pre_check(T x, T y, T &out) {
-    using FPB = fputil::FPBits<T>;
-    const T quiet_nan = FPB::build_quiet_nan(0);
-    FPB sx(x), sy(y);
+    using FPBits = fputil::FPBits<T>;
+    const T quiet_nan = FPBits::build_quiet_nan(0);
+    FPBits sx(x), sy(y);
     if (LIBC_LIKELY(!sy.is_zero() && !sy.is_inf_or_nan() &&
                     !sx.is_inf_or_nan())) {
       return false;
@@ -167,11 +167,11 @@ template <typename T> struct FModFastMathWrapper {
 
 template <typename T> class FModDivisionSimpleHelper {
 private:
-  using intU_t = typename FPBits<T>::UIntType;
+  using UIntType = typename FPBits<T>::UIntType;
 
 public:
-  LIBC_INLINE constexpr static intU_t
-  execute(int exp_diff, int sides_zeroes_count, intU_t m_x, intU_t m_y) {
+  LIBC_INLINE constexpr static UIntType
+  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
     while (exp_diff > sides_zeroes_count) {
       exp_diff -= sides_zeroes_count;
       m_x <<= sides_zeroes_count;
@@ -185,24 +185,24 @@ public:
 
 template <typename T> class FModDivisionInvMultHelper {
 private:
-  using FPB = FPBits<T>;
-  using intU_t = typename FPB::UIntType;
+  using FPBits = FPBits<T>;
+  using UIntType = typename FPBits::UIntType;
 
 public:
-  LIBC_INLINE constexpr static intU_t
-  execute(int exp_diff, int sides_zeroes_count, intU_t m_x, intU_t m_y) {
+  LIBC_INLINE constexpr static UIntType
+  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
     if (exp_diff > sides_zeroes_count) {
-      intU_t inv_hy = (cpp::numeric_limits<intU_t>::max() / m_y);
+      UIntType inv_hy = (cpp::numeric_limits<UIntType>::max() / m_y);
       while (exp_diff > sides_zeroes_count) {
         exp_diff -= sides_zeroes_count;
-        intU_t hd =
-            (m_x * inv_hy) >> (FPB::FloatProp::BIT_WIDTH - sides_zeroes_count);
+        UIntType hd =
+            (m_x * inv_hy) >> (FPBits::BIT_WIDTH - sides_zeroes_count);
         m_x <<= sides_zeroes_count;
         m_x -= hd * m_y;
         while (LIBC_UNLIKELY(m_x > m_y))
           m_x -= m_y;
       }
-      intU_t hd = (m_x * inv_hy) >> (FPB::FloatProp::BIT_WIDTH - exp_diff);
+      UIntType hd = (m_x * inv_hy) >> (FPBits::BIT_WIDTH - exp_diff);
       m_x <<= exp_diff;
       m_x -= hd * m_y;
       while (LIBC_UNLIKELY(m_x > m_y))
@@ -222,44 +222,44 @@ class FMod {
                 "FMod instantiated with invalid type.");
 
 private:
-  using FPB = FPBits<T>;
-  using intU_t = typename FPB::UIntType;
+  using FPBits = FPBits<T>;
+  using UIntType = typename FPBits::UIntType;
 
-  LIBC_INLINE static constexpr FPB eval_internal(FPB sx, FPB sy) {
+  LIBC_INLINE static constexpr FPBits eval_internal(FPBits sx, FPBits sy) {
 
     if (LIBC_LIKELY(sx.uintval() <= sy.uintval())) {
       if (sx.uintval() < sy.uintval())
-        return sx;             // |x|<|y| return x
-      return FPB(FPB::zero()); // |x|=|y| return 0.0
+        return sx;                   // |x|<|y| return x
+      return FPBits(FPBits::zero()); // |x|=|y| return 0.0
     }
 
     int e_x = sx.get_biased_exponent();
     int e_y = sy.get_biased_exponent();
 
     // Most common case where |y| is "very normal" and |x/y| < 2^EXPONENT_WIDTH
-    if (LIBC_LIKELY(e_y > int(FPB::FloatProp::MANTISSA_WIDTH) &&
-                    e_x - e_y <= int(FPB::FloatProp::EXPONENT_WIDTH))) {
-      intU_t m_x = sx.get_explicit_mantissa();
-      intU_t m_y = sy.get_explicit_mantissa();
-      intU_t d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
+    if (LIBC_LIKELY(e_y > int(FPBits::MANTISSA_WIDTH) &&
+                    e_x - e_y <= int(FPBits::EXPONENT_WIDTH))) {
+      UIntType m_x = sx.get_explicit_mantissa();
+      UIntType m_y = sy.get_explicit_mantissa();
+      UIntType d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
       if (d == 0)
-        return FPB(FPB::zero());
+        return FPBits(FPBits::zero());
       // iy - 1 because of "zero power" for number with power 1
-      return FPB::make_value(d, e_y - 1);
+      return FPBits::make_value(d, e_y - 1);
     }
     /* Both subnormal special case. */
     if (LIBC_UNLIKELY(e_x == 0 && e_y == 0)) {
-      FPB d;
+      FPBits d;
       d.set_mantissa(sx.uintval() % sy.uintval());
       return d;
     }
 
     // Note that hx is not subnormal by conditions above.
-    intU_t m_x = sx.get_explicit_mantissa();
+    UIntType m_x = sx.get_explicit_mantissa();
     e_x--;
 
-    intU_t m_y = sy.get_explicit_mantissa();
-    int lead_zeros_m_y = FPB::FloatProp::EXPONENT_WIDTH;
+    UIntType m_y = sy.get_explicit_mantissa();
+    int lead_zeros_m_y = FPBits::EXPONENT_WIDTH;
     if (LIBC_LIKELY(e_y > 0)) {
       e_y--;
     } else {
@@ -282,34 +282,34 @@ private:
 
     {
       // Shift hx left until the end or n = 0
-      int left_shift = exp_diff < int(FPB::FloatProp::EXPONENT_WIDTH)
+      int left_shift = exp_diff < int(FPBits::EXPONENT_WIDTH)
                            ? exp_diff
-                           : FPB::FloatProp::EXPONENT_WIDTH;
+                           : FPBits::EXPONENT_WIDTH;
       m_x <<= left_shift;
       exp_diff -= left_shift;
     }
 
     m_x %= m_y;
     if (LIBC_UNLIKELY(m_x == 0))
-      return FPB(FPB::zero());
+      return FPBits(FPBits::zero());
 
     if (exp_diff == 0)
-      return FPB::make_value(m_x, e_y);
+      return FPBits::make_value(m_x, e_y);
 
     /* hx next can't be 0, because hx < hy, hy % 2 == 1 hx * 2^i % hy != 0 */
     m_x = DivisionHelper::execute(exp_diff, sides_zeroes_count, m_x, m_y);
-    return FPB::make_value(m_x, e_y);
+    return FPBits::make_value(m_x, e_y);
   }
 
 public:
   LIBC_INLINE static T eval(T x, T y) {
     if (T out; Wrapper::pre_check(x, y, out))
       return out;
-    FPB sx(x), sy(y);
+    FPBits sx(x), sy(y);
     bool sign = sx.get_sign();
     sx.set_sign(false);
     sy.set_sign(false);
-    FPB result = eval_internal(sx, sy);
+    FPBits result = eval_internal(sx, sy);
     result.set_sign(sign);
     return result.get_val();
   }

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -26,10 +26,19 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
-template <> struct FPBits<long double> {
-  using UIntType = UInt128;
+template <> struct FPBits<long double> : private FloatProperties<long double> {
+  using typename FloatProperties<long double>::UIntType;
+  using FloatProperties<long double>::BIT_WIDTH;
+  using FloatProperties<long double>::EXP_MANT_MASK;
+  using FloatProperties<long double>::EXPONENT_MASK;
+  using FloatProperties<long double>::EXPONENT_BIAS;
+  using FloatProperties<long double>::EXPONENT_WIDTH;
+  using FloatProperties<long double>::MANTISSA_MASK;
+  using FloatProperties<long double>::MANTISSA_WIDTH;
+  using FloatProperties<long double>::QUIET_NAN_MASK;
+  using FloatProperties<long double>::SIGN_MASK;
 
-  static constexpr int EXPONENT_BIAS = 0x3FFF;
+  // static constexpr int EXPONENT_BIAS = 0x3FFF;
   static constexpr int MAX_EXPONENT = 0x7FFF;
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
@@ -41,59 +50,52 @@ template <> struct FPBits<long double> {
       (UIntType(MAX_EXPONENT - 1) << (MantissaWidth<long double>::VALUE + 1)) |
       (UIntType(1) << MantissaWidth<long double>::VALUE) | MAX_SUBNORMAL;
 
-  using FloatProp = FloatProperties<long double>;
-
   UIntType bits;
 
   LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
-    mantVal &= (FloatProp::MANTISSA_MASK);
-    bits &= ~(FloatProp::MANTISSA_MASK);
+    mantVal &= MANTISSA_MASK;
+    bits &= ~MANTISSA_MASK;
     bits |= mantVal;
   }
 
   LIBC_INLINE constexpr UIntType get_mantissa() const {
-    return bits & FloatProp::MANTISSA_MASK;
+    return bits & MANTISSA_MASK;
   }
 
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() const {
     // The x86 80 bit float represents the leading digit of the mantissa
     // explicitly. This is the mask for that bit.
-    constexpr UIntType EXPLICIT_BIT_MASK =
-        (UIntType(1) << FloatProp::MANTISSA_WIDTH);
-    return bits & (FloatProp::MANTISSA_MASK | EXPLICIT_BIT_MASK);
+    constexpr UIntType EXPLICIT_BIT_MASK = UIntType(1) << MANTISSA_WIDTH;
+    return bits & (MANTISSA_MASK | EXPLICIT_BIT_MASK);
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal =
-        (expVal << (FloatProp::BIT_WIDTH - 1 - FloatProp::EXPONENT_WIDTH)) &
-        FloatProp::EXPONENT_MASK;
-    bits &= ~(FloatProp::EXPONENT_MASK);
+    expVal = (expVal << (BIT_WIDTH - 1 - EXPONENT_WIDTH)) & EXPONENT_MASK;
+    bits &= ~EXPONENT_MASK;
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & FloatProp::EXPONENT_MASK) >>
-                    (FloatProp::BIT_WIDTH - 1 - FloatProp::EXPONENT_WIDTH));
+    return uint16_t((bits & EXPONENT_MASK) >> (BIT_WIDTH - 1 - EXPONENT_WIDTH));
   }
 
   LIBC_INLINE constexpr void set_implicit_bit(bool implicitVal) {
-    bits &= ~(UIntType(1) << FloatProp::MANTISSA_WIDTH);
-    bits |= (UIntType(implicitVal) << FloatProp::MANTISSA_WIDTH);
+    bits &= ~(UIntType(1) << MANTISSA_WIDTH);
+    bits |= (UIntType(implicitVal) << MANTISSA_WIDTH);
   }
 
   LIBC_INLINE constexpr bool get_implicit_bit() const {
-    return bool((bits & (UIntType(1) << FloatProp::MANTISSA_WIDTH)) >>
-                FloatProp::MANTISSA_WIDTH);
+    return bool((bits & (UIntType(1) << MANTISSA_WIDTH)) >> MANTISSA_WIDTH);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {
-    bits &= ~(FloatProp::SIGN_MASK);
-    UIntType sign1 = UIntType(signVal) << (FloatProp::BIT_WIDTH - 1);
+    bits &= ~SIGN_MASK;
+    UIntType sign1 = UIntType(signVal) << (BIT_WIDTH - 1);
     bits |= sign1;
   }
 
   LIBC_INLINE constexpr bool get_sign() const {
-    return bool((bits & FloatProp::SIGN_MASK) >> (FloatProp::BIT_WIDTH - 1));
+    return bool((bits & SIGN_MASK) >> (BIT_WIDTH - 1));
   }
 
   LIBC_INLINE constexpr FPBits() : bits(0) {}
@@ -117,7 +119,7 @@ template <> struct FPBits<long double> {
 
   LIBC_INLINE constexpr UIntType uintval() {
     // We zero the padding bits as they can contain garbage.
-    return bits & FloatProp::FP_MASK;
+    return bits & FP_MASK;
   }
 
   LIBC_INLINE constexpr long double get_val() const {
@@ -196,7 +198,7 @@ template <> struct FPBits<long double> {
   }
 
   LIBC_INLINE static constexpr long double build_quiet_nan(UIntType v) {
-    return build_nan(FloatProp::QUIET_NAN_MASK | v);
+    return build_nan(QUIET_NAN_MASK | v);
   }
 
   LIBC_INLINE static constexpr long double min_normal() {

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -71,7 +71,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 eisel_lemire(ExpandedFloat<T> init_num,
              RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -184,7 +184,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<long double>>
 eisel_lemire<long double>(ExpandedFloat<long double> init_num,
                           RoundDirection round) {
   using FPBits = typename fputil::FPBits<long double>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<long double>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -322,7 +322,7 @@ LIBC_INLINE FloatConvertReturn<T>
 simple_decimal_conversion(const char *__restrict numStart,
                           RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   int32_t exp2 = 0;
@@ -516,7 +516,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 clinger_fast_path(ExpandedFloat<T> init_num,
                   RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -724,7 +724,7 @@ LIBC_INLINE FloatConvertReturn<T> binary_exp_to_float(ExpandedFloat<T> init_num,
                                                       bool truncated,
                                                       RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -19,8 +19,8 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
-  using FPBits_t = typename fputil::FPBits<float>;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<float>;
+  FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
 
   if (LIBC_UNLIKELY(x <= 1.0f)) {
@@ -29,12 +29,12 @@ LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
     // x < 1.
     fputil::set_errno_if_required(EDOM);
     fputil::raise_except_if_required(FE_INVALID);
-    return FPBits_t::build_quiet_nan(0);
+    return FPBits::build_quiet_nan(0);
   }
 
   if (LIBC_UNLIKELY(x_u >= 0x4f8ffb03)) {
     // Check for exceptional values.
-    uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
+    uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
     if (LIBC_UNLIKELY(x_abs >= 0x7f80'0000U)) {
       // x is +inf or NaN.
       return x;

--- a/libc/src/math/generic/asinhf.cpp
+++ b/libc/src/math/generic/asinhf.cpp
@@ -18,10 +18,10 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, asinhf, (float x)) {
-  using FPBits_t = typename fputil::FPBits<float>;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<float>;
+  FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
 
   // |x| <= 2^-3
   if (LIBC_UNLIKELY(x_abs <= 0x3e80'0000U)) {

--- a/libc/src/math/generic/atanhf.cpp
+++ b/libc/src/math/generic/atanhf.cpp
@@ -17,7 +17,7 @@ LLVM_LIBC_FUNCTION(float, atanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   bool sign = xbits.get_sign();
-  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
 
   // |x| >= 1.0
   if (LIBC_UNLIKELY(x_abs >= 0x3F80'0000U)) {

--- a/libc/src/math/generic/erff.cpp
+++ b/libc/src/math/generic/erff.cpp
@@ -154,7 +154,7 @@ LLVM_LIBC_FUNCTION(float, erff, (float x)) {
   double xd = static_cast<double>(x);
   double xsq = xd * xd;
 
-  const uint32_t EIGHT = 3 << FPBits::FloatProp::MANTISSA_WIDTH;
+  const uint32_t EIGHT = 3 << FPBits::MANTISSA_WIDTH;
   int idx = static_cast<int>(FPBits(x_abs + EIGHT).get_val());
 
   double x4 = xsq * xsq;

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -274,18 +274,17 @@ template <bool is_sinh> LIBC_INLINE double exp_pm_eval(float x) {
 
 // x should be positive, normal finite value
 LIBC_INLINE static double log2_eval(double x) {
-  using FPB = fputil::FPBits<double>;
-  FPB bs(x);
+  using FPBits = fputil::FPBits<double>;
+  FPBits bs(x);
 
   double result = 0;
   result += bs.get_exponent();
 
-  int p1 =
-      (bs.get_mantissa() >> (FPB::FloatProp::MANTISSA_WIDTH - LOG_P1_BITS)) &
-      (LOG_P1_SIZE - 1);
+  int p1 = (bs.get_mantissa() >> (FPBits::MANTISSA_WIDTH - LOG_P1_BITS)) &
+           (LOG_P1_SIZE - 1);
 
-  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> LOG_P1_BITS;
-  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.bits &= FPBits::MANTISSA_MASK >> LOG_P1_BITS;
+  bs.set_biased_exponent(FPBits::EXPONENT_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
   // Taylor series for log(2,1+x)
@@ -304,19 +303,18 @@ LIBC_INLINE static double log2_eval(double x) {
 LIBC_INLINE static double log_eval(double x) {
   // For x = 2^ex * (1 + mx)
   //   log(x) = ex * log(2) + log(1 + mx)
-  using FPB = fputil::FPBits<double>;
-  FPB bs(x);
+  using FPBits = fputil::FPBits<double>;
+  FPBits bs(x);
 
   double ex = static_cast<double>(bs.get_exponent());
 
   // p1 is the leading 7 bits of mx, i.e.
   // p1 * 2^(-7) <= m_x < (p1 + 1) * 2^(-7).
-  int p1 = static_cast<int>(bs.get_mantissa() >>
-                            (FPB::FloatProp::MANTISSA_WIDTH - 7));
+  int p1 = static_cast<int>(bs.get_mantissa() >> (FPBits::MANTISSA_WIDTH - 7));
 
   // Set bs to (1 + (mx - p1*2^(-7))
-  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> 7;
-  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.bits &= FPBits::MANTISSA_MASK >> 7;
+  bs.set_biased_exponent(FPBits::EXPONENT_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
 

--- a/libc/src/math/generic/inv_trigf_utils.h
+++ b/libc/src/math/generic/inv_trigf_utils.h
@@ -37,21 +37,21 @@ extern const double ATAN_K[5];
 
 // x should be positive, normal finite value
 LIBC_INLINE double atan_eval(double x) {
-  using FPB = fputil::FPBits<double>;
+  using FPBits = fputil::FPBits<double>;
   // Added some small value to umin and umax mantissa to avoid possible rounding
   // errors.
-  FPB::UIntType umin =
-      FPB::create_value(false, FPB::EXPONENT_BIAS - ATAN_T_BITS - 1,
-                        0x100000000000UL)
+  FPBits::UIntType umin =
+      FPBits::create_value(false, FPBits::EXPONENT_BIAS - ATAN_T_BITS - 1,
+                           0x100000000000UL)
           .uintval();
-  FPB::UIntType umax =
-      FPB::create_value(false, FPB::EXPONENT_BIAS + ATAN_T_BITS,
-                        0xF000000000000UL)
+  FPBits::UIntType umax =
+      FPBits::create_value(false, FPBits::EXPONENT_BIAS + ATAN_T_BITS,
+                           0xF000000000000UL)
           .uintval();
 
-  FPB bs(x);
+  FPBits bs(x);
   bool sign = bs.get_sign();
-  auto x_abs = bs.uintval() & FPB::FloatProp::EXP_MANT_MASK;
+  auto x_abs = bs.uintval() & FPBits::EXP_MANT_MASK;
 
   if (x_abs <= umin) {
     double pe = LIBC_NAMESPACE::fputil::polyeval(
@@ -67,7 +67,7 @@ LIBC_INLINE double atan_eval(double x) {
     return fputil::multiply_add(pe, one_over_x_m, sign ? (-M_MATH_PI_2) : (M_MATH_PI_2));
   }
 
-  double pos_x = FPB(x_abs).get_val();
+  double pos_x = FPBits(x_abs).get_val();
   bool one_over_x = pos_x > 1.0;
   if (one_over_x) {
     pos_x = 1.0 / pos_x;

--- a/libc/src/math/generic/log.cpp
+++ b/libc/src/math/generic/log.cpp
@@ -730,29 +730,29 @@ double log_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log, (double x)) {
-  using FPBits_t = typename fputil::FPBits<double>;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<double>;
+  FPBits xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
-                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
+                    xbits.uintval() > FPBits::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits_t::neg_inf());
+      return static_cast<double>(FPBits::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan(0);
+      return FPBits::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -786,7 +786,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits_t(x_m).get_val();
+  double m = FPBits(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -796,7 +796,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits_t(c_m).get_val();
+  double c = FPBits(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/log10.cpp
+++ b/libc/src/math/generic/log10.cpp
@@ -731,29 +731,29 @@ double log10_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log10, (double x)) {
-  using FPBits_t = typename fputil::FPBits<double>;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<double>;
+  FPBits xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log10(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
-                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
+                    xbits.uintval() > FPBits::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits_t::neg_inf());
+      return static_cast<double>(FPBits::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan(0);
+      return FPBits::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -787,7 +787,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits_t(x_m).get_val();
+  double m = FPBits(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -797,7 +797,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits_t(c_m).get_val();
+  double c = FPBits(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -871,11 +871,11 @@ LIBC_INLINE double log1p_accurate(int e_x, int index,
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
-  using FPBits_t = typename fputil::FPBits<double>;
-  constexpr int EXPONENT_BIAS = FPBits_t::EXPONENT_BIAS;
-  constexpr int MANTISSA_WIDTH = FPBits_t::FloatProp::MANTISSA_WIDTH;
-  constexpr uint64_t MANTISSA_MASK = FPBits_t::FloatProp::MANTISSA_MASK;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<double>;
+  constexpr int EXPONENT_BIAS = FPBits::EXPONENT_BIAS;
+  constexpr int MANTISSA_WIDTH = FPBits::MANTISSA_WIDTH;
+  constexpr uint64_t MANTISSA_MASK = FPBits::MANTISSA_MASK;
+  FPBits xbits(x);
   uint64_t x_u = xbits.uintval();
 
   fputil::DoubleDouble x_dd{0.0, 0.0};
@@ -886,19 +886,19 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
     // |x| >= 1
     if (LIBC_UNLIKELY(x_u >= 0x4650'0000'0000'0000ULL)) {
       // x >= 2^102 or x is negative, inf, or NaN
-      if (LIBC_UNLIKELY(x_u > FPBits_t::MAX_NORMAL)) {
+      if (LIBC_UNLIKELY(x_u > FPBits::MAX_NORMAL)) {
         // x <= -1.0 or x is Inf or NaN
         if (x_u == 0xbff0'0000'0000'0000ULL) {
           // x = -1.0
           fputil::set_errno_if_required(ERANGE);
           fputil::raise_except_if_required(FE_DIVBYZERO);
-          return static_cast<double>(FPBits_t::neg_inf());
+          return static_cast<double>(FPBits::neg_inf());
         }
         if (xbits.get_sign() && !xbits.is_nan()) {
           // x < -1.0
           fputil::set_errno_if_required(EDOM);
           fputil::raise_except_if_required(FE_INVALID);
-          return FPBits_t::build_quiet_nan(0);
+          return FPBits::build_quiet_nan(0);
         }
         // x is +Inf or NaN
         return x;
@@ -928,11 +928,11 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
       bool rdn = (tn - 0x1p-24f != tn);
 
       if (x > 0 && rdp) {
-        return FPBits_t(x_u - 1).get_val();
+        return FPBits(x_u - 1).get_val();
       }
 
       if (x < 0 && rdn) {
-        return FPBits_t(x_u + 1).get_val();
+        return FPBits(x_u + 1).get_val();
       }
 
       return x;
@@ -945,7 +945,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   //   |x_dd.hi| >= 2^-54
   //   |x_dd.lo| < ulp(x_dd.hi)
 
-  FPBits_t xhi_bits(x_dd.hi);
+  FPBits xhi_bits(x_dd.hi);
   x_u = xhi_bits.uintval();
   // Range reduction:
   // Find k such that |x_hi - k * 2^-7| <= 2^-8.
@@ -969,10 +969,10 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   // Scaling factior = 2^(-xh_bits.get_exponent())
   uint64_t s_u =
       (static_cast<uint64_t>(EXPONENT_BIAS) << (MANTISSA_WIDTH + 1)) -
-      (x_u & FPBits_t::FloatProp::EXPONENT_MASK);
+      (x_u & FPBits::EXPONENT_MASK);
   // When the exponent of x is 2^1023, its inverse, 2^(-1023), is subnormal.
   const double EXPONENT_CORRECTION[2] = {0.0, 0x1.0p-1023};
-  double scaling = FPBits_t(s_u).get_val() + EXPONENT_CORRECTION[s_u == 0];
+  double scaling = FPBits(s_u).get_val() + EXPONENT_CORRECTION[s_u == 0];
   // Normalize arguments:
   //   1 <= m_dd.hi < 2
   //   |m_dd.lo| < 2^-52.
@@ -999,8 +999,8 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   v_hi = fputil::multiply_add(r, m_dd.hi, -1.0); // Exact.
 #else
   // c = 1 + idx * 2^-7.
-  double c = FPBits_t((static_cast<uint64_t>(idx) << (MANTISSA_WIDTH - 7)) +
-                      uint64_t(0x3FF0'0000'0000'0000ULL))
+  double c = FPBits((static_cast<uint64_t>(idx) << (MANTISSA_WIDTH - 7)) +
+                    uint64_t(0x3FF0'0000'0000'0000ULL))
                  .get_val();
   v_hi = fputil::multiply_add(r, m_dd.hi - c, RCM1[idx]); // Exact
 #endif // LIBC_TARGET_CPU_HAS_FMA

--- a/libc/src/math/generic/log2.cpp
+++ b/libc/src/math/generic/log2.cpp
@@ -852,29 +852,29 @@ double log2_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log2, (double x)) {
-  using FPBits_t = typename fputil::FPBits<double>;
-  FPBits_t xbits(x);
+  using FPBits = typename fputil::FPBits<double>;
+  FPBits xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log2(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
-                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
+                    xbits.uintval() > FPBits::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits_t::neg_inf());
+      return static_cast<double>(FPBits::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan(0);
+      return FPBits::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -901,7 +901,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits_t(x_m).get_val();
+  double m = FPBits(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -911,7 +911,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits_t(c_m).get_val();
+  double c = FPBits(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/sinhf.cpp
+++ b/libc/src/math/generic/sinhf.cpp
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
-  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
 
   // When |x| >= 90, or x is inf or nan
   if (LIBC_UNLIKELY(x_abs >= 0x42b4'0000U || x_abs <= 0x3da0'0000U)) {
@@ -57,8 +57,7 @@ LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
     int rounding = fputil::quick_get_round();
     if (sign) {
       if (LIBC_UNLIKELY(rounding == FE_UPWARD || rounding == FE_TOWARDZERO))
-        return FPBits(FPBits::MAX_NORMAL | FPBits::FloatProp::SIGN_MASK)
-            .get_val();
+        return FPBits(FPBits::MAX_NORMAL | FPBits::SIGN_MASK).get_val();
     } else {
       if (LIBC_UNLIKELY(rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO))
         return FPBits(FPBits::MAX_NORMAL).get_val();

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
 
   // When |x| >= 15, or x is inf or nan, or |x| <= 0.078125
   if (LIBC_UNLIKELY((x_abs >= 0x4170'0000U) || (x_abs <= 0x3da0'0000U))) {


### PR DESCRIPTION
Also make type naming consistent:
 - `UIntType` instead of `intU_t`
 - `FPBits` instead of `FPBits_t`, `FPB`
