### PR TITLE
[libc][NFC] Rename `MANTISSA_WIDTH` in `FRACTION_LEN`

### DIFF
--- a/libc/fuzzing/stdio/printf_float_conv_fuzz.cpp
+++ b/libc/fuzzing/stdio/printf_float_conv_fuzz.cpp
@@ -90,7 +90,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   int prec = 0;
   int width = 0;
 
-  LIBC_NAMESPACE::fputil::FPBits<double>::UIntType raw_num = 0;
+  LIBC_NAMESPACE::fputil::FPBits<double>::StorageType raw_num = 0;
 
   // Copy as many bytes of data as will fit into num, prec, and with. Any extras
   // are ignored.

--- a/libc/fuzzing/stdlib/strtofloat_fuzz.cpp
+++ b/libc/fuzzing/stdlib/strtofloat_fuzz.cpp
@@ -33,7 +33,7 @@ template <typename F> inline constexpr int effective_precision(int exponent) {
   // This is intended to be 0 when the exponent is the lowest normal and
   // increase as the exponent's magnitude increases.
   const int bits_below_normal =
-      (-exponent) - (FloatProperties<F>::EXPONENT_BIAS - 1);
+      (-exponent) - (FloatProperties<F>::EXP_BIAS - 1);
 
   // The precision should be the normal, full precision, minus the bits lost
   // by this being a subnormal, minus one for the implicit leading one.

--- a/libc/src/__support/FPUtil/DivisionAndRemainderOperations.h
+++ b/libc/src/__support/FPUtil/DivisionAndRemainderOperations.h
@@ -53,13 +53,13 @@ LIBC_INLINE T remquo(T x, T y, int &q) {
 
   NormalFloat<T> normalx(xbits), normaly(ybits);
   int exp = normalx.exponent - normaly.exponent;
-  typename NormalFloat<T>::UIntType mx = normalx.mantissa,
-                                    my = normaly.mantissa;
+  typename NormalFloat<T>::StorageType mx = normalx.mantissa,
+                                       my = normaly.mantissa;
 
   q = 0;
   while (exp >= 0) {
     unsigned shift_count = 0;
-    typename NormalFloat<T>::UIntType n = mx;
+    typename NormalFloat<T>::StorageType n = mx;
     for (shift_count = 0; n < my; n <<= 1, ++shift_count)
       ;
 

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -31,45 +31,45 @@ namespace fputil {
 template <typename T> struct FPBits : private FloatProperties<T> {
   static_assert(cpp::is_floating_point_v<T>,
                 "FPBits instantiated with invalid type.");
-  using typename FloatProperties<T>::UIntType;
-  using FloatProperties<T>::BIT_WIDTH;
+  using typename FloatProperties<T>::StorageType;
+  using FloatProperties<T>::TOTAL_LEN;
   using FloatProperties<T>::EXP_MANT_MASK;
-  using FloatProperties<T>::EXPONENT_MASK;
-  using FloatProperties<T>::EXPONENT_BIAS;
-  using FloatProperties<T>::EXPONENT_WIDTH;
+  using FloatProperties<T>::EXP_MASK;
+  using FloatProperties<T>::EXP_BIAS;
+  using FloatProperties<T>::EXP_LEN;
   using FloatProperties<T>::FRACTION_MASK;
-  using FloatProperties<T>::FRACTION_BITS;
+  using FloatProperties<T>::FRACTION_LEN;
   using FloatProperties<T>::QUIET_NAN_MASK;
   using FloatProperties<T>::SIGN_MASK;
 
   // Reinterpreting bits as an integer value and interpreting the bits of an
   // integer value as a floating point value is used in tests. So, a convenient
   // type is provided for such reinterpretations.
-  UIntType bits;
+  StorageType bits;
 
-  LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
+  LIBC_INLINE constexpr void set_mantissa(StorageType mantVal) {
     mantVal &= FRACTION_MASK;
     bits &= ~FRACTION_MASK;
     bits |= mantVal;
   }
 
-  LIBC_INLINE constexpr UIntType get_mantissa() const {
+  LIBC_INLINE constexpr StorageType get_mantissa() const {
     return bits & FRACTION_MASK;
   }
 
-  LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal = (expVal << FRACTION_BITS) & EXPONENT_MASK;
-    bits &= ~EXPONENT_MASK;
+  LIBC_INLINE constexpr void set_biased_exponent(StorageType expVal) {
+    expVal = (expVal << FRACTION_LEN) & EXP_MASK;
+    bits &= ~EXP_MASK;
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & EXPONENT_MASK) >> FRACTION_BITS);
+    return uint16_t((bits & EXP_MASK) >> FRACTION_LEN);
   }
 
   // The function return mantissa with the implicit bit set iff the current
   // value is a valid normal number.
-  LIBC_INLINE constexpr UIntType get_explicit_mantissa() {
+  LIBC_INLINE constexpr StorageType get_explicit_mantissa() {
     return ((get_biased_exponent() > 0 && !is_inf_or_nan())
                 ? (FRACTION_MASK + 1)
                 : 0) |
@@ -86,25 +86,25 @@ template <typename T> struct FPBits : private FloatProperties<T> {
     return (bits & SIGN_MASK) != 0;
   }
 
-  static_assert(sizeof(T) == sizeof(UIntType),
+  static_assert(sizeof(T) == sizeof(StorageType),
                 "Data type and integral representation have different sizes.");
 
-  static constexpr int MAX_EXPONENT = (1 << EXPONENT_WIDTH) - 1;
+  static constexpr int MAX_EXPONENT = (1 << EXP_LEN) - 1;
 
-  static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
-  static constexpr UIntType MAX_SUBNORMAL = FRACTION_MASK;
-  static constexpr UIntType MIN_NORMAL = (UIntType(1) << FRACTION_BITS);
-  static constexpr UIntType MAX_NORMAL =
-      ((UIntType(MAX_EXPONENT) - 1) << FRACTION_BITS) | MAX_SUBNORMAL;
+  static constexpr StorageType MIN_SUBNORMAL = StorageType(1);
+  static constexpr StorageType MAX_SUBNORMAL = FRACTION_MASK;
+  static constexpr StorageType MIN_NORMAL = (StorageType(1) << FRACTION_LEN);
+  static constexpr StorageType MAX_NORMAL =
+      ((StorageType(MAX_EXPONENT) - 1) << FRACTION_LEN) | MAX_SUBNORMAL;
 
   // We don't want accidental type promotions/conversions, so we require exact
   // type match.
   template <typename XType, cpp::enable_if_t<cpp::is_same_v<T, XType>, int> = 0>
   LIBC_INLINE constexpr explicit FPBits(XType x)
-      : bits(cpp::bit_cast<UIntType>(x)) {}
+      : bits(cpp::bit_cast<StorageType>(x)) {}
 
   template <typename XType,
-            cpp::enable_if_t<cpp::is_same_v<XType, UIntType>, int> = 0>
+            cpp::enable_if_t<cpp::is_same_v<XType, StorageType>, int> = 0>
   LIBC_INLINE constexpr explicit FPBits(XType x) : bits(x) {}
 
   LIBC_INLINE constexpr FPBits() : bits(0) {}
@@ -112,15 +112,15 @@ template <typename T> struct FPBits : private FloatProperties<T> {
   LIBC_INLINE constexpr T get_val() const { return cpp::bit_cast<T>(bits); }
 
   LIBC_INLINE constexpr void set_val(T value) {
-    bits = cpp::bit_cast<UIntType>(value);
+    bits = cpp::bit_cast<StorageType>(value);
   }
 
   LIBC_INLINE constexpr explicit operator T() const { return get_val(); }
 
-  LIBC_INLINE constexpr UIntType uintval() const { return bits; }
+  LIBC_INLINE constexpr StorageType uintval() const { return bits; }
 
   LIBC_INLINE constexpr int get_exponent() const {
-    return int(get_biased_exponent()) - EXPONENT_BIAS;
+    return int(get_biased_exponent()) - EXP_BIAS;
   }
 
   // If the number is subnormal, the exponent is treated as if it were the
@@ -134,9 +134,9 @@ template <typename T> struct FPBits : private FloatProperties<T> {
     if (is_zero()) {
       return 0;
     } else if (biased_exp == 0) {
-      return 1 - EXPONENT_BIAS;
+      return 1 - EXP_BIAS;
     } else {
-      return biased_exp - EXPONENT_BIAS;
+      return biased_exp - EXP_BIAS;
     }
   }
 
@@ -146,29 +146,29 @@ template <typename T> struct FPBits : private FloatProperties<T> {
   }
 
   LIBC_INLINE constexpr bool is_inf() const {
-    return (bits & EXP_MANT_MASK) == EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) == EXP_MASK;
   }
 
   LIBC_INLINE constexpr bool is_nan() const {
-    return (bits & EXP_MANT_MASK) > EXPONENT_MASK;
+    return (bits & EXP_MANT_MASK) > EXP_MASK;
   }
 
   LIBC_INLINE constexpr bool is_quiet_nan() const {
-    return (bits & EXP_MANT_MASK) == (EXPONENT_MASK | QUIET_NAN_MASK);
+    return (bits & EXP_MANT_MASK) == (EXP_MASK | QUIET_NAN_MASK);
   }
 
   LIBC_INLINE constexpr bool is_inf_or_nan() const {
-    return (bits & EXPONENT_MASK) == EXPONENT_MASK;
+    return (bits & EXP_MASK) == EXP_MASK;
   }
 
   LIBC_INLINE static constexpr T zero(bool sign = false) {
-    return FPBits(sign ? SIGN_MASK : UIntType(0)).get_val();
+    return FPBits(sign ? SIGN_MASK : StorageType(0)).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_zero() { return zero(true); }
 
   LIBC_INLINE static constexpr T inf(bool sign = false) {
-    return FPBits((sign ? SIGN_MASK : UIntType(0)) | EXPONENT_MASK).get_val();
+    return FPBits((sign ? SIGN_MASK : StorageType(0)) | EXP_MASK).get_val();
   }
 
   LIBC_INLINE static constexpr T neg_inf() { return inf(true); }
@@ -189,13 +189,13 @@ template <typename T> struct FPBits : private FloatProperties<T> {
     return FPBits(MAX_SUBNORMAL).get_val();
   }
 
-  LIBC_INLINE static constexpr T build_nan(UIntType v) {
+  LIBC_INLINE static constexpr T build_nan(StorageType v) {
     FPBits<T> bits(inf());
     bits.set_mantissa(v);
     return T(bits);
   }
 
-  LIBC_INLINE static constexpr T build_quiet_nan(UIntType v) {
+  LIBC_INLINE static constexpr T build_quiet_nan(StorageType v) {
     return build_nan(QUIET_NAN_MASK | v);
   }
 
@@ -209,10 +209,11 @@ template <typename T> struct FPBits : private FloatProperties<T> {
   //   3) The function did not check exponent high limit.
   //   4) "number" zero value is not processed correctly.
   //   5) Number is unsigned, so the result can be only positive.
-  LIBC_INLINE static constexpr FPBits<T> make_value(UIntType number, int ep) {
+  LIBC_INLINE static constexpr FPBits<T> make_value(StorageType number,
+                                                    int ep) {
     FPBits<T> result;
     // offset: +1 for sign, but -1 for implicit first bit
-    int lz = cpp::countl_zero(number) - EXPONENT_WIDTH;
+    int lz = cpp::countl_zero(number) - EXP_LEN;
     number <<= lz;
     ep -= lz;
 
@@ -227,7 +228,7 @@ template <typename T> struct FPBits : private FloatProperties<T> {
   }
 
   LIBC_INLINE static constexpr FPBits<T>
-  create_value(bool sign, UIntType biased_exp, UIntType mantissa) {
+  create_value(bool sign, StorageType biased_exp, StorageType mantissa) {
     FPBits<T> result;
     result.set_sign(sign);
     result.set_biased_exponent(biased_exp);

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -152,18 +152,16 @@ private:
           ? bit_at(SIG_BITS - 1) | bit_at(SIG_BITS - 3) // 0b1010...
           : bit_at(SIG_BITS - 2);                       // 0b0100...
 
-  // The number of bits after the decimal dot when the number if in normal form.
+public:
+  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = TOTAL_BITS;
+  // The number of bits after the decimal dot when the number is in normal form.
   LIBC_INLINE_VAR static constexpr int FRACTION_BITS =
       UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision ? SIG_BITS - 1
                                                                   : SIG_BITS;
-
-public:
-  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = TOTAL_BITS;
-  LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_WIDTH = FRACTION_BITS;
   LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_PRECISION =
-      MANTISSA_WIDTH + 1;
-  LIBC_INLINE_VAR static constexpr UIntType MANTISSA_MASK =
-      mask_trailing_ones<UIntType, MANTISSA_WIDTH>();
+      FRACTION_BITS + 1;
+  LIBC_INLINE_VAR static constexpr UIntType FRACTION_MASK =
+      mask_trailing_ones<UIntType, FRACTION_BITS>();
   LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = EXP_BITS;
   LIBC_INLINE_VAR static constexpr int32_t EXPONENT_BIAS = EXP_BIAS;
   LIBC_INLINE_VAR static constexpr UIntType EXPONENT_MASK = EXP_MASK;

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -41,42 +41,42 @@ enum class FPEncoding {
 template <FPType> struct FPBaseProperties {};
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary16> {
-  using UIntType = uint16_t;
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 16;
-  LIBC_INLINE_VAR static constexpr int SIG_BITS = 10;
-  LIBC_INLINE_VAR static constexpr int EXP_BITS = 5;
+  using StorageType = uint16_t;
+  LIBC_INLINE_VAR static constexpr int TOTAL_LEN = 16;
+  LIBC_INLINE_VAR static constexpr int SIG_LEN = 10;
+  LIBC_INLINE_VAR static constexpr int EXP_LEN = 5;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary32> {
-  using UIntType = uint32_t;
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 32;
-  LIBC_INLINE_VAR static constexpr int SIG_BITS = 23;
-  LIBC_INLINE_VAR static constexpr int EXP_BITS = 8;
+  using StorageType = uint32_t;
+  LIBC_INLINE_VAR static constexpr int TOTAL_LEN = 32;
+  LIBC_INLINE_VAR static constexpr int SIG_LEN = 23;
+  LIBC_INLINE_VAR static constexpr int EXP_LEN = 8;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary64> {
-  using UIntType = uint64_t;
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 64;
-  LIBC_INLINE_VAR static constexpr int SIG_BITS = 52;
-  LIBC_INLINE_VAR static constexpr int EXP_BITS = 11;
+  using StorageType = uint64_t;
+  LIBC_INLINE_VAR static constexpr int TOTAL_LEN = 64;
+  LIBC_INLINE_VAR static constexpr int SIG_LEN = 52;
+  LIBC_INLINE_VAR static constexpr int EXP_LEN = 11;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
 };
 
 template <> struct FPBaseProperties<FPType::IEEE754_Binary128> {
-  using UIntType = UInt128;
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 128;
-  LIBC_INLINE_VAR static constexpr int SIG_BITS = 112;
-  LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
+  using StorageType = UInt128;
+  LIBC_INLINE_VAR static constexpr int TOTAL_LEN = 128;
+  LIBC_INLINE_VAR static constexpr int SIG_LEN = 112;
+  LIBC_INLINE_VAR static constexpr int EXP_LEN = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING = FPEncoding::IEEE754;
 };
 
 template <> struct FPBaseProperties<FPType::X86_Binary80> {
-  using UIntType = UInt128;
-  LIBC_INLINE_VAR static constexpr int TOTAL_BITS = 80;
-  LIBC_INLINE_VAR static constexpr int SIG_BITS = 64;
-  LIBC_INLINE_VAR static constexpr int EXP_BITS = 15;
+  using StorageType = UInt128;
+  LIBC_INLINE_VAR static constexpr int TOTAL_LEN = 80;
+  LIBC_INLINE_VAR static constexpr int SIG_LEN = 64;
+  LIBC_INLINE_VAR static constexpr int EXP_LEN = 15;
   LIBC_INLINE_VAR static constexpr auto ENCODING =
       FPEncoding::X86_ExtendedPrecision;
 };
@@ -87,90 +87,88 @@ template <FPType fp_type>
 struct FPProperties : public internal::FPBaseProperties<fp_type> {
 private:
   using UP = internal::FPBaseProperties<fp_type>;
-  // The number of bits to represent sign. For documentation purpose, always 1.
-  LIBC_INLINE_VAR static constexpr int SIGN_BITS = 1;
-  using UP::EXP_BITS;   // The number of bits for the *exponent* part
-  using UP::SIG_BITS;   // The number of bits for the *significand* part
-  using UP::TOTAL_BITS; // For convenience, the sum of `SIG_BITS`, `EXP_BITS`,
-                        // and `SIGN_BITS`.
-  static_assert(SIGN_BITS + EXP_BITS + SIG_BITS == TOTAL_BITS);
 
 public:
+  // The number of bits to represent sign. For documentation purpose, always 1.
+  LIBC_INLINE_VAR static constexpr int SIGN_LEN = 1;
+  using UP::EXP_LEN;   // The number of bits for the *exponent* part
+  using UP::SIG_LEN;   // The number of bits for the *significand* part
+  using UP::TOTAL_LEN; // For convenience, the sum of `SIG_LEN`, `EXP_LEN`,
+                       // and `SIGN_LEN`.
+  static_assert(SIGN_LEN + EXP_LEN + SIG_LEN == TOTAL_LEN);
+
   // An unsigned integer that is wide enough to contain all of the floating
   // point bits.
-  using UIntType = typename UP::UIntType;
+  using StorageType = typename UP::StorageType;
 
-  // The number of bits in UIntType.
-  LIBC_INLINE_VAR static constexpr int UINTTYPE_BITS =
-      sizeof(UIntType) * CHAR_BIT;
-  static_assert(UINTTYPE_BITS >= TOTAL_BITS);
+  // The number of bits in StorageType.
+  LIBC_INLINE_VAR static constexpr int STORAGE_LEN =
+      sizeof(StorageType) * CHAR_BIT;
+  static_assert(STORAGE_LEN >= TOTAL_LEN);
 
-private:
   // The exponent bias. Always positive.
   LIBC_INLINE_VAR static constexpr int32_t EXP_BIAS =
-      (1U << (EXP_BITS - 1U)) - 1U;
+      (1U << (EXP_LEN - 1U)) - 1U;
   static_assert(EXP_BIAS > 0);
 
+private:
   // The shift amount to get the *significand* part to the least significant
   // bit. Always `0` but kept for consistency.
   LIBC_INLINE_VAR static constexpr int SIG_MASK_SHIFT = 0;
   // The shift amount to get the *exponent* part to the least significant bit.
-  LIBC_INLINE_VAR static constexpr int EXP_MASK_SHIFT = SIG_BITS;
+  LIBC_INLINE_VAR static constexpr int EXP_MASK_SHIFT = SIG_LEN;
   // The shift amount to get the *sign* part to the least significant bit.
-  LIBC_INLINE_VAR static constexpr int SIGN_MASK_SHIFT = SIG_BITS + EXP_BITS;
+  LIBC_INLINE_VAR static constexpr int SIGN_MASK_SHIFT = SIG_LEN + EXP_LEN;
 
   // The bit pattern that keeps only the *significand* part.
-  LIBC_INLINE_VAR static constexpr UIntType SIG_MASK =
-      mask_trailing_ones<UIntType, SIG_BITS>() << SIG_MASK_SHIFT;
-  // The bit pattern that keeps only the *exponent* part.
-  LIBC_INLINE_VAR static constexpr UIntType EXP_MASK =
-      mask_trailing_ones<UIntType, EXP_BITS>() << EXP_MASK_SHIFT;
+  LIBC_INLINE_VAR static constexpr StorageType SIG_MASK =
+      mask_trailing_ones<StorageType, SIG_LEN>() << SIG_MASK_SHIFT;
 
 public:
+  // The bit pattern that keeps only the *exponent* part.
+  LIBC_INLINE_VAR static constexpr StorageType EXP_MASK =
+      mask_trailing_ones<StorageType, EXP_LEN>() << EXP_MASK_SHIFT;
   // The bit pattern that keeps only the *sign* part.
-  LIBC_INLINE_VAR static constexpr UIntType SIGN_MASK =
-      mask_trailing_ones<UIntType, SIGN_BITS>() << SIGN_MASK_SHIFT;
+  LIBC_INLINE_VAR static constexpr StorageType SIGN_MASK =
+      mask_trailing_ones<StorageType, SIGN_LEN>() << SIGN_MASK_SHIFT;
   // The bit pattern that keeps only the *sign + exponent + significand* part.
-  LIBC_INLINE_VAR static constexpr UIntType FP_MASK =
-      mask_trailing_ones<UIntType, TOTAL_BITS>();
+  LIBC_INLINE_VAR static constexpr StorageType FP_MASK =
+      mask_trailing_ones<StorageType, TOTAL_LEN>();
 
   static_assert((SIG_MASK & EXP_MASK & SIGN_MASK) == 0, "masks disjoint");
   static_assert((SIG_MASK | EXP_MASK | SIGN_MASK) == FP_MASK, "masks cover");
 
 private:
-  LIBC_INLINE static constexpr UIntType bit_at(int position) {
-    return UIntType(1) << position;
+  LIBC_INLINE static constexpr StorageType bit_at(int position) {
+    return StorageType(1) << position;
   }
 
-  LIBC_INLINE_VAR static constexpr UIntType QNAN_MASK =
+  LIBC_INLINE_VAR static constexpr StorageType QNAN_MASK =
       UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision
-          ? bit_at(SIG_BITS - 1) | bit_at(SIG_BITS - 2) // 0b1100...
-          : bit_at(SIG_BITS - 1);                       // 0b1000...
+          ? bit_at(SIG_LEN - 1) | bit_at(SIG_LEN - 2) // 0b1100...
+          : bit_at(SIG_LEN - 1);                      // 0b1000...
 
-  LIBC_INLINE_VAR static constexpr UIntType SNAN_MASK =
+  LIBC_INLINE_VAR static constexpr StorageType SNAN_MASK =
       UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision
-          ? bit_at(SIG_BITS - 1) | bit_at(SIG_BITS - 3) // 0b1010...
-          : bit_at(SIG_BITS - 2);                       // 0b0100...
+          ? bit_at(SIG_LEN - 1) | bit_at(SIG_LEN - 3) // 0b1010...
+          : bit_at(SIG_LEN - 2);                      // 0b0100...
 
 public:
-  LIBC_INLINE_VAR static constexpr uint32_t BIT_WIDTH = TOTAL_BITS;
   // The number of bits after the decimal dot when the number is in normal form.
-  LIBC_INLINE_VAR static constexpr int FRACTION_BITS =
-      UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision ? SIG_BITS - 1
-                                                                  : SIG_BITS;
+  LIBC_INLINE_VAR static constexpr int FRACTION_LEN =
+      UP::ENCODING == internal::FPEncoding::X86_ExtendedPrecision ? SIG_LEN - 1
+                                                                  : SIG_LEN;
   LIBC_INLINE_VAR static constexpr uint32_t MANTISSA_PRECISION =
-      FRACTION_BITS + 1;
-  LIBC_INLINE_VAR static constexpr UIntType FRACTION_MASK =
-      mask_trailing_ones<UIntType, FRACTION_BITS>();
-  LIBC_INLINE_VAR static constexpr uint32_t EXPONENT_WIDTH = EXP_BITS;
-  LIBC_INLINE_VAR static constexpr int32_t EXPONENT_BIAS = EXP_BIAS;
-  LIBC_INLINE_VAR static constexpr UIntType EXPONENT_MASK = EXP_MASK;
-  LIBC_INLINE_VAR static constexpr UIntType EXP_MANT_MASK = EXP_MASK | SIG_MASK;
+      FRACTION_LEN + 1;
+  LIBC_INLINE_VAR static constexpr StorageType FRACTION_MASK =
+      mask_trailing_ones<StorageType, FRACTION_LEN>();
+  LIBC_INLINE_VAR static constexpr StorageType EXP_MANT_MASK =
+      EXP_MASK | SIG_MASK;
 
   // If a number x is a NAN, then it is a quiet NAN if:
   //   QuietNaNMask & bits(x) != 0
   // Else, it is a signalling NAN.
-  static constexpr UIntType QUIET_NAN_MASK = QNAN_MASK;
+  static constexpr StorageType QUIET_NAN_MASK = QNAN_MASK;
 };
 
 //-----------------------------------------------------------------------------

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -124,7 +124,7 @@ LIBC_INLINE T hypot(T x, T y) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if ((exp_diff >= FPBits_t::MANTISSA_WIDTH + 2) || (x == 0) || (y == 0)) {
+  if ((exp_diff >= FPBits_t::FRACTION_BITS + 2) || (x == 0) || (y == 0)) {
     return abs(x) + abs(y);
   }
 
@@ -148,7 +148,7 @@ LIBC_INLINE T hypot(T x, T y) {
   out_exp = a_exp;
 
   // Add an extra bit to simplify the final rounding bit computation.
-  constexpr UIntType ONE = UIntType(1) << (FPBits_t::MANTISSA_WIDTH + 1);
+  constexpr UIntType ONE = UIntType(1) << (FPBits_t::FRACTION_BITS + 1);
 
   a_mant <<= 1;
   b_mant <<= 1;
@@ -158,7 +158,7 @@ LIBC_INLINE T hypot(T x, T y) {
   if (a_exp != 0) {
     leading_one = ONE;
     a_mant |= ONE;
-    y_mant_width = FPBits_t::MANTISSA_WIDTH + 1;
+    y_mant_width = FPBits_t::FRACTION_BITS + 1;
   } else {
     leading_one = internal::find_leading_one(a_mant, y_mant_width);
     a_exp = 1;
@@ -258,7 +258,7 @@ LIBC_INLINE T hypot(T x, T y) {
     }
   }
 
-  y_new |= static_cast<UIntType>(out_exp) << FPBits_t::MANTISSA_WIDTH;
+  y_new |= static_cast<UIntType>(out_exp) << FPBits_t::FRACTION_BITS;
   return cpp::bit_cast<T>(y_new);
 }
 

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -105,8 +105,8 @@ template <> struct DoubleLength<uint64_t> {
 template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T hypot(T x, T y) {
   using FPBits_t = FPBits<T>;
-  using UIntType = typename FPBits<T>::UIntType;
-  using DUIntType = typename DoubleLength<UIntType>::Type;
+  using StorageType = typename FPBits<T>::StorageType;
+  using DUIntType = typename DoubleLength<StorageType>::Type;
 
   FPBits_t x_bits(x), y_bits(y);
 
@@ -124,12 +124,12 @@ LIBC_INLINE T hypot(T x, T y) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if ((exp_diff >= FPBits_t::FRACTION_BITS + 2) || (x == 0) || (y == 0)) {
+  if ((exp_diff >= FPBits_t::FRACTION_LEN + 2) || (x == 0) || (y == 0)) {
     return abs(x) + abs(y);
   }
 
   uint16_t a_exp, b_exp, out_exp;
-  UIntType a_mant, b_mant;
+  StorageType a_mant, b_mant;
   DUIntType a_mant_sq, b_mant_sq;
   bool sticky_bits;
 
@@ -148,17 +148,17 @@ LIBC_INLINE T hypot(T x, T y) {
   out_exp = a_exp;
 
   // Add an extra bit to simplify the final rounding bit computation.
-  constexpr UIntType ONE = UIntType(1) << (FPBits_t::FRACTION_BITS + 1);
+  constexpr StorageType ONE = StorageType(1) << (FPBits_t::FRACTION_LEN + 1);
 
   a_mant <<= 1;
   b_mant <<= 1;
 
-  UIntType leading_one;
+  StorageType leading_one;
   int y_mant_width;
   if (a_exp != 0) {
     leading_one = ONE;
     a_mant |= ONE;
-    y_mant_width = FPBits_t::FRACTION_BITS + 1;
+    y_mant_width = FPBits_t::FRACTION_LEN + 1;
   } else {
     leading_one = internal::find_leading_one(a_mant, y_mant_width);
     a_exp = 1;
@@ -207,22 +207,22 @@ LIBC_INLINE T hypot(T x, T y) {
     }
   }
 
-  UIntType y_new = leading_one;
-  UIntType r = static_cast<UIntType>(sum >> y_mant_width) - leading_one;
-  UIntType tail_bits = static_cast<UIntType>(sum) & (leading_one - 1);
+  StorageType y_new = leading_one;
+  StorageType r = static_cast<StorageType>(sum >> y_mant_width) - leading_one;
+  StorageType tail_bits = static_cast<StorageType>(sum) & (leading_one - 1);
 
-  for (UIntType current_bit = leading_one >> 1; current_bit;
+  for (StorageType current_bit = leading_one >> 1; current_bit;
        current_bit >>= 1) {
     r = (r << 1) + ((tail_bits & current_bit) ? 1 : 0);
-    UIntType tmp = (y_new << 1) + current_bit; // 2*y_new(n - 1) + 2^(-n)
+    StorageType tmp = (y_new << 1) + current_bit; // 2*y_new(n - 1) + 2^(-n)
     if (r >= tmp) {
       r -= tmp;
       y_new += current_bit;
     }
   }
 
-  bool round_bit = y_new & UIntType(1);
-  bool lsb = y_new & UIntType(2);
+  bool round_bit = y_new & StorageType(1);
+  bool lsb = y_new & StorageType(2);
 
   if (y_new >= ONE) {
     y_new -= ONE;
@@ -258,7 +258,7 @@ LIBC_INLINE T hypot(T x, T y) {
     }
   }
 
-  y_new |= static_cast<UIntType>(out_exp) << FPBits_t::FRACTION_BITS;
+  y_new |= static_cast<StorageType>(out_exp) << FPBits_t::FRACTION_LEN;
   return cpp::bit_cast<T>(y_new);
 }
 

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -106,7 +106,7 @@ template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T hypot(T x, T y) {
   using FPBits_t = FPBits<T>;
   using StorageType = typename FPBits<T>::StorageType;
-  using DUIntType = typename DoubleLength<StorageType>::Type;
+  using DStorageType = typename DoubleLength<StorageType>::Type;
 
   FPBits_t x_bits(x), y_bits(y);
 
@@ -130,7 +130,7 @@ LIBC_INLINE T hypot(T x, T y) {
 
   uint16_t a_exp, b_exp, out_exp;
   StorageType a_mant, b_mant;
-  DUIntType a_mant_sq, b_mant_sq;
+  DStorageType a_mant_sq, b_mant_sq;
   bool sticky_bits;
 
   if (abs(x) >= abs(y)) {
@@ -170,8 +170,8 @@ LIBC_INLINE T hypot(T x, T y) {
     b_exp = 1;
   }
 
-  a_mant_sq = static_cast<DUIntType>(a_mant) * a_mant;
-  b_mant_sq = static_cast<DUIntType>(b_mant) * b_mant;
+  a_mant_sq = static_cast<DStorageType>(a_mant) * a_mant;
+  b_mant_sq = static_cast<DStorageType>(b_mant) * b_mant;
 
   // At this point, a_exp >= b_exp > a_exp - 25, so in order to line up aSqMant
   // and bSqMant, we need to shift bSqMant to the right by (a_exp - b_exp) bits.
@@ -180,12 +180,12 @@ LIBC_INLINE T hypot(T x, T y) {
   // difference between a and b.
   uint16_t shift_length = static_cast<uint16_t>(2 * (a_exp - b_exp));
   sticky_bits =
-      ((b_mant_sq & ((DUIntType(1) << shift_length) - DUIntType(1))) !=
-       DUIntType(0));
+      ((b_mant_sq & ((DStorageType(1) << shift_length) - DStorageType(1))) !=
+       DStorageType(0));
   b_mant_sq >>= shift_length;
 
-  DUIntType sum = a_mant_sq + b_mant_sq;
-  if (sum >= (DUIntType(1) << (2 * y_mant_width + 2))) {
+  DStorageType sum = a_mant_sq + b_mant_sq;
+  if (sum >= (DStorageType(1) << (2 * y_mant_width + 2))) {
     // a^2 + b^2 >= 4* leading_one^2, so we will need an extra bit to the left.
     if (leading_one == ONE) {
       // For normal result, we discard the last 2 bits of the sum and increase

--- a/libc/src/__support/FPUtil/ManipulationFunctions.h
+++ b/libc/src/__support/FPUtil/ManipulationFunctions.h
@@ -130,7 +130,7 @@ LIBC_INLINE T ldexp(T x, int exp) {
   // early. Because the result of the ldexp operation can be a subnormal number,
   // we need to accommodate the (mantissaWidht + 1) worth of shift in
   // calculating the limit.
-  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::FRACTION_BITS + 1;
+  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::FRACTION_LEN + 1;
   if (exp > exp_limit)
     return bits.get_sign() ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
 
@@ -164,8 +164,8 @@ LIBC_INLINE T nextafter(T from, U to) {
   if (static_cast<U>(from) == to)
     return static_cast<T>(to);
 
-  using UIntType = typename FPBits<T>::UIntType;
-  UIntType int_val = from_bits.uintval();
+  using StorageType = typename FPBits<T>::StorageType;
+  StorageType int_val = from_bits.uintval();
   if (from != FPBits<T>::zero()) {
     if ((static_cast<U>(from) < to) == (from > FPBits<T>::zero())) {
       ++int_val;
@@ -178,10 +178,10 @@ LIBC_INLINE T nextafter(T from, U to) {
       int_val |= FloatProperties<T>::SIGN_MASK;
   }
 
-  UIntType exponent_bits = int_val & FloatProperties<T>::EXPONENT_MASK;
-  if (exponent_bits == UIntType(0))
+  StorageType exponent_bits = int_val & FloatProperties<T>::EXP_MASK;
+  if (exponent_bits == StorageType(0))
     raise_except_if_required(FE_UNDERFLOW | FE_INEXACT);
-  else if (exponent_bits == FloatProperties<T>::EXPONENT_MASK)
+  else if (exponent_bits == FloatProperties<T>::EXP_MASK)
     raise_except_if_required(FE_OVERFLOW | FE_INEXACT);
 
   return cpp::bit_cast<T>(int_val);

--- a/libc/src/__support/FPUtil/ManipulationFunctions.h
+++ b/libc/src/__support/FPUtil/ManipulationFunctions.h
@@ -130,7 +130,7 @@ LIBC_INLINE T ldexp(T x, int exp) {
   // early. Because the result of the ldexp operation can be a subnormal number,
   // we need to accommodate the (mantissaWidht + 1) worth of shift in
   // calculating the limit.
-  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::MANTISSA_WIDTH + 1;
+  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::FRACTION_BITS + 1;
   if (exp > exp_limit)
     return bits.get_sign() ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
 

--- a/libc/src/__support/FPUtil/NearestIntegerOperations.h
+++ b/libc/src/__support/FPUtil/NearestIntegerOperations.h
@@ -36,7 +36,7 @@ LIBC_INLINE T trunc(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_LEN))
     return x;
 
   // If the exponent is such that abs(x) is less than 1, then return 0.
@@ -47,7 +47,7 @@ LIBC_INLINE T trunc(T x) {
       return T(0.0);
   }
 
-  int trim_size = FPBits<T>::FRACTION_BITS - exponent;
+  int trim_size = FPBits<T>::FRACTION_LEN - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   return T(bits);
 }
@@ -65,7 +65,7 @@ LIBC_INLINE T ceil(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_LEN))
     return x;
 
   if (exponent <= -1) {
@@ -75,7 +75,7 @@ LIBC_INLINE T ceil(T x) {
       return T(1.0);
   }
 
-  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_LEN - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(bits);
 
@@ -102,7 +102,7 @@ LIBC_INLINE T floor(T x) {
 
 template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T round(T x) {
-  using UIntType = typename FPBits<T>::UIntType;
+  using StorageType = typename FPBits<T>::StorageType;
   FPBits<T> bits(x);
 
   // If x is infinity NaN or zero, return it.
@@ -114,7 +114,7 @@ LIBC_INLINE T round(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_LEN))
     return x;
 
   if (exponent == -1) {
@@ -133,9 +133,9 @@ LIBC_INLINE T round(T x) {
       return T(0.0);
   }
 
-  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_LEN - exponent;
   bool half_bit_set =
-      bool(bits.get_mantissa() & (UIntType(1) << (trim_size - 1)));
+      bool(bits.get_mantissa() & (StorageType(1) << (trim_size - 1)));
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(bits);
 
@@ -154,7 +154,7 @@ LIBC_INLINE T round(T x) {
 
 template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE T round_using_current_rounding_mode(T x) {
-  using UIntType = typename FPBits<T>::UIntType;
+  using StorageType = typename FPBits<T>::StorageType;
   FPBits<T> bits(x);
 
   // If x is infinity NaN or zero, return it.
@@ -167,7 +167,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_LEN))
     return x;
 
   if (exponent <= -1) {
@@ -188,7 +188,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
     }
   }
 
-  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_LEN - exponent;
   FPBits<T> new_bits = bits;
   new_bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(new_bits);
@@ -197,12 +197,14 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
   if (trunc_value == x)
     return x;
 
-  UIntType trim_value = bits.get_mantissa() & ((UIntType(1) << trim_size) - 1);
-  UIntType half_value = (UIntType(1) << (trim_size - 1));
+  StorageType trim_value =
+      bits.get_mantissa() & ((StorageType(1) << trim_size) - 1);
+  StorageType half_value = (StorageType(1) << (trim_size - 1));
   // If exponent is 0, trimSize will be equal to the mantissa width, and
   // truncIsOdd` will not be correct. So, we handle it as a special case
   // below.
-  UIntType trunc_is_odd = new_bits.get_mantissa() & (UIntType(1) << trim_size);
+  StorageType trunc_is_odd =
+      new_bits.get_mantissa() & (StorageType(1) << trim_size);
 
   switch (rounding_mode) {
   case FE_DOWNWARD:

--- a/libc/src/__support/FPUtil/NearestIntegerOperations.h
+++ b/libc/src/__support/FPUtil/NearestIntegerOperations.h
@@ -36,7 +36,7 @@ LIBC_INLINE T trunc(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
     return x;
 
   // If the exponent is such that abs(x) is less than 1, then return 0.
@@ -47,7 +47,7 @@ LIBC_INLINE T trunc(T x) {
       return T(0.0);
   }
 
-  int trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
+  int trim_size = FPBits<T>::FRACTION_BITS - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   return T(bits);
 }
@@ -65,7 +65,7 @@ LIBC_INLINE T ceil(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
     return x;
 
   if (exponent <= -1) {
@@ -75,7 +75,7 @@ LIBC_INLINE T ceil(T x) {
       return T(1.0);
   }
 
-  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(bits);
 
@@ -114,7 +114,7 @@ LIBC_INLINE T round(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
     return x;
 
   if (exponent == -1) {
@@ -133,7 +133,7 @@ LIBC_INLINE T round(T x) {
       return T(0.0);
   }
 
-  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
   bool half_bit_set =
       bool(bits.get_mantissa() & (UIntType(1) << (trim_size - 1)));
   bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
@@ -167,7 +167,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
 
   // If the exponent is greater than the most negative mantissa
   // exponent, then x is already an integer.
-  if (exponent >= static_cast<int>(FPBits<T>::MANTISSA_WIDTH))
+  if (exponent >= static_cast<int>(FPBits<T>::FRACTION_BITS))
     return x;
 
   if (exponent <= -1) {
@@ -188,7 +188,7 @@ LIBC_INLINE T round_using_current_rounding_mode(T x) {
     }
   }
 
-  uint32_t trim_size = FPBits<T>::MANTISSA_WIDTH - exponent;
+  uint32_t trim_size = FPBits<T>::FRACTION_BITS - exponent;
   FPBits<T> new_bits = bits;
   new_bits.set_mantissa((bits.get_mantissa() >> trim_size) << trim_size);
   T trunc_value = T(new_bits);

--- a/libc/src/__support/FPUtil/NormalFloat.h
+++ b/libc/src/__support/FPUtil/NormalFloat.h
@@ -32,7 +32,7 @@ template <typename T> struct NormalFloat {
       "NormalFloat template parameter has to be a floating point type.");
 
   using UIntType = typename FPBits<T>::UIntType;
-  static constexpr UIntType ONE = (UIntType(1) << FPBits<T>::MANTISSA_WIDTH);
+  static constexpr UIntType ONE = (UIntType(1) << FPBits<T>::FRACTION_BITS);
 
   // Unbiased exponent value.
   int32_t exponent;
@@ -40,7 +40,7 @@ template <typename T> struct NormalFloat {
   UIntType mantissa;
   // We want |UIntType| to have atleast one bit more than the actual mantissa
   // bit width to accommodate the implicit 1 value.
-  static_assert(sizeof(UIntType) * 8 >= FPBits<T>::MANTISSA_WIDTH + 1,
+  static_assert(sizeof(UIntType) * 8 >= FPBits<T>::FRACTION_BITS + 1,
                 "Bad type for mantissa in NormalFloat.");
 
   bool sign;
@@ -105,7 +105,7 @@ template <typename T> struct NormalFloat {
       unsigned shift = SUBNORMAL_EXPONENT - exponent;
       // Since exponent > subnormalExponent, shift is strictly greater than
       // zero.
-      if (shift <= FPBits<T>::MANTISSA_WIDTH + 1) {
+      if (shift <= FPBits<T>::FRACTION_BITS + 1) {
         // Generate a subnormal number. Might lead to loss of precision.
         // We round to nearest and round halfway cases to even.
         const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
@@ -163,7 +163,7 @@ private:
 
   LIBC_INLINE unsigned evaluate_normalization_shift(UIntType m) {
     unsigned shift = 0;
-    for (; (ONE & m) == 0 && (shift < FPBits<T>::MANTISSA_WIDTH);
+    for (; (ONE & m) == 0 && (shift < FPBits<T>::FRACTION_BITS);
          m <<= 1, ++shift)
       ;
     return shift;
@@ -222,7 +222,7 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
   constexpr int SUBNORMAL_EXPONENT = -LDBits::EXPONENT_BIAS + 1;
   if (exponent < SUBNORMAL_EXPONENT) {
     unsigned shift = SUBNORMAL_EXPONENT - exponent;
-    if (shift <= LDBits::MANTISSA_WIDTH + 1) {
+    if (shift <= LDBits::FRACTION_BITS + 1) {
       // Generate a subnormal number. Might lead to loss of precision.
       // We round to nearest and round halfway cases to even.
       const UIntType shift_out_mask = (UIntType(1) << shift) - 1;

--- a/libc/src/__support/FPUtil/NormalFloat.h
+++ b/libc/src/__support/FPUtil/NormalFloat.h
@@ -31,21 +31,22 @@ template <typename T> struct NormalFloat {
       cpp::is_floating_point_v<T>,
       "NormalFloat template parameter has to be a floating point type.");
 
-  using UIntType = typename FPBits<T>::UIntType;
-  static constexpr UIntType ONE = (UIntType(1) << FPBits<T>::FRACTION_BITS);
+  using StorageType = typename FPBits<T>::StorageType;
+  static constexpr StorageType ONE =
+      (StorageType(1) << FPBits<T>::FRACTION_LEN);
 
   // Unbiased exponent value.
   int32_t exponent;
 
-  UIntType mantissa;
-  // We want |UIntType| to have atleast one bit more than the actual mantissa
+  StorageType mantissa;
+  // We want |StorageType| to have atleast one bit more than the actual mantissa
   // bit width to accommodate the implicit 1 value.
-  static_assert(sizeof(UIntType) * 8 >= FPBits<T>::FRACTION_BITS + 1,
+  static_assert(sizeof(StorageType) * 8 >= FPBits<T>::FRACTION_LEN + 1,
                 "Bad type for mantissa in NormalFloat.");
 
   bool sign;
 
-  LIBC_INLINE NormalFloat(int32_t e, UIntType m, bool s)
+  LIBC_INLINE NormalFloat(int32_t e, StorageType m, bool s)
       : exponent(e), mantissa(m), sign(s) {
     if (mantissa >= ONE)
       return;
@@ -90,9 +91,9 @@ template <typename T> struct NormalFloat {
   }
 
   LIBC_INLINE operator T() const {
-    int biased_exponent = exponent + FPBits<T>::EXPONENT_BIAS;
+    int biased_exponent = exponent + FPBits<T>::EXP_BIAS;
     // Max exponent is of the form 0xFF...E. That is why -2 and not -1.
-    constexpr int MAX_EXPONENT_VALUE = (1 << FPBits<T>::EXPONENT_WIDTH) - 2;
+    constexpr int MAX_EXPONENT_VALUE = (1 << FPBits<T>::EXP_LEN) - 2;
     if (biased_exponent > MAX_EXPONENT_VALUE) {
       return sign ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
     }
@@ -100,20 +101,20 @@ template <typename T> struct NormalFloat {
     FPBits<T> result(T(0.0));
     result.set_sign(sign);
 
-    constexpr int SUBNORMAL_EXPONENT = -FPBits<T>::EXPONENT_BIAS + 1;
+    constexpr int SUBNORMAL_EXPONENT = -FPBits<T>::EXP_BIAS + 1;
     if (exponent < SUBNORMAL_EXPONENT) {
       unsigned shift = SUBNORMAL_EXPONENT - exponent;
       // Since exponent > subnormalExponent, shift is strictly greater than
       // zero.
-      if (shift <= FPBits<T>::FRACTION_BITS + 1) {
+      if (shift <= FPBits<T>::FRACTION_LEN + 1) {
         // Generate a subnormal number. Might lead to loss of precision.
         // We round to nearest and round halfway cases to even.
-        const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
-        const UIntType shift_out_value = mantissa & shift_out_mask;
-        const UIntType halfway_value = UIntType(1) << (shift - 1);
+        const StorageType shift_out_mask = (StorageType(1) << shift) - 1;
+        const StorageType shift_out_value = mantissa & shift_out_mask;
+        const StorageType halfway_value = StorageType(1) << (shift - 1);
         result.set_biased_exponent(0);
         result.set_mantissa(mantissa >> shift);
-        UIntType new_mantissa = result.get_mantissa();
+        StorageType new_mantissa = result.get_mantissa();
         if (shift_out_value > halfway_value) {
           new_mantissa += 1;
         } else if (shift_out_value == halfway_value) {
@@ -133,7 +134,7 @@ template <typename T> struct NormalFloat {
       }
     }
 
-    result.set_biased_exponent(exponent + FPBits<T>::EXPONENT_BIAS);
+    result.set_biased_exponent(exponent + FPBits<T>::EXP_BIAS);
     result.set_mantissa(mantissa);
     return T(result);
   }
@@ -153,17 +154,17 @@ private:
     // Normalize subnormal numbers.
     if (bits.get_biased_exponent() == 0) {
       unsigned shift = evaluate_normalization_shift(bits.get_mantissa());
-      mantissa = UIntType(bits.get_mantissa()) << shift;
-      exponent = 1 - FPBits<T>::EXPONENT_BIAS - shift;
+      mantissa = StorageType(bits.get_mantissa()) << shift;
+      exponent = 1 - FPBits<T>::EXP_BIAS - shift;
     } else {
-      exponent = bits.get_biased_exponent() - FPBits<T>::EXPONENT_BIAS;
+      exponent = bits.get_biased_exponent() - FPBits<T>::EXP_BIAS;
       mantissa = ONE | bits.get_mantissa();
     }
   }
 
-  LIBC_INLINE unsigned evaluate_normalization_shift(UIntType m) {
+  LIBC_INLINE unsigned evaluate_normalization_shift(StorageType m) {
     unsigned shift = 0;
-    for (; (ONE & m) == 0 && (shift < FPBits<T>::FRACTION_BITS);
+    for (; (ONE & m) == 0 && (shift < FPBits<T>::FRACTION_LEN);
          m <<= 1, ++shift)
       ;
     return shift;
@@ -209,9 +210,9 @@ NormalFloat<long double>::init_from_bits(FPBits<long double> bits) {
 
 template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
   using LDBits = FPBits<long double>;
-  int biased_exponent = exponent + LDBits::EXPONENT_BIAS;
+  int biased_exponent = exponent + LDBits::EXP_BIAS;
   // Max exponent is of the form 0xFF...E. That is why -2 and not -1.
-  constexpr int MAX_EXPONENT_VALUE = (1 << LDBits::EXPONENT_WIDTH) - 2;
+  constexpr int MAX_EXPONENT_VALUE = (1 << LDBits::EXP_LEN) - 2;
   if (biased_exponent > MAX_EXPONENT_VALUE) {
     return sign ? LDBits::neg_inf() : LDBits::inf();
   }
@@ -219,18 +220,18 @@ template <> LIBC_INLINE NormalFloat<long double>::operator long double() const {
   FPBits<long double> result(0.0l);
   result.set_sign(sign);
 
-  constexpr int SUBNORMAL_EXPONENT = -LDBits::EXPONENT_BIAS + 1;
+  constexpr int SUBNORMAL_EXPONENT = -LDBits::EXP_BIAS + 1;
   if (exponent < SUBNORMAL_EXPONENT) {
     unsigned shift = SUBNORMAL_EXPONENT - exponent;
-    if (shift <= LDBits::FRACTION_BITS + 1) {
+    if (shift <= LDBits::FRACTION_LEN + 1) {
       // Generate a subnormal number. Might lead to loss of precision.
       // We round to nearest and round halfway cases to even.
-      const UIntType shift_out_mask = (UIntType(1) << shift) - 1;
-      const UIntType shift_out_value = mantissa & shift_out_mask;
-      const UIntType halfway_value = UIntType(1) << (shift - 1);
+      const StorageType shift_out_mask = (StorageType(1) << shift) - 1;
+      const StorageType shift_out_value = mantissa & shift_out_mask;
+      const StorageType halfway_value = StorageType(1) << (shift - 1);
       result.set_biased_exponent(0);
       result.set_mantissa(mantissa >> shift);
-      UIntType new_mantissa = result.get_mantissa();
+      StorageType new_mantissa = result.get_mantissa();
       if (shift_out_value > halfway_value) {
         new_mantissa += 1;
       } else if (shift_out_value == halfway_value) {

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -42,10 +42,10 @@ template <size_t Bits> struct DyadicFloat {
 
   template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
   DyadicFloat(T x) {
-    static_assert(FloatProperties<T>::FRACTION_BITS < Bits);
+    static_assert(FloatProperties<T>::FRACTION_LEN < Bits);
     FPBits<T> x_bits(x);
     sign = x_bits.get_sign();
-    exponent = x_bits.get_exponent() - FloatProperties<T>::FRACTION_BITS;
+    exponent = x_bits.get_exponent() - FloatProperties<T>::FRACTION_LEN;
     mantissa = MantissaType(x_bits.get_explicit_mantissa());
     normalize();
   }
@@ -86,7 +86,7 @@ template <size_t Bits> struct DyadicFloat {
   // TODO(lntue): Test or add specialization for x86 long double.
   template <typename T, typename = cpp::enable_if_t<
                             cpp::is_floating_point_v<T> &&
-                                (FloatProperties<T>::FRACTION_BITS < Bits),
+                                (FloatProperties<T>::FRACTION_LEN < Bits),
                             void>>
   explicit operator T() const {
     // TODO(lntue): Do we need to treat signed zeros properly?
@@ -95,10 +95,10 @@ template <size_t Bits> struct DyadicFloat {
 
     // Assume that it is normalized, and output is also normal.
     constexpr uint32_t PRECISION = FloatProperties<T>::MANTISSA_PRECISION;
-    using output_bits_t = typename FPBits<T>::UIntType;
+    using output_bits_t = typename FPBits<T>::StorageType;
 
-    int exp_hi = exponent + static_cast<int>((Bits - 1) +
-                                             FloatProperties<T>::EXPONENT_BIAS);
+    int exp_hi =
+        exponent + static_cast<int>((Bits - 1) + FloatProperties<T>::EXP_BIAS);
 
     bool denorm = false;
     uint32_t shift = Bits - PRECISION;
@@ -107,7 +107,7 @@ template <size_t Bits> struct DyadicFloat {
       denorm = true;
       shift = (Bits - PRECISION) + static_cast<uint32_t>(1 - exp_hi);
 
-      exp_hi = FloatProperties<T>::EXPONENT_BIAS;
+      exp_hi = FloatProperties<T>::EXP_BIAS;
     }
 
     int exp_lo = exp_hi - static_cast<int>(PRECISION) - 1;
@@ -130,14 +130,14 @@ template <size_t Bits> struct DyadicFloat {
     if (LIBC_UNLIKELY(exp_lo <= 0)) {
       // d_lo is denormal, but the output is normal.
       int scale_up_exponent = 2 * PRECISION;
-      T scale_up_factor =
-          FPBits<T>::create_value(
-              sign, FloatProperties<T>::EXPONENT_BIAS + scale_up_exponent,
-              output_bits_t(0))
-              .get_val();
+      T scale_up_factor = FPBits<T>::create_value(sign,
+                                                  FloatProperties<T>::EXP_BIAS +
+                                                      scale_up_exponent,
+                                                  output_bits_t(0))
+                              .get_val();
       T scale_down_factor =
           FPBits<T>::create_value(
-              sign, FloatProperties<T>::EXPONENT_BIAS - scale_up_exponent,
+              sign, FloatProperties<T>::EXP_BIAS - scale_up_exponent,
               output_bits_t(0))
               .get_val();
 
@@ -157,7 +157,7 @@ template <size_t Bits> struct DyadicFloat {
     if (LIBC_UNLIKELY(denorm)) {
       // Output is denormal, simply clear the exponent field.
       output_bits_t clear_exp = output_bits_t(exp_hi)
-                                << FloatProperties<T>::FRACTION_BITS;
+                                << FloatProperties<T>::FRACTION_LEN;
       output_bits_t r_bits = FPBits<T>(r).uintval() - clear_exp;
       return FPBits<T>(r_bits).get_val();
     }

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -42,10 +42,10 @@ template <size_t Bits> struct DyadicFloat {
 
   template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
   DyadicFloat(T x) {
-    static_assert(FloatProperties<T>::MANTISSA_WIDTH < Bits);
+    static_assert(FloatProperties<T>::FRACTION_BITS < Bits);
     FPBits<T> x_bits(x);
     sign = x_bits.get_sign();
-    exponent = x_bits.get_exponent() - FloatProperties<T>::MANTISSA_WIDTH;
+    exponent = x_bits.get_exponent() - FloatProperties<T>::FRACTION_BITS;
     mantissa = MantissaType(x_bits.get_explicit_mantissa());
     normalize();
   }
@@ -86,7 +86,7 @@ template <size_t Bits> struct DyadicFloat {
   // TODO(lntue): Test or add specialization for x86 long double.
   template <typename T, typename = cpp::enable_if_t<
                             cpp::is_floating_point_v<T> &&
-                                (FloatProperties<T>::MANTISSA_WIDTH < Bits),
+                                (FloatProperties<T>::FRACTION_BITS < Bits),
                             void>>
   explicit operator T() const {
     // TODO(lntue): Do we need to treat signed zeros properly?
@@ -116,7 +116,7 @@ template <size_t Bits> struct DyadicFloat {
 
     T d_hi = FPBits<T>::create_value(sign, exp_hi,
                                      static_cast<output_bits_t>(m_hi) &
-                                         FloatProperties<T>::MANTISSA_MASK)
+                                         FloatProperties<T>::FRACTION_MASK)
                  .get_val();
 
     const MantissaType round_mask = MantissaType(1) << (shift - 1);
@@ -157,7 +157,7 @@ template <size_t Bits> struct DyadicFloat {
     if (LIBC_UNLIKELY(denorm)) {
       // Output is denormal, simply clear the exponent field.
       output_bits_t clear_exp = output_bits_t(exp_hi)
-                                << FloatProperties<T>::MANTISSA_WIDTH;
+                                << FloatProperties<T>::FRACTION_BITS;
       output_bits_t r_bits = FPBits<T>(r).uintval() - clear_exp;
       return FPBits<T>(r_bits).get_val();
     }

--- a/libc/src/__support/FPUtil/except_value_utils.h
+++ b/libc/src/__support/FPUtil/except_value_utils.h
@@ -26,7 +26,7 @@ namespace fputil {
 //
 // Define list of exceptional inputs and outputs:
 //   static constexpr int N = ...;  // Number of exceptional values.
-//   static constexpr fputil::ExceptValues<UIntType, N> Excepts {
+//   static constexpr fputil::ExceptValues<StorageType, N> Excepts {
 //     <list of input bits, output bits and offsets>
 //   };
 //
@@ -37,22 +37,22 @@ namespace fputil {
 template <typename T, size_t N> struct ExceptValues {
   static_assert(cpp::is_floating_point_v<T>, "Must be a floating point type.");
 
-  using UIntType = typename FPBits<T>::UIntType;
+  using StorageType = typename FPBits<T>::StorageType;
 
   struct Mapping {
-    UIntType input;
-    UIntType rnd_towardzero_result;
-    UIntType rnd_upward_offset;
-    UIntType rnd_downward_offset;
-    UIntType rnd_tonearest_offset;
+    StorageType input;
+    StorageType rnd_towardzero_result;
+    StorageType rnd_upward_offset;
+    StorageType rnd_downward_offset;
+    StorageType rnd_tonearest_offset;
   };
 
   Mapping values[N];
 
-  LIBC_INLINE constexpr cpp::optional<T> lookup(UIntType x_bits) const {
+  LIBC_INLINE constexpr cpp::optional<T> lookup(StorageType x_bits) const {
     for (size_t i = 0; i < N; ++i) {
       if (LIBC_UNLIKELY(x_bits == values[i].input)) {
-        UIntType out_bits = values[i].rnd_towardzero_result;
+        StorageType out_bits = values[i].rnd_towardzero_result;
         switch (fputil::quick_get_round()) {
         case FE_UPWARD:
           out_bits += values[i].rnd_upward_offset;
@@ -70,11 +70,11 @@ template <typename T, size_t N> struct ExceptValues {
     return cpp::nullopt;
   }
 
-  LIBC_INLINE constexpr cpp::optional<T> lookup_odd(UIntType x_abs,
+  LIBC_INLINE constexpr cpp::optional<T> lookup_odd(StorageType x_abs,
                                                     bool sign) const {
     for (size_t i = 0; i < N; ++i) {
       if (LIBC_UNLIKELY(x_abs == values[i].input)) {
-        UIntType out_bits = values[i].rnd_towardzero_result;
+        StorageType out_bits = values[i].rnd_towardzero_result;
         switch (fputil::quick_get_round()) {
         case FE_UPWARD:
           out_bits += sign ? values[i].rnd_downward_offset

--- a/libc/src/__support/FPUtil/fpbits_str.h
+++ b/libc/src/__support/FPUtil/fpbits_str.h
@@ -56,8 +56,7 @@ template <typename T> LIBC_INLINE cpp::string str(fputil::FPBits<T> x) {
   const details::ZeroPaddedHexFmt<uint16_t> exponent(x.get_biased_exponent());
   s += exponent.view();
 
-  if constexpr (cpp::is_same_v<T, long double> &&
-                fputil::FloatProperties<long double>::MANTISSA_WIDTH == 63) {
+  if constexpr (fputil::get_fp_type<T>() == fputil::FPType::X86_Binary80) {
     s += ", I: ";
     s += sign_char(x.get_implicit_bit());
   }

--- a/libc/src/__support/FPUtil/fpbits_str.h
+++ b/libc/src/__support/FPUtil/fpbits_str.h
@@ -35,7 +35,7 @@ using ZeroPaddedHexFmt = IntegerToString<
 // 3. The exponent is always 16 bits wide irrespective of the type of the
 //    floating encoding.
 template <typename T> LIBC_INLINE cpp::string str(fputil::FPBits<T> x) {
-  using UIntType = typename fputil::FPBits<T>::UIntType;
+  using StorageType = typename fputil::FPBits<T>::StorageType;
 
   if (x.is_nan())
     return "(NaN)";
@@ -46,7 +46,7 @@ template <typename T> LIBC_INLINE cpp::string str(fputil::FPBits<T> x) {
 
   cpp::string s;
 
-  const details::ZeroPaddedHexFmt<UIntType> bits(x.bits);
+  const details::ZeroPaddedHexFmt<StorageType> bits(x.bits);
   s += bits.view();
 
   s += " = (S: ";
@@ -62,7 +62,7 @@ template <typename T> LIBC_INLINE cpp::string str(fputil::FPBits<T> x) {
   }
 
   s += ", M: ";
-  const details::ZeroPaddedHexFmt<UIntType> mantissa(x.get_mantissa());
+  const details::ZeroPaddedHexFmt<StorageType> mantissa(x.get_mantissa());
   s += mantissa.view();
 
   s += ')';

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -159,10 +159,10 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
 
   UInt128 prod_mant = x_mant * y_mant << 10;
   int prod_lsb_exp =
-      x_exp + y_exp - (FPBits::EXPONENT_BIAS + 2 * FPBits::MANTISSA_WIDTH + 10);
+      x_exp + y_exp - (FPBits::EXPONENT_BIAS + 2 * FPBits::FRACTION_BITS + 10);
 
   z_mant <<= 64;
-  int z_lsb_exp = z_exp - (FPBits::MANTISSA_WIDTH + 64);
+  int z_lsb_exp = z_exp - (FPBits::FRACTION_BITS + 64);
   bool round_bit = false;
   bool sticky_bits = false;
   bool z_shifted = false;
@@ -268,8 +268,8 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
   }
 
   // Remove hidden bit and append the exponent field and sign bit.
-  result = (result & FloatProp::MANTISSA_MASK) |
-           (static_cast<uint64_t>(r_exp) << FloatProp::MANTISSA_WIDTH);
+  result = (result & FloatProp::FRACTION_MASK) |
+           (static_cast<uint64_t>(r_exp) << FloatProp::FRACTION_BITS);
   if (prod_sign) {
     result |= FloatProp::SIGN_MASK;
   }

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -159,10 +159,10 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
 
   UInt128 prod_mant = x_mant * y_mant << 10;
   int prod_lsb_exp =
-      x_exp + y_exp - (FPBits::EXPONENT_BIAS + 2 * FPBits::FRACTION_BITS + 10);
+      x_exp + y_exp - (FPBits::EXP_BIAS + 2 * FPBits::FRACTION_LEN + 10);
 
   z_mant <<= 64;
-  int z_lsb_exp = z_exp - (FPBits::FRACTION_BITS + 64);
+  int z_lsb_exp = z_exp - (FPBits::FRACTION_LEN + 64);
   bool round_bit = false;
   bool sticky_bits = false;
   bool z_shifted = false;
@@ -269,7 +269,7 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
 
   // Remove hidden bit and append the exponent field and sign bit.
   result = (result & FloatProp::FRACTION_MASK) |
-           (static_cast<uint64_t>(r_exp) << FloatProp::FRACTION_BITS);
+           (static_cast<uint64_t>(r_exp) << FloatProp::FRACTION_LEN);
   if (prod_sign) {
     result |= FloatProp::SIGN_MASK;
   }

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -167,11 +167,13 @@ template <typename T> struct FModFastMathWrapper {
 
 template <typename T> class FModDivisionSimpleHelper {
 private:
-  using UIntType = typename FPBits<T>::UIntType;
+  using StorageType = typename FPBits<T>::StorageType;
 
 public:
-  LIBC_INLINE constexpr static UIntType
-  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
+  LIBC_INLINE constexpr static StorageType execute(int exp_diff,
+                                                   int sides_zeroes_count,
+                                                   StorageType m_x,
+                                                   StorageType m_y) {
     while (exp_diff > sides_zeroes_count) {
       exp_diff -= sides_zeroes_count;
       m_x <<= sides_zeroes_count;
@@ -186,22 +188,25 @@ public:
 template <typename T> class FModDivisionInvMultHelper {
 private:
   using FPB = FPBits<T>;
-  using UIntType = typename FPB::UIntType;
+  using StorageType = typename FPB::StorageType;
 
 public:
-  LIBC_INLINE constexpr static UIntType
-  execute(int exp_diff, int sides_zeroes_count, UIntType m_x, UIntType m_y) {
+  LIBC_INLINE constexpr static StorageType execute(int exp_diff,
+                                                   int sides_zeroes_count,
+                                                   StorageType m_x,
+                                                   StorageType m_y) {
     if (exp_diff > sides_zeroes_count) {
-      UIntType inv_hy = (cpp::numeric_limits<UIntType>::max() / m_y);
+      StorageType inv_hy = (cpp::numeric_limits<StorageType>::max() / m_y);
       while (exp_diff > sides_zeroes_count) {
         exp_diff -= sides_zeroes_count;
-        UIntType hd = (m_x * inv_hy) >> (FPB::BIT_WIDTH - sides_zeroes_count);
+        StorageType hd =
+            (m_x * inv_hy) >> (FPB::TOTAL_LEN - sides_zeroes_count);
         m_x <<= sides_zeroes_count;
         m_x -= hd * m_y;
         while (LIBC_UNLIKELY(m_x > m_y))
           m_x -= m_y;
       }
-      UIntType hd = (m_x * inv_hy) >> (FPB::BIT_WIDTH - exp_diff);
+      StorageType hd = (m_x * inv_hy) >> (FPB::TOTAL_LEN - exp_diff);
       m_x <<= exp_diff;
       m_x -= hd * m_y;
       while (LIBC_UNLIKELY(m_x > m_y))
@@ -222,7 +227,7 @@ class FMod {
 
 private:
   using FPB = FPBits<T>;
-  using UIntType = typename FPB::UIntType;
+  using StorageType = typename FPB::StorageType;
 
   LIBC_INLINE static constexpr FPB eval_internal(FPB sx, FPB sy) {
 
@@ -235,12 +240,12 @@ private:
     int e_x = sx.get_biased_exponent();
     int e_y = sy.get_biased_exponent();
 
-    // Most common case where |y| is "very normal" and |x/y| < 2^EXPONENT_WIDTH
-    if (LIBC_LIKELY(e_y > int(FPB::FRACTION_BITS) &&
-                    e_x - e_y <= int(FPB::EXPONENT_WIDTH))) {
-      UIntType m_x = sx.get_explicit_mantissa();
-      UIntType m_y = sy.get_explicit_mantissa();
-      UIntType d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
+    // Most common case where |y| is "very normal" and |x/y| < 2^EXP_LEN
+    if (LIBC_LIKELY(e_y > int(FPB::FRACTION_LEN) &&
+                    e_x - e_y <= int(FPB::EXP_LEN))) {
+      StorageType m_x = sx.get_explicit_mantissa();
+      StorageType m_y = sy.get_explicit_mantissa();
+      StorageType d = (e_x == e_y) ? (m_x - m_y) : (m_x << (e_x - e_y)) % m_y;
       if (d == 0)
         return FPB(FPB::zero());
       // iy - 1 because of "zero power" for number with power 1
@@ -254,11 +259,11 @@ private:
     }
 
     // Note that hx is not subnormal by conditions above.
-    UIntType m_x = sx.get_explicit_mantissa();
+    StorageType m_x = sx.get_explicit_mantissa();
     e_x--;
 
-    UIntType m_y = sy.get_explicit_mantissa();
-    int lead_zeros_m_y = FPB::EXPONENT_WIDTH;
+    StorageType m_y = sy.get_explicit_mantissa();
+    int lead_zeros_m_y = FPB::EXP_LEN;
     if (LIBC_LIKELY(e_y > 0)) {
       e_y--;
     } else {
@@ -281,8 +286,7 @@ private:
 
     {
       // Shift hx left until the end or n = 0
-      int left_shift =
-          exp_diff < int(FPB::EXPONENT_WIDTH) ? exp_diff : FPB::EXPONENT_WIDTH;
+      int left_shift = exp_diff < int(FPB::EXP_LEN) ? exp_diff : FPB::EXP_LEN;
       m_x <<= left_shift;
       exp_diff -= left_shift;
     }

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -236,7 +236,7 @@ private:
     int e_y = sy.get_biased_exponent();
 
     // Most common case where |y| is "very normal" and |x/y| < 2^EXPONENT_WIDTH
-    if (LIBC_LIKELY(e_y > int(FPB::MANTISSA_WIDTH) &&
+    if (LIBC_LIKELY(e_y > int(FPB::FRACTION_BITS) &&
                     e_x - e_y <= int(FPB::EXPONENT_WIDTH))) {
       UIntType m_x = sx.get_explicit_mantissa();
       UIntType m_y = sy.get_explicit_mantissa();

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -35,9 +35,9 @@ template <> struct SpecialLongDouble<long double> {
 
 template <typename T>
 LIBC_INLINE void normalize(int &exponent,
-                           typename FPBits<T>::UIntType &mantissa) {
+                           typename FPBits<T>::StorageType &mantissa) {
   const int shift = cpp::countl_zero(mantissa) -
-                    (8 * sizeof(mantissa) - 1 - FPBits<T>::FRACTION_BITS);
+                    (8 * sizeof(mantissa) - 1 - FPBits<T>::FRACTION_LEN);
   exponent -= shift;
   mantissa <<= shift;
 }
@@ -71,8 +71,8 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
     return x86::sqrt(x);
   } else {
     // IEEE floating points formats.
-    using UIntType = typename FPBits<T>::UIntType;
-    constexpr UIntType ONE = UIntType(1) << FPBits<T>::FRACTION_BITS;
+    using StorageType = typename FPBits<T>::StorageType;
+    constexpr StorageType ONE = StorageType(1) << FPBits<T>::FRACTION_LEN;
 
     FPBits<T> bits(x);
 
@@ -94,7 +94,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       return FPBits<T>::build_quiet_nan(ONE >> 1);
     } else {
       int x_exp = bits.get_exponent();
-      UIntType x_mant = bits.get_mantissa();
+      StorageType x_mant = bits.get_mantissa();
 
       // Step 1a: Normalize denormal input and append hidden bit to the mantissa
       if (bits.get_biased_exponent() == 0) {
@@ -122,12 +122,12 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       // So the nth digit y_n of the mantissa of sqrt(x) can be found by:
       //   y_n = 1 if 2*r(n-1) >= 2*y(n - 1) + 2^(-n-1)
       //         0 otherwise.
-      UIntType y = ONE;
-      UIntType r = x_mant - ONE;
+      StorageType y = ONE;
+      StorageType r = x_mant - ONE;
 
-      for (UIntType current_bit = ONE >> 1; current_bit; current_bit >>= 1) {
+      for (StorageType current_bit = ONE >> 1; current_bit; current_bit >>= 1) {
         r <<= 1;
-        UIntType tmp = (y << 1) + current_bit; // 2*y(n - 1) + 2^(-n-1)
+        StorageType tmp = (y << 1) + current_bit; // 2*y(n - 1) + 2^(-n-1)
         if (r >= tmp) {
           r -= tmp;
           y += current_bit;
@@ -138,17 +138,17 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       bool lsb = static_cast<bool>(y & 1); // Least significant bit
       bool rb = false;                     // Round bit
       r <<= 2;
-      UIntType tmp = (y << 2) + 1;
+      StorageType tmp = (y << 2) + 1;
       if (r >= tmp) {
         r -= tmp;
         rb = true;
       }
 
       // Remove hidden bit and append the exponent field.
-      x_exp = ((x_exp >> 1) + FPBits<T>::EXPONENT_BIAS);
+      x_exp = ((x_exp >> 1) + FPBits<T>::EXP_BIAS);
 
       y = (y - ONE) |
-          (static_cast<UIntType>(x_exp) << FPBits<T>::FRACTION_BITS);
+          (static_cast<StorageType>(x_exp) << FPBits<T>::FRACTION_LEN);
 
       switch (quick_get_round()) {
       case FE_TONEAREST:

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -37,7 +37,7 @@ template <typename T>
 LIBC_INLINE void normalize(int &exponent,
                            typename FPBits<T>::UIntType &mantissa) {
   const int shift = cpp::countl_zero(mantissa) -
-                    (8 * sizeof(mantissa) - 1 - FPBits<T>::MANTISSA_WIDTH);
+                    (8 * sizeof(mantissa) - 1 - FPBits<T>::FRACTION_BITS);
   exponent -= shift;
   mantissa <<= shift;
 }
@@ -72,7 +72,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
   } else {
     // IEEE floating points formats.
     using UIntType = typename FPBits<T>::UIntType;
-    constexpr UIntType ONE = UIntType(1) << FPBits<T>::MANTISSA_WIDTH;
+    constexpr UIntType ONE = UIntType(1) << FPBits<T>::FRACTION_BITS;
 
     FPBits<T> bits(x);
 
@@ -148,7 +148,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
       x_exp = ((x_exp >> 1) + FPBits<T>::EXPONENT_BIAS);
 
       y = (y - ONE) |
-          (static_cast<UIntType>(x_exp) << FPBits<T>::MANTISSA_WIDTH);
+          (static_cast<UIntType>(x_exp) << FPBits<T>::FRACTION_BITS);
 
       switch (quick_get_round()) {
       case FE_TONEAREST:

--- a/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
+++ b/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
@@ -23,7 +23,7 @@ namespace x86 {
 LIBC_INLINE void normalize(int &exponent, UInt128 &mantissa) {
   const unsigned int shift = static_cast<unsigned int>(
       cpp::countl_zero(static_cast<uint64_t>(mantissa)) -
-      (8 * sizeof(uint64_t) - 1 - FPBits<long double>::FRACTION_BITS));
+      (8 * sizeof(uint64_t) - 1 - FPBits<long double>::FRACTION_LEN));
   exponent -= shift;
   mantissa <<= shift;
 }
@@ -37,8 +37,8 @@ LIBC_INLINE long double sqrt(long double x);
 #if defined(LIBC_LONG_DOUBLE_IS_X86_FLOAT80)
 LIBC_INLINE long double sqrt(long double x) {
   using LDBits = FPBits<long double>;
-  using UIntType = typename LDBits::UIntType;
-  constexpr UIntType ONE = UIntType(1) << int(LDBits::FRACTION_BITS);
+  using StorageType = typename LDBits::StorageType;
+  constexpr StorageType ONE = StorageType(1) << int(LDBits::FRACTION_LEN);
 
   FPBits<long double> bits(x);
 
@@ -60,7 +60,7 @@ LIBC_INLINE long double sqrt(long double x) {
     return LDBits::build_quiet_nan(ONE >> 1);
   } else {
     int x_exp = bits.get_explicit_exponent();
-    UIntType x_mant = bits.get_mantissa();
+    StorageType x_mant = bits.get_mantissa();
 
     // Step 1a: Normalize denormal input
     if (bits.get_implicit_bit()) {
@@ -87,12 +87,12 @@ LIBC_INLINE long double sqrt(long double x) {
     // So the nth digit y_n of the mantissa of sqrt(x) can be found by:
     //   y_n = 1 if 2*r(n-1) >= 2*y(n - 1) + 2^(-n-1)
     //         0 otherwise.
-    UIntType y = ONE;
-    UIntType r = x_mant - ONE;
+    StorageType y = ONE;
+    StorageType r = x_mant - ONE;
 
-    for (UIntType current_bit = ONE >> 1; current_bit; current_bit >>= 1) {
+    for (StorageType current_bit = ONE >> 1; current_bit; current_bit >>= 1) {
       r <<= 1;
-      UIntType tmp = (y << 1) + current_bit; // 2*y(n - 1) + 2^(-n-1)
+      StorageType tmp = (y << 1) + current_bit; // 2*y(n - 1) + 2^(-n-1)
       if (r >= tmp) {
         r -= tmp;
         y += current_bit;
@@ -103,15 +103,15 @@ LIBC_INLINE long double sqrt(long double x) {
     bool lsb = static_cast<bool>(y & 1); // Least significant bit
     bool rb = false;                     // Round bit
     r <<= 2;
-    UIntType tmp = (y << 2) + 1;
+    StorageType tmp = (y << 2) + 1;
     if (r >= tmp) {
       r -= tmp;
       rb = true;
     }
 
     // Append the exponent field.
-    x_exp = ((x_exp >> 1) + LDBits::EXPONENT_BIAS);
-    y |= (static_cast<UIntType>(x_exp) << (LDBits::FRACTION_BITS + 1));
+    x_exp = ((x_exp >> 1) + LDBits::EXP_BIAS);
+    y |= (static_cast<StorageType>(x_exp) << (LDBits::FRACTION_LEN + 1));
 
     switch (quick_get_round()) {
     case FE_TONEAREST:

--- a/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
+++ b/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
@@ -23,7 +23,7 @@ namespace x86 {
 LIBC_INLINE void normalize(int &exponent, UInt128 &mantissa) {
   const unsigned int shift = static_cast<unsigned int>(
       cpp::countl_zero(static_cast<uint64_t>(mantissa)) -
-      (8 * sizeof(uint64_t) - 1 - FPBits<long double>::MANTISSA_WIDTH));
+      (8 * sizeof(uint64_t) - 1 - FPBits<long double>::FRACTION_BITS));
   exponent -= shift;
   mantissa <<= shift;
 }
@@ -38,7 +38,7 @@ LIBC_INLINE long double sqrt(long double x);
 LIBC_INLINE long double sqrt(long double x) {
   using LDBits = FPBits<long double>;
   using UIntType = typename LDBits::UIntType;
-  constexpr UIntType ONE = UIntType(1) << int(LDBits::MANTISSA_WIDTH);
+  constexpr UIntType ONE = UIntType(1) << int(LDBits::FRACTION_BITS);
 
   FPBits<long double> bits(x);
 
@@ -111,7 +111,7 @@ LIBC_INLINE long double sqrt(long double x) {
 
     // Append the exponent field.
     x_exp = ((x_exp >> 1) + LDBits::EXPONENT_BIAS);
-    y |= (static_cast<UIntType>(x_exp) << (LDBits::MANTISSA_WIDTH + 1));
+    y |= (static_cast<UIntType>(x_exp) << (LDBits::FRACTION_BITS + 1));
 
     switch (quick_get_round()) {
     case FE_TONEAREST:

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -33,37 +33,37 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   using FloatProperties<long double>::EXPONENT_MASK;
   using FloatProperties<long double>::EXPONENT_BIAS;
   using FloatProperties<long double>::EXPONENT_WIDTH;
-  using FloatProperties<long double>::MANTISSA_MASK;
-  using FloatProperties<long double>::MANTISSA_WIDTH;
+  using FloatProperties<long double>::FRACTION_MASK;
+  using FloatProperties<long double>::FRACTION_BITS;
   using FloatProperties<long double>::QUIET_NAN_MASK;
   using FloatProperties<long double>::SIGN_MASK;
 
   static constexpr int MAX_EXPONENT = 0x7FFF;
   static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
-  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << MANTISSA_WIDTH) - 1;
-  static constexpr UIntType MIN_NORMAL = (UIntType(3) << MANTISSA_WIDTH);
+  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << FRACTION_BITS) - 1;
+  static constexpr UIntType MIN_NORMAL = (UIntType(3) << FRACTION_BITS);
   static constexpr UIntType MAX_NORMAL =
-      (UIntType(MAX_EXPONENT - 1) << (MANTISSA_WIDTH + 1)) |
-      (UIntType(1) << MANTISSA_WIDTH) | MAX_SUBNORMAL;
+      (UIntType(MAX_EXPONENT - 1) << (FRACTION_BITS + 1)) |
+      (UIntType(1) << FRACTION_BITS) | MAX_SUBNORMAL;
 
   UIntType bits;
 
   LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
-    mantVal &= MANTISSA_MASK;
-    bits &= ~MANTISSA_MASK;
+    mantVal &= FRACTION_MASK;
+    bits &= ~FRACTION_MASK;
     bits |= mantVal;
   }
 
   LIBC_INLINE constexpr UIntType get_mantissa() const {
-    return bits & MANTISSA_MASK;
+    return bits & FRACTION_MASK;
   }
 
   LIBC_INLINE constexpr UIntType get_explicit_mantissa() const {
     // The x86 80 bit float represents the leading digit of the mantissa
     // explicitly. This is the mask for that bit.
-    constexpr UIntType EXPLICIT_BIT_MASK = UIntType(1) << MANTISSA_WIDTH;
-    return bits & (MANTISSA_MASK | EXPLICIT_BIT_MASK);
+    constexpr UIntType EXPLICIT_BIT_MASK = UIntType(1) << FRACTION_BITS;
+    return bits & (FRACTION_MASK | EXPLICIT_BIT_MASK);
   }
 
   LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
@@ -77,12 +77,12 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   }
 
   LIBC_INLINE constexpr void set_implicit_bit(bool implicitVal) {
-    bits &= ~(UIntType(1) << MANTISSA_WIDTH);
-    bits |= (UIntType(implicitVal) << MANTISSA_WIDTH);
+    bits &= ~(UIntType(1) << FRACTION_BITS);
+    bits |= (UIntType(implicitVal) << FRACTION_BITS);
   }
 
   LIBC_INLINE constexpr bool get_implicit_bit() const {
-    return bool((bits & (UIntType(1) << MANTISSA_WIDTH)) >> MANTISSA_WIDTH);
+    return bool((bits & (UIntType(1) << FRACTION_BITS)) >> FRACTION_BITS);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -27,72 +27,73 @@ namespace LIBC_NAMESPACE {
 namespace fputil {
 
 template <> struct FPBits<long double> : private FloatProperties<long double> {
-  using typename FloatProperties<long double>::UIntType;
-  using FloatProperties<long double>::BIT_WIDTH;
+  using typename FloatProperties<long double>::StorageType;
+  using FloatProperties<long double>::TOTAL_LEN;
   using FloatProperties<long double>::EXP_MANT_MASK;
-  using FloatProperties<long double>::EXPONENT_MASK;
-  using FloatProperties<long double>::EXPONENT_BIAS;
-  using FloatProperties<long double>::EXPONENT_WIDTH;
+  using FloatProperties<long double>::EXP_MASK;
+  using FloatProperties<long double>::EXP_BIAS;
+  using FloatProperties<long double>::EXP_LEN;
   using FloatProperties<long double>::FRACTION_MASK;
-  using FloatProperties<long double>::FRACTION_BITS;
+  using FloatProperties<long double>::FRACTION_LEN;
   using FloatProperties<long double>::QUIET_NAN_MASK;
   using FloatProperties<long double>::SIGN_MASK;
 
   static constexpr int MAX_EXPONENT = 0x7FFF;
-  static constexpr UIntType MIN_SUBNORMAL = UIntType(1);
+  static constexpr StorageType MIN_SUBNORMAL = StorageType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
-  static constexpr UIntType MAX_SUBNORMAL = (UIntType(1) << FRACTION_BITS) - 1;
-  static constexpr UIntType MIN_NORMAL = (UIntType(3) << FRACTION_BITS);
-  static constexpr UIntType MAX_NORMAL =
-      (UIntType(MAX_EXPONENT - 1) << (FRACTION_BITS + 1)) |
-      (UIntType(1) << FRACTION_BITS) | MAX_SUBNORMAL;
+  static constexpr StorageType MAX_SUBNORMAL =
+      (StorageType(1) << FRACTION_LEN) - 1;
+  static constexpr StorageType MIN_NORMAL = (StorageType(3) << FRACTION_LEN);
+  static constexpr StorageType MAX_NORMAL =
+      (StorageType(MAX_EXPONENT - 1) << (FRACTION_LEN + 1)) |
+      (StorageType(1) << FRACTION_LEN) | MAX_SUBNORMAL;
 
-  UIntType bits;
+  StorageType bits;
 
-  LIBC_INLINE constexpr void set_mantissa(UIntType mantVal) {
+  LIBC_INLINE constexpr void set_mantissa(StorageType mantVal) {
     mantVal &= FRACTION_MASK;
     bits &= ~FRACTION_MASK;
     bits |= mantVal;
   }
 
-  LIBC_INLINE constexpr UIntType get_mantissa() const {
+  LIBC_INLINE constexpr StorageType get_mantissa() const {
     return bits & FRACTION_MASK;
   }
 
-  LIBC_INLINE constexpr UIntType get_explicit_mantissa() const {
+  LIBC_INLINE constexpr StorageType get_explicit_mantissa() const {
     // The x86 80 bit float represents the leading digit of the mantissa
     // explicitly. This is the mask for that bit.
-    constexpr UIntType EXPLICIT_BIT_MASK = UIntType(1) << FRACTION_BITS;
+    constexpr StorageType EXPLICIT_BIT_MASK = StorageType(1) << FRACTION_LEN;
     return bits & (FRACTION_MASK | EXPLICIT_BIT_MASK);
   }
 
-  LIBC_INLINE constexpr void set_biased_exponent(UIntType expVal) {
-    expVal = (expVal << (BIT_WIDTH - 1 - EXPONENT_WIDTH)) & EXPONENT_MASK;
-    bits &= ~EXPONENT_MASK;
+  LIBC_INLINE constexpr void set_biased_exponent(StorageType expVal) {
+    expVal = (expVal << (TOTAL_LEN - 1 - EXP_LEN)) & EXP_MASK;
+    bits &= ~EXP_MASK;
     bits |= expVal;
   }
 
   LIBC_INLINE constexpr uint16_t get_biased_exponent() const {
-    return uint16_t((bits & EXPONENT_MASK) >> (BIT_WIDTH - 1 - EXPONENT_WIDTH));
+    return uint16_t((bits & EXP_MASK) >> (TOTAL_LEN - 1 - EXP_LEN));
   }
 
   LIBC_INLINE constexpr void set_implicit_bit(bool implicitVal) {
-    bits &= ~(UIntType(1) << FRACTION_BITS);
-    bits |= (UIntType(implicitVal) << FRACTION_BITS);
+    bits &= ~(StorageType(1) << FRACTION_LEN);
+    bits |= (StorageType(implicitVal) << FRACTION_LEN);
   }
 
   LIBC_INLINE constexpr bool get_implicit_bit() const {
-    return bool((bits & (UIntType(1) << FRACTION_BITS)) >> FRACTION_BITS);
+    return bool((bits & (StorageType(1) << FRACTION_LEN)) >> FRACTION_LEN);
   }
 
   LIBC_INLINE constexpr void set_sign(bool signVal) {
     bits &= ~SIGN_MASK;
-    UIntType sign1 = UIntType(signVal) << (BIT_WIDTH - 1);
+    StorageType sign1 = StorageType(signVal) << (TOTAL_LEN - 1);
     bits |= sign1;
   }
 
   LIBC_INLINE constexpr bool get_sign() const {
-    return bool((bits & SIGN_MASK) >> (BIT_WIDTH - 1));
+    return bool((bits & SIGN_MASK) >> (TOTAL_LEN - 1));
   }
 
   LIBC_INLINE constexpr FPBits() : bits(0) {}
@@ -100,21 +101,21 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   template <typename XType,
             cpp::enable_if_t<cpp::is_same_v<long double, XType>, int> = 0>
   LIBC_INLINE constexpr explicit FPBits(XType x)
-      : bits(cpp::bit_cast<UIntType>(x)) {
+      : bits(cpp::bit_cast<StorageType>(x)) {
     // bits starts uninitialized, and setting it to a long double only
     // overwrites the first 80 bits. This clears those upper bits.
-    bits = bits & ((UIntType(1) << 80) - 1);
+    bits = bits & ((StorageType(1) << 80) - 1);
   }
 
   template <typename XType,
-            cpp::enable_if_t<cpp::is_same_v<XType, UIntType>, int> = 0>
+            cpp::enable_if_t<cpp::is_same_v<XType, StorageType>, int> = 0>
   LIBC_INLINE constexpr explicit FPBits(XType x) : bits(x) {}
 
   LIBC_INLINE constexpr operator long double() {
     return cpp::bit_cast<long double>(bits);
   }
 
-  LIBC_INLINE constexpr UIntType uintval() {
+  LIBC_INLINE constexpr StorageType uintval() {
     // We zero the padding bits as they can contain garbage.
     return bits & FP_MASK;
   }
@@ -124,7 +125,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   }
 
   LIBC_INLINE constexpr int get_exponent() const {
-    return int(get_biased_exponent()) - EXPONENT_BIAS;
+    return int(get_biased_exponent()) - EXP_BIAS;
   }
 
   // If the number is subnormal, the exponent is treated as if it were the
@@ -138,9 +139,9 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
     if (is_zero()) {
       return 0;
     } else if (biased_exp == 0) {
-      return 1 - EXPONENT_BIAS;
+      return 1 - EXP_BIAS;
     } else {
-      return biased_exp - EXPONENT_BIAS;
+      return biased_exp - EXP_BIAS;
     }
   }
 
@@ -186,7 +187,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
 
   LIBC_INLINE static constexpr long double neg_inf() { return inf(true); }
 
-  LIBC_INLINE static constexpr long double build_nan(UIntType v) {
+  LIBC_INLINE static constexpr long double build_nan(StorageType v) {
     FPBits<long double> bits(0.0l);
     bits.set_biased_exponent(MAX_EXPONENT);
     bits.set_implicit_bit(1);
@@ -194,7 +195,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
     return bits;
   }
 
-  LIBC_INLINE static constexpr long double build_quiet_nan(UIntType v) {
+  LIBC_INLINE static constexpr long double build_quiet_nan(StorageType v) {
     return build_nan(QUIET_NAN_MASK | v);
   }
 
@@ -215,7 +216,7 @@ template <> struct FPBits<long double> : private FloatProperties<long double> {
   }
 
   LIBC_INLINE static constexpr FPBits<long double>
-  create_value(bool sign, UIntType biased_exp, UIntType mantissa) {
+  create_value(bool sign, StorageType biased_exp, StorageType mantissa) {
     FPBits<long double> result;
     result.set_sign(sign);
     result.set_biased_exponent(biased_exp);

--- a/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
+++ b/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
@@ -45,8 +45,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
 
   using UIntType = FPBits::UIntType;
   constexpr UIntType SIGN_VAL = (UIntType(1) << 79);
-  constexpr UIntType MANTISSA_MASK =
-      (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1;
+  constexpr UIntType FRACTION_MASK = FPBits::FRACTION_MASK;
   UIntType int_val = from_bits.uintval();
   if (from < 0.0l) {
     if (from > to) {
@@ -54,7 +53,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         // We deal with normal/subnormal boundary separately to avoid
         // dealing with the implicit bit.
         int_val = SIGN_VAL + FPBits::MIN_NORMAL;
-      } else if ((int_val & MANTISSA_MASK) == MANTISSA_MASK) {
+      } else if ((int_val & FRACTION_MASK) == FRACTION_MASK) {
         from_bits.set_mantissa(0);
         // Incrementing exponent might overflow the value to infinity,
         // which is what is expected. Since NaNs are handling separately,
@@ -71,8 +70,8 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
         // We deal with normal/subnormal boundary separately to avoid
         // dealing with the implicit bit.
         int_val = SIGN_VAL + FPBits::MAX_SUBNORMAL;
-      } else if ((int_val & MANTISSA_MASK) == 0) {
-        from_bits.set_mantissa(MANTISSA_MASK);
+      } else if ((int_val & FRACTION_MASK) == 0) {
+        from_bits.set_mantissa(FRACTION_MASK);
         // from == 0 is handled separately so decrementing the exponent will not
         // lead to underflow.
         from_bits.set_biased_exponent(from_bits.get_biased_exponent() - 1);
@@ -90,8 +89,8 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     if (from > to) {
       if (int_val == FPBits::MIN_NORMAL) {
         int_val = FPBits::MAX_SUBNORMAL;
-      } else if ((int_val & MANTISSA_MASK) == 0) {
-        from_bits.set_mantissa(MANTISSA_MASK);
+      } else if ((int_val & FRACTION_MASK) == 0) {
+        from_bits.set_mantissa(FRACTION_MASK);
         // from == 0 is handled separately so decrementing the exponent will not
         // lead to underflow.
         from_bits.set_biased_exponent(from_bits.get_biased_exponent() - 1);
@@ -102,7 +101,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     } else {
       if (int_val == FPBits::MAX_SUBNORMAL) {
         int_val = FPBits::MIN_NORMAL;
-      } else if ((int_val & MANTISSA_MASK) == MANTISSA_MASK) {
+      } else if ((int_val & FRACTION_MASK) == FRACTION_MASK) {
         from_bits.set_mantissa(0);
         // Incrementing exponent might overflow the value to infinity,
         // which is what is expected. Since NaNs are handling separately,
@@ -117,7 +116,7 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     }
   }
 
-  UIntType implicit_bit = int_val & (UIntType(1) << FPBits::MANTISSA_WIDTH);
+  UIntType implicit_bit = int_val & (UIntType(1) << FPBits::FRACTION_BITS);
   if (implicit_bit == UIntType(0))
     raise_except_if_required(FE_UNDERFLOW | FE_INEXACT);
 

--- a/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
+++ b/libc/src/__support/FPUtil/x86_64/NextAfterLongDouble.h
@@ -43,10 +43,10 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     from_bits.set_biased_exponent(1);
   }
 
-  using UIntType = FPBits::UIntType;
-  constexpr UIntType SIGN_VAL = (UIntType(1) << 79);
-  constexpr UIntType FRACTION_MASK = FPBits::FRACTION_MASK;
-  UIntType int_val = from_bits.uintval();
+  using StorageType = FPBits::StorageType;
+  constexpr StorageType SIGN_VAL = (StorageType(1) << 79);
+  constexpr StorageType FRACTION_MASK = FPBits::FRACTION_MASK;
+  StorageType int_val = from_bits.uintval();
   if (from < 0.0l) {
     if (from > to) {
       if (int_val == (SIGN_VAL + FPBits::MAX_SUBNORMAL)) {
@@ -116,8 +116,8 @@ LIBC_INLINE long double nextafter(long double from, long double to) {
     }
   }
 
-  UIntType implicit_bit = int_val & (UIntType(1) << FPBits::FRACTION_BITS);
-  if (implicit_bit == UIntType(0))
+  StorageType implicit_bit = int_val & (StorageType(1) << FPBits::FRACTION_LEN);
+  if (implicit_bit == StorageType(0))
     raise_except_if_required(FE_UNDERFLOW | FE_INEXACT);
 
   return cpp::bit_cast<long double>(int_val);

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -416,7 +416,7 @@ class FloatToString {
   int exponent;
   FloatProp::UIntType mantissa;
 
-  static constexpr int MANT_WIDTH = fputil::FPBits<T>::MANTISSA_WIDTH;
+  static constexpr int FRACTION_BITS = fputil::FPBits<T>::FRACTION_BITS;
   static constexpr int EXP_BIAS = fputil::FPBits<T>::EXPONENT_BIAS;
 
 public:
@@ -426,7 +426,7 @@ public:
     mantissa = float_bits.get_explicit_mantissa();
 
     // Adjust for the width of the mantissa.
-    exponent -= MANT_WIDTH;
+    exponent -= FRACTION_BITS;
 
     // init_convert();
   }
@@ -440,7 +440,7 @@ public:
   // get_block returns an integer that represents the digits in the requested
   // block.
   LIBC_INLINE constexpr BlockInt get_positive_block(int block_index) {
-    if (exponent >= -MANT_WIDTH) {
+    if (exponent >= -FRACTION_BITS) {
       // idx is ceil(exponent/16) or 0 if exponent is negative. This is used to
       // find the coarse section of the POW10_SPLIT table that will be used to
       // calculate the 9 digit window, as well as some other related values.
@@ -567,12 +567,13 @@ public:
   }
 
   LIBC_INLINE constexpr size_t get_positive_blocks() {
-    if (exponent >= -MANT_WIDTH) {
+    if (exponent >= -FRACTION_BITS) {
       const uint32_t idx =
           exponent < 0
               ? 0
               : static_cast<uint32_t>(exponent + (IDX_SIZE - 1)) / IDX_SIZE;
-      const uint32_t len = internal::length_for_num(idx * IDX_SIZE, MANT_WIDTH);
+      const uint32_t len =
+          internal::length_for_num(idx * IDX_SIZE, FRACTION_BITS);
       return len;
     } else {
       return 0;
@@ -608,12 +609,13 @@ public:
 
 template <>
 LIBC_INLINE constexpr size_t FloatToString<long double>::get_positive_blocks() {
-  if (exponent >= -MANT_WIDTH) {
+  if (exponent >= -FRACTION_BITS) {
     const uint32_t idx =
         exponent < 0
             ? 0
             : static_cast<uint32_t>(exponent + (IDX_SIZE - 1)) / IDX_SIZE;
-    const uint32_t len = internal::length_for_num(idx * IDX_SIZE, MANT_WIDTH);
+    const uint32_t len =
+        internal::length_for_num(idx * IDX_SIZE, FRACTION_BITS);
     return len;
   } else {
     return 0;
@@ -639,7 +641,7 @@ LIBC_INLINE constexpr bool FloatToString<long double>::is_lowest_block(size_t) {
 template <>
 LIBC_INLINE constexpr BlockInt
 FloatToString<long double>::get_positive_block(int block_index) {
-  if (exponent >= -MANT_WIDTH) {
+  if (exponent >= -FRACTION_BITS) {
 
     // idx is ceil(exponent/16) or 0 if exponent is negative. This is used to
     // find the coarse section of the POW10_SPLIT table that will be used to

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -382,10 +382,10 @@ LIBC_INLINE uint32_t fast_uint_mod_1e9(const cpp::UInt<MID_INT_SIZE> &val) {
                                (1000000000 * shifted));
 }
 
-LIBC_INLINE uint32_t mul_shift_mod_1e9(const FloatProp::UIntType mantissa,
+LIBC_INLINE uint32_t mul_shift_mod_1e9(const FloatProp::StorageType mantissa,
                                        const cpp::UInt<MID_INT_SIZE> &large,
                                        const int32_t shift_amount) {
-  cpp::UInt<MID_INT_SIZE + FloatProp::UINTTYPE_BITS> val(large);
+  cpp::UInt<MID_INT_SIZE + FloatProp::STORAGE_LEN> val(large);
   val = (val * mantissa) >> shift_amount;
   return static_cast<uint32_t>(
       val.div_uint32_times_pow_2(1000000000, 0).value());
@@ -414,10 +414,10 @@ class FloatToString {
   fputil::FPBits<T> float_bits;
   bool is_negative;
   int exponent;
-  FloatProp::UIntType mantissa;
+  FloatProp::StorageType mantissa;
 
-  static constexpr int FRACTION_BITS = fputil::FPBits<T>::FRACTION_BITS;
-  static constexpr int EXP_BIAS = fputil::FPBits<T>::EXPONENT_BIAS;
+  static constexpr int FRACTION_LEN = fputil::FPBits<T>::FRACTION_LEN;
+  static constexpr int EXP_BIAS = fputil::FPBits<T>::EXP_BIAS;
 
 public:
   LIBC_INLINE constexpr FloatToString(T init_float) : float_bits(init_float) {
@@ -426,7 +426,7 @@ public:
     mantissa = float_bits.get_explicit_mantissa();
 
     // Adjust for the width of the mantissa.
-    exponent -= FRACTION_BITS;
+    exponent -= FRACTION_LEN;
 
     // init_convert();
   }
@@ -440,7 +440,7 @@ public:
   // get_block returns an integer that represents the digits in the requested
   // block.
   LIBC_INLINE constexpr BlockInt get_positive_block(int block_index) {
-    if (exponent >= -FRACTION_BITS) {
+    if (exponent >= -FRACTION_LEN) {
       // idx is ceil(exponent/16) or 0 if exponent is negative. This is used to
       // find the coarse section of the POW10_SPLIT table that will be used to
       // calculate the 9 digit window, as well as some other related values.
@@ -567,13 +567,13 @@ public:
   }
 
   LIBC_INLINE constexpr size_t get_positive_blocks() {
-    if (exponent >= -FRACTION_BITS) {
+    if (exponent >= -FRACTION_LEN) {
       const uint32_t idx =
           exponent < 0
               ? 0
               : static_cast<uint32_t>(exponent + (IDX_SIZE - 1)) / IDX_SIZE;
       const uint32_t len =
-          internal::length_for_num(idx * IDX_SIZE, FRACTION_BITS);
+          internal::length_for_num(idx * IDX_SIZE, FRACTION_LEN);
       return len;
     } else {
       return 0;
@@ -609,13 +609,12 @@ public:
 
 template <>
 LIBC_INLINE constexpr size_t FloatToString<long double>::get_positive_blocks() {
-  if (exponent >= -FRACTION_BITS) {
+  if (exponent >= -FRACTION_LEN) {
     const uint32_t idx =
         exponent < 0
             ? 0
             : static_cast<uint32_t>(exponent + (IDX_SIZE - 1)) / IDX_SIZE;
-    const uint32_t len =
-        internal::length_for_num(idx * IDX_SIZE, FRACTION_BITS);
+    const uint32_t len = internal::length_for_num(idx * IDX_SIZE, FRACTION_LEN);
     return len;
   } else {
     return 0;
@@ -641,7 +640,7 @@ LIBC_INLINE constexpr bool FloatToString<long double>::is_lowest_block(size_t) {
 template <>
 LIBC_INLINE constexpr BlockInt
 FloatToString<long double>::get_positive_block(int block_index) {
-  if (exponent >= -FRACTION_BITS) {
+  if (exponent >= -FRACTION_LEN) {
 
     // idx is ceil(exponent/16) or 0 if exponent is negative. This is used to
     // find the coarse section of the POW10_SPLIT table that will be used to

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -29,7 +29,7 @@ namespace LIBC_NAMESPACE {
 namespace internal {
 
 template <class T> struct ExpandedFloat {
-  typename fputil::FPBits<T>::UIntType mantissa;
+  typename fputil::FPBits<T>::StorageType mantissa;
   int32_t exponent;
 };
 
@@ -72,9 +72,9 @@ eisel_lemire(ExpandedFloat<T> init_num,
              RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
   using FloatProp = typename fputil::FloatProperties<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
-  UIntType mantissa = init_num.mantissa;
+  StorageType mantissa = init_num.mantissa;
   int32_t exp10 = init_num.exponent;
 
   if (sizeof(T) > 8) { // This algorithm cannot handle anything longer than a
@@ -89,11 +89,11 @@ eisel_lemire(ExpandedFloat<T> init_num,
   }
 
   // Normalization
-  uint32_t clz = cpp::countl_zero<UIntType>(mantissa);
+  uint32_t clz = cpp::countl_zero<StorageType>(mantissa);
   mantissa <<= clz;
 
-  int32_t exp2 = exp10_to_exp2(exp10) + FloatProp::UINTTYPE_BITS +
-                 FloatProp::EXPONENT_BIAS - clz;
+  int32_t exp2 =
+      exp10_to_exp2(exp10) + FloatProp::STORAGE_LEN + FloatProp::EXP_BIAS - clz;
 
   // Multiplication
   const uint64_t *power_of_ten =
@@ -110,8 +110,8 @@ eisel_lemire(ExpandedFloat<T> init_num,
   // accuracy, and the most significant bit is ignored.) = 9 bits. Similarly,
   // it's 6 bits for floats in this case.
   const uint64_t halfway_constant =
-      (uint64_t(1) << (FloatProp::UINTTYPE_BITS -
-                       (FloatProp::FRACTION_BITS + 3))) -
+      (uint64_t(1) << (FloatProp::STORAGE_LEN -
+                       (FloatProp::FRACTION_LEN + 3))) -
       1;
   if ((high64(first_approx) & halfway_constant) == halfway_constant &&
       low64(first_approx) + mantissa < mantissa) {
@@ -131,11 +131,11 @@ eisel_lemire(ExpandedFloat<T> init_num,
   }
 
   // Shifting to 54 bits for doubles and 25 bits for floats
-  UIntType msb = static_cast<UIntType>(high64(final_approx) >>
-                                       (FloatProp::UINTTYPE_BITS - 1));
-  UIntType final_mantissa = static_cast<UIntType>(
+  StorageType msb = static_cast<StorageType>(high64(final_approx) >>
+                                             (FloatProp::STORAGE_LEN - 1));
+  StorageType final_mantissa = static_cast<StorageType>(
       high64(final_approx) >>
-      (msb + FloatProp::UINTTYPE_BITS - (FloatProp::FRACTION_BITS + 3)));
+      (msb + FloatProp::STORAGE_LEN - (FloatProp::FRACTION_LEN + 3)));
   exp2 -= static_cast<uint32_t>(1 ^ msb); // same as !msb
 
   if (round == RoundDirection::Nearest) {
@@ -161,14 +161,14 @@ eisel_lemire(ExpandedFloat<T> init_num,
 
   // From 54 to 53 bits for doubles and 25 to 24 bits for floats
   final_mantissa >>= 1;
-  if ((final_mantissa >> (FloatProp::FRACTION_BITS + 1)) > 0) {
+  if ((final_mantissa >> (FloatProp::FRACTION_LEN + 1)) > 0) {
     final_mantissa >>= 1;
     ++exp2;
   }
 
   // The if block is equivalent to (but has fewer branches than):
   //   if exp2 <= 0 || exp2 >= 0x7FF { etc }
-  if (static_cast<uint32_t>(exp2) - 1 >= (1 << FloatProp::EXPONENT_WIDTH) - 2) {
+  if (static_cast<uint32_t>(exp2) - 1 >= (1 << FloatProp::EXP_LEN) - 2) {
     return cpp::nullopt;
   }
 
@@ -185,9 +185,9 @@ eisel_lemire<long double>(ExpandedFloat<long double> init_num,
                           RoundDirection round) {
   using FPBits = typename fputil::FPBits<long double>;
   using FloatProp = typename fputil::FloatProperties<long double>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
-  UIntType mantissa = init_num.mantissa;
+  StorageType mantissa = init_num.mantissa;
   int32_t exp10 = init_num.exponent;
 
   // Exp10 Range
@@ -206,11 +206,11 @@ eisel_lemire<long double>(ExpandedFloat<long double> init_num,
   }
 
   // Normalization
-  uint32_t clz = cpp::countl_zero<UIntType>(mantissa);
+  uint32_t clz = cpp::countl_zero<StorageType>(mantissa);
   mantissa <<= clz;
 
-  int32_t exp2 = exp10_to_exp2(exp10) + FloatProp::UINTTYPE_BITS +
-                 FloatProp::EXPONENT_BIAS - clz;
+  int32_t exp2 =
+      exp10_to_exp2(exp10) + FloatProp::STORAGE_LEN + FloatProp::EXP_BIAS - clz;
 
   // Multiplication
   const uint64_t *power_of_ten =
@@ -247,8 +247,7 @@ eisel_lemire<long double>(ExpandedFloat<long double> init_num,
   // accuracy, and the most significant bit is ignored.) = 61 bits. Similarly,
   // it's 12 bits for 128 bit floats in this case.
   constexpr UInt128 HALFWAY_CONSTANT =
-      (UInt128(1) << (FloatProp::UINTTYPE_BITS -
-                      (FloatProp::FRACTION_BITS + 3))) -
+      (UInt128(1) << (FloatProp::STORAGE_LEN - (FloatProp::FRACTION_LEN + 3))) -
       1;
 
   if ((final_approx_upper & HALFWAY_CONSTANT) == HALFWAY_CONSTANT &&
@@ -257,11 +256,11 @@ eisel_lemire<long double>(ExpandedFloat<long double> init_num,
   }
 
   // Shifting to 65 bits for 80 bit floats and 113 bits for 128 bit floats
-  uint32_t msb = static_cast<uint32_t>(final_approx_upper >>
-                                       (FloatProp::UINTTYPE_BITS - 1));
-  UIntType final_mantissa =
+  uint32_t msb =
+      static_cast<uint32_t>(final_approx_upper >> (FloatProp::STORAGE_LEN - 1));
+  StorageType final_mantissa =
       final_approx_upper >>
-      (msb + FloatProp::UINTTYPE_BITS - (FloatProp::FRACTION_BITS + 3));
+      (msb + FloatProp::STORAGE_LEN - (FloatProp::FRACTION_LEN + 3));
   exp2 -= static_cast<uint32_t>(1 ^ msb); // same as !msb
 
   if (round == RoundDirection::Nearest) {
@@ -286,14 +285,14 @@ eisel_lemire<long double>(ExpandedFloat<long double> init_num,
   // From 65 to 64 bits for 80 bit floats and 113  to 112 bits for 128 bit
   // floats
   final_mantissa >>= 1;
-  if ((final_mantissa >> (FloatProp::FRACTION_BITS + 1)) > 0) {
+  if ((final_mantissa >> (FloatProp::FRACTION_LEN + 1)) > 0) {
     final_mantissa >>= 1;
     ++exp2;
   }
 
   // The if block is equivalent to (but has fewer branches than):
   //   if exp2 <= 0 || exp2 >= MANTISSA_MAX { etc }
-  if (exp2 - 1 >= (1 << FloatProp::EXPONENT_WIDTH) - 2) {
+  if (exp2 - 1 >= (1 << FloatProp::EXP_LEN) - 2) {
     return cpp::nullopt;
   }
 
@@ -323,7 +322,7 @@ simple_decimal_conversion(const char *__restrict numStart,
                           RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
   using FloatProp = typename fputil::FloatProperties<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   int32_t exp2 = 0;
   HighPrecisionDecimal hpd = HighPrecisionDecimal(numStart);
@@ -338,7 +337,7 @@ simple_decimal_conversion(const char *__restrict numStart,
   // If the exponent is too large and can't be represented in this size of
   // float, return inf.
   if (hpd.get_decimal_point() > 0 &&
-      exp10_to_exp2(hpd.get_decimal_point() - 1) > FloatProp::EXPONENT_BIAS) {
+      exp10_to_exp2(hpd.get_decimal_point() - 1) > FloatProp::EXP_BIAS) {
     output.num = {0, fputil::FPBits<T>::MAX_EXPONENT};
     output.error = ERANGE;
     return output;
@@ -346,8 +345,8 @@ simple_decimal_conversion(const char *__restrict numStart,
   // If the exponent is too small even for a subnormal, return 0.
   if (hpd.get_decimal_point() < 0 &&
       exp10_to_exp2(-hpd.get_decimal_point()) >
-          (FloatProp::EXPONENT_BIAS +
-           static_cast<int32_t>(FloatProp::FRACTION_BITS))) {
+          (FloatProp::EXP_BIAS +
+           static_cast<int32_t>(FloatProp::FRACTION_LEN))) {
     output.num = {0, 0};
     output.error = ERANGE;
     return output;
@@ -386,7 +385,7 @@ simple_decimal_conversion(const char *__restrict numStart,
   hpd.shift(1);
 
   // Get the biased exponent
-  exp2 += FloatProp::EXPONENT_BIAS;
+  exp2 += FloatProp::EXP_BIAS;
 
   // Handle the exponent being too large (and return inf).
   if (exp2 >= FPBits::MAX_EXPONENT) {
@@ -396,8 +395,8 @@ simple_decimal_conversion(const char *__restrict numStart,
   }
 
   // Shift left to fill the mantissa
-  hpd.shift(FloatProp::FRACTION_BITS);
-  UIntType final_mantissa = hpd.round_to_integer_type<UIntType>();
+  hpd.shift(FloatProp::FRACTION_LEN);
+  StorageType final_mantissa = hpd.round_to_integer_type<StorageType>();
 
   // Handle subnormals
   if (exp2 <= 0) {
@@ -409,16 +408,16 @@ simple_decimal_conversion(const char *__restrict numStart,
     // Shift right one more time to compensate for the left shift to get it
     // between 1 and 2.
     hpd.shift(-1);
-    final_mantissa = hpd.round_to_integer_type<UIntType>(round);
+    final_mantissa = hpd.round_to_integer_type<StorageType>(round);
 
     // Check if by shifting right we've caused this to round to a normal number.
-    if ((final_mantissa >> FloatProp::FRACTION_BITS) != 0) {
+    if ((final_mantissa >> FloatProp::FRACTION_LEN) != 0) {
       ++exp2;
     }
   }
 
   // Check if rounding added a bit, and shift down if that's the case.
-  if (final_mantissa == UIntType(2) << FloatProp::FRACTION_BITS) {
+  if (final_mantissa == StorageType(2) << FloatProp::FRACTION_LEN) {
     final_mantissa >>= 1;
     ++exp2;
 
@@ -517,18 +516,18 @@ clinger_fast_path(ExpandedFloat<T> init_num,
                   RoundDirection round = RoundDirection::Nearest) {
   using FPBits = typename fputil::FPBits<T>;
   using FloatProp = typename fputil::FloatProperties<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
-  UIntType mantissa = init_num.mantissa;
+  StorageType mantissa = init_num.mantissa;
   int32_t exp10 = init_num.exponent;
 
-  if ((mantissa >> FloatProp::FRACTION_BITS) > 0) {
+  if ((mantissa >> FloatProp::FRACTION_LEN) > 0) {
     return cpp::nullopt;
   }
 
   FPBits result;
   T float_mantissa;
-  if constexpr (cpp::is_same_v<UIntType, cpp::UInt<128>>) {
+  if constexpr (cpp::is_same_v<StorageType, cpp::UInt<128>>) {
     float_mantissa = static_cast<T>(fputil::DyadicFloat<128>(
         false, 0,
         fputil::DyadicFloat<128>::MantissaType(
@@ -606,7 +605,7 @@ clinger_fast_path(ExpandedFloat<T> init_num,
 // log10(2^(exponent bias)).
 // The generic approximation uses the fact that log10(2^x) ~= x/3
 template <typename T> constexpr int32_t get_upper_bound() {
-  return fputil::FloatProperties<T>::EXPONENT_BIAS / 3;
+  return fputil::FloatProperties<T>::EXP_BIAS / 3;
 }
 
 template <> constexpr int32_t get_upper_bound<float>() { return 39; }
@@ -623,10 +622,10 @@ template <> constexpr int32_t get_upper_bound<double>() { return 309; }
 // end of the final mantissa.
 template <typename T> constexpr int32_t get_lower_bound() {
   using FloatProp = typename fputil::FloatProperties<T>;
-  return -((FloatProp::EXPONENT_BIAS +
-            static_cast<int32_t>(FloatProp::FRACTION_BITS +
-                                 FloatProp::UINTTYPE_BITS)) /
-           3);
+  return -(
+      (FloatProp::EXP_BIAS +
+       static_cast<int32_t>(FloatProp::FRACTION_LEN + FloatProp::STORAGE_LEN)) /
+      3);
 }
 
 template <> constexpr int32_t get_lower_bound<float>() {
@@ -647,9 +646,9 @@ LIBC_INLINE FloatConvertReturn<T>
 decimal_exp_to_float(ExpandedFloat<T> init_num, const char *__restrict numStart,
                      bool truncated, RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
-  UIntType mantissa = init_num.mantissa;
+  StorageType mantissa = init_num.mantissa;
   int32_t exp10 = init_num.exponent;
 
   FloatConvertReturn<T> output;
@@ -725,45 +724,46 @@ LIBC_INLINE FloatConvertReturn<T> binary_exp_to_float(ExpandedFloat<T> init_num,
                                                       RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
   using FloatProp = typename fputil::FloatProperties<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
-  UIntType mantissa = init_num.mantissa;
+  StorageType mantissa = init_num.mantissa;
   int32_t exp2 = init_num.exponent;
 
   FloatConvertReturn<T> output;
 
   // This is the number of leading zeroes a properly normalized float of type T
   // should have.
-  constexpr int32_t INF_EXP = (1 << FloatProp::EXPONENT_WIDTH) - 1;
+  constexpr int32_t INF_EXP = (1 << FloatProp::EXP_LEN) - 1;
 
-  // Normalization step 1: Bring the leading bit to the highest bit of UIntType.
-  uint32_t amount_to_shift_left = cpp::countl_zero<UIntType>(mantissa);
+  // Normalization step 1: Bring the leading bit to the highest bit of
+  // StorageType.
+  uint32_t amount_to_shift_left = cpp::countl_zero<StorageType>(mantissa);
   mantissa <<= amount_to_shift_left;
 
-  // Keep exp2 representing the exponent of the lowest bit of UIntType.
+  // Keep exp2 representing the exponent of the lowest bit of StorageType.
   exp2 -= amount_to_shift_left;
 
   // biased_exponent represents the biased exponent of the most significant bit.
   int32_t biased_exponent =
-      exp2 + FloatProp::UINTTYPE_BITS + FPBits::EXPONENT_BIAS - 1;
+      exp2 + FloatProp::STORAGE_LEN + FPBits::EXP_BIAS - 1;
 
   // Handle numbers that're too large and get squashed to inf
   if (biased_exponent >= INF_EXP) {
     // This indicates an overflow, so we make the result INF and set errno.
-    output.num = {0, (1 << FloatProp::EXPONENT_WIDTH) - 1};
+    output.num = {0, (1 << FloatProp::EXP_LEN) - 1};
     output.error = ERANGE;
     return output;
   }
 
   uint32_t amount_to_shift_right =
-      FloatProp::UINTTYPE_BITS - FloatProp::FRACTION_BITS - 1;
+      FloatProp::STORAGE_LEN - FloatProp::FRACTION_LEN - 1;
 
   // Handle subnormals.
   if (biased_exponent <= 0) {
     amount_to_shift_right += 1 - biased_exponent;
     biased_exponent = 0;
 
-    if (amount_to_shift_right > FloatProp::UINTTYPE_BITS) {
+    if (amount_to_shift_right > FloatProp::STORAGE_LEN) {
       // Return 0 if the exponent is too small.
       output.num = {0, 0};
       output.error = ERANGE;
@@ -771,19 +771,19 @@ LIBC_INLINE FloatConvertReturn<T> binary_exp_to_float(ExpandedFloat<T> init_num,
     }
   }
 
-  UIntType round_bit_mask = UIntType(1) << (amount_to_shift_right - 1);
-  UIntType sticky_mask = round_bit_mask - 1;
+  StorageType round_bit_mask = StorageType(1) << (amount_to_shift_right - 1);
+  StorageType sticky_mask = round_bit_mask - 1;
   bool round_bit = static_cast<bool>(mantissa & round_bit_mask);
   bool sticky_bit = static_cast<bool>(mantissa & sticky_mask) || truncated;
 
-  if (amount_to_shift_right < FloatProp::UINTTYPE_BITS) {
+  if (amount_to_shift_right < FloatProp::STORAGE_LEN) {
     // Shift the mantissa and clear the implicit bit.
     mantissa >>= amount_to_shift_right;
     mantissa &= FloatProp::FRACTION_MASK;
   } else {
     mantissa = 0;
   }
-  bool least_significant_bit = static_cast<bool>(mantissa & UIntType(1));
+  bool least_significant_bit = static_cast<bool>(mantissa & StorageType(1));
 
   // TODO: check that this rounding behavior is correct.
 
@@ -844,7 +844,7 @@ LIBC_INLINE StrToNumResult<ExpandedFloat<T>>
 decimal_string_to_float(const char *__restrict src, const char DECIMAL_POINT,
                         RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   constexpr uint32_t BASE = 10;
   constexpr char EXPONENT_MARKER = 'e';
@@ -852,7 +852,7 @@ decimal_string_to_float(const char *__restrict src, const char DECIMAL_POINT,
   bool truncated = false;
   bool seen_digit = false;
   bool after_decimal = false;
-  UIntType mantissa = 0;
+  StorageType mantissa = 0;
   int32_t exponent = 0;
 
   size_t index = 0;
@@ -863,8 +863,8 @@ decimal_string_to_float(const char *__restrict src, const char DECIMAL_POINT,
   // the format mantissa * (base ^ exponent)
 
   // The loop fills the mantissa with as many digits as it can hold
-  const UIntType bitstype_max_div_by_base =
-      cpp::numeric_limits<UIntType>::max() / BASE;
+  const StorageType bitstype_max_div_by_base =
+      cpp::numeric_limits<StorageType>::max() / BASE;
   while (true) {
     if (isdigit(src[index])) {
       uint32_t digit = src[index] - '0';
@@ -953,7 +953,7 @@ LIBC_INLINE StrToNumResult<ExpandedFloat<T>>
 hexadecimal_string_to_float(const char *__restrict src,
                             const char DECIMAL_POINT, RoundDirection round) {
   using FPBits = typename fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   constexpr uint32_t BASE = 16;
   constexpr char EXPONENT_MARKER = 'p';
@@ -961,7 +961,7 @@ hexadecimal_string_to_float(const char *__restrict src,
   bool truncated = false;
   bool seen_digit = false;
   bool after_decimal = false;
-  UIntType mantissa = 0;
+  StorageType mantissa = 0;
   int32_t exponent = 0;
 
   size_t index = 0;
@@ -972,8 +972,8 @@ hexadecimal_string_to_float(const char *__restrict src,
   // the format mantissa * (base ^ exponent)
 
   // The loop fills the mantissa with as many digits as it can hold
-  const UIntType bitstype_max_div_by_base =
-      cpp::numeric_limits<UIntType>::max() / BASE;
+  const StorageType bitstype_max_div_by_base =
+      cpp::numeric_limits<StorageType>::max() / BASE;
   while (true) {
     if (isalnum(src[index])) {
       uint32_t digit = b36_char_to_int(src[index]);
@@ -1060,7 +1060,7 @@ hexadecimal_string_to_float(const char *__restrict src,
 template <class T>
 LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
   using FPBits = typename fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   FPBits result = FPBits();
   bool seen_digit = false;
@@ -1134,7 +1134,7 @@ LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
         tolower(src[index + 2]) == nan_string[2]) {
       seen_digit = true;
       index += 3;
-      UIntType nan_mantissa = 0;
+      StorageType nan_mantissa = 0;
       // this handles the case of `NaN(n-character-sequence)`, where the
       // n-character-sequence is made of 0 or more letters and numbers in any
       // order.
@@ -1148,10 +1148,10 @@ LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
         if (src[index] == ')') {
           ++index;
           if (isdigit(src[left_paren + 1])) {
-            // This is to prevent errors when UIntType is larger than 64 bits,
-            // since strtointeger only supports up to 64 bits. This is actually
-            // more than is required by the specification, which says for the
-            // input type "NAN(n-char-sequence)" that "the meaning of
+            // This is to prevent errors when StorageType is larger than 64
+            // bits, since strtointeger only supports up to 64 bits. This is
+            // actually more than is required by the specification, which says
+            // for the input type "NAN(n-char-sequence)" that "the meaning of
             // the n-char sequence is implementation-defined."
 
             auto strtoint_result =
@@ -1159,7 +1159,7 @@ LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
             if (strtoint_result.has_error()) {
               error = strtoint_result.error;
             }
-            nan_mantissa = static_cast<UIntType>(strtoint_result.value);
+            nan_mantissa = static_cast<StorageType>(strtoint_result.value);
             if (src[left_paren + 1 + strtoint_result.parsed_len] != ')')
               nan_mantissa = 0;
           }

--- a/libc/src/math/generic/asinf.cpp
+++ b/libc/src/math/generic/asinf.cpp
@@ -108,7 +108,7 @@ LLVM_LIBC_FUNCTION(float, asinf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return x + FPBits::build_nan(1 << (FPBits::MANTISSA_WIDTH - 1));
+    return x + FPBits::build_nan(FPBits::FRACTION_MASK);
   }
 
   // Check for exceptional values

--- a/libc/src/math/generic/erff.cpp
+++ b/libc/src/math/generic/erff.cpp
@@ -154,7 +154,7 @@ LLVM_LIBC_FUNCTION(float, erff, (float x)) {
   double xd = static_cast<double>(x);
   double xsq = xd * xd;
 
-  const uint32_t EIGHT = 3 << FPBits::MANTISSA_WIDTH;
+  const uint32_t EIGHT = 3 << FPBits::FRACTION_BITS;
   int idx = static_cast<int>(FPBits(x_abs + EIGHT).get_val());
 
   double x4 = xsq * xsq;

--- a/libc/src/math/generic/erff.cpp
+++ b/libc/src/math/generic/erff.cpp
@@ -154,7 +154,7 @@ LLVM_LIBC_FUNCTION(float, erff, (float x)) {
   double xd = static_cast<double>(x);
   double xsq = xd * xd;
 
-  const uint32_t EIGHT = 3 << FPBits::FRACTION_BITS;
+  const uint32_t EIGHT = 3 << FPBits::FRACTION_LEN;
   int idx = static_cast<int>(FPBits(x_abs + EIGHT).get_val());
 
   double x4 = xsq * xsq;

--- a/libc/src/math/generic/exp.cpp
+++ b/libc/src/math/generic/exp.cpp
@@ -382,7 +382,7 @@ LLVM_LIBC_FUNCTION(double, exp, (double x)) {
     if (LIBC_LIKELY(upper == lower)) {
       // to multiply by 2^hi, a fast way is to simply add hi to the exponent
       // field.
-      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
       double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
       return r;
     }
@@ -400,7 +400,7 @@ LLVM_LIBC_FUNCTION(double, exp, (double x)) {
     double lower_dd = r_dd.hi + (r_dd.lo - ERR_DD);
 
     if (LIBC_LIKELY(upper_dd == lower_dd)) {
-      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
       double r =
           cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
       return r;

--- a/libc/src/math/generic/exp.cpp
+++ b/libc/src/math/generic/exp.cpp
@@ -382,7 +382,7 @@ LLVM_LIBC_FUNCTION(double, exp, (double x)) {
     if (LIBC_LIKELY(upper == lower)) {
       // to multiply by 2^hi, a fast way is to simply add hi to the exponent
       // field.
-      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
       double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
       return r;
     }
@@ -400,7 +400,7 @@ LLVM_LIBC_FUNCTION(double, exp, (double x)) {
     double lower_dd = r_dd.hi + (r_dd.lo - ERR_DD);
 
     if (LIBC_LIKELY(upper_dd == lower_dd)) {
-      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+      int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
       double r =
           cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
       return r;

--- a/libc/src/math/generic/exp10.cpp
+++ b/libc/src/math/generic/exp10.cpp
@@ -395,7 +395,7 @@ LLVM_LIBC_FUNCTION(double, exp10, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -462,7 +462,7 @@ LLVM_LIBC_FUNCTION(double, exp10, (double x)) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/exp10.cpp
+++ b/libc/src/math/generic/exp10.cpp
@@ -395,7 +395,7 @@ LLVM_LIBC_FUNCTION(double, exp10, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -462,7 +462,7 @@ LLVM_LIBC_FUNCTION(double, exp10, (double x)) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/exp2.cpp
+++ b/libc/src/math/generic/exp2.cpp
@@ -362,7 +362,7 @@ LLVM_LIBC_FUNCTION(double, exp2, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -376,7 +376,7 @@ LLVM_LIBC_FUNCTION(double, exp2, (double x)) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/exp2.cpp
+++ b/libc/src/math/generic/exp2.cpp
@@ -362,7 +362,7 @@ LLVM_LIBC_FUNCTION(double, exp2, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -376,7 +376,7 @@ LLVM_LIBC_FUNCTION(double, exp2, (double x)) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/exp2f_impl.h
+++ b/libc/src/math/generic/exp2f_impl.h
@@ -137,7 +137,7 @@ LIBC_INLINE float exp2f(float x) {
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi =
       static_cast<int64_t>(static_cast<uint64_t>(k >> ExpBase::MID_BITS)
-                           << fputil::FloatProperties<double>::MANTISSA_WIDTH);
+                           << fputil::FloatProperties<double>::FRACTION_BITS);
   // mh = 2^hi * 2^mid
   // mh_bits = bit field of mh
   int64_t mh_bits = ExpBase::EXP_2_MID[k & ExpBase::MID_MASK] + exp_hi;

--- a/libc/src/math/generic/exp2f_impl.h
+++ b/libc/src/math/generic/exp2f_impl.h
@@ -137,7 +137,7 @@ LIBC_INLINE float exp2f(float x) {
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi =
       static_cast<int64_t>(static_cast<uint64_t>(k >> ExpBase::MID_BITS)
-                           << fputil::FloatProperties<double>::FRACTION_BITS);
+                           << fputil::FloatProperties<double>::FRACTION_LEN);
   // mh = 2^hi * 2^mid
   // mh_bits = bit field of mh
   int64_t mh_bits = ExpBase::EXP_2_MID[k & ExpBase::MID_MASK] + exp_hi;

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -162,7 +162,7 @@ template <class Base> LIBC_INLINE exp_b_reduc_t exp_b_range_reduc(float x) {
   // hi = floor(kd * 2^(-MID_BITS))
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi = static_cast<int64_t>((k >> Base::MID_BITS))
-                   << fputil::FloatProperties<double>::FRACTION_BITS;
+                   << fputil::FloatProperties<double>::FRACTION_LEN;
   // mh = 2^hi * 2^mid
   // mh_bits = bit field of mh
   int64_t mh_bits = Base::EXP_2_MID[k & Base::MID_MASK] + exp_hi;
@@ -235,9 +235,9 @@ template <bool is_sinh> LIBC_INLINE double exp_pm_eval(float x) {
   // hi = floor(kf * 2^(-5))
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi_p = static_cast<int64_t>((k_p >> ExpBase::MID_BITS))
-                     << fputil::FloatProperties<double>::FRACTION_BITS;
+                     << fputil::FloatProperties<double>::FRACTION_LEN;
   int64_t exp_hi_m = static_cast<int64_t>((k_m >> ExpBase::MID_BITS))
-                     << fputil::FloatProperties<double>::FRACTION_BITS;
+                     << fputil::FloatProperties<double>::FRACTION_LEN;
   // mh_p = 2^(hi + mid)
   // mh_m = 2^(-(hi + mid))
   // mh_bits_* = bit field of mh_*
@@ -280,11 +280,11 @@ LIBC_INLINE static double log2_eval(double x) {
   double result = 0;
   result += bs.get_exponent();
 
-  int p1 = (bs.get_mantissa() >> (FPB::FRACTION_BITS - LOG_P1_BITS)) &
+  int p1 = (bs.get_mantissa() >> (FPB::FRACTION_LEN - LOG_P1_BITS)) &
            (LOG_P1_SIZE - 1);
 
   bs.bits &= FPB::FRACTION_MASK >> LOG_P1_BITS;
-  bs.set_biased_exponent(FPB::EXPONENT_BIAS);
+  bs.set_biased_exponent(FPB::EXP_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
   // Taylor series for log(2,1+x)
@@ -310,11 +310,11 @@ LIBC_INLINE static double log_eval(double x) {
 
   // p1 is the leading 7 bits of mx, i.e.
   // p1 * 2^(-7) <= m_x < (p1 + 1) * 2^(-7).
-  int p1 = static_cast<int>(bs.get_mantissa() >> (FPB::FRACTION_BITS - 7));
+  int p1 = static_cast<int>(bs.get_mantissa() >> (FPB::FRACTION_LEN - 7));
 
   // Set bs to (1 + (mx - p1*2^(-7))
   bs.bits &= FPB::FRACTION_MASK >> 7;
-  bs.set_biased_exponent(FPB::EXPONENT_BIAS);
+  bs.set_biased_exponent(FPB::EXP_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
 
@@ -345,7 +345,7 @@ LIBC_INLINE cpp::optional<double> ziv_test_denorm(int hi, double mid, double lo,
   using FloatProp = typename fputil::FloatProperties<double>;
 
   // Scaling factor = 1/(min normal number) = 2^1022
-  int64_t exp_hi = static_cast<int64_t>(hi + 1022) << FloatProp::FRACTION_BITS;
+  int64_t exp_hi = static_cast<int64_t>(hi + 1022) << FloatProp::FRACTION_LEN;
   double mid_hi = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(mid));
   double lo_scaled =
       (lo != 0.0) ? cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(lo))

--- a/libc/src/math/generic/explogxf.h
+++ b/libc/src/math/generic/explogxf.h
@@ -162,7 +162,7 @@ template <class Base> LIBC_INLINE exp_b_reduc_t exp_b_range_reduc(float x) {
   // hi = floor(kd * 2^(-MID_BITS))
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi = static_cast<int64_t>((k >> Base::MID_BITS))
-                   << fputil::FloatProperties<double>::MANTISSA_WIDTH;
+                   << fputil::FloatProperties<double>::FRACTION_BITS;
   // mh = 2^hi * 2^mid
   // mh_bits = bit field of mh
   int64_t mh_bits = Base::EXP_2_MID[k & Base::MID_MASK] + exp_hi;
@@ -235,9 +235,9 @@ template <bool is_sinh> LIBC_INLINE double exp_pm_eval(float x) {
   // hi = floor(kf * 2^(-5))
   // exp_hi = shift hi to the exponent field of double precision.
   int64_t exp_hi_p = static_cast<int64_t>((k_p >> ExpBase::MID_BITS))
-                     << fputil::FloatProperties<double>::MANTISSA_WIDTH;
+                     << fputil::FloatProperties<double>::FRACTION_BITS;
   int64_t exp_hi_m = static_cast<int64_t>((k_m >> ExpBase::MID_BITS))
-                     << fputil::FloatProperties<double>::MANTISSA_WIDTH;
+                     << fputil::FloatProperties<double>::FRACTION_BITS;
   // mh_p = 2^(hi + mid)
   // mh_m = 2^(-(hi + mid))
   // mh_bits_* = bit field of mh_*
@@ -280,10 +280,10 @@ LIBC_INLINE static double log2_eval(double x) {
   double result = 0;
   result += bs.get_exponent();
 
-  int p1 = (bs.get_mantissa() >> (FPB::MANTISSA_WIDTH - LOG_P1_BITS)) &
+  int p1 = (bs.get_mantissa() >> (FPB::FRACTION_BITS - LOG_P1_BITS)) &
            (LOG_P1_SIZE - 1);
 
-  bs.bits &= FPB::MANTISSA_MASK >> LOG_P1_BITS;
+  bs.bits &= FPB::FRACTION_MASK >> LOG_P1_BITS;
   bs.set_biased_exponent(FPB::EXPONENT_BIAS);
   double dx = (bs.get_val() - 1.0) * LOG_P1_1_OVER[p1];
 
@@ -310,10 +310,10 @@ LIBC_INLINE static double log_eval(double x) {
 
   // p1 is the leading 7 bits of mx, i.e.
   // p1 * 2^(-7) <= m_x < (p1 + 1) * 2^(-7).
-  int p1 = static_cast<int>(bs.get_mantissa() >> (FPB::MANTISSA_WIDTH - 7));
+  int p1 = static_cast<int>(bs.get_mantissa() >> (FPB::FRACTION_BITS - 7));
 
   // Set bs to (1 + (mx - p1*2^(-7))
-  bs.bits &= FPB::MANTISSA_MASK >> 7;
+  bs.bits &= FPB::FRACTION_MASK >> 7;
   bs.set_biased_exponent(FPB::EXPONENT_BIAS);
   // dx = (mx - p1*2^(-7)) / (1 + p1*2^(-7)).
   double dx = (bs.get_val() - 1.0) * ONE_OVER_F[p1];
@@ -345,7 +345,7 @@ LIBC_INLINE cpp::optional<double> ziv_test_denorm(int hi, double mid, double lo,
   using FloatProp = typename fputil::FloatProperties<double>;
 
   // Scaling factor = 1/(min normal number) = 2^1022
-  int64_t exp_hi = static_cast<int64_t>(hi + 1022) << FloatProp::MANTISSA_WIDTH;
+  int64_t exp_hi = static_cast<int64_t>(hi + 1022) << FloatProp::FRACTION_BITS;
   double mid_hi = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(mid));
   double lo_scaled =
       (lo != 0.0) ? cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(lo))

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -390,7 +390,7 @@ LLVM_LIBC_FUNCTION(double, expm1, (double x)) {
 
   // -2^(-hi)
   double one_scaled =
-      FPBits::create_value(true, FPBits::EXPONENT_BIAS - hi, 0).get_val();
+      FPBits::create_value(true, FPBits::EXP_BIAS - hi, 0).get_val();
 
   // 2^(mid1 + mid2) - 2^(-hi)
   DoubleDouble hi_part = x_sign ? fputil::exact_add(one_scaled, exp_mid.hi)
@@ -465,7 +465,7 @@ LLVM_LIBC_FUNCTION(double, expm1, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // to multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -479,7 +479,7 @@ LLVM_LIBC_FUNCTION(double, expm1, (double x)) {
   double lower_dd = r_dd.hi + (r_dd.lo - err_dd);
 
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_LEN;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -465,7 +465,7 @@ LLVM_LIBC_FUNCTION(double, expm1, (double x)) {
   if (LIBC_LIKELY(upper == lower)) {
     // to multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -479,7 +479,7 @@ LLVM_LIBC_FUNCTION(double, expm1, (double x)) {
   double lower_dd = r_dd.hi + (r_dd.lo - err_dd);
 
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
-    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::MANTISSA_WIDTH;
+    int64_t exp_hi = static_cast<int64_t>(hi) << FloatProp::FRACTION_BITS;
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/math/generic/hypotf.cpp
+++ b/libc/src/math/generic/hypotf.cpp
@@ -23,7 +23,7 @@ LLVM_LIBC_FUNCTION(float, hypotf, (float x, float y)) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if (exp_diff >= FPBits::FRACTION_BITS + 2) {
+  if (exp_diff >= FPBits::FRACTION_LEN + 2) {
     return fputil::abs(x) + fputil::abs(y);
   }
 

--- a/libc/src/math/generic/hypotf.cpp
+++ b/libc/src/math/generic/hypotf.cpp
@@ -23,7 +23,7 @@ LLVM_LIBC_FUNCTION(float, hypotf, (float x, float y)) {
   uint16_t y_exp = y_bits.get_biased_exponent();
   uint16_t exp_diff = (x_exp > y_exp) ? (x_exp - y_exp) : (y_exp - x_exp);
 
-  if (exp_diff >= FPBits::MANTISSA_WIDTH + 2) {
+  if (exp_diff >= FPBits::FRACTION_BITS + 2) {
     return fputil::abs(x) + fputil::abs(y);
   }
 

--- a/libc/src/math/generic/inv_trigf_utils.h
+++ b/libc/src/math/generic/inv_trigf_utils.h
@@ -40,13 +40,12 @@ LIBC_INLINE double atan_eval(double x) {
   using FPB = fputil::FPBits<double>;
   // Added some small value to umin and umax mantissa to avoid possible rounding
   // errors.
-  FPB::UIntType umin =
-      FPB::create_value(false, FPB::EXPONENT_BIAS - ATAN_T_BITS - 1,
+  FPB::StorageType umin =
+      FPB::create_value(false, FPB::EXP_BIAS - ATAN_T_BITS - 1,
                         0x100000000000UL)
           .uintval();
-  FPB::UIntType umax =
-      FPB::create_value(false, FPB::EXPONENT_BIAS + ATAN_T_BITS,
-                        0xF000000000000UL)
+  FPB::StorageType umax =
+      FPB::create_value(false, FPB::EXP_BIAS + ATAN_T_BITS, 0xF000000000000UL)
           .uintval();
 
   FPB bs(x);

--- a/libc/src/math/generic/log.cpp
+++ b/libc/src/math/generic/log.cpp
@@ -734,7 +734,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
   FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXP_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log(1.0) = +0.0

--- a/libc/src/math/generic/log10.cpp
+++ b/libc/src/math/generic/log10.cpp
@@ -735,7 +735,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
   FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXP_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log10(1.0) = +0.0

--- a/libc/src/math/generic/log10f.cpp
+++ b/libc/src/math/generic/log10f.cpp
@@ -158,7 +158,7 @@ LLVM_LIBC_FUNCTION(float, log10f, (float x)) {
     }
   }
 
-  int m = -FPBits::EXPONENT_BIAS;
+  int m = -FPBits::EXP_BIAS;
 
   if (LIBC_UNLIKELY(x_u < FPBits::MIN_NORMAL || x_u > FPBits::MAX_NORMAL)) {
     if (xbits.is_zero()) {

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -872,8 +872,8 @@ LIBC_INLINE double log1p_accurate(int e_x, int index,
 
 LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   using FPBits_t = typename fputil::FPBits<double>;
-  constexpr int EXPONENT_BIAS = FPBits_t::EXPONENT_BIAS;
-  constexpr int FRACTION_BITS = FPBits_t::FRACTION_BITS;
+  constexpr int EXP_BIAS = FPBits_t::EXP_BIAS;
+  constexpr int FRACTION_LEN = FPBits_t::FRACTION_LEN;
   constexpr uint64_t FRACTION_MASK = FPBits_t::FRACTION_MASK;
   FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
@@ -882,7 +882,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
 
   uint16_t x_exp = xbits.get_biased_exponent();
 
-  if (x_exp >= EXPONENT_BIAS) {
+  if (x_exp >= EXP_BIAS) {
     // |x| >= 1
     if (LIBC_UNLIKELY(x_u >= 0x4650'0000'0000'0000ULL)) {
       // x >= 2^102 or x is negative, inf, or NaN
@@ -910,7 +910,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   } else {
     // |x| < 1
     if (LIBC_UNLIKELY(xbits.get_biased_exponent() <
-                      EXPONENT_BIAS - FRACTION_BITS - 1)) {
+                      EXP_BIAS - FRACTION_LEN - 1)) {
       // Quick return when |x| < 2^-53.
       // Since log(1 + x) = x - x^2/2 + x^3/3 - ...,
       // for |x| < 2^-53,
@@ -949,9 +949,9 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   x_u = xhi_bits.uintval();
   // Range reduction:
   // Find k such that |x_hi - k * 2^-7| <= 2^-8.
-  int idx = static_cast<int>(
-      ((x_u & FRACTION_MASK) + (1ULL << (FRACTION_BITS - 8))) >>
-      (FRACTION_BITS - 7));
+  int idx =
+      static_cast<int>(((x_u & FRACTION_MASK) + (1ULL << (FRACTION_LEN - 8))) >>
+                       (FRACTION_LEN - 7));
   int x_e = xhi_bits.get_exponent() + (idx >> 7);
   double e_x = static_cast<double>(x_e);
 
@@ -967,8 +967,8 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   double err_hi = ERR_HI[hi == 0.0];
 
   // Scaling factior = 2^(-xh_bits.get_exponent())
-  uint64_t s_u = (static_cast<uint64_t>(EXPONENT_BIAS) << (FRACTION_BITS + 1)) -
-                 (x_u & FPBits_t::EXPONENT_MASK);
+  uint64_t s_u = (static_cast<uint64_t>(EXP_BIAS) << (FRACTION_LEN + 1)) -
+                 (x_u & FPBits_t::EXP_MASK);
   // When the exponent of x is 2^1023, its inverse, 2^(-1023), is subnormal.
   const double EXPONENT_CORRECTION[2] = {0.0, 0x1.0p-1023};
   double scaling = FPBits_t(s_u).get_val() + EXPONENT_CORRECTION[s_u == 0];
@@ -998,7 +998,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
   v_hi = fputil::multiply_add(r, m_dd.hi, -1.0); // Exact.
 #else
   // c = 1 + idx * 2^-7.
-  double c = FPBits_t((static_cast<uint64_t>(idx) << (FRACTION_BITS - 7)) +
+  double c = FPBits_t((static_cast<uint64_t>(idx) << (FRACTION_LEN - 7)) +
                       uint64_t(0x3FF0'0000'0000'0000ULL))
                  .get_val();
   v_hi = fputil::multiply_add(r, m_dd.hi - c, RCM1[idx]); // Exact

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -57,7 +57,7 @@ LIBC_INLINE float log(double x) {
   // Get the 8 highest bits, use 7 bits (excluding the implicit hidden bit) for
   // lookup tables.
   int f_index = static_cast<int>(xbits.get_mantissa() >>
-                                 (fputil::FPBits<double>::MANTISSA_WIDTH - 7));
+                                 (fputil::FPBits<double>::FRACTION_BITS - 7));
 
   // Set bits to 1.m
   xbits.set_biased_exponent(0x3FF);

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -57,7 +57,7 @@ LIBC_INLINE float log(double x) {
   // Get the 8 highest bits, use 7 bits (excluding the implicit hidden bit) for
   // lookup tables.
   int f_index = static_cast<int>(xbits.get_mantissa() >>
-                                 (fputil::FPBits<double>::FRACTION_BITS - 7));
+                                 (fputil::FPBits<double>::FRACTION_LEN - 7));
 
   // Set bits to 1.m
   xbits.set_biased_exponent(0x3FF);

--- a/libc/src/math/generic/log2.cpp
+++ b/libc/src/math/generic/log2.cpp
@@ -856,7 +856,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
   FPBits_t xbits(x);
   uint64_t x_u = xbits.uintval();
 
-  int x_e = -FPBits_t::EXPONENT_BIAS;
+  int x_e = -FPBits_t::EXP_BIAS;
 
   if (LIBC_UNLIKELY(x_u == 0x3FF0'0000'0000'0000ULL)) {
     // log2(1.0) = +0.0

--- a/libc/src/math/generic/log2f.cpp
+++ b/libc/src/math/generic/log2f.cpp
@@ -61,7 +61,7 @@ LLVM_LIBC_FUNCTION(float, log2f, (float x)) {
   // Hard to round value(s).
   using fputil::round_result_slightly_up;
 
-  int m = -FPBits::EXPONENT_BIAS;
+  int m = -FPBits::EXP_BIAS;
 
   // log2(1.0f) = 0.0f.
   if (LIBC_UNLIKELY(x_u == 0x3f80'0000U))

--- a/libc/src/math/generic/logf.cpp
+++ b/libc/src/math/generic/logf.cpp
@@ -57,7 +57,7 @@ LLVM_LIBC_FUNCTION(float, logf, (float x)) {
   FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
 
-  int m = -FPBits::EXPONENT_BIAS;
+  int m = -FPBits::EXP_BIAS;
 
   using fputil::round_result_slightly_down;
   using fputil::round_result_slightly_up;

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -389,22 +389,22 @@ static constexpr DoubleDouble LOG2_R2_DD[] = {
 LIBC_INLINE bool is_odd_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
-  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
-                                     FloatProp::FRACTION_BITS);
-  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
+  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXP_MASK) >>
+                                     FloatProp::FRACTION_LEN);
+  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXP_MASK);
   constexpr int32_t UNIT_EXPONENT =
-      FloatProp::EXPONENT_BIAS + static_cast<int32_t>(FloatProp::FRACTION_BITS);
+      FloatProp::EXP_BIAS + static_cast<int32_t>(FloatProp::FRACTION_LEN);
   return (x_e + lsb == UNIT_EXPONENT);
 }
 
 LIBC_INLINE bool is_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
-  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
-                                     FloatProp::FRACTION_BITS);
-  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
+  int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXP_MASK) >>
+                                     FloatProp::FRACTION_LEN);
+  int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXP_MASK);
   constexpr int32_t UNIT_EXPONENT =
-      FloatProp::EXPONENT_BIAS + static_cast<int32_t>(FloatProp::FRACTION_BITS);
+      FloatProp::EXP_BIAS + static_cast<int32_t>(FloatProp::FRACTION_LEN);
   return (x_e + lsb >= UNIT_EXPONENT);
 }
 
@@ -589,7 +589,7 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
     }
   }
 
-  int ex = -FloatBits::EXPONENT_BIAS;
+  int ex = -FloatBits::EXP_BIAS;
   uint64_t sign = 0;
 
   // y is finite and non-zero.
@@ -669,11 +669,11 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
   x_u = FloatBits(x).uintval();
 
   // Extract exponent field of x.
-  ex += (x_u >> FloatProp::FRACTION_BITS);
+  ex += (x_u >> FloatProp::FRACTION_LEN);
   double e_x = static_cast<double>(ex);
   // Use the highest 7 fractional bits of m_x as the index for look up tables.
   uint32_t x_mant = x_u & FloatProp::FRACTION_MASK;
-  int idx_x = static_cast<int>(x_mant >> (FloatProp::FRACTION_BITS - 7));
+  int idx_x = static_cast<int>(x_mant >> (FloatProp::FRACTION_LEN - 7));
   // Add the hidden bit to the mantissa.
   // 1 <= m_x < 2
   float m_x = cpp::bit_cast<float>(x_mant | 0x3f800000);
@@ -774,7 +774,7 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
   int idx_y = hm_i & 0x3f;
 
   // 2^hi
-  int64_t exp_hi_i = (hm_i >> 6) << DoubleProp::FRACTION_BITS;
+  int64_t exp_hi_i = (hm_i >> 6) << DoubleProp::FRACTION_LEN;
   // 2^mid
   int64_t exp_mid_i = cpp::bit_cast<uint64_t>(EXP2_MID1[idx_y].hi);
   // (-1)^sign * 2^hi * 2^mid

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -390,11 +390,10 @@ LIBC_INLINE bool is_odd_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
   int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
-                                     FloatProp::MANTISSA_WIDTH);
+                                     FloatProp::FRACTION_BITS);
   int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
   constexpr int32_t UNIT_EXPONENT =
-      FloatProp::EXPONENT_BIAS +
-      static_cast<int32_t>(FloatProp::MANTISSA_WIDTH);
+      FloatProp::EXPONENT_BIAS + static_cast<int32_t>(FloatProp::FRACTION_BITS);
   return (x_e + lsb == UNIT_EXPONENT);
 }
 
@@ -402,11 +401,10 @@ LIBC_INLINE bool is_integer(float x) {
   using FloatProp = typename fputil::FloatProperties<float>;
   uint32_t x_u = cpp::bit_cast<uint32_t>(x);
   int32_t x_e = static_cast<int32_t>((x_u & FloatProp::EXPONENT_MASK) >>
-                                     FloatProp::MANTISSA_WIDTH);
+                                     FloatProp::FRACTION_BITS);
   int32_t lsb = cpp::countr_zero(x_u | FloatProp::EXPONENT_MASK);
   constexpr int32_t UNIT_EXPONENT =
-      FloatProp::EXPONENT_BIAS +
-      static_cast<int32_t>(FloatProp::MANTISSA_WIDTH);
+      FloatProp::EXPONENT_BIAS + static_cast<int32_t>(FloatProp::FRACTION_BITS);
   return (x_e + lsb >= UNIT_EXPONENT);
 }
 
@@ -502,7 +500,7 @@ double powf_double_double(int idx_x, double dx, double y6, double lo6_hi,
     bool lo_sign = DoubleBits(r.lo).get_sign();
     if (hi_sign == lo_sign) {
       ++r_bits;
-    } else if ((r_bits & DoubleProp::MANTISSA_MASK) > 0) {
+    } else if ((r_bits & DoubleProp::FRACTION_MASK) > 0) {
       --r_bits;
     }
   }
@@ -671,11 +669,11 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
   x_u = FloatBits(x).uintval();
 
   // Extract exponent field of x.
-  ex += (x_u >> FloatProp::MANTISSA_WIDTH);
+  ex += (x_u >> FloatProp::FRACTION_BITS);
   double e_x = static_cast<double>(ex);
   // Use the highest 7 fractional bits of m_x as the index for look up tables.
-  uint32_t x_mant = x_u & FloatProp::MANTISSA_MASK;
-  int idx_x = static_cast<int>(x_mant >> (FloatProp::MANTISSA_WIDTH - 7));
+  uint32_t x_mant = x_u & FloatProp::FRACTION_MASK;
+  int idx_x = static_cast<int>(x_mant >> (FloatProp::FRACTION_BITS - 7));
   // Add the hidden bit to the mantissa.
   // 1 <= m_x < 2
   float m_x = cpp::bit_cast<float>(x_mant | 0x3f800000);
@@ -776,7 +774,7 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
   int idx_y = hm_i & 0x3f;
 
   // 2^hi
-  int64_t exp_hi_i = (hm_i >> 6) << DoubleProp::MANTISSA_WIDTH;
+  int64_t exp_hi_i = (hm_i >> 6) << DoubleProp::FRACTION_BITS;
   // 2^mid
   int64_t exp_mid_i = cpp::bit_cast<uint64_t>(EXP2_MID1[idx_y].hi);
   // (-1)^sign * 2^hi * 2^mid

--- a/libc/src/math/generic/range_reduction.h
+++ b/libc/src/math/generic/range_reduction.h
@@ -59,7 +59,7 @@ LIBC_INLINE int64_t small_range_reduction(double x, double &y) {
 LIBC_INLINE int64_t large_range_reduction(double x, int x_exp, double &y) {
   int idx = 0;
   y = 0;
-  int x_lsb_exp_m4 = x_exp - fputil::FloatProperties<float>::MANTISSA_WIDTH;
+  int x_lsb_exp_m4 = x_exp - fputil::FloatProperties<float>::FRACTION_BITS;
 
   // Skipping the first parts of 32/pi such that:
   //   LSB of x * LSB of THIRTYTWO_OVER_PI_28[i] >= 32.

--- a/libc/src/math/generic/range_reduction.h
+++ b/libc/src/math/generic/range_reduction.h
@@ -59,7 +59,7 @@ LIBC_INLINE int64_t small_range_reduction(double x, double &y) {
 LIBC_INLINE int64_t large_range_reduction(double x, int x_exp, double &y) {
   int idx = 0;
   y = 0;
-  int x_lsb_exp_m4 = x_exp - fputil::FloatProperties<float>::FRACTION_BITS;
+  int x_lsb_exp_m4 = x_exp - fputil::FloatProperties<float>::FRACTION_LEN;
 
   // Skipping the first parts of 32/pi such that:
   //   LSB of x * LSB of THIRTYTWO_OVER_PI_28[i] >= 32.

--- a/libc/src/math/generic/sincosf.cpp
+++ b/libc/src/math/generic/sincosf.cpp
@@ -148,7 +148,7 @@ LLVM_LIBC_FUNCTION(void, sincosf, (float x, float *sinp, float *cosp)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    *sinp = x + FPBits::build_nan(1 << (FPBits::MANTISSA_WIDTH - 1));
+    *sinp = x + FPBits::build_nan(FPBits::FRACTION_MASK);
     *cosp = *sinp;
     return;
   }

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -90,7 +90,7 @@ LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   // -hi = floor(-k * 2^(-MID_BITS))
   // exp_mhi = shift -hi to the exponent field of double precision.
   int64_t exp_mhi = static_cast<int64_t>(mk >> ExpBase::MID_BITS)
-                    << fputil::FloatProperties<double>::MANTISSA_WIDTH;
+                    << fputil::FloatProperties<double>::FRACTION_BITS;
   // mh = 2^(-hi - mid)
   int64_t mh_bits = ExpBase::EXP_2_MID[mk & ExpBase::MID_MASK] + exp_mhi;
   double mh = fputil::FPBits<double>(uint64_t(mh_bits)).get_val();

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -90,7 +90,7 @@ LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   // -hi = floor(-k * 2^(-MID_BITS))
   // exp_mhi = shift -hi to the exponent field of double precision.
   int64_t exp_mhi = static_cast<int64_t>(mk >> ExpBase::MID_BITS)
-                    << fputil::FloatProperties<double>::FRACTION_BITS;
+                    << fputil::FloatProperties<double>::FRACTION_LEN;
   // mh = 2^(-hi - mid)
   int64_t mh_bits = ExpBase::EXP_2_MID[mk & ExpBase::MID_MASK] + exp_mhi;
   double mh = fputil::FPBits<double>(uint64_t(mh_bits)).get_val();

--- a/libc/src/stdio/printf_core/core_structs.h
+++ b/libc/src/stdio/printf_core/core_structs.h
@@ -46,7 +46,7 @@ struct FormatSection {
   int precision = -1;
 
   // Needs to be large enough to hold a long double.
-  fputil::FPBits<long double>::UIntType conv_val_raw;
+  fputil::FPBits<long double>::StorageType conv_val_raw;
   void *conv_val_ptr;
 
   char conv_name;

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -31,7 +31,7 @@
 namespace LIBC_NAMESPACE {
 namespace printf_core {
 
-using MantissaInt = fputil::FPBits<long double>::StorageType;
+using StorageType = fputil::FPBits<long double>::StorageType;
 using DecimalString = IntegerToString<intmax_t>;
 using ExponentString =
     IntegerToString<intmax_t, radix::Dec::WithWidth<2>::WithSign>;
@@ -594,7 +594,7 @@ LIBC_INLINE int convert_float_dec_exp_typed(Writer *writer,
   constexpr int32_t FRACTION_LEN = fputil::FloatProperties<T>::FRACTION_LEN;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
-  MantissaInt mantissa = float_bits.get_explicit_mantissa();
+  StorageType mantissa = float_bits.get_explicit_mantissa();
 
   const char a = (to_conv.conv_name & 32) | 'A';
 
@@ -757,7 +757,7 @@ LIBC_INLINE int convert_float_dec_auto_typed(Writer *writer,
   constexpr int32_t FRACTION_LEN = fputil::FloatProperties<T>::FRACTION_LEN;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
-  MantissaInt mantissa = float_bits.get_explicit_mantissa();
+  StorageType mantissa = float_bits.get_explicit_mantissa();
 
   // From the standard: Let P (init_precision) equal the precision if nonzero, 6
   // if the precision is omitted, or 1 if the precision is zero.

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -477,8 +477,8 @@ template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
-  // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
+  // signed because later we use -FRACTION_BITS
+  constexpr int32_t FRACTION_BITS = fputil::FloatProperties<T>::FRACTION_BITS;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
 
@@ -536,7 +536,7 @@ LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
     float_writer.write_first_block(0);
   }
 
-  if (exponent < MANT_WIDTH) {
+  if (exponent < FRACTION_BITS) {
     const uint32_t blocks = (precision / static_cast<uint32_t>(BLOCK_SIZE)) + 1;
     uint32_t i = 0;
     // if all the blocks we should write are zero
@@ -569,9 +569,9 @@ LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
           digits /= 10;
         }
         RoundDirection round;
-        const bool truncated =
-            !zero_after_digits(exponent - MANT_WIDTH, precision,
-                               float_bits.get_explicit_mantissa(), MANT_WIDTH);
+        const bool truncated = !zero_after_digits(
+            exponent - FRACTION_BITS, precision,
+            float_bits.get_explicit_mantissa(), FRACTION_BITS);
         round = get_round_direction(last_digit, truncated, is_negative);
 
         RET_IF_RESULT_NEGATIVE(
@@ -590,8 +590,8 @@ template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE int convert_float_dec_exp_typed(Writer *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
-  // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
+  // signed because later we use -FRACTION_BITS
+  constexpr int32_t FRACTION_BITS = fputil::FloatProperties<T>::FRACTION_BITS;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
   MantissaInt mantissa = float_bits.get_explicit_mantissa();
@@ -733,11 +733,11 @@ LIBC_INLINE int convert_float_dec_exp_typed(Writer *writer,
       }
     }
     // If it's still not truncated and there are digits below the decimal point
-    if (!truncated && exponent - MANT_WIDTH < 0) {
+    if (!truncated && exponent - FRACTION_BITS < 0) {
       // Use the formula from %f.
-      truncated =
-          !zero_after_digits(exponent - MANT_WIDTH, precision - final_exponent,
-                             float_bits.get_explicit_mantissa(), MANT_WIDTH);
+      truncated = !zero_after_digits(
+          exponent - FRACTION_BITS, precision - final_exponent,
+          float_bits.get_explicit_mantissa(), FRACTION_BITS);
     }
   }
   round = get_round_direction(last_digit, truncated, is_negative);
@@ -753,8 +753,8 @@ template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE int convert_float_dec_auto_typed(Writer *writer,
                                              const FormatSection &to_conv,
                                              fputil::FPBits<T> float_bits) {
-  // signed because later we use -MANT_WIDTH
-  constexpr int32_t MANT_WIDTH = fputil::FloatProperties<T>::MANTISSA_WIDTH;
+  // signed because later we use -FRACTION_BITS
+  constexpr int32_t FRACTION_BITS = fputil::FloatProperties<T>::FRACTION_BITS;
   bool is_negative = float_bits.get_sign();
   int exponent = float_bits.get_explicit_exponent();
   MantissaInt mantissa = float_bits.get_explicit_mantissa();
@@ -980,11 +980,11 @@ LIBC_INLINE int convert_float_dec_auto_typed(Writer *writer,
       }
     }
     // If it's still not truncated and there are digits below the decimal point
-    if (!truncated && exponent - MANT_WIDTH < 0) {
+    if (!truncated && exponent - FRACTION_BITS < 0) {
       // Use the formula from %f.
-      truncated =
-          !zero_after_digits(exponent - MANT_WIDTH, exp_precision - base_10_exp,
-                             float_bits.get_explicit_mantissa(), MANT_WIDTH);
+      truncated = !zero_after_digits(
+          exponent - FRACTION_BITS, exp_precision - base_10_exp,
+          float_bits.get_explicit_mantissa(), FRACTION_BITS);
     }
   }
 

--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -28,7 +28,7 @@ namespace printf_core {
 LIBC_INLINE int convert_float_hex_exp(Writer *writer,
                                       const FormatSection &to_conv) {
   using LDBits = fputil::FPBits<long double>;
-  using MantissaInt = LDBits::StorageType;
+  using StorageType = LDBits::StorageType;
   // All of the letters will be defined relative to variable a, which will be
   // the appropriate case based on the name of the conversion. This converts any
   // conversion name into the letter 'a' with the appropriate case.
@@ -36,7 +36,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
 
   bool is_negative;
   int exponent;
-  MantissaInt mantissa;
+  StorageType mantissa;
   bool is_inf_or_nan;
   uint32_t fraction_bits;
   if (to_conv.length_modifier == LengthModifier::L) {
@@ -100,9 +100,9 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
     const size_t shift_amount =
         (mant_len - intended_digits) * BITS_IN_HEX_DIGIT;
 
-    const MantissaInt truncated_bits =
-        mantissa & ((MantissaInt(1) << shift_amount) - 1);
-    const MantissaInt halfway_const = MantissaInt(1) << (shift_amount - 1);
+    const StorageType truncated_bits =
+        mantissa & ((StorageType(1) << shift_amount) - 1);
+    const StorageType halfway_const = StorageType(1) << (shift_amount - 1);
 
     mantissa >>= shift_amount;
 
@@ -128,7 +128,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
 
     // If the rounding caused an overflow, shift the mantissa and adjust the
     // exponent to match.
-    if (mantissa >= (MantissaInt(1) << (intended_digits * BITS_IN_HEX_DIGIT))) {
+    if (mantissa >= (StorageType(1) << (intended_digits * BITS_IN_HEX_DIGIT))) {
       mantissa >>= BITS_IN_HEX_DIGIT;
       exponent += BITS_IN_HEX_DIGIT;
     }

--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -38,9 +38,9 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   int exponent;
   MantissaInt mantissa;
   bool is_inf_or_nan;
-  uint32_t mantissa_width;
+  uint32_t fraction_bits;
   if (to_conv.length_modifier == LengthModifier::L) {
-    mantissa_width = LDBits::MANTISSA_WIDTH;
+    fraction_bits = LDBits::FRACTION_BITS;
     LDBits::UIntType float_raw = to_conv.conv_val_raw;
     LDBits float_bits(float_raw);
     is_negative = float_bits.get_sign();
@@ -49,7 +49,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
     is_inf_or_nan = float_bits.is_inf_or_nan();
   } else {
     using LBits = fputil::FPBits<double>;
-    mantissa_width = LBits::MANTISSA_WIDTH;
+    fraction_bits = LBits::FRACTION_BITS;
     LBits::UIntType float_raw =
         static_cast<LBits::UIntType>(to_conv.conv_val_raw);
     LBits float_bits(float_raw);
@@ -78,8 +78,8 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // digits. This is primarily relevant for x86 80 bit long doubles, which have
   // 63 bit mantissas. In the case where the mantissa is 0, however, the
   // exponent should stay as 0.
-  if (mantissa_width % BITS_IN_HEX_DIGIT != 0 && mantissa > 0) {
-    exponent -= mantissa_width % BITS_IN_HEX_DIGIT;
+  if (fraction_bits % BITS_IN_HEX_DIGIT != 0 && mantissa > 0) {
+    exponent -= fraction_bits % BITS_IN_HEX_DIGIT;
   }
 
   // This is the max number of digits it can take to represent the mantissa.
@@ -87,10 +87,10 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // for the extra implicit bit. We use the larger of the two possible values
   // since the size must be constant.
   constexpr size_t MANT_BUFF_LEN =
-      (LDBits::MANTISSA_WIDTH / BITS_IN_HEX_DIGIT) + 1;
+      (LDBits::FRACTION_BITS / BITS_IN_HEX_DIGIT) + 1;
   char mant_buffer[MANT_BUFF_LEN];
 
-  size_t mant_len = (mantissa_width / BITS_IN_HEX_DIGIT) + 1;
+  size_t mant_len = (fraction_bits / BITS_IN_HEX_DIGIT) + 1;
 
   // Precision only tracks the number of digits after the hexadecimal point, so
   // we have to add one to account for the digit before the hexadecimal point.

--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -28,7 +28,7 @@ namespace printf_core {
 LIBC_INLINE int convert_float_hex_exp(Writer *writer,
                                       const FormatSection &to_conv) {
   using LDBits = fputil::FPBits<long double>;
-  using MantissaInt = LDBits::UIntType;
+  using MantissaInt = LDBits::StorageType;
   // All of the letters will be defined relative to variable a, which will be
   // the appropriate case based on the name of the conversion. This converts any
   // conversion name into the letter 'a' with the appropriate case.
@@ -40,8 +40,8 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   bool is_inf_or_nan;
   uint32_t fraction_bits;
   if (to_conv.length_modifier == LengthModifier::L) {
-    fraction_bits = LDBits::FRACTION_BITS;
-    LDBits::UIntType float_raw = to_conv.conv_val_raw;
+    fraction_bits = LDBits::FRACTION_LEN;
+    LDBits::StorageType float_raw = to_conv.conv_val_raw;
     LDBits float_bits(float_raw);
     is_negative = float_bits.get_sign();
     exponent = float_bits.get_explicit_exponent();
@@ -49,9 +49,9 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
     is_inf_or_nan = float_bits.is_inf_or_nan();
   } else {
     using LBits = fputil::FPBits<double>;
-    fraction_bits = LBits::FRACTION_BITS;
-    LBits::UIntType float_raw =
-        static_cast<LBits::UIntType>(to_conv.conv_val_raw);
+    fraction_bits = LBits::FRACTION_LEN;
+    LBits::StorageType float_raw =
+        static_cast<LBits::StorageType>(to_conv.conv_val_raw);
     LBits float_bits(float_raw);
     is_negative = float_bits.get_sign();
     exponent = float_bits.get_explicit_exponent();
@@ -87,7 +87,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // for the extra implicit bit. We use the larger of the two possible values
   // since the size must be constant.
   constexpr size_t MANT_BUFF_LEN =
-      (LDBits::FRACTION_BITS / BITS_IN_HEX_DIGIT) + 1;
+      (LDBits::FRACTION_LEN / BITS_IN_HEX_DIGIT) + 1;
   char mant_buffer[MANT_BUFF_LEN];
 
   size_t mant_len = (fraction_bits / BITS_IN_HEX_DIGIT) + 1;
@@ -158,7 +158,7 @@ LIBC_INLINE int convert_float_hex_exp(Writer *writer,
   // 15 -> 5
   // 11 -> 4
   // 8  -> 3
-  constexpr size_t EXP_LEN = (((LDBits::EXPONENT_WIDTH * 5) + 15) / 16) + 1;
+  constexpr size_t EXP_LEN = (((LDBits::EXP_LEN * 5) + 15) / 16) + 1;
   char exp_buffer[EXP_LEN];
 
   bool exp_is_negative = false;

--- a/libc/src/stdio/printf_core/float_inf_nan_converter.h
+++ b/libc/src/stdio/printf_core/float_inf_nan_converter.h
@@ -21,7 +21,7 @@
 namespace LIBC_NAMESPACE {
 namespace printf_core {
 
-using MantissaInt = fputil::FPBits<long double>::UIntType;
+using MantissaInt = fputil::FPBits<long double>::StorageType;
 
 LIBC_INLINE int convert_inf_nan(Writer *writer, const FormatSection &to_conv) {
   // All of the letters will be defined relative to variable a, which will be
@@ -31,13 +31,13 @@ LIBC_INLINE int convert_inf_nan(Writer *writer, const FormatSection &to_conv) {
   bool is_negative;
   MantissaInt mantissa;
   if (to_conv.length_modifier == LengthModifier::L) {
-    fputil::FPBits<long double>::UIntType float_raw = to_conv.conv_val_raw;
+    fputil::FPBits<long double>::StorageType float_raw = to_conv.conv_val_raw;
     fputil::FPBits<long double> float_bits(float_raw);
     is_negative = float_bits.get_sign();
     mantissa = float_bits.get_mantissa();
   } else {
-    fputil::FPBits<double>::UIntType float_raw =
-        static_cast<fputil::FPBits<double>::UIntType>(to_conv.conv_val_raw);
+    fputil::FPBits<double>::StorageType float_raw =
+        static_cast<fputil::FPBits<double>::StorageType>(to_conv.conv_val_raw);
     fputil::FPBits<double> float_bits(float_raw);
     is_negative = float_bits.get_sign();
     mantissa = float_bits.get_mantissa();

--- a/libc/src/stdio/printf_core/float_inf_nan_converter.h
+++ b/libc/src/stdio/printf_core/float_inf_nan_converter.h
@@ -21,7 +21,7 @@
 namespace LIBC_NAMESPACE {
 namespace printf_core {
 
-using MantissaInt = fputil::FPBits<long double>::StorageType;
+using StorageType = fputil::FPBits<long double>::StorageType;
 
 LIBC_INLINE int convert_inf_nan(Writer *writer, const FormatSection &to_conv) {
   // All of the letters will be defined relative to variable a, which will be
@@ -29,7 +29,7 @@ LIBC_INLINE int convert_inf_nan(Writer *writer, const FormatSection &to_conv) {
   const char a = (to_conv.conv_name & 32) | 'A';
 
   bool is_negative;
-  MantissaInt mantissa;
+  StorageType mantissa;
   if (to_conv.length_modifier == LengthModifier::L) {
     fputil::FPBits<long double>::StorageType float_raw = to_conv.conv_val_raw;
     fputil::FPBits<long double> float_bits(float_raw);

--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -26,10 +26,10 @@ template <typename T> struct int_type_of {
   using type = T;
 };
 template <> struct int_type_of<double> {
-  using type = fputil::FPBits<double>::UIntType;
+  using type = fputil::FPBits<double>::StorageType;
 };
 template <> struct int_type_of<long double> {
-  using type = fputil::FPBits<long double>::UIntType;
+  using type = fputil::FPBits<long double>::StorageType;
 };
 template <typename T> using int_type_of_v = typename int_type_of<T>::type;
 

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -61,7 +61,7 @@ template <TestCond C, typename T> FPMatcher<T, C> getMatcher(T expectedValue) {
 
 template <typename T> struct FPTest : public Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
   static constexpr T zero = FPBits::zero();
   static constexpr T neg_zero = FPBits::neg_zero();
   static constexpr T aNaN = FPBits::build_quiet_nan(1);
@@ -87,7 +87,7 @@ template <typename T> struct FPTest : public Test {
 
 #define DECLARE_SPECIAL_CONSTANTS(T)                                           \
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;                            \
-  using UIntType = typename FPBits::UIntType;                                  \
+  using StorageType = typename FPBits::StorageType;                            \
   const T zero = FPBits::zero();                                               \
   const T neg_zero = FPBits::neg_zero();                                       \
   const T aNaN = FPBits::build_quiet_nan(1);                                   \

--- a/libc/test/UnitTest/PrintfMatcher.cpp
+++ b/libc/test/UnitTest/PrintfMatcher.cpp
@@ -77,7 +77,7 @@ static void display(FormatSection form) {
            << "\n";
     else if (form.conv_name != '%')
       tlog << "\tvalue: "
-           << int_to_hex<fputil::FPBits<long double>::UIntType>(
+           << int_to_hex<fputil::FPBits<long double>::StorageType>(
                   form.conv_val_raw)
            << "\n";
   }

--- a/libc/test/src/__support/str_to_fp_test.h
+++ b/libc/test/src/__support/str_to_fp_test.h
@@ -16,13 +16,13 @@
 namespace LIBC_NAMESPACE {
 
 template <typename T> struct LlvmLibcStrToFloatTest : public testing::Test {
-  using UIntType = typename fputil::FloatProperties<T>::UIntType;
+  using StorageType = typename fputil::FloatProperties<T>::StorageType;
 
-  void clinger_fast_path_test(const UIntType inputMantissa,
+  void clinger_fast_path_test(const StorageType inputMantissa,
                               const int32_t inputExp10,
-                              const UIntType expectedOutputMantissa,
+                              const StorageType expectedOutputMantissa,
                               const uint32_t expectedOutputExp2) {
-    UIntType actual_output_mantissa = 0;
+    StorageType actual_output_mantissa = 0;
     uint32_t actual_output_exp2 = 0;
 
     auto result = internal::clinger_fast_path<T>({inputMantissa, inputExp10});
@@ -36,16 +36,17 @@ template <typename T> struct LlvmLibcStrToFloatTest : public testing::Test {
     EXPECT_EQ(actual_output_exp2, expectedOutputExp2);
   }
 
-  void clinger_fast_path_fails_test(const UIntType inputMantissa,
+  void clinger_fast_path_fails_test(const StorageType inputMantissa,
                                     const int32_t inputExp10) {
     ASSERT_FALSE(internal::clinger_fast_path<T>({inputMantissa, inputExp10})
                      .has_value());
   }
 
-  void eisel_lemire_test(const UIntType inputMantissa, const int32_t inputExp10,
-                         const UIntType expectedOutputMantissa,
+  void eisel_lemire_test(const StorageType inputMantissa,
+                         const int32_t inputExp10,
+                         const StorageType expectedOutputMantissa,
                          const uint32_t expectedOutputExp2) {
-    UIntType actual_output_mantissa = 0;
+    StorageType actual_output_mantissa = 0;
     uint32_t actual_output_exp2 = 0;
 
     auto result = internal::eisel_lemire<T>({inputMantissa, inputExp10});
@@ -60,10 +61,10 @@ template <typename T> struct LlvmLibcStrToFloatTest : public testing::Test {
   }
 
   void simple_decimal_conversion_test(const char *__restrict numStart,
-                                      const UIntType expectedOutputMantissa,
+                                      const StorageType expectedOutputMantissa,
                                       const uint32_t expectedOutputExp2,
                                       const int expectedErrno = 0) {
-    UIntType actual_output_mantissa = 0;
+    StorageType actual_output_mantissa = 0;
     uint32_t actual_output_exp2 = 0;
     libc_errno = 0;
 

--- a/libc/test/src/math/CeilTest.h
+++ b/libc/test/src/math/CeilTest.h
@@ -64,9 +64,9 @@ public:
   }
 
   void testRange(CeilFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/CopySignTest.h
+++ b/libc/test/src/math/CopySignTest.h
@@ -34,9 +34,9 @@ public:
   }
 
   void testRange(CopySignFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/FAbsTest.h
+++ b/libc/test/src/math/FAbsTest.h
@@ -32,9 +32,9 @@ public:
   }
 
   void testRange(FabsFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/FDimTest.h
+++ b/libc/test/src/math/FDimTest.h
@@ -17,7 +17,7 @@ class FDimTestTemplate : public LIBC_NAMESPACE::testing::Test {
 public:
   using FuncPtr = T (*)(T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   void test_na_n_arg(FuncPtr func) {
     EXPECT_FP_EQ(nan, func(nan, inf));
@@ -53,9 +53,9 @@ public:
   }
 
   void test_in_range(FuncPtr func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FMaxTest.h
+++ b/libc/test/src/math/FMaxTest.h
@@ -55,9 +55,9 @@ public:
   }
 
   void testRange(FMaxFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FMinTest.h
+++ b/libc/test/src/math/FMinTest.h
@@ -55,9 +55,9 @@ public:
   }
 
   void testRange(FMinFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FloorTest.h
+++ b/libc/test/src/math/FloorTest.h
@@ -64,9 +64,9 @@ public:
   }
 
   void testRange(FloorFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/FmaTest.h
+++ b/libc/test/src/math/FmaTest.h
@@ -68,9 +68,8 @@ public:
 
   void test_subnormal_range(Func func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
          v <= FPBits::MAX_SUBNORMAL && w >= FPBits::MIN_SUBNORMAL;
          v += STEP, w -= STEP) {
@@ -85,8 +84,7 @@ public:
   void test_normal_range(Func func) {
     constexpr StorageType COUNT = 100'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
          v <= FPBits::MAX_NORMAL && w >= FPBits::MIN_NORMAL;
          v += STEP, w -= STEP) {

--- a/libc/test/src/math/FmaTest.h
+++ b/libc/test/src/math/FmaTest.h
@@ -22,16 +22,16 @@ class FmaTestTemplate : public LIBC_NAMESPACE::testing::Test {
 private:
   using Func = T (*)(T, T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
   const T nan = T(FPBits::build_quiet_nan(1));
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
 
-  UIntType get_random_bit_pattern() {
-    UIntType bits{0};
-    for (UIntType i = 0; i < sizeof(UIntType) / 2; ++i) {
+  StorageType get_random_bit_pattern() {
+    StorageType bits{0};
+    for (StorageType i = 0; i < sizeof(StorageType) / 2; ++i) {
       bits = (bits << 2) +
              static_cast<uint16_t>(LIBC_NAMESPACE::testutils::rand());
     }
@@ -52,9 +52,9 @@ public:
     // Test underflow rounding up.
     EXPECT_FP_EQ(func(T(0.5), T(FPBits(FPBits::MIN_SUBNORMAL)),
                       T(FPBits(FPBits::MIN_SUBNORMAL))),
-                 T(FPBits(UIntType(2))));
+                 T(FPBits(StorageType(2))));
     // Test underflow rounding down.
-    T v = T(FPBits(FPBits::MIN_NORMAL + UIntType(1)));
+    T v = T(FPBits(FPBits::MIN_NORMAL + StorageType(1)));
     EXPECT_FP_EQ(func(T(1) / T(FPBits::MIN_NORMAL << 1), v,
                       T(FPBits(FPBits::MIN_NORMAL))),
                  v);
@@ -67,11 +67,11 @@ public:
   }
 
   void test_subnormal_range(Func func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
          v <= FPBits::MAX_SUBNORMAL && w >= FPBits::MIN_SUBNORMAL;
          v += STEP, w -= STEP) {
       T x = T(FPBits(get_random_bit_pattern())), y = T(FPBits(v)),
@@ -83,10 +83,11 @@ public:
   }
 
   void test_normal_range(Func func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
          v <= FPBits::MAX_NORMAL && w >= FPBits::MIN_NORMAL;
          v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w)),

--- a/libc/test/src/math/FrexpTest.h
+++ b/libc/test/src/math/FrexpTest.h
@@ -20,7 +20,7 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*FrexpFunc)(T, int *);

--- a/libc/test/src/math/FrexpTest.h
+++ b/libc/test/src/math/FrexpTest.h
@@ -19,8 +19,9 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*FrexpFunc)(T, int *);
@@ -92,10 +93,10 @@ public:
   }
 
   void testRange(FrexpFunc func) {
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)
         continue;

--- a/libc/test/src/math/HypotTest.h
+++ b/libc/test/src/math/HypotTest.h
@@ -23,7 +23,7 @@ class HypotTestTemplate : public LIBC_NAMESPACE::testing::Test {
 private:
   using Func = T (*)(T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
   const T nan = T(FPBits::build_quiet_nan(1));
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());
@@ -59,12 +59,12 @@ public:
   }
 
   void test_subnormal_range(Func func) {
-    constexpr UIntType COUNT = 10'001;
+    constexpr StorageType COUNT = 10'001;
     for (unsigned scale = 0; scale < 4; ++scale) {
-      UIntType max_value = FPBits::MAX_SUBNORMAL << scale;
-      UIntType step = (max_value - FPBits::MIN_SUBNORMAL) / COUNT;
+      StorageType max_value = FPBits::MAX_SUBNORMAL << scale;
+      StorageType step = (max_value - FPBits::MIN_SUBNORMAL) / COUNT;
       for (int signs = 0; signs < 4; ++signs) {
-        for (UIntType v = FPBits::MIN_SUBNORMAL, w = max_value;
+        for (StorageType v = FPBits::MIN_SUBNORMAL, w = max_value;
              v <= max_value && w >= FPBits::MIN_SUBNORMAL;
              v += step, w -= step) {
           T x = T(FPBits(v)), y = T(FPBits(w));
@@ -84,11 +84,12 @@ public:
   }
 
   void test_normal_range(Func func) {
-    constexpr UIntType COUNT = 10'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
+    constexpr StorageType COUNT = 10'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
     for (int signs = 0; signs < 4; ++signs) {
-      for (UIntType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
+      for (StorageType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
            v <= FPBits::MAX_NORMAL && w >= FPBits::MIN_NORMAL;
            v += STEP, w -= STEP) {
         T x = T(FPBits(v)), y = T(FPBits(w));

--- a/libc/test/src/math/ILogbTest.h
+++ b/libc/test/src/math/ILogbTest.h
@@ -74,12 +74,12 @@ public:
   template <typename T>
   void test_subnormal_range(typename ILogbFunc<T>::Func func) {
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 10'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 10'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
          v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0)
@@ -94,11 +94,13 @@ public:
   template <typename T>
   void test_normal_range(typename ILogbFunc<T>::Func func) {
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 10'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL; v += STEP) {
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 10'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL;
+         v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0)
         continue;

--- a/libc/test/src/math/ILogbTest.h
+++ b/libc/test/src/math/ILogbTest.h
@@ -76,9 +76,8 @@ public:
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 10'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
          v += STEP) {
       T x = T(FPBits(v));
@@ -97,8 +96,7 @@ public:
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 10'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL;
          v += STEP) {
       T x = T(FPBits(v));

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -22,10 +22,10 @@ template <typename T>
 class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
-  using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType FRACTION_BITS = FPBits::FRACTION_BITS;
+  using StorageType = typename FPBits::StorageType;
+  static constexpr StorageType FRACTION_LEN = FPBits::FRACTION_LEN;
   // A normalized mantissa to be used with tests.
-  static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
+  static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
@@ -69,7 +69,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
+    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,11 +82,11 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
+    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
-    T x = NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0);
+    T x = NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0);
     for (int32_t exp : exp_array) {
       ASSERT_FP_EQ(func(x, -exp), x > 0 ? zero : neg_zero);
     }
@@ -98,9 +98,9 @@ public:
         NormalFloat(100, MANTISSA, 0), NormalFloat(-100, MANTISSA, 0),
         NormalFloat(100, MANTISSA, 1), NormalFloat(-100, MANTISSA, 1),
         // Subnormal numbers
-        NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0),
-        NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_BITS); ++exp) {
+        NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0),
+        NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 1)};
+    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_LEN); ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -118,14 +118,14 @@ public:
     }
 
     // Normal which trigger mantissa overflow.
-    T x = NormalFloat(-FPBits::EXPONENT_BIAS + 1,
-                      UIntType(2) * NormalFloat::ONE - UIntType(1), 0);
+    T x = NormalFloat(-FPBits::EXP_BIAS + 1,
+                      StorageType(2) * NormalFloat::ONE - StorageType(1), 0);
     ASSERT_FP_EQ(func(x, -1), x / 2);
     ASSERT_FP_EQ(func(-x, -1), -x / 2);
 
     // Start with a normal number high exponent but pass a very low number for
     // exp. The result should be a subnormal number.
-    x = NormalFloat(FPBits::EXPONENT_BIAS, NormalFloat::ONE, 0);
+    x = NormalFloat(FPBits::EXP_BIAS, NormalFloat::ONE, 0);
     int exp = -FPBits::MAX_EXPONENT - 5;
     T result = func(x, exp);
     FPBits result_bits(result);
@@ -134,12 +134,12 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_BITS) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_LEN) - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.
     // The result should not be infinity.
-    x = NormalFloat(-FPBits::EXPONENT_BIAS + 1, NormalFloat::ONE >> 10, 0);
+    x = NormalFloat(-FPBits::EXP_BIAS + 1, NormalFloat::ONE >> 10, 0);
     exp = FPBits::MAX_EXPONENT + 5;
     ASSERT_FALSE(FPBits(func(x, exp)).is_inf());
     // But if the exp is large enough to oversome than the normalization shift,

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -23,7 +23,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MANTISSA_WIDTH = FPBits::MANTISSA_WIDTH;
+  static constexpr UIntType FRACTION_BITS = FPBits::FRACTION_BITS;
   // A normalized mantissa to be used with tests.
   static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
 
@@ -69,7 +69,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(MANTISSA_WIDTH);
+    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,7 +82,7 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(MANTISSA_WIDTH);
+    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -100,7 +100,7 @@ public:
         // Subnormal numbers
         NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0),
         NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(MANTISSA_WIDTH); ++exp) {
+    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_BITS); ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -134,7 +134,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(MANTISSA_WIDTH) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_BITS) - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -23,7 +23,6 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using StorageType = typename FPBits::StorageType;
-  static constexpr StorageType FRACTION_LEN = FPBits::FRACTION_LEN;
   // A normalized mantissa to be used with tests.
   static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;
 
@@ -69,7 +68,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
+    int32_t base_exponent = FPBits::EXP_BIAS + FPBits::FRACTION_LEN;
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,7 +81,7 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
+    int32_t base_exponent = FPBits::EXP_BIAS + FPBits::FRACTION_LEN;
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -100,7 +99,7 @@ public:
         // Subnormal numbers
         NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0),
         NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_LEN); ++exp) {
+    for (int32_t exp = 0; exp <= FPBits::FRACTION_LEN; ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -134,7 +133,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_LEN) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - FPBits::FRACTION_LEN - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.

--- a/libc/test/src/math/LogbTest.h
+++ b/libc/test/src/math/LogbTest.h
@@ -19,8 +19,9 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*LogbFunc)(T);
@@ -71,10 +72,10 @@ public:
   }
 
   void testRange(LogbFunc func) {
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)
         continue;

--- a/libc/test/src/math/LogbTest.h
+++ b/libc/test/src/math/LogbTest.h
@@ -20,7 +20,7 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*LogbFunc)(T);

--- a/libc/test/src/math/ModfTest.h
+++ b/libc/test/src/math/ModfTest.h
@@ -84,9 +84,9 @@ public:
   }
 
   void testRange(ModfFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == T(0.0))
         continue;

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -22,9 +22,6 @@ class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
 
-  static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
-
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
   const T inf = T(FPBits::inf());
@@ -55,7 +52,7 @@ public:
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, T(-1));
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -66,7 +63,7 @@ public:
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -84,13 +81,12 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = FPBits::SIGN_MASK + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -104,8 +100,7 @@ public:
 
     x = -x;
     result = func(x, -1);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, 0), T(-0.0));
@@ -124,13 +119,12 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, -inf);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -152,7 +146,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = FPBits::SIGN_MASK + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -163,8 +163,7 @@ public:
     FPBits result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
@@ -177,8 +176,7 @@ public:
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -20,20 +20,20 @@
 template <typename T>
 class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::BIT_WIDTH;
+      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());
   const T nan = T(FPBits::build_quiet_nan(1));
-  const UIntType min_subnormal = FPBits::MIN_SUBNORMAL;
-  const UIntType max_subnormal = FPBits::MAX_SUBNORMAL;
-  const UIntType min_normal = FPBits::MIN_NORMAL;
-  const UIntType max_normal = FPBits::MAX_NORMAL;
+  const StorageType min_subnormal = FPBits::MIN_SUBNORMAL;
+  const StorageType max_subnormal = FPBits::MAX_SUBNORMAL;
+  const StorageType min_normal = FPBits::MIN_NORMAL;
+  const StorageType max_normal = FPBits::MAX_NORMAL;
 
 public:
   typedef T (*NextAfterFunc)(T, T);
@@ -50,12 +50,12 @@ public:
     // 'from' is zero|neg_zero.
     T x = zero;
     T result = func(x, T(1));
-    UIntType expected_bits = 1;
+    StorageType expected_bits = 1;
     T expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, T(-1));
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -66,7 +66,7 @@ public:
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -84,13 +84,13 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -105,7 +105,7 @@ public:
     x = -x;
     result = func(x, -1);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, 0), T(-0.0));
@@ -124,12 +124,13 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, -inf);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits =
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -151,7 +152,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);
@@ -168,7 +169,8 @@ public:
     result = func(x, T(33.0));
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
 
     x = -x;
 
@@ -181,7 +183,8 @@ public:
     result = func(x, T(-33.0));
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
   }
 };
 

--- a/libc/test/src/math/RIntTest.h
+++ b/libc/test/src/math/RIntTest.h
@@ -94,9 +94,8 @@ public:
 
   void testSubnormalRange(RIntFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       T x = T(FPBits(i));
@@ -111,8 +110,7 @@ public:
   void testNormalRange(RIntFunc func) {
     constexpr StorageType COUNT = 100'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL;
          i += STEP) {
       T x = T(FPBits(i));

--- a/libc/test/src/math/RIntTest.h
+++ b/libc/test/src/math/RIntTest.h
@@ -31,7 +31,7 @@ public:
 
 private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
@@ -93,11 +93,11 @@ public:
   }
 
   void testSubnormalRange(RIntFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       T x = T(FPBits(i));
       for (int mode : ROUNDING_MODES) {
@@ -109,10 +109,12 @@ public:
   }
 
   void testNormalRange(RIntFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL; i += STEP) {
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL;
+         i += STEP) {
       T x = T(FPBits(i));
       // In normal range on x86 platforms, the long double implicit 1 bit can be
       // zero making the numbers NaN. We will skip them.

--- a/libc/test/src/math/RemQuoTest.h
+++ b/libc/test/src/math/RemQuoTest.h
@@ -21,7 +21,7 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 template <typename T>
 class RemQuoTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
@@ -95,11 +95,11 @@ public:
   }
 
   void testSubnormalRange(RemQuoFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
          v <= FPBits::MAX_SUBNORMAL && w >= FPBits::MIN_SUBNORMAL;
          v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
@@ -111,10 +111,11 @@ public:
   }
 
   void testNormalRange(RemQuoFunc func) {
-    constexpr UIntType COUNT = 1'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
+    constexpr StorageType COUNT = 1'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
          v <= FPBits::MAX_NORMAL && w >= FPBits::MIN_NORMAL;
          v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));

--- a/libc/test/src/math/RemQuoTest.h
+++ b/libc/test/src/math/RemQuoTest.h
@@ -96,9 +96,8 @@ public:
 
   void testSubnormalRange(RemQuoFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_SUBNORMAL, w = FPBits::MAX_SUBNORMAL;
          v <= FPBits::MAX_SUBNORMAL && w >= FPBits::MIN_SUBNORMAL;
          v += STEP, w -= STEP) {
@@ -113,8 +112,7 @@ public:
   void testNormalRange(RemQuoFunc func) {
     constexpr StorageType COUNT = 1'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_NORMAL, w = FPBits::MAX_NORMAL;
          v <= FPBits::MAX_NORMAL && w >= FPBits::MIN_NORMAL;
          v += STEP, w -= STEP) {

--- a/libc/test/src/math/RoundTest.h
+++ b/libc/test/src/math/RoundTest.h
@@ -64,9 +64,9 @@ public:
   }
 
   void testRange(RoundFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -30,7 +30,7 @@ public:
 
 private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<F>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const F zero = F(FPBits::zero());
   const F neg_zero = F(FPBits::neg_zero());
@@ -126,7 +126,7 @@ public:
     // We start with 1.0 so that the implicit bit for x86 long doubles
     // is set.
     FPBits bits(F(1.0));
-    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
+    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXP_BIAS);
     bits.set_sign(1);
     bits.set_mantissa(0);
 
@@ -190,7 +190,7 @@ public:
     // We start with 1.0 so that the implicit bit for x86 long doubles
     // is set.
     FPBits bits(F(1.0));
-    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
+    bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXP_BIAS);
     bits.set_sign(1);
     bits.set_mantissa(FPBits::FRACTION_MASK);
 
@@ -213,11 +213,11 @@ public:
   }
 
   void testSubnormalRange(RoundToIntegerFunc func) {
-    constexpr UIntType COUNT = 1'000'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
+    constexpr StorageType COUNT = 1'000'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       F x = F(FPBits(i));
       if (x == F(0.0))
@@ -258,10 +258,12 @@ public:
     if (sizeof(I) > sizeof(long))
       return;
 
-    constexpr UIntType COUNT = 1'000'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL; i += STEP) {
+    constexpr StorageType COUNT = 1'000'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL;
+         i += STEP) {
       F x = F(FPBits(i));
       // In normal range on x86 platforms, the long double implicit 1 bit can be
       // zero making the numbers NaN. We will skip them.

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -214,9 +214,8 @@ public:
 
   void testSubnormalRange(RoundToIntegerFunc func) {
     constexpr StorageType COUNT = 1'000'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       F x = F(FPBits(i));
@@ -260,8 +259,7 @@ public:
 
     constexpr StorageType COUNT = 1'000'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType i = FPBits::MIN_NORMAL; i <= FPBits::MAX_NORMAL;
          i += STEP) {
       F x = F(FPBits(i));

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -192,7 +192,7 @@ public:
     FPBits bits(F(1.0));
     bits.set_biased_exponent(EXPONENT_LIMIT + FPBits::EXPONENT_BIAS);
     bits.set_sign(1);
-    bits.set_mantissa(UIntType(0x1) << (FPBits::MANTISSA_WIDTH - 1));
+    bits.set_mantissa(FPBits::FRACTION_MASK);
 
     F x = F(bits);
     if (TestModes) {

--- a/libc/test/src/math/SqrtTest.h
+++ b/libc/test/src/math/SqrtTest.h
@@ -20,7 +20,7 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*SqrtFunc)(T);

--- a/libc/test/src/math/SqrtTest.h
+++ b/libc/test/src/math/SqrtTest.h
@@ -19,8 +19,9 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*SqrtFunc)(T);
@@ -38,25 +39,25 @@ public:
   }
 
   void test_denormal_values(SqrtFunc func) {
-    for (UIntType mant = 1; mant < HIDDEN_BIT; mant <<= 1) {
+    for (StorageType mant = 1; mant < HIDDEN_BIT; mant <<= 1) {
       FPBits denormal(T(0.0));
       denormal.set_mantissa(mant);
       T x = T(denormal);
       EXPECT_MPFR_MATCH_ALL_ROUNDING(mpfr::Operation::Sqrt, x, func(x), 0.5);
     }
 
-    constexpr UIntType COUNT = 200'001;
-    constexpr UIntType STEP = HIDDEN_BIT / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 200'001;
+    constexpr StorageType STEP = HIDDEN_BIT / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = LIBC_NAMESPACE::cpp::bit_cast<T>(v);
       EXPECT_MPFR_MATCH_ALL_ROUNDING(mpfr::Operation::Sqrt, x, func(x), 0.5);
     }
   }
 
   void test_normal_range(SqrtFunc func) {
-    constexpr UIntType COUNT = 200'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 200'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = LIBC_NAMESPACE::cpp::bit_cast<T>(v);
       if (isnan(x) || (x < 0)) {
         continue;

--- a/libc/test/src/math/TruncTest.h
+++ b/libc/test/src/math/TruncTest.h
@@ -64,9 +64,9 @@ public:
   }
 
   void testRange(TruncFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))
         continue;

--- a/libc/test/src/math/cos_test.cpp
+++ b/libc/test/src/math/cos_test.cpp
@@ -19,9 +19,9 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 
 TEST_F(LlvmLibcCosTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
-  constexpr UIntType COUNT = 100'000;
-  constexpr UIntType STEP = UIntType(-1) / COUNT;
-  for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+  constexpr StorageType COUNT = 100'000;
+  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.
     if (isnan(x) || isinf(x) || x > _2pi || x < -_2pi)

--- a/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
+++ b/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
@@ -17,9 +17,8 @@ namespace testing {
 template <typename T> class BinaryOpSingleOutputDiff {
   using FPBits = fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
-  static constexpr StorageType MSBIT = StorageType(1)
-                                       << (FPBits::STORAGE_LEN - 1);
-  static constexpr StorageType UINTMAX = (MSBIT - 1) + MSBIT;
+  static constexpr StorageType UIntMax =
+      cpp::numeric_limits<StorageType>::max();
 
 public:
   typedef T Func(T, T);

--- a/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
+++ b/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
@@ -16,23 +16,25 @@ namespace testing {
 
 template <typename T> class BinaryOpSingleOutputDiff {
   using FPBits = fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MSBIT = UIntType(1) << (8 * sizeof(UIntType) - 1);
-  static constexpr UIntType UINTMAX = (MSBIT - 1) + MSBIT;
+  using StorageType = typename FPBits::StorageType;
+  static constexpr StorageType MSBIT = StorageType(1)
+                                       << (8 * sizeof(StorageType) - 1);
+  static constexpr StorageType UINTMAX = (MSBIT - 1) + MSBIT;
 
 public:
   typedef T Func(T, T);
 
   static uint64_t run_diff_in_range(Func myFunc, Func otherFunc,
-                                    UIntType startingBit, UIntType endingBit,
-                                    UIntType N, std::ofstream &log) {
+                                    StorageType startingBit,
+                                    StorageType endingBit, StorageType N,
+                                    std::ofstream &log) {
     uint64_t result = 0;
     if (endingBit < startingBit) {
       return result;
     }
 
-    UIntType step = (endingBit - startingBit) / N;
-    for (UIntType bitsX = startingBit, bitsY = endingBit;;
+    StorageType step = (endingBit - startingBit) / N;
+    for (StorageType bitsX = startingBit, bitsY = endingBit;;
          bitsX += step, bitsY -= step) {
       T x = T(FPBits(bitsX));
       T y = T(FPBits(bitsY));
@@ -57,16 +59,16 @@ public:
   }
 
   static void run_perf_in_range(Func myFunc, Func otherFunc,
-                                UIntType startingBit, UIntType endingBit,
-                                UIntType N, std::ofstream &log) {
+                                StorageType startingBit, StorageType endingBit,
+                                StorageType N, std::ofstream &log) {
     auto runner = [=](Func func) {
       volatile T result;
       if (endingBit < startingBit) {
         return;
       }
 
-      UIntType step = (endingBit - startingBit) / N;
-      for (UIntType bitsX = startingBit, bitsY = endingBit;;
+      StorageType step = (endingBit - startingBit) / N;
+      for (StorageType bitsX = startingBit, bitsY = endingBit;;
            bitsX += step, bitsY -= step) {
         T x = T(FPBits(bitsX));
         T y = T(FPBits(bitsY));
@@ -107,7 +109,7 @@ public:
   static void run_perf(Func myFunc, Func otherFunc, const char *logFile) {
     std::ofstream log(logFile);
     log << " Performance tests with inputs in denormal range:\n";
-    run_perf_in_range(myFunc, otherFunc, /* startingBit= */ UIntType(0),
+    run_perf_in_range(myFunc, otherFunc, /* startingBit= */ StorageType(0),
                       /* endingBit= */ FPBits::MAX_SUBNORMAL, 1'000'001, log);
     log << "\n Performance tests with inputs in normal range:\n";
     run_perf_in_range(myFunc, otherFunc, /* startingBit= */ FPBits::MIN_NORMAL,
@@ -124,7 +126,7 @@ public:
     std::ofstream log(logFile);
     log << " Diff tests with inputs in denormal range:\n";
     diffCount += run_diff_in_range(
-        myFunc, otherFunc, /* startingBit= */ UIntType(0),
+        myFunc, otherFunc, /* startingBit= */ StorageType(0),
         /* endingBit= */ FPBits::MAX_SUBNORMAL, 1'000'001, log);
     log << "\n Diff tests with inputs in normal range:\n";
     diffCount += run_diff_in_range(

--- a/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
+++ b/libc/test/src/math/differential_testing/BinaryOpSingleOutputDiff.h
@@ -18,7 +18,7 @@ template <typename T> class BinaryOpSingleOutputDiff {
   using FPBits = fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
   static constexpr StorageType MSBIT = StorageType(1)
-                                       << (8 * sizeof(StorageType) - 1);
+                                       << (FPBits::STORAGE_LEN - 1);
   static constexpr StorageType UINTMAX = (MSBIT - 1) + MSBIT;
 
 public:

--- a/libc/test/src/math/differential_testing/SingleInputSingleOutputDiff.h
+++ b/libc/test/src/math/differential_testing/SingleInputSingleOutputDiff.h
@@ -17,9 +17,8 @@ namespace testing {
 template <typename T> class SingleInputSingleOutputDiff {
   using FPBits = fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
-  static constexpr StorageType MSBit = StorageType(1)
-                                       << (8 * sizeof(StorageType) - 1);
-  static constexpr StorageType UIntMax = (MSBit - 1) + MSBit;
+  static constexpr StorageType UIntMax =
+      cpp::numeric_limits<StorageType>::max();
 
 public:
   typedef T Func(T);

--- a/libc/test/src/math/differential_testing/SingleInputSingleOutputDiff.h
+++ b/libc/test/src/math/differential_testing/SingleInputSingleOutputDiff.h
@@ -16,24 +16,25 @@ namespace testing {
 
 template <typename T> class SingleInputSingleOutputDiff {
   using FPBits = fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MSBit = UIntType(1) << (8 * sizeof(UIntType) - 1);
-  static constexpr UIntType UIntMax = (MSBit - 1) + MSBit;
+  using StorageType = typename FPBits::StorageType;
+  static constexpr StorageType MSBit = StorageType(1)
+                                       << (8 * sizeof(StorageType) - 1);
+  static constexpr StorageType UIntMax = (MSBit - 1) + MSBit;
 
 public:
   typedef T Func(T);
 
   static void runDiff(Func myFunc, Func otherFunc, const char *logFile) {
-    UIntType diffCount = 0;
+    StorageType diffCount = 0;
     std::ofstream log(logFile);
     log << "Starting diff for values from 0 to " << UIntMax << '\n'
         << "Only differing results will be logged.\n\n";
-    for (UIntType bits = 0;; ++bits) {
+    for (StorageType bits = 0;; ++bits) {
       T x = T(FPBits(bits));
       T myResult = myFunc(x);
       T otherResult = otherFunc(x);
-      UIntType myBits = FPBits(myResult).uintval();
-      UIntType otherBits = FPBits(otherResult).uintval();
+      StorageType myBits = FPBits(myResult).uintval();
+      StorageType otherBits = FPBits(otherResult).uintval();
       if (myBits != otherBits) {
         ++diffCount;
         log << "       Input: " << bits << " (" << x << ")\n"
@@ -47,11 +48,12 @@ public:
     log << "Total number of differing results: " << diffCount << '\n';
   }
 
-  static void runPerfInRange(Func myFunc, Func otherFunc, UIntType startingBit,
-                             UIntType endingBit, std::ofstream &log) {
+  static void runPerfInRange(Func myFunc, Func otherFunc,
+                             StorageType startingBit, StorageType endingBit,
+                             std::ofstream &log) {
     auto runner = [=](Func func) {
       volatile T result;
-      for (UIntType bits = startingBit;; ++bits) {
+      for (StorageType bits = startingBit;; ++bits) {
         T x = T(FPBits(bits));
         result = func(x);
         if (bits == endingBit)
@@ -64,7 +66,7 @@ public:
     runner(myFunc);
     timer.stop();
 
-    UIntType numberOfRuns = endingBit - startingBit + 1;
+    StorageType numberOfRuns = endingBit - startingBit + 1;
     double myAverage = static_cast<double>(timer.nanoseconds()) / numberOfRuns;
     log << "-- My function --\n";
     log << "     Total time      : " << timer.nanoseconds() << " ns \n";
@@ -91,7 +93,7 @@ public:
   static void runPerf(Func myFunc, Func otherFunc, const char *logFile) {
     std::ofstream log(logFile);
     log << " Performance tests with inputs in denormal range:\n";
-    runPerfInRange(myFunc, otherFunc, /* startingBit= */ UIntType(0),
+    runPerfInRange(myFunc, otherFunc, /* startingBit= */ StorageType(0),
                    /* endingBit= */ FPBits::MAX_SUBNORMAL, log);
     log << "\n Performance tests with inputs in normal range:\n";
     runPerfInRange(myFunc, otherFunc, /* startingBit= */ FPBits::MIN_NORMAL,

--- a/libc/test/src/math/exhaustive/hypotf_test.cpp
+++ b/libc/test/src/math/exhaustive/hypotf_test.cpp
@@ -18,7 +18,7 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 struct HypotfChecker : public virtual LIBC_NAMESPACE::testing::Test {
   using FloatType = float;
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   uint64_t check(uint32_t start, uint32_t stop, mpfr::RoundingMode rounding) {
     // Range of the second input: [2^37, 2^48).

--- a/libc/test/src/math/exhaustive/sincosf_test.cpp
+++ b/libc/test/src/math/exhaustive/sincosf_test.cpp
@@ -15,13 +15,14 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 struct SincosfChecker : public virtual LIBC_NAMESPACE::testing::Test {
   using FloatType = float;
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float>;
-  using UIntType = uint32_t;
+  using StorageType = uint32_t;
 
-  uint64_t check(UIntType start, UIntType stop, mpfr::RoundingMode rounding) {
+  uint64_t check(StorageType start, StorageType stop,
+                 mpfr::RoundingMode rounding) {
     mpfr::ForceRoundingMode r(rounding);
     if (!r.success)
       return (stop > start);
-    UIntType bits = start;
+    StorageType bits = start;
     uint64_t failed = 0;
     do {
       FPBits xbits(bits);

--- a/libc/test/src/math/sin_test.cpp
+++ b/libc/test/src/math/sin_test.cpp
@@ -20,9 +20,9 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 
 TEST_F(LlvmLibcSinTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
-  constexpr UIntType COUNT = 100'000;
-  constexpr UIntType STEP = UIntType(-1) / COUNT;
-  for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+  constexpr StorageType COUNT = 100'000;
+  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.
     if (isnan(x) || isinf(x) || x > _2pi || x < -_2pi)

--- a/libc/test/src/math/smoke/CopySignTest.h
+++ b/libc/test/src/math/smoke/CopySignTest.h
@@ -31,9 +31,9 @@ public:
   }
 
   void testRange(CopySignFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       FPBits x_bits = FPBits(v);
       T x = T(v);
       if (x_bits.is_nan() || x_bits.is_inf())

--- a/libc/test/src/math/smoke/FDimTest.h
+++ b/libc/test/src/math/smoke/FDimTest.h
@@ -17,7 +17,7 @@ class FDimTestTemplate : public LIBC_NAMESPACE::testing::Test {
 public:
   using FuncPtr = T (*)(T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   void test_na_n_arg(FuncPtr func) {
     EXPECT_FP_EQ(nan, func(nan, inf));
@@ -53,9 +53,9 @@ public:
   }
 
   void test_in_range(FuncPtr func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/FMaxTest.h
+++ b/libc/test/src/math/smoke/FMaxTest.h
@@ -52,9 +52,9 @@ public:
   }
 
   void testRange(FMaxFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/FMinTest.h
+++ b/libc/test/src/math/smoke/FMinTest.h
@@ -52,9 +52,9 @@ public:
   }
 
   void testRange(FMinFunc func) {
-    constexpr UIntType COUNT = 100'001;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0, w = UIntType(-1); i <= COUNT;
+    constexpr StorageType COUNT = 100'001;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/FmaTest.h
+++ b/libc/test/src/math/smoke/FmaTest.h
@@ -18,7 +18,7 @@ class FmaTestTemplate : public LIBC_NAMESPACE::testing::Test {
 private:
   using Func = T (*)(T, T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
   const T nan = T(FPBits::build_quiet_nan(1));
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());
@@ -39,9 +39,9 @@ public:
     // Test underflow rounding up.
     EXPECT_FP_EQ(func(T(0.5), T(FPBits(FPBits::MIN_SUBNORMAL)),
                       T(FPBits(FPBits::MIN_SUBNORMAL))),
-                 T(FPBits(UIntType(2))));
+                 T(FPBits(StorageType(2))));
     // Test underflow rounding down.
-    T v = T(FPBits(FPBits::MIN_NORMAL + UIntType(1)));
+    T v = T(FPBits(FPBits::MIN_NORMAL + StorageType(1)));
     EXPECT_FP_EQ(func(T(1) / T(FPBits::MIN_NORMAL << 1), v,
                       T(FPBits(FPBits::MIN_NORMAL))),
                  v);

--- a/libc/test/src/math/smoke/FrexpTest.h
+++ b/libc/test/src/math/smoke/FrexpTest.h
@@ -17,7 +17,7 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*FrexpFunc)(T, int *);

--- a/libc/test/src/math/smoke/FrexpTest.h
+++ b/libc/test/src/math/smoke/FrexpTest.h
@@ -16,8 +16,9 @@ template <typename T> class FrexpTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*FrexpFunc)(T, int *);

--- a/libc/test/src/math/smoke/HypotTest.h
+++ b/libc/test/src/math/smoke/HypotTest.h
@@ -20,7 +20,7 @@ class HypotTestTemplate : public LIBC_NAMESPACE::testing::Test {
 private:
   using Func = T (*)(T, T);
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
   const T nan = T(FPBits::build_quiet_nan(1));
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());

--- a/libc/test/src/math/smoke/ILogbTest.h
+++ b/libc/test/src/math/smoke/ILogbTest.h
@@ -74,12 +74,12 @@ public:
   template <typename T>
   void test_subnormal_range(typename ILogbFunc<T>::Func func) {
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 10'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 10'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
          v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0)
@@ -94,11 +94,13 @@ public:
   template <typename T>
   void test_normal_range(typename ILogbFunc<T>::Func func) {
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 10'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_NORMAL) - UIntType(FPBits::MIN_NORMAL)) / COUNT;
-    for (UIntType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL; v += STEP) {
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 10'001;
+    constexpr StorageType STEP =
+        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
+        COUNT;
+    for (StorageType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL;
+         v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0)
         continue;

--- a/libc/test/src/math/smoke/ILogbTest.h
+++ b/libc/test/src/math/smoke/ILogbTest.h
@@ -76,9 +76,8 @@ public:
     using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 10'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_SUBNORMAL; v <= FPBits::MAX_SUBNORMAL;
          v += STEP) {
       T x = T(FPBits(v));
@@ -97,8 +96,7 @@ public:
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 10'001;
     constexpr StorageType STEP =
-        (StorageType(FPBits::MAX_NORMAL) - StorageType(FPBits::MIN_NORMAL)) /
-        COUNT;
+        (FPBits::MAX_NORMAL - FPBits::MIN_NORMAL) / COUNT;
     for (StorageType v = FPBits::MIN_NORMAL; v <= FPBits::MAX_NORMAL;
          v += STEP) {
       T x = T(FPBits(v));

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -22,10 +22,10 @@ template <typename T>
 class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
-  using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType FRACTION_BITS = FPBits::FRACTION_BITS;
+  using StorageType = typename FPBits::StorageType;
+  static constexpr StorageType FRACTION_LEN = FPBits::FRACTION_LEN;
   // A normalized mantissa to be used with tests.
-  static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
+  static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
@@ -69,7 +69,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
+    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,11 +82,11 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
+    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
-    T x = NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0);
+    T x = NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0);
     for (int32_t exp : exp_array) {
       ASSERT_FP_EQ(func(x, -exp), x > 0 ? zero : neg_zero);
     }
@@ -98,9 +98,9 @@ public:
         NormalFloat(100, MANTISSA, 0), NormalFloat(-100, MANTISSA, 0),
         NormalFloat(100, MANTISSA, 1), NormalFloat(-100, MANTISSA, 1),
         // Subnormal numbers
-        NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0),
-        NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_BITS); ++exp) {
+        NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0),
+        NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 1)};
+    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_LEN); ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -118,14 +118,14 @@ public:
     }
 
     // Normal which trigger mantissa overflow.
-    T x = NormalFloat(-FPBits::EXPONENT_BIAS + 1,
-                      UIntType(2) * NormalFloat::ONE - UIntType(1), 0);
+    T x = NormalFloat(-FPBits::EXP_BIAS + 1,
+                      StorageType(2) * NormalFloat::ONE - StorageType(1), 0);
     ASSERT_FP_EQ(func(x, -1), x / 2);
     ASSERT_FP_EQ(func(-x, -1), -x / 2);
 
     // Start with a normal number high exponent but pass a very low number for
     // exp. The result should be a subnormal number.
-    x = NormalFloat(FPBits::EXPONENT_BIAS, NormalFloat::ONE, 0);
+    x = NormalFloat(FPBits::EXP_BIAS, NormalFloat::ONE, 0);
     int exp = -FPBits::MAX_EXPONENT - 5;
     T result = func(x, exp);
     FPBits result_bits(result);
@@ -134,12 +134,12 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_BITS) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_LEN) - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.
     // The result should not be infinity.
-    x = NormalFloat(-FPBits::EXPONENT_BIAS + 1, NormalFloat::ONE >> 10, 0);
+    x = NormalFloat(-FPBits::EXP_BIAS + 1, NormalFloat::ONE >> 10, 0);
     exp = FPBits::MAX_EXPONENT + 5;
     ASSERT_FALSE(FPBits(func(x, exp)).is_inf());
     // But if the exp is large enough to oversome than the normalization shift,

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -23,7 +23,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using UIntType = typename FPBits::UIntType;
-  static constexpr UIntType MANTISSA_WIDTH = FPBits::MANTISSA_WIDTH;
+  static constexpr UIntType FRACTION_BITS = FPBits::FRACTION_BITS;
   // A normalized mantissa to be used with tests.
   static constexpr UIntType MANTISSA = NormalFloat::ONE + 0x1234;
 
@@ -69,7 +69,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(MANTISSA_WIDTH);
+    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,7 +82,7 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(MANTISSA_WIDTH);
+    int32_t base_exponent = FPBits::EXPONENT_BIAS + int32_t(FRACTION_BITS);
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -100,7 +100,7 @@ public:
         // Subnormal numbers
         NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 0),
         NormalFloat(-FPBits::EXPONENT_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(MANTISSA_WIDTH); ++exp) {
+    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_BITS); ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -134,7 +134,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(MANTISSA_WIDTH) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_BITS) - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -23,7 +23,6 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using NormalFloat = LIBC_NAMESPACE::fputil::NormalFloat<T>;
   using StorageType = typename FPBits::StorageType;
-  static constexpr StorageType FRACTION_LEN = FPBits::FRACTION_LEN;
   // A normalized mantissa to be used with tests.
   static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;
 
@@ -69,7 +68,7 @@ public:
   void testUnderflowToZeroOnNormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
+    int32_t base_exponent = FPBits::EXP_BIAS + FPBits::FRACTION_LEN;
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -82,7 +81,7 @@ public:
   void testUnderflowToZeroOnSubnormal(LdExpFunc func) {
     // In this test, we pass a normal nubmer to func and expect zero
     // to be returned due to underflow.
-    int32_t base_exponent = FPBits::EXP_BIAS + int32_t(FRACTION_LEN);
+    int32_t base_exponent = FPBits::EXP_BIAS + FPBits::FRACTION_LEN;
     int32_t exp_array[] = {base_exponent + 5, base_exponent + 4,
                            base_exponent + 3, base_exponent + 2,
                            base_exponent + 1};
@@ -100,7 +99,7 @@ public:
         // Subnormal numbers
         NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 0),
         NormalFloat(-FPBits::EXP_BIAS, MANTISSA, 1)};
-    for (int32_t exp = 0; exp <= static_cast<int32_t>(FRACTION_LEN); ++exp) {
+    for (int32_t exp = 0; exp <= FPBits::FRACTION_LEN; ++exp) {
       for (T x : val_array) {
         // We compare the result of ldexp with the result
         // of the native multiplication/division instruction.
@@ -134,7 +133,7 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - int(FRACTION_LEN) - 5);
+    result = func(x, -FPBits::MAX_EXPONENT - FPBits::FRACTION_LEN - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.

--- a/libc/test/src/math/smoke/LogbTest.h
+++ b/libc/test/src/math/smoke/LogbTest.h
@@ -16,8 +16,9 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*LogbFunc)(T);
@@ -68,10 +69,10 @@ public:
   }
 
   void testRange(LogbFunc func) {
-    using UIntType = typename FPBits::UIntType;
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    using StorageType = typename FPBits::StorageType;
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)
         continue;

--- a/libc/test/src/math/smoke/LogbTest.h
+++ b/libc/test/src/math/smoke/LogbTest.h
@@ -17,7 +17,7 @@ template <typename T> class LogbTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*LogbFunc)(T);

--- a/libc/test/src/math/smoke/ModfTest.h
+++ b/libc/test/src/math/smoke/ModfTest.h
@@ -81,9 +81,9 @@ public:
   }
 
   void testRange(ModfFunc func) {
-    constexpr UIntType COUNT = 100'000;
-    constexpr UIntType STEP = UIntType(-1) / COUNT;
-    for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+    constexpr StorageType COUNT = 100'000;
+    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == T(0.0))
         continue;

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -33,9 +33,6 @@ class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
 
-  static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
-
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
   const T inf = T(FPBits::inf());
@@ -66,7 +63,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, T(-1));
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -77,7 +74,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -95,13 +92,12 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = FPBits::SIGN_MASK + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -115,8 +111,7 @@ public:
 
     x = -x;
     result = func(x, -1);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
     ASSERT_FP_EQ_WITH_UNDERFLOW(func(x, 0), T(-0.0));
@@ -135,13 +130,12 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -inf);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -163,7 +157,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = FPBits::SIGN_MASK + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -31,20 +31,20 @@
 template <typename T>
 class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::BIT_WIDTH;
+      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
   const T inf = T(FPBits::inf());
   const T neg_inf = T(FPBits::neg_inf());
   const T nan = T(FPBits::build_quiet_nan(1));
-  const UIntType min_subnormal = FPBits::MIN_SUBNORMAL;
-  const UIntType max_subnormal = FPBits::MAX_SUBNORMAL;
-  const UIntType min_normal = FPBits::MIN_NORMAL;
-  const UIntType max_normal = FPBits::MAX_NORMAL;
+  const StorageType min_subnormal = FPBits::MIN_SUBNORMAL;
+  const StorageType max_subnormal = FPBits::MAX_SUBNORMAL;
+  const StorageType min_normal = FPBits::MIN_NORMAL;
+  const StorageType max_normal = FPBits::MAX_NORMAL;
 
 public:
   typedef T (*NextAfterFunc)(T, T);
@@ -61,12 +61,12 @@ public:
     // 'from' is zero|neg_zero.
     T x = zero;
     T result = func(x, T(1));
-    UIntType expected_bits = 1;
+    StorageType expected_bits = 1;
     T expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, T(-1));
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -77,7 +77,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -95,13 +95,13 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -116,7 +116,7 @@ public:
     x = -x;
     result = func(x, -1);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
     ASSERT_FP_EQ_WITH_UNDERFLOW(func(x, 0), T(-0.0));
@@ -135,12 +135,13 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -inf);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits =
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -162,7 +163,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);
@@ -179,7 +180,8 @@ public:
     result = func(x, T(33.0));
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
 
     x = -x;
 
@@ -192,7 +194,8 @@ public:
     result = func(x, T(-33.0));
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
   }
 };
 

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -174,8 +174,7 @@ public:
     FPBits result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, T(33.0));
     result_bits = FPBits(result);
@@ -188,8 +187,7 @@ public:
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, T(-33.0));
     result_bits = FPBits(result);

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -188,8 +188,7 @@ public:
     FPBits result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, 33.0);
     result_bits = FPBits(result);
@@ -202,8 +201,7 @@ public:
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(),
               uint16_t(x_bits.get_biased_exponent() - 1));
-    ASSERT_EQ(result_bits.get_mantissa(),
-              (UIntType(1) << FPBits::MANTISSA_WIDTH) - 1);
+    ASSERT_EQ(result_bits.get_mantissa(), FPBits::FRACTION_MASK);
 
     result = func(x, -33.0);
     result_bits = FPBits(result);

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -35,9 +35,6 @@ class NextTowardTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using ToFPBits = LIBC_NAMESPACE::fputil::FPBits<long double>;
   using StorageType = typename FPBits::StorageType;
 
-  static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
-
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
   const T inf = T(FPBits::inf());
@@ -73,7 +70,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -84,7 +81,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = FPBits::SIGN_MASK + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -102,13 +99,12 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = FPBits::SIGN_MASK + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -122,8 +118,7 @@ public:
 
     x = -x;
     result = func(x, -1);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
     ASSERT_FP_EQ_WITH_UNDERFLOW(func(x, 0), T(-0.0));
@@ -142,13 +137,12 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = FPBits::SIGN_MASK + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -inf);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits = FPBits::SIGN_MASK + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -162,8 +156,7 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits =
-        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal - 1;
+    expected_bits = FPBits::SIGN_MASK + max_normal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ_WITH_OVERFLOW(func(x, -inf), -inf);
@@ -178,7 +171,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = FPBits::SIGN_MASK + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -33,10 +33,10 @@ template <typename T>
 class NextTowardTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using ToFPBits = LIBC_NAMESPACE::fputil::FPBits<long double>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   static constexpr int BIT_WIDTH_OF_TYPE =
-      LIBC_NAMESPACE::fputil::FloatProperties<T>::BIT_WIDTH;
+      LIBC_NAMESPACE::fputil::FloatProperties<T>::TOTAL_LEN;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());
@@ -48,10 +48,10 @@ class NextTowardTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const long double to_neg_zero = ToFPBits::neg_zero();
   const long double to_nan = ToFPBits::build_quiet_nan(1);
 
-  const UIntType min_subnormal = FPBits::MIN_SUBNORMAL;
-  const UIntType max_subnormal = FPBits::MAX_SUBNORMAL;
-  const UIntType min_normal = FPBits::MIN_NORMAL;
-  const UIntType max_normal = FPBits::MAX_NORMAL;
+  const StorageType min_subnormal = FPBits::MIN_SUBNORMAL;
+  const StorageType max_subnormal = FPBits::MAX_SUBNORMAL;
+  const StorageType min_normal = FPBits::MIN_NORMAL;
+  const StorageType max_normal = FPBits::MAX_NORMAL;
 
 public:
   typedef T (*NextTowardFunc)(T, long double);
@@ -68,12 +68,12 @@ public:
     // 'from' is zero|neg_zero.
     T x = zero;
     T result = func(x, 1);
-    UIntType expected_bits = 1;
+    StorageType expected_bits = 1;
     T expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -84,7 +84,7 @@ public:
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -102,13 +102,13 @@ public:
     x = -x;
 
     result = func(x, -1);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
     result = func(x, 0);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
@@ -123,7 +123,7 @@ public:
     x = -x;
     result = func(x, -1);
     expected_bits =
-        (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_subnormal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
     ASSERT_FP_EQ_WITH_UNDERFLOW(func(x, 0), T(-0.0));
@@ -142,12 +142,13 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_subnormal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected);
 
     result = func(x, -inf);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
+    expected_bits =
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + min_normal + 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
 
@@ -161,7 +162,8 @@ public:
 
     x = -x;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal - 1;
+    expected_bits =
+        (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal - 1;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ_WITH_OVERFLOW(func(x, -inf), -inf);
@@ -176,7 +178,7 @@ public:
 
     x = neg_inf;
     result = func(x, 0);
-    expected_bits = (UIntType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
+    expected_bits = (StorageType(1) << (BIT_WIDTH_OF_TYPE - 1)) + max_normal;
     expected = LIBC_NAMESPACE::cpp::bit_cast<T>(expected_bits);
     ASSERT_FP_EQ(result, expected);
     ASSERT_FP_EQ(func(x, neg_inf), neg_inf);
@@ -193,7 +195,8 @@ public:
     result = func(x, 33.0);
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
 
     x = -x;
 
@@ -206,7 +209,8 @@ public:
     result = func(x, -33.0);
     result_bits = FPBits(result);
     ASSERT_EQ(result_bits.get_biased_exponent(), x_bits.get_biased_exponent());
-    ASSERT_EQ(result_bits.get_mantissa(), x_bits.get_mantissa() + UIntType(1));
+    ASSERT_EQ(result_bits.get_mantissa(),
+              x_bits.get_mantissa() + StorageType(1));
   }
 };
 

--- a/libc/test/src/math/smoke/RIntTest.h
+++ b/libc/test/src/math/smoke/RIntTest.h
@@ -28,7 +28,7 @@ public:
 
 private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());

--- a/libc/test/src/math/smoke/RemQuoTest.h
+++ b/libc/test/src/math/smoke/RemQuoTest.h
@@ -18,7 +18,7 @@
 template <typename T>
 class RemQuoTestTemplate : public LIBC_NAMESPACE::testing::Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const T zero = T(FPBits::zero());
   const T neg_zero = T(FPBits::neg_zero());

--- a/libc/test/src/math/smoke/RoundToIntegerTest.h
+++ b/libc/test/src/math/smoke/RoundToIntegerTest.h
@@ -110,9 +110,8 @@ public:
 
   void testSubnormalRange(RoundToIntegerFunc func) {
     constexpr StorageType COUNT = 1'000'001;
-    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
-                                  StorageType(FPBits::MIN_SUBNORMAL)) /
-                                 COUNT;
+    constexpr StorageType STEP =
+        (FPBits::MAX_SUBNORMAL - FPBits::MIN_SUBNORMAL) / COUNT;
     for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       F x = F(FPBits(i));

--- a/libc/test/src/math/smoke/RoundToIntegerTest.h
+++ b/libc/test/src/math/smoke/RoundToIntegerTest.h
@@ -27,7 +27,7 @@ public:
 
 private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<F>;
-  using UIntType = typename FPBits::UIntType;
+  using StorageType = typename FPBits::StorageType;
 
   const F zero = F(LIBC_NAMESPACE::fputil::FPBits<F>::zero());
   const F neg_zero = F(LIBC_NAMESPACE::fputil::FPBits<F>::neg_zero());
@@ -109,11 +109,11 @@ public:
   }
 
   void testSubnormalRange(RoundToIntegerFunc func) {
-    constexpr UIntType COUNT = 1'000'001;
-    constexpr UIntType STEP =
-        (UIntType(FPBits::MAX_SUBNORMAL) - UIntType(FPBits::MIN_SUBNORMAL)) /
-        COUNT;
-    for (UIntType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
+    constexpr StorageType COUNT = 1'000'001;
+    constexpr StorageType STEP = (StorageType(FPBits::MAX_SUBNORMAL) -
+                                  StorageType(FPBits::MIN_SUBNORMAL)) /
+                                 COUNT;
+    for (StorageType i = FPBits::MIN_SUBNORMAL; i <= FPBits::MAX_SUBNORMAL;
          i += STEP) {
       F x = F(FPBits(i));
       if (x == F(0.0))

--- a/libc/test/src/math/smoke/SqrtTest.h
+++ b/libc/test/src/math/smoke/SqrtTest.h
@@ -16,8 +16,9 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
 
   DECLARE_SPECIAL_CONSTANTS(T)
 
-  static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
+  static constexpr StorageType HIDDEN_BIT =
+      StorageType(1)
+      << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_LEN;
 
 public:
   typedef T (*SqrtFunc)(T);

--- a/libc/test/src/math/smoke/SqrtTest.h
+++ b/libc/test/src/math/smoke/SqrtTest.h
@@ -17,7 +17,7 @@ template <typename T> class SqrtTest : public LIBC_NAMESPACE::testing::Test {
   DECLARE_SPECIAL_CONSTANTS(T)
 
   static constexpr UIntType HIDDEN_BIT =
-      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::MANTISSA_WIDTH;
+      UIntType(1) << LIBC_NAMESPACE::fputil::FloatProperties<T>::FRACTION_BITS;
 
 public:
   typedef T (*SqrtFunc)(T);

--- a/libc/test/src/math/tan_test.cpp
+++ b/libc/test/src/math/tan_test.cpp
@@ -19,9 +19,9 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 
 TEST_F(LlvmLibcTanTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
-  constexpr UIntType COUNT = 100'000;
-  constexpr UIntType STEP = UIntType(-1) / COUNT;
-  for (UIntType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
+  constexpr StorageType COUNT = 100'000;
+  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.
     if (isnan(x) || isinf(x) || x > _2pi || x < -_2pi)

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -450,17 +450,17 @@ public:
       return MPFRNumber(0.0);
 
     if (is_nan()) {
-      if (fputil::FPBits<T>(input).is_nan())
+      if (FPBits<T>(input).is_nan())
         return MPFRNumber(0.0);
-      return MPFRNumber(static_cast<T>(fputil::FPBits<T>::inf()));
+      return MPFRNumber(static_cast<T>(FPBits<T>::inf()));
     }
 
-    int thisExponent = fputil::FPBits<T>(thisAsT).get_exponent();
-    int inputExponent = fputil::FPBits<T>(input).get_exponent();
+    int thisExponent = FPBits<T>(thisAsT).get_exponent();
+    int inputExponent = FPBits<T>(input).get_exponent();
     // Adjust the exponents for denormal numbers.
-    if (fputil::FPBits<T>(thisAsT).get_biased_exponent() == 0)
+    if (FPBits<T>(thisAsT).get_biased_exponent() == 0)
       ++thisExponent;
-    if (fputil::FPBits<T>(input).get_biased_exponent() == 0)
+    if (FPBits<T>(input).get_biased_exponent() == 0)
       ++inputExponent;
 
     if (thisAsT * input < 0 || thisExponent == inputExponent) {
@@ -468,8 +468,7 @@ public:
       mpfr_sub(inputMPFR.value, value, inputMPFR.value, MPFR_RNDN);
       mpfr_abs(inputMPFR.value, inputMPFR.value, MPFR_RNDN);
       mpfr_mul_2si(inputMPFR.value, inputMPFR.value,
-                   -thisExponent + int(fputil::FPBits<T>::FRACTION_LEN),
-                   MPFR_RNDN);
+                   -thisExponent + FPBits<T>::FRACTION_LEN, MPFR_RNDN);
       return inputMPFR;
     }
 
@@ -480,12 +479,12 @@ public:
     input = std::abs(input);
     T min = thisAsT > input ? input : thisAsT;
     T max = thisAsT > input ? thisAsT : input;
-    int minExponent = fputil::FPBits<T>(min).get_exponent();
-    int maxExponent = fputil::FPBits<T>(max).get_exponent();
+    int minExponent = FPBits<T>(min).get_exponent();
+    int maxExponent = FPBits<T>(max).get_exponent();
     // Adjust the exponents for denormal numbers.
-    if (fputil::FPBits<T>(min).get_biased_exponent() == 0)
+    if (FPBits<T>(min).get_biased_exponent() == 0)
       ++minExponent;
-    if (fputil::FPBits<T>(max).get_biased_exponent() == 0)
+    if (FPBits<T>(max).get_biased_exponent() == 0)
       ++maxExponent;
 
     MPFRNumber minMPFR(min);
@@ -496,13 +495,11 @@ public:
 
     mpfr_sub(minMPFR.value, pivot.value, minMPFR.value, MPFR_RNDN);
     mpfr_mul_2si(minMPFR.value, minMPFR.value,
-                 -minExponent + int(fputil::FPBits<T>::FRACTION_LEN),
-                 MPFR_RNDN);
+                 -minExponent + FPBits<T>::FRACTION_LEN, MPFR_RNDN);
 
     mpfr_sub(maxMPFR.value, maxMPFR.value, pivot.value, MPFR_RNDN);
     mpfr_mul_2si(maxMPFR.value, maxMPFR.value,
-                 -maxExponent + int(fputil::FPBits<T>::FRACTION_LEN),
-                 MPFR_RNDN);
+                 -maxExponent + FPBits<T>::FRACTION_LEN, MPFR_RNDN);
 
     mpfr_add(minMPFR.value, minMPFR.value, maxMPFR.value, MPFR_RNDN);
     return minMPFR;

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -468,7 +468,7 @@ public:
       mpfr_sub(inputMPFR.value, value, inputMPFR.value, MPFR_RNDN);
       mpfr_abs(inputMPFR.value, inputMPFR.value, MPFR_RNDN);
       mpfr_mul_2si(inputMPFR.value, inputMPFR.value,
-                   -thisExponent + int(fputil::FPBits<T>::FRACTION_BITS),
+                   -thisExponent + int(fputil::FPBits<T>::FRACTION_LEN),
                    MPFR_RNDN);
       return inputMPFR;
     }
@@ -496,12 +496,12 @@ public:
 
     mpfr_sub(minMPFR.value, pivot.value, minMPFR.value, MPFR_RNDN);
     mpfr_mul_2si(minMPFR.value, minMPFR.value,
-                 -minExponent + int(fputil::FPBits<T>::FRACTION_BITS),
+                 -minExponent + int(fputil::FPBits<T>::FRACTION_LEN),
                  MPFR_RNDN);
 
     mpfr_sub(maxMPFR.value, maxMPFR.value, pivot.value, MPFR_RNDN);
     mpfr_mul_2si(maxMPFR.value, maxMPFR.value,
-                 -maxExponent + int(fputil::FPBits<T>::FRACTION_BITS),
+                 -maxExponent + int(fputil::FPBits<T>::FRACTION_LEN),
                  MPFR_RNDN);
 
     mpfr_add(minMPFR.value, minMPFR.value, maxMPFR.value, MPFR_RNDN);

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -468,7 +468,7 @@ public:
       mpfr_sub(inputMPFR.value, value, inputMPFR.value, MPFR_RNDN);
       mpfr_abs(inputMPFR.value, inputMPFR.value, MPFR_RNDN);
       mpfr_mul_2si(inputMPFR.value, inputMPFR.value,
-                   -thisExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
+                   -thisExponent + int(fputil::FPBits<T>::FRACTION_BITS),
                    MPFR_RNDN);
       return inputMPFR;
     }
@@ -496,12 +496,12 @@ public:
 
     mpfr_sub(minMPFR.value, pivot.value, minMPFR.value, MPFR_RNDN);
     mpfr_mul_2si(minMPFR.value, minMPFR.value,
-                 -minExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
+                 -minExponent + int(fputil::FPBits<T>::FRACTION_BITS),
                  MPFR_RNDN);
 
     mpfr_sub(maxMPFR.value, maxMPFR.value, pivot.value, MPFR_RNDN);
     mpfr_mul_2si(maxMPFR.value, maxMPFR.value,
-                 -maxExponent + int(fputil::FPBits<T>::MANTISSA_WIDTH),
+                 -maxExponent + int(fputil::FPBits<T>::FRACTION_BITS),
                  MPFR_RNDN);
 
     mpfr_add(minMPFR.value, minMPFR.value, maxMPFR.value, MPFR_RNDN);


### PR DESCRIPTION
This one might be a bit controversial since the terminology has been introduced from the start but I think `FRACTION_LEN` is a better name here. AFAICT it really is "the number of bits after the decimal dot when the number is in normal form."

`MANTISSA_WIDTH` is less precise as it's unclear whether we take the leading bit into account.
This patch also renames most of the properties to use the `_LEN` suffix and fixes useless casts or variables.