### PR TITLE
[llvm][cmake] Use $<CONFIG> instead of ${CMAKE_CFG_INTDIR} for llvm-config

### DIFF
--- a/llvm/tools/llvm-config/CMakeLists.txt
+++ b/llvm/tools/llvm-config/CMakeLists.txt
@@ -80,7 +80,7 @@ llvm_expand_pseudo_components(LLVM_DYLIB_COMPONENTS_expanded "${LLVM_DYLIB_COMPO
 configure_file(${BUILDVARIABLES_SRCPATH} ${BUILDVARIABLES_OBJPATH} @ONLY)
 
 # Set build-time environment(s).
-add_compile_definitions(CMAKE_CFG_INTDIR="${CMAKE_CFG_INTDIR}")
+add_compile_definitions(CMAKE_CFG_INTDIR="$<CONFIG>")
 
 if(LLVM_ENABLE_MODULES)
   target_compile_options(llvm-config PUBLIC


### PR DESCRIPTION
${CMAKE_CFG_INTDIR} does not work correctly for llvm-config when building with the Ninja Multi-Config generator. It tries to find files in the ${CONFIGURATION} directory. Using the $<CONFIG> generator expression instead fixes this.

Really this needs to be done everywhere as ${CMAKE_CFG_INTDIR} is deprecated as of 3.21 (LLVM's current min version is 3.20), but this is sufficient to get `check-llvm` to pass.

See https://cmake.org/cmake/help/latest/variable/CMAKE_CFG_INTDIR.html