### PR TITLE
[lld][WebAssembly] Don't set importUndefined when -shared is used. NFC

### DIFF
--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -606,7 +606,6 @@ static void setConfigs() {
       config->memoryImport =
           std::pair<llvm::StringRef, llvm::StringRef>(defaultModule, memoryName);
     }
-    config->importUndefined = true;
   }
 
   // If neither export-memory nor import-memory is specified, default to


### PR DESCRIPTION
`importUndefined` is only used a couple of places and both of those already handle `isPic` separately.