### PR TITLE
[libc] [startup] add cmake function to merge separated crt1 objects

### DIFF
--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -6,6 +6,7 @@
 # A crt object has arch-specific code and arch-agnostic code. To reduce code
 # duplication, the implementation is split into multiple units. As a result,
 # we need to merge them into a single relocatable object.
+# See also:  https://maskray.me/blog/2022-11-21-relocatable-linking
 function(merge_relocatable_object name)
   set(obj_list "")
   set(fq_link_libraries "")
@@ -24,7 +25,7 @@ function(merge_relocatable_object name)
     ${obj_list}
   )
   # Pass -r to the driver is much cleaner than passing -Wl,-r: the compiler knows it is
-  # a relocatable linking and will not passing other irrelevant flags to the linker.
+  # a relocatable linking and will not pass other irrelevant flags to the linker.
   target_link_options(${relocatable_target} PRIVATE -r)
   set_target_properties(
     ${relocatable_target}

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -4,7 +4,7 @@
 # executable or a shared library. It is an intermediate file format that can
 # be passed into the linker.
 # A crt object has arch-specific code and arch-agnostic code. To reduce code
-# cohesion, the implementation is splitted into multiple units. As a result,
+# duplication, the implementation is split into multiple units. As a result,
 # we need to merge them into a single relocatable object.
 function(merge_relocatable_object name)
   set(obj_list "")
@@ -18,25 +18,22 @@ function(merge_relocatable_object name)
   list(REMOVE_DUPLICATES obj_list)
   list(REMOVE_DUPLICATES fq_link_libraries)
   get_fq_target_name(${name} fq_name)
+  set(relocatable_target "${fq_name}.__relocatable__")
   add_executable(
-    ${fq_name}.relocatable
+    ${relocatable_target}
     ${obj_list}
   )
-  target_link_options(
-    ${fq_name}.relocatable
-    PRIVATE
-      -nostdlib
-      -ffreestanding
-      -no-pie
-      -nostartfiles
-      -Wl,-r)
+  # Pass -r to the driver is much cleaner than passing -Wl,-r: the compiler knows it is
+  # a relocatable linking and will not passing other irrelevant flags to the linker.
+  target_link_options(${relocatable_target} PRIVATE -r)
   set_target_properties(
-    ${fq_name}.relocatable
+    ${relocatable_target}
     PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       OUTPUT_NAME ${name}.o
   )
   add_library(${fq_name} OBJECT IMPORTED GLOBAL)
-  add_dependencies(${fq_name} ${fq_name}.relocatable)
+  add_dependencies(${fq_name} ${relocatable_target})
   target_link_libraries(${fq_name} INTERFACE ${fq_link_libraries})
   set_target_properties(
     ${fq_name} 
@@ -71,6 +68,13 @@ function(add_startup_object name)
       OUTPUT_NAME ${name}.o
   )
 endfunction()
+
+llvm_check_linker_flag(CXX "-r" LIBC_LINKER_SUPPORTS_RELOCATABLE)
+
+if(NOT LIBC_LINKER_SUPPORTS_RELOCATABLE)
+  message(STATUS "Skipping startup for target architecture ${LIBC_TARGET_ARCHITECTURE}: linker does not support -r")
+  return()
+endif()
 
 if(NOT (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE}))
   message(STATUS "Skipping startup for target architecture ${LIBC_TARGET_ARCHITECTURE}")

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -3,7 +3,7 @@
 # A relocatable object is an object file that is not fully linked into an
 # executable or a shared library. It is an intermediate file format that can
 # be passed into the linker.
-# A crt object have arch-specific code and arch-agnostic code. To reduce code
+# A crt object has arch-specific code and arch-agnostic code. To reduce code
 # cohesion, the implementation is splitted into multiple units. As a result,
 # we need to merge them into a single relocatable object.
 function(merge_relocatable_object name)

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -40,19 +40,14 @@ endfunction()
 function(add_startup_object name)
   cmake_parse_arguments(
     "ADD_STARTUP_OBJECT"
-    "ALIAS" # Option argument
+    "" # Option argument
     "SRC"   # Single value arguments
     "DEPENDS;COMPILE_OPTIONS" # Multi value arguments
     ${ARGN}
   )
 
   get_fq_target_name(${name} fq_target_name)
