### PR TITLE
[PowerPC] Emit libcall to frexpl for calls to frexp(ppcDoublDouble)

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3414,8 +3414,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     // Linux PPC will not be adding additional PPCDoubleDouble support.
     // WIP to switch default to IEEE long double. Will emit libcall for
     // frexpl instead of legalizing this type in the BE.
-    if (getTarget().getTriple().isPPC() &&
-        &getTarget().getLongDoubleFormat() == &llvm::APFloat::PPCDoubleDouble())
+    if (&getTarget().getLongDoubleFormat() == &llvm::APFloat::PPCDoubleDouble())
       break;
     LLVM_FALLTHROUGH;
   }

--- a/clang/test/CodeGen/math-builtins-long.c
+++ b/clang/test/CodeGen/math-builtins-long.c
@@ -35,7 +35,7 @@ void foo(long double f, long double *l, int *i, const char *c) {
   __builtin_fabsl(f);
 
   // F80: call { x86_fp80, i32 } @llvm.frexp.f80.i32(x86_fp80 %{{.+}})
-  // PPC: call { ppc_fp128, i32 } @llvm.frexp.ppcf128.i32(ppc_fp128 %{{.+}})
+  // PPC: call ppc_fp128 @frexpl(ppc_fp128 noundef %{{.+}}, ptr noundef %{{.+}})
   // X86F128: call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.+}})
   // PPCF128: call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.+}})
   __builtin_frexpl(f,i);

--- a/libcxx/test/libcxx/numerics/c.math/constexpr-cxx23-clang.pass.cpp
+++ b/libcxx/test/libcxx/numerics/c.math/constexpr-cxx23-clang.pass.cpp
@@ -58,15 +58,9 @@ int main(int, char**) {
 
   ASSERT_NOT_CONSTEXPR_CXX23(std::frexp(0.0f, &DummyInt) == 0.0f);
   ASSERT_NOT_CONSTEXPR_CXX23(std::frexp(0.0, &DummyInt) == 0.0);
-//FIXME: currently linux powerpc does not support this expansion
-// since 0.0L lowers to ppcf128 and special handling is required.
-#if !defined(__LONG_DOUBLE_IBM128__)
   ASSERT_NOT_CONSTEXPR_CXX23(std::frexp(0.0L, &DummyInt) == 0.0L);
-#endif
   ASSERT_NOT_CONSTEXPR_CXX23(std::frexpf(0.0f, &DummyInt) == 0.0f);
-#if !defined(__LONG_DOUBLE_IBM128__)
   ASSERT_NOT_CONSTEXPR_CXX23(std::frexpl(0.0L, &DummyInt) == 0.0L);
-#endif
 
   ASSERT_NOT_CONSTEXPR_CXX23(std::ilogb(1.0f) == 0);
   ASSERT_NOT_CONSTEXPR_CXX23(std::ilogb(1.0) == 0);


### PR DESCRIPTION
On Linux PPC call lib func ``frexpl`` for calls to ``frexp()`` for input of type PPCDoubleDouble.

Fixes bug: https://github.com/llvm/llvm-project/issues/64426