### PR TITLE
Revert "[LinkerWrapper] Add 'Freestanding' config to the LTO pass"

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -526,7 +526,6 @@ std::unique_ptr<lto::LTO> createLTO(
 
   Conf.CPU = Arch.str();
   Conf.Options = codegen::InitTargetOptionsFromCodeGenFlags(Triple);
-  Conf.Freestanding = true;
 
   StringRef OptLevel = Args.getLastArgValue(OPT_opt_level, "O2");
   Conf.MAttrs = Features;


### PR DESCRIPTION
This reverts commit 47d9fbc04b91fb03b6da294e82c2fb4bca6b6343.

It creates a segmentation falt on SPEChpc soma on Frontier on a GPU for the kernel generate_new_beads