### PR TITLE
[analyzer] Fix broken testcase

### DIFF
--- a/clang/test/Analysis/enum-cast-out-of-range.cpp
+++ b/clang/test/Analysis/enum-cast-out-of-range.cpp
@@ -226,7 +226,7 @@ enum WidgetKind { A=1, B, C, X=99 }; // expected-note {{enum declared here}}
 void foo() {
   WidgetKind c = static_cast<WidgetKind>(3);  // OK
   WidgetKind x = static_cast<WidgetKind>(99); // OK
-  WidgetKind d = static_cast<WidgetKind>(4);  // expected-warning {{The value provided to the cast expression is not in the valid range of values for 'WidgetKind'}}
+  WidgetKind d = static_cast<WidgetKind>(4);  // expected-warning {{The value '4' provided to the cast expression is not in the valid range of values for 'WidgetKind'}}
 
   ignore_unused(c, x, d);
 }


### PR DESCRIPTION
When merging commit c873f77e87a9ebd02f94d6b9d46e84d43e1ceb38 I didn't manually rebase it onto the tip of the main branch, so I didn't notice that the testcase that's added by it needs to be tweaked to account for the effects of commit 2f29ded4f98e8e1fa26725c618a08082a09b405a (which was also merged by me a few days ago).