### PR TITLE
[lld][COFF] Merge .00cfg section into .rdata.

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1940,6 +1940,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   parseMerge(".didat=.rdata");
   parseMerge(".edata=.rdata");
   parseMerge(".xdata=.rdata");
+  parseMerge(".00cfg=.rdata");
   parseMerge(".bss=.data");
 
   if (config->mingw) {

--- a/lld/test/COFF/Inputs/loadconfig-arm64ec.s
+++ b/lld/test/COFF/Inputs/loadconfig-arm64ec.s
@@ -1,4 +1,4 @@
-        .section .rdata,"dr"
+        .section .00cfg,"dr"
         .globl _load_config_used
         .p2align 3, 0
 _load_config_used:

--- a/lld/test/COFF/Inputs/loadconfig-cfg-x64.s
+++ b/lld/test/COFF/Inputs/loadconfig-cfg-x64.s
@@ -1,6 +1,6 @@
 # This is the _load_config_used definition needed for /guard:cf tests.
 
-        .section .rdata,"dr"
+        .section .00cfg,"dr"
 .globl _load_config_used
 _load_config_used:
         .long 256

--- a/lld/test/COFF/merge-00cfg.s
+++ b/lld/test/COFF/merge-00cfg.s
@@ -1,0 +1,17 @@
+// REQUIRES: x86
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-windows %s -o %t-x86_64.obj
+// RUN: llvm-mc -filetype=obj -triple=i686-windows %s -o %t-x86.obj
+// RUN: lld-link -machine:amd64 -out:%t-x86_64.dll %t-x86_64.obj -dll -noentry
+// RUN: lld-link -machine:x86 -out:%t-x86.dll %t-x86.obj -dll -noentry -safeseh:no
+
+// RUN: llvm-readobj --hex-dump=.rdata %t-x86_64.dll | FileCheck %s -check-prefix=RDATA
+// RUN: llvm-readobj --hex-dump=.rdata %t-x86.dll | FileCheck %s -check-prefix=RDATA
+// RDATA: 78563412
+
+// RUN: llvm-readobj --sections %t-x86_64.dll | FileCheck %s -check-prefix=SECTIONS
+// RUN: llvm-readobj --sections %t-x86.dll | FileCheck %s -check-prefix=SECTIONS
+// SECTIONS-NOT: .00cfg
+
+        .section ".00cfg", "dr"
+        .long 0x12345678


### PR DESCRIPTION
.00cfg section is used by crt for load config and is merged by MS link.exe into .rdata.

cc @bylaws 