### PR TITLE
[orc-rt] Add ORC_ENABLE_OSX to control whether to build the orc runtime

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -450,10 +450,16 @@ if(APPLE)
   set(TSAN_SUPPORTED_OS osx)
   set(XRAY_SUPPORTED_OS osx)
   set(FUZZER_SUPPORTED_OS osx)
-  set(ORC_SUPPORTED_OS osx)
+  set(ORC_SUPPORTED_OS)
   set(UBSAN_SUPPORTED_OS osx)
   set(LSAN_SUPPORTED_OS osx)
   set(STATS_SUPPORTED_OS osx)
+
+  # FIXME: Support a general COMPILER_RT_ENABLE_OSX to match other platforms.
+  set(ORC_ENABLE_OSX 1 CACHE BOOL "Whether to build the orc runtime library for osx")
+  if(ORC_ENABLE_OSX)
+    set(ORC_SUPPORTED_OS osx)
+  endif()
 
   # Note: In order to target x86_64h on OS X the minimum deployment target must
   # be 10.8 or higher.

--- a/compiler-rt/lib/orc/tests/CMakeLists.txt
+++ b/compiler-rt/lib/orc/tests/CMakeLists.txt
@@ -27,7 +27,9 @@ endfunction()
 
 function(get_orc_lib_for_arch arch lib)
   if(APPLE)
-    set(tgt_name "RTOrc.test.osx")
+    if("osx" IN_LIST ORC_SUPPORTED_OS)
+      set(tgt_name "RTOrc.test.osx")
+    endif()
   else()
     set(tgt_name "RTOrc.test.${arch}")
   endif()
@@ -65,14 +67,16 @@ macro(add_orc_unittest testname)
     foreach(arch ${ORC_TEST_ARCH})
       set(TEST_OBJECTS)
       get_orc_lib_for_arch(${arch} ORC_RUNTIME_LIBS)
-      generate_compiler_rt_tests(TEST_OBJECTS
-        OrcRTUnitTests "${testname}-${arch}-Test" "${arch}"
-        SOURCES ${TEST_SOURCES} ${COMPILER_RT_GTEST_SOURCE}
-        RUNTIME "${ORC_RUNTIME_LIBS}"
-        COMPILE_DEPS ${TEST_HEADERS} ${ORC_HEADERS}
-        DEPS llvm_gtest ${ORC_DEPS}
-        CFLAGS ${ORC_UNITTEST_CFLAGS} ${COMPILER_RT_GTEST_CFLAGS}
-        LINK_FLAGS ${ORC_UNITTEST_LINK_FLAGS})
+      if(ORC_RUNTIME_LIBS)
+        generate_compiler_rt_tests(TEST_OBJECTS
+          OrcRTUnitTests "${testname}-${arch}-Test" "${arch}"
+          SOURCES ${TEST_SOURCES} ${COMPILER_RT_GTEST_SOURCE}
+          RUNTIME "${ORC_RUNTIME_LIBS}"
+          COMPILE_DEPS ${TEST_HEADERS} ${ORC_HEADERS}
+          DEPS llvm_gtest ${ORC_DEPS}
+          CFLAGS ${ORC_UNITTEST_CFLAGS} ${COMPILER_RT_GTEST_CFLAGS}
+          LINK_FLAGS ${ORC_UNITTEST_LINK_FLAGS})
+      endif()
     endforeach()
   endif()
 endmacro()
@@ -83,21 +87,25 @@ macro(add_orc_tool toolname)
     foreach(arch ${ORC_TEST_ARCH})
       set(TOOL_OBJECTS)
       get_orc_lib_for_arch(${arch} ORC_RUNTIME_LIBS)
-      generate_compiler_rt_tests(TOOL_OBJECTS
-        OrcRTTools "${toolname}-${arch}" "${arch}"
-        SOURCES ${TOOL_SOURCES}
-        RUNTIME "${ORC_RUNTIME_LIBS}"
-        COMPILE_DEPS ${TOOL_HEADERS} ${ORC_HEADERS}
-        DEPS ${ORC_DEPS}
-        CFLAGS ${ORC_UNITTEST_CFLAGS}
-        LINK_FLAGS ${ORC_UNITTEST_LINK_FLAGS})
+      if(ORC_RUNTIME_LIBS)
+        generate_compiler_rt_tests(TOOL_OBJECTS
+          OrcRTTools "${toolname}-${arch}" "${arch}"
+          SOURCES ${TOOL_SOURCES}
+          RUNTIME "${ORC_RUNTIME_LIBS}"
+          COMPILE_DEPS ${TOOL_HEADERS} ${ORC_HEADERS}
+          DEPS ${ORC_DEPS}
+          CFLAGS ${ORC_UNITTEST_CFLAGS}
+          LINK_FLAGS ${ORC_UNITTEST_LINK_FLAGS})
+      endif()
     endforeach()
   endif()
 endmacro()
 
 if (APPLE)
-  add_orc_lib("RTOrc.test.osx"
-    $<TARGET_OBJECTS:RTOrc.osx>)
+  if("osx" IN_LIST ORC_SUPPORTED_OS)
+    add_orc_lib("RTOrc.test.osx"
+      $<TARGET_OBJECTS:RTOrc.osx>)
+  endif()
 else()
   foreach(arch ${ORC_SUPPORTED_ARCH})
     add_orc_lib("RTOrc.test.${arch}"


### PR DESCRIPTION
Embedded Darwin platforms have generalized COMPILER_RT_ENABLE_<PLATFORM> configuration settings, but currently 'osx' is always eabled on Darwin. Add ORC_ENABLE_OSX to allow explicitly *disabling* the orc runtime for macOS platform. This can be useful if you only want to build a specific embedded platform. It would be nice to generalize this to handle other compiler-rt projects (i.e. add COMPILER_RT_ENABLE_OSX), but would require additional attention from each compiler-rt project.

Note: some tests currently only are configured for osx, so these are disabled when osx is disabled.