### PR TITLE
[mlir][gpu] Fix crash in `gpu-module-to-binary`

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -101,6 +101,9 @@ LogicalResult moduleSerializer(GPUModuleOp op,
                                const TargetOptions &targetOptions) {
   OpBuilder builder(op->getContext());
   SmallVector<Attribute> objects;
+  // Fail if there are no target attributes
+  if (!op.getTargetsAttr())
+    return op.emitError("the module has no target attributes");
   // Serialize all targets.
   for (auto targetAttr : op.getTargetsAttr()) {
     assert(targetAttr && "Target attribute cannot be null.");

--- a/mlir/test/Dialect/GPU/module-to-binary-invalid.mlir
+++ b/mlir/test/Dialect/GPU/module-to-binary-invalid.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt %s --gpu-module-to-binary --verify-diagnostics
+
+module attributes {gpu.container_module} {
+  // expected-error @below {{the module has no target attributes}}
+  gpu.module @kernel_module1 {
+    llvm.func @kernel(%arg0: i32, %arg1: !llvm.ptr,
+        %arg2: !llvm.ptr, %arg3: i64, %arg4: i64,
+        %arg5: i64) attributes {gpu.kernel} {
+      llvm.return
+    }
+  }
+}


### PR DESCRIPTION
This patch fixes the error in issue #75434. The crash was being caused by not checking for a lack of target attributes in a GPU module. It's now considered an error to invoke the pass with a GPU module with no target attributes.