### PR TITLE
Disable PGO instrumentation on naked function

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -892,6 +892,10 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
     }
   }
 
+  if (FD->hasAttr<NakedAttr>()) {
+    Fn->addFnAttr(llvm::Attribute::NoProfile);
+  }
+
   unsigned Count, Offset;
   if (const auto *Attr =
           D ? D->getAttr<PatchableFunctionEntryAttr>() : nullptr) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -892,10 +892,6 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
     }
   }
 
-  if (FD->hasAttr<NakedAttr>()) {
-    Fn->addFnAttr(llvm::Attribute::NoProfile);
-  }
-
   unsigned Count, Offset;
   if (const auto *Attr =
           D ? D->getAttr<PatchableFunctionEntryAttr>() : nullptr) {

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -1783,6 +1783,8 @@ static bool skipPGOUse(const Function &F) {
 static bool skipPGOGen(const Function &F) {
   if (skipPGOUse(F))
     return true;
+  if (F.hasFnAttribute(llvm::Attribute::Naked))
+    return true;
   if (F.hasFnAttribute(llvm::Attribute::NoProfile))
     return true;
   if (F.hasFnAttribute(llvm::Attribute::SkipProfile))

--- a/llvm/test/Transforms/PGOProfile/timestamp.ll
+++ b/llvm/test/Transforms/PGOProfile/timestamp.ll
@@ -3,10 +3,21 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
+; CHECK-LABEL: define void @foo(
 define void @foo() {
 entry:
   ; CHECK: call void @llvm.instrprof.timestamp({{.*}})
   ret void
 }
 
-; CHECK: declare void @llvm.instrprof.timestamp(
+; CHECK-LABEL: define void @bar(
+define void @bar() #0 {
+entry:
+  ; CHECK-NOT: call void @llvm.instrprof.timestamp({{.*}})
+  call void asm sideeffect "retq;", "~{dirflag},~{fpsr},~{flags}"()
+  unreachable
+}
+
+; CHECK-LABEL: declare void @llvm.instrprof.timestamp(
+
+attributes #0 = { naked }


### PR DESCRIPTION
We only allow for assembly code in naked function, and PGO instrumentation (esp. temporal instrumentation that introduces a function call) can wreak havoc in this.

Fix #74573