### PR TITLE
[flang][openacc/mp][NFC] Fix order of template arguments

### DIFF
--- a/flang/lib/Lower/DirectivesCommon.h
+++ b/flang/lib/Lower/DirectivesCommon.h
@@ -885,7 +885,7 @@ mlir::Value gatherDataOperandAddrAndBounds(
 
                 if (!arrayElement->subscripts.empty()) {
                   asFortran << '(';
-                  bounds = genBoundsOps<BoundsType, BoundsOp>(
+                  bounds = genBoundsOps<BoundsOp, BoundsType>(
                       builder, operandLocation, converter, stmtCtx,
                       arrayElement->subscripts, asFortran, dataExv, baseAddr,
                       treatIndexAsSection);
@@ -898,7 +898,7 @@ mlir::Value gatherDataOperandAddrAndBounds(
                 baseAddr = fir::getBase(compExv);
                 if (fir::unwrapRefType(baseAddr.getType())
                         .isa<fir::SequenceType>())
-                  bounds = genBaseBoundsOps<BoundsType, BoundsOp>(
+                  bounds = genBaseBoundsOps<BoundsOp, BoundsType>(
                       builder, operandLocation, converter, compExv, baseAddr);
                 asFortran << (*expr).AsFortran();
 
@@ -917,7 +917,7 @@ mlir::Value gatherDataOperandAddrAndBounds(
                 if (auto boxAddrOp = mlir::dyn_cast_or_null<fir::BoxAddrOp>(
                         baseAddr.getDefiningOp())) {
                   baseAddr = boxAddrOp.getVal();
-                  bounds = genBoundsOpsFromBox<BoundsType, BoundsOp>(
+                  bounds = genBoundsOpsFromBox<BoundsOp, BoundsType>(
                       builder, operandLocation, converter, compExv, baseAddr);
                 }
               } else {
@@ -944,11 +944,11 @@ mlir::Value gatherDataOperandAddrAndBounds(
                       converter, builder, *name.symbol, operandLocation);
                   if (fir::unwrapRefType(baseAddr.getType())
                           .isa<fir::BaseBoxType>())
-                    bounds = genBoundsOpsFromBox<BoundsType, BoundsOp>(
+                    bounds = genBoundsOpsFromBox<BoundsOp, BoundsType>(
                         builder, operandLocation, converter, dataExv, baseAddr);
                   if (fir::unwrapRefType(baseAddr.getType())
                           .isa<fir::SequenceType>())
-                    bounds = genBaseBoundsOps<BoundsType, BoundsOp>(
+                    bounds = genBaseBoundsOps<BoundsOp, BoundsType>(
                         builder, operandLocation, converter, dataExv, baseAddr);
                   asFortran << name.ToString();
                 } else { // Unsupported

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -266,10 +266,11 @@ genDataOperandOperations(const Fortran::parser::AccObjectList &objectList,
     std::stringstream asFortran;
     mlir::Location operandLocation = genOperandLocation(converter, accObject);
     mlir::Value baseAddr = Fortran::lower::gatherDataOperandAddrAndBounds<
-        Fortran::parser::AccObject, mlir::acc::DataBoundsType,
-        mlir::acc::DataBoundsOp>(converter, builder, semanticsContext, stmtCtx,
-                                 accObject, operandLocation, asFortran, bounds,
-                                 /*treatIndexAsSection=*/true);
+        Fortran::parser::AccObject, mlir::acc::DataBoundsOp,
+        mlir::acc::DataBoundsType>(converter, builder, semanticsContext,
+                                   stmtCtx, accObject, operandLocation,
+                                   asFortran, bounds,
+                                   /*treatIndexAsSection=*/true);
     Op op = createDataEntryOp<Op>(builder, operandLocation, baseAddr, asFortran,
                                   bounds, structured, implicit, dataClause,
                                   baseAddr.getType());
@@ -291,9 +292,10 @@ static void genDeclareDataOperandOperations(
     std::stringstream asFortran;
     mlir::Location operandLocation = genOperandLocation(converter, accObject);
     mlir::Value baseAddr = Fortran::lower::gatherDataOperandAddrAndBounds<
-        Fortran::parser::AccObject, mlir::acc::DataBoundsType,
-        mlir::acc::DataBoundsOp>(converter, builder, semanticsContext, stmtCtx,
-                                 accObject, operandLocation, asFortran, bounds);
+        Fortran::parser::AccObject, mlir::acc::DataBoundsOp,
+        mlir::acc::DataBoundsType>(converter, builder, semanticsContext,
+                                   stmtCtx, accObject, operandLocation,
+                                   asFortran, bounds);
     EntryOp op = createDataEntryOp<EntryOp>(
         builder, operandLocation, baseAddr, asFortran, bounds, structured,
         implicit, dataClause, baseAddr.getType());
@@ -748,9 +750,10 @@ genPrivatizations(const Fortran::parser::AccObjectList &objectList,
     std::stringstream asFortran;
     mlir::Location operandLocation = genOperandLocation(converter, accObject);
     mlir::Value baseAddr = Fortran::lower::gatherDataOperandAddrAndBounds<
-        Fortran::parser::AccObject, mlir::acc::DataBoundsType,
-        mlir::acc::DataBoundsOp>(converter, builder, semanticsContext, stmtCtx,
-                                 accObject, operandLocation, asFortran, bounds);
+        Fortran::parser::AccObject, mlir::acc::DataBoundsOp,
+        mlir::acc::DataBoundsType>(converter, builder, semanticsContext,
+                                   stmtCtx, accObject, operandLocation,
+                                   asFortran, bounds);
 
     RecipeOp recipe;
     mlir::Type retTy = getTypeFromBounds(bounds, baseAddr.getType());
@@ -1324,9 +1327,10 @@ genReductions(const Fortran::parser::AccObjectListWithReduction &objectList,
     std::stringstream asFortran;
     mlir::Location operandLocation = genOperandLocation(converter, accObject);
     mlir::Value baseAddr = Fortran::lower::gatherDataOperandAddrAndBounds<
-        Fortran::parser::AccObject, mlir::acc::DataBoundsType,
-        mlir::acc::DataBoundsOp>(converter, builder, semanticsContext, stmtCtx,
-                                 accObject, operandLocation, asFortran, bounds);
+        Fortran::parser::AccObject, mlir::acc::DataBoundsOp,
+        mlir::acc::DataBoundsType>(converter, builder, semanticsContext,
+                                   stmtCtx, accObject, operandLocation,
+                                   asFortran, bounds);
 
     mlir::Type reductionTy = fir::unwrapRefType(baseAddr.getType());
     if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(reductionTy))

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -1794,8 +1794,8 @@ bool ClauseProcessor::processMap(
           llvm::SmallVector<mlir::Value> bounds;
           std::stringstream asFortran;
           mlir::Value baseAddr = Fortran::lower::gatherDataOperandAddrAndBounds<
-              Fortran::parser::OmpObject, mlir::omp::DataBoundsType,
-              mlir::omp::DataBoundsOp>(
+              Fortran::parser::OmpObject, mlir::omp::DataBoundsOp,
+              mlir::omp::DataBoundsType>(
               converter, firOpBuilder, semanticsContext, stmtCtx, ompObject,
               clauseLocation, asFortran, bounds, treatIndexAsSection);
 


### PR DESCRIPTION
Some template parameters for the bounds ops generation have been inverted. It should be consistent to be `BoundsOp, BoundsType`. 