### PR TITLE
[Clang][CodeGen] Fix crash when using bool vector in compound assignment

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -2085,10 +2085,15 @@ RValue CodeGenFunction::EmitLoadOfLValue(LValue LV, SourceLocation Loc) {
   }
 
   if (LV.isVectorElt()) {
-    llvm::LoadInst *Load = Builder.CreateLoad(LV.getVectorAddress(),
-                                              LV.isVolatileQualified());
-    return RValue::get(Builder.CreateExtractElement(Load, LV.getVectorIdx(),
-                                                    "vecext"));
+    llvm::Value *Load = nullptr;
+    if (LV.getType()->isExtVectorBoolType())
+      Load = EmitLoadOfScalar(LV.getVectorAddress(), LV.isVolatileQualified(),
+                              LV.getType(), Loc);
+    else
+      Load =
+          Builder.CreateLoad(LV.getVectorAddress(), LV.isVolatileQualified());
+    return RValue::get(
+        Builder.CreateExtractElement(Load, LV.getVectorIdx(), "vecext"));
   }
 
   // If this is a reference to a subset of the elements of a vector, either

--- a/clang/test/CodeGen/gh72468.c
+++ b/clang/test/CodeGen/gh72468.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -S -emit-llvm -o - %s
+
+typedef __attribute__((__ext_vector_type__(4))) _Bool BoolVector;
+
+BoolVector vec;
+
+void f(int i, int j) {
+  vec[i] |= vec[j];
+}

--- a/clang/test/SemaCXX/vector-bool.cpp
+++ b/clang/test/SemaCXX/vector-bool.cpp
@@ -38,10 +38,10 @@ void Operations() {
   // (void)(eight_bools > other_eight_bools);
   // (void)(eight_bools >= other_eight_bools);
 
-  // // Legal assignments
-  // (void)(eight_bools |= other_eight_bools);
-  // (void)(eight_bools &= other_eight_bools);
-  // (void)(eight_bools ^= other_eight_bools);
+  // Legal assignments
+  (void)(eight_bools |= other_eight_bools);
+  (void)(eight_bools &= other_eight_bools);
+  (void)(eight_bools ^= other_eight_bools);
 
   // Illegal operators
   (void)(eight_bools || other_eight_bools); // expected-error@47 {{invalid operands to binary expression ('EightBools' (vector of 8 'bool' values) and 'EightBools')}}


### PR DESCRIPTION
Fixes: #72468.
The left side bool vector`vec[i]` did not perform a specific conversion(`CodeGenFunction::emitBoolVecConversion`) in compound assignment.