### PR TITLE
[LLD][COFF] Fix ARM64 EC chunks comparator

### DIFF
--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1480,7 +1480,8 @@ void Writer::sortECChunks() {
       llvm::stable_sort(sec->chunks, [=](const Chunk *a, const Chunk *b) {
         std::optional<chpe_range_type> aType = a->getArm64ECRangeType(),
                                        bType = b->getArm64ECRangeType();
-        return !aType || (bType && *aType < *bType);
+        return (!aType ? 0 : (unsigned)*aType + 1) <
+               (!bType ? 0 : (unsigned)*bType + 1);
       });
   }
 }


### PR DESCRIPTION
Fix string weak ordering relationship. Since we were only testing `!aType` before, `comp(a, b)` and `comp(b, a)` would both return `true` if both values were `nullopt`

This has been found by the Debug MS-STL.