### PR TITLE
[mlir][ArmSME] Add missing dependencies in ArmSME transforms

### DIFF
--- a/mlir/include/mlir/Dialect/ArmSME/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/ArmSME/Transforms/CMakeLists.txt
@@ -3,5 +3,6 @@ mlir_tablegen(Passes.h.inc -gen-pass-decls -name ArmSME)
 mlir_tablegen(PassesEnums.h.inc -gen-enum-decls)
 mlir_tablegen(PassesEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRArmSMETransformsIncGen)
+add_dependencies(mlir-headers MLIRArmSMETransformsIncGen)
 
 add_mlir_doc(Passes ArmSMEPasses ./ -gen-pass-doc)


### PR DESCRIPTION
Inject missing dependency between generated files that could cause build issues.