### PR TITLE
[OpenMP] Fix compile error caused by #74397

### DIFF
--- a/openmp/libomptarget/src/PluginManager.cpp
+++ b/openmp/libomptarget/src/PluginManager.cpp
@@ -47,7 +47,7 @@ PluginAdaptorTy::create(const std::string &Name) {
       new PluginAdaptorTy(Name, std::move(LibraryHandler)));
   if (auto Err = PluginAdaptor->init())
     return Err;
-  return PluginAdaptor;
+  return std::move(PluginAdaptor);
 }
 
 PluginAdaptorTy::PluginAdaptorTy(const std::string &Name,


### PR DESCRIPTION
This patch fixed the following compile error caused by #74397.

```
openmp/libomptarget/src/PluginManager.cpp: In static member function ‘static llvm::Expected<std::unique_ptr<PluginAdaptorTy> >
PluginAdaptorTy::create(const string&)’:
openmp/libomptarget/src/PluginManager.cpp:50:10: error: could not convert ‘PluginAdaptor’ from ‘std::unique_ptr<PluginAdaptorTy
>’ to ‘llvm::Expected<std::unique_ptr<PluginAdaptorTy> >’
   return PluginAdaptor;                                                                                                                                                                    ^~~~~~~~~~~~~
```
