### PR TITLE
[flang][runtime] Fix spelling of INQUIRE result

### DIFF
--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -1346,7 +1346,7 @@ bool InquireUnconnectedFileState::Inquire(
   case HashInquiryKeyword("SEQUENTIAL"):
   case HashInquiryKeyword("STREAM"):
   case HashInquiryKeyword("UNFORMATTED"):
-    str = "UNKNONN";
+    str = "UNKNOWN";
     break;
   case HashInquiryKeyword("READ"):
     str =


### PR DESCRIPTION
Embarrassingly, the runtime was returning UNKNONN rather than UNKNOWN for things like INQUIRE(..., FORMAT=).