### PR TITLE
[libc++] Add CI job for testing macOS C++03

### DIFF
--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -967,12 +967,18 @@ public:
 // For more details, see the "Using libc++" documentation page or
 // the documentation for __sanitizer_annotate_contiguous_container.
     _LIBCPP_HIDE_FROM_ABI void __annotate_double_ended_contiguous_container(
-       [[__maybe_unused__]] const void* __beg,
-       [[__maybe_unused__]] const void* __end,
-       [[__maybe_unused__]] const void* __old_con_beg,
-       [[__maybe_unused__]] const void* __old_con_end,
-       [[__maybe_unused__]] const void* __new_con_beg,
-       [[__maybe_unused__]] const void* __new_con_end) const {
+        const void* __beg,
+        const void* __end,
+        const void* __old_con_beg,
+        const void* __old_con_end,
+        const void* __new_con_beg,
+        const void* __new_con_end) const {
+        (void)__beg;
+        (void)__end;
+        (void)__old_con_beg;
+        (void)__old_con_end;
+        (void)__new_con_beg;
+        (void)__new_con_end;
 #ifndef _LIBCPP_HAS_NO_ASAN
         if (__beg != nullptr && __asan_annotate_container_with_allocator<_Allocator>::value)
             __sanitizer_annotate_double_ended_contiguous_container(
@@ -982,10 +988,14 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI
     void __annotate_from_to(
-            [[__maybe_unused__]] size_type __beg,
-            [[__maybe_unused__]] size_type __end,
-            [[__maybe_unused__]] __asan_annotation_type __annotation_type,
-            [[__maybe_unused__]] __asan_annotation_place __place) const _NOEXCEPT {
+            size_type __beg,
+            size_type __end,
+            __asan_annotation_type __annotation_type,
+            __asan_annotation_place __place) const _NOEXCEPT {
+        (void)__beg;
+        (void)__end;
+        (void)__annotation_type;
+        (void)__place;
 #ifndef _LIBCPP_HAS_NO_ASAN
         // __beg - index of the first item to annotate
         // __end - index behind the last item to annotate (so last item + 1)

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1917,8 +1917,9 @@ private:
         {return __is_long() ? __get_long_pointer() : __get_short_pointer();}
 
     // The following functions are no-ops outside of AddressSanitizer mode.
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_contiguous_container(
-        [[__maybe_unused__]] const void* __old_mid, [[__maybe_unused__]] const void* __new_mid) const {
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_contiguous_container(const void* __old_mid, const void* __new_mid) const {
+        (void)__old_mid;
+        (void)__new_mid;
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
         const void* __begin = data();
         const void* __end = data() + capacity() + 1;

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -852,11 +852,15 @@ private:
     // the documentation for __sanitizer_annotate_contiguous_container.
 
     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
-    void __annotate_contiguous_container([[__maybe_unused__]] const void *__beg,
-                                         [[__maybe_unused__]] const void *__end,
-                                         [[__maybe_unused__]] const void *__old_mid,
-                                         [[__maybe_unused__]] const void *__new_mid) const
+    void __annotate_contiguous_container(const void *__beg,
+                                         const void *__end,
+                                         const void *__old_mid,
+                                         const void *__new_mid) const
     {
+      (void)__beg;
+      (void)__end;
+      (void)__old_mid;
+      (void)__new_mid;
 #ifndef _LIBCPP_HAS_NO_ASAN
       if (!__libcpp_is_constant_evaluated() && __beg != nullptr && __asan_annotate_container_with_allocator<_Allocator>::value)
         __sanitizer_annotate_contiguous_container(__beg, __end, __old_mid, __new_mid);

--- a/libcxx/test/support/assert_macros.h
+++ b/libcxx/test/support/assert_macros.h
@@ -50,7 +50,7 @@ void test_log(const char* condition, const char* file, int line, const F& functo
 }
 
 template <class Arg>
-[[noreturn]] void test_fail(const char* file, int line, const Arg& arg) {
+TEST_NORETURN void test_fail(const char* file, int line, const Arg& arg) {
   test_log("", file, line, arg);
   std::abort();
 }

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -156,6 +156,11 @@ steps:
     <<: *mac_agent_any_arch
     <<: *common
 
+  - label: MacOS with C++03
+    command: libcxx/utils/ci/run-buildbot generic-cxx03
+    <<: *mac_agent_any_arch
+    <<: *common
+
     # Build with the configuration we use to generate libc++.dylib on Apple platforms
   - label: Apple system
     command: libcxx/utils/ci/run-buildbot apple-system


### PR DESCRIPTION
It's not that I have much love for C++03, but we should ensure that it works. Some recent changes broke this configuration because slightly older Clang versions don't support attribute syntax in C++03 mode.