### PR TITLE
[CMake] Include opt-viewer in Fuchsia toolchain

### DIFF
--- a/clang/cmake/caches/Fuchsia-stage2.cmake
+++ b/clang/cmake/caches/Fuchsia-stage2.cmake
@@ -336,6 +336,7 @@ set(LLVM_TOOLCHAIN_TOOLS
   llvm-symbolizer
   llvm-undname
   llvm-xray
+  opt-viewer
   sancov
   scan-build-py
   CACHE STRING "")


### PR DESCRIPTION
This is necessary for visualization of optimization remarks.