### PR TITLE
[AMDGPU] Remove s_cbranch_cdbg* for GFX12

### DIFF
--- a/llvm/test/MC/AMDGPU/gfx12_unsupported.s
+++ b/llvm/test/MC/AMDGPU/gfx12_unsupported.s
@@ -10,6 +10,18 @@ s_subvector_loop_begin s0, 0x1234
 s_subvector_loop_end s0, 0x1234
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
+s_cbranch_cdbgsys 0
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
+
+s_cbranch_cdbguser 0
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
+
+s_cbranch_cdbgsys_or_user 0
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
+
+s_cbranch_cdbgsys_and_user 0
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
+
 ds_cmpstore_f32 v0, v1, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
 


### PR DESCRIPTION
No GFX12 encoding was added for these, so this patch just adds tests
that they are not recognized by the assembler.