-  if(ADD_STARTUP_OBJECT_ALIAS)
-    get_fq_deps_list(fq_dep_list ${ADD_STARTUP_OBJECT_DEPENDS})
-    add_library(${fq_target_name} ALIAS ${fq_dep_list})
-    return()
-  endif()
-
+  
   add_object_library(
     ${name}
     SRCS ${ADD_STARTUP_OBJECT_SRC}

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -1,3 +1,42 @@
+# This function merges multiple objects into a single relocatable object
+#                     cc -r obj1.o obj2.o -o obj.o
+# A relocatable object is an object file that is not fully linked into an
+# executable or a shared library. It is an intermediate file format that can
+# be passed into the linker.
+# A crt object have arch-specific code and arch-agnostic code. To reduce code
+# cohesion, the implementation is splitted into multiple units. As a result,
+# we need to merge them into a single relocatable object.
+function(merge_relocatable_object name)
+  set(obj_list "")
+  set(fq_link_libraries "")
+  get_fq_deps_list(fq_dep_list ${ARGN})
+  foreach(target IN LISTS fq_dep_list)
+    list(APPEND obj_list "$<TARGET_OBJECTS:${target}>")
+    get_target_property(libs ${target} DEPS)
+    list(APPEND fq_link_libraries "${libs}")
+  endforeach()
+  get_fq_target_name(${name} fq_name)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
+    COMMAND ${CMAKE_CXX_COMPILER} -r ${obj_list} -o ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
+    DEPENDS ${obj_list}
+    COMMAND_EXPAND_LISTS
+  )
+  add_custom_target(${fq_name}.relocatable DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${name}.o)
+  add_library(${fq_name} OBJECT IMPORTED GLOBAL)
+  add_dependencies(${fq_name} ${fq_name}.relocatable)
+  target_link_libraries(${fq_name} INTERFACE ${fq_link_libraries})
+  set_target_properties(
+    ${fq_name} 
+    PROPERTIES
+      LINKER_LANGUAGE CXX
+      OBJECT_FILES ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
+      IMPORTED_OBJECTS ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
+      TARGET_TYPE ${OBJECT_LIBRARY_TARGET_TYPE}
+      DEPS "${fq_link_libraries}"
+  ) 
+endfunction()
+
 function(add_startup_object name)
   cmake_parse_arguments(
     "ADD_STARTUP_OBJECT"
@@ -34,11 +73,10 @@ endif()
 
 add_subdirectory(${LIBC_TARGET_ARCHITECTURE})
 
-add_startup_object(
+# TODO: factor out crt1 into multiple objects
+merge_relocatable_object(
   crt1
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_ARCHITECTURE}.crt1
+  .${LIBC_TARGET_ARCHITECTURE}.crt1
 )
 
 add_startup_object(

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -70,7 +70,7 @@ function(add_startup_object name)
   )
 endfunction()
 
-llvm_check_linker_flag(CXX "-r" LIBC_LINKER_SUPPORTS_RELOCATABLE)
+check_cxx_compiler_flag("-r" LIBC_LINKER_SUPPORTS_RELOCATABLE)
 
 if(NOT LIBC_LINKER_SUPPORTS_RELOCATABLE)
   message(STATUS "Skipping startup for target architecture ${LIBC_TARGET_ARCHITECTURE}: linker does not support -r")

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -15,14 +15,26 @@ function(merge_relocatable_object name)
     get_target_property(libs ${target} DEPS)
     list(APPEND fq_link_libraries "${libs}")
   endforeach()
+  list(REMOVE_DUPLICATES obj_list)
+  list(REMOVE_DUPLICATES fq_link_libraries)
   get_fq_target_name(${name} fq_name)
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
-    COMMAND ${CMAKE_CXX_COMPILER} -r ${obj_list} -o ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
-    DEPENDS ${obj_list}
-    COMMAND_EXPAND_LISTS
+  add_executable(
+    ${fq_name}.relocatable
+    ${obj_list}
   )
-  add_custom_target(${fq_name}.relocatable DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${name}.o)
+  target_link_options(
+    ${fq_name}.relocatable
+    PRIVATE
+      -nostdlib
+      -ffreestanding
+      -no-pie
+      -nostartfiles
+      -Wl,-r)
+  set_target_properties(
+    ${fq_name}.relocatable
+    PROPERTIES
+      OUTPUT_NAME ${name}.o
+  )
   add_library(${fq_name} OBJECT IMPORTED GLOBAL)
   add_dependencies(${fq_name} ${fq_name}.relocatable)
   target_link_libraries(${fq_name} INTERFACE ${fq_link_libraries})
@@ -30,7 +42,6 @@ function(merge_relocatable_object name)
     ${fq_name} 
     PROPERTIES
       LINKER_LANGUAGE CXX
-      OBJECT_FILES ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
       IMPORTED_OBJECTS ${CMAKE_CURRENT_BINARY_DIR}/${name}.o
       TARGET_TYPE ${OBJECT_LIBRARY_TARGET_TYPE}
       DEPS "${fq_link_libraries}"


### PR DESCRIPTION
As part of startup refactoring, this patch adds a function to merge multiple objects into a single relocatable object:
                     cc -r obj1.o obj2.o -o obj.o

A relocatable object is an object file that is not fully linked into an executable or a shared library. It is an intermediate file format that can be passed into the linker.

A crt object can have arch-specific code and arch-agnostic code. To reduce code cohesion, the implementation is splitted into multiple units. As a result, we need to merge them into a single relocatable object.