### PR TITLE
[LLVM][Support] Fixed the compile error caused by #73603

### DIFF
--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -1036,8 +1036,7 @@ Expected<ListeningSocket> ListeningSocket::createUnix(StringRef SocketPath,
 #else
   UnixSocket = MaybeWinsocket;
 #endif // _WIN32
-  ListeningSocket ListenSocket(UnixSocket, SocketPath);
-  return ListenSocket;
+  return ListeningSocket{UnixSocket, SocketPath};
 }
 
 Expected<std::unique_ptr<raw_socket_stream>> ListeningSocket::accept() {


### PR DESCRIPTION
This patch fixed the following compile error caused by #73603.

```
llvm/lib/Support/raw_ostream.cpp: In static member function ‘static llvm::Expected<llvm::ListeningSocket> llvm::ListeningSocket::createUnix(llvm::StringRef, int)’:
llvm/lib/Support/raw_ostream.cpp:1040:10: error: could not convert ‘ListenSocket’ from ‘llvm::ListeningSocket’ to ‘llvm::Expected<llvm::ListeningSocket>’
   return ListenSocket;
          ^~~~~~~~~~~~
```
