### PR TITLE
Fix lldb-dap pickProcess command for selecting process for debugger attachment

### DIFF
--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -125,7 +125,7 @@ The JSON configuration file can contain the following `lldb-dap` specific launch
 |**type**           |string  |Y| Must be "lldb-dap".
 |**request**        |string  |Y| Must be "attach".
 |**program**        |string  | | Path to the executable to attach to. This value is optional but can help to resolve breakpoints prior the attaching to the program.
-|**pid**            |number  | | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **porgram**. Setting this value to `${command:pickMyProcess}` will allow interactive process selection in the IDE.
+|**pid**            |number  | | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **program**. Setting this value to `${command:pickProcess}` will allow interactive process selection in the IDE.
 |**stopOnEntry**    |boolean| | Whether to stop program immediately after launching.
 |**waitFor**        |boolean | | Wait for the process to launch.
 |**initCommands**   |[string]| | LLDB commands executed upon debugger startup prior to creating the LLDB target. Commands and command output will be sent to the debugger console when they are executed.

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -124,6 +124,9 @@
 						"swift"
 					]
 				},
+				"variables": {
+					"pickProcess": "extension.pickNativeProcess"
+				},
 				"program": "./bin/lldb-dap",
 				"windows": {
 					"program": "./bin/lldb-dap.exe"


### PR DESCRIPTION
Hi,

I see that the documentation for lldb-dap refers to a ${command.pickMyProcess} which can be used for interactive process selection within the VS Code IDE. It appears that this functionality no longer works, perhaps due to internal changes in VS Code.

I can get interactive process selection if I add the following snippet to the lldp-dap extension package.json:

```
"variables": {
	"pickProcess": "extension.pickNativeProcess"
},
```
and then use
```
"pid": "${command:pickProcess}",
```
within my launch.json configuration for lldb-dap.

However, referencing extension.pickNativeProcess here is only valid if the Microsoft VSCode CPPTools extension is installed & enabled, as that is the extension that registers a native process picker under the name 'extension.pickNativeProcess'.
I'm not sure if it's desirable behaviour for the lldb-dap extension to be dependent on the presence of the Microsoft CPPTools extension?

It appears (although I am not familiar with VSCode extension development) that any solution to this that was fully integrated in the lldp-dap extension would require typescript source to be added to the extension in order to register a private native process picker under a custom name - something like `extension.lldb-dap.pickNativeProcess`. I would assume that this implementation would look very similar, if not identical, to the command currently exposed by the Microsoft CPPTools extension.

In the PR I have included the minimal changes required to make the process picker work when the Microsoft VSCode CPPTools extension is also installed.

What are the recommendations on how we could proceed here?


Thanks!
