### PR TITLE
[libc][NFC] Remove ExponentWidth traits

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -24,10 +24,6 @@ template <typename T> struct MantissaWidth {
   static constexpr unsigned VALUE = FloatProperties<T>::MANTISSA_WIDTH;
 };
 
-template <typename T> struct ExponentWidth {
-  static constexpr unsigned VALUE = FloatProperties<T>::EXPONENT_WIDTH;
-};
-
 // A generic class to represent single precision, double precision, and quad
 // precision IEEE 754 floating point formats.
 // On most platforms, the 'float' type corresponds to single precision floating

--- a/libc/src/__support/FPUtil/NormalFloat.h
+++ b/libc/src/__support/FPUtil/NormalFloat.h
@@ -92,7 +92,7 @@ template <typename T> struct NormalFloat {
   LIBC_INLINE operator T() const {
     int biased_exponent = exponent + FPBits<T>::EXPONENT_BIAS;
     // Max exponent is of the form 0xFF...E. That is why -2 and not -1.
-    constexpr int MAX_EXPONENT_VALUE = (1 << ExponentWidth<T>::VALUE) - 2;
+    constexpr int MAX_EXPONENT_VALUE = (1 << FPBits<T>::EXPONENT_WIDTH) - 2;
     if (biased_exponent > MAX_EXPONENT_VALUE) {
       return sign ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
     }
@@ -208,18 +208,18 @@ NormalFloat<long double>::init_from_bits(FPBits<long double> bits) {
 }
 
 template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
-  int biased_exponent = exponent + FPBits<long double>::EXPONENT_BIAS;
+  using LDBits = FPBits<long double>;
+  int biased_exponent = exponent + LDBits::EXPONENT_BIAS;
   // Max exponent is of the form 0xFF...E. That is why -2 and not -1.
-  constexpr int MAX_EXPONENT_VALUE =
-      (1 << ExponentWidth<long double>::VALUE) - 2;
+  constexpr int MAX_EXPONENT_VALUE = (1 << LDBits::EXPONENT_WIDTH) - 2;
   if (biased_exponent > MAX_EXPONENT_VALUE) {
-    return sign ? FPBits<long double>::neg_inf() : FPBits<long double>::inf();
+    return sign ? LDBits::neg_inf() : LDBits::inf();
   }
 
   FPBits<long double> result(0.0l);
   result.set_sign(sign);
 
-  constexpr int SUBNORMAL_EXPONENT = -FPBits<long double>::EXPONENT_BIAS + 1;
+  constexpr int SUBNORMAL_EXPONENT = -LDBits::EXPONENT_BIAS + 1;
   if (exponent < SUBNORMAL_EXPONENT) {
     unsigned shift = SUBNORMAL_EXPONENT - exponent;
     if (shift <= MantissaWidth<long double>::VALUE + 1) {

--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -25,10 +25,10 @@
 namespace LIBC_NAMESPACE {
 namespace printf_core {
 
-using MantissaInt = fputil::FPBits<long double>::UIntType;
-
 LIBC_INLINE int convert_float_hex_exp(Writer *writer,
                                       const FormatSection &to_conv) {
+  using LDBits = fputil::FPBits<long double>;
+  using MantissaInt = LDBits::UIntType;
   // All of the letters will be defined relative to variable a, which will be
   // the appropriate case based on the name of the conversion. This converts any
   // conversion name into the letter 'a' with the appropriate case.
@@ -40,18 +40,19 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   bool is_inf_or_nan;
   uint32_t mantissa_width;
   if (to_conv.length_modifier == LengthModifier::L) {
-    mantissa_width = fputil::MantissaWidth<long double>::VALUE;
-    fputil::FPBits<long double>::UIntType float_raw = to_conv.conv_val_raw;
-    fputil::FPBits<long double> float_bits(float_raw);
+    mantissa_width = LDBits::MANTISSA_WIDTH;
+    LDBits::UIntType float_raw = to_conv.conv_val_raw;
+    LDBits float_bits(float_raw);
     is_negative = float_bits.get_sign();
     exponent = float_bits.get_explicit_exponent();
     mantissa = float_bits.get_explicit_mantissa();
     is_inf_or_nan = float_bits.is_inf_or_nan();
   } else {
-    mantissa_width = fputil::MantissaWidth<double>::VALUE;
-    fputil::FPBits<double>::UIntType float_raw =
-        static_cast<fputil::FPBits<double>::UIntType>(to_conv.conv_val_raw);
-    fputil::FPBits<double> float_bits(float_raw);
+    using LBits = fputil::FPBits<double>;
+    mantissa_width = LBits::MANTISSA_WIDTH;
+    LBits::UIntType float_raw =
+        static_cast<LBits::UIntType>(to_conv.conv_val_raw);
+    LBits float_bits(float_raw);
     is_negative = float_bits.get_sign();
     exponent = float_bits.get_explicit_exponent();
     mantissa = float_bits.get_explicit_mantissa();
@@ -157,8 +158,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // 15 -> 5
   // 11 -> 4
   // 8  -> 3
-  constexpr size_t EXP_LEN =
-      (((fputil::ExponentWidth<long double>::VALUE * 5) + 15) / 16) + 1;
+  constexpr size_t EXP_LEN = (((LDBits::EXPONENT_WIDTH * 5) + 15) / 16) + 1;
   char exp_buffer[EXP_LEN];
 
   bool exp_is_negative = false;


### PR DESCRIPTION
Is it redundant with `FloatProperties::EXPONENT_WIDTH` and does bear its weight.
