### PR TITLE
[flang][runtime] Flush output before INQUIRE(..., SIZE=)

### DIFF
--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -1219,6 +1219,7 @@ bool InquireUnitState::Inquire(
   case HashInquiryKeyword("SIZE"):
     result = -1;
     if (unit().IsConnected()) {
+      unit().FlushOutput(*this);
       if (auto size{unit().knownSize()}) {
         result = *size;
       }


### PR DESCRIPTION
Ensure that any buffered data has tranferred to an external unit before measuring its file size.