### PR TITLE
[MemProf][NFC] Clear each IndexedMemProfRecord after it is written

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -538,6 +538,11 @@ public:
                 offset_type /*Unused*/) {
     assert(Schema != nullptr && "MemProf schema is not initialized!");
     V.serialize(*Schema, Out);
+    // Clear the IndexedMemProfRecord which results in clearing/freeing its
+    // vectors of allocs and callsites. This is owned by the associated on-disk
+    // hash table, but unused after this point. See also the comment added to
+    // the client which constructs the on-disk hash table for this trait.
+    V.clear();
   }
 };
 

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -537,6 +537,9 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
       RecordTableGenerator.insert(I.first, I.second);
     }
 
+    // The call to Emit invokes RecordWriterTrait::EmitData which destructs
+    // the memprof record copies owned by the RecordTableGenerator. This works
+    // because the RecordTableGenerator is not used after this point.
     uint64_t RecordTableOffset =
         RecordTableGenerator.Emit(OS.OS, *RecordWriter);
 


### PR DESCRIPTION
The on-disk hash table for the memprof writer holds copies of all the
memprof records to be written. These hold a lot of memory in aggregate,
due to the lists of alloc sites (which each have a list of context
frames) and call sites. Clear each one after emitting it.

This drops the peak memory when writing a very large indexed memprof
profile by about 2.5G.
