### PR TITLE
[clang-scan-deps] Fix check for empty `Compilation`

### DIFF
--- a/clang/test/ClangScanDeps/empty.cpp
+++ b/clang/test/ClangScanDeps/empty.cpp
@@ -1,0 +1,4 @@
+// RUN: rm -rf %t
+// RUN: not clang-scan-deps --format=p1689 -- %clang this-file-does-not-exist.cpp 2>&1 | FileCheck %s --check-prefix=CHECK
+// CHECK: error: no such file or directory: 'this-file-does-not-exist.cpp'
+// CHECK: error: no input files

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -728,7 +728,7 @@ getCompilationDataBase(int argc, char **argv, std::string &ErrorMessage) {
                            *Diags);
   std::unique_ptr<driver::Compilation> C(
       TheDriver.BuildCompilation(CommandLine));
-  if (!C)
+  if (!C || C->getJobs().empty())
     return nullptr;
 
   auto Cmd = C->getJobs().begin();


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/64144

Instead of checking for `nullptr`  we need to ensure that `JobList` is not empty to proceed