### PR TITLE
[MLIR][LLVM] Support nameless and scopeless global constants

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -424,9 +424,9 @@ def LLVM_DIGlobalVariableExpressionAttr
 def LLVM_DIGlobalVariable : LLVM_Attr<"DIGlobalVariable", "di_global_variable",
                                       /*traits=*/[], "DINodeAttr"> {
   let parameters = (ins
-    "DIScopeAttr":$scope,
-    "StringAttr":$name,
-    "StringAttr":$linkageName,
+    OptionalParameter<"DIScopeAttr">:$scope,
+    OptionalParameter<"StringAttr">:$name,
+    OptionalParameter<"StringAttr">:$linkageName,
     "DIFileAttr":$file,
     "unsigned":$line,
     "DITypeAttr":$type,

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -118,12 +118,19 @@ DebugImporter::translateImpl(llvm::DILexicalBlockFile *node) {
 
 DIGlobalVariableAttr
 DebugImporter::translateImpl(llvm::DIGlobalVariable *node) {
+  // Names of DIGlobalVariables can be empty. MLIR models them as null, instead
+  // of empty strings, so this special handling is necessary.
+  auto convertToStringAttr = [&](StringRef name) -> StringAttr {
+    if (name.empty())
+      return {};
+    return StringAttr::get(context, node->getName());
+  };
   return DIGlobalVariableAttr::get(
       context, translate(node->getScope()),
-      StringAttr::get(context, node->getName()),
-      StringAttr::get(context, node->getLinkageName()),
-      translate(node->getFile()), node->getLine(), translate(node->getType()),
-      node->isLocalToUnit(), node->isDefinition(), node->getAlignInBits());
+      convertToStringAttr(node->getName()),
+      convertToStringAttr(node->getLinkageName()), translate(node->getFile()),
+      node->getLine(), translate(node->getType()), node->isLocalToUnit(),
+      node->isDefinition(), node->getAlignInBits());
 }
 
 DILocalVariableAttr DebugImporter::translateImpl(llvm::DILocalVariable *node) {

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -795,7 +795,8 @@ LogicalResult ModuleTranslation::convertGlobals() {
 
       // Get the compile unit (scope) of the the global variable.
       if (llvm::DICompileUnit *compileUnit =
-              dyn_cast<llvm::DICompileUnit>(diGlobalVar->getScope())) {
+              dyn_cast_if_present<llvm::DICompileUnit>(
+                  diGlobalVar->getScope())) {
         // Update the compile unit with this incoming global variable expression
         // during the finalizing step later.
         allGVars[compileUnit].push_back(diGlobalExpr);

--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -270,3 +270,27 @@ define void @bar() {
 !7 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression(DW_OP_constu, 3, DW_OP_plus))
 !100 = !{i32 2, !"Debug Info Version", i32 3}
 !llvm.module.flags = !{!100}
+
+; // -----
+
+; Nameless and scopeless global variable.
+
+; CHECK-DAG: #[[FILE:.*]] = #llvm.di_file
+; CHECK-DAG: #[[COMPOSITE_TYPE:.*]] = #llvm.di_composite_type
+; CHECK-DAG: #[[GLOBAL_VAR:.*]] = #llvm.di_global_variable<file = #[[FILE]], line = 268, type = #[[COMPOSITE_TYPE]], isLocalToUnit = true, isDefined = true>
+; CHECK-DAG: #[[GLOBAL_VAR_EXPR:.*]] = #llvm.di_global_variable_expression<var = #[[GLOBAL_VAR]], expr = <>>
+
+; CHECK-DAG: llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #[[GLOBAL_VAR_EXPR]]}
+
+@.str.1 = external constant [10 x i8], !dbg !0
+
+!llvm.module.flags = !{!7}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(scope: null, file: !2, line: 268, type: !3, isLocal: true, isDefinition: true)
+!2 = !DIFile(filename: "source.c", directory: "/path/to/file")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 80, elements: !6)
+!4 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !5)
+!5 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!6 = !{}
+!7 = !{i32 2, !"Debug Info Version", i32 3}

--- a/mlir/test/Target/LLVMIR/llvmir-debug.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug.mlir
@@ -292,6 +292,24 @@ llvm.mlir.global external @global_with_expr_2() {addr_space = 0 : i32, dbg_expr 
 
 // -----
 
+// Nameless and scopeless global constant.
+
+// CHECK-LABEL: @.str.1 = external constant [10 x i8]
+// CHECK-SAME: !dbg ![[GLOBAL_VAR_EXPR:.*]]
+// CHECK-DAG: ![[GLOBAL_VAR_EXPR]] = !DIGlobalVariableExpression(var: ![[GLOBAL_VAR:.*]], expr: !DIExpression())
+// CHECK-DAG: ![[GLOBAL_VAR]] = distinct !DIGlobalVariable(scope: null, file: !{{[0-9]+}}, line: 268, type: !{{[0-9]+}}, isLocal: true, isDefinition: true)
+
+#di_basic_type = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "char", sizeInBits = 8, encoding = DW_ATE_signed_char>
+#di_file = #llvm.di_file<"file.c" in "/path/to/file">
+#di_derived_type = #llvm.di_derived_type<tag = DW_TAG_const_type, baseType = #di_basic_type>
+#di_composite_type = #llvm.di_composite_type<tag = DW_TAG_array_type, baseType = #di_derived_type, sizeInBits = 80>
+#di_global_variable = #llvm.di_global_variable<file = #di_file, line = 268, type = #di_composite_type, isLocalToUnit = true, isDefined = true>
+#di_global_variable_expression = #llvm.di_global_variable_expression<var = #di_global_variable, expr = <>>
+
+llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #di_global_variable_expression} : !llvm.array<10 x i8>
+
+// -----
+
 // CHECK-DAG: ![[FILE1:.*]] = !DIFile(filename: "foo1.mlir", directory: "/test/")
 #di_file_1 = #llvm.di_file<"foo1.mlir" in "/test/">
 // CHECK-DAG: ![[FILE2:.*]] = !DIFile(filename: "foo2.mlir", directory: "/test/")


### PR DESCRIPTION
This commit ensures that we model DI information for global constants correctly. These constructs can lack scopes, names, and linkage names, so these parameters were made optional for the DIGlobalVariable attribute.