### PR TITLE
[libc][NFC] Remove MantissaWidth traits

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -20,10 +20,6 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
-template <typename T> struct MantissaWidth {
-  static constexpr unsigned VALUE = FloatProperties<T>::MANTISSA_WIDTH;
-};
-
 // A generic class to represent single precision, double precision, and quad
 // precision IEEE 754 floating point formats.
 // On most platforms, the 'float' type corresponds to single precision floating

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -124,7 +124,7 @@ LIBC_INLINE T hypot(T x, T y) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if ((exp_diff >= MantissaWidth<T>::VALUE + 2) || (x == 0) || (y == 0)) {
+  if ((exp_diff >= FPBits_t::MANTISSA_WIDTH + 2) || (x == 0) || (y == 0)) {
     return abs(x) + abs(y);
   }
 
@@ -148,7 +148,7 @@ LIBC_INLINE T hypot(T x, T y) {
   out_exp = a_exp;
 
   // Add an extra bit to simplify the final rounding bit computation.
-  constexpr UIntType ONE = UIntType(1) << (MantissaWidth<T>::VALUE + 1);
+  constexpr UIntType ONE = UIntType(1) << (FPBits_t::MANTISSA_WIDTH + 1);
 
   a_mant <<= 1;
   b_mant <<= 1;
@@ -158,7 +158,7 @@ LIBC_INLINE T hypot(T x, T y) {
   if (a_exp != 0) {
     leading_one = ONE;
     a_mant |= ONE;
-    y_mant_width = MantissaWidth<T>::VALUE + 1;
+    y_mant_width = FPBits_t::MANTISSA_WIDTH + 1;
   } else {
     leading_one = internal::find_leading_one(a_mant, y_mant_width);
     a_exp = 1;
@@ -258,7 +258,7 @@ LIBC_INLINE T hypot(T x, T y) {
     }
   }
 
-  y_new |= static_cast<UIntType>(out_exp) << MantissaWidth<T>::VALUE;
+  y_new |= static_cast<UIntType>(out_exp) << FPBits_t::MANTISSA_WIDTH;
   return cpp::bit_cast<T>(y_new);
 }
 

--- a/libc/src/__support/FPUtil/ManipulationFunctions.h
+++ b/libc/src/__support/FPUtil/ManipulationFunctions.h
@@ -130,7 +130,7 @@ LIBC_INLINE T ldexp(T x, int exp) {
   // early. Because the result of the ldexp operation can be a subnormal number,
   // we need to accommodate the (mantissaWidht + 1) worth of shift in
   // calculating the limit.
-  int exp_limit = FPBits<T>::MAX_EXPONENT + MantissaWidth<T>::VALUE + 1;
+  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::MANTISSA_WIDTH + 1;
   if (exp > exp_limit)
     return bits.get_sign() ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
 

--- a/libc/src/__support/FPUtil/NearestIntegerOperations.h
+++ b/libc/src/__support/FPUtil/NearestIntegerOperations.h
@@ -36,7 +36,7 @@ LIBC_INLINE T trunc(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(MantissaWidth<T>::VALUE))
+  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
     return x;
 
   // If the exponent is such that abs(x) is less than 1, then return 0.
@@ -47,7 +47,7 @@ LIBC_INLINE T trunc(T x) {
       return T(0.0);
   }
 
-  int trim_size = MantissaWidth<T>::VALUE - exponent;
+  int trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   return T(bits);
 }
@@ -65,7 +65,7 @@ LIBC_INLINE T ceil(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(MantissaWidth<T>::VALUE))
+  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
     return x;
 
   if (exponent <= -1) {
@@ -75,7 +75,7 @@ LIBC_INLINE T ceil(T x) {
       return T(1.0);
   }
 
-  uint32_t trim_size = MantissaWidth<T>::VALUE - exponent;
+  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(bits);
 
@@ -114,7 +114,7 @@ LIBC_INLINE T round(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(MantissaWidth<T>::VALUE))
+  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
     return x;
 
   if (exponent == -1) {
@@ -133,7 +133,7 @@ LIBC_INLINE T round(T x) {
       return T(0.0);
   }
 
-  uint32_t trim_size = MantissaWidth<T>::VALUE - exponent;
+  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
   bool half_bit_set =
       bool(bits.get_mantissa() & (UIntType(1) << (trim_size - 1)));
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
@@ -167,7 +167,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(MantissaWidth<T>::VALUE))
+  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
     return x;
 
   if (exponent <= -1) {
@@ -188,7 +188,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
     }
   }
 
-  uint32_t trim_size = MantissaWidth<T>::VALUE - exponent;
+  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
   FPBits<T> new_bits = bits;
   new_bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(new_bits);

--- a/libc/src/__support/FPUtil/NormalFloat.h
+++ b/libc/src/__support/FPUtil/NormalFloat.h
@@ -32,7 +32,7 @@ template <typename T> struct NormalFloat {
       "NormalFloat template parameter has to be a floating point type.");
 
   using UIntType = typename FPBits<T>::UIntType;
-  static constexpr UIntType ONE = (UIntType(1) << MantissaWidth<T>::VALUE);
+  static constexpr UIntType ONE = (UIntType(1) << FPBits<T>::MANTISSA_WIDTH);
 
   // Unbiased exponent value.
   int32_t exponent;
@@ -40,7 +40,7 @@ template <typename T> struct NormalFloat {
   UIntType mantissa;
   // We want |UIntType| to have atleast one bit more than the actual mantissa
   // bit width to accommodate the implicit 1 value.
-  static_assert(sizeof(UIntType) * 8 >= MantissaWidth<T>::VALUE + 1,
+  static_assert(sizeof(UIntType) * 8 >= FPBits<T>::MANTISSA_WIDTH + 1,
                 "Bad type for mantissa in NormalFloat.");
 
   bool sign;
@@ -105,7 +105,7 @@ template <typename T> struct NormalFloat {
       unsigned shift = SUBNORMAL_EXPONENT - exponent;
       // Since exponent > subnormalExponent, shift is strictly greater than
       // zero.
-      if (shift <= MantissaWidth<T>::VALUE + 1) {
+      if (shift <= FPBits<T>::MANTISSA_WIDTH + 1) {
         // Generate a subnormal number. Might lead to loss of precision.
         // We round to nearest and round halfway cases to even.
         const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
@@ -163,7 +163,7 @@ private:
 
   LIBC_INLINE unsigned evaluate_normalization_shift(UIntType m) {
     unsigned shift = 0;
-    for (; (ONE & m) == 0 && (shift < MantissaWidth<T>::VALUE);
+    for (; (ONE & m) == 0 && (shift < FPBits<T>::MANTISSA_WIDTH);
          m <<= 1, ++shift)
       ;
     return shift;
@@ -222,7 +222,7 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
   constexpr int SUBNORMAL_EXPONENT = -LDBits::EXPONENT_BIAS + 1;
   if (exponent < SUBNORMAL_EXPONENT) {
     unsigned shift = SUBNORMAL_EXPONENT - exponent;
-    if (shift <= MantissaWidth<long double>::VALUE + 1) {
+    if (shift <= LDBits::MANTISSA_WIDTH + 1) {
       // Generate a subnormal number. Might lead to loss of precision.
       // We round to nearest and round halfway cases to even.
       const UIntType shift_out_mask = (UIntType(1) << shift) - 1;

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -159,11 +159,10 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
 
   UInt128 prod_mant = x_mant * y_mant << 10;
   int prod_lsb_exp =
-      x_exp + y_exp -
-      (FPBits::EXPONENT_BIAS + 2 * MantissaWidth<double>::VALUE + 10);
+      x_exp + y_exp - (FPBits::EXPONENT_BIAS + 2 * FPBits::MANTISSA_WIDTH + 10);
 
   z_mant <<= 64;
-  int z_lsb_exp = z_exp - (MantissaWidth<double>::VALUE + 64);
+  int z_lsb_exp = z_exp - (FPBits::MANTISSA_WIDTH + 64);
   bool round_bit = false;
   bool sticky_bits = false;
   bool z_shifted = false;

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -37,7 +37,7 @@ template <typename T>
 LIBC_INLINE void normalize(int &exponent,
                            typename FPBits<T>::UIntType &mantissa) {
   const int shift = cpp::countl_zero(mantissa) -
-                    (8 * sizeof(mantissa) - 1 - MantissaWidth<T>::VALUE);
+                    (8 * sizeof(mantissa) - 1 - FPBits<T>::MANTISSA_WIDTH);
   exponent -= shift;
   mantissa <<= shift;
 }
@@ -72,7 +72,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
   } else {
     // IEEE floating points formats.
     using UIntType = typename FPBits<T>::UIntType;
-    constexpr UIntType ONE = UIntType(1) << MantissaWidth<T>::VALUE;
+    constexpr UIntType ONE = UIntType(1) << FPBits<T>::MANTISSA_WIDTH;
 
     FPBits<T> bits(x);
 
@@ -147,7 +147,8 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       // Remove hidden bit and append the exponent field.
       x_exp = ((x_exp >> 1) + FPBits<T>::EXPONENT_BIAS);
 
-      y = (y - ONE) | (static_cast<UIntType>(x_exp) << MantissaWidth<T>::VALUE);
+      y = (y - ONE) |
+          (static_cast<UIntType>(x_exp) << FPBits<T>::MANTISSA_WIDTH);
 
       switch (quick_get_round()) {
       case FE_TONEAREST:

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -41,13 +41,11 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   static constexpr int MAX_EXPONENT = 0x7FFF;
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
-  static constexpr UIntType MAX_SUBNORMAL =
-      (UIntType(1) << (MantissaWidth<long double>::VALUE)) - 1;
-  static constexpr UIntType MIN_NORMAL =
-      (UIntType(3) << MantissaWidth<long double>::VALUE);
+  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << MANTISSA_WIDTH) - 1;
+  static constexpr UIntType MIN_NORMAL = (UIntType(3) << MANTISSA_WIDTH);
   static constexpr UIntType MAX_NORMAL =
-      (UIntType(MAX_EXPONENT - 1) << (MantissaWidth<long double>::VALUE + 1)) |
-      (UIntType(1) << MantissaWidth<long double>::VALUE) | MAX_SUBNORMAL;
+      (UIntType(MAX_EXPONENT - 1) << (MANTISSA_WIDTH + 1)) |
+      (UIntType(1) << MANTISSA_WIDTH) | MAX_SUBNORMAL;
 
   UIntType bits;
 

--- a/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
+++ b/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
@@ -46,7 +46,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
   using UIntType = FPBits::UIntType;
   constexpr UIntType SIGN_VAL = (UIntType(1) << 79);
   constexpr UIntType MANTISSA_MASK =
-      (UIntType(1) << MantissaWidth<long double>::VALUE) - 1;
+      (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1;
   UIntType int_val = from_bits.uintval();
   if (from < 0.0l) {
     if (from > to) {
@@ -117,8 +117,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     }
   }
 
-  UIntType implicit_bit =
-      int_val & (UIntType(1) << MantissaWidth<long double>::VALUE);
+  UIntType implicit_bit = int_val & (UIntType(1) << FPBits::MANTISSA_WIDTH);
   if (implicit_bit == UIntType(0))
     raise_except_if_required(FE_UNDERFLOW | FE_INEXACT);
 

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -416,7 +416,7 @@ class FloatToString {
   int exponent;
   FloatProp::UIntType mantissa;
 
-  static constexpr int MANT_WIDTH = fputil::MantissaWidth<T>::VALUE;
+  static constexpr int MANT_WIDTH = fputil::FPBits<T>::MANTISSA_WIDTH;
   static constexpr int EXP_BIAS = fputil::FPBits<T>::EXPONENT_BIAS;
 
 public:

--- a/libc/src/math/generic/asinf.cpp
+++ b/libc/src/math/generic/asinf.cpp
@@ -108,8 +108,7 @@ LLVM_LIBC_FUNCTION(float, asinf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return x +
-           FPBits::build_nan(1 << (fputil::MantissaWidth<float>::VALUE - 1));
+    return x + FPBits::build_nan(1 << (FPBits::MANTISSA_WIDTH - 1));
   }
 
   // Check for exceptional values

--- a/libc/src/math/generic/hypotf.cpp
+++ b/libc/src/math/generic/hypotf.cpp
@@ -23,7 +23,7 @@ LLVM_LIBC_FUNCTION(float, hypotf, (float x, float y)) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if (exp_diff >= fputil::MantissaWidth<float>::VALUE + 2) {
+  if (exp_diff >= FPBits::MANTISSA_WIDTH + 2) {
     return fputil::abs(x) + fputil::abs(y);
   }
 

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -57,7 +57,7 @@ LIBC_INLINE float log(double x) {
   // Get the 8 highest bits, use 7 bits (excluding the implicit hidden bit) for
   // lookup tables.
   int f_index = static_cast<int>(
-      xbits.get_mantissa() >> 45); // fputil::MantissaWidth<double>::VALUE - 7
+      xbits.get_mantissa() >> 45); // fputil::FPBits<double>::MANTISSA_WIDTH - 7
 
   // Set bits to 1.m
   xbits.set_biased_exponent(0x3FF);

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -56,8 +56,8 @@ LIBC_INLINE float log(double x) {
 
   // Get the 8 highest bits, use 7 bits (excluding the implicit hidden bit) for
   // lookup tables.
-  int f_index = static_cast<int>(
-      xbits.get_mantissa() >> 45); // fputil::FPBits<double>::MANTISSA_WIDTH - 7
+  int f_index = static_cast<int>(xbits.get_mantissa() >>
+                                 (fputil::FPBits<double>::MANTISSA_WIDTH - 7));
 
   // Set bits to 1.m
   xbits.set_biased_exponent(0x3FF);

--- a/libc/src/math/generic/sincosf.cpp
+++ b/libc/src/math/generic/sincosf.cpp
@@ -148,8 +148,7 @@ LLVM_LIBC_FUNCTION(void, sincosf, (float x, float *sinp, float *cosp)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    *sinp =
-        x + FPBits::build_nan(1 << (fputil::MantissaWidth<float>::VALUE - 1));
+    *sinp = x + FPBits::build_nan(1 << (FPBits::MANTISSA_WIDTH - 1));
     *cosp = *sinp;
     return;
   }

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -478,7 +478,7 @@ LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
   // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::MantissaWidth<T>::VALUE;
+  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
 
@@ -591,7 +591,7 @@ LIBC_INLINE int convert_float_dec_exp_typed(Writer *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
   // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::MantissaWidth<T>::VALUE;
+  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
   MantissaInt mantissa = float_bits.get_explicit_mantissa();
@@ -754,7 +754,7 @@ LIBC_INLINE int convert_float_dec_auto_typed(Writer *writer,
                                              const FormatSection &to_conv,
                                              fputil::FPBits<T> float_bits) {
   // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::MantissaWidth<T>::VALUE;
+  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
   MantissaInt mantissa = float_bits.get_explicit_mantissa();

--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -87,7 +87,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // for the extra implicit bit. We use the larger of the two possible values
   // since the size must be constant.
   constexpr size_t MANT_BUFF_LEN =
-      (fputil::MantissaWidth<long double>::VALUE / BITS_IN_HEX_DIGIT) + 1;
+      (LDBits::MANTISSA_WIDTH / BITS_IN_HEX_DIGIT) + 1;
   char mant_buffer[MANT_BUFF_LEN];
 
   size_t mant_len = (mantissa_width / BITS_IN_HEX_DIGIT) + 1;

--- a/libc/test/src/math/FrexpTest.h
+++ b/libc/test/src/math/FrexpTest.h
@@ -20,7 +20,7 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*FrexpFunc)(T, int *);

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -23,8 +23,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MANTISSA_WIDTH =
-      LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+  static constexpr UIntType MANTISSA_WIDTH = FPBits::MANTISSA_WIDTH;
   // A normalized mantissa to be used with tests.
   static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
 

--- a/libc/test/src/math/LogbTest.h
+++ b/libc/test/src/math/LogbTest.h
@@ -20,7 +20,7 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*LogbFunc)(T);

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -20,7 +20,6 @@
 template <typename T>
 class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using MantissaWidth = LIBC_NAMESPACE::fputil::MantissaWidth<T>;
   using UIntType = typename FPBits::UIntType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
@@ -165,7 +164,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
@@ -179,7 +178,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -32,11 +32,11 @@ private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<F>;
   using UIntType = typename FPBits::UIntType;
 
-  const F zero = F(LIBC_NAMESPACE::fputil::FPBits<F>::zero());
-  const F neg_zero = F(LIBC_NAMESPACE::fputil::FPBits<F>::neg_zero());
-  const F inf = F(LIBC_NAMESPACE::fputil::FPBits<F>::inf());
-  const F neg_inf = F(LIBC_NAMESPACE::fputil::FPBits<F>::neg_inf());
-  const F nan = F(LIBC_NAMESPACE::fputil::FPBits<F>::build_quiet_nan(1));
+  const F zero = F(FPBits::zero());
+  const F neg_zero = F(FPBits::neg_zero());
+  const F inf = F(FPBits::inf());
+  const F neg_inf = F(FPBits::neg_inf());
+  const F nan = F(FPBits::build_quiet_nan(1));
   static constexpr I INTEGER_MIN = I(1) << (sizeof(I) * 8 - 1);
   static constexpr I INTEGER_MAX = -(INTEGER_MIN + 1);
 
@@ -192,8 +192,7 @@ public:
     FPBits bits(F(1.0));
     bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
     bits.set_sign(1);
-    bits.set_mantissa(UIntType(0x1)
-                      << (LIBC_NAMESPACE::fputil::MantissaWidth<F>::VALUE - 1));
+    bits.set_mantissa(UIntType(0x1) << (FPBits::MANTISSA_WIDTH - 1));
 
     F x = F(bits);
     if (TestModes) {

--- a/libc/test/src/math/SqrtTest.h
+++ b/libc/test/src/math/SqrtTest.h
@@ -20,7 +20,7 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*SqrtFunc)(T);

--- a/libc/test/src/math/smoke/FrexpTest.h
+++ b/libc/test/src/math/smoke/FrexpTest.h
@@ -17,7 +17,7 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*FrexpFunc)(T, int *);

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -23,8 +23,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MANTISSA_WIDTH =
-      LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+  static constexpr UIntType MANTISSA_WIDTH = FPBits::MANTISSA_WIDTH;
   // A normalized mantissa to be used with tests.
   static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
 

--- a/libc/test/src/math/smoke/LogbTest.h
+++ b/libc/test/src/math/smoke/LogbTest.h
@@ -17,7 +17,7 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*LogbFunc)(T);

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -31,7 +31,6 @@
 template <typename T>
 class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using MantissaWidth = LIBC_NAMESPACE::fputil::MantissaWidth<T>;
   using UIntType = typename FPBits::UIntType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
@@ -176,7 +175,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
@@ -190,7 +189,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -33,7 +33,6 @@ template <typename T>
 class NextTowardTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using ToFPBits = LIBC_NAMESPACE::fputil::FPBits<long double>;
-  using MantissaWidth = LIBC_NAMESPACE::fputil::MantissaWidth<T>;
   using UIntType = typename FPBits::UIntType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
@@ -190,7 +189,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, 33.0);
     result_bits = FPBits(result);
@@ -204,7 +203,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
     ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << MantissaWidth::VALUE) - 1);
+              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
 
     result = func(x, -33.0);
     result_bits = FPBits(result);

--- a/libc/test/src/math/smoke/SqrtTest.h
+++ b/libc/test/src/math/smoke/SqrtTest.h
@@ -17,7 +17,7 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::MantissaWidth<T>::VALUE;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
 
 public:
   typedef T (*SqrtFunc)(T);

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -468,7 +468,7 @@ public:
       mpfr_sub(inputMPFR.value, value, inputMPFR.value, MPFR_RNDN);
       mpfr_abs(inputMPFR.value, inputMPFR.value, MPFR_RNDN);
       mpfr_mul_2si(inputMPFR.value, inputMPFR.value,
-                   -thisExponent + int(fputil::MantissaWidth<T>::VALUE),
+                   -thisExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
                    MPFR_RNDN);
       return inputMPFR;
     }
@@ -496,12 +496,12 @@ public:
 
     mpfr_sub(minMPFR.value, pivot.value, minMPFR.value, MPFR_RNDN);
     mpfr_mul_2si(minMPFR.value, minMPFR.value,
-                 -minExponent + int(fputil::MantissaWidth<T>::VALUE),
+                 -minExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
                  MPFR_RNDN);
 
     mpfr_sub(maxMPFR.value, maxMPFR.value, pivot.value, MPFR_RNDN);
     mpfr_mul_2si(maxMPFR.value, maxMPFR.value,
-                 -maxExponent + int(fputil::MantissaWidth<T>::VALUE),
+                 -maxExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
                  MPFR_RNDN);
 
     mpfr_add(minMPFR.value, minMPFR.value, maxMPFR.value, MPFR_RNDN);


### PR DESCRIPTION
Same as #75362, the traits does not bring a lot of value over `FloatProperties::MANTISSA_WIDTH` (or `FPBits::MANTISSA_WIDTH`).
