### PR TITLE
[libc++][Modules] Swift/C++ interoperability (e.g. let s: std.string) doesn't work after splitting up the clang module

### DIFF
--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1,426 +1,541 @@
+// "Umbrella" module that will import all of the available libc++ modules below.
+// Swift clients must use this module so that C++ types can get "hoisted" into
+// this module, i.e. so that writing `let s: std.string = "Hello C++ world!"`
+// works. Importing only the needed modules below is likely to be more performant
+// for Objective-C++ clients.
+module std [system] {
+  header "__std_clang_module"
+  export *
+}
+
 // Main C++ standard library interfaces
 module std_algorithm [system] {
+  export_as std
   header "algorithm"
   export *
 }
 module std_any [system] {
+  export_as std
   header "any"
   export *
 }
 module std_array [system] {
+  export_as std
   header "array"
   export *
 }
 module std_atomic [system] {
+  export_as std
   header "atomic"
   export *
 }
 module std_barrier [system] {
+  export_as std
   header "barrier"
   export *
 }
 module std_bit [system] {
+  export_as std
   header "bit"
   export *
 }
 module std_bitset [system] {
+  export_as std
   header "bitset"
   export *
 }
 module std_charconv [system] {
+  export_as std
   header "charconv"
   export *
 }
 module std_chrono [system] {
+  export_as std
   header "chrono"
   export *
 }
 module std_codecvt [system] {
+  export_as std
   header "codecvt"
   export *
 }
 module std_compare [system] {
+  export_as std
   header "compare"
   export *
 }
 module std_complex [system] {
+  export_as std
   header "complex"
   export *
 }
 module std_concepts [system] {
+  export_as std
   header "concepts"
   export *
 }
 module std_condition_variable [system] {
+  export_as std
   header "condition_variable"
   export *
 }
 module std_coroutine [system] {
+  export_as std
   header "coroutine"
   export *
 }
 module std_deque [system] {
+  export_as std
   header "deque"
   export *
 }
 module std_exception [system] {
+  export_as std
   header "exception"
   export *
 }
 module std_execution [system] {
+  export_as std
   header "execution"
   export *
 }
 module std_expected [system] {
+  export_as std
   header "expected"
   export *
 }
 module std_filesystem [system] {
+  export_as std
   header "filesystem"
   export *
 }
 module std_format [system] {
+  export_as std
   header "format"
   export *
 }
 module std_forward_list [system] {
+  export_as std
   header "forward_list"
   export *
 }
 module std_fstream [system] {
+  export_as std
   header "fstream"
   export *
 }
 module std_functional [system] {
+  export_as std
   header "functional"
   export *
 }
 module std_future [system] {
+  export_as std
   header "future"
   export *
 }
 module std_initializer_list [system] {
+  export_as std
   header "initializer_list"
   export *
 }
 module std_iomanip [system] {
+  export_as std
   header "iomanip"
   export *
 }
 module std_ios [system] {
+  export_as std
   header "ios"
   export *
 }
 module std_iosfwd [system] {
+  export_as std
   header "iosfwd"
   export *
 }
 module std_iostream [system] {
+  export_as std
   header "iostream"
   export *
 }
 module std_istream [system] {
+  export_as std
   header "istream"
   export *
 }
 module std_iterator [system] {
+  export_as std
   header "iterator"
   export *
 }
 module std_latch [system] {
+  export_as std
   header "latch"
   export *
 }
 module std_limits [system] {
+  export_as std
   header "limits"
   export *
 }
 module std_list [system] {
+  export_as std
   header "list"
   export *
 }
 module std_locale [system] {
+  export_as std
   header "locale"
   export *
 }
 module std_map [system] {
+  export_as std
   header "map"
   export *
 }
 module std_mdspan [system] {
+  export_as std
   header "mdspan"
   export *
 }
 module std_memory [system] {
+  export_as std
   header "memory"
   export *
 }
 module std_memory_resource [system] {
+  export_as std
   header "memory_resource"
   export *
 }
 module std_mutex [system] {
+  export_as std
   header "mutex"
   export *
 }
 module std_new [system] {
+  export_as std
   header "new"
   export *
 }
 module std_numbers [system] {
+  export_as std
   header "numbers"
   export *
 }
 module std_numeric [system] {
+  export_as std
   header "numeric"
   export *
 }
 module std_optional [system] {
+  export_as std
   header "optional"
   export *
 }
 module std_ostream [system] {
+  export_as std
   header "ostream"
   export *
 }
 module std_print [system] {
+  export_as std
   header "print"
   export *
 }
 module std_queue [system] {
+  export_as std
   header "queue"
   export *
 }
 module std_random [system] {
+  export_as std
   header "random"
   export *
 }
 module std_ranges [system] {
+  export_as std
   header "ranges"
   export *
 }
 module std_ratio [system] {
+  export_as std
   header "ratio"
   export *
 }
 module std_regex [system] {
+  export_as std
   header "regex"
   export *
 }
 module std_scoped_allocator [system] {
+  export_as std
   header "scoped_allocator"
   export *
 }
 module std_semaphore [system] {
+  export_as std
   header "semaphore"
   export *
 }
 module std_set [system] {
+  export_as std
   header "set"
   export *
 }
 module std_shared_mutex [system] {
+  export_as std
   header "shared_mutex"
   export std_version
 }
 module std_source_location [system] {
+  export_as std
   header "source_location"
   export *
 }
 module std_span [system] {
+  export_as std
   header "span"
   export std_private_ranges_enable_borrowed_range
   export std_version
   export std_private_span_span_fwd
 }
 module std_sstream [system] {
+  export_as std
   header "sstream"
   export *
 }
 module std_stack [system] {
+  export_as std
   header "stack"
   export *
 }
 module std_stdexcept [system] {
+  export_as std
   header "stdexcept"
   export *
 }
 module std_stop_token {
+  export_as std
   header "stop_token"
   export *
 }
 module std_streambuf [system] {
+  export_as std
   header "streambuf"
   export *
 }
 module std_string [system] {
+  export_as std
   header "string"
   export *
 }
 module std_string_view [system] {
+  export_as std
   header "string_view"
   export *
 }
 module std_strstream [system] {
+  export_as std
   header "strstream"
   export *
 }
 module std_syncstream [system] {
+  export_as std
   header "syncstream"
   export *
 }
 module std_system_error [system] {
+  export_as std
   header "system_error"
   export *
 }
 module std_thread [system] {
+  export_as std
   header "thread"
   export *
 }
 module std_tuple [system] {
+  export_as std
   header "tuple"
   export *
 }
 module std_type_traits [system] {
+  export_as std
   header "type_traits"
   export *
 }
 module std_typeindex [system] {
+  export_as std
   header "typeindex"
   export *
 }
 module std_typeinfo [system] {
+  export_as std
   header "typeinfo"
   export *
 }
 module std_unordered_map [system] {
+  export_as std
   header "unordered_map"
   export *
 }
 module std_unordered_set [system] {
+  export_as std
   header "unordered_set"
   export *
 }
 module std_utility [system] {
+  export_as std
   header "utility"
   export *
 }
 module std_valarray [system] {
+  export_as std
   header "valarray"
   export *
 }
 module std_variant [system] {
+  export_as std
   header "variant"
   export *
 }
 module std_vector [system] {
+  export_as std
   header "vector"
   export *
 }
 module std_version [system] {
+  export_as std
   header "version"
   export *
 }
 
 // C standard library interface wrappers
 module std_cassert [system] {
+  export_as std
   // <cassert>'s use of NDEBUG requires textual inclusion.
   textual header "cassert"
 }
 module std_ccomplex [system] {
+  export_as std
   header "ccomplex"
   export *
 }
 module std_cctype [system] {
+  export_as std
   header "cctype"
   export *
 }
 module std_cerrno [system] {
+  export_as std
   header "cerrno"
   export *
 }
 module std_cfenv [system] {
+  export_as std
   header "cfenv"
   export *
 }
 module std_cfloat [system] {
+  export_as std
   header "cfloat"
   export *
 }
 module std_cinttypes [system] {
+  export_as std
   header "cinttypes"
   export *
 }
 module std_ciso646 [system] {
+  export_as std
   header "ciso646"
   export *
 }
 module std_climits [system] {
+  export_as std
   header "climits"
   export *
 }
 module std_clocale [system] {
+  export_as std
   header "clocale"
   export *
 }
 module std_cmath [system] {
+  export_as std
   header "cmath"
   export *
 }
 module std_csetjmp [system] {
+  export_as std
   header "csetjmp"
   export *
 }
 module std_csignal [system] {
+  export_as std
   header "csignal"
   export *
 }
 // FIXME: <cstdalign> is missing.
 module std_cstdarg [system] {
+  export_as std
   header "cstdarg"
   export *
 }
 module std_cstdbool [system] {
+  export_as std
   header "cstdbool"
   export *
 }
 module std_cstddef [system] {
+  export_as std
   header "cstddef"
   export *
 }
 module std_cstdint [system] {
+  export_as std
   header "cstdint"
   export *
 }
 module std_cstdio [system] {
+  export_as std
   header "cstdio"
   export *
 }
 module std_cstdlib [system] {
+  export_as std
   header "cstdlib"
   export *
 }
 module std_cstring [system] {
+  export_as std
   header "cstring"
   export *
 }
 module std_ctgmath [system] {
+  export_as std
   header "ctgmath"
   export *
 }
 module std_ctime [system] {
+  export_as std
   header "ctime"
   export *
 }
 module std_cuchar [system] {
+  export_as std
   header "cuchar"
   export *
 }
 module std_cwchar [system] {
+  export_as std
   header "cwchar"
   export *
 }
 module std_cwctype [system] {
+  export_as std
   header "cwctype"
   export *
 }
