### PR TITLE
[libc] fix -Wmacro-redefined

### DIFF
--- a/libc/include/llvm-libc-macros/linux/fcntl-macros.h
+++ b/libc/include/llvm-libc-macros/linux/fcntl-macros.h
@@ -46,31 +46,6 @@
 #define O_RDWR 00000002
 #define O_WRONLY 00000001
 
-// File mode flags
-#define S_IRWXU 0700
-#define S_IRUSR 0400
-#define S_IWUSR 0200
-#define S_IXUSR 0100
-#define S_IRWXG 070
-#define S_IRGRP 040
-#define S_IWGRP 020
-#define S_IXGRP 010
-#define S_IRWXO 07
-#define S_IROTH 04
-#define S_IWOTH 02
-#define S_IXOTH 01
-#define S_ISUID 04000
-#define S_ISGID 02000
-
-// File type flags
-#define S_IFMT 0170000
-#define S_IFDIR 0040000
-#define S_IFCHR 0020000
-#define S_IFBLK 0060000
-#define S_IFREG 0100000
-#define S_FIFO 0010000
-#define S_IFLNK 0120000
-
 // Special directory FD to indicate that the path argument to
 // openat is relative to the current directory.
 #define AT_FDCWD -100

--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -10,7 +10,7 @@
 #define __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H
 
 // Definitions from linux/stat.h
-#define S_IFMT   0170000
+#define S_IFMT 0170000
 #define S_IFSOCK 0140000
 #define S_IFLNK  0120000
 #define S_IFREG  0100000

--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -10,7 +10,7 @@
 #define __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H
 
 // Definitions from linux/stat.h
-#define S_IFMT  00170000
+#define S_IFMT   0170000
 #define S_IFSOCK 0140000
 #define S_IFLNK  0120000
 #define S_IFREG  0100000

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -18,6 +18,7 @@
 #include <fcntl.h> // For mode_t and other flags to the open syscall
 #include <stdio.h>
 #include <sys/syscall.h> // For syscall numbers
+#include <sys/stat.h> // For S_IS*, S_IF*, and S_IR* flags.
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -17,8 +17,8 @@
 
 #include <fcntl.h> // For mode_t and other flags to the open syscall
 #include <stdio.h>
+#include <sys/stat.h>    // For S_IS*, S_IF*, and S_IR* flags.
 #include <sys/syscall.h> // For syscall numbers
-#include <sys/stat.h> // For S_IS*, S_IF*, and S_IR* flags.
 
 namespace LIBC_NAMESPACE {
 


### PR DESCRIPTION
When building with compiler-rt enabled, warnings such as the following are
observed:

    llvm-project/llvm/build/projects/compiler-rt/../libc/include/llvm-libc-macros/linux/sys-stat-macros.h:46:9:
    warning: 'S_IXOTH' macro redefined [-Wmacro-redefined]
    #define S_IXOTH 00001
            ^
    llvm-project/llvm/build/projects/compiler-rt/../libc/include/llvm-libc-macros/linux/fcntl-macros.h:61:9:
    note: previous definition is here
    #define S_IXOTH 01
            ^
It looks like we have these multiply defined. Deduplicate these flags; users
should expect to find them in sys/stat.h.  S_FIFO was wrong anyways (should
have been S_IFIFO).
