### PR TITLE
[DWP] Fix default for continue-on-cu-index-overflow

### DIFF
--- a/llvm/test/tools/llvm-dwp/X86/simple.test
+++ b/llvm/test/tools/llvm-dwp/X86/simple.test
@@ -3,6 +3,14 @@ RUN: llvm-dwarfdump -v %t | FileCheck --check-prefixes=CHECK,NOTYP %s
 RUN: llvm-objdump -h %t | FileCheck --check-prefix=NOTYPOBJ %s
 RUN: llvm-dwp %p/../Inputs/simple/types/a.dwo %p/../Inputs/simple/types/b.dwo -o - \
 RUN:   | llvm-dwarfdump -v - | FileCheck --check-prefixes=CHECK,TYPES %s
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     --continue-on-cu-index-overflow
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     --continue-on-cu-index-overflow=continue
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     --continue-on-cu-index-overflow=soft-stop
+RUN: not llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t --continue-on-cu-index-overflow=foobar
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     -continue-on-cu-index-overflow
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     -continue-on-cu-index-overflow=continue
+RUN: llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t     -continue-on-cu-index-overflow=soft-stop
+RUN: not llvm-dwp %p/../Inputs/simple/notypes/a.dwo %p/../Inputs/simple/notypes/b.dwo -o %t -continue-on-cu-index-overflow=foobar
 
 DWP from non-type-unit debug info for these two translation units:
 a.cpp:

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -9,7 +9,10 @@ def version : F<"version", "Display the version of this program">;
 
 def execFileNames : S<"e", "Specify the executable/library files to get the list of *.dwo from.">, MetaVarName<"<filename>">;
 def outputFileName : S<"o", "Specify the output file.">, MetaVarName<"<filename>">;
-def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", "default = continue, This turns an error when offset "
-                                         "for .debug_*.dwo sections overfolws into a warning. = soft-stop, This produces a "
-                                         "truncated but valid DWP file, discarding any DWO files that would not fit within "
-                                         "the 32 bit/4GB limits of the format.">, MetaVarName<"<filename>">;
+def continueOnCuIndexOverflow : Flag<["-", "--"], "continue-on-cu-index-overflow">;
+def continueOnCuIndexOverflow_EQ : Joined<["-", "--"], "continue-on-cu-index-overflow=">,
+  HelpText<"default = continue, This turns an error when offset \n"
+    "\t\tfor .debug_*.dwo sections overfolws into a warning. = soft-stop, This produces a \n"
+    "\t\ttruncated but valid DWP file, discarding any DWO files that would not fit within \n"
+    "\t\tthe 32 bit/4GB limits of the format.">,
+  Values<"continue,soft-stop">;

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -144,13 +144,21 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   }
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
-  if (Args.hasArg(OPT_continueOnCuIndexOverflow)) {
-    ContinueOption =
-        Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "continue");
-    if (ContinueOption == "soft-stop") {
-      OverflowOptValue = OnCuIndexOverflow::SoftStop;
-    } else {
+  if (Arg *Arg = Args.getLastArg(OPT_continueOnCuIndexOverflow,
+                                 OPT_continueOnCuIndexOverflow_EQ)) {
+    if (Arg->getOption().matches(OPT_continueOnCuIndexOverflow)) {
       OverflowOptValue = OnCuIndexOverflow::Continue;
+    } else {
+      ContinueOption = Arg->getValue();
+      if (ContinueOption == "soft-stop") {
+        OverflowOptValue = OnCuIndexOverflow::SoftStop;
+      } else if (ContinueOption == "continue") {
+        OverflowOptValue = OnCuIndexOverflow::Continue;
+      } else {
+        llvm::errs() << "invalid value for --continue-on-cu-index-overflow"
+                     << ContinueOption << '\n';
+        exit(1);
+      }
     }
   }
 


### PR DESCRIPTION
This is follow up for https://github.com/llvm/llvm-project/pull/71902. The
default option --continue-on-cu-index-overflow returned an error
--continue-on-cu-index-overflow: missing argument. Changed it so that it is the
same behavior as other flags like -gsplit-dwarf. Where
--continue-on-cu-index-overflow will default to continue, and user can set mode
with --continue-on-cu-index-overflow=\<value>.