@@ -428,35 +543,43 @@ module std_cwctype [system] {
 // C standard library interfaces augmented/replaced in C++
 // <assert.h> provided by C library.
 module std_complex_h [system] {
+  export_as std
   header "complex.h"
   export *
 }
 module std_ctype_h [system] {
+  export_as std
   header "ctype.h"
   export *
 }
 module std_errno_h [system] {
+  export_as std
   header "errno.h"
   export *
 }
 module std_fenv_h [system] {
+  export_as std
   header "fenv.h"
   export *
 }
 module std_float_h [system] {
+  export_as std
   header "float.h"
   export *
 }
 module std_inttypes_h [system] {
+  export_as std
   header "inttypes.h"
   export *
 }
 // <iso646.h> provided by compiler.
 module std_locale_h [system] {
+  export_as std
   header "locale.h"
   export *
 }
 module std_math_h [system] {
+  export_as std
   header "math.h"
   export *
 }
@@ -465,58 +588,70 @@ module std_math_h [system] {
 // FIXME: <stdalign.h> is missing.
 // <stdarg.h> provided by compiler.
 module std_stdatomic_h [system] {
+  export_as std
   header "stdatomic.h"
   export *
 }
 module std_stdbool_h [system] {
+  export_as std
   // <stdbool.h>'s __bool_true_false_are_defined macro requires textual inclusion.
   textual header "stdbool.h"
   export *
 }
 module std_stddef_h [system] {
+  export_as std
   // <stddef.h>'s __need_* macros require textual inclusion.
   textual header "stddef.h"
   export *
 }
 module std_stdint_h [system] {
+  export_as std
   header "stdint.h"
   export *
 }
 module std_stdio_h [system] {
+  export_as std
   // <stdio.h>'s __need_* macros require textual inclusion.
   textual header "stdio.h"
   export *
 }
 module std_stdlib_h [system] {
+  export_as std
   // <stdlib.h>'s __need_* macros require textual inclusion.
   textual header "stdlib.h"
   export *
 }
 module std_string_h [system] {
+  export_as std
   header "string.h"
   export *
 }
 module std_tgmath_h [system] {
+  export_as std
   header "tgmath.h"
   export *
 }
 module std_uchar_h [system] {
+  export_as std
   header "uchar.h"
   export *
 }
 // <time.h> provided by C library.
 module std_wchar_h [system] {
+  export_as std
   // <wchar.h>'s __need_* macros require textual inclusion.
   textual header "wchar.h"
   export *
 }
 module std_wctype_h [system] {
+  export_as std
   header "wctype.h"
   export *
 }
 
 // Experimental C++ standard library interfaces
 module std_experimental [system] {
+  export_as std
   module iterator {
     header "experimental/iterator"
     export *
@@ -564,844 +699,1943 @@ module std_experimental [system] {
   }
 }
 
-// Convenience method to get all of the above modules in a single import statement.
-// Importing only the needed modules is likely to be more performant.
-module std [system] {
-  header "__std_clang_module"
-  export *
-}
-
 // Implementation detail headers that are private to libc++. These modules
 // must not be directly imported.
-module std_private_assert            [system] {
+module std_private_assert [system] {
+  export_as std
   header "__assert"
   export *
 }
-module std_private_availability      [system] {
+module std_private_availability [system] {
+  export_as std
   header "__availability"
   export *
 }
-module std_private_bit_reference     [system] {
+module std_private_bit_reference [system] {
+  export_as std
   header "__bit_reference"
   export *
 }
 module std_private_fwd_bit_reference [system] {
+  export_as std
   header "__fwd/bit_reference.h"
 }
-module std_private_config            [system] {
+module std_private_config [system] {
+  export_as std
   textual header "__config"
   export *
 }
-module std_private_hash_table        [system] {
+module std_private_hash_table [system] {
+  export_as std
   header "__hash_table"
   export *
 }
-module std_private_locale            [system] {
+module std_private_locale [system] {
+  export_as std
   header "__locale"
   export *
 }
-module std_private_mbstate_t         [system] {
+module std_private_mbstate_t [system] {
+  export_as std
   header "__mbstate_t.h"
   export *
 }
-module std_private_node_handle       [system] {
+module std_private_node_handle [system] {
+  export_as std
   header "__node_handle"
   export *
 }
-module std_private_split_buffer      [system] {
+module std_private_split_buffer [system] {
+  export_as std
   header "__split_buffer"
   export *
 }
-module std_private_std_mbstate_t     [system] {
+module std_private_std_mbstate_t [system] {
+  export_as std
   header "__std_mbstate_t.h"
   export *
 }
 module std_private_threading_support [system] {
+  export_as std
   header "__threading_support"
   export *
 }
-module std_private_tree              [system] {
+module std_private_tree [system] {
+  export_as std
   header "__tree"
   export *
 }
-module std_private_undef_macros      [system] {
+module std_private_undef_macros [system] {
+  export_as std
   textual header "__undef_macros"
   export *
 }
-module std_private_verbose_abort     [system] {
+module std_private_verbose_abort [system] {
+  export_as std
   header "__verbose_abort"
   export *
 }
 
-module std_private_algorithm_adjacent_find                               [system] { header "__algorithm/adjacent_find.h" }
-module std_private_algorithm_all_of                                      [system] { header "__algorithm/all_of.h" }
-module std_private_algorithm_any_of                                      [system] { header "__algorithm/any_of.h" }
-module std_private_algorithm_binary_search                               [system] { header "__algorithm/binary_search.h" }
-module std_private_algorithm_clamp                                       [system] { header "__algorithm/clamp.h" }
-module std_private_algorithm_comp                                        [system] { header "__algorithm/comp.h" }
-module std_private_algorithm_comp_ref_type                               [system] { header "__algorithm/comp_ref_type.h" }
-module std_private_algorithm_copy                                        [system] {
+module std_private_algorithm_adjacent_find [system] {
+  export_as std
+  header "__algorithm/adjacent_find.h"
+}
+module std_private_algorithm_all_of [system] {
+  export_as std
+  header "__algorithm/all_of.h"
+}
+module std_private_algorithm_any_of [system] {
+  export_as std
+  header "__algorithm/any_of.h"
+}
+module std_private_algorithm_binary_search [system] {
+  export_as std
+  header "__algorithm/binary_search.h"
+}
+module std_private_algorithm_clamp [system] {
+  export_as std
+  header "__algorithm/clamp.h"
+}
+module std_private_algorithm_comp [system] {
+  export_as std
+  header "__algorithm/comp.h"
+}
+module std_private_algorithm_comp_ref_type [system] {
+  export_as std
+  header "__algorithm/comp_ref_type.h"
+}
+module std_private_algorithm_copy [system] {
+  export_as std
   header "__algorithm/copy.h"
   export std_private_algorithm_copy_move_common
 }
-module std_private_algorithm_copy_backward                               [system] { header "__algorithm/copy_backward.h" }
-module std_private_algorithm_copy_if                                     [system] { header "__algorithm/copy_if.h" }
-module std_private_algorithm_copy_move_common                            [system] {
+module std_private_algorithm_copy_backward [system] {
+  export_as std
+  header "__algorithm/copy_backward.h"
+}
+module std_private_algorithm_copy_if [system] {
+  export_as std
+  header "__algorithm/copy_if.h"
+}
+module std_private_algorithm_copy_move_common [system] {
+  export_as std
   header "__algorithm/copy_move_common.h"
   export std_private_type_traits_is_trivially_copyable
 }
-module std_private_algorithm_copy_n                                      [system] { header "__algorithm/copy_n.h" }
-module std_private_algorithm_count                                       [system] { header "__algorithm/count.h" }
-module std_private_algorithm_count_if                                    [system] { header "__algorithm/count_if.h" }
-module std_private_algorithm_equal                                       [system] { header "__algorithm/equal.h" }
-module std_private_algorithm_equal_range                                 [system] { header "__algorithm/equal_range.h" }
-module std_private_algorithm_fill                                        [system] { header "__algorithm/fill.h" }
-module std_private_algorithm_fill_n                                      [system] { header "__algorithm/fill_n.h" }
-module std_private_algorithm_find                                        [system] {
+module std_private_algorithm_copy_n [system] {
+  export_as std
+  header "__algorithm/copy_n.h"
+}
+module std_private_algorithm_count [system] {
+  export_as std
+  header "__algorithm/count.h"
+}
+module std_private_algorithm_count_if [system] {
+  export_as std
+  header "__algorithm/count_if.h"
+}
+module std_private_algorithm_equal [system] {
+  export_as std
+  header "__algorithm/equal.h"
+}
+module std_private_algorithm_equal_range [system] {
+  export_as std
+  header "__algorithm/equal_range.h"
+}
+module std_private_algorithm_fill [system] {
+  export_as std
+  header "__algorithm/fill.h"
+}
+module std_private_algorithm_fill_n [system] {
+  export_as std
+  header "__algorithm/fill_n.h"
+}
+module std_private_algorithm_find [system] {
+  export_as std
   header "__algorithm/find.h"
   export std_private_algorithm_unwrap_iter
 }
-module std_private_algorithm_find_end                                    [system] { header "__algorithm/find_end.h" }
-module std_private_algorithm_find_first_of                               [system] { header "__algorithm/find_first_of.h" }
-module std_private_algorithm_find_if                                     [system] { header "__algorithm/find_if.h" }
-module std_private_algorithm_find_if_not                                 [system] { header "__algorithm/find_if_not.h" }
-module std_private_algorithm_for_each                                    [system] { header "__algorithm/for_each.h" }
-module std_private_algorithm_for_each_n                                  [system] { header "__algorithm/for_each_n.h" }
-module std_private_algorithm_for_each_segment                            [system] { header "__algorithm/for_each_segment.h" }
-module std_private_algorithm_generate                                    [system] { header "__algorithm/generate.h" }
-module std_private_algorithm_generate_n                                  [system] { header "__algorithm/generate_n.h" }
-module std_private_algorithm_half_positive                               [system] { header "__algorithm/half_positive.h" }
-module std_private_algorithm_in_found_result                             [system] { header "__algorithm/in_found_result.h" }
-module std_private_algorithm_in_fun_result                               [system] { header "__algorithm/in_fun_result.h" }
-module std_private_algorithm_in_in_out_result                            [system] { header "__algorithm/in_in_out_result.h" }
-module std_private_algorithm_in_in_result                                [system] { header "__algorithm/in_in_result.h" }
-module std_private_algorithm_in_out_out_result                           [system] { header "__algorithm/in_out_out_result.h" }
-module std_private_algorithm_in_out_result                               [system] { header "__algorithm/in_out_result.h" }
-module std_private_algorithm_includes                                    [system] { header "__algorithm/includes.h" }
-module std_private_algorithm_inplace_merge                               [system] { header "__algorithm/inplace_merge.h" }
-module std_private_algorithm_is_heap                                     [system] { header "__algorithm/is_heap.h" }
-module std_private_algorithm_is_heap_until                               [system] { header "__algorithm/is_heap_until.h" }
-module std_private_algorithm_is_partitioned                              [system] { header "__algorithm/is_partitioned.h" }
-module std_private_algorithm_is_permutation                              [system] { header "__algorithm/is_permutation.h" }
-module std_private_algorithm_is_sorted                                   [system] { header "__algorithm/is_sorted.h" }
-module std_private_algorithm_is_sorted_until                             [system] { header "__algorithm/is_sorted_until.h" }
-module std_private_algorithm_iter_swap                                   [system] { header "__algorithm/iter_swap.h" }
-module std_private_algorithm_iterator_operations                         [system] {
+module std_private_algorithm_find_end [system] {
+  export_as std
+  header "__algorithm/find_end.h"
+}
+module std_private_algorithm_find_first_of [system] {
+  export_as std
+  header "__algorithm/find_first_of.h"
+}
+module std_private_algorithm_find_if [system] {
+  export_as std
+  header "__algorithm/find_if.h"
+}
+module std_private_algorithm_find_if_not [system] {
+  export_as std
+  header "__algorithm/find_if_not.h"
+}
+module std_private_algorithm_for_each [system] {
+  export_as std
+  header "__algorithm/for_each.h"
+}
+module std_private_algorithm_for_each_n [system] {
+  export_as std
+  header "__algorithm/for_each_n.h"
+}
+module std_private_algorithm_for_each_segment [system] {
+  export_as std
+  header "__algorithm/for_each_segment.h"
+}
+module std_private_algorithm_generate [system] {
+  export_as std
+  header "__algorithm/generate.h"
+}
+module std_private_algorithm_generate_n [system] {
+  export_as std
+  header "__algorithm/generate_n.h"
+}
+module std_private_algorithm_half_positive [system] {
+  export_as std
+  header "__algorithm/half_positive.h"
+}
+module std_private_algorithm_in_found_result [system] {
+  export_as std
+  header "__algorithm/in_found_result.h"
+}
+module std_private_algorithm_in_fun_result [system] {
+  export_as std
+  header "__algorithm/in_fun_result.h"
+}
+module std_private_algorithm_in_in_out_result [system] {
+  export_as std
+  header "__algorithm/in_in_out_result.h"
+}
+module std_private_algorithm_in_in_result [system] {
+  export_as std
+  header "__algorithm/in_in_result.h"
+}
+module std_private_algorithm_in_out_out_result [system] {
+  export_as std
+  header "__algorithm/in_out_out_result.h"
+}
+module std_private_algorithm_in_out_result [system] {
+  export_as std
+  header "__algorithm/in_out_result.h"
+}
+module std_private_algorithm_includes [system] {
+  export_as std
+  header "__algorithm/includes.h"
+}
+module std_private_algorithm_inplace_merge [system] {
+  export_as std
+  header "__algorithm/inplace_merge.h"
+}
+module std_private_algorithm_is_heap [system] {
+  export_as std
+  header "__algorithm/is_heap.h"
+}
+module std_private_algorithm_is_heap_until [system] {
+  export_as std
+  header "__algorithm/is_heap_until.h"
+}
+module std_private_algorithm_is_partitioned [system] {
+  export_as std
+  header "__algorithm/is_partitioned.h"
+}
+module std_private_algorithm_is_permutation [system] {
+  export_as std
+  header "__algorithm/is_permutation.h"
+}
+module std_private_algorithm_is_sorted [system] {
+  export_as std
+  header "__algorithm/is_sorted.h"
+}
+module std_private_algorithm_is_sorted_until [system] {
+  export_as std
+  header "__algorithm/is_sorted_until.h"
+}
+module std_private_algorithm_iter_swap [system] {
+  export_as std
+  header "__algorithm/iter_swap.h"
+}
+module std_private_algorithm_iterator_operations [system] {
+  export_as std
   header "__algorithm/iterator_operations.h"
   export *
 }
-module std_private_algorithm_lexicographical_compare                     [system] { header "__algorithm/lexicographical_compare.h" }
-module std_private_algorithm_lexicographical_compare_three_way           [system] { header "__algorithm/lexicographical_compare_three_way.h" }
-module std_private_algorithm_lower_bound                                 [system] { header "__algorithm/lower_bound.h" }
-module std_private_algorithm_make_heap                                   [system] { header "__algorithm/make_heap.h" }
-module std_private_algorithm_make_projected                              [system] { header "__algorithm/make_projected.h" }
-module std_private_algorithm_max                                         [system] { header "__algorithm/max.h" }
-module std_private_algorithm_max_element                                 [system] { header "__algorithm/max_element.h" }
-module std_private_algorithm_merge                                       [system] { header "__algorithm/merge.h" }
-module std_private_algorithm_min                                         [system] { header "__algorithm/min.h" }
-module std_private_algorithm_min_element                                 [system] { header "__algorithm/min_element.h" }
-module std_private_algorithm_min_max_result                              [system] { header "__algorithm/min_max_result.h" }
-module std_private_algorithm_minmax                                      [system] {
+module std_private_algorithm_lexicographical_compare [system] {
+  export_as std
+  header "__algorithm/lexicographical_compare.h"
+}
+module std_private_algorithm_lexicographical_compare_three_way [system] {
+  export_as std
+  header "__algorithm/lexicographical_compare_three_way.h"
+}
+module std_private_algorithm_lower_bound [system] {
+  export_as std
+  header "__algorithm/lower_bound.h"
+}
+module std_private_algorithm_make_heap [system] {
+  export_as std
+  header "__algorithm/make_heap.h"
+}
+module std_private_algorithm_make_projected [system] {
+  export_as std
+  header "__algorithm/make_projected.h"
+}
+module std_private_algorithm_max [system] {
+  export_as std
+  header "__algorithm/max.h"
+}
+module std_private_algorithm_max_element [system] {
+  export_as std
+  header "__algorithm/max_element.h"
+}
+module std_private_algorithm_merge [system] {
+  export_as std
+  header "__algorithm/merge.h"
+}
+module std_private_algorithm_min [system] {
+  export_as std
+  header "__algorithm/min.h"
+}
+module std_private_algorithm_min_element [system] {
+  export_as std
+  header "__algorithm/min_element.h"
+}
+module std_private_algorithm_min_max_result [system] {
+  export_as std
+  header "__algorithm/min_max_result.h"
+}
+module std_private_algorithm_minmax [system] {
+  export_as std
   header "__algorithm/minmax.h"
   export *
 }
-module std_private_algorithm_minmax_element                              [system] { header "__algorithm/minmax_element.h" }
-module std_private_algorithm_mismatch                                    [system] { header "__algorithm/mismatch.h" }
-module std_private_algorithm_move                                        [system] { header "__algorithm/move.h" }
-module std_private_algorithm_move_backward                               [system] { header "__algorithm/move_backward.h" }
-module std_private_algorithm_next_permutation                            [system] { header "__algorithm/next_permutation.h" }
-module std_private_algorithm_none_of                                     [system] { header "__algorithm/none_of.h" }
-module std_private_algorithm_nth_element                                 [system] { header "__algorithm/nth_element.h" }
-module std_private_algorithm_partial_sort                                [system] { header "__algorithm/partial_sort.h" }
-module std_private_algorithm_partial_sort_copy                           [system] { header "__algorithm/partial_sort_copy.h" }
-module std_private_algorithm_partition                                   [system] { header "__algorithm/partition.h" }
-module std_private_algorithm_partition_copy                              [system] { header "__algorithm/partition_copy.h" }
-module std_private_algorithm_partition_point                             [system] { header "__algorithm/partition_point.h" }
-module std_private_algorithm_pop_heap                                    [system] { header "__algorithm/pop_heap.h" }
-module std_private_algorithm_prev_permutation                            [system] { header "__algorithm/prev_permutation.h" }
-module std_private_algorithm_pstl_any_all_none_of                        [system] { header "__algorithm/pstl_any_all_none_of.h" }
-module std_private_algorithm_pstl_backend                                [system] {
+module std_private_algorithm_minmax_element [system] {
+  export_as std
+  header "__algorithm/minmax_element.h"
+}
+module std_private_algorithm_mismatch [system] {
+  export_as std
+  header "__algorithm/mismatch.h"
+}
+module std_private_algorithm_move [system] {
+  export_as std
+  header "__algorithm/move.h"
+}
+module std_private_algorithm_move_backward [system] {
+  export_as std
+  header "__algorithm/move_backward.h"
+}
+module std_private_algorithm_next_permutation [system] {
+  export_as std
+  header "__algorithm/next_permutation.h"
+}
+module std_private_algorithm_none_of [system] {
+  export_as std
+  header "__algorithm/none_of.h"
+}
+module std_private_algorithm_nth_element [system] {
+  export_as std
+  header "__algorithm/nth_element.h"
+}
+module std_private_algorithm_partial_sort [system] {
+  export_as std
+  header "__algorithm/partial_sort.h"
+}
+module std_private_algorithm_partial_sort_copy [system] {
+  export_as std
+  header "__algorithm/partial_sort_copy.h"
+}
+module std_private_algorithm_partition [system] {
+  export_as std
+  header "__algorithm/partition.h"
+}
+module std_private_algorithm_partition_copy [system] {
+  export_as std
+  header "__algorithm/partition_copy.h"
+}
+module std_private_algorithm_partition_point [system] {
+  export_as std
+  header "__algorithm/partition_point.h"
+}
+module std_private_algorithm_pop_heap [system] {
+  export_as std
+  header "__algorithm/pop_heap.h"
+}
+module std_private_algorithm_prev_permutation [system] {
+  export_as std
+  header "__algorithm/prev_permutation.h"
+}
+module std_private_algorithm_pstl_any_all_none_of [system] {
+  export_as std
+  header "__algorithm/pstl_any_all_none_of.h"
+}
+module std_private_algorithm_pstl_backend [system] {
+  export_as std
   header "__algorithm/pstl_backend.h"
   export *
 }
-module std_private_algorithm_pstl_backends_cpu_backend                   [system] {
+module std_private_algorithm_pstl_backends_cpu_backend [system] {
+  export_as std
   header "__algorithm/pstl_backends/cpu_backend.h"
   export *
 }
-module std_private_algorithm_pstl_backends_cpu_backends_any_of           [system] { header "__algorithm/pstl_backends/cpu_backends/any_of.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_backend          [system] {
+module std_private_algorithm_pstl_backends_cpu_backends_any_of [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/any_of.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_backend [system] {
+  export_as std
   header "__algorithm/pstl_backends/cpu_backends/backend.h"
   export *
 }
-module std_private_algorithm_pstl_backends_cpu_backends_fill             [system] { header "__algorithm/pstl_backends/cpu_backends/fill.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_find_if          [system] { header "__algorithm/pstl_backends/cpu_backends/find_if.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_for_each         [system] { header "__algorithm/pstl_backends/cpu_backends/for_each.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_libdispatch      [system] { header "__algorithm/pstl_backends/cpu_backends/libdispatch.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_merge            [system] { header "__algorithm/pstl_backends/cpu_backends/merge.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_serial           [system] { textual header "__algorithm/pstl_backends/cpu_backends/serial.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_stable_sort      [system] { header "__algorithm/pstl_backends/cpu_backends/stable_sort.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_thread           [system] { textual header "__algorithm/pstl_backends/cpu_backends/thread.h" }
-module std_private_algorithm_pstl_backends_cpu_backends_transform        [system] {
+module std_private_algorithm_pstl_backends_cpu_backends_fill [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/fill.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_find_if [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/find_if.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_for_each [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/for_each.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_libdispatch [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/libdispatch.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_merge [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/merge.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_serial [system] {
+  export_as std
+  textual header "__algorithm/pstl_backends/cpu_backends/serial.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_stable_sort [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/stable_sort.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_thread [system] {
+  export_as std
+  textual header "__algorithm/pstl_backends/cpu_backends/thread.h"
+}
+module std_private_algorithm_pstl_backends_cpu_backends_transform [system] {
+  export_as std
   header "__algorithm/pstl_backends/cpu_backends/transform.h"
   export std_private_algorithm_transform
 }
-module std_private_algorithm_pstl_backends_cpu_backends_transform_reduce [system] { header "__algorithm/pstl_backends/cpu_backends/transform_reduce.h" }
-module std_private_algorithm_pstl_copy                                   [system] { header "__algorithm/pstl_copy.h" }
-module std_private_algorithm_pstl_count                                  [system] { header "__algorithm/pstl_count.h" }
-module std_private_algorithm_pstl_equal                                  [system] { header "__algorithm/pstl_equal.h" }
-module std_private_algorithm_pstl_fill                                   [system] { header "__algorithm/pstl_fill.h" }
-module std_private_algorithm_pstl_find                                   [system] {
+module std_private_algorithm_pstl_backends_cpu_backends_transform_reduce [system] {
+  export_as std
+  header "__algorithm/pstl_backends/cpu_backends/transform_reduce.h"
+}
+module std_private_algorithm_pstl_copy [system] {
+  export_as std
+  header "__algorithm/pstl_copy.h"
+}
+module std_private_algorithm_pstl_count [system] {
+  export_as std
+  header "__algorithm/pstl_count.h"
+}
+module std_private_algorithm_pstl_equal [system] {
+  export_as std
+  header "__algorithm/pstl_equal.h"
+}
+module std_private_algorithm_pstl_fill [system] {
+  export_as std
+  header "__algorithm/pstl_fill.h"
+}
+module std_private_algorithm_pstl_find [system] {
+  export_as std
   header "__algorithm/pstl_find.h"
   export *
 }
-module std_private_algorithm_pstl_for_each                               [system] {
+module std_private_algorithm_pstl_for_each [system] {
+  export_as std
   header "__algorithm/pstl_for_each.h"
   export *
 }
-module std_private_algorithm_pstl_frontend_dispatch                      [system] {
+module std_private_algorithm_pstl_frontend_dispatch [system] {
+  export_as std
   header "__algorithm/pstl_frontend_dispatch.h"
   export std_private_utility_forward
 }
-module std_private_algorithm_pstl_generate                               [system] { header "__algorithm/pstl_generate.h" }
-module std_private_algorithm_pstl_is_partitioned                         [system] { header "__algorithm/pstl_is_partitioned.h" }
-module std_private_algorithm_pstl_merge                                  [system] { header "__algorithm/pstl_merge.h" }
-module std_private_algorithm_pstl_move                                   [system] { header "__algorithm/pstl_move.h" }
-module std_private_algorithm_pstl_replace                                [system] { header "__algorithm/pstl_replace.h" }
-module std_private_algorithm_pstl_rotate_copy                            [system] { header "__algorithm/pstl_rotate_copy.h" }
-module std_private_algorithm_pstl_sort                                   [system] { header "__algorithm/pstl_sort.h" }
-module std_private_algorithm_pstl_stable_sort                            [system] {
+module std_private_algorithm_pstl_generate [system] {
+  export_as std
+  header "__algorithm/pstl_generate.h"
+}
+module std_private_algorithm_pstl_is_partitioned [system] {
+  export_as std
+  header "__algorithm/pstl_is_partitioned.h"
+}
+module std_private_algorithm_pstl_merge [system] {
+  export_as std
+  header "__algorithm/pstl_merge.h"
+}
+module std_private_algorithm_pstl_move [system] {
+  export_as std
+  header "__algorithm/pstl_move.h"
+}
+module std_private_algorithm_pstl_replace [system] {
+  export_as std
+  header "__algorithm/pstl_replace.h"
+}
+module std_private_algorithm_pstl_rotate_copy [system] {
+  export_as std
+  header "__algorithm/pstl_rotate_copy.h"
+}
+module std_private_algorithm_pstl_sort [system] {
+  export_as std
+  header "__algorithm/pstl_sort.h"
+}
+module std_private_algorithm_pstl_stable_sort [system] {
+  export_as std
   header "__algorithm/pstl_stable_sort.h"
   export std_private_functional_operations
 }
-module std_private_algorithm_pstl_transform                              [system] { header "__algorithm/pstl_transform.h" }
-module std_private_algorithm_push_heap                                   [system] { header "__algorithm/push_heap.h" }
-module std_private_algorithm_ranges_adjacent_find                        [system] { header "__algorithm/ranges_adjacent_find.h" }
-module std_private_algorithm_ranges_all_of                               [system] { header "__algorithm/ranges_all_of.h" }
-module std_private_algorithm_ranges_any_of                               [system] { header "__algorithm/ranges_any_of.h" }
-module std_private_algorithm_ranges_binary_search                        [system] {
+module std_private_algorithm_pstl_transform [system] {
+  export_as std
+  header "__algorithm/pstl_transform.h"
+}
+module std_private_algorithm_push_heap [system] {
+  export_as std
+  header "__algorithm/push_heap.h"
+}
+module std_private_algorithm_ranges_adjacent_find [system] {
+  export_as std
+  header "__algorithm/ranges_adjacent_find.h"
+}
+module std_private_algorithm_ranges_all_of [system] {
+  export_as std
+  header "__algorithm/ranges_all_of.h"
+}
+module std_private_algorithm_ranges_any_of [system] {
+  export_as std
+  header "__algorithm/ranges_any_of.h"
+}
+module std_private_algorithm_ranges_binary_search [system] {
+  export_as std
   header "__algorithm/ranges_binary_search.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_clamp                                [system] {
+module std_private_algorithm_ranges_clamp [system] {
+  export_as std
   header "__algorithm/ranges_clamp.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_copy                                 [system] {
+module std_private_algorithm_ranges_copy [system] {
+  export_as std
   header "__algorithm/ranges_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_copy_backward                        [system] {
+module std_private_algorithm_ranges_copy_backward [system] {
+  export_as std
   header "__algorithm/ranges_copy_backward.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_copy_if                              [system] {
+module std_private_algorithm_ranges_copy_if [system] {
+  export_as std
   header "__algorithm/ranges_copy_if.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_copy_n                               [system] {
+module std_private_algorithm_ranges_copy_n [system] {
+  export_as std
   header "__algorithm/ranges_copy_n.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_count                                [system] { header "__algorithm/ranges_count.h" }
-module std_private_algorithm_ranges_count_if                             [system] { header "__algorithm/ranges_count_if.h" }
-module std_private_algorithm_ranges_ends_with                            [system] { header "__algorithm/ranges_ends_with.h" }
-module std_private_algorithm_ranges_equal                                [system] { header "__algorithm/ranges_equal.h" }
-module std_private_algorithm_ranges_equal_range                          [system] {
+module std_private_algorithm_ranges_count [system] {
+  export_as std
+  header "__algorithm/ranges_count.h"
+}
+module std_private_algorithm_ranges_count_if [system] {
+  export_as std
+  header "__algorithm/ranges_count_if.h"
+}
+module std_private_algorithm_ranges_ends_with [system] {
+  export_as std
+  header "__algorithm/ranges_ends_with.h"
+}
+module std_private_algorithm_ranges_equal [system] {
+  export_as std
+  header "__algorithm/ranges_equal.h"
+}
+module std_private_algorithm_ranges_equal_range [system] {
+  export_as std
   header "__algorithm/ranges_equal_range.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_fill                                 [system] { header "__algorithm/ranges_fill.h" }
-module std_private_algorithm_ranges_fill_n                               [system] { header "__algorithm/ranges_fill_n.h" }
-module std_private_algorithm_ranges_find                                 [system] { header "__algorithm/ranges_find.h" }
-module std_private_algorithm_ranges_find_end                             [system] { header "__algorithm/ranges_find_end.h" }
-module std_private_algorithm_ranges_find_first_of                        [system] { header "__algorithm/ranges_find_first_of.h" }
-module std_private_algorithm_ranges_find_if                              [system] { header "__algorithm/ranges_find_if.h" }
-module std_private_algorithm_ranges_find_if_not                          [system] { header "__algorithm/ranges_find_if_not.h" }
-module std_private_algorithm_ranges_for_each                             [system] {
+module std_private_algorithm_ranges_fill [system] {
+  export_as std
+  header "__algorithm/ranges_fill.h"
+}
+module std_private_algorithm_ranges_fill_n [system] {
+  export_as std
+  header "__algorithm/ranges_fill_n.h"
+}
+module std_private_algorithm_ranges_find [system] {
+  export_as std
+  header "__algorithm/ranges_find.h"
+}
+module std_private_algorithm_ranges_find_end [system] {
+  export_as std
+  header "__algorithm/ranges_find_end.h"
+}
+module std_private_algorithm_ranges_find_first_of [system] {
+  export_as std
+  header "__algorithm/ranges_find_first_of.h"
+}
+module std_private_algorithm_ranges_find_if [system] {
+  export_as std
+  header "__algorithm/ranges_find_if.h"
+}
+module std_private_algorithm_ranges_find_if_not [system] {
+  export_as std
+  header "__algorithm/ranges_find_if_not.h"
+}
+module std_private_algorithm_ranges_for_each [system] {
+  export_as std
   header "__algorithm/ranges_for_each.h"
   export std_private_algorithm_in_fun_result
 }
-module std_private_algorithm_ranges_for_each_n                           [system] {
+module std_private_algorithm_ranges_for_each_n [system] {
+  export_as std
   header "__algorithm/ranges_for_each_n.h"
   export std_private_algorithm_in_fun_result
 }
-module std_private_algorithm_ranges_generate                             [system] { header "__algorithm/ranges_generate.h" }
-module std_private_algorithm_ranges_generate_n                           [system] { header "__algorithm/ranges_generate_n.h" }
-module std_private_algorithm_ranges_includes                             [system] {
+module std_private_algorithm_ranges_generate [system] {
+  export_as std
+  header "__algorithm/ranges_generate.h"
+}
+module std_private_algorithm_ranges_generate_n [system] {
+  export_as std
+  header "__algorithm/ranges_generate_n.h"
+}
+module std_private_algorithm_ranges_includes [system] {
+  export_as std
   header "__algorithm/ranges_includes.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_inplace_merge                        [system] {
+module std_private_algorithm_ranges_inplace_merge [system] {
+  export_as std
   header "__algorithm/ranges_inplace_merge.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_is_heap                              [system] {
+module std_private_algorithm_ranges_is_heap [system] {
+  export_as std
   header "__algorithm/ranges_is_heap.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_is_heap_until                        [system] {
+module std_private_algorithm_ranges_is_heap_until [system] {
+  export_as std
   header "__algorithm/ranges_is_heap_until.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_is_partitioned                       [system] { header "__algorithm/ranges_is_partitioned.h" }
-module std_private_algorithm_ranges_is_permutation                       [system] { header "__algorithm/ranges_is_permutation.h" }
-module std_private_algorithm_ranges_is_sorted                            [system] {
+module std_private_algorithm_ranges_is_partitioned [system] {
+  export_as std
+  header "__algorithm/ranges_is_partitioned.h"
+}
+module std_private_algorithm_ranges_is_permutation [system] {
+  export_as std
+  header "__algorithm/ranges_is_permutation.h"
+}
+module std_private_algorithm_ranges_is_sorted [system] {
+  export_as std
   header "__algorithm/ranges_is_sorted.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_is_sorted_until                      [system] {
+module std_private_algorithm_ranges_is_sorted_until [system] {
+  export_as std
   header "__algorithm/ranges_is_sorted_until.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_iterator_concept                     [system] { header "__algorithm/ranges_iterator_concept.h" }
-module std_private_algorithm_ranges_lexicographical_compare              [system] {
+module std_private_algorithm_ranges_iterator_concept [system] {
+  export_as std
+  header "__algorithm/ranges_iterator_concept.h"
+}
+module std_private_algorithm_ranges_lexicographical_compare [system] {
+  export_as std
   header "__algorithm/ranges_lexicographical_compare.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_lower_bound                          [system] {
+module std_private_algorithm_ranges_lower_bound [system] {
+  export_as std
   header "__algorithm/ranges_lower_bound.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_make_heap                            [system] {
+module std_private_algorithm_ranges_make_heap [system] {
+  export_as std
   header "__algorithm/ranges_make_heap.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_max                                  [system] {
+module std_private_algorithm_ranges_max [system] {
+  export_as std
   header "__algorithm/ranges_max.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_max_element                          [system] {
+module std_private_algorithm_ranges_max_element [system] {
+  export_as std
   header "__algorithm/ranges_max_element.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_merge                                [system] {
+module std_private_algorithm_ranges_merge [system] {
+  export_as std
   header "__algorithm/ranges_merge.h"
   export std_private_algorithm_in_in_out_result
 }
-module std_private_algorithm_ranges_min                                  [system] {
+module std_private_algorithm_ranges_min [system] {
+  export_as std
   header "__algorithm/ranges_min.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_min_element                          [system] {
+module std_private_algorithm_ranges_min_element [system] {
+  export_as std
   header "__algorithm/ranges_min_element.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_minmax                               [system] {
+module std_private_algorithm_ranges_minmax [system] {
+  export_as std
   header "__algorithm/ranges_minmax.h"
   export std_private_functional_ranges_operations
   export std_private_algorithm_min_max_result
 }
-module std_private_algorithm_ranges_minmax_element                       [system] {
+module std_private_algorithm_ranges_minmax_element [system] {
+  export_as std
   header "__algorithm/ranges_minmax_element.h"
   export std_private_functional_ranges_operations
   export std_private_algorithm_min_max_result
 }
-module std_private_algorithm_ranges_mismatch                             [system] {
+module std_private_algorithm_ranges_mismatch [system] {
+  export_as std
   header "__algorithm/ranges_mismatch.h"
   export std_private_algorithm_in_in_result
 }
-module std_private_algorithm_ranges_move                                 [system] {
+module std_private_algorithm_ranges_move [system] {
+  export_as std
   header "__algorithm/ranges_move.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_move_backward                        [system] {
+module std_private_algorithm_ranges_move_backward [system] {
+  export_as std
   header "__algorithm/ranges_move_backward.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_next_permutation                     [system] {
+module std_private_algorithm_ranges_next_permutation [system] {
+  export_as std
   header "__algorithm/ranges_next_permutation.h"
   export std_private_algorithm_in_found_result
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_none_of                              [system] { header "__algorithm/ranges_none_of.h" }
-module std_private_algorithm_ranges_nth_element                          [system] {
+module std_private_algorithm_ranges_none_of [system] {
+  export_as std
+  header "__algorithm/ranges_none_of.h"
+}
+module std_private_algorithm_ranges_nth_element [system] {
+  export_as std
   header "__algorithm/ranges_nth_element.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_partial_sort                         [system] {
+module std_private_algorithm_ranges_partial_sort [system] {
+  export_as std
   header "__algorithm/ranges_partial_sort.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_partial_sort_copy                    [system] {
+module std_private_algorithm_ranges_partial_sort_copy [system] {
+  export_as std
   header "__algorithm/ranges_partial_sort_copy.h"
   export std_private_algorithm_in_out_result
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_partition                            [system] { header "__algorithm/ranges_partition.h" }
-module std_private_algorithm_ranges_partition_copy                       [system] { header "__algorithm/ranges_partition_copy.h" }
-module std_private_algorithm_ranges_partition_point                      [system] { header "__algorithm/ranges_partition_point.h" }
-module std_private_algorithm_ranges_pop_heap                             [system] {
+module std_private_algorithm_ranges_partition [system] {
+  export_as std
+  header "__algorithm/ranges_partition.h"
+}
+module std_private_algorithm_ranges_partition_copy [system] {
+  export_as std
+  header "__algorithm/ranges_partition_copy.h"
+}
+module std_private_algorithm_ranges_partition_point [system] {
+  export_as std
+  header "__algorithm/ranges_partition_point.h"
+}
+module std_private_algorithm_ranges_pop_heap [system] {
+  export_as std
   header "__algorithm/ranges_pop_heap.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_prev_permutation                     [system] {
+module std_private_algorithm_ranges_prev_permutation [system] {
+  export_as std
   header "__algorithm/ranges_prev_permutation.h"
   export std_private_algorithm_in_found_result
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_push_heap                            [system] {
+module std_private_algorithm_ranges_push_heap [system] {
+  export_as std
   header "__algorithm/ranges_push_heap.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_remove                               [system] { header "__algorithm/ranges_remove.h" }
-module std_private_algorithm_ranges_remove_copy                          [system] {
+module std_private_algorithm_ranges_remove [system] {
+  export_as std
+  header "__algorithm/ranges_remove.h"
+}
+module std_private_algorithm_ranges_remove_copy [system] {
+  export_as std
   header "__algorithm/ranges_remove_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_remove_copy_if                       [system] {
+module std_private_algorithm_ranges_remove_copy_if [system] {
+  export_as std
   header "__algorithm/ranges_remove_copy_if.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_remove_if                            [system] { header "__algorithm/ranges_remove_if.h" }
-module std_private_algorithm_ranges_replace                              [system] { header "__algorithm/ranges_replace.h" }
-module std_private_algorithm_ranges_replace_copy                         [system] {
+module std_private_algorithm_ranges_remove_if [system] {
+  export_as std
+  header "__algorithm/ranges_remove_if.h"
+}
+module std_private_algorithm_ranges_replace [system] {
+  export_as std
+  header "__algorithm/ranges_replace.h"
+}
+module std_private_algorithm_ranges_replace_copy [system] {
+  export_as std
   header "__algorithm/ranges_replace_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_replace_copy_if                      [system] {
+module std_private_algorithm_ranges_replace_copy_if [system] {
+  export_as std
   header "__algorithm/ranges_replace_copy_if.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_replace_if                           [system] { header "__algorithm/ranges_replace_if.h" }
-module std_private_algorithm_ranges_reverse                              [system] { header "__algorithm/ranges_reverse.h" }
-module std_private_algorithm_ranges_reverse_copy                         [system] {
+module std_private_algorithm_ranges_replace_if [system] {
+  export_as std
+  header "__algorithm/ranges_replace_if.h"
+}
+module std_private_algorithm_ranges_reverse [system] {
+  export_as std
+  header "__algorithm/ranges_reverse.h"
+}
+module std_private_algorithm_ranges_reverse_copy [system] {
+  export_as std
   header "__algorithm/ranges_reverse_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_rotate                               [system] { header "__algorithm/ranges_rotate.h" }
-module std_private_algorithm_ranges_rotate_copy                          [system] {
+module std_private_algorithm_ranges_rotate [system] {
+  export_as std
+  header "__algorithm/ranges_rotate.h"
+}
+module std_private_algorithm_ranges_rotate_copy [system] {
+  export_as std
   header "__algorithm/ranges_rotate_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_sample                               [system] { header "__algorithm/ranges_sample.h" }
-module std_private_algorithm_ranges_search                               [system] { header "__algorithm/ranges_search.h" }
-module std_private_algorithm_ranges_search_n                             [system] { header "__algorithm/ranges_search_n.h" }
-module std_private_algorithm_ranges_set_difference                       [system] {
+module std_private_algorithm_ranges_sample [system] {
+  export_as std
+  header "__algorithm/ranges_sample.h"
+}
+module std_private_algorithm_ranges_search [system] {
+  export_as std
+  header "__algorithm/ranges_search.h"
+}
+module std_private_algorithm_ranges_search_n [system] {
+  export_as std
+  header "__algorithm/ranges_search_n.h"
+}
+module std_private_algorithm_ranges_set_difference [system] {
+  export_as std
   header "__algorithm/ranges_set_difference.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_set_intersection                     [system] {
+module std_private_algorithm_ranges_set_intersection [system] {
+  export_as std
   header "__algorithm/ranges_set_intersection.h"
   export std_private_algorithm_in_in_out_result
 }
-module std_private_algorithm_ranges_set_symmetric_difference             [system] {
+module std_private_algorithm_ranges_set_symmetric_difference [system] {
+  export_as std
   header "__algorithm/ranges_set_symmetric_difference.h"
   export std_private_algorithm_in_in_out_result
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_set_union                            [system] {
+module std_private_algorithm_ranges_set_union [system] {
+  export_as std
   header "__algorithm/ranges_set_union.h"
   export std_private_algorithm_in_in_out_result
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_shuffle                              [system] { header "__algorithm/ranges_shuffle.h" }
-module std_private_algorithm_ranges_sort                                 [system] {
+module std_private_algorithm_ranges_shuffle [system] {
+  export_as std
+  header "__algorithm/ranges_shuffle.h"
+}
+module std_private_algorithm_ranges_sort [system] {
+  export_as std
   header "__algorithm/ranges_sort.h"
   export std_private_algorithm_make_projected
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_sort_heap                            [system] {
+module std_private_algorithm_ranges_sort_heap [system] {
+  export_as std
   header "__algorithm/ranges_sort_heap.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_stable_partition                     [system] { header "__algorithm/ranges_stable_partition.h" }
-module std_private_algorithm_ranges_stable_sort                          [system] {
+module std_private_algorithm_ranges_stable_partition [system] {
+  export_as std
+  header "__algorithm/ranges_stable_partition.h"
+}
+module std_private_algorithm_ranges_stable_sort [system] {
+  export_as std
   header "__algorithm/ranges_stable_sort.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_ranges_starts_with                          [system] { header "__algorithm/ranges_starts_with.h" }
-module std_private_algorithm_ranges_swap_ranges                          [system] {
+module std_private_algorithm_ranges_starts_with [system] {
+  export_as std
+  header "__algorithm/ranges_starts_with.h"
+}
+module std_private_algorithm_ranges_swap_ranges [system] {
+  export_as std
   header "__algorithm/ranges_swap_ranges.h"
   export std_private_algorithm_in_in_result
 }
-module std_private_algorithm_ranges_transform                            [system] {
+module std_private_algorithm_ranges_transform [system] {
+  export_as std
   header "__algorithm/ranges_transform.h"
   export std_private_algorithm_in_in_out_result
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_unique                               [system] { header "__algorithm/ranges_unique.h" }
-module std_private_algorithm_ranges_unique_copy                          [system] {
+module std_private_algorithm_ranges_unique [system] {
+  export_as std
+  header "__algorithm/ranges_unique.h"
+}
+module std_private_algorithm_ranges_unique_copy [system] {
+  export_as std
   header "__algorithm/ranges_unique_copy.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_algorithm_ranges_upper_bound                          [system] {
+module std_private_algorithm_ranges_upper_bound [system] {
+  export_as std
   header "__algorithm/ranges_upper_bound.h"
   export std_private_functional_ranges_operations
 }
-module std_private_algorithm_remove                                      [system] { header "__algorithm/remove.h" }
-module std_private_algorithm_remove_copy                                 [system] { header "__algorithm/remove_copy.h" }
-module std_private_algorithm_remove_copy_if                              [system] { header "__algorithm/remove_copy_if.h" }
-module std_private_algorithm_remove_if                                   [system] { header "__algorithm/remove_if.h" }
-module std_private_algorithm_replace                                     [system] { header "__algorithm/replace.h" }
-module std_private_algorithm_replace_copy                                [system] { header "__algorithm/replace_copy.h" }
-module std_private_algorithm_replace_copy_if                             [system] { header "__algorithm/replace_copy_if.h" }
-module std_private_algorithm_replace_if                                  [system] { header "__algorithm/replace_if.h" }
-module std_private_algorithm_reverse                                     [system] { header "__algorithm/reverse.h" }
-module std_private_algorithm_reverse_copy                                [system] { header "__algorithm/reverse_copy.h" }
-module std_private_algorithm_rotate                                      [system] { header "__algorithm/rotate.h" }
-module std_private_algorithm_rotate_copy                                 [system] { header "__algorithm/rotate_copy.h" }
-module std_private_algorithm_sample                                      [system] { header "__algorithm/sample.h" }
-module std_private_algorithm_search                                      [system] { header "__algorithm/search.h" }
-module std_private_algorithm_search_n                                    [system] { header "__algorithm/search_n.h" }
-module std_private_algorithm_set_difference                              [system] { header "__algorithm/set_difference.h" }
-module std_private_algorithm_set_intersection                            [system] { header "__algorithm/set_intersection.h" }
-module std_private_algorithm_set_symmetric_difference                    [system] { header "__algorithm/set_symmetric_difference.h" }
-module std_private_algorithm_set_union                                   [system] { header "__algorithm/set_union.h" }
-module std_private_algorithm_shift_left                                  [system] { header "__algorithm/shift_left.h" }
-module std_private_algorithm_shift_right                                 [system] { header "__algorithm/shift_right.h" }
-module std_private_algorithm_shuffle                                     [system] { header "__algorithm/shuffle.h" }
-module std_private_algorithm_sift_down                                   [system] { header "__algorithm/sift_down.h" }
-module std_private_algorithm_sort                                        [system] {
+module std_private_algorithm_remove [system] {
+  export_as std
+  header "__algorithm/remove.h"
+}
+module std_private_algorithm_remove_copy [system] {
+  export_as std
+  header "__algorithm/remove_copy.h"
+}
+module std_private_algorithm_remove_copy_if [system] {
+  export_as std
+  header "__algorithm/remove_copy_if.h"
+}
+module std_private_algorithm_remove_if [system] {
+  export_as std
+  header "__algorithm/remove_if.h"
+}
+module std_private_algorithm_replace [system] {
+  export_as std
+  header "__algorithm/replace.h"
+}
+module std_private_algorithm_replace_copy [system] {
+  export_as std
+  header "__algorithm/replace_copy.h"
+}
+module std_private_algorithm_replace_copy_if [system] {
+  export_as std
+  header "__algorithm/replace_copy_if.h"
+}
+module std_private_algorithm_replace_if [system] {
+  export_as std
+  header "__algorithm/replace_if.h"
+}
+module std_private_algorithm_reverse [system] {
+  export_as std
+  header "__algorithm/reverse.h"
+}
+module std_private_algorithm_reverse_copy [system] {
+  export_as std
+  header "__algorithm/reverse_copy.h"
+}
+module std_private_algorithm_rotate [system] {
+  export_as std
+  header "__algorithm/rotate.h"
+}
+module std_private_algorithm_rotate_copy [system] {
+  export_as std
+  header "__algorithm/rotate_copy.h"
+}
+module std_private_algorithm_sample [system] {
+  export_as std
+  header "__algorithm/sample.h"
+}
+module std_private_algorithm_search [system] {
+  export_as std
+  header "__algorithm/search.h"
+}
+module std_private_algorithm_search_n [system] {
+  export_as std
+  header "__algorithm/search_n.h"
+}
+module std_private_algorithm_set_difference [system] {
+  export_as std
+  header "__algorithm/set_difference.h"
+}
+module std_private_algorithm_set_intersection [system] {
+  export_as std
+  header "__algorithm/set_intersection.h"
+}
+module std_private_algorithm_set_symmetric_difference [system] {
+  export_as std
+  header "__algorithm/set_symmetric_difference.h"
+}
+module std_private_algorithm_set_union [system] {
+  export_as std
+  header "__algorithm/set_union.h"
+}
+module std_private_algorithm_shift_left [system] {
+  export_as std
+  header "__algorithm/shift_left.h"
+}
+module std_private_algorithm_shift_right [system] {
+  export_as std
+  header "__algorithm/shift_right.h"
+}
+module std_private_algorithm_shuffle [system] {
+  export_as std
+  header "__algorithm/shuffle.h"
+}
+module std_private_algorithm_sift_down [system] {
+  export_as std
+  header "__algorithm/sift_down.h"
+}
+module std_private_algorithm_sort [system] {
+  export_as std
   header "__algorithm/sort.h"
   export std_private_debug_utils_strict_weak_ordering_check
 }
-module std_private_algorithm_sort_heap                                   [system] { header "__algorithm/sort_heap.h" }
-module std_private_algorithm_stable_partition                            [system] { header "__algorithm/stable_partition.h" }
-module std_private_algorithm_stable_sort                                 [system] { header "__algorithm/stable_sort.h" }
-module std_private_algorithm_swap_ranges                                 [system] {
+module std_private_algorithm_sort_heap [system] {
+  export_as std
+  header "__algorithm/sort_heap.h"
+}
+module std_private_algorithm_stable_partition [system] {
+  export_as std
+  header "__algorithm/stable_partition.h"
+}
+module std_private_algorithm_stable_sort [system] {
+  export_as std
+  header "__algorithm/stable_sort.h"
+}
+module std_private_algorithm_swap_ranges [system] {
+  export_as std
   header "__algorithm/swap_ranges.h"
   export std_private_algorithm_iterator_operations
 }
-module std_private_algorithm_three_way_comp_ref_type                     [system] { header "__algorithm/three_way_comp_ref_type.h" }
-module std_private_algorithm_transform                                   [system] { header "__algorithm/transform.h" }
-module std_private_algorithm_uniform_random_bit_generator_adaptor        [system] { header "__algorithm/uniform_random_bit_generator_adaptor.h" }
-module std_private_algorithm_unique                                      [system] { header "__algorithm/unique.h" }
-module std_private_algorithm_unique_copy                                 [system] { header "__algorithm/unique_copy.h" }
-module std_private_algorithm_unwrap_iter                                 [system] {
+module std_private_algorithm_three_way_comp_ref_type [system] {
+  export_as std
+  header "__algorithm/three_way_comp_ref_type.h"
+}
+module std_private_algorithm_transform [system] {
+  export_as std
+  header "__algorithm/transform.h"
+}
+module std_private_algorithm_uniform_random_bit_generator_adaptor [system] {
+  export_as std
+  header "__algorithm/uniform_random_bit_generator_adaptor.h"
+}
+module std_private_algorithm_unique [system] {
+  export_as std
+  header "__algorithm/unique.h"
+}
+module std_private_algorithm_unique_copy [system] {
+  export_as std
+  header "__algorithm/unique_copy.h"
+}
+module std_private_algorithm_unwrap_iter [system] {
+  export_as std
   header "__algorithm/unwrap_iter.h"
   export std_private_iterator_iterator_traits
 }
-module std_private_algorithm_unwrap_range                                [system] {
+module std_private_algorithm_unwrap_range [system] {
+  export_as std
   header "__algorithm/unwrap_range.h"
   export std_private_utility_pair
 }
-module std_private_algorithm_upper_bound                                 [system] { header "__algorithm/upper_bound.h" }
+module std_private_algorithm_upper_bound [system] {
+  export_as std
+  header "__algorithm/upper_bound.h"
+}
 
-module std_private_array_array_fwd [system] { header "__fwd/array.h" }
+module std_private_array_array_fwd [system] {
+  export_as std
+  header "__fwd/array.h"
+}
 
-module std_private_atomic_aliases             [system] {
+module std_private_atomic_aliases [system] {
+  export_as std
   header "__atomic/aliases.h"
   export std_private_atomic_atomic
 }
-module std_private_atomic_atomic              [system] {
+module std_private_atomic_atomic [system] {
+  export_as std
   header "__atomic/atomic.h"
   export std_private_atomic_atomic_base
 }
-module std_private_atomic_atomic_base         [system] { header "__atomic/atomic_base.h" }
-module std_private_atomic_atomic_flag         [system] {
+module std_private_atomic_atomic_base [system] {
+  export_as std
+  header "__atomic/atomic_base.h"
+}
+module std_private_atomic_atomic_flag [system] {
+  export_as std
   header "__atomic/atomic_flag.h"
   export *
 }
-module std_private_atomic_atomic_init         [system] { header "__atomic/atomic_init.h" }
-module std_private_atomic_atomic_lock_free    [system] { header "__atomic/atomic_lock_free.h" }
-module std_private_atomic_atomic_sync         [system] { header "__atomic/atomic_sync.h" }
-module std_private_atomic_check_memory_order  [system] { header "__atomic/check_memory_order.h" }
-module std_private_atomic_contention_t        [system] { header "__atomic/contention_t.h" }
-module std_private_atomic_cxx_atomic_impl     [system] { header "__atomic/cxx_atomic_impl.h" }
-module std_private_atomic_fence               [system] { header "__atomic/fence.h" }
-module std_private_atomic_is_always_lock_free [system] { header "__atomic/is_always_lock_free.h" }
-module std_private_atomic_kill_dependency     [system] { header "__atomic/kill_dependency.h" }
-module std_private_atomic_memory_order        [system] { header "__atomic/memory_order.h" }
+module std_private_atomic_atomic_init [system] {
+  export_as std
+  header "__atomic/atomic_init.h"
+}
+module std_private_atomic_atomic_lock_free [system] {
+  export_as std
+  header "__atomic/atomic_lock_free.h"
+}
+module std_private_atomic_atomic_sync [system] {
+  export_as std
+  header "__atomic/atomic_sync.h"
+}
+module std_private_atomic_check_memory_order [system] {
+  export_as std
+  header "__atomic/check_memory_order.h"
+}
+module std_private_atomic_contention_t [system] {
+  export_as std
+  header "__atomic/contention_t.h"
+}
+module std_private_atomic_cxx_atomic_impl [system] {
+  export_as std
+  header "__atomic/cxx_atomic_impl.h"
+}
+module std_private_atomic_fence [system] {
+  export_as std
+  header "__atomic/fence.h"
+}
+module std_private_atomic_is_always_lock_free [system] {
+  export_as std
+  header "__atomic/is_always_lock_free.h"
+}
+module std_private_atomic_kill_dependency [system] {
+  export_as std
+  header "__atomic/kill_dependency.h"
+}
+module std_private_atomic_memory_order [system] {
+  export_as std
+  header "__atomic/memory_order.h"
+}
 
-module std_private_bit_bit_cast       [system] { header "__bit/bit_cast.h" }
-module std_private_bit_bit_ceil       [system] { header "__bit/bit_ceil.h" }
-module std_private_bit_bit_floor      [system] { header "__bit/bit_floor.h" }
-module std_private_bit_bit_log2       [system] { header "__bit/bit_log2.h" }
-module std_private_bit_bit_width      [system] { header "__bit/bit_width.h" }
-module std_private_bit_blsr           [system] { header "__bit/blsr.h" }
-module std_private_bit_byteswap       [system] { header "__bit/byteswap.h" }
-module std_private_bit_countl         [system] { header "__bit/countl.h" }
-module std_private_bit_countr         [system] { header "__bit/countr.h" }
-module std_private_bit_endian         [system] { header "__bit/endian.h" }
-module std_private_bit_has_single_bit [system] { header "__bit/has_single_bit.h" }
-module std_private_bit_invert_if      [system] { header "__bit/invert_if.h" }
-module std_private_bit_popcount       [system] { header "__bit/popcount.h" }
-module std_private_bit_rotate         [system] { header "__bit/rotate.h" }
+module std_private_bit_bit_cast [system] {
+  export_as std
+  header "__bit/bit_cast.h"
+}
+module std_private_bit_bit_ceil [system] {
+  export_as std
+  header "__bit/bit_ceil.h"
+}
+module std_private_bit_bit_floor [system] {
+  export_as std
+  header "__bit/bit_floor.h"
+}
+module std_private_bit_bit_log2 [system] {
+  export_as std
+  header "__bit/bit_log2.h"
+}
+module std_private_bit_bit_width [system] {
+  export_as std
+  header "__bit/bit_width.h"
+}
+module std_private_bit_blsr [system] {
+  export_as std
+  header "__bit/blsr.h"
+}
+module std_private_bit_byteswap [system] {
+  export_as std
+  header "__bit/byteswap.h"
+}
+module std_private_bit_countl [system] {
+  export_as std
+  header "__bit/countl.h"
+}
+module std_private_bit_countr [system] {
+  export_as std
+  header "__bit/countr.h"
+}
+module std_private_bit_endian [system] {
+  export_as std
+  header "__bit/endian.h"
+}
+module std_private_bit_has_single_bit [system] {
+  export_as std
+  header "__bit/has_single_bit.h"
+}
+module std_private_bit_invert_if [system] {
+  export_as std
+  header "__bit/invert_if.h"
+}
+module std_private_bit_popcount [system] {
+  export_as std
+  header "__bit/popcount.h"
+}
+module std_private_bit_rotate [system] {
+  export_as std
+  header "__bit/rotate.h"
+}
 
-module std_private_charconv_chars_format            [system] { header "__charconv/chars_format.h" }
-module std_private_charconv_from_chars_integral     [system] { header "__charconv/from_chars_integral.h" }
-module std_private_charconv_from_chars_result       [system] { header "__charconv/from_chars_result.h" }
-module std_private_charconv_tables                  [system] { header "__charconv/tables.h" }
-module std_private_charconv_to_chars                [system] { header "__charconv/to_chars.h" }
-module std_private_charconv_to_chars_base_10        [system] { header "__charconv/to_chars_base_10.h" }
-module std_private_charconv_to_chars_floating_point [system] { header "__charconv/to_chars_floating_point.h" }
-module std_private_charconv_to_chars_integral       [system] { header "__charconv/to_chars_integral.h" }
-module std_private_charconv_to_chars_result         [system] { header "__charconv/to_chars_result.h" }
-module std_private_charconv_traits                  [system] { header "__charconv/traits.h" }
+module std_private_charconv_chars_format [system] {
+  export_as std
+  header "__charconv/chars_format.h"
+}
+module std_private_charconv_from_chars_integral [system] {
+  export_as std
+  header "__charconv/from_chars_integral.h"
+}
+module std_private_charconv_from_chars_result [system] {
+  export_as std
+  header "__charconv/from_chars_result.h"
+}
+module std_private_charconv_tables [system] {
+  export_as std
+  header "__charconv/tables.h"
+}
+module std_private_charconv_to_chars [system] {
+  export_as std
+  header "__charconv/to_chars.h"
+}
+module std_private_charconv_to_chars_base_10 [system] {
+  export_as std
+  header "__charconv/to_chars_base_10.h"
+}
+module std_private_charconv_to_chars_floating_point [system] {
+  export_as std
+  header "__charconv/to_chars_floating_point.h"
+}
+module std_private_charconv_to_chars_integral [system] {
+  export_as std
+  header "__charconv/to_chars_integral.h"
+}
+module std_private_charconv_to_chars_result [system] {
+  export_as std
+  header "__charconv/to_chars_result.h"
+}
+module std_private_charconv_traits [system] {
+  export_as std
+  header "__charconv/traits.h"
+}
 
-module std_private_chrono_calendar               [system] { header "__chrono/calendar.h" }
-module std_private_chrono_concepts               [system] { header "__chrono/concepts.h" }
-module std_private_chrono_convert_to_timespec    [system] { header "__chrono/convert_to_timespec.h" }
-module std_private_chrono_convert_to_tm          [system] { header "__chrono/convert_to_tm.h" }
-module std_private_chrono_day                    [system] { header "__chrono/day.h" }
-module std_private_chrono_duration               [system] {
+module std_private_chrono_calendar [system] {
+  export_as std
+  header "__chrono/calendar.h"
+}
+module std_private_chrono_concepts [system] {
+  export_as std
+  header "__chrono/concepts.h"
+}
+module std_private_chrono_convert_to_timespec [system] {
+  export_as std
+  header "__chrono/convert_to_timespec.h"
+}
+module std_private_chrono_convert_to_tm [system] {
+  export_as std
+  header "__chrono/convert_to_tm.h"
+}
+module std_private_chrono_day [system] {
+  export_as std
+  header "__chrono/day.h"
+}
+module std_private_chrono_duration [system] {
+  export_as std
   header "__chrono/duration.h"
   export std_private_type_traits_is_convertible
 }
-module std_private_chrono_file_clock             [system] { header "__chrono/file_clock.h" }
-module std_private_chrono_formatter              [system] {
+module std_private_chrono_file_clock [system] {
+  export_as std
+  header "__chrono/file_clock.h"
+}
+module std_private_chrono_formatter [system] {
+  export_as std
   header "__chrono/formatter.h"
 }
-module std_private_chrono_hh_mm_ss               [system] { header "__chrono/hh_mm_ss.h" }
-module std_private_chrono_high_resolution_clock  [system] {
+module std_private_chrono_hh_mm_ss [system] {
+  export_as std
+  header "__chrono/hh_mm_ss.h"
+}
+module std_private_chrono_high_resolution_clock [system] {
+  export_as std
   header "__chrono/high_resolution_clock.h"
   export std_private_chrono_steady_clock
   export std_private_chrono_system_clock
 }
-module std_private_chrono_literals               [system] { header "__chrono/literals.h" }
-module std_private_chrono_month                  [system] { header "__chrono/month.h" }
-module std_private_chrono_month_weekday          [system] { header "__chrono/month_weekday.h" }
-module std_private_chrono_monthday               [system] { header "__chrono/monthday.h" }
-module std_private_chrono_ostream                [system] {
+module std_private_chrono_literals [system] {
+  export_as std
+  header "__chrono/literals.h"
+}
+module std_private_chrono_month [system] {
+  export_as std
+  header "__chrono/month.h"
+}
+module std_private_chrono_month_weekday [system] {
+  export_as std
+  header "__chrono/month_weekday.h"
+}
+module std_private_chrono_monthday [system] {
+  export_as std
+  header "__chrono/monthday.h"
+}
+module std_private_chrono_ostream [system] {
+  export_as std
   header "__chrono/ostream.h"
 }
 module std_private_chrono_parser_std_format_spec [system] {
+  export_as std
   header "__chrono/parser_std_format_spec.h"
 }
-module std_private_chrono_statically_widen       [system] { header "__chrono/statically_widen.h" }
-module std_private_chrono_steady_clock           [system] {
+module std_private_chrono_statically_widen [system] {
+  export_as std
+  header "__chrono/statically_widen.h"
+}
+module std_private_chrono_steady_clock [system] {
+  export_as std
   header "__chrono/steady_clock.h"
   export std_private_chrono_time_point
 }
-module std_private_chrono_system_clock           [system] {
+module std_private_chrono_system_clock [system] {
+  export_as std
   header "__chrono/system_clock.h"
   export std_private_chrono_time_point
 }
-module std_private_chrono_tzdb                   [system] {
+module std_private_chrono_tzdb [system] {
+  export_as std
   header "__chrono/tzdb.h"
   export *
 }
-module std_private_chrono_tzdb_list              [system] {
+module std_private_chrono_tzdb_list [system] {
+  export_as std
   header "__chrono/tzdb_list.h"
   export *
 }
-module std_private_chrono_time_point             [system] { header "__chrono/time_point.h" }
-module std_private_chrono_weekday                [system] { header "__chrono/weekday.h" }
-module std_private_chrono_year                   [system] { header "__chrono/year.h" }
-module std_private_chrono_year_month             [system] { header "__chrono/year_month.h" }
-module std_private_chrono_year_month_day         [system] { header "__chrono/year_month_day.h" }
-module std_private_chrono_year_month_weekday     [system] { header "__chrono/year_month_weekday.h" }
+module std_private_chrono_time_point [system] {
+  export_as std
+  header "__chrono/time_point.h"
+}
+module std_private_chrono_weekday [system] {
+  export_as std
+  header "__chrono/weekday.h"
+}
+module std_private_chrono_year [system] {
+  export_as std
+  header "__chrono/year.h"
+}
+module std_private_chrono_year_month [system] {
+  export_as std
+  header "__chrono/year_month.h"
+}
+module std_private_chrono_year_month_day [system] {
+  export_as std
+  header "__chrono/year_month_day.h"
+}
+module std_private_chrono_year_month_weekday [system] {
+  export_as std
+  header "__chrono/year_month_weekday.h"
+}
 
-module std_private_compare_common_comparison_category     [system] { header "__compare/common_comparison_category.h" }
-module std_private_compare_compare_partial_order_fallback [system] { header "__compare/compare_partial_order_fallback.h" }
-module std_private_compare_compare_strong_order_fallback  [system] { header "__compare/compare_strong_order_fallback.h" }
-module std_private_compare_compare_three_way              [system] { header "__compare/compare_three_way.h" }
-module std_private_compare_compare_three_way_result       [system] { header "__compare/compare_three_way_result.h" }
-module std_private_compare_compare_weak_order_fallback    [system] { header "__compare/compare_weak_order_fallback.h" }
-module std_private_compare_is_eq                          [system] { header "__compare/is_eq.h" }
-module std_private_compare_ordering                       [system] { header "__compare/ordering.h" }
-module std_private_compare_partial_order                  [system] { header "__compare/partial_order.h" }
-module std_private_compare_strong_order                   [system] { header "__compare/strong_order.h" }
-module std_private_compare_synth_three_way                [system] { header "__compare/synth_three_way.h" }
-module std_private_compare_three_way_comparable           [system] { header "__compare/three_way_comparable.h" }
-module std_private_compare_weak_order                     [system] { header "__compare/weak_order.h" }
+module std_private_compare_common_comparison_category [system] {
+  export_as std
+  header "__compare/common_comparison_category.h"
+}
+module std_private_compare_compare_partial_order_fallback [system] {
+  export_as std
+  header "__compare/compare_partial_order_fallback.h"
+}
+module std_private_compare_compare_strong_order_fallback [system] {
+  export_as std
+  header "__compare/compare_strong_order_fallback.h"
+}
+module std_private_compare_compare_three_way [system] {
+  export_as std
+  header "__compare/compare_three_way.h"
+}
+module std_private_compare_compare_three_way_result [system] {
+  export_as std
+  header "__compare/compare_three_way_result.h"
+}
+module std_private_compare_compare_weak_order_fallback [system] {
+  export_as std
+  header "__compare/compare_weak_order_fallback.h"
+}
+module std_private_compare_is_eq [system] {
+  export_as std
+  header "__compare/is_eq.h"
+}
+module std_private_compare_ordering [system] {
+  export_as std
+  header "__compare/ordering.h"
+}
+module std_private_compare_partial_order [system] {
+  export_as std
+  header "__compare/partial_order.h"
+}
+module std_private_compare_strong_order [system] {
+  export_as std
+  header "__compare/strong_order.h"
+}
+module std_private_compare_synth_three_way [system] {
+  export_as std
+  header "__compare/synth_three_way.h"
+}
+module std_private_compare_three_way_comparable [system] {
+  export_as std
+  header "__compare/three_way_comparable.h"
+}
+module std_private_compare_weak_order [system] {
+  export_as std
+  header "__compare/weak_order.h"
+}
 
-module std_private_concepts_arithmetic            [system] { header "__concepts/arithmetic.h" }
-module std_private_concepts_assignable            [system] { header "__concepts/assignable.h" }
-module std_private_concepts_boolean_testable      [system] { header "__concepts/boolean_testable.h" }
-module std_private_concepts_class_or_enum         [system] { header "__concepts/class_or_enum.h" }
-module std_private_concepts_common_reference_with [system] { header "__concepts/common_reference_with.h" }
-module std_private_concepts_common_with           [system] { header "__concepts/common_with.h" }
-module std_private_concepts_constructible         [system] {
+module std_private_concepts_arithmetic [system] {
+  export_as std
+  header "__concepts/arithmetic.h"
+}
+module std_private_concepts_assignable [system] {
+  export_as std
+  header "__concepts/assignable.h"
+}
+module std_private_concepts_boolean_testable [system] {
+  export_as std
+  header "__concepts/boolean_testable.h"
+}
+module std_private_concepts_class_or_enum [system] {
+  export_as std
+  header "__concepts/class_or_enum.h"
+}
+module std_private_concepts_common_reference_with [system] {
+  export_as std
+  header "__concepts/common_reference_with.h"
+}
+module std_private_concepts_common_with [system] {
+  export_as std
+  header "__concepts/common_with.h"
+}
+module std_private_concepts_constructible [system] {
+  export_as std
   header "__concepts/constructible.h"
   export std_private_concepts_destructible
 }
-module std_private_concepts_convertible_to        [system] { header "__concepts/convertible_to.h" }
-module std_private_concepts_copyable              [system] { header "__concepts/copyable.h" }
-module std_private_concepts_derived_from          [system] { header "__concepts/derived_from.h" }
-module std_private_concepts_destructible          [system] {
+module std_private_concepts_convertible_to [system] {
+  export_as std
+  header "__concepts/convertible_to.h"
+}
+module std_private_concepts_copyable [system] {
+  export_as std
+  header "__concepts/copyable.h"
+}
+module std_private_concepts_derived_from [system] {
+  export_as std
+  header "__concepts/derived_from.h"
+}
+module std_private_concepts_destructible [system] {
+  export_as std
   header "__concepts/destructible.h"
   export std_private_type_traits_is_nothrow_destructible
 }
-module std_private_concepts_different_from        [system] { header "__concepts/different_from.h" }
-module std_private_concepts_equality_comparable   [system] {
+module std_private_concepts_different_from [system] {
+  export_as std
+  header "__concepts/different_from.h"
+}
+module std_private_concepts_equality_comparable [system] {
+  export_as std
   header "__concepts/equality_comparable.h"
   export std_private_type_traits_common_reference
 }
-module std_private_concepts_invocable             [system] { header "__concepts/invocable.h" }
-module std_private_concepts_movable               [system] {
+module std_private_concepts_invocable [system] {
+  export_as std
+  header "__concepts/invocable.h"
+}
+module std_private_concepts_movable [system] {
+  export_as std
   header "__concepts/movable.h"
   export std_private_type_traits_is_object
 }
-module std_private_concepts_predicate             [system] { header "__concepts/predicate.h" }
-module std_private_concepts_regular               [system] { header "__concepts/regular.h" }
-module std_private_concepts_relation              [system] { header "__concepts/relation.h" }
-module std_private_concepts_same_as               [system] {
+module std_private_concepts_predicate [system] {
+  export_as std
+  header "__concepts/predicate.h"
+}
+module std_private_concepts_regular [system] {
+  export_as std
+  header "__concepts/regular.h"
+}
+module std_private_concepts_relation [system] {
+  export_as std
+  header "__concepts/relation.h"
+}
+module std_private_concepts_same_as [system] {
+  export_as std
   header "__concepts/same_as.h"
   export std_private_type_traits_is_same
 }
-module std_private_concepts_semiregular           [system] { header "__concepts/semiregular.h" }
-module std_private_concepts_swappable             [system] { header "__concepts/swappable.h" }
-module std_private_concepts_totally_ordered       [system] { header "__concepts/totally_ordered.h" }
+module std_private_concepts_semiregular [system] {
+  export_as std
+  header "__concepts/semiregular.h"
+}
+module std_private_concepts_swappable [system] {
+  export_as std
+  header "__concepts/swappable.h"
+}
+module std_private_concepts_totally_ordered [system] {
+  export_as std
+  header "__concepts/totally_ordered.h"
+}
 
 module std_private_condition_variable_condition_variable [system] {
+  export_as std
   header "__condition_variable/condition_variable.h"
   export *
 }
 
-module std_private_coroutine_coroutine_handle      [system] { header "__coroutine/coroutine_handle.h" }
-module std_private_coroutine_coroutine_traits      [system] { header "__coroutine/coroutine_traits.h" }
-module std_private_coroutine_noop_coroutine_handle [system] { header "__coroutine/noop_coroutine_handle.h" }
-module std_private_coroutine_trivial_awaitables    [system] { header "__coroutine/trivial_awaitables.h" }
+module std_private_coroutine_coroutine_handle [system] {
+  export_as std
+  header "__coroutine/coroutine_handle.h"
+}
+module std_private_coroutine_coroutine_traits [system] {
+  export_as std
+  header "__coroutine/coroutine_traits.h"
+}
+module std_private_coroutine_noop_coroutine_handle [system] {
+  export_as std
+  header "__coroutine/noop_coroutine_handle.h"
+}
+module std_private_coroutine_trivial_awaitables [system] {
+  export_as std
+  header "__coroutine/trivial_awaitables.h"
+}
 
-module std_private_debug_utils_randomize_range            [system] { header "__debug_utils/randomize_range.h" }
+module std_private_debug_utils_randomize_range [system] {
+  export_as std
+  header "__debug_utils/randomize_range.h"
+}
 module std_private_debug_utils_strict_weak_ordering_check [system] {
+  export_as std
   header "__debug_utils/strict_weak_ordering_check.h"
   export std_private_type_traits_is_constant_evaluated
 }
 
-module std_private_exception_exception        [system] { header "__exception/exception.h" }
-module std_private_exception_exception_ptr    [system] {
+module std_private_exception_exception [system] {
+  export_as std
+  header "__exception/exception.h"
+}
+module std_private_exception_exception_ptr [system] {
+  export_as std
   header "__exception/exception_ptr.h"
   export std_private_exception_operations
 }
-module std_private_exception_nested_exception [system] { header "__exception/nested_exception.h" }
-module std_private_exception_operations       [system] { header "__exception/operations.h" }
-module std_private_exception_terminate        [system] { header "__exception/terminate.h" }
+module std_private_exception_nested_exception [system] {
+  export_as std
+  header "__exception/nested_exception.h"
+}
+module std_private_exception_operations [system] {
+  export_as std
+  header "__exception/operations.h"
+}
+module std_private_exception_terminate [system] {
+  export_as std
+  header "__exception/terminate.h"
+}
 
-module std_private_expected_bad_expected_access [system] { header "__expected/bad_expected_access.h" }
-module std_private_expected_expected            [system] { header "__expected/expected.h" }
-module std_private_expected_unexpect            [system] { header "__expected/unexpect.h" }
-module std_private_expected_unexpected          [system] { header "__expected/unexpected.h" }
+module std_private_expected_bad_expected_access [system] {
+  export_as std
+  header "__expected/bad_expected_access.h"
+}
+module std_private_expected_expected [system] {
+  export_as std
+  header "__expected/expected.h"
+}
+module std_private_expected_unexpect [system] {
+  export_as std
+  header "__expected/unexpect.h"
+}
+module std_private_expected_unexpected [system] {
+  export_as std
+  header "__expected/unexpected.h"
+}
 
-module std_private_filesystem_copy_options                 [system] { header "__filesystem/copy_options.h" }
-module std_private_filesystem_directory_entry              [system] {
+module std_private_filesystem_copy_options [system] {
+  export_as std
+  header "__filesystem/copy_options.h"
+}
+module std_private_filesystem_directory_entry [system] {
+  export_as std
   header "__filesystem/directory_entry.h"
   export *
 }
-module std_private_filesystem_directory_iterator           [system] {
+module std_private_filesystem_directory_iterator [system] {
+  export_as std
   header "__filesystem/directory_iterator.h"
   export *
 }
-module std_private_filesystem_directory_options            [system] { header "__filesystem/directory_options.h" }
-module std_private_filesystem_file_status                  [system] { header "__filesystem/file_status.h" }
-module std_private_filesystem_file_time_type               [system] { header "__filesystem/file_time_type.h" }
-module std_private_filesystem_file_type                    [system] { header "__filesystem/file_type.h" }
-module std_private_filesystem_filesystem_error             [system] {
+module std_private_filesystem_directory_options [system] {
+  export_as std
+  header "__filesystem/directory_options.h"
+}
+module std_private_filesystem_file_status [system] {
+  export_as std
+  header "__filesystem/file_status.h"
+}
+module std_private_filesystem_file_time_type [system] {
+  export_as std
+  header "__filesystem/file_time_type.h"
+}
+module std_private_filesystem_file_type [system] {
+  export_as std
+  header "__filesystem/file_type.h"
+}
+module std_private_filesystem_filesystem_error [system] {
+  export_as std
   header "__filesystem/filesystem_error.h"
   export *
 }
-module std_private_filesystem_operations                   [system] { header "__filesystem/operations.h" }
-module std_private_filesystem_path                         [system] {
+module std_private_filesystem_operations [system] {
+  export_as std
+  header "__filesystem/operations.h"
+}
+module std_private_filesystem_path [system] {
+  export_as std
   header "__filesystem/path.h"
   export *
 }
-module std_private_filesystem_path_iterator                [system] { header "__filesystem/path_iterator.h" }
-module std_private_filesystem_perm_options                 [system] { header "__filesystem/perm_options.h" }
-module std_private_filesystem_perms                        [system] { header "__filesystem/perms.h" }
+module std_private_filesystem_path_iterator [system] {
+  export_as std
+  header "__filesystem/path_iterator.h"
+}
+module std_private_filesystem_perm_options [system] {
+  export_as std
+  header "__filesystem/perm_options.h"
+}
+module std_private_filesystem_perms [system] {
+  export_as std
+  header "__filesystem/perms.h"
+}
 module std_private_filesystem_recursive_directory_iterator [system] {
+  export_as std
   header "__filesystem/recursive_directory_iterator.h"
   export *
 }
-module std_private_filesystem_space_info                   [system] { header "__filesystem/space_info.h" }
-module std_private_filesystem_u8path                       [system] { header "__filesystem/u8path.h" }
+module std_private_filesystem_space_info [system] {
+  export_as std
+  header "__filesystem/space_info.h"
+}
+module std_private_filesystem_u8path [system] {
+  export_as std
+  header "__filesystem/u8path.h"
+}
 
-module std_private_format_buffer                          [system] { header "__format/buffer.h" }
-module std_private_format_concepts                        [system] { header "__format/concepts.h" }
-module std_private_format_container_adaptor               [system] { header "__format/container_adaptor.h" }
-module std_private_format_enable_insertable               [system] { header "__format/enable_insertable.h" }
-module std_private_format_escaped_output_table            [system] { header "__format/escaped_output_table.h" }
-module std_private_format_extended_grapheme_cluster_table [system] { header "__format/extended_grapheme_cluster_table.h" }
-module std_private_format_format_arg                      [system] { header "__format/format_arg.h" }
-module std_private_format_format_arg_store                [system] { header "__format/format_arg_store.h" }
-module std_private_format_format_args                     [system] { header "__format/format_args.h" }
-module std_private_format_format_context                  [system] {
+module std_private_format_buffer [system] {
+  export_as std
+  header "__format/buffer.h"
+}
+module std_private_format_concepts [system] {
+  export_as std
+  header "__format/concepts.h"
+}
+module std_private_format_container_adaptor [system] {
+  export_as std
+  header "__format/container_adaptor.h"
+}
+module std_private_format_enable_insertable [system] {
+  export_as std
+  header "__format/enable_insertable.h"
+}
+module std_private_format_escaped_output_table [system] {
+  export_as std
+  header "__format/escaped_output_table.h"
+}
+module std_private_format_extended_grapheme_cluster_table [system] {
+  export_as std
+  header "__format/extended_grapheme_cluster_table.h"
+}
+module std_private_format_format_arg [system] {
+  export_as std
+  header "__format/format_arg.h"
+}
+module std_private_format_format_arg_store [system] {
+  export_as std
+  header "__format/format_arg_store.h"
+}
+module std_private_format_format_args [system] {
+  export_as std
+  header "__format/format_args.h"
+}
+module std_private_format_format_context [system] {
+  export_as std
   header "__format/format_context.h"
   export *
 }
-module std_private_format_format_error                    [system] { header "__format/format_error.h" }
-module std_private_format_format_functions                [system] {
+module std_private_format_format_error [system] {
+  export_as std
+  header "__format/format_error.h"
+}
+module std_private_format_format_functions [system] {
+  export_as std
   header "__format/format_functions.h"
   export std_string
 }
-module std_private_format_format_fwd                      [system] { header "__format/format_fwd.h" }
-module std_private_format_format_parse_context            [system] { header "__format/format_parse_context.h" }
-module std_private_format_format_string                   [system] { header "__format/format_string.h" }
-module std_private_format_format_to_n_result              [system] {
+module std_private_format_format_fwd [system] {
+  export_as std
+  header "__format/format_fwd.h"
+}
+module std_private_format_format_parse_context [system] {
+  export_as std
+  header "__format/format_parse_context.h"
+}
+module std_private_format_format_string [system] {
+  export_as std
+  header "__format/format_string.h"
+}
+module std_private_format_format_to_n_result [system] {
+  export_as std
   header "__format/format_to_n_result.h"
   export std_private_iterator_incrementable_traits
 }
-module std_private_format_formatter                       [system] { header "__format/formatter.h" }
-module std_private_format_formatter_bool                  [system] { header "__format/formatter_bool.h" }
-module std_private_format_formatter_char                  [system] { header "__format/formatter_char.h" }
-module std_private_format_formatter_floating_point        [system] { header "__format/formatter_floating_point.h" }
-module std_private_format_formatter_integer               [system] { header "__format/formatter_integer.h" }
-module std_private_format_formatter_integral              [system] { header "__format/formatter_integral.h" }
-module std_private_format_formatter_output                [system] { header "__format/formatter_output.h" }
-module std_private_format_formatter_pointer               [system] { header "__format/formatter_pointer.h" }
-module std_private_format_formatter_string                [system] { header "__format/formatter_string.h" }
-module std_private_format_formatter_tuple                 [system] { header "__format/formatter_tuple.h" }
-module std_private_format_parser_std_format_spec          [system] { header "__format/parser_std_format_spec.h" }
-module std_private_format_range_default_formatter         [system] { header "__format/range_default_formatter.h" }
-module std_private_format_range_formatter                 [system] { header "__format/range_formatter.h" }
-module std_private_format_unicode                         [system] {
+module std_private_format_formatter [system] {
+  export_as std
+  header "__format/formatter.h"
+}
+module std_private_format_formatter_bool [system] {
+  export_as std
+  header "__format/formatter_bool.h"
+}
+module std_private_format_formatter_char [system] {
+  export_as std
+  header "__format/formatter_char.h"
+}
+module std_private_format_formatter_floating_point [system] {
+  export_as std
+  header "__format/formatter_floating_point.h"
+}
+module std_private_format_formatter_integer [system] {
+  export_as std
+  header "__format/formatter_integer.h"
+}
+module std_private_format_formatter_integral [system] {
+  export_as std
+  header "__format/formatter_integral.h"
+}
+module std_private_format_formatter_output [system] {
+  export_as std
+  header "__format/formatter_output.h"
+}
+module std_private_format_formatter_pointer [system] {
+  export_as std
+  header "__format/formatter_pointer.h"
+}
+module std_private_format_formatter_string [system] {
+  export_as std
+  header "__format/formatter_string.h"
+}
+module std_private_format_formatter_tuple [system] {
+  export_as std
+  header "__format/formatter_tuple.h"
+}
+module std_private_format_parser_std_format_spec [system] {
+  export_as std
+  header "__format/parser_std_format_spec.h"
+}
+module std_private_format_range_default_formatter [system] {
+  export_as std
+  header "__format/range_default_formatter.h"
+}
+module std_private_format_range_formatter [system] {
+  export_as std
+  header "__format/range_formatter.h"
+}
+module std_private_format_unicode [system] {
+  export_as std
   header "__format/unicode.h"
   export std_private_format_extended_grapheme_cluster_table
 }
-module std_private_format_width_estimation_table          [system] { header "__format/width_estimation_table.h" }
-module std_private_format_write_escaped                   [system] { header "__format/write_escaped.h" }
+module std_private_format_width_estimation_table [system] {
+  export_as std
+  header "__format/width_estimation_table.h"
+}
+module std_private_format_write_escaped [system] {
+  export_as std
+  header "__format/write_escaped.h"
+}
 
-module std_private_functional_binary_function            [system] { header "__functional/binary_function.h" }
-module std_private_functional_binary_negate              [system] { header "__functional/binary_negate.h" }
-module std_private_functional_bind                       [system] { header "__functional/bind.h" }
-module std_private_functional_bind_back                  [system] { header "__functional/bind_back.h" }
-module std_private_functional_bind_front                 [system] { header "__functional/bind_front.h" }
-module std_private_functional_binder1st                  [system] { header "__functional/binder1st.h" }
-module std_private_functional_binder2nd                  [system] { header "__functional/binder2nd.h" }
-module std_private_functional_boyer_moore_searcher       [system] {
+module std_private_functional_binary_function [system] {
+  export_as std
+  header "__functional/binary_function.h"
+}
+module std_private_functional_binary_negate [system] {
+  export_as std
+  header "__functional/binary_negate.h"
+}
+module std_private_functional_bind [system] {
+  export_as std
+  header "__functional/bind.h"
+}
+module std_private_functional_bind_back [system] {
+  export_as std
+  header "__functional/bind_back.h"
+}
+module std_private_functional_bind_front [system] {
+  export_as std
+  header "__functional/bind_front.h"
+}
+module std_private_functional_binder1st [system] {
+  export_as std
+  header "__functional/binder1st.h"
+}
+module std_private_functional_binder2nd [system] {
+  export_as std
+  header "__functional/binder2nd.h"
+}
+module std_private_functional_boyer_moore_searcher [system] {
+  export_as std
   header "__functional/boyer_moore_searcher.h"
   export std_private_memory_shared_ptr
 }
-module std_private_functional_compose                    [system] {
+module std_private_functional_compose [system] {
+  export_as std
   header "__functional/compose.h"
   export std_private_functional_perfect_forward
 }
-module std_private_functional_default_searcher           [system] { header "__functional/default_searcher.h" }
-module std_private_functional_function                   [system] { header "__functional/function.h" }
-module std_private_functional_hash                       [system] {
+module std_private_functional_default_searcher [system] {
+  export_as std
+  header "__functional/default_searcher.h"
+}
+module std_private_functional_function [system] {
+  export_as std
+  header "__functional/function.h"
+}
+module std_private_functional_hash [system] {
+  export_as std
   header "__functional/hash.h"
   export std_cstdint
   export std_private_type_traits_underlying_type
   export std_private_utility_pair
 }
-module std_private_functional_hash_fwd                   [system] { header "__fwd/hash.h" }
-module std_private_functional_identity                   [system] { header "__functional/identity.h" }
-module std_private_functional_invoke                     [system] {
+module std_private_functional_hash_fwd [system] {
+  export_as std
+  header "__fwd/hash.h"
+}
+module std_private_functional_identity [system] {
+  export_as std
+  header "__functional/identity.h"
+}
+module std_private_functional_invoke [system] {
+  export_as std
   header "__functional/invoke.h"
   export *
 }
-module std_private_functional_is_transparent             [system] { header "__functional/is_transparent.h" }
-module std_private_functional_mem_fn                     [system] { header "__functional/mem_fn.h" }
-module std_private_functional_mem_fun_ref                [system] { header "__functional/mem_fun_ref.h" }
-module std_private_functional_not_fn                     [system] { header "__functional/not_fn.h" }
-module std_private_functional_operations                 [system] { header "__functional/operations.h" }
-module std_private_functional_perfect_forward            [system] {
+module std_private_functional_is_transparent [system] {
+  export_as std
+  header "__functional/is_transparent.h"
+}
+module std_private_functional_mem_fn [system] {
+  export_as std
+  header "__functional/mem_fn.h"
+}
+module std_private_functional_mem_fun_ref [system] {
+  export_as std
+  header "__functional/mem_fun_ref.h"
+}
+module std_private_functional_not_fn [system] {
+  export_as std
+  header "__functional/not_fn.h"
+}
+module std_private_functional_operations [system] {
+  export_as std
+  header "__functional/operations.h"
+}
+module std_private_functional_perfect_forward [system] {
+  export_as std
   header "__functional/perfect_forward.h"
   export *
 }
-module std_private_functional_pointer_to_binary_function [system] { header "__functional/pointer_to_binary_function.h" }
-module std_private_functional_pointer_to_unary_function  [system] { header "__functional/pointer_to_unary_function.h" }
-module std_private_functional_ranges_operations          [system] { header "__functional/ranges_operations.h" }
-module std_private_functional_reference_wrapper          [system] { header "__functional/reference_wrapper.h" }
-module std_private_functional_unary_function             [system] { header "__functional/unary_function.h" }
-module std_private_functional_unary_negate               [system] { header "__functional/unary_negate.h" }
-module std_private_functional_weak_result_type           [system] { header "__functional/weak_result_type.h" }
+module std_private_functional_pointer_to_binary_function [system] {
+  export_as std
+  header "__functional/pointer_to_binary_function.h"
+}
+module std_private_functional_pointer_to_unary_function [system] {
+  export_as std
+  header "__functional/pointer_to_unary_function.h"
+}
+module std_private_functional_ranges_operations [system] {
+  export_as std
+  header "__functional/ranges_operations.h"
+}
+module std_private_functional_reference_wrapper [system] {
+  export_as std
+  header "__functional/reference_wrapper.h"
+}
+module std_private_functional_unary_function [system] {
+  export_as std
+  header "__functional/unary_function.h"
+}
+module std_private_functional_unary_negate [system] {
+  export_as std
+  header "__functional/unary_negate.h"
+}
+module std_private_functional_weak_result_type [system] {
+  export_as std
+  header "__functional/weak_result_type.h"
+}
 
-module std_private_ios_fpos [system] { header "__ios/fpos.h" }
+module std_private_ios_fpos [system] {
+  export_as std
+  header "__ios/fpos.h"
+}
 
-module std_private_iosfwd_fstream_fwd   [system] { header "__fwd/fstream.h" }
-module std_private_iosfwd_ios_fwd       [system] { header "__fwd/ios.h" }
-module std_private_iosfwd_istream_fwd   [system] { header "__fwd/istream.h" }
-module std_private_iosfwd_ostream_fwd   [system] { header "__fwd/ostream.h" }
-module std_private_iosfwd_sstream_fwd   [system] { header "__fwd/sstream.h" }
-module std_private_iosfwd_streambuf_fwd [system] { header "__fwd/streambuf.h" }
+module std_private_iosfwd_fstream_fwd [system] {
+  export_as std
+  header "__fwd/fstream.h"
+}
+module std_private_iosfwd_ios_fwd [system] {
+  export_as std
+  header "__fwd/ios.h"
+}
+module std_private_iosfwd_istream_fwd [system] {
+  export_as std
+  header "__fwd/istream.h"
+}
+module std_private_iosfwd_ostream_fwd [system] {
+  export_as std
+  header "__fwd/ostream.h"
+}
+module std_private_iosfwd_sstream_fwd [system] {
+  export_as std
+  header "__fwd/sstream.h"
+}
+module std_private_iosfwd_streambuf_fwd [system] {
+  export_as std
+  header "__fwd/streambuf.h"
+}
 
-module std_private_iterator_access                  [system] { header "__iterator/access.h" }
-module std_private_iterator_advance                 [system] { header "__iterator/advance.h" }
-module std_private_iterator_back_insert_iterator    [system] { header "__iterator/back_insert_iterator.h" }
-module std_private_iterator_bounded_iter            [system] { header "__iterator/bounded_iter.h" }
-module std_private_iterator_common_iterator         [system] { header "__iterator/common_iterator.h" }
-module std_private_iterator_concepts                [system] {
+module std_private_iterator_access [system] {
+  export_as std
+  header "__iterator/access.h"
+}
+module std_private_iterator_advance [system] {
+  export_as std
+  header "__iterator/advance.h"
+}
+module std_private_iterator_back_insert_iterator [system] {
+  export_as std
+  header "__iterator/back_insert_iterator.h"
+}
+module std_private_iterator_bounded_iter [system] {
+  export_as std
+  header "__iterator/bounded_iter.h"
+}
+module std_private_iterator_common_iterator [system] {
+  export_as std
+  header "__iterator/common_iterator.h"
+}
+module std_private_iterator_concepts [system] {
+  export_as std
   header "__iterator/concepts.h"
   export std_private_concepts_constructible
   export std_private_concepts_equality_comparable
@@ -1410,432 +2644,1135 @@ module std_private_iterator_concepts                [system] {
   export std_private_type_traits_is_reference
   export std_private_type_traits_remove_cvref
 }
-module std_private_iterator_counted_iterator        [system] { header "__iterator/counted_iterator.h" }
-module std_private_iterator_cpp17_iterator_concepts [system] { header "__iterator/cpp17_iterator_concepts.h" }
-module std_private_iterator_data                    [system] { header "__iterator/data.h" }
-module std_private_iterator_default_sentinel        [system] { header "__iterator/default_sentinel.h" }
-module std_private_iterator_distance                [system] {
+module std_private_iterator_counted_iterator [system] {
+  export_as std
+  header "__iterator/counted_iterator.h"
+}
+module std_private_iterator_cpp17_iterator_concepts [system] {
+  export_as std
+  header "__iterator/cpp17_iterator_concepts.h"
+}
+module std_private_iterator_data [system] {
+  export_as std
+  header "__iterator/data.h"
+}
+module std_private_iterator_default_sentinel [system] {
+  export_as std
+  header "__iterator/default_sentinel.h"
+}
+module std_private_iterator_distance [system] {
+  export_as std
   header "__iterator/distance.h"
   export std_private_ranges_size
 }
-module std_private_iterator_empty                   [system] { header "__iterator/empty.h" }
-module std_private_iterator_erase_if_container      [system] { header "__iterator/erase_if_container.h" }
-module std_private_iterator_front_insert_iterator   [system] { header "__iterator/front_insert_iterator.h" }
-module std_private_iterator_incrementable_traits    [system] { header "__iterator/incrementable_traits.h" }
-module std_private_iterator_indirectly_comparable   [system] { header "__iterator/indirectly_comparable.h" }
-module std_private_iterator_insert_iterator         [system] { header "__iterator/insert_iterator.h" }
-module std_private_iterator_istream_iterator        [system] { header "__iterator/istream_iterator.h" }
-module std_private_iterator_istreambuf_iterator     [system] { header "__iterator/istreambuf_iterator.h" }
-module std_private_iterator_iter_move               [system] { header "__iterator/iter_move.h" }
-module std_private_iterator_iter_swap               [system] { header "__iterator/iter_swap.h" }
-module std_private_iterator_iterator                [system] { header "__iterator/iterator.h" }
-module std_private_iterator_iterator_traits         [system] {
+module std_private_iterator_empty [system] {
+  export_as std
+  header "__iterator/empty.h"
+}
+module std_private_iterator_erase_if_container [system] {
+  export_as std
+  header "__iterator/erase_if_container.h"
+}
+module std_private_iterator_front_insert_iterator [system] {
+  export_as std
+  header "__iterator/front_insert_iterator.h"
+}
+module std_private_iterator_incrementable_traits [system] {
+  export_as std
+  header "__iterator/incrementable_traits.h"
+}
+module std_private_iterator_indirectly_comparable [system] {
+  export_as std
+  header "__iterator/indirectly_comparable.h"
+}
+module std_private_iterator_insert_iterator [system] {
+  export_as std
+  header "__iterator/insert_iterator.h"
+}
+module std_private_iterator_istream_iterator [system] {
+  export_as std
+  header "__iterator/istream_iterator.h"
+}
+module std_private_iterator_istreambuf_iterator [system] {
+  export_as std
+  header "__iterator/istreambuf_iterator.h"
+}
+module std_private_iterator_iter_move [system] {
+  export_as std
+  header "__iterator/iter_move.h"
+}
+module std_private_iterator_iter_swap [system] {
+  export_as std
+  header "__iterator/iter_swap.h"
+}
+module std_private_iterator_iterator [system] {
+  export_as std
+  header "__iterator/iterator.h"
+}
+module std_private_iterator_iterator_traits [system] {
+  export_as std
   header "__iterator/iterator_traits.h"
   export std_private_type_traits_is_primary_template
 }
-module std_private_iterator_iterator_with_data      [system] { header "__iterator/iterator_with_data.h" }
-module std_private_iterator_mergeable               [system] {
+module std_private_iterator_iterator_with_data [system] {
+  export_as std
+  header "__iterator/iterator_with_data.h"
+}
+module std_private_iterator_mergeable [system] {
+  export_as std
   header "__iterator/mergeable.h"
   export std_private_functional_ranges_operations
 }
-module std_private_iterator_move_iterator           [system] { header "__iterator/move_iterator.h" }
-module std_private_iterator_move_sentinel           [system] { header "__iterator/move_sentinel.h" }
-module std_private_iterator_next                    [system] { header "__iterator/next.h" }
-module std_private_iterator_ostream_iterator        [system] { header "__iterator/ostream_iterator.h" }
-module std_private_iterator_ostreambuf_iterator     [system] {
+module std_private_iterator_move_iterator [system] {
+  export_as std
+  header "__iterator/move_iterator.h"
+}
+module std_private_iterator_move_sentinel [system] {
+  export_as std
+  header "__iterator/move_sentinel.h"
+}
+module std_private_iterator_next [system] {
+  export_as std
+  header "__iterator/next.h"
+}
+module std_private_iterator_ostream_iterator [system] {
+  export_as std
+  header "__iterator/ostream_iterator.h"
+}
+module std_private_iterator_ostreambuf_iterator [system] {
+  export_as std
   header "__iterator/ostreambuf_iterator.h"
   export *
 }
-module std_private_iterator_permutable              [system] { header "__iterator/permutable.h" }
-module std_private_iterator_prev                    [system] { header "__iterator/prev.h" }
-module std_private_iterator_projected               [system] { header "__iterator/projected.h" }
-module std_private_iterator_ranges_iterator_traits  [system] { header "__iterator/ranges_iterator_traits.h" }
-module std_private_iterator_readable_traits         [system] { header "__iterator/readable_traits.h" }
-module std_private_iterator_reverse_access          [system] { header "__iterator/reverse_access.h" }
-module std_private_iterator_reverse_iterator        [system] { header "__iterator/reverse_iterator.h" }
-module std_private_iterator_segmented_iterator      [system] { header "__iterator/segmented_iterator.h" }
-module std_private_iterator_size                    [system] { header "__iterator/size.h" }
-module std_private_iterator_sortable                [system] {
+module std_private_iterator_permutable [system] {
+  export_as std
+  header "__iterator/permutable.h"
+}
+module std_private_iterator_prev [system] {
+  export_as std
+  header "__iterator/prev.h"
+}
+module std_private_iterator_projected [system] {
+  export_as std
+  header "__iterator/projected.h"
+}
+module std_private_iterator_ranges_iterator_traits [system] {
+  export_as std
+  header "__iterator/ranges_iterator_traits.h"
+}
+module std_private_iterator_readable_traits [system] {
+  export_as std
+  header "__iterator/readable_traits.h"
+}
+module std_private_iterator_reverse_access [system] {
+  export_as std
+  header "__iterator/reverse_access.h"
+}
+module std_private_iterator_reverse_iterator [system] {
+  export_as std
+  header "__iterator/reverse_iterator.h"
+}
+module std_private_iterator_segmented_iterator [system] {
+  export_as std
+  header "__iterator/segmented_iterator.h"
+}
+module std_private_iterator_size [system] {
+  export_as std
+  header "__iterator/size.h"
+}
+module std_private_iterator_sortable [system] {
+  export_as std
   header "__iterator/sortable.h"
   export std_private_functional_ranges_operations
 }
-module std_private_iterator_unreachable_sentinel    [system] { header "__iterator/unreachable_sentinel.h" }
-module std_private_iterator_wrap_iter               [system] { header "__iterator/wrap_iter.h" }
+module std_private_iterator_unreachable_sentinel [system] {
+  export_as std
+  header "__iterator/unreachable_sentinel.h"
+}
+module std_private_iterator_wrap_iter [system] {
+  export_as std
+  header "__iterator/wrap_iter.h"
+}
 
-module std_private_locale_locale_base_api_bsd_locale_defaults  [system] { textual header "__locale_dir/locale_base_api/bsd_locale_defaults.h" }
-module std_private_locale_locale_base_api_bsd_locale_fallbacks [system] { textual header "__locale_dir/locale_base_api/bsd_locale_fallbacks.h" }
-module std_private_locale_locale_base_api_locale_guard         [system] { header "__locale_dir/locale_base_api/locale_guard.h" }
+module std_private_locale_locale_base_api_bsd_locale_defaults [system] {
+  export_as std
+  textual header "__locale_dir/locale_base_api/bsd_locale_defaults.h"
+}
+module std_private_locale_locale_base_api_bsd_locale_fallbacks [system] {
+  export_as std
+  textual header "__locale_dir/locale_base_api/bsd_locale_fallbacks.h"
+}
+module std_private_locale_locale_base_api_locale_guard [system] {
+  export_as std
+  header "__locale_dir/locale_base_api/locale_guard.h"
+}
 
-module std_private_math_abs                             [system] { header "__math/abs.h" }
-module std_private_math_copysign                        [system] { header "__math/copysign.h" }
-module std_private_math_error_functions                 [system] { header "__math/error_functions.h" }
-module std_private_math_exponential_functions           [system] { header "__math/exponential_functions.h" }
-module std_private_math_fdim                            [system] { header "__math/fdim.h" }
-module std_private_math_fma                             [system] { header "__math/fma.h" }
-module std_private_math_gamma                           [system] { header "__math/gamma.h" }
-module std_private_math_hyperbolic_functions            [system] { header "__math/hyperbolic_functions.h" }
-module std_private_math_hypot                           [system] { header "__math/hypot.h" }
-module std_private_math_inverse_hyperbolic_functions    [system] { header "__math/inverse_hyperbolic_functions.h" }
-module std_private_math_inverse_trigonometric_functions [system] { header "__math/inverse_trigonometric_functions.h" }
-module std_private_math_logarithms                      [system] { header "__math/logarithms.h" }
-module std_private_math_min_max                         [system] { header "__math/min_max.h" }
-module std_private_math_modulo                          [system] { header "__math/modulo.h" }
-module std_private_math_remainder                       [system] { header "__math/remainder.h" }
-module std_private_math_roots                           [system] { header "__math/roots.h" }
-module std_private_math_rounding_functions              [system] { header "__math/rounding_functions.h" }
-module std_private_math_traits                          [system] { header "__math/traits.h" }
-module std_private_math_trigonometric_functions         [system] { header "__math/trigonometric_functions.h" }
+module std_private_math_abs [system] {
+  export_as std
+  header "__math/abs.h"
+}
+module std_private_math_copysign [system] {
+  export_as std
+  header "__math/copysign.h"
+}
+module std_private_math_error_functions [system] {
+  export_as std
+  header "__math/error_functions.h"
+}
+module std_private_math_exponential_functions [system] {
+  export_as std
+  header "__math/exponential_functions.h"
+}
+module std_private_math_fdim [system] {
+  export_as std
+  header "__math/fdim.h"
+}
+module std_private_math_fma [system] {
+  export_as std
+  header "__math/fma.h"
+}
+module std_private_math_gamma [system] {
+  export_as std
+  header "__math/gamma.h"
+}
+module std_private_math_hyperbolic_functions [system] {
+  export_as std
+  header "__math/hyperbolic_functions.h"
+}
+module std_private_math_hypot [system] {
+  export_as std
+  header "__math/hypot.h"
+}
+module std_private_math_inverse_hyperbolic_functions [system] {
+  export_as std
+  header "__math/inverse_hyperbolic_functions.h"
+}
+module std_private_math_inverse_trigonometric_functions [system] {
+  export_as std
+  header "__math/inverse_trigonometric_functions.h"
+}
+module std_private_math_logarithms [system] {
+  export_as std
+  header "__math/logarithms.h"
+}
+module std_private_math_min_max [system] {
+  export_as std
+  header "__math/min_max.h"
+}
+module std_private_math_modulo [system] {
+  export_as std
+  header "__math/modulo.h"
+}
+module std_private_math_remainder [system] {
+  export_as std
+  header "__math/remainder.h"
+}
+module std_private_math_roots [system] {
+  export_as std
+  header "__math/roots.h"
+}
+module std_private_math_rounding_functions [system] {
+  export_as std
+  header "__math/rounding_functions.h"
+}
+module std_private_math_traits [system] {
+  export_as std
+  header "__math/traits.h"
+}
+module std_private_math_trigonometric_functions [system] {
+  export_as std
+  header "__math/trigonometric_functions.h"
+}
 
-module std_private_mdspan_default_accessor [system] { header "__mdspan/default_accessor.h" }
-module std_private_mdspan_extents          [system] {
+module std_private_mdspan_default_accessor [system] {
+  export_as std
+  header "__mdspan/default_accessor.h"
+}
+module std_private_mdspan_extents [system] {
+  export_as std
   header "__mdspan/extents.h"
   export *
 }
-module std_private_mdspan_layout_left      [system] { header "__mdspan/layout_left.h" }
-module std_private_mdspan_layout_right     [system] { header "__mdspan/layout_right.h" }
-module std_private_mdspan_layout_stride    [system] { header "__mdspan/layout_stride.h" }
-module std_private_mdspan_mdspan           [system] { header "__mdspan/mdspan.h" }
-module std_private_mdspan_mdspan_fwd       [system] { header "__fwd/mdspan.h" }
+module std_private_mdspan_layout_left [system] {
+  export_as std
+  header "__mdspan/layout_left.h"
+}
+module std_private_mdspan_layout_right [system] {
+  export_as std
+  header "__mdspan/layout_right.h"
+}
+module std_private_mdspan_layout_stride [system] {
+  export_as std
+  header "__mdspan/layout_stride.h"
+}
+module std_private_mdspan_mdspan [system] {
+  export_as std
+  header "__mdspan/mdspan.h"
+}
+module std_private_mdspan_mdspan_fwd [system] {
+  export_as std
+  header "__fwd/mdspan.h"
+}
 
-module std_private_memory_addressof                       [system] { header "__memory/addressof.h" }
-module std_private_memory_align                           [system] { header "__memory/align.h" }
-module std_private_memory_aligned_alloc                   [system] { header "__memory/aligned_alloc.h" }
-module std_private_memory_allocate_at_least               [system] { header "__memory/allocate_at_least.h" }
-module std_private_memory_allocation_guard                [system] { header "__memory/allocation_guard.h" }
-module std_private_memory_allocator                       [system] { header "__memory/allocator.h" }
-module std_private_memory_allocator_arg_t                 [system] { header "__memory/allocator_arg_t.h" }
-module std_private_memory_allocator_destructor            [system] { header "__memory/allocator_destructor.h" }
-module std_private_memory_allocator_traits                [system] { header "__memory/allocator_traits.h" }
-module std_private_memory_assume_aligned                  [system] { header "__memory/assume_aligned.h" }
-module std_private_memory_auto_ptr                        [system] { header "__memory/auto_ptr.h" }
-module std_private_memory_builtin_new_allocator           [system] {
+module std_private_memory_addressof [system] {
+  export_as std
+  header "__memory/addressof.h"
+}
+module std_private_memory_align [system] {
+  export_as std
+  header "__memory/align.h"
+}
+module std_private_memory_aligned_alloc [system] {
+  export_as std
+  header "__memory/aligned_alloc.h"
+}
+module std_private_memory_allocate_at_least [system] {
+  export_as std
+  header "__memory/allocate_at_least.h"
+}
+module std_private_memory_allocation_guard [system] {
+  export_as std
+  header "__memory/allocation_guard.h"
+}
+module std_private_memory_allocator [system] {
+  export_as std
+  header "__memory/allocator.h"
+}
+module std_private_memory_allocator_arg_t [system] {
+  export_as std
+  header "__memory/allocator_arg_t.h"
+}
+module std_private_memory_allocator_destructor [system] {
+  export_as std
+  header "__memory/allocator_destructor.h"
+}
+module std_private_memory_allocator_traits [system] {
+  export_as std
+  header "__memory/allocator_traits.h"
+}
+module std_private_memory_assume_aligned [system] {
+  export_as std
+  header "__memory/assume_aligned.h"
+}
+module std_private_memory_auto_ptr [system] {
+  export_as std
+  header "__memory/auto_ptr.h"
+}
+module std_private_memory_builtin_new_allocator [system] {
+  export_as std
   header "__memory/builtin_new_allocator.h"
   export *
 }
-module std_private_memory_compressed_pair                 [system] { header "__memory/compressed_pair.h" }
-module std_private_memory_concepts                        [system] {
+module std_private_memory_compressed_pair [system] {
+  export_as std
+  header "__memory/compressed_pair.h"
+}
+module std_private_memory_concepts [system] {
+  export_as std
   header "__memory/concepts.h"
   export std_private_type_traits_remove_reference
 }
-module std_private_memory_construct_at                    [system] { header "__memory/construct_at.h" }
-module std_private_memory_destruct_n                      [system] { header "__memory/destruct_n.h" }
-module std_private_memory_pointer_traits                  [system] { header "__memory/pointer_traits.h" }
-module std_private_memory_ranges_construct_at             [system] { header "__memory/ranges_construct_at.h" }
+module std_private_memory_construct_at [system] {
+  export_as std
+  header "__memory/construct_at.h"
+}
+module std_private_memory_destruct_n [system] {
+  export_as std
+  header "__memory/destruct_n.h"
+}
+module std_private_memory_pointer_traits [system] {
+  export_as std
+  header "__memory/pointer_traits.h"
+}
+module std_private_memory_ranges_construct_at [system] {
+  export_as std
+  header "__memory/ranges_construct_at.h"
+}
 module std_private_memory_ranges_uninitialized_algorithms [system] {
+  export_as std
   header "__memory/ranges_uninitialized_algorithms.h"
   export std_private_algorithm_in_out_result
 }
-module std_private_memory_raw_storage_iterator            [system] { header "__memory/raw_storage_iterator.h" }
-module std_private_memory_shared_ptr                      [system] {
+module std_private_memory_raw_storage_iterator [system] {
+  export_as std
+  header "__memory/raw_storage_iterator.h"
+}
+module std_private_memory_shared_ptr [system] {
+  export_as std
   header "__memory/shared_ptr.h"
   export std_private_memory_uninitialized_algorithms
 }
-module std_private_memory_swap_allocator                  [system] { header "__memory/swap_allocator.h" }
-module std_private_memory_temp_value                      [system] { header "__memory/temp_value.h" }
-module std_private_memory_temporary_buffer                [system] { header "__memory/temporary_buffer.h" }
-module std_private_memory_uninitialized_algorithms        [system] {
+module std_private_memory_swap_allocator [system] {
+  export_as std
+  header "__memory/swap_allocator.h"
+}
+module std_private_memory_temp_value [system] {
+  export_as std
+  header "__memory/temp_value.h"
+}
+module std_private_memory_temporary_buffer [system] {
+  export_as std
+  header "__memory/temporary_buffer.h"
+}
+module std_private_memory_uninitialized_algorithms [system] {
+  export_as std
   header "__memory/uninitialized_algorithms.h"
   export std_private_algorithm_copy
 }
-module std_private_memory_unique_ptr                      [system] {
+module std_private_memory_unique_ptr [system] {
+  export_as std
   header "__memory/unique_ptr.h"
   export std_private_type_traits_add_lvalue_reference
   export std_private_type_traits_is_pointer
   export std_private_type_traits_type_identity
 }
-module std_private_memory_uses_allocator                  [system] { header "__memory/uses_allocator.h" }
-module std_private_memory_uses_allocator_construction     [system] { header "__memory/uses_allocator_construction.h" }
-module std_private_memory_voidify                         [system] { header "__memory/voidify.h" }
+module std_private_memory_uses_allocator [system] {
+  export_as std
+  header "__memory/uses_allocator.h"
+}
+module std_private_memory_uses_allocator_construction [system] {
+  export_as std
+  header "__memory/uses_allocator_construction.h"
+}
+module std_private_memory_voidify [system] {
+  export_as std
+  header "__memory/voidify.h"
+}
 
-module std_private_memory_resource_memory_resource              [system] { header "__memory_resource/memory_resource.h" }
-module std_private_memory_resource_memory_resource_fwd          [system] { header "__fwd/memory_resource.h" }
-module std_private_memory_resource_monotonic_buffer_resource    [system] { header "__memory_resource/monotonic_buffer_resource.h" }
-module std_private_memory_resource_polymorphic_allocator        [system] { header "__memory_resource/polymorphic_allocator.h" }
-module std_private_memory_resource_pool_options                 [system] { header "__memory_resource/pool_options.h" }
-module std_private_memory_resource_synchronized_pool_resource   [system] {
+module std_private_memory_resource_memory_resource [system] {
+  export_as std
+  header "__memory_resource/memory_resource.h"
+}
+module std_private_memory_resource_memory_resource_fwd [system] {
+  export_as std
+  header "__fwd/memory_resource.h"
+}
+module std_private_memory_resource_monotonic_buffer_resource [system] {
+  export_as std
+  header "__memory_resource/monotonic_buffer_resource.h"
+}
+module std_private_memory_resource_polymorphic_allocator [system] {
+  export_as std
+  header "__memory_resource/polymorphic_allocator.h"
+}
+module std_private_memory_resource_pool_options [system] {
+  export_as std
+  header "__memory_resource/pool_options.h"
+}
+module std_private_memory_resource_synchronized_pool_resource [system] {
+  export_as std
   header "__memory_resource/synchronized_pool_resource.h"
   export *
 }
-module std_private_memory_resource_unsynchronized_pool_resource [system] { header "__memory_resource/unsynchronized_pool_resource.h" }
+module std_private_memory_resource_unsynchronized_pool_resource [system] {
+  export_as std
+  header "__memory_resource/unsynchronized_pool_resource.h"
+}
 
-module std_private_mutex_lock_guard  [system] { header "__mutex/lock_guard.h" }
-module std_private_mutex_mutex       [system] { header "__mutex/mutex.h" }
-module std_private_mutex_once_flag  [system]  { header "__mutex/once_flag.h" }
-module std_private_mutex_tag_types   [system] { header "__mutex/tag_types.h" }
-module std_private_mutex_unique_lock [system] { header "__mutex/unique_lock.h" }
+module std_private_mutex_lock_guard [system] {
+  export_as std
+  header "__mutex/lock_guard.h"
+}
+module std_private_mutex_mutex [system] {
+  export_as std
+  header "__mutex/mutex.h"
+}
+module std_private_mutex_once_flag [system] {
+  export_as std
+  header "__mutex/once_flag.h"
+}
+module std_private_mutex_tag_types [system] {
+  export_as std
+  header "__mutex/tag_types.h"
+}
+module std_private_mutex_unique_lock [system] {
+  export_as std
+  header "__mutex/unique_lock.h"
+}
 
-module std_private_numeric_accumulate               [system] { header "__numeric/accumulate.h" }
-module std_private_numeric_adjacent_difference      [system] { header "__numeric/adjacent_difference.h" }
-module std_private_numeric_exclusive_scan           [system] { header "__numeric/exclusive_scan.h" }
-module std_private_numeric_gcd_lcm                  [system] { header "__numeric/gcd_lcm.h" }
-module std_private_numeric_inclusive_scan           [system] { header "__numeric/inclusive_scan.h" }
-module std_private_numeric_inner_product            [system] { header "__numeric/inner_product.h" }
-module std_private_numeric_iota                     [system] { header "__numeric/iota.h" }
-module std_private_numeric_midpoint                 [system] { header "__numeric/midpoint.h" }
-module std_private_numeric_partial_sum              [system] { header "__numeric/partial_sum.h" }
-module std_private_numeric_pstl_reduce              [system] { header "__numeric/pstl_reduce.h" }
-module std_private_numeric_pstl_transform_reduce    [system] {
+module std_private_numeric_accumulate [system] {
+  export_as std
+  header "__numeric/accumulate.h"
+}
+module std_private_numeric_adjacent_difference [system] {
+  export_as std
+  header "__numeric/adjacent_difference.h"
+}
+module std_private_numeric_exclusive_scan [system] {
+  export_as std
+  header "__numeric/exclusive_scan.h"
+}
+module std_private_numeric_gcd_lcm [system] {
+  export_as std
+  header "__numeric/gcd_lcm.h"
+}
+module std_private_numeric_inclusive_scan [system] {
+  export_as std
+  header "__numeric/inclusive_scan.h"
+}
+module std_private_numeric_inner_product [system] {
+  export_as std
+  header "__numeric/inner_product.h"
+}
+module std_private_numeric_iota [system] {
+  export_as std
+  header "__numeric/iota.h"
+}
+module std_private_numeric_midpoint [system] {
+  export_as std
+  header "__numeric/midpoint.h"
+}
+module std_private_numeric_partial_sum [system] {
+  export_as std
+  header "__numeric/partial_sum.h"
+}
+module std_private_numeric_pstl_reduce [system] {
+  export_as std
+  header "__numeric/pstl_reduce.h"
+}
+module std_private_numeric_pstl_transform_reduce [system] {
+  export_as std
   header "__numeric/pstl_transform_reduce.h"
   export *
 }
-module std_private_numeric_reduce                   [system] { header "__numeric/reduce.h" }
-module std_private_numeric_transform_exclusive_scan [system] { header "__numeric/transform_exclusive_scan.h" }
-module std_private_numeric_transform_inclusive_scan [system] { header "__numeric/transform_inclusive_scan.h" }
-module std_private_numeric_transform_reduce         [system] { header "__numeric/transform_reduce.h" }
+module std_private_numeric_reduce [system] {
+  export_as std
+  header "__numeric/reduce.h"
+}
+module std_private_numeric_transform_exclusive_scan [system] {
+  export_as std
+  header "__numeric/transform_exclusive_scan.h"
+}
+module std_private_numeric_transform_inclusive_scan [system] {
+  export_as std
+  header "__numeric/transform_inclusive_scan.h"
+}
+module std_private_numeric_transform_reduce [system] {
+  export_as std
+  header "__numeric/transform_reduce.h"
+}
 
-module std_private_random_bernoulli_distribution          [system] { header "__random/bernoulli_distribution.h" }
-module std_private_random_binomial_distribution           [system] { header "__random/binomial_distribution.h" }
-module std_private_random_cauchy_distribution             [system] { header "__random/cauchy_distribution.h" }
-module std_private_random_chi_squared_distribution        [system] { header "__random/chi_squared_distribution.h" }
-module std_private_random_clamp_to_integral               [system] { header "__random/clamp_to_integral.h" }
-module std_private_random_default_random_engine           [system] { header "__random/default_random_engine.h" }
-module std_private_random_discard_block_engine            [system] { header "__random/discard_block_engine.h" }
-module std_private_random_discrete_distribution           [system] {
+module std_private_random_bernoulli_distribution [system] {
+  export_as std
+  header "__random/bernoulli_distribution.h"
+}
+module std_private_random_binomial_distribution [system] {
+  export_as std
+  header "__random/binomial_distribution.h"
+}
+module std_private_random_cauchy_distribution [system] {
+  export_as std
+  header "__random/cauchy_distribution.h"
+}
+module std_private_random_chi_squared_distribution [system] {
+  export_as std
+  header "__random/chi_squared_distribution.h"
+}
+module std_private_random_clamp_to_integral [system] {
+  export_as std
+  header "__random/clamp_to_integral.h"
+}
+module std_private_random_default_random_engine [system] {
+  export_as std
+  header "__random/default_random_engine.h"
+}
+module std_private_random_discard_block_engine [system] {
+  export_as std
+  header "__random/discard_block_engine.h"
+}
+module std_private_random_discrete_distribution [system] {
+  export_as std
   header "__random/discrete_distribution.h"
   export *
 }
-module std_private_random_exponential_distribution        [system] { header "__random/exponential_distribution.h" }
-module std_private_random_extreme_value_distribution      [system] { header "__random/extreme_value_distribution.h" }
-module std_private_random_fisher_f_distribution           [system] { header "__random/fisher_f_distribution.h" }
-module std_private_random_gamma_distribution              [system] { header "__random/gamma_distribution.h" }
-module std_private_random_generate_canonical              [system] { header "__random/generate_canonical.h" }
-module std_private_random_geometric_distribution          [system] { header "__random/geometric_distribution.h" }
-module std_private_random_independent_bits_engine         [system] { header "__random/independent_bits_engine.h" }
-module std_private_random_is_seed_sequence                [system] { header "__random/is_seed_sequence.h" }
-module std_private_random_is_valid                        [system] { header "__random/is_valid.h" }
-module std_private_random_knuth_b                         [system] { header "__random/knuth_b.h" }
-module std_private_random_linear_congruential_engine      [system] { header "__random/linear_congruential_engine.h" }
-module std_private_random_log2                            [system] { header "__random/log2.h" }
-module std_private_random_lognormal_distribution          [system] { header "__random/lognormal_distribution.h" }
-module std_private_random_mersenne_twister_engine         [system] { header "__random/mersenne_twister_engine.h" }
-module std_private_random_negative_binomial_distribution  [system] { header "__random/negative_binomial_distribution.h" }
-module std_private_random_normal_distribution             [system] { header "__random/normal_distribution.h" }
+module std_private_random_exponential_distribution [system] {
+  export_as std
+  header "__random/exponential_distribution.h"
+}
+module std_private_random_extreme_value_distribution [system] {
+  export_as std
+  header "__random/extreme_value_distribution.h"
+}
+module std_private_random_fisher_f_distribution [system] {
+  export_as std
+  header "__random/fisher_f_distribution.h"
+}
+module std_private_random_gamma_distribution [system] {
+  export_as std
+  header "__random/gamma_distribution.h"
+}
+module std_private_random_generate_canonical [system] {
+  export_as std
+  header "__random/generate_canonical.h"
+}
+module std_private_random_geometric_distribution [system] {
+  export_as std
+  header "__random/geometric_distribution.h"
+}
+module std_private_random_independent_bits_engine [system] {
+  export_as std
+  header "__random/independent_bits_engine.h"
+}
+module std_private_random_is_seed_sequence [system] {
+  export_as std
+  header "__random/is_seed_sequence.h"
+}
+module std_private_random_is_valid [system] {
+  export_as std
+  header "__random/is_valid.h"
+}
+module std_private_random_knuth_b [system] {
+  export_as std
+  header "__random/knuth_b.h"
+}
+module std_private_random_linear_congruential_engine [system] {
+  export_as std
+  header "__random/linear_congruential_engine.h"
+}
+module std_private_random_log2 [system] {
+  export_as std
+  header "__random/log2.h"
+}
+module std_private_random_lognormal_distribution [system] {
+  export_as std
+  header "__random/lognormal_distribution.h"
+}
+module std_private_random_mersenne_twister_engine [system] {
+  export_as std
+  header "__random/mersenne_twister_engine.h"
+}
+module std_private_random_negative_binomial_distribution [system] {
+  export_as std
+  header "__random/negative_binomial_distribution.h"
+}
+module std_private_random_normal_distribution [system] {
+  export_as std
+  header "__random/normal_distribution.h"
+}
 module std_private_random_piecewise_constant_distribution [system] {
+  export_as std
   header "__random/piecewise_constant_distribution.h"
   export *
 }
-module std_private_random_piecewise_linear_distribution   [system] {
+module std_private_random_piecewise_linear_distribution [system] {
+  export_as std
   header "__random/piecewise_linear_distribution.h"
   export *
 }
-module std_private_random_poisson_distribution            [system] { header "__random/poisson_distribution.h" }
-module std_private_random_random_device                   [system] {
+module std_private_random_poisson_distribution [system] {
+  export_as std
+  header "__random/poisson_distribution.h"
+}
+module std_private_random_random_device [system] {
+  export_as std
   header "__random/random_device.h"
   export *
 }
-module std_private_random_ranlux                          [system] { header "__random/ranlux.h" }
-module std_private_random_seed_seq                        [system] {
+module std_private_random_ranlux [system] {
+  export_as std
+  header "__random/ranlux.h"
+}
+module std_private_random_seed_seq [system] {
+  export_as std
   header "__random/seed_seq.h"
   export *
 }
-module std_private_random_shuffle_order_engine            [system] { header "__random/shuffle_order_engine.h" }
-module std_private_random_student_t_distribution          [system] { header "__random/student_t_distribution.h" }
-module std_private_random_subtract_with_carry_engine      [system] { header "__random/subtract_with_carry_engine.h" }
-module std_private_random_uniform_int_distribution        [system] { header "__random/uniform_int_distribution.h" }
-module std_private_random_uniform_random_bit_generator    [system] { header "__random/uniform_random_bit_generator.h" }
-module std_private_random_uniform_real_distribution       [system] { header "__random/uniform_real_distribution.h" }
-module std_private_random_weibull_distribution            [system] { header "__random/weibull_distribution.h" }
+module std_private_random_shuffle_order_engine [system] {
+  export_as std
+  header "__random/shuffle_order_engine.h"
+}
+module std_private_random_student_t_distribution [system] {
+  export_as std
+  header "__random/student_t_distribution.h"
+}
+module std_private_random_subtract_with_carry_engine [system] {
+  export_as std
+  header "__random/subtract_with_carry_engine.h"
+}
+module std_private_random_uniform_int_distribution [system] {
+  export_as std
+  header "__random/uniform_int_distribution.h"
+}
+module std_private_random_uniform_random_bit_generator [system] {
+  export_as std
+  header "__random/uniform_random_bit_generator.h"
+}
+module std_private_random_uniform_real_distribution [system] {
+  export_as std
+  header "__random/uniform_real_distribution.h"
+}
+module std_private_random_weibull_distribution [system] {
+  export_as std
+  header "__random/weibull_distribution.h"
+}
 
-module std_private_ranges_access                     [system] { header "__ranges/access.h" }
-module std_private_ranges_all                        [system] {
+module std_private_ranges_access [system] {
+  export_as std
+  header "__ranges/access.h"
+}
+module std_private_ranges_all [system] {
+  export_as std
   header "__ranges/all.h"
   export std_private_functional_compose
   export std_private_functional_perfect_forward
   export std_private_ranges_owning_view
 }
-module std_private_ranges_as_rvalue_view             [system] { header "__ranges/as_rvalue_view.h" }
-module std_private_ranges_chunk_by_view              [system] { header "__ranges/chunk_by_view.h" }
-module std_private_ranges_common_view                [system] { header "__ranges/common_view.h" }
-module std_private_ranges_concepts                   [system] {
+module std_private_ranges_as_rvalue_view [system] {
+  export_as std
+  header "__ranges/as_rvalue_view.h"
+}
+module std_private_ranges_chunk_by_view [system] {
+  export_as std
+  header "__ranges/chunk_by_view.h"
+}
+module std_private_ranges_common_view [system] {
+  export_as std
+  header "__ranges/common_view.h"
+}
+module std_private_ranges_concepts [system] {
+  export_as std
   header "__ranges/concepts.h"
   export std_private_iterator_concepts
 }
-module std_private_ranges_container_compatible_range [system] { header "__ranges/container_compatible_range.h" }
-module std_private_ranges_counted                    [system] {
+module std_private_ranges_container_compatible_range [system] {
+  export_as std
+  header "__ranges/container_compatible_range.h"
+}
+module std_private_ranges_counted [system] {
+  export_as std
   header "__ranges/counted.h"
   export std_span
 }
-module std_private_ranges_dangling                   [system] { header "__ranges/dangling.h" }
-module std_private_ranges_data                       [system] { header "__ranges/data.h" }
-module std_private_ranges_drop_view                  [system] { header "__ranges/drop_view.h" }
-module std_private_ranges_drop_while_view            [system] { header "__ranges/drop_while_view.h" }
-module std_private_ranges_elements_view              [system] { header "__ranges/elements_view.h" }
-module std_private_ranges_empty                      [system] { header "__ranges/empty.h" }
-module std_private_ranges_empty_view                 [system] { header "__ranges/empty_view.h" }
-module std_private_ranges_enable_borrowed_range      [system] { header "__ranges/enable_borrowed_range.h" }
-module std_private_ranges_enable_view                [system] { header "__ranges/enable_view.h" }
-module std_private_ranges_filter_view                [system] {
+module std_private_ranges_dangling [system] {
+  export_as std
+  header "__ranges/dangling.h"
+}
+module std_private_ranges_data [system] {
+  export_as std
+  header "__ranges/data.h"
+}
+module std_private_ranges_drop_view [system] {
+  export_as std
+  header "__ranges/drop_view.h"
+}
+module std_private_ranges_drop_while_view [system] {
+  export_as std
+  header "__ranges/drop_while_view.h"
+}
+module std_private_ranges_elements_view [system] {
+  export_as std
+  header "__ranges/elements_view.h"
+}
+module std_private_ranges_empty [system] {
+  export_as std
+  header "__ranges/empty.h"
+}
+module std_private_ranges_empty_view [system] {
+  export_as std
+  header "__ranges/empty_view.h"
+}
+module std_private_ranges_enable_borrowed_range [system] {
+  export_as std
+  header "__ranges/enable_borrowed_range.h"
+}
+module std_private_ranges_enable_view [system] {
+  export_as std
+  header "__ranges/enable_view.h"
+}
+module std_private_ranges_filter_view [system] {
+  export_as std
   header "__ranges/filter_view.h"
   export std_private_ranges_range_adaptor
 }
-module std_private_ranges_from_range                 [system] { header "__ranges/from_range.h" }
-module std_private_ranges_iota_view                  [system] { header "__ranges/iota_view.h" }
-module std_private_ranges_istream_view               [system] {
+module std_private_ranges_from_range [system] {
+  export_as std
+  header "__ranges/from_range.h"
+}
+module std_private_ranges_iota_view [system] {
+  export_as std
+  header "__ranges/iota_view.h"
+}
+module std_private_ranges_istream_view [system] {
+  export_as std
   header "__ranges/istream_view.h"
 }
-module std_private_ranges_join_view                  [system] {
+module std_private_ranges_join_view [system] {
+  export_as std
   header "__ranges/join_view.h"
   export std_private_iterator_iterator_with_data
   export std_private_iterator_segmented_iterator
 }
-module std_private_ranges_lazy_split_view            [system] {
+module std_private_ranges_lazy_split_view [system] {
+  export_as std
   header "__ranges/lazy_split_view.h"
   export std_private_ranges_non_propagating_cache
 }
-module std_private_ranges_movable_box                [system] { header "__ranges/movable_box.h" }
-module std_private_ranges_non_propagating_cache      [system] { header "__ranges/non_propagating_cache.h" }
-module std_private_ranges_owning_view                [system] { header "__ranges/owning_view.h" }
-module std_private_ranges_range_adaptor              [system] { header "__ranges/range_adaptor.h" }
-module std_private_ranges_rbegin                     [system] { header "__ranges/rbegin.h" }
-module std_private_ranges_ref_view                   [system] { header "__ranges/ref_view.h" }
-module std_private_ranges_rend                       [system] { header "__ranges/rend.h" }
-module std_private_ranges_repeat_view                [system] { header "__ranges/repeat_view.h" }
-module std_private_ranges_reverse_view               [system] { header "__ranges/reverse_view.h" }
-module std_private_ranges_single_view                [system] { header "__ranges/single_view.h" }
-module std_private_ranges_size                       [system] {
+module std_private_ranges_movable_box [system] {
+  export_as std
+  header "__ranges/movable_box.h"
+}
+module std_private_ranges_non_propagating_cache [system] {
+  export_as std
+  header "__ranges/non_propagating_cache.h"
+}
+module std_private_ranges_owning_view [system] {
+  export_as std
+  header "__ranges/owning_view.h"
+}
+module std_private_ranges_range_adaptor [system] {
+  export_as std
+  header "__ranges/range_adaptor.h"
+}
+module std_private_ranges_rbegin [system] {
+  export_as std
+  header "__ranges/rbegin.h"
+}
+module std_private_ranges_ref_view [system] {
+  export_as std
+  header "__ranges/ref_view.h"
+}
+module std_private_ranges_rend [system] {
+  export_as std
+  header "__ranges/rend.h"
+}
+module std_private_ranges_repeat_view [system] {
+  export_as std
+  header "__ranges/repeat_view.h"
+}
+module std_private_ranges_reverse_view [system] {
+  export_as std
+  header "__ranges/reverse_view.h"
+}
+module std_private_ranges_single_view [system] {
+  export_as std
+  header "__ranges/single_view.h"
+}
+module std_private_ranges_size [system] {
+  export_as std
   header "__ranges/size.h"
   export std_private_type_traits_make_unsigned
 }
-module std_private_ranges_split_view                 [system] { header "__ranges/split_view.h" }
-module std_private_ranges_subrange                   [system] {
+module std_private_ranges_split_view [system] {
+  export_as std
+  header "__ranges/split_view.h"
+}
+module std_private_ranges_subrange [system] {
+  export_as std
   header "__ranges/subrange.h"
   export std_private_ranges_subrange_fwd
 }
-module std_private_ranges_subrange_fwd               [system] {
+module std_private_ranges_subrange_fwd [system] {
+  export_as std
   header "__fwd/subrange.h"
   export std_private_iterator_concepts
 }
-module std_private_ranges_take_view                  [system] { header "__ranges/take_view.h" }
-module std_private_ranges_take_while_view            [system] { header "__ranges/take_while_view.h" }
-module std_private_ranges_to                         [system] { header "__ranges/to.h" }
-module std_private_ranges_transform_view             [system] {
+module std_private_ranges_take_view [system] {
+  export_as std
+  header "__ranges/take_view.h"
+}
+module std_private_ranges_take_while_view [system] {
+  export_as std
+  header "__ranges/take_while_view.h"
+}
+module std_private_ranges_to [system] {
+  export_as std
+  header "__ranges/to.h"
+}
+module std_private_ranges_transform_view [system] {
+  export_as std
   header "__ranges/transform_view.h"
   export std_private_functional_bind_back
   export std_private_functional_perfect_forward
   export std_private_ranges_movable_box
 }
-module std_private_ranges_view_interface             [system] { header "__ranges/view_interface.h" }
-module std_private_ranges_views                      [system] { header "__ranges/views.h" }
-module std_private_ranges_zip_view                   [system] { header "__ranges/zip_view.h" }
+module std_private_ranges_view_interface [system] {
+  export_as std
+  header "__ranges/view_interface.h"
+}
+module std_private_ranges_views [system] {
+  export_as std
+  header "__ranges/views.h"
+}
+module std_private_ranges_zip_view [system] {
+  export_as std
+  header "__ranges/zip_view.h"
+}
 
-module std_private_span_span_fwd [system] { header "__fwd/span.h" }
+module std_private_span_span_fwd [system] {
+  export_as std
+  header "__fwd/span.h"
+}
 
-module std_private_stop_token_atomic_unique_lock   [system] { header "__stop_token/atomic_unique_lock.h" }
-module std_private_stop_token_intrusive_list_view  [system] { header "__stop_token/intrusive_list_view.h" }
-module std_private_stop_token_intrusive_shared_ptr [system] { header "__stop_token/intrusive_shared_ptr.h" }
-module std_private_stop_token_stop_callback        [system] { header "__stop_token/stop_callback.h" }
-module std_private_stop_token_stop_source          [system] {
+module std_private_stop_token_atomic_unique_lock [system] {
+  export_as std
+  header "__stop_token/atomic_unique_lock.h"
+}
+module std_private_stop_token_intrusive_list_view [system] {
+  export_as std
+  header "__stop_token/intrusive_list_view.h"
+}
+module std_private_stop_token_intrusive_shared_ptr [system] {
+  export_as std
+  header "__stop_token/intrusive_shared_ptr.h"
+}
+module std_private_stop_token_stop_callback [system] {
+  export_as std
+  header "__stop_token/stop_callback.h"
+}
+module std_private_stop_token_stop_source [system] {
+  export_as std
   header "__stop_token/stop_source.h"
   export *
 }
-module std_private_stop_token_stop_state           [system] {
+module std_private_stop_token_stop_state [system] {
+  export_as std
   header "__stop_token/stop_state.h"
   export *
 }
-module std_private_stop_token_stop_token           [system] {
+module std_private_stop_token_stop_token [system] {
+  export_as std
   header "__stop_token/stop_token.h"
   export *
 }
 
-module std_private_string_char_traits           [system] {
+module std_private_string_char_traits [system] {
+  export_as std
   header "__string/char_traits.h"
   export *
 }
 module std_private_string_constexpr_c_functions [system] {
+  export_as std
   header "__string/constexpr_c_functions.h"
   export std_private_type_traits_is_equality_comparable
 }
-module std_private_string_extern_template_lists [system] { header "__string/extern_template_lists.h" }
-module std_private_string_string_fwd            [system] { header "__fwd/string.h" }
+module std_private_string_extern_template_lists [system] {
+  export_as std
+  header "__string/extern_template_lists.h"
+}
+module std_private_string_string_fwd [system] {
+  export_as std
+  header "__fwd/string.h"
+}
 
-module std_private_string_view_string_view_fwd [system] { header "__fwd/string_view.h" }
+module std_private_string_view_string_view_fwd [system] {
+  export_as std
+  header "__fwd/string_view.h"
+}
 
-module std_private_system_error_errc            [system] { header "__system_error/errc.h" }
-module std_private_system_error_error_category  [system] { header "__system_error/error_category.h" }
-module std_private_system_error_error_code      [system] {
+module std_private_system_error_errc [system] {
+  export_as std
+  header "__system_error/errc.h"
+}
+module std_private_system_error_error_category [system] {
+  export_as std
+  header "__system_error/error_category.h"
+}
+module std_private_system_error_error_code [system] {
+  export_as std
   header "__system_error/error_code.h"
   export std_private_functional_hash
   export std_private_functional_unary_function
 }
 module std_private_system_error_error_condition [system] {
+  export_as std
   header "__system_error/error_condition.h"
   export std_private_functional_hash
   export std_private_functional_unary_function
 }
-module std_private_system_error_system_error    [system] { header "__system_error/system_error.h" }
+module std_private_system_error_system_error [system] {
+  export_as std
+  header "__system_error/system_error.h"
+}
 
-module std_private_thread_formatter            [system] { header "__thread/formatter.h" }
-module std_private_thread_id                   [system] { header "__thread/id.h" }
-module std_private_thread_jthread              [system] {
+module std_private_thread_formatter [system] {
+  export_as std
+  header "__thread/formatter.h"
+}
+module std_private_thread_id [system] {
+  export_as std
+  header "__thread/id.h"
+}
+module std_private_thread_jthread [system] {
+  export_as std
   header "__thread/jthread.h"
   export *
 }
-module std_private_thread_poll_with_backoff    [system] { header "__thread/poll_with_backoff.h" }
-module std_private_thread_this_thread          [system] { header "__thread/this_thread.h" }
-module std_private_thread_thread               [system] {
+module std_private_thread_poll_with_backoff [system] {
+  export_as std
+  header "__thread/poll_with_backoff.h"
+}
+module std_private_thread_this_thread [system] {
+  export_as std
+  header "__thread/this_thread.h"
+}
+module std_private_thread_thread [system] {
+  export_as std
   header "__thread/thread.h"
   export *
 }
-module std_private_thread_timed_backoff_policy [system] { header "__thread/timed_backoff_policy.h" }
+module std_private_thread_timed_backoff_policy [system] {
+  export_as std
+  header "__thread/timed_backoff_policy.h"
+}
 
-module std_private_tuple_get_fwd          [system] { header "__fwd/get.h" }
-module std_private_tuple_make_tuple_types [system] { header "__tuple/make_tuple_types.h" }
-module std_private_tuple_pair_like        [system] {
+module std_private_tuple_get_fwd [system] {
+  export_as std
+  header "__fwd/get.h"
+}
+module std_private_tuple_make_tuple_types [system] {
+  export_as std
+  header "__tuple/make_tuple_types.h"
+}
+module std_private_tuple_pair_like [system] {
+  export_as std
   header "__tuple/pair_like.h"
   export std_private_tuple_tuple_like
 }
-module std_private_tuple_sfinae_helpers   [system] { header "__tuple/sfinae_helpers.h" }
-module std_private_tuple_tuple_element    [system] { header "__tuple/tuple_element.h" }
-module std_private_tuple_tuple_fwd        [system] { header "__fwd/tuple.h" }
-module std_private_tuple_tuple_indices    [system] { header "__tuple/tuple_indices.h" }
-module std_private_tuple_tuple_like       [system] { header "__tuple/tuple_like.h" }
-module std_private_tuple_tuple_like_ext   [system] { header "__tuple/tuple_like_ext.h" }
-module std_private_tuple_tuple_size       [system] { header "__tuple/tuple_size.h" }
-module std_private_tuple_tuple_types      [system] { header "__tuple/tuple_types.h" }
+module std_private_tuple_sfinae_helpers [system] {
+  export_as std
+  header "__tuple/sfinae_helpers.h"
+}
+module std_private_tuple_tuple_element [system] {
+  export_as std
+  header "__tuple/tuple_element.h"
+}
+module std_private_tuple_tuple_fwd [system] {
+  export_as std
+  header "__fwd/tuple.h"
+}
+module std_private_tuple_tuple_indices [system] {
+  export_as std
+  header "__tuple/tuple_indices.h"
+}
+module std_private_tuple_tuple_like [system] {
+  export_as std
+  header "__tuple/tuple_like.h"
+}
+module std_private_tuple_tuple_like_ext [system] {
+  export_as std
+  header "__tuple/tuple_like_ext.h"
+}
+module std_private_tuple_tuple_size [system] {
+  export_as std
+  header "__tuple/tuple_size.h"
+}
+module std_private_tuple_tuple_types [system] {
+  export_as std
+  header "__tuple/tuple_types.h"
+}
 
-module std_private_type_traits_add_const                                 [system] { header "__type_traits/add_const.h" }
-module std_private_type_traits_add_cv                                    [system] { header "__type_traits/add_cv.h" }
-module std_private_type_traits_add_lvalue_reference                      [system] {
+module std_private_type_traits_add_const [system] {
+  export_as std
+  header "__type_traits/add_const.h"
+}
+module std_private_type_traits_add_cv [system] {
+  export_as std
+  header "__type_traits/add_cv.h"
+}
+module std_private_type_traits_add_lvalue_reference [system] {
+  export_as std
   header "__type_traits/add_lvalue_reference.h"
   export std_private_type_traits_is_referenceable
 }
-module std_private_type_traits_add_pointer                               [system] { header "__type_traits/add_pointer.h" }
-module std_private_type_traits_add_rvalue_reference                      [system] { header "__type_traits/add_rvalue_reference.h" }
-module std_private_type_traits_add_volatile                              [system] { header "__type_traits/add_volatile.h" }
-module std_private_type_traits_aligned_storage                           [system] { header "__type_traits/aligned_storage.h" }
-module std_private_type_traits_aligned_union                             [system] { header "__type_traits/aligned_union.h" }
-module std_private_type_traits_alignment_of                              [system] { header "__type_traits/alignment_of.h" }
-module std_private_type_traits_apply_cv                                  [system] {
+module std_private_type_traits_add_pointer [system] {
+  export_as std
+  header "__type_traits/add_pointer.h"
+}
+module std_private_type_traits_add_rvalue_reference [system] {
+  export_as std
+  header "__type_traits/add_rvalue_reference.h"
+}
+module std_private_type_traits_add_volatile [system] {
+  export_as std
+  header "__type_traits/add_volatile.h"
+}
+module std_private_type_traits_aligned_storage [system] {
+  export_as std
+  header "__type_traits/aligned_storage.h"
+}
+module std_private_type_traits_aligned_union [system] {
+  export_as std
+  header "__type_traits/aligned_union.h"
+}
+module std_private_type_traits_alignment_of [system] {
+  export_as std
+  header "__type_traits/alignment_of.h"
+}
+module std_private_type_traits_apply_cv [system] {
+  export_as std
   header "__type_traits/apply_cv.h"
   export std_private_type_traits_is_const
   export std_private_type_traits_is_volatile
 }
-module std_private_type_traits_can_extract_key                           [system] { header "__type_traits/can_extract_key.h" }
-module std_private_type_traits_common_reference                          [system] {
+module std_private_type_traits_can_extract_key [system] {
+  export_as std
+  header "__type_traits/can_extract_key.h"
+}
+module std_private_type_traits_common_reference [system] {
+  export_as std
   header "__type_traits/common_reference.h"
   export std_private_type_traits_remove_cvref
 }
-module std_private_type_traits_common_type                               [system] {
+module std_private_type_traits_common_type [system] {
+  export_as std
   header "__type_traits/common_type.h"
   export std_private_utility_declval
 }
-module std_private_type_traits_conditional                               [system] { header "__type_traits/conditional.h" }
-module std_private_type_traits_conjunction                               [system] { header "__type_traits/conjunction.h" }
-module std_private_type_traits_copy_cv                                   [system] { header "__type_traits/copy_cv.h" }
-module std_private_type_traits_copy_cvref                                [system] { header "__type_traits/copy_cvref.h" }
-module std_private_type_traits_datasizeof                                [system] { header "__type_traits/datasizeof.h" }
-module std_private_type_traits_decay                                     [system] {
+module std_private_type_traits_conditional [system] {
+  export_as std
+  header "__type_traits/conditional.h"
+}
+module std_private_type_traits_conjunction [system] {
+  export_as std
+  header "__type_traits/conjunction.h"
+}
+module std_private_type_traits_copy_cv [system] {
+  export_as std
+  header "__type_traits/copy_cv.h"
+}
+module std_private_type_traits_copy_cvref [system] {
+  export_as std
+  header "__type_traits/copy_cvref.h"
+}
+module std_private_type_traits_datasizeof [system] {
+  export_as std
+  header "__type_traits/datasizeof.h"
+}
+module std_private_type_traits_decay [system] {
+  export_as std
   header "__type_traits/decay.h"
   export std_private_type_traits_add_pointer
 }
-module std_private_type_traits_dependent_type                            [system] { header "__type_traits/dependent_type.h" }
-module std_private_type_traits_disjunction                               [system] { header "__type_traits/disjunction.h" }
-module std_private_type_traits_enable_if                                 [system] { header "__type_traits/enable_if.h" }
-module std_private_type_traits_extent                                    [system] { header "__type_traits/extent.h" }
-module std_private_type_traits_has_unique_object_representation          [system] { header "__type_traits/has_unique_object_representation.h" }
-module std_private_type_traits_has_virtual_destructor                    [system] { header "__type_traits/has_virtual_destructor.h" }
-module std_private_type_traits_integral_constant                         [system] { header "__type_traits/integral_constant.h" }
-module std_private_type_traits_invoke                                    [system] {
+module std_private_type_traits_dependent_type [system] {
+  export_as std
+  header "__type_traits/dependent_type.h"
+}
+module std_private_type_traits_disjunction [system] {
+  export_as std
+  header "__type_traits/disjunction.h"
+}
+module std_private_type_traits_enable_if [system] {
+  export_as std
+  header "__type_traits/enable_if.h"
+}
+module std_private_type_traits_extent [system] {
+  export_as std
+  header "__type_traits/extent.h"
+}
+module std_private_type_traits_has_unique_object_representation [system] {
+  export_as std
+  header "__type_traits/has_unique_object_representation.h"
+}
+module std_private_type_traits_has_virtual_destructor [system] {
+  export_as std
+  header "__type_traits/has_virtual_destructor.h"
+}
+module std_private_type_traits_integral_constant [system] {
+  export_as std
+  header "__type_traits/integral_constant.h"
+}
+module std_private_type_traits_invoke [system] {
+  export_as std
   header "__type_traits/invoke.h"
   export std_private_type_traits_conditional
   export std_private_type_traits_decay
@@ -1849,203 +3786,538 @@ module std_private_type_traits_invoke                                    [system
   export std_private_type_traits_nat
   export std_private_type_traits_remove_cv
 }
-module std_private_type_traits_is_abstract                               [system] { header "__type_traits/is_abstract.h" }
-module std_private_type_traits_is_aggregate                              [system] { header "__type_traits/is_aggregate.h" }
-module std_private_type_traits_is_allocator                              [system] { header "__type_traits/is_allocator.h" }
-module std_private_type_traits_is_always_bitcastable                     [system] { header "__type_traits/is_always_bitcastable.h" }
-module std_private_type_traits_is_arithmetic                             [system] {
+module std_private_type_traits_is_abstract [system] {
+  export_as std
+  header "__type_traits/is_abstract.h"
+}
+module std_private_type_traits_is_aggregate [system] {
+  export_as std
+  header "__type_traits/is_aggregate.h"
+}
+module std_private_type_traits_is_allocator [system] {
+  export_as std
+  header "__type_traits/is_allocator.h"
+}
+module std_private_type_traits_is_always_bitcastable [system] {
+  export_as std
+  header "__type_traits/is_always_bitcastable.h"
+}
+module std_private_type_traits_is_arithmetic [system] {
+  export_as std
   header "__type_traits/is_arithmetic.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_array                                  [system] {
+module std_private_type_traits_is_array [system] {
+  export_as std
   header "__type_traits/is_array.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_assignable                             [system] { header "__type_traits/is_assignable.h" }
-module std_private_type_traits_is_base_of                                [system] { header "__type_traits/is_base_of.h" }
-module std_private_type_traits_is_bounded_array                          [system] { header "__type_traits/is_bounded_array.h" }
-module std_private_type_traits_is_callable                               [system] { header "__type_traits/is_callable.h" }
-module std_private_type_traits_is_char_like_type                         [system] { header "__type_traits/is_char_like_type.h" }
-module std_private_type_traits_is_class                                  [system] { header "__type_traits/is_class.h" }
-module std_private_type_traits_is_compound                               [system] { header "__type_traits/is_compound.h" }
-module std_private_type_traits_is_const                                  [system] { header "__type_traits/is_const.h" }
-module std_private_type_traits_is_constant_evaluated                     [system] { header "__type_traits/is_constant_evaluated.h" }
-module std_private_type_traits_is_constructible                          [system] { header "__type_traits/is_constructible.h" }
-module std_private_type_traits_is_convertible                            [system] {
+module std_private_type_traits_is_assignable [system] {
+  export_as std
+  header "__type_traits/is_assignable.h"
+}
+module std_private_type_traits_is_base_of [system] {
+  export_as std
+  header "__type_traits/is_base_of.h"
+}
+module std_private_type_traits_is_bounded_array [system] {
+  export_as std
+  header "__type_traits/is_bounded_array.h"
+}
+module std_private_type_traits_is_callable [system] {
+  export_as std
+  header "__type_traits/is_callable.h"
+}
+module std_private_type_traits_is_char_like_type [system] {
+  export_as std
+  header "__type_traits/is_char_like_type.h"
+}
+module std_private_type_traits_is_class [system] {
+  export_as std
+  header "__type_traits/is_class.h"
+}
+module std_private_type_traits_is_compound [system] {
+  export_as std
+  header "__type_traits/is_compound.h"
+}
+module std_private_type_traits_is_const [system] {
+  export_as std
+  header "__type_traits/is_const.h"
+}
+module std_private_type_traits_is_constant_evaluated [system] {
+  export_as std
+  header "__type_traits/is_constant_evaluated.h"
+}
+module std_private_type_traits_is_constructible [system] {
+  export_as std
+  header "__type_traits/is_constructible.h"
+}
+module std_private_type_traits_is_convertible [system] {
+  export_as std
   header "__type_traits/is_convertible.h"
   export std_private_type_traits_is_array
 }
-module std_private_type_traits_is_copy_assignable                        [system] { header "__type_traits/is_copy_assignable.h" }
-module std_private_type_traits_is_copy_constructible                     [system] { header "__type_traits/is_copy_constructible.h" }
-module std_private_type_traits_is_core_convertible                       [system] {
+module std_private_type_traits_is_copy_assignable [system] {
+  export_as std
+  header "__type_traits/is_copy_assignable.h"
+}
+module std_private_type_traits_is_copy_constructible [system] {
+  export_as std
+  header "__type_traits/is_copy_constructible.h"
+}
+module std_private_type_traits_is_core_convertible [system] {
+  export_as std
   header "__type_traits/is_core_convertible.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_default_constructible                  [system] { header "__type_traits/is_default_constructible.h" }
-module std_private_type_traits_is_destructible                           [system] { header "__type_traits/is_destructible.h" }
-module std_private_type_traits_is_empty                                  [system] { header "__type_traits/is_empty.h" }
-module std_private_type_traits_is_enum                                   [system] {
+module std_private_type_traits_is_default_constructible [system] {
+  export_as std
+  header "__type_traits/is_default_constructible.h"
+}
+module std_private_type_traits_is_destructible [system] {
+  export_as std
+  header "__type_traits/is_destructible.h"
+}
+module std_private_type_traits_is_empty [system] {
+  export_as std
+  header "__type_traits/is_empty.h"
+}
+module std_private_type_traits_is_enum [system] {
+  export_as std
   header "__type_traits/is_enum.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_equality_comparable                    [system] {
+module std_private_type_traits_is_equality_comparable [system] {
+  export_as std
   header "__type_traits/is_equality_comparable.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_execution_policy                       [system] {
+module std_private_type_traits_is_execution_policy [system] {
+  export_as std
   header "__type_traits/is_execution_policy.h"
   export std_private_type_traits_remove_cvref
 }
-module std_private_type_traits_is_final                                  [system] { header "__type_traits/is_final.h" }
-module std_private_type_traits_is_floating_point                         [system] { header "__type_traits/is_floating_point.h" }
-module std_private_type_traits_is_function                               [system] { header "__type_traits/is_function.h" }
-module std_private_type_traits_is_fundamental                            [system] { header "__type_traits/is_fundamental.h" }
-module std_private_type_traits_is_implicitly_default_constructible       [system] { header "__type_traits/is_implicitly_default_constructible.h" }
-module std_private_type_traits_is_integral                               [system] { header "__type_traits/is_integral.h" }
-module std_private_type_traits_is_literal_type                           [system] { header "__type_traits/is_literal_type.h" }
-module std_private_type_traits_is_member_function_pointer                [system] { header "__type_traits/is_member_function_pointer.h" }
-module std_private_type_traits_is_member_object_pointer                  [system] { header "__type_traits/is_member_object_pointer.h" }
-module std_private_type_traits_is_member_pointer                         [system] { header "__type_traits/is_member_pointer.h" }
-module std_private_type_traits_is_move_assignable                        [system] { header "__type_traits/is_move_assignable.h" }
-module std_private_type_traits_is_move_constructible                     [system] { header "__type_traits/is_move_constructible.h" }
-module std_private_type_traits_is_nothrow_assignable                     [system] { header "__type_traits/is_nothrow_assignable.h" }
-module std_private_type_traits_is_nothrow_constructible                  [system] { header "__type_traits/is_nothrow_constructible.h" }
-module std_private_type_traits_is_nothrow_convertible                    [system] { header "__type_traits/is_nothrow_convertible.h" }
-module std_private_type_traits_is_nothrow_copy_assignable                [system] { header "__type_traits/is_nothrow_copy_assignable.h" }
-module std_private_type_traits_is_nothrow_copy_constructible             [system] { header "__type_traits/is_nothrow_copy_constructible.h" }
-module std_private_type_traits_is_nothrow_default_constructible          [system] { header "__type_traits/is_nothrow_default_constructible.h" }
-module std_private_type_traits_is_nothrow_destructible                   [system] {
+module std_private_type_traits_is_final [system] {
+  export_as std
+  header "__type_traits/is_final.h"
+}
+module std_private_type_traits_is_floating_point [system] {
+  export_as std
+  header "__type_traits/is_floating_point.h"
+}
+module std_private_type_traits_is_function [system] {
+  export_as std
+  header "__type_traits/is_function.h"
+}
+module std_private_type_traits_is_fundamental [system] {
+  export_as std
+  header "__type_traits/is_fundamental.h"
+}
+module std_private_type_traits_is_implicitly_default_constructible [system] {
+  export_as std
+  header "__type_traits/is_implicitly_default_constructible.h"
+}
+module std_private_type_traits_is_integral [system] {
+  export_as std
+  header "__type_traits/is_integral.h"
+}
+module std_private_type_traits_is_literal_type [system] {
+  export_as std
+  header "__type_traits/is_literal_type.h"
+}
+module std_private_type_traits_is_member_function_pointer [system] {
+  export_as std
+  header "__type_traits/is_member_function_pointer.h"
+}
+module std_private_type_traits_is_member_object_pointer [system] {
+  export_as std
+  header "__type_traits/is_member_object_pointer.h"
+}
+module std_private_type_traits_is_member_pointer [system] {
+  export_as std
+  header "__type_traits/is_member_pointer.h"
+}
+module std_private_type_traits_is_move_assignable [system] {
+  export_as std
+  header "__type_traits/is_move_assignable.h"
+}
+module std_private_type_traits_is_move_constructible [system] {
+  export_as std
+  header "__type_traits/is_move_constructible.h"
+}
+module std_private_type_traits_is_nothrow_assignable [system] {
+  export_as std
+  header "__type_traits/is_nothrow_assignable.h"
+}
+module std_private_type_traits_is_nothrow_constructible [system] {
+  export_as std
+  header "__type_traits/is_nothrow_constructible.h"
+}
+module std_private_type_traits_is_nothrow_convertible [system] {
+  export_as std
+  header "__type_traits/is_nothrow_convertible.h"
+}
+module std_private_type_traits_is_nothrow_copy_assignable [system] {
+  export_as std
+  header "__type_traits/is_nothrow_copy_assignable.h"
+}
+module std_private_type_traits_is_nothrow_copy_constructible [system] {
+  export_as std
+  header "__type_traits/is_nothrow_copy_constructible.h"
+}
+module std_private_type_traits_is_nothrow_default_constructible [system] {
+  export_as std
+  header "__type_traits/is_nothrow_default_constructible.h"
+}
+module std_private_type_traits_is_nothrow_destructible [system] {
+  export_as std
   header "__type_traits/is_nothrow_destructible.h"
   export std_private_type_traits_is_destructible
 }
-module std_private_type_traits_is_nothrow_move_assignable                [system] { header "__type_traits/is_nothrow_move_assignable.h" }
-module std_private_type_traits_is_nothrow_move_constructible             [system] {
+module std_private_type_traits_is_nothrow_move_assignable [system] {
+  export_as std
+  header "__type_traits/is_nothrow_move_assignable.h"
+}
+module std_private_type_traits_is_nothrow_move_constructible [system] {
+  export_as std
   header "__type_traits/is_nothrow_move_constructible.h"
   export std_private_type_traits_is_nothrow_constructible
 }
-module std_private_type_traits_is_null_pointer                           [system] {
+module std_private_type_traits_is_null_pointer [system] {
+  export_as std
   header "__type_traits/is_null_pointer.h"
   export std_cstddef
 }
-module std_private_type_traits_is_object                                 [system] {
+module std_private_type_traits_is_object [system] {
+  export_as std
   header "__type_traits/is_object.h"
   export std_private_type_traits_is_scalar
 }
-module std_private_type_traits_is_pod                                    [system] { header "__type_traits/is_pod.h" }
-module std_private_type_traits_is_pointer                                [system] { header "__type_traits/is_pointer.h" }
-module std_private_type_traits_is_polymorphic                            [system] { header "__type_traits/is_polymorphic.h" }
-module std_private_type_traits_is_primary_template                       [system] {
+module std_private_type_traits_is_pod [system] {
+  export_as std
+  header "__type_traits/is_pod.h"
+}
+module std_private_type_traits_is_pointer [system] {
+  export_as std
+  header "__type_traits/is_pointer.h"
+}
+module std_private_type_traits_is_polymorphic [system] {
+  export_as std
+  header "__type_traits/is_polymorphic.h"
+}
+module std_private_type_traits_is_primary_template [system] {
+  export_as std
   header "__type_traits/is_primary_template.h"
   export std_private_type_traits_enable_if
 }
-module std_private_type_traits_is_reference                              [system] { header "__type_traits/is_reference.h" }
-module std_private_type_traits_is_reference_wrapper                      [system] { header "__type_traits/is_reference_wrapper.h" }
-module std_private_type_traits_is_referenceable                          [system] { header "__type_traits/is_referenceable.h" }
-module std_private_type_traits_is_same                                   [system] {
+module std_private_type_traits_is_reference [system] {
+  export_as std
+  header "__type_traits/is_reference.h"
+}
+module std_private_type_traits_is_reference_wrapper [system] {
+  export_as std
+  header "__type_traits/is_reference_wrapper.h"
+}
+module std_private_type_traits_is_referenceable [system] {
+  export_as std
+  header "__type_traits/is_referenceable.h"
+}
+module std_private_type_traits_is_same [system] {
+  export_as std
   header "__type_traits/is_same.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_scalar                                 [system] {
+module std_private_type_traits_is_scalar [system] {
+  export_as std
   header "__type_traits/is_scalar.h"
   export std_private_type_traits_is_null_pointer
 }
-module std_private_type_traits_is_scoped_enum                            [system] { header "__type_traits/is_scoped_enum.h" }
-module std_private_type_traits_is_signed                                 [system] { header "__type_traits/is_signed.h" }
-module std_private_type_traits_is_signed_integer                         [system] { header "__type_traits/is_signed_integer.h" }
-module std_private_type_traits_is_specialization                         [system] { header "__type_traits/is_specialization.h" }
-module std_private_type_traits_is_standard_layout                        [system] { header "__type_traits/is_standard_layout.h" }
-module std_private_type_traits_is_swappable                              [system] {
+module std_private_type_traits_is_scoped_enum [system] {
+  export_as std
+  header "__type_traits/is_scoped_enum.h"
+}
+module std_private_type_traits_is_signed [system] {
+  export_as std
+  header "__type_traits/is_signed.h"
+}
+module std_private_type_traits_is_signed_integer [system] {
+  export_as std
+  header "__type_traits/is_signed_integer.h"
+}
+module std_private_type_traits_is_specialization [system] {
+  export_as std
+  header "__type_traits/is_specialization.h"
+}
+module std_private_type_traits_is_standard_layout [system] {
+  export_as std
+  header "__type_traits/is_standard_layout.h"
+}
+module std_private_type_traits_is_swappable [system] {
+  export_as std
   header "__type_traits/is_swappable.h"
   export std_private_type_traits_is_move_constructible
 }
-module std_private_type_traits_is_trivial                                [system] { header "__type_traits/is_trivial.h" }
-module std_private_type_traits_is_trivially_assignable                   [system] { header "__type_traits/is_trivially_assignable.h" }
-module std_private_type_traits_is_trivially_constructible                [system] { header "__type_traits/is_trivially_constructible.h" }
-module std_private_type_traits_is_trivially_copy_assignable              [system] { header "__type_traits/is_trivially_copy_assignable.h" }
-module std_private_type_traits_is_trivially_copy_constructible           [system] { header "__type_traits/is_trivially_copy_constructible.h" }
-module std_private_type_traits_is_trivially_copyable                     [system] { header "__type_traits/is_trivially_copyable.h" }
-module std_private_type_traits_is_trivially_default_constructible        [system] { header "__type_traits/is_trivially_default_constructible.h" }
-module std_private_type_traits_is_trivially_destructible                 [system] { header "__type_traits/is_trivially_destructible.h" }
-module std_private_type_traits_is_trivially_lexicographically_comparable [system] { header "__type_traits/is_trivially_lexicographically_comparable.h" }
-module std_private_type_traits_is_trivially_move_assignable              [system] { header "__type_traits/is_trivially_move_assignable.h" }
-module std_private_type_traits_is_trivially_move_constructible           [system] { header "__type_traits/is_trivially_move_constructible.h" }
-module std_private_type_traits_is_unbounded_array                        [system] { header "__type_traits/is_unbounded_array.h" }
-module std_private_type_traits_is_union                                  [system] { header "__type_traits/is_union.h" }
-module std_private_type_traits_is_unsigned                               [system] { header "__type_traits/is_unsigned.h" }
-module std_private_type_traits_is_unsigned_integer                       [system] { header "__type_traits/is_unsigned_integer.h" }
-module std_private_type_traits_is_valid_expansion                        [system] { header "__type_traits/is_valid_expansion.h" }
-module std_private_type_traits_is_void                                   [system] {
+module std_private_type_traits_is_trivial [system] {
+  export_as std
+  header "__type_traits/is_trivial.h"
+}
+module std_private_type_traits_is_trivially_assignable [system] {
+  export_as std
+  header "__type_traits/is_trivially_assignable.h"
+}
+module std_private_type_traits_is_trivially_constructible [system] {
+  export_as std
+  header "__type_traits/is_trivially_constructible.h"
+}
+module std_private_type_traits_is_trivially_copy_assignable [system] {
+  export_as std
+  header "__type_traits/is_trivially_copy_assignable.h"
+}
+module std_private_type_traits_is_trivially_copy_constructible [system] {
+  export_as std
+  header "__type_traits/is_trivially_copy_constructible.h"
+}
+module std_private_type_traits_is_trivially_copyable [system] {
+  export_as std
+  header "__type_traits/is_trivially_copyable.h"
+}
+module std_private_type_traits_is_trivially_default_constructible [system] {
+  export_as std
+  header "__type_traits/is_trivially_default_constructible.h"
+}
+module std_private_type_traits_is_trivially_destructible [system] {
+  export_as std
+  header "__type_traits/is_trivially_destructible.h"
+}
+module std_private_type_traits_is_trivially_lexicographically_comparable [system] {
+  export_as std
+  header "__type_traits/is_trivially_lexicographically_comparable.h"
+}
+module std_private_type_traits_is_trivially_move_assignable [system] {
+  export_as std
+  header "__type_traits/is_trivially_move_assignable.h"
+}
+module std_private_type_traits_is_trivially_move_constructible [system] {
+  export_as std
+  header "__type_traits/is_trivially_move_constructible.h"
+}
+module std_private_type_traits_is_unbounded_array [system] {
+  export_as std
+  header "__type_traits/is_unbounded_array.h"
+}
+module std_private_type_traits_is_union [system] {
+  export_as std
+  header "__type_traits/is_union.h"
+}
+module std_private_type_traits_is_unsigned [system] {
+  export_as std
+  header "__type_traits/is_unsigned.h"
+}
+module std_private_type_traits_is_unsigned_integer [system] {
+  export_as std
+  header "__type_traits/is_unsigned_integer.h"
+}
+module std_private_type_traits_is_valid_expansion [system] {
+  export_as std
+  header "__type_traits/is_valid_expansion.h"
+}
+module std_private_type_traits_is_void [system] {
+  export_as std
   header "__type_traits/is_void.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_volatile                               [system] { header "__type_traits/is_volatile.h" }
-module std_private_type_traits_lazy                                      [system] { header "__type_traits/lazy.h" }
-module std_private_type_traits_make_32_64_or_128_bit                     [system] { header "__type_traits/make_32_64_or_128_bit.h" }
-module std_private_type_traits_make_const_lvalue_ref                     [system] { header "__type_traits/make_const_lvalue_ref.h" }
-module std_private_type_traits_make_signed                               [system] { header "__type_traits/make_signed.h" }
-module std_private_type_traits_make_unsigned                             [system] {
+module std_private_type_traits_is_volatile [system] {
+  export_as std
+  header "__type_traits/is_volatile.h"
+}
+module std_private_type_traits_lazy [system] {
+  export_as std
+  header "__type_traits/lazy.h"
+}
+module std_private_type_traits_make_32_64_or_128_bit [system] {
+  export_as std
+  header "__type_traits/make_32_64_or_128_bit.h"
+}
+module std_private_type_traits_make_const_lvalue_ref [system] {
+  export_as std
+  header "__type_traits/make_const_lvalue_ref.h"
+}
+module std_private_type_traits_make_signed [system] {
+  export_as std
+  header "__type_traits/make_signed.h"
+}
+module std_private_type_traits_make_unsigned [system] {
+  export_as std
   header "__type_traits/make_unsigned.h"
   export std_private_type_traits_is_unsigned
 }
-module std_private_type_traits_maybe_const                               [system] { header "__type_traits/maybe_const.h" }
-module std_private_type_traits_nat                                       [system] { header "__type_traits/nat.h" }
-module std_private_type_traits_negation                                  [system] { header "__type_traits/negation.h" }
-module std_private_type_traits_noexcept_move_assign_container            [system] { header "__type_traits/noexcept_move_assign_container.h" }
-module std_private_type_traits_operation_traits                          [system] { header "__type_traits/operation_traits.h" }
-module std_private_type_traits_promote                                   [system] { header "__type_traits/promote.h" }
-module std_private_type_traits_rank                                      [system] { header "__type_traits/rank.h" }
-module std_private_type_traits_remove_all_extents                        [system] { header "__type_traits/remove_all_extents.h" }
-module std_private_type_traits_remove_const                              [system] { header "__type_traits/remove_const.h" }
-module std_private_type_traits_remove_const_ref                          [system] { header "__type_traits/remove_const_ref.h" }
-module std_private_type_traits_remove_cv                                 [system] {
+module std_private_type_traits_maybe_const [system] {
+  export_as std
+  header "__type_traits/maybe_const.h"
+}
+module std_private_type_traits_nat [system] {
+  export_as std
+  header "__type_traits/nat.h"
+}
+module std_private_type_traits_negation [system] {
+  export_as std
+  header "__type_traits/negation.h"
+}
+module std_private_type_traits_noexcept_move_assign_container [system] {
+  export_as std
+  header "__type_traits/noexcept_move_assign_container.h"
+}
+module std_private_type_traits_operation_traits [system] {
+  export_as std
+  header "__type_traits/operation_traits.h"
+}
+module std_private_type_traits_promote [system] {
+  export_as std
+  header "__type_traits/promote.h"
+}
+module std_private_type_traits_rank [system] {
+  export_as std
+  header "__type_traits/rank.h"
+}
+module std_private_type_traits_remove_all_extents [system] {
+  export_as std
+  header "__type_traits/remove_all_extents.h"
+}
+module std_private_type_traits_remove_const [system] {
+  export_as std
+  header "__type_traits/remove_const.h"
+}
+module std_private_type_traits_remove_const_ref [system] {
+  export_as std
+  header "__type_traits/remove_const_ref.h"
+}
+module std_private_type_traits_remove_cv [system] {
+  export_as std
   header "__type_traits/remove_cv.h"
   export std_private_type_traits_remove_const
   export std_private_type_traits_remove_volatile
 }
-module std_private_type_traits_remove_cvref                              [system] { header "__type_traits/remove_cvref.h" }
-module std_private_type_traits_remove_extent                             [system] { header "__type_traits/remove_extent.h" }
-module std_private_type_traits_remove_pointer                            [system] { header "__type_traits/remove_pointer.h" }
-module std_private_type_traits_remove_reference                          [system] { header "__type_traits/remove_reference.h" }
-module std_private_type_traits_remove_volatile                           [system] { header "__type_traits/remove_volatile.h" }
-module std_private_type_traits_result_of                                 [system] { header "__type_traits/result_of.h" }
-module std_private_type_traits_strip_signature                           [system] { header "__type_traits/strip_signature.h" }
-module std_private_type_traits_type_identity                             [system] { header "__type_traits/type_identity.h" }
-module std_private_type_traits_type_list                                 [system] { header "__type_traits/type_list.h" }
-module std_private_type_traits_underlying_type                           [system] {
+module std_private_type_traits_remove_cvref [system] {
+  export_as std
+  header "__type_traits/remove_cvref.h"
+}
+module std_private_type_traits_remove_extent [system] {
+  export_as std
+  header "__type_traits/remove_extent.h"
+}
+module std_private_type_traits_remove_pointer [system] {
+  export_as std
+  header "__type_traits/remove_pointer.h"
+}
+module std_private_type_traits_remove_reference [system] {
+  export_as std
+  header "__type_traits/remove_reference.h"
+}
+module std_private_type_traits_remove_volatile [system] {
+  export_as std
+  header "__type_traits/remove_volatile.h"
+}
+module std_private_type_traits_result_of [system] {
+  export_as std
+  header "__type_traits/result_of.h"
+}
+module std_private_type_traits_strip_signature [system] {
+  export_as std
+  header "__type_traits/strip_signature.h"
+}
+module std_private_type_traits_type_identity [system] {
+  export_as std
+  header "__type_traits/type_identity.h"
+}
+module std_private_type_traits_type_list [system] {
+  export_as std
+  header "__type_traits/type_list.h"
+}
+module std_private_type_traits_underlying_type [system] {
+  export_as std
   header "__type_traits/underlying_type.h"
   export std_private_type_traits_is_enum
 }
-module std_private_type_traits_unwrap_ref                                [system] { header "__type_traits/unwrap_ref.h" }
-module std_private_type_traits_void_t                                    [system] { header "__type_traits/void_t.h" }
+module std_private_type_traits_unwrap_ref [system] {
+  export_as std
+  header "__type_traits/unwrap_ref.h"
+}
+module std_private_type_traits_void_t [system] {
+  export_as std
+  header "__type_traits/void_t.h"
+}
 
-module std_private_utility_as_const               [system] { header "__utility/as_const.h" }
-module std_private_utility_as_lvalue              [system] { header "__utility/as_lvalue.h" }
-module std_private_utility_auto_cast              [system] {
+module std_private_utility_as_const [system] {
+  export_as std
+  header "__utility/as_const.h"
+}
+module std_private_utility_as_lvalue [system] {
+  export_as std
+  header "__utility/as_lvalue.h"
+}
+module std_private_utility_auto_cast [system] {
+  export_as std
   header "__utility/auto_cast.h"
   export std_private_type_traits_decay
 }
-module std_private_utility_cmp                    [system] {
+module std_private_utility_cmp [system] {
+  export_as std
   header "__utility/cmp.h"
   export std_private_type_traits_make_unsigned
 }
-module std_private_utility_convert_to_integral    [system] { header "__utility/convert_to_integral.h" }
-module std_private_utility_declval                [system] { header "__utility/declval.h" }
-module std_private_utility_empty                  [system] { header "__utility/empty.h" }
-module std_private_utility_exception_guard        [system] { header "__utility/exception_guard.h" }
-module std_private_utility_exchange               [system] { header "__utility/exchange.h" }
-module std_private_utility_forward                [system] { header "__utility/forward.h" }
-module std_private_utility_forward_like           [system] { header "__utility/forward_like.h" }
-module std_private_utility_in_place               [system] { header "__utility/in_place.h" }
-module std_private_utility_integer_sequence       [system] { header "__utility/integer_sequence.h" }
-module std_private_utility_is_pointer_in_range    [system] { header "__utility/is_pointer_in_range.h" }
-module std_private_utility_move                   [system] {
+module std_private_utility_convert_to_integral [system] {
+  export_as std
+  header "__utility/convert_to_integral.h"
+}
+module std_private_utility_declval [system] {
+  export_as std
+  header "__utility/declval.h"
+}
+module std_private_utility_empty [system] {
+  export_as std
+  header "__utility/empty.h"
+}
+module std_private_utility_exception_guard [system] {
+  export_as std
+  header "__utility/exception_guard.h"
+}
+module std_private_utility_exchange [system] {
+  export_as std
+  header "__utility/exchange.h"
+}
+module std_private_utility_forward [system] {
+  export_as std
+  header "__utility/forward.h"
+}
+module std_private_utility_forward_like [system] {
+  export_as std
+  header "__utility/forward_like.h"
+}
+module std_private_utility_in_place [system] {
+  export_as std
+  header "__utility/in_place.h"
+}
+module std_private_utility_integer_sequence [system] {
+  export_as std
+  header "__utility/integer_sequence.h"
+}
+module std_private_utility_is_pointer_in_range [system] {
+  export_as std
+  header "__utility/is_pointer_in_range.h"
+}
+module std_private_utility_move [system] {
+  export_as std
   header "__utility/move.h"
   export std_private_type_traits_is_copy_constructible
   export std_private_type_traits_is_nothrow_move_constructible
   export std_private_type_traits_remove_reference
 }
-module std_private_utility_no_destroy             [system] { header "__utility/no_destroy.h" }
-module std_private_utility_pair                   [system] {
+module std_private_utility_no_destroy [system] {
+  export_as std
+  header "__utility/no_destroy.h"
+}
+module std_private_utility_pair [system] {
+  export_as std
   header "__utility/pair.h"
   export std_private_ranges_subrange_fwd
   export std_private_tuple_pair_like
@@ -2059,16 +4331,41 @@ module std_private_utility_pair                   [system] {
   export std_private_type_traits_is_nothrow_move_assignable
   export std_private_utility_pair_fwd
 }
-module std_private_utility_pair_fwd               [system] { header "__fwd/pair.h" }
-module std_private_utility_piecewise_construct    [system] { header "__utility/piecewise_construct.h" }
-module std_private_utility_priority_tag           [system] { header "__utility/priority_tag.h" }
-module std_private_utility_rel_ops                [system] { header "__utility/rel_ops.h" }
-module std_private_utility_small_buffer           [system] { header "__utility/small_buffer.h" }
-module std_private_utility_swap                   [system] {
+module std_private_utility_pair_fwd [system] {
+  export_as std
+  header "__fwd/pair.h"
+}
+module std_private_utility_piecewise_construct [system] {
+  export_as std
+  header "__utility/piecewise_construct.h"
+}
+module std_private_utility_priority_tag [system] {
+  export_as std
+  header "__utility/priority_tag.h"
+}
+module std_private_utility_rel_ops [system] {
+  export_as std
+  header "__utility/rel_ops.h"
+}
+module std_private_utility_small_buffer [system] {
+  export_as std
+  header "__utility/small_buffer.h"
+}
+module std_private_utility_swap [system] {
+  export_as std
   header "__utility/swap.h"
   export std_private_type_traits_is_swappable
 }
-module std_private_utility_to_underlying          [system] { header "__utility/to_underlying.h" }
-module std_private_utility_unreachable            [system] { header "__utility/unreachable.h" }
+module std_private_utility_to_underlying [system] {
+  export_as std
+  header "__utility/to_underlying.h"
+}
+module std_private_utility_unreachable [system] {
+  export_as std
+  header "__utility/unreachable.h"
+}
 
-module std_private_variant_monostate [system] { header "__variant/monostate.h" }
+module std_private_variant_monostate [system] {
+  export_as std
+  header "__variant/monostate.h"
+}


### PR DESCRIPTION
Swift's C++ interoperability relies on the types all being in the `std` module. The libc++ headers can't actually go into one giant module due to module cycles with the clang and OS C standard library modules, but they can be "moved" to `std` via `export_as`.