### PR TITLE
[RISCV] Remove mfd and mpd CSR names for SiFive.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -332,8 +332,6 @@ def : SiFiveReg<"mnepc", 0x351>;
 def : SiFiveReg<"mncause", 0x352>;
 def : SiFiveReg<"mnstatus", 0x353>;
 def : SiFiveReg<"mbpm", 0x7C0>;
-def : SiFiveReg<"mfd", 0x7C1>;
-def : SiFiveReg<"mpd", 0x7C8>;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
These names do not appear in the spec that was referenced for their addition. They appear to have been made up for LLVM.

These also don't belong to Xsfcie which is not an official SiFive extension name and appears to have been made up for LLVM too.

I made a big mistake in approving the original patches.

There are no official names defined currently. I'm willing to help get names defined, but only if the names are really needed.