### PR TITLE
[ADT] Deprecate StringRef::{starts,ends}with

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -258,7 +258,9 @@ namespace llvm {
       return Length >= Prefix.Length &&
              compareMemory(Data, Prefix.Data, Prefix.Length) == 0;
     }
-    [[nodiscard]] bool startswith(StringRef Prefix) const {
+    [[nodiscard]] LLVM_DEPRECATED(
+        "Use starts_with instead",
+        "starts_with") bool startswith(StringRef Prefix) const {
       return starts_with(Prefix);
     }
 
@@ -271,7 +273,9 @@ namespace llvm {
              compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) ==
                  0;
     }
-    [[nodiscard]] bool endswith(StringRef Suffix) const {
+    [[nodiscard]] LLVM_DEPRECATED(
+        "Use ends_with instead",
+        "ends_with") bool endswith(StringRef Suffix) const {
       return ends_with(Suffix);
     }
 


### PR DESCRIPTION
This patch deprecates StringRef::{starts,ends}with.  Note that I've
replaced all known uses of StringRef::{starts,ends}with with
StringRef::{starts,ends}_with for consistency with
std::{string,string_view}::{starts,ends}_with in C++20.
