### PR TITLE
[flang][driver] Don't use -whole-archive on Darwin

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1143,6 +1143,7 @@ void tools::addFortranRuntimeLibs(const ToolChain &TC, const ArgList &Args,
         }
       }
 
+      // TODO: Find an equivalent of `--whole-archive` for Darwin.
       if (!WholeArchiveActive && !TC.getTriple().isMacOSX()) {
         CmdArgs.push_back("--whole-archive");
         CmdArgs.push_back("-lFortran_main");

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1132,24 +1132,29 @@ void tools::addFortranRuntimeLibs(const ToolChain &TC, const ArgList &Args,
       // --whole-archive flag to the link line.  If it's not, add a proper
       // --whole-archive/--no-whole-archive bracket to the link line.
       bool WholeArchiveActive = false;
-      for (auto *Arg : Args.filtered(options::OPT_Wl_COMMA))
-        if (Arg)
+      for (auto *Arg : Args.filtered(options::OPT_Wl_COMMA)) {
+        if (Arg) {
           for (StringRef ArgValue : Arg->getValues()) {
             if (ArgValue == "--whole-archive")
               WholeArchiveActive = true;
             if (ArgValue == "--no-whole-archive")
               WholeArchiveActive = false;
           }
+        }
+      }
 
-      if (!WholeArchiveActive)
+      if (!WholeArchiveActive && !TC.getTriple().isMacOSX()) {
         CmdArgs.push_back("--whole-archive");
-      CmdArgs.push_back("-lFortran_main");
-      if (!WholeArchiveActive)
+        CmdArgs.push_back("-lFortran_main");
         CmdArgs.push_back("--no-whole-archive");
+      } else {
+        CmdArgs.push_back("-lFortran_main");
+      }
+
+      // Perform regular linkage of the remaining runtime libraries.
+      CmdArgs.push_back("-lFortranRuntime");
+      CmdArgs.push_back("-lFortranDecimal");
     }
-    // Perform regular linkage of the remaining runtime libraries.
-    CmdArgs.push_back("-lFortranRuntime");
-    CmdArgs.push_back("-lFortranDecimal");
   } else {
     if (LinkFortranMain) {
       unsigned RTOptionID = options::OPT__SLASH_MT;

--- a/flang/test/Driver/no-duplicate-main.f90
+++ b/flang/test/Driver/no-duplicate-main.f90
@@ -1,4 +1,4 @@
-! UNSUPPORTED: system-windows
+! UNSUPPORTED: system-windows, system-darwin
 
 ! RUN: %flang -x ir -o %t.c-object -c %S/Inputs/no_duplicate_main.ll
 ! RUN: %flang -o %t -c %s


### PR DESCRIPTION
Direct follow-up of #73124 - the linker on Darwin does not support
`-whole-archive`, so that needs to be removed from the linker
invocation.

For context:
  * https://github.com/llvm/llvm-project/pull/73124
