### PR TITLE
[OptTable] Make new lines in help text respect indentation

### DIFF
--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -664,15 +664,24 @@ static void PrintHelpOptionList(raw_ostream &OS, StringRef Title,
   const unsigned InitialPad = 2;
   for (const OptionInfo &Opt : OptionHelp) {
     const std::string &Option = Opt.Name;
-    int Pad = OptionFieldWidth - int(Option.size());
+    int Pad = OptionFieldWidth + InitialPad;
+    int FirstLinePad = OptionFieldWidth - int(Option.size());
     OS.indent(InitialPad) << Option;
 
     // Break on long option names.
-    if (Pad < 0) {
+    if (FirstLinePad < 0) {
       OS << "\n";
-      Pad = OptionFieldWidth + InitialPad;
+      FirstLinePad = OptionFieldWidth + InitialPad;
+      Pad = FirstLinePad;
     }
-    OS.indent(Pad + 1) << Opt.HelpText << '\n';
+
+    SmallVector<StringRef> Lines;
+    Opt.HelpText.split(Lines, '\n');
+    assert(Lines.size() && "Expected at least the first line in the help text");
+    auto *LinesIt = Lines.begin();
+    OS.indent(FirstLinePad + 1) << *LinesIt << '\n';
+    while (Lines.end() != ++LinesIt)
+      OS.indent(Pad + 1) << *LinesIt << '\n';
   }
 }
 

--- a/llvm/unittests/Option/OptionParsingTest.cpp
+++ b/llvm/unittests/Option/OptionParsingTest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
+#include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
 #include "gtest/gtest.h"
 
@@ -50,6 +51,7 @@ enum OptionFlags {
 
 enum OptionVisibility {
   SubtoolVis = (1 << 2),
+  MultiLineVis = (1 << 3),
 };
 
 static constexpr OptTable::Info InfoTable[] = {
@@ -537,4 +539,24 @@ TYPED_TEST(OptTableTest, UnknownGroupedShortOptions) {
   EXPECT_EQ("-z", Unknown[1]);
   EXPECT_EQ("-u", Unknown[2]);
   EXPECT_EQ("-z", Unknown[3]);
+}
+
+TYPED_TEST(OptTableTest, PrintMultilineHelpText) {
+  TypeParam T;
+  std::string Help;
+  raw_string_ostream RSO(Help);
+  T.printHelp(RSO, "usage", "title", /*ShowHidden=*/false,
+              /*ShowAllAliases=*/false, Visibility(MultiLineVis));
+  EXPECT_STREQ(Help.c_str(), R"(OVERVIEW: title
+
+USAGE: usage
+
+OPTIONS:
+  -multiline-help-with-long-name
+                  This a help text that has
+                  multiple lines in it
+                  and a long name
+  -multiline-help This a help text that has
+                  multiple lines in it
+)");
 }

--- a/llvm/unittests/Option/Opts.td
+++ b/llvm/unittests/Option/Opts.td
@@ -5,6 +5,7 @@ def OptFlag2 : OptionFlag;
 def OptFlag3 : OptionFlag;
 
 def SubtoolVis : OptionVisibility;
+def MultiLineVis: OptionVisibility;
 
 def A : Flag<["-"], "A">, HelpText<"The A option">, Flags<[OptFlag1]>;
 def AB : Flag<["-"], "AB">;
@@ -49,6 +50,16 @@ def Blurmpq_eq : Flag<["--"], "blurmp=">;
 
 def Q : Flag<["-"], "Q">, Visibility<[SubtoolVis]>;
 def R : Flag<["-"], "R">, Visibility<[DefaultVis, SubtoolVis]>;
+
+def multiline_help : Flag<["-"], "multiline-help">, HelpText<"This a help text that has\nmultiple lines in it">, Visibility<[MultiLineVis]>;
+
+def multiline_help_long : 
+  Flag<["-"], "multiline-help-with-long-name">, 
+  HelpText<"This a help text that has\n"
+           "multiple lines in it\n"
+           "and a long name">,
+  Visibility<[MultiLineVis]>;
+
 
 class XOpts<string base> : KeyPathAndMacro<"X->", base> {}
 

--- a/llvm/unittests/Option/Opts.td
+++ b/llvm/unittests/Option/Opts.td
@@ -53,13 +53,12 @@ def R : Flag<["-"], "R">, Visibility<[DefaultVis, SubtoolVis]>;
 
 def multiline_help : Flag<["-"], "multiline-help">, HelpText<"This a help text that has\nmultiple lines in it">, Visibility<[MultiLineVis]>;
 
-def multiline_help_long : 
-  Flag<["-"], "multiline-help-with-long-name">, 
+def multiline_help_long :
+  Flag<["-"], "multiline-help-with-long-name">,
   HelpText<"This a help text that has\n"
            "multiple lines in it\n"
            "and a long name">,
   Visibility<[MultiLineVis]>;
-
 
 class XOpts<string base> : KeyPathAndMacro<"X->", base> {}
 


### PR DESCRIPTION
With this changes, new lines in the HelpText defined in OptTable have the same indentation as the first line.

Before, the help output will look something like:

```
--color=<value>       Whether to use color when
symbolizing log markup: always, auto, never
```

With this change:

```
--color=<value>       Whether to use color when
                      symbolizing log markup: always, auto, never
```