### PR TITLE
[flang] Fix compilation error due to variable no being used

### DIFF
--- a/flang/lib/Optimizer/HLFIR/IR/HLFIROps.cpp
+++ b/flang/lib/Optimizer/HLFIR/IR/HLFIROps.cpp
@@ -663,7 +663,6 @@ template <typename NumericalReductionOp>
 static mlir::LogicalResult
 verifyArrayAndMaskForReductionOp(NumericalReductionOp reductionOp) {
   mlir::Value array = reductionOp->getArray();
-  mlir::Value dim = reductionOp->getDim();
   mlir::Value mask = reductionOp->getMask();
 
   fir::SequenceType arrayTy =


### PR DESCRIPTION
My builds were failing because the variable 'dim' was not used.  This produced a warning, and my builds have warnings set as errors.