### PR TITLE
[clang-format] Fix a bug in git-clang-format.bat

### DIFF
--- a/clang/tools/clang-format/git-clang-format.bat
+++ b/clang/tools/clang-format/git-clang-format.bat
@@ -1,1 +1,1 @@
-py -3 git-clang-format %*
+py -3 %~pn0 %*


### PR DESCRIPTION
Pass the fully-qualified path name (less the file extension) of
git-clang-format.bat to py so that it can be run from anywhere.

Fixes #75265.