### PR TITLE
[reland][libc][NFC] Implement `FPBits` in terms of `FloatProperties` to reduce clutter (#75196)

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -36,71 +36,74 @@ template <typename T> struct ExponentWidth {
 // floating numbers. On x86 platforms however, the 'long double' type maps to
 // an x87 floating point format. This format is an IEEE 754 extension format.
 // It is handled as an explicit specialization of this class.
-template <typename T> struct FPBits {
+template <typename T> struct FPBits : private FloatProperties<T> {
   static_assert(cpp::is_floating_point_v<T>,
                 "FPBits instantiated with invalid type.");
+  using typename FloatProperties<T>::UIntType;
+  using FloatProperties<T>::BIT_WIDTH;
+  using FloatProperties<T>::EXP_MANT_MASK;
+  using FloatProperties<T>::EXPONENT_MASK;
+  using FloatProperties<T>::EXPONENT_BIAS;
+  using FloatProperties<T>::EXPONENT_WIDTH;
+  using FloatProperties<T>::MANTISSA_MASK;
+  using FloatProperties<T>::MANTISSA_WIDTH;
+  using FloatProperties<T>::QUIET_NAN_MASK;
+  using FloatProperties<T>::SIGN_MASK;
 
   // Reinterpreting bits as an integer value and interpreting the bits of an
   // integer value as a floating point value is used in tests. So, a convenient
   // type is provided for such reinterpretations.
-  using FloatProp = FloatProperties<T>;
-  using UIntType = typename FloatProp::UIntType;
-
   UIntType bits;
 
   LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
-    mantVal &= (FloatProp::MANTISSA_MASK);
-    bits &= ~(FloatProp::MANTISSA_MASK);
+    mantVal &= MANTISSA_MASK;
+    bits &= ~MANTISSA_MASK;
     bits |= mantVal;
   }
 
   LIBC_INLINE constexpr UIntType get_mantissa() const {
-    return bits & FloatProp::MANTISSA_MASK;
+    return bits & MANTISSA_MASK;
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal = (expVal << (FloatProp::MANTISSA_WIDTH)) & FloatProp::EXPONENT_MASK;
-    bits &= ~(FloatProp::EXPONENT_MASK);
+    expVal = (expVal << MANTISSA_WIDTH) & EXPONENT_MASK;
+    bits &= ~EXPONENT_MASK;
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & FloatProp::EXPONENT_MASK) >>
-                    (FloatProp::MANTISSA_WIDTH));
+    return uint16_t((bits & EXPONENT_MASK) >> MANTISSA_WIDTH);
   }
 
   // The function return mantissa with the implicit bit set iff the current
   // value is a valid normal number.
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() {
     return ((get_biased_exponent() > 0 && !is_inf_or_nan())
-                ? (FloatProp::MANTISSA_MASK + 1)
+                ? (MANTISSA_MASK + 1)
                 : 0) |
-           (FloatProp::MANTISSA_MASK & bits);
+           (MANTISSA_MASK & bits);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {
-    bits |= FloatProp::SIGN_MASK;
+    bits |= SIGN_MASK;
     if (!signVal)
-      bits -= FloatProp::SIGN_MASK;
+      bits -= SIGN_MASK;
   }
 
   LIBC_INLINE constexpr bool get_sign() const {
-    return (bits & FloatProp::SIGN_MASK) != 0;
+    return (bits & SIGN_MASK) != 0;
   }
 
   static_assert(sizeof(T) == sizeof(UIntType),
                 "Data type and integral representation have different sizes.");
 
-  static constexpr int EXPONENT_BIAS = (1 << (ExponentWidth<T>::VALUE - 1)) - 1;
-  static constexpr int MAX_EXPONENT = (1 << ExponentWidth<T>::VALUE) - 1;
+  static constexpr int MAX_EXPONENT = (1 << EXPONENT_WIDTH) - 1;
 
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
-  static constexpr UIntType MAX_SUBNORMAL =
-      (UIntType(1) << MantissaWidth<T>::VALUE) - 1;
-  static constexpr UIntType MIN_NORMAL =
-      (UIntType(1) << MantissaWidth<T>::VALUE);
+  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << MANTISSA_WIDTH) - 1;
+  static constexpr UIntType MIN_NORMAL = (UIntType(1) << MANTISSA_WIDTH);
   static constexpr UIntType MAX_NORMAL =
-      ((UIntType(MAX_EXPONENT) - 1) << MantissaWidth<T>::VALUE) | MAX_SUBNORMAL;
+      ((UIntType(MAX_EXPONENT) - 1) << MANTISSA_WIDTH) | MAX_SUBNORMAL;
 
   // We don't want accidental type promotions/conversions, so we require exact
   // type match.
@@ -151,32 +154,29 @@ template <typename T> struct FPBits {
   }
 
   LIBC_INLINE constexpr bool is_inf() const {
-    return (bits & FloatProp::EXP_MANT_MASK) == FloatProp::EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) == EXPONENT_MASK;
   }
 
   LIBC_INLINE constexpr bool is_nan() const {
-    return (bits & FloatProp::EXP_MANT_MASK) > FloatProp::EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) > EXPONENT_MASK;
   }
 
   LIBC_INLINE constexpr bool is_quiet_nan() const {
-    return (bits & FloatProp::EXP_MANT_MASK) ==
-           (FloatProp::EXPONENT_MASK | FloatProp::QUIET_NAN_MASK);
+    return (bits & EXP_MANT_MASK) == (EXPONENT_MASK | QUIET_NAN_MASK);
   }
 
   LIBC_INLINE constexpr bool is_inf_or_nan() const {
-    return (bits & FloatProp::EXPONENT_MASK) == FloatProp::EXPONENT_MASK;
+    return (bits & EXPONENT_MASK) == EXPONENT_MASK;
   }
 
   LIBC_INLINE static constexpr T zero(bool sign = false) {
-    return FPBits(sign ? FloatProp::SIGN_MASK : UIntType(0)).get_val();
+    return FPBits(sign ? SIGN_MASK : UIntType(0)).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_zero() { return zero(true); }
 
   LIBC_INLINE static constexpr T inf(bool sign = false) {
-    return FPBits((sign ? FloatProp::SIGN_MASK : UIntType(0)) |
-                  FloatProp::EXPONENT_MASK)
-        .get_val();
+    return FPBits((sign ? SIGN_MASK : UIntType(0)) | EXPONENT_MASK).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_inf() { return inf(true); }
@@ -204,7 +204,7 @@ template <typename T> struct FPBits {
   }
 
   LIBC_INLINE static constexpr T build_quiet_nan(UIntType v) {
-    return build_nan(FloatProp::QUIET_NAN_MASK | v);
+    return build_nan(QUIET_NAN_MASK | v);
   }
 
   // The function convert integer number and unbiased exponent to proper float
@@ -220,7 +220,7 @@ template <typename T> struct FPBits {
   LIBC_INLINE static constexpr FPBits<T> make_value(UIntType number, int ep) {
     FPBits<T> result;
     // offset: +1 for sign, but -1 for implicit first bit
-    int lz = cpp::countl_zero(number) - FloatProp::EXPONENT_WIDTH;
+    int lz = cpp::countl_zero(number) - EXPONENT_WIDTH;
     number <<= lz;
     ep -= lz;
 

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -167,11 +167,11 @@ template <typename T> struct FModFastMathWrapper {
 
 template <typename T> class FModDivisionSimpleHelper {
 private:
-  using intU_t = typename FPBits<T>::UIntType;
+  using UIntType = typename FPBits<T>::UIntType;
 
 public:
-  LIBC_INLINE constexpr static intU_t
-  execute(int exp_diff, int sides_zeroes_count, intU_t m_x, intU_t m_y) {
+  LIBC_INLINE constexpr static UIntType
+  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
     while (exp_diff > sides_zeroes_count) {
       exp_diff -= sides_zeroes_count;
       m_x <<= sides_zeroes_count;
@@ -186,23 +186,22 @@ public:
 template <typename T> class FModDivisionInvMultHelper {
 private:
   using FPB = FPBits<T>;
-  using intU_t = typename FPB::UIntType;
+  using UIntType = typename FPB::UIntType;
 
 public:
-  LIBC_INLINE constexpr static intU_t
-  execute(int exp_diff, int sides_zeroes_count, intU_t m_x, intU_t m_y) {
+  LIBC_INLINE constexpr static UIntType
+  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
     if (exp_diff > sides_zeroes_count) {
-      intU_t inv_hy = (cpp::numeric_limits<intU_t>::max() / m_y);
+      UIntType inv_hy = (cpp::numeric_limits<UIntType>::max() / m_y);
       while (exp_diff > sides_zeroes_count) {
         exp_diff -= sides_zeroes_count;
-        intU_t hd =
-            (m_x * inv_hy) >> (FPB::FloatProp::BIT_WIDTH - sides_zeroes_count);
+        UIntType hd = (m_x * inv_hy) >> (FPB::BIT_WIDTH - sides_zeroes_count);
         m_x <<= sides_zeroes_count;
         m_x -= hd * m_y;
         while (LIBC_UNLIKELY(m_x > m_y))
           m_x -= m_y;
       }
-      intU_t hd = (m_x * inv_hy) >> (FPB::FloatProp::BIT_WIDTH - exp_diff);
+      UIntType hd = (m_x * inv_hy) >> (FPB::BIT_WIDTH - exp_diff);
       m_x <<= exp_diff;
       m_x -= hd * m_y;
       while (LIBC_UNLIKELY(m_x > m_y))
@@ -223,7 +222,7 @@ class FMod {
 
 private:
   using FPB = FPBits<T>;
-  using intU_t = typename FPB::UIntType;
+  using UIntType = typename FPB::UIntType;
 
   LIBC_INLINE static constexpr FPB eval_internal(FPB sx, FPB sy) {
 
@@ -237,11 +236,11 @@ private:
     int e_y = sy.get_biased_exponent();
 
     // Most common case where |y| is "very normal" and |x/y| < 2^EXPONENT_WIDTH
-    if (LIBC_LIKELY(e_y > int(FPB::FloatProp::MANTISSA_WIDTH) &&
-                    e_x - e_y <= int(FPB::FloatProp::EXPONENT_WIDTH))) {
-      intU_t m_x = sx.get_explicit_mantissa();
-      intU_t m_y = sy.get_explicit_mantissa();
-      intU_t d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
+    if (LIBC_LIKELY(e_y > int(FPB::MANTISSA_WIDTH) &&
+                    e_x - e_y <= int(FPB::EXPONENT_WIDTH))) {
+      UIntType m_x = sx.get_explicit_mantissa();
+      UIntType m_y = sy.get_explicit_mantissa();
+      UIntType d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
       if (d == 0)
         return FPB(FPB::zero());
       // iy - 1 because of "zero power" for number with power 1
@@ -255,11 +254,11 @@ private:
     }
 
     // Note that hx is not subnormal by conditions above.
-    intU_t m_x = sx.get_explicit_mantissa();
+    UIntType m_x = sx.get_explicit_mantissa();
     e_x--;
 
-    intU_t m_y = sy.get_explicit_mantissa();
-    int lead_zeros_m_y = FPB::FloatProp::EXPONENT_WIDTH;
+    UIntType m_y = sy.get_explicit_mantissa();
+    int lead_zeros_m_y = FPB::EXPONENT_WIDTH;
     if (LIBC_LIKELY(e_y > 0)) {
       e_y--;
     } else {
@@ -282,9 +281,8 @@ private:
 
     {
       // Shift hx left until the end or n = 0
-      int left_shift = exp_diff < int(FPB::FloatProp::EXPONENT_WIDTH)
-                           ? exp_diff
-                           : FPB::FloatProp::EXPONENT_WIDTH;
+      int left_shift =
+          exp_diff < int(FPB::EXPONENT_WIDTH) ? exp_diff : FPB::EXPONENT_WIDTH;
       m_x <<= left_shift;
       exp_diff -= left_shift;
     }

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -71,7 +71,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 eisel_lemire(ExpandedFloat<T> init_num,
              RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -184,7 +184,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<long double>>
 eisel_lemire<long double>(ExpandedFloat<long double> init_num,
                           RoundDirection round) {
   using FPBits = typename fputil::FPBits<long double>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<long double>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -322,7 +322,7 @@ LIBC_INLINE FloatConvertReturn<T>
 simple_decimal_conversion(const char *__restrict numStart,
                           RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   int32_t exp2 = 0;
@@ -516,7 +516,7 @@ LIBC_INLINE cpp::optional<ExpandedFloat<T>>
 clinger_fast_path(ExpandedFloat<T> init_num,
                   RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;
@@ -724,7 +724,7 @@ LIBC_INLINE FloatConvertReturn<T> binary_exp_to_float(ExpandedFloat<T> init_num,
                                                       bool truncated,
                                                       RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using FloatProp = typename FPBits::FloatProp;
+  using FloatProp = typename fputil::FloatProperties<T>;
   using UIntType = typename FPBits::UIntType;
 
   UIntType mantissa = init_num.mantissa;

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -34,7 +34,7 @@ LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
 
   if (LIBC_UNLIKELY(x_u >= 0x4f8ffb03)) {
     // Check for exceptional values.
-    uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
+    uint32_t x_abs = x_u & FPBits_t::EXP_MANT_MASK;
     if (LIBC_UNLIKELY(x_abs >= 0x7f80'0000U)) {
       // x is +inf or NaN.
       return x;

--- a/libc/src/math/generic/asinhf.cpp
+++ b/libc/src/math/generic/asinhf.cpp
@@ -21,7 +21,7 @@ LLVM_LIBC_FUNCTION(float, asinhf, (float x)) {
   using FPBits_t = typename fputil::FPBits<float>;
   FPBits_t xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits_t::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits_t::EXP_MANT_MASK;
 
   // |x| <= 2^-3
   if (LIBC_UNLIKELY(x_abs <= 0x3e80'0000U)) {

--- a/libc/src/math/generic/atanhf.cpp
+++ b/libc/src/math/generic/atanhf.cpp
@@ -17,7 +17,7 @@ LLVM_LIBC_FUNCTION(float, atanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   bool sign = xbits.get_sign();
-  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
 
   // |x| >= 1.0
   if (LIBC_UNLIKELY(x_abs >= 0x3F80'0000U)) {

--- a/libc/src/math/generic/erff.cpp
+++ b/libc/src/math/generic/erff.cpp
@@ -154,7 +154,7 @@ LLVM_LIBC_FUNCTION(float, erff, (float x)) {
   double xd = static_cast<double>(x);
   double xsq = xd * xd;
 
-  const uint32_t EIGHT = 3 << FPBits::FloatProp::MANTISSA_WIDTH;
+  const uint32_t EIGHT = 3 << FPBits::MANTISSA_WIDTH;
   int idx = static_cast<int>(FPBits(x_abs + EIGHT).get_val());
 
   double x4 = xsq * xsq;

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -280,12 +280,11 @@ LIBC_INLINE static double log2_eval(double x) {
   double result = 0;
   result += bs.get_exponent();
 
-  int p1 =
-      (bs.get_mantissa() >> (FPB::FloatProp::MANTISSA_WIDTH - LOG_P1_BITS)) &
-      (LOG_P1_SIZE - 1);
+  int p1 = (bs.get_mantissa() >> (FPB::MANTISSA_WIDTH - LOG_P1_BITS)) &
+           (LOG_P1_SIZE - 1);
 
-  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> LOG_P1_BITS;
-  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.bits &= FPB::MANTISSA_MASK >> LOG_P1_BITS;
+  bs.set_biased_exponent(FPB::EXPONENT_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
   // Taylor series for log(2,1+x)
@@ -311,12 +310,11 @@ LIBC_INLINE static double log_eval(double x) {
 
   // p1 is the leading 7 bits of mx, i.e.
   // p1 * 2^(-7) <= m_x < (p1 + 1) * 2^(-7).
-  int p1 = static_cast<int>(bs.get_mantissa() >>
-                            (FPB::FloatProp::MANTISSA_WIDTH - 7));
+  int p1 = static_cast<int>(bs.get_mantissa() >> (FPB::MANTISSA_WIDTH - 7));
 
   // Set bs to (1 + (mx - p1*2^(-7))
-  bs.bits &= FPB::FloatProp::MANTISSA_MASK >> 7;
-  bs.set_biased_exponent(FPB::FloatProp::EXPONENT_BIAS);
+  bs.bits &= FPB::MANTISSA_MASK >> 7;
+  bs.set_biased_exponent(FPB::EXPONENT_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
 

--- a/libc/src/math/generic/inv_trigf_utils.h
+++ b/libc/src/math/generic/inv_trigf_utils.h
@@ -51,7 +51,7 @@ LIBC_INLINE double atan_eval(double x) {
 
   FPB bs(x);
   bool sign = bs.get_sign();
-  auto x_abs = bs.uintval() & FPB::FloatProp::EXP_MANT_MASK;
+  auto x_abs = bs.uintval() & FPB::EXP_MANT_MASK;
 
   if (x_abs <= umin) {
     double pe = LIBC_NAMESPACE::fputil::polyeval(
@@ -64,7 +64,8 @@ LIBC_INLINE double atan_eval(double x) {
     double one_over_x2 = one_over_x_m * one_over_x_m;
     double pe = LIBC_NAMESPACE::fputil::polyeval(
         one_over_x2, ATAN_K[0], ATAN_K[1], ATAN_K[2], ATAN_K[3]);
-    return fputil::multiply_add(pe, one_over_x_m, sign ? (-M_MATH_PI_2) : (M_MATH_PI_2));
+    return fputil::multiply_add(pe, one_over_x_m,
+                                sign ? (-M_MATH_PI_2) : (M_MATH_PI_2));
   }
 
   double pos_x = FPB(x_abs).get_val();

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -873,8 +873,8 @@ LIBC_INLINE double log1p_accurate(int e_x, int index,
 LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   using FPBits_t = typename fputil::FPBits<double>;
   constexpr int EXPONENT_BIAS = FPBits_t::EXPONENT_BIAS;
-  constexpr int MANTISSA_WIDTH = FPBits_t::FloatProp::MANTISSA_WIDTH;
-  constexpr uint64_t MANTISSA_MASK = FPBits_t::FloatProp::MANTISSA_MASK;
+  constexpr int MANTISSA_WIDTH = FPBits_t::MANTISSA_WIDTH;
+  constexpr uint64_t MANTISSA_MASK = FPBits_t::MANTISSA_MASK;
   FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
@@ -969,7 +969,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   // Scaling factior = 2^(-xh_bits.get_exponent())
   uint64_t s_u =
       (static_cast<uint64_t>(EXPONENT_BIAS) << (MANTISSA_WIDTH + 1)) -
-      (x_u & FPBits_t::FloatProp::EXPONENT_MASK);
+      (x_u & FPBits_t::EXPONENT_MASK);
   // When the exponent of x is 2^1023, its inverse, 2^(-1023), is subnormal.
   const double EXPONENT_CORRECTION[2] = {0.0, 0x1.0p-1023};
   double scaling = FPBits_t(s_u).get_val() + EXPONENT_CORRECTION[s_u == 0];

--- a/libc/src/math/generic/sinhf.cpp
+++ b/libc/src/math/generic/sinhf.cpp
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
-  uint32_t x_abs = xbits.uintval() & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
 
   // When |x| >= 90, or x is inf or nan
   if (LIBC_UNLIKELY(x_abs >= 0x42b4'0000U || x_abs <= 0x3da0'0000U)) {
@@ -57,8 +57,7 @@ LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
     int rounding = fputil::quick_get_round();
     if (sign) {
       if (LIBC_UNLIKELY(rounding == FE_UPWARD || rounding == FE_TOWARDZERO))
-        return FPBits(FPBits::MAX_NORMAL | FPBits::FloatProp::SIGN_MASK)
-            .get_val();
+        return FPBits(FPBits::MAX_NORMAL | FPBits::SIGN_MASK).get_val();
     } else {
       if (LIBC_UNLIKELY(rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO))
         return FPBits(FPBits::MAX_NORMAL).get_val();

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
   FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits::FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
 
   // When |x| >= 15, or x is inf or nan, or |x| <= 0.078125
   if (LIBC_UNLIKELY((x_abs >= 0x4170'0000U) || (x_abs <= 0x3da0'0000U))) {


### PR DESCRIPTION
Also make type naming consistent by using `UIntType` instead of `intU_t`.
This patch is a reland of #75196 but does not include the "use `FPBits` instead of `FPBits_t`, `FPB`" part. This needs more work.
