### PR TITLE
[llvm] Add support for running tests as root

### DIFF
--- a/llvm/test/tools/llvm-ar/error-opening-permission.test
+++ b/llvm/test/tools/llvm-ar/error-opening-permission.test
@@ -1,6 +1,7 @@
 ## Unsupported on windows as marking files "unreadable"
 ## is non-trivial on windows.
 # UNSUPPORTED: system-windows
+# REQUIRES: non-root-user
 
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: echo file1 > %t/1.txt

--- a/llvm/test/tools/llvm-dwarfdump/X86/output.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/output.s
@@ -1,3 +1,4 @@
+# REQUIRES: non-root-user
 # RUN: rm -f %t1.txt %t2.txt %t3.txt
 # RUN: llvm-mc %S/brief.s -filetype obj -triple x86_64-apple-darwin -o %t.o
 

--- a/llvm/test/tools/llvm-ifs/fail-file-write.test
+++ b/llvm/test/tools/llvm-ifs/fail-file-write.test
@@ -1,6 +1,7 @@
 ## Test failing to write output file on non-windows platforms.
 
 # UNSUPPORTED: system-windows
+# REQUIRES: non-root-user
 # RUN: rm -rf %t.TestDir
 # RUN: mkdir %t.TestDir
 # RUN: touch %t.TestDir/Output.TestFile

--- a/llvm/test/tools/llvm-ranlib/error-opening-permission.test
+++ b/llvm/test/tools/llvm-ranlib/error-opening-permission.test
@@ -1,5 +1,6 @@
 ## Unsupported on windows as marking files "unreadable" is non-trivial on windows.
 # UNSUPPORTED: system-windows
+# REQUIRES: non-root-user
 
 # RUN: rm -rf %t && split-file %s %t && cd %t
 # RUN: yaml2obj 1.yaml -o 1.o

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 import sys
 import errno
-import getpass
 
 import lit.util
 from lit.llvm.subst import FindTool
@@ -15,10 +14,9 @@ lit_path_displayed = False
 
 
 def user_is_root():
-    # getpass.getuser() can throw an exception in some cases:
-    # See https://github.com/python/cpython/issues/76912
+    # os.getuid() is not available on all platforms
     try:
-        if getpass.getuser() == "root":
+        if os.getuid() == 0:
             return True
     except:
         pass

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -13,11 +13,12 @@ from lit.llvm.subst import ToolSubst
 
 lit_path_displayed = False
 
+
 def user_is_root():
     # getpass.getuser() can throw an exception in some cases:
     # See https://github.com/python/cpython/issues/76912
     try:
-        if getpass.getuser() == 'root':
+        if getpass.getuser() == "root":
             return True
     except:
         pass
@@ -167,7 +168,7 @@ class LLVMConfig(object):
                 features.add('target=powerpc64le-linux')
 
         if not user_is_root():
-            features.add('non-root-user')
+            features.add("non-root-user")
 
         use_gmalloc = lit_config.params.get("use_gmalloc", None)
         if lit.util.pythonize_bool(use_gmalloc):

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -5,12 +5,24 @@ import re
 import subprocess
 import sys
 import errno
+import getpass
 
 import lit.util
 from lit.llvm.subst import FindTool
 from lit.llvm.subst import ToolSubst
 
 lit_path_displayed = False
+
+def user_is_root():
+    # getpass.getuser() can throw an exception in some cases:
+    # See https://github.com/python/cpython/issues/76912
+    try:
+        if getpass.getuser() == 'root':
+            return True
+    except:
+        pass
+
+    return False
 
 
 class LLVMConfig(object):
@@ -153,6 +165,9 @@ class LLVMConfig(object):
                 features.add("target-arm")
             if re.match(r'^ppc64le.*-linux', target_triple):
                 features.add('target=powerpc64le-linux')
+
+        if not user_is_root():
+            features.add('non-root-user')
 
         use_gmalloc = lit_config.params.get("use_gmalloc", None)
         if lit.util.pythonize_bool(use_gmalloc):


### PR DESCRIPTION
There are a few test that check access permissions, so they need to be disabled when running the tests as root.

The most common use case for running tests as root is inside of a container.  GitHub Actions, for example, only supports running the root user inside of containers, so this change is necessary in order to run the tests inside of a container running in the GitHub Actions environment.