### PR TITLE
[lldb][NFCI] Remove unused parameter from BreakpointResolver*::CreateFromStructuredData

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
@@ -31,8 +31,7 @@ public:
   ~BreakpointResolverAddress() override = default;
 
   static lldb::BreakpointResolverSP
-  CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
-                           const StructuredData::Dictionary &options_dict,
+  CreateFromStructuredData(const StructuredData::Dictionary &options_dict,
                            Status &error);
 
   StructuredData::ObjectSP SerializeToStructuredData() override;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverFileLine.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverFileLine.h
@@ -28,8 +28,7 @@ public:
       std::optional<llvm::StringRef> removed_prefix_opt = std::nullopt);
 
   static lldb::BreakpointResolverSP
-  CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
-                           const StructuredData::Dictionary &data_dict,
+  CreateFromStructuredData(const StructuredData::Dictionary &data_dict,
                            Status &error);
 
   StructuredData::ObjectSP SerializeToStructuredData() override;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverFileRegex.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverFileRegex.h
@@ -28,8 +28,7 @@ public:
       const std::unordered_set<std::string> &func_name_set, bool exact_match);
 
   static lldb::BreakpointResolverSP
-  CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
-                           const StructuredData::Dictionary &options_dict,
+  CreateFromStructuredData(const StructuredData::Dictionary &options_dict,
                            Status &error);
 
   StructuredData::ObjectSP SerializeToStructuredData() override;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
@@ -51,8 +51,7 @@ public:
                          bool skip_prologue);
 
   static lldb::BreakpointResolverSP
-  CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
-                           const StructuredData::Dictionary &data_dict,
+  CreateFromStructuredData(const StructuredData::Dictionary &data_dict,
                            Status &error);
 
   StructuredData::ObjectSP SerializeToStructuredData() override;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
@@ -31,8 +31,7 @@ public:
   ~BreakpointResolverScripted() override = default;
 
   static lldb::BreakpointResolverSP
-  CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
-                           const StructuredData::Dictionary &options_dict,
+  CreateFromStructuredData(const StructuredData::Dictionary &options_dict,
                            Status &error);
 
   StructuredData::ObjectSP SerializeToStructuredData() override;

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -113,23 +113,23 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
   switch (resolver_type) {
   case FileLineResolver:
     result_sp = BreakpointResolverFileLine::CreateFromStructuredData(
-        nullptr, *subclass_options, error);
+        *subclass_options, error);
     break;
   case AddressResolver:
     result_sp = BreakpointResolverAddress::CreateFromStructuredData(
-        nullptr, *subclass_options, error);
+        *subclass_options, error);
     break;
   case NameResolver:
     result_sp = BreakpointResolverName::CreateFromStructuredData(
-        nullptr, *subclass_options, error);
+        *subclass_options, error);
     break;
   case FileRegexResolver:
     result_sp = BreakpointResolverFileRegex::CreateFromStructuredData(
-        nullptr, *subclass_options, error);
+        *subclass_options, error);
     break;
   case PythonResolver:
     result_sp = BreakpointResolverScripted::CreateFromStructuredData(
-        nullptr, *subclass_options, error);
+        *subclass_options, error);
     break;
   case ExceptionResolver:
     error.SetErrorString("Exception resolvers are hard.");

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -31,8 +31,7 @@ BreakpointResolverAddress::BreakpointResolverAddress(const BreakpointSP &bkpt,
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS) {}
 
 BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
-    const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
-    Status &error) {
+    const StructuredData::Dictionary &options_dict, Status &error) {
   llvm::StringRef module_name;
   lldb::offset_t addr_offset;
   FileSpec module_filespec;
@@ -56,7 +55,7 @@ BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
     }
     module_filespec.SetFile(module_name, FileSpec::Style::native);
   }
-  return std::make_shared<BreakpointResolverAddress>(bkpt, address,
+  return std::make_shared<BreakpointResolverAddress>(nullptr, address,
                                                      module_filespec);
 }
 

--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -31,8 +31,7 @@ BreakpointResolverFileLine::BreakpointResolverFileLine(
       m_removed_prefix_opt(removed_prefix_opt) {}
 
 BreakpointResolverSP BreakpointResolverFileLine::CreateFromStructuredData(
-    const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
-    Status &error) {
+    const StructuredData::Dictionary &options_dict, Status &error) {
   llvm::StringRef filename;
   uint32_t line;
   uint16_t column;
@@ -91,7 +90,7 @@ BreakpointResolverSP BreakpointResolverFileLine::CreateFromStructuredData(
     return nullptr;
 
   return std::make_shared<BreakpointResolverFileLine>(
-      bkpt, offset, skip_prologue, location_spec);
+      nullptr, offset, skip_prologue, location_spec);
 }
 
 StructuredData::ObjectSP

--- a/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
@@ -27,7 +27,6 @@ BreakpointResolverFileRegex::BreakpointResolverFileRegex(
       m_function_names(func_names) {}
 
 BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
-    const lldb::BreakpointSP &bkpt,
     const StructuredData::Dictionary &options_dict, Status &error) {
   bool success;
 
@@ -67,8 +66,8 @@ BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
     }
   }
 
-  return std::make_shared<BreakpointResolverFileRegex>(bkpt, std::move(regex),
-                                                       names_set, exact_match);
+  return std::make_shared<BreakpointResolverFileRegex>(
+      nullptr, std::move(regex), names_set, exact_match);
 }
 
 StructuredData::ObjectSP

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -87,8 +87,7 @@ BreakpointResolverName::BreakpointResolverName(
       m_language(rhs.m_language), m_skip_prologue(rhs.m_skip_prologue) {}
 
 BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
-    const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
-    Status &error) {
+    const StructuredData::Dictionary &options_dict, Status &error) {
   LanguageType language = eLanguageTypeUnknown;
   llvm::StringRef language_name;
   bool success = options_dict.GetValueForKeyAsString(
@@ -123,7 +122,8 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
       GetKey(OptionNames::RegexString), regex_text);
   if (success) {
     return std::make_shared<BreakpointResolverName>(
-        bkpt, RegularExpression(regex_text), language, offset, skip_prologue);
+        nullptr, RegularExpression(regex_text), language, offset,
+        skip_prologue);
   } else {
     StructuredData::Array *names_array;
     success = options_dict.GetValueForKeyAsArray(
@@ -173,7 +173,7 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
 
     std::shared_ptr<BreakpointResolverName> resolver_sp =
         std::make_shared<BreakpointResolverName>(
-            bkpt, names[0].c_str(), name_masks[0], language,
+            nullptr, names[0].c_str(), name_masks[0], language,
             Breakpoint::MatchType::Exact, offset, skip_prologue);
     for (size_t i = 1; i < num_elem; i++) {
       resolver_sp->AddNameLookup(ConstString(names[i]), name_masks[i]);

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -59,8 +59,7 @@ void BreakpointResolverScripted::NotifyBreakpointSet() {
 }
 
 BreakpointResolverSP BreakpointResolverScripted::CreateFromStructuredData(
-    const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
-    Status &error) {
+    const StructuredData::Dictionary &options_dict, Status &error) {
   llvm::StringRef class_name;
   bool success;
 
@@ -79,8 +78,8 @@ BreakpointResolverSP BreakpointResolverScripted::CreateFromStructuredData(
   if (options_dict.GetValueForKeyAsDictionary(GetKey(OptionNames::ScriptArgs),
                                               args_dict))
     args_data_impl.SetObjectSP(args_dict->shared_from_this());
-  return std::make_shared<BreakpointResolverScripted>(bkpt, class_name, depth,
-                                                      args_data_impl);
+  return std::make_shared<BreakpointResolverScripted>(nullptr, class_name,
+                                                      depth, args_data_impl);
 }
 
 StructuredData::ObjectSP


### PR DESCRIPTION
These appear to be unused.