### PR TITLE
[MLIR][LLVM] Remove disallowlist from LLVM inliner

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp
@@ -632,8 +632,7 @@ struct LLVMInlinerInterface : public DialectInlinerInterface {
                        bool wouldBeCloned) const final {
     if (!wouldBeCloned)
       return false;
-    auto callOp = dyn_cast<LLVM::CallOp>(call);
-    if (!callOp) {
+    if (!isa<LLVM::CallOp>(call)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Cannot inline: call is not an LLVM::CallOp\n");
       return false;
@@ -684,40 +683,8 @@ struct LLVMInlinerInterface : public DialectInlinerInterface {
     return true;
   }
 
-  /// Conservative allowlist of operations supported so far.
   bool isLegalToInline(Operation *op, Region *, bool, IRMapping &) const final {
-    if (isPure(op))
-      return true;
-    // clang-format off
-    if (isa<LLVM::AllocaOp,
-            LLVM::AssumeOp,
-            LLVM::AtomicRMWOp,
-            LLVM::AtomicCmpXchgOp,
-            LLVM::CallOp,
-            LLVM::CallIntrinsicOp,
-            LLVM::DbgDeclareOp,
-            LLVM::DbgLabelOp,
-            LLVM::DbgValueOp,
-            LLVM::FenceOp,
-            LLVM::InlineAsmOp,
-            LLVM::LifetimeEndOp,
-            LLVM::LifetimeStartOp,
-            LLVM::LoadOp,
-            LLVM::MemcpyOp,
-            LLVM::MemcpyInlineOp,
-            LLVM::MemmoveOp,
-            LLVM::MemsetOp,
-            LLVM::NoAliasScopeDeclOp,
-            LLVM::StackRestoreOp,
-            LLVM::StackSaveOp,
-            LLVM::StoreOp,
-            LLVM::UnreachableOp>(op))
-      return true;
-    // clang-format on
-    LLVM_DEBUG(llvm::dbgs()
-               << "Cannot inline: unhandled side effecting operation \""
-               << op->getName() << "\"\n");
-    return false;
+    return true;
   }
 
   /// Handle the given inlined return by replacing it with a branch. This


### PR DESCRIPTION
The disallowlist was used as a migration strategy while support was extended to more side effecting operations. We now (to the best of our knowledge) support all side effecting operations, so never fail `isLegalToInline` on any LLVM operation.

There is no test included, because that's exactly the reason for this change: there are no more unsupported operations in inlining; the existing tests for unsupported inlines have already been burninated.