### PR TITLE
[Coverage] Fix CoverageMapping.cpp compilation on Solaris

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -281,7 +281,7 @@ public:
       : ExecutedTestVectorBitmap(Bitmap), Region(Region), Branches(Branches),
         NumConditions(Region.MCDCParams.NumConditions),
         Folded(NumConditions, false), IndependencePairs(NumConditions),
-        TestVectors(pow(2, NumConditions)) {}
+        TestVectors(pow(2.0, (double)NumConditions)) {}
 
 private:
   void recordTestVector(MCDCRecord::TestVector &TV,


### PR DESCRIPTION
8ecbb0404d740d1ab173554e47cef39cd5e3ef8c broke the Solaris build:

```
FAILED: lib/ProfileData/Coverage/CMakeFiles/LLVMCoverage.dir/CoverageMapping.cpp.o
[...]
/opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp:284:21: error: call to 'pow' is ambiguous
  284 |         TestVectors(pow(2, NumConditions)) {}
      |                     ^~~
/usr/include/iso/math_iso.h:64:15: note: candidate function
   64 | extern double pow __P((double, double));
      |               ^
/usr/include/iso/math_iso.h:141:16: note: candidate function
  141 |         inline double pow(double __X, int __Y) { return
      |                       ^
/usr/include/iso/math_iso.h:161:15: note: candidate function
  161 |         inline float pow(float __X, float __Y) { return __powf(__X, __Y); }
      |                      ^
/usr/include/iso/math_iso.h:163:16: note: candidate function
  163 |         inline double pow(float __X, int __Y) { return
      |                       ^
/usr/include/iso/math_iso.h:197:21: note: candidate function
  197 |         inline long double pow(long double __X, long double __Y) { return
      |                            ^
/usr/include/iso/math_iso.h:199:21: note: candidate function
  199 |         inline long double pow(long double __X, int __Y) { return
      |                            ^
```
Fixed by disambiguating the `pow` call.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.