### PR TITLE
[BOLT] Fix double conversion in CacheMetrics

### DIFF
--- a/bolt/lib/Passes/CacheMetrics.cpp
+++ b/bolt/lib/Passes/CacheMetrics.cpp
@@ -14,22 +14,18 @@
 #include "bolt/Passes/CacheMetrics.h"
 #include "bolt/Core/BinaryBasicBlock.h"
 #include "bolt/Core/BinaryFunction.h"
-#include "llvm/Support/CommandLine.h"
 #include <unordered_map>
 
 using namespace llvm;
 using namespace bolt;
 
-namespace opts {
-
-extern cl::OptionCategory BoltOptCategory;
-
-extern cl::opt<unsigned> ITLBPageSize;
-extern cl::opt<unsigned> ITLBEntries;
-
-} // namespace opts
-
 namespace {
+
+/// The size of an i-tlb cache page.
+constexpr unsigned ITLBPageSize = 4096;
+
+/// The number of entries in the i-tlb cache.
+constexpr unsigned ITLBEntries = 16;
 
 /// Initialize and return a position map for binary basic blocks
 void extractBasicBlockInfo(
@@ -133,9 +129,6 @@ double expectedCacheHitRatio(
     const std::vector<BinaryFunction *> &BinaryFunctions,
     const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBAddr,
     const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBSize) {
-
-  const double PageSize = opts::ITLBPageSize;
-  const uint64_t CacheEntries = opts::ITLBEntries;
   std::unordered_map<const BinaryFunction *, Predecessors> Calls =
       extractFunctionCalls(BinaryFunctions);
   // Compute 'hotness' of the functions
@@ -155,7 +148,7 @@ double expectedCacheHitRatio(
   for (BinaryFunction *BF : BinaryFunctions) {
     if (BF->getLayout().block_empty())
       continue;
-    double Page = BBAddr.at(BF->getLayout().block_front()) / PageSize;
+    uint64_t Page = BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
     PageSamples[Page] += FunctionSamples.at(BF);
   }
 
@@ -166,15 +159,15 @@ double expectedCacheHitRatio(
     if (BF->getLayout().block_empty() || FunctionSamples.at(BF) == 0.0)
       continue;
     double Samples = FunctionSamples.at(BF);
-    double Page = BBAddr.at(BF->getLayout().block_front()) / PageSize;
+    uint64_t Page = BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
     // The probability that the page is not present in the cache
-    double MissProb = pow(1.0 - PageSamples[Page] / TotalSamples, CacheEntries);
+    double MissProb = pow(1.0 - PageSamples[Page] / TotalSamples, ITLBEntries);
 
     // Processing all callers of the function
     for (std::pair<BinaryFunction *, uint64_t> Pair : Calls[BF]) {
       BinaryFunction *SrcFunction = Pair.first;
-      double SrcPage =
-          BBAddr.at(SrcFunction->getLayout().block_front()) / PageSize;
+      uint64_t SrcPage =
+          BBAddr.at(SrcFunction->getLayout().block_front()) / ITLBPageSize;
       // Is this a 'long' or a 'short' call?
       if (Page != SrcPage) {
         // This is a miss

--- a/bolt/lib/Passes/CacheMetrics.cpp
+++ b/bolt/lib/Passes/CacheMetrics.cpp
@@ -21,10 +21,11 @@ using namespace bolt;
 
 namespace {
 
-/// The size of an i-tlb cache page.
+/// The following constants are used to estimate the number of i-TLB cache
+/// misses for a given code layout. Empirically the values result in high
+/// correlations between the estimations and the perf measurements.
+/// The constants do not affect the code layout algorithms.
 constexpr unsigned ITLBPageSize = 4096;
-
-/// The number of entries in the i-tlb cache.
 constexpr unsigned ITLBEntries = 16;
 
 /// Initialize and return a position map for binary basic blocks

--- a/bolt/lib/Passes/CacheMetrics.cpp
+++ b/bolt/lib/Passes/CacheMetrics.cpp
@@ -148,7 +148,8 @@ double expectedCacheHitRatio(
   for (BinaryFunction *BF : BinaryFunctions) {
     if (BF->getLayout().block_empty())
       continue;
-    uint64_t Page = BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
+    const uint64_t Page =
+        BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
     PageSamples[Page] += FunctionSamples.at(BF);
   }
 
@@ -159,14 +160,16 @@ double expectedCacheHitRatio(
     if (BF->getLayout().block_empty() || FunctionSamples.at(BF) == 0.0)
       continue;
     double Samples = FunctionSamples.at(BF);
-    uint64_t Page = BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
+    const uint64_t Page =
+        BBAddr.at(BF->getLayout().block_front()) / ITLBPageSize;
     // The probability that the page is not present in the cache
-    double MissProb = pow(1.0 - PageSamples[Page] / TotalSamples, ITLBEntries);
+    const double MissProb =
+        pow(1.0 - PageSamples[Page] / TotalSamples, ITLBEntries);
 
     // Processing all callers of the function
     for (std::pair<BinaryFunction *, uint64_t> Pair : Calls[BF]) {
       BinaryFunction *SrcFunction = Pair.first;
-      uint64_t SrcPage =
+      const uint64_t SrcPage =
           BBAddr.at(SrcFunction->getLayout().block_front()) / ITLBPageSize;
       // Is this a 'long' or a 'short' call?
       if (Page != SrcPage) {


### PR DESCRIPTION
The change (i) fixes an issue with double-int conversion in CacheMetrics and 
(ii) removes command-line options for computing metrics (which aren't modified
anyway).
This change might break some tests verifying the exact output of CacheMetrics.