### PR TITLE
[libc] add mempcpy to bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2275,6 +2275,19 @@ libc_function(
 )
 
 libc_function(
+    name = "mempcpy",
+    srcs = ["src/string/mempcpy.cpp"],
+    hdrs = ["src/string/mempcpy.h"],
+    copts = ["-mllvm --tail-merge-threshold=0"],
+    features = no_sanitize_features,
+    weak = True,
+    deps = [
+        ":__support_common",
+        ":string_memory_utils",
+    ],
+)
+
+libc_function(
     name = "bcopy",
     srcs = ["src/string/bcopy.cpp"],
     hdrs = ["src/string/bcopy.h"],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -136,6 +136,14 @@ libc_test(
 )
 
 libc_test(
+    name = "mempcpy_test",
+    srcs = ["mempcpy_test.cpp"],
+    libc_function_deps = [
+        "//libc:mempcpy",
+    ],
+)
+
+libc_test(
     name = "memset_test",
     srcs = ["memset_test.cpp"],
     libc_function_deps = [


### PR DESCRIPTION
We'd like to begin overlaying mempcpy.
