### PR TITLE
[clangd] Extract Function: add hoisting support

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
@@ -798,7 +798,11 @@ QualType getReturnTypeForHoisted(const FunctionDecl &EnclosingFunc,
   if (ToHoist.size() == 1) {
     if (const auto *const VDecl = llvm::dyn_cast<VarDecl>(*ToHoist.begin());
         VDecl != nullptr) {
-      return VDecl->getType();
+      const auto Type = VDecl->getType();
+      if (const auto *const RDecl = Type->getAsCXXRecordDecl();
+          RDecl != nullptr && RDecl->isLambda())
+        return EnclosingFunc.getParentASTContext().getAutoDeductType();
+      return Type;
     }
   }
 

--- a/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
@@ -70,8 +70,8 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/raw_os_ostream.h"
 #include <optional>
+#include <string>
 
 namespace clang {
 namespace clangd {
@@ -475,7 +475,7 @@ std::string NewFunction::renderDeclarationName(FunctionDeclKind K) const {
 
 // Renders the HoistSet to a comma separated list or a single named decl.
 std::string renderHoistSet(const HoistSet &ToHoist) {
-  std::string Res{};
+  std::string Res;
   bool NeedsComma = false;
 
   for (const NamedDecl *DeclToHoist : ToHoist) {
@@ -492,8 +492,8 @@ std::string renderHoistSet(const HoistSet &ToHoist) {
 }
 
 std::string NewFunction::renderHoistedCall() const {
-  auto HoistedVarDecls = std::string{};
-  auto ExplicitUnpacking = std::string{};
+  std::string HoistedVarDecls;
+  std::string ExplicitUnpacking;
   const auto HasStructuredBinding = LangOpts->CPlusPlus17;
 
   if (ToHoist.size() > 1) {
@@ -554,8 +554,8 @@ std::string NewFunction::getFuncBody(const SourceManager &SM) const {
   // - hoist decls
   // - add return statement
   // - Add semicolon
-  auto Body = toSourceCode(SM, BodyRange).str() +
-              (SemicolonPolicy.isNeededInExtractedFunction() ? ";" : "");
+  std::string Body = toSourceCode(SM, BodyRange).str() +
+                     (SemicolonPolicy.isNeededInExtractedFunction() ? ";" : "");
 
   if (ToHoist.empty())
     return Body;
@@ -588,7 +588,7 @@ struct CapturedZoneInfo {
     // FIXME: Capture mutation information
     DeclInformation(const Decl *TheDecl, ZoneRelative DeclaredIn,
                     unsigned DeclIndex)
-        : TheDecl(TheDecl), DeclaredIn(DeclaredIn), DeclIndex(DeclIndex){};
+        : TheDecl(TheDecl), DeclaredIn(DeclaredIn), DeclIndex(DeclIndex) {};
     // Marks the occurence of a reference for this declaration
     void markOccurence(ZoneRelative ReferenceLoc);
   };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -81,6 +81,9 @@ Objective-C
 Miscellaneous
 ^^^^^^^^^^^^^
 
+- The extract function tweak gained support for hoisting, i.e. returning decls declared
+  inside the selection that are used outside of the selection.
+
 Improvements to clang-doc
 -------------------------
 


### PR DESCRIPTION
Adds support to hoist variables declared inside the selected region
and used afterwards back out of the extraced function for later use.
Uses the explicit variable type if only one decl needs hoisting,
otherwise uses std::pair or std::tuple with auto return type
deduction (requires c++14) and a structured binding (requires c++17)
or explicitly unpacking the variables with get<>.
