### PR TITLE
[libc++][test] Enhance `ADDITIONAL_COMPILE_FLAGS`, use `TEST_MEOW_DIAGNOSTIC_IGNORED` sparingly

### DIFF
--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MSVC warning C4244: 'argument': conversion from 'const _Ty2' to 'T', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4244
+
 // <algorithm>
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -19,7 +19,11 @@
 //   equal(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2);
 
 // We test the cartesian product, so we sometimes compare differently signed types
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// MSVC warning C4242: 'argument': conversion from 'int' to 'const _Ty', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'wchar_t' to 'const _Ty', possible loss of data
+// MSVC warning C4389: '==': signed/unsigned mismatch
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244 /wd4389
 
 #include <algorithm>
 #include <cassert>
@@ -58,6 +62,10 @@ struct Test {
 struct TestNarrowingEqualTo {
   template <class UnderlyingType>
   TEST_CONSTEXPR_CXX20 void operator()() {
+    TEST_DIAGNOSTIC_PUSH
+    // MSVC warning C4310: cast truncates constant value
+    TEST_MSVC_DIAGNOSTIC_IGNORED(4310)
+
     UnderlyingType a[] = {
         UnderlyingType(0x1000),
         UnderlyingType(0x1001),
@@ -70,6 +78,8 @@ struct TestNarrowingEqualTo {
         UnderlyingType(0x1602),
         UnderlyingType(0x1603),
         UnderlyingType(0x1604)};
+
+    TEST_DIAGNOSTIC_POP
 
     assert(std::equal(a, a + 5, b, std::equal_to<char>()));
 #if TEST_STD_VER >= 14

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// MSVC warning C4389: '==': signed/unsigned mismatch
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4389
 
 // <algorithm>
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -10,7 +10,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// MSVC warning C4242: 'argument': conversion from 'const _Ty' to 'ElementT', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'const _Ty' to 'ElementT', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244
 
 // template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
 //   requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>

--- a/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
@@ -74,8 +74,14 @@ void test() {
 
   TEST_IGNORE_NODISCARD a.is_lock_free();
 
+  TEST_DIAGNOSTIC_PUSH
+  // MSVC warning C4197: 'volatile std::atomic<operator_hijacker>': top-level volatile in cast is ignored
+  TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
   TEST_IGNORE_NODISCARD T();
   TEST_IGNORE_NODISCARD T(v);
+
+  TEST_DIAGNOSTIC_POP
 
   TEST_IGNORE_NODISCARD a.load();
   TEST_IGNORE_NODISCARD static_cast<typename T::value_type>(a);

--- a/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
@@ -98,8 +98,16 @@ void test() {
 
   a.store(v);
   a = v;
+
+  TEST_DIAGNOSTIC_PUSH
+  // MSVC warning C4197: 'volatile std::atomic<operator_hijacker *>': top-level volatile in cast is ignored
+  TEST_MSVC_DIAGNOSTIC_IGNORED(4197)
+
   TEST_IGNORE_NODISCARD T();
   TEST_IGNORE_NODISCARD T(v);
+
+  TEST_DIAGNOSTIC_POP
+
   TEST_IGNORE_NODISCARD a.load();
   TEST_IGNORE_NODISCARD static_cast<typename T::value_type>(a);
   TEST_IGNORE_NODISCARD* a;

--- a/libcxx/test/std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp
@@ -10,7 +10,7 @@
 
 // We voluntarily use std::default_initializable on types that have redundant
 // or ignored cv-qualifiers -- don't warn about it.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ignored-qualifiers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-ignored-qualifiers
 
 // template<class T>
 //     concept default_initializable = constructible_from<T> &&

--- a/libcxx/test/std/containers/associative/map/map.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.modifiers/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <map>
 

--- a/libcxx/test/std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <map>
 

--- a/libcxx/test/std/containers/associative/multiset/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <set>
 

--- a/libcxx/test/std/containers/associative/set/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <set>
 

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
@@ -11,7 +11,7 @@
 // template <size_t I, class T, size_t N> T& get(array<T, N>& a);
 
 // Prevent -Warray-bounds from issuing a diagnostic when testing with clang verify.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-array-bounds
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-array-bounds
 
 #include <array>
 #include <cassert>

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <unordered_map>
 

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <unordered_map>
 

--- a/libcxx/test/std/containers/unord/unord.multiset/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <set>
 

--- a/libcxx/test/std/containers/unord/unord.set/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/insert_range.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Some fields in the test case variables are deliberately not explicitly initialized, this silences a warning on GCC.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-missing-field-initializers
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers
 
 // <set>
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-ctad-maybe-unsupported
 
 // <mdspan>
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
+// MSVC warning C4244: 'initializing': conversion from '_Ty' to '_Ty', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4244
+
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcxx/test/std/depr/depr.c.headers/setjmp_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/setjmp_h.compile.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MSVC warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4611
+
 // test <setjmp.h>
 //
 // Even though <setjmp.h> is not provided by libc++, we still test that

--- a/libcxx/test/std/depr/depr.numeric.limits.has.denorm/deprecated.verify.cpp
+++ b/libcxx/test/std/depr/depr.numeric.limits.has.denorm/deprecated.verify.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-value
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-unused-value
 
 #include <limits>
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS -D_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
+// MSVC warning C4242: '+=': conversion from 'const _Ty' to 'size_t', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'std::streamsize' to 'size_t', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244
 // UNSUPPORTED: c++03
 
 // <fstream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS -D_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
+// MSVC warning C4242: '+=': conversion from 'const _Ty' to 'size_t', possible loss of data
+// MSVC warning C4244: 'argument': conversion from 'std::streamsize' to 'size_t', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244
 // UNSUPPORTED: c++03
 
 // <fstream>

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
@@ -27,7 +27,7 @@
 // <TODO:Remove brackets> below
 
 // Make sure we catch forced conversions to the difference_type if they happen.
-// ADDITIONAL_COMPILE_FLAGS<TODO:Remove brackets>: -Wsign-conversion
+// ADDITIONAL_COMPILE_FLAGS<TODO:Remove brackets>(gcc-style-warnings): -Wsign-conversion
 
 #include <iterator>
 #include <cassert>

--- a/libcxx/test/std/language.support/support.runtime/csetjmp.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/csetjmp.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MSVC warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4611
+
 // test <csetjmp>
 
 #include <csetjmp>

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp
@@ -8,6 +8,9 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+// This is a compile-only test, so "inline function is not defined" warnings are irrelevant.
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-undefined-inline
+
 // template<input_range V, forward_range Pattern>
 //   requires view<V> && view<Pattern> &&
 //            indirectly_comparable<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&

--- a/libcxx/test/std/ranges/range.utility/range.utility.conv/to.pass.cpp
+++ b/libcxx/test/std/ranges/range.utility/range.utility.conv/to.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MSVC warning C4244: 'argument': conversion from '_Ty' to 'int', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4244
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // template<class C, input_range R, class... Args> requires (!view<C>)

--- a/libcxx/test/std/strings/basic.string/string.cons/from_range_deduction.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/from_range_deduction.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // To silence a GCC warning-turned-error re. `BadAlloc::value_type`.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-local-typedefs
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-unused-local-typedefs
 
 // template<ranges::input_range R,
 //          class Allocator = allocator<ranges::range_value_t<R>>>

--- a/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
+++ b/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
@@ -35,12 +35,18 @@
 
 int condition_variable_lock_skipped_counter = 0;
 
+TEST_DIAGNOSTIC_PUSH
+// MSVC warning C4583: 'X::cv_': destructor is not implicitly called
+TEST_MSVC_DIAGNOSTIC_IGNORED(4583)
+
 union X {
     X() : cv_() {}
     ~X() {}
     std::condition_variable cv_;
     unsigned char bytes_[sizeof(std::condition_variable)];
 };
+
+TEST_DIAGNOSTIC_POP
 
 void test()
 {

--- a/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: libcpp-has-no-experimental-stop_token
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: availability-synchronization_library-missing
-// ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-self-move
 
 // jthread& operator=(jthread&&) noexcept;
 

--- a/libcxx/test/std/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
@@ -23,9 +23,10 @@
 
 // Ignore warnings about volatile in parameters being deprecated.
 // We know it is, but we still have to test it.
-#if defined(TEST_COMPILER_GCC)
-#   pragma GCC diagnostic ignored "-Wvolatile"
-#endif
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated-volatile")
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wvolatile")
+// MSVC warning C5215: a function parameter with a volatile qualified type is deprecated in C++20
+TEST_MSVC_DIAGNOSTIC_IGNORED(5215)
 
 struct wat
 {
@@ -64,9 +65,6 @@ void test_result_of_imp()
     test_invoke_result<T, U>::call();
 #endif
 }
-
-// Do not warn on deprecated uses of 'volatile' below.
-_LIBCPP_SUPPRESS_DEPRECATED_PUSH
 
 int main(int, char**)
 {
@@ -184,5 +182,3 @@ int main(int, char**)
 
   return 0;
 }
-
-_LIBCPP_SUPPRESS_DEPRECATED_POP

--- a/libcxx/test/std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp
@@ -11,7 +11,9 @@
 // UNSUPPORTED: c++03, c++11
 
 // ignore deprecated volatile return types
-// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-deprecated-volatile
+// MSVC warning C5216: 'volatile int' a volatile qualified return type is deprecated in C++20
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd5216
 
 #include <type_traits>
 #include <utility>

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03
 
 // Self assignment post-conditions are tested.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-self-move
 
 // <memory>
 

--- a/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
@@ -16,7 +16,7 @@
 
 // We make sure that it is not ill-formed, however we still produce a warning for
 // this one because explicit construction from a variant using CTAD is ambiguous
-// (in the sense that the programer intent is not clear).
+// (in the sense that the programmer intent is not clear).
 // ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-ctad-maybe-unsupported
 
 #include <variant>

--- a/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/implicit_ctad.pass.cpp
@@ -17,7 +17,7 @@
 // We make sure that it is not ill-formed, however we still produce a warning for
 // this one because explicit construction from a variant using CTAD is ambiguous
 // (in the sense that the programer intent is not clear).
-// ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-ctad-maybe-unsupported
 
 #include <variant>
 

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -104,14 +104,4 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 
 #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
 
-#ifdef __clang__
-#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
-    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
-#  define _LIBCPP_SUPPRESS_DEPRECATED_POP _Pragma("GCC diagnostic pop")
-#else // ^^^ clang / MSVC vvv
-#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
-    __pragma(warning(push)) __pragma(warning(disable : 4996)) __pragma(warning(disable : 5215))
-#  define _LIBCPP_SUPPRESS_DEPRECATED_POP __pragma(warning(pop))
-#endif // __clang__
-
 #endif // SUPPORT_MSVC_STDLIB_FORCE_INCLUDE_H


### PR DESCRIPTION
This is the last PR that's needed (for now) to get libc++'s tests working with MSVC's STL.

It returns to the overall approach of #74974 by enhancing `ADDITIONAL_COMPILE_FLAGS` with `gcc-style-warnings` and `cl-style-warnings` features (because `-Wno-meow` and `/wdNNNN` are mutually unintelligible), addressing @philnik777's objection in https://github.com/llvm/llvm-project/pull/75133#pullrequestreview-1778075863 by keeping #75133's approach of introducing `TEST_MEOW_DIAGNOSTIC_IGNORED` only for local suppressions. The result is a minimal change from the status quo (it doesn't change any files away from using `ADDITIONAL_COMPILE_FLAGS` for whole-test suppressions) and should hopefully be acceptable to all maintainers.

I thought it was simplest to open a fresh PR with the following well-structured commits:

* features.py: Add `gcc-style-warnings` and `cl-style-warnings`.
  + Also refactor `_isClang` and `_isGCC`.
* Update `ADDITIONAL_COMPILE_FLAGS`, using `gcc-style-warnings` and `cl-style-warnings`.
* advance.pass.cpp: Remember to use `gcc-style-warnings`.
* implicit_ctad.pass.cpp: Fix comment typo.
* equal.pass.cpp: Use `gcc-style-warnings` and `cl-style-warnings`, locally suppress MSVC warning C4310.
* Locally suppress MSVC warnings C4197 and C4583.
* result_of11.pass.cpp: Overhaul how we suppress "deprecated volatile" warnings.
  + This avoids using the internal macros `_LIBCPP_SUPPRESS_DEPRECATED_PUSH`/`_LIBCPP_SUPPRESS_DEPRECATED_POP`.
  + This test was previously using `#pragma GCC diagnostic ignored "-Wvolatile"` for a whole-test suppression, but that doesn't need to apply to product code headers, so there wasn't a weird dance of having to include `"test_macros.h"` at the very top. I've chosen a minimal change of converting this to `TEST_MEOW_DIAGNOSTIC_IGNORED` in-place. If desired, I could attempt to replace this with `ADDITIONAL_COMPILE_FLAGS` for consistency with other whole-test suppresions.
* msvc_stdlib_force_include.h: No longer needs to simulate `_LIBCPP_SUPPRESS_DEPRECATED_PUSH`/`_LIBCPP_SUPPRESS_DEPRECATED_POP`.
