### PR TITLE
Revert "[libc][NFC] Implement `FPBits` in terms of `FloatProperties` to reduce clutter"

### DIFF
--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -104,14 +104,14 @@ template <> struct DoubleLength<uint64_t> {
 //
 template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T hypot(T x, T y) {
-  using FPBits = FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using FPBits_t = FPBits<T>;
+  using UIntType = typename FPBits<T>::UIntType;
   using DUIntType = typename DoubleLength<UIntType>::Type;
 
-  FPBits x_bits(x), y_bits(y);
+  FPBits_t x_bits(x), y_bits(y);
 
   if (x_bits.is_inf() || y_bits.is_inf()) {
-    return T(FPBits::inf());
+    return T(FPBits_t::inf());
   }
   if (x_bits.is_nan()) {
     return x;
@@ -193,11 +193,11 @@ LIBC_INLINE T hypot(T x, T y) {
       sticky_bits = sticky_bits || ((sum & 0x3U) != 0);
       sum >>= 2;
       ++out_exp;
-      if (out_exp >= FPBits::MAX_EXPONENT) {
+      if (out_exp >= FPBits_t::MAX_EXPONENT) {
         if (int round_mode = quick_get_round();
             round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
-          return T(FPBits::inf());
-        return T(FPBits(FPBits::MAX_NORMAL));
+          return T(FPBits_t::inf());
+        return T(FPBits_t(FPBits_t::MAX_NORMAL));
       }
     } else {
       // For denormal result, we simply move the leading bit of the result to
@@ -251,10 +251,10 @@ LIBC_INLINE T hypot(T x, T y) {
   if (y_new >= (ONE >> 1)) {
     y_new -= ONE >> 1;
     ++out_exp;
-    if (out_exp >= FPBits::MAX_EXPONENT) {
+    if (out_exp >= FPBits_t::MAX_EXPONENT) {
       if (round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
-        return T(FPBits::inf());
-      return T(FPBits(FPBits::MAX_NORMAL));
+        return T(FPBits_t::inf());
+      return T(FPBits_t(FPBits_t::MAX_NORMAL));
     }
   }
 

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -26,19 +26,10 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
-template <> struct FPBits<long double> : private FloatProperties<long double> {
-  using typename FloatProperties<long double>::UIntType;
-  using FloatProperties<long double>::BIT_WIDTH;
-  using FloatProperties<long double>::EXP_MANT_MASK;
-  using FloatProperties<long double>::EXPONENT_MASK;
-  using FloatProperties<long double>::EXPONENT_BIAS;
-  using FloatProperties<long double>::EXPONENT_WIDTH;
-  using FloatProperties<long double>::MANTISSA_MASK;
-  using FloatProperties<long double>::MANTISSA_WIDTH;
-  using FloatProperties<long double>::QUIET_NAN_MASK;
-  using FloatProperties<long double>::SIGN_MASK;
+template <> struct FPBits<long double> {
+  using UIntType = UInt128;
 
-  // static constexpr int EXPONENT_BIAS = 0x3FFF;
+  static constexpr int EXPONENT_BIAS = 0x3FFF;
   static constexpr int MAX_EXPONENT = 0x7FFF;
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
@@ -50,52 +41,59 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
       (UIntType(MAX_EXPONENT - 1) << (MantissaWidth<long double>::VALUE + 1)) |
       (UIntType(1) << MantissaWidth<long double>::VALUE) | MAX_SUBNORMAL;
 
+  using FloatProp = FloatProperties<long double>;
+
   UIntType bits;
 
   LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
-    mantVal &= MANTISSA_MASK;
-    bits &= ~MANTISSA_MASK;
+    mantVal &= (FloatProp::MANTISSA_MASK);
+    bits &= ~(FloatProp::MANTISSA_MASK);
     bits |= mantVal;
   }
 
   LIBC_INLINE constexpr UIntType get_mantissa() const {
-    return bits & MANTISSA_MASK;
+    return bits & FloatProp::MANTISSA_MASK;
   }
 
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() const {
     // The x86 80 bit float represents the leading digit of the mantissa
     // explicitly. This is the mask for that bit.
-    constexpr UIntType EXPLICIT_BIT_MASK = UIntType(1) << MANTISSA_WIDTH;
-    return bits & (MANTISSA_MASK | EXPLICIT_BIT_MASK);
+    constexpr UIntType EXPLICIT_BIT_MASK =
+        (UIntType(1) << FloatProp::MANTISSA_WIDTH);
+    return bits & (FloatProp::MANTISSA_MASK | EXPLICIT_BIT_MASK);
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal = (expVal << (BIT_WIDTH - 1 - EXPONENT_WIDTH)) & EXPONENT_MASK;
-    bits &= ~EXPONENT_MASK;
+    expVal =
+        (expVal << (FloatProp::BIT_WIDTH - 1 - FloatProp::EXPONENT_WIDTH)) &
+        FloatProp::EXPONENT_MASK;
+    bits &= ~(FloatProp::EXPONENT_MASK);
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & EXPONENT_MASK) >> (BIT_WIDTH - 1 - EXPONENT_WIDTH));
+    return uint16_t((bits & FloatProp::EXPONENT_MASK) >>
+                    (FloatProp::BIT_WIDTH - 1 - FloatProp::EXPONENT_WIDTH));
   }
 
   LIBC_INLINE constexpr void set_implicit_bit(bool implicitVal) {
-    bits &= ~(UIntType(1) << MANTISSA_WIDTH);
-    bits |= (UIntType(implicitVal) << MANTISSA_WIDTH);
+    bits &= ~(UIntType(1) << FloatProp::MANTISSA_WIDTH);
+    bits |= (UIntType(implicitVal) << FloatProp::MANTISSA_WIDTH);
   }
 
   LIBC_INLINE constexpr bool get_implicit_bit() const {
-    return bool((bits & (UIntType(1) << MANTISSA_WIDTH)) >> MANTISSA_WIDTH);
+    return bool((bits & (UIntType(1) << FloatProp::MANTISSA_WIDTH)) >>
+                FloatProp::MANTISSA_WIDTH);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {
-    bits &= ~SIGN_MASK;
-    UIntType sign1 = UIntType(signVal) << (BIT_WIDTH - 1);
+    bits &= ~(FloatProp::SIGN_MASK);
+    UIntType sign1 = UIntType(signVal) << (FloatProp::BIT_WIDTH - 1);
     bits |= sign1;
   }
 
   LIBC_INLINE constexpr bool get_sign() const {
-    return bool((bits & SIGN_MASK) >> (BIT_WIDTH - 1));
+    return bool((bits & FloatProp::SIGN_MASK) >> (FloatProp::BIT_WIDTH - 1));
   }
 
   LIBC_INLINE constexpr FPBits() : bits(0) {}
@@ -119,7 +117,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
 
   LIBC_INLINE constexpr UIntType uintval() {
     // We zero the padding bits as they can contain garbage.
-    return bits & FP_MASK;
+    return bits & FloatProp::FP_MASK;
   }
 
   LIBC_INLINE constexpr long double get_val() const {
@@ -198,7 +196,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   }
 
   LIBC_INLINE static constexpr long double build_quiet_nan(UIntType v) {
-    return build_nan(QUIET_NAN_MASK | v);
+    return build_nan(FloatProp::QUIET_NAN_MASK | v);
   }
 
   LIBC_INLINE static constexpr long double min_normal() {

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -71,7 +71,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 eisel_lemire(ExpandedFloat<T> init_num,
              RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename fputil::FloatProperties<T>;
+  using FloatProp = typename FPBits::FloatProp;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -184,7 +184,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<long double>>
 eisel_lemire<long double>(ExpandedFloat<long double> init_num,
                           RoundDirection round) {
   using FPBits = typename fputil::FPBits<long double>;
-  using FloatProp = typename fputil::FloatProperties<long double>;
+  using FloatProp = typename FPBits::FloatProp;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -322,7 +322,7 @@ LIBC_INLINE FloatConvertReturn<T>
 simple_decimal_conversion(const char *__restrict numStart,
                           RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename fputil::FloatProperties<T>;
+  using FloatProp = typename FPBits::FloatProp;
   using UIntType = typename FPBits::UIntType;
 
   int32_t exp2 = 0;
@@ -516,7 +516,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 clinger_fast_path(ExpandedFloat<T> init_num,
                   RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename fputil::FloatProperties<T>;
+  using FloatProp = typename FPBits::FloatProp;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -724,7 +724,7 @@ LIBC_INLINE FloatConvertReturn<T> binary_exp_to_float(ExpandedFloat<T> init_num,
                                                       bool truncated,
                                                       RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename fputil::FloatProperties<T>;
+  using FloatProp = typename FPBits::FloatProp;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -19,8 +19,8 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
-  using FPBits = typename fputil::FPBits<float>;
-  FPBits xbits(x);
+  using FPBits_t = typename fputil::FPBits<float>;
+  FPBits_t xbits(x);
   uint32_t x_u = xbits.uintval();
 
   if (LIBC_UNLIKELY(x <= 1.0f)) {
@@ -29,12 +29,12 @@ LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
     // x < 1.
     fputil::set_errno_if_required(EDOM);
     fputil::raise_except_if_required(FE_INVALID);
-    return FPBits::build_quiet_nan(0);
+    return FPBits_t::build_quiet_nan(0);
   }
 
   if (LIBC_UNLIKELY(x_u >= 0x4f8ffb03)) {
     // Check for exceptional values.
-    uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
+    uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
     if (LIBC_UNLIKELY(x_abs >= 0x7f80'0000U)) {
       // x is +inf or NaN.
       return x;

--- a/libc/src/math/generic/asinhf.cpp
+++ b/libc/src/math/generic/asinhf.cpp
@@ -18,10 +18,10 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, asinhf, (float x)) {
-  using FPBits = typename fputil::FPBits<float>;
-  FPBits xbits(x);
+  using FPBits_t = typename fputil::FPBits<float>;
+  FPBits_t xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
 
   // |x| <= 2^-3
   if (LIBC_UNLIKELY(x_abs <= 0x3e80'0000U)) {

--- a/libc/src/math/generic/atanhf.cpp
+++ b/libc/src/math/generic/atanhf.cpp
@@ -17,7 +17,7 @@ LLVM_LIBC_FUNCTION(float, atanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   bool sign = xbits.get_sign();
-  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
 
   // |x| >= 1.0
   if (LIBC_UNLIKELY(x_abs >= 0x3F80'0000U)) {

--- a/libc/src/math/generic/erff.cpp
+++ b/libc/src/math/generic/erff.cpp
@@ -154,7 +154,7 @@ LLVM_LIBC_FUNCTION(float, erff, (float x)) {
   double xd = static_cast<double>(x);
   double xsq = xd * xd;
 
-  const uint32_t EIGHT = 3 << FPBits::MANTISSA_WIDTH;
+  const uint32_t EIGHT = 3 << FPBits::FloatProp::MANTISSA_WIDTH;
   int idx = static_cast<int>(FPBits(x_abs + EIGHT).get_val());
 
   double x4 = xsq * xsq;

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -274,17 +274,18 @@ template <bool is_sinh> LIBC_INLINE double exp_pm_eval(float x) {
 
 // x should be positive, normal finite value
 LIBC_INLINE static double log2_eval(double x) {
-  using FPBits = fputil::FPBits<double>;
-  FPBits bs(x);
+  using FPB = fputil::FPBits<double>;
+  FPB bs(x);
 
   double result = 0;
   result += bs.get_exponent();
 
-  int p1 = (bs.get_mantissa() >> (FPBits::MANTISSA_WIDTH - LOG_P1_BITS)) &
-           (LOG_P1_SIZE - 1);
+  int p1 =
+      (bs.get_mantissa() >> (FPB::FloatProp::MANTISSA_WIDTH - LOG_P1_BITS)) &
+      (LOG_P1_SIZE - 1);
 
-  bs.bits &= FPBits::MANTISSA_MASK >> LOG_P1_BITS;
-  bs.set_biased_exponent(FPBits::EXPONENT_BIAS);
+  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> LOG_P1_BITS;
+  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
   // Taylor series for log(2,1+x)
@@ -303,18 +304,19 @@ LIBC_INLINE static double log2_eval(double x) {
 LIBC_INLINE static double log_eval(double x) {
   // For x = 2^ex * (1 + mx)
   //   log(x) = ex * log(2) + log(1 + mx)
-  using FPBits = fputil::FPBits<double>;
-  FPBits bs(x);
+  using FPB = fputil::FPBits<double>;
+  FPB bs(x);
 
   double ex = static_cast<double>(bs.get_exponent());
 
   // p1 is the leading 7 bits of mx, i.e.
   // p1 * 2^(-7) <= m_x < (p1 + 1) * 2^(-7).
-  int p1 = static_cast<int>(bs.get_mantissa() >> (FPBits::MANTISSA_WIDTH - 7));
+  int p1 = static_cast<int>(bs.get_mantissa() >>
+                            (FPB::FloatProp::MANTISSA_WIDTH - 7));
 
   // Set bs to (1 + (mx - p1*2^(-7))
-  bs.bits &= FPBits::MANTISSA_MASK >> 7;
-  bs.set_biased_exponent(FPBits::EXPONENT_BIAS);
+  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> 7;
+  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
 

--- a/libc/src/math/generic/inv_trigf_utils.h
+++ b/libc/src/math/generic/inv_trigf_utils.h
@@ -37,21 +37,21 @@ extern const double ATAN_K[5];
 
 // x should be positive, normal finite value
 LIBC_INLINE double atan_eval(double x) {
-  using FPBits = fputil::FPBits<double>;
+  using FPB = fputil::FPBits<double>;
   // Added some small value to umin and umax mantissa to avoid possible rounding
   // errors.
-  FPBits::UIntType umin =
-      FPBits::create_value(false, FPBits::EXPONENT_BIAS - ATAN_T_BITS - 1,
-                           0x100000000000UL)
+  FPB::UIntType umin =
+      FPB::create_value(false, FPB::EXPONENT_BIAS - ATAN_T_BITS - 1,
+                        0x100000000000UL)
           .uintval();
-  FPBits::UIntType umax =
-      FPBits::create_value(false, FPBits::EXPONENT_BIAS + ATAN_T_BITS,
-                           0xF000000000000UL)
+  FPB::UIntType umax =
+      FPB::create_value(false, FPB::EXPONENT_BIAS + ATAN_T_BITS,
+                        0xF000000000000UL)
           .uintval();
 
-  FPBits bs(x);
+  FPB bs(x);
   bool sign = bs.get_sign();
-  auto x_abs = bs.uintval() & FPBits::EXP_MANT_MASK;
+  auto x_abs = bs.uintval() & FPB::FloatProp::EXP_MANT_MASK;
 
   if (x_abs <= umin) {
     double pe = LIBC_NAMESPACE::fputil::polyeval(
@@ -67,7 +67,7 @@ LIBC_INLINE double atan_eval(double x) {
     return fputil::multiply_add(pe, one_over_x_m, sign ? (-M_MATH_PI_2) : (M_MATH_PI_2));
   }
 
-  double pos_x = FPBits(x_abs).get_val();
+  double pos_x = FPB(x_abs).get_val();
   bool one_over_x = pos_x > 1.0;
   if (one_over_x) {
     pos_x = 1.0 / pos_x;

--- a/libc/src/math/generic/log.cpp
+++ b/libc/src/math/generic/log.cpp
@@ -730,29 +730,29 @@ double log_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log, (double x)) {
-  using FPBits = typename fputil::FPBits<double>;
-  FPBits xbits(x);
+  using FPBits_t = typename fputil::FPBits<double>;
+  FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
-                    xbits.uintval() > FPBits::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
+                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits::neg_inf());
+      return static_cast<double>(FPBits_t::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits::build_quiet_nan(0);
+      return FPBits_t::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -786,7 +786,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits(x_m).get_val();
+  double m = FPBits_t(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -796,7 +796,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits(c_m).get_val();
+  double c = FPBits_t(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/log10.cpp
+++ b/libc/src/math/generic/log10.cpp
@@ -731,29 +731,29 @@ double log10_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log10, (double x)) {
-  using FPBits = typename fputil::FPBits<double>;
-  FPBits xbits(x);
+  using FPBits_t = typename fputil::FPBits<double>;
+  FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log10(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
-                    xbits.uintval() > FPBits::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
+                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits::neg_inf());
+      return static_cast<double>(FPBits_t::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits::build_quiet_nan(0);
+      return FPBits_t::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -787,7 +787,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits(x_m).get_val();
+  double m = FPBits_t(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -797,7 +797,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits(c_m).get_val();
+  double c = FPBits_t(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/log2.cpp
+++ b/libc/src/math/generic/log2.cpp
@@ -852,29 +852,29 @@ double log2_accurate(int e_x, int index, double m_x) {
 } // namespace
 
 LLVM_LIBC_FUNCTION(double, log2, (double x)) {
-  using FPBits = typename fputil::FPBits<double>;
-  FPBits xbits(x);
+  using FPBits_t = typename fputil::FPBits<double>;
+  FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXPONENT_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log2(1.0) = +0.0
     return 0.0;
   }
 
-  if (LIBC_UNLIKELY(xbits.uintval() < FPBits::MIN_NORMAL ||
-                    xbits.uintval() > FPBits::MAX_NORMAL)) {
+  if (LIBC_UNLIKELY(xbits.uintval() < FPBits_t::MIN_NORMAL ||
+                    xbits.uintval() > FPBits_t::MAX_NORMAL)) {
     if (xbits.is_zero()) {
       // return -Inf and raise FE_DIVBYZERO.
       fputil::set_errno_if_required(ERANGE);
       fputil::raise_except_if_required(FE_DIVBYZERO);
-      return static_cast<double>(FPBits::neg_inf());
+      return static_cast<double>(FPBits_t::neg_inf());
     }
     if (xbits.get_sign() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits::build_quiet_nan(0);
+      return FPBits_t::build_quiet_nan(0);
     }
     if (xbits.is_inf_or_nan()) {
       return x;
@@ -901,7 +901,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
 
   // Set m = 1.mantissa.
   uint64_t x_m = (x_u & 0x000F'FFFF'FFFF'FFFFULL) | 0x3FF0'0000'0000'0000ULL;
-  double m = FPBits(x_m).get_val();
+  double m = FPBits_t(x_m).get_val();
 
   double u, u_sq, err;
   fputil::DoubleDouble r1;
@@ -911,7 +911,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
   u = fputil::multiply_add(r, m, -1.0); // exact
 #else
   uint64_t c_m = x_m & 0x3FFF'E000'0000'0000ULL;
-  double c = FPBits(c_m).get_val();
+  double c = FPBits_t(c_m).get_val();
   u = fputil::multiply_add(r, m - c, CD[index]); // exact
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/math/generic/sinhf.cpp
+++ b/libc/src/math/generic/sinhf.cpp
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
-  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
 
   // When |x| >= 90, or x is inf or nan
   if (LIBC_UNLIKELY(x_abs >= 0x42b4'0000U || x_abs <= 0x3da0'0000U)) {
@@ -57,7 +57,8 @@ LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
     int rounding = fputil::quick_get_round();
     if (sign) {
       if (LIBC_UNLIKELY(rounding == FE_UPWARD || rounding == FE_TOWARDZERO))
-        return FPBits(FPBits::MAX_NORMAL | FPBits::SIGN_MASK).get_val();
+        return FPBits(FPBits::MAX_NORMAL | FPBits::FloatProp::SIGN_MASK)
+            .get_val();
     } else {
       if (LIBC_UNLIKELY(rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO))
         return FPBits(FPBits::MAX_NORMAL).get_val();

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits::FloatProp::EXP_MANT_MASK;
 
   // When |x| >= 15, or x is inf or nan, or |x| <= 0.078125
   if (LIBC_UNLIKELY((x_abs >= 0x4170'0000U) || (x_abs <= 0x3da0'0000U))) {


### PR DESCRIPTION
Reverts llvm/llvm-project#75196

GCC complains about change of meaning for `FPBits`
```
/home/llvm-libc-buildbot/buildbot-worker/libc-x86_64-debian-fullbuild/libc-x86_64-debian-gcc-fullbuild-dbg/llvm-project/libc/src/__support/FPUtil/generic/FMod.h:188:9: error: declaration of ‘using FPBits = struct __llvm_libc_18_0_0_git::fputil::FPBits<T>’ changes meaning of ‘FPBits’ [-fpermissive]
  188 |   using FPBits = FPBits<T>;
      |         ^~~~~~
```

I'll reland with a different name.