### PR TITLE
[clang-repl] fix top-level statement declaration context

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -4440,7 +4440,8 @@ class TopLevelStmtDecl : public Decl {
   virtual void anchor();
 
 public:
-  static TopLevelStmtDecl *Create(ASTContext &C, Stmt *Statement);
+  static TopLevelStmtDecl *Create(ASTContext &C, DeclContext *DC,
+                                  Stmt *Statement);
   static TopLevelStmtDecl *CreateDeserialized(ASTContext &C, unsigned ID);
 
   SourceRange getSourceRange() const override LLVM_READONLY;

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5513,13 +5513,13 @@ FileScopeAsmDecl *FileScopeAsmDecl::CreateDeserialized(ASTContext &C,
 
 void TopLevelStmtDecl::anchor() {}
 
-TopLevelStmtDecl *TopLevelStmtDecl::Create(ASTContext &C, Stmt *Statement) {
+TopLevelStmtDecl *TopLevelStmtDecl::Create(ASTContext &C, DeclContext *DC,
+                                           Stmt *Statement) {
   assert(Statement);
   assert(C.getLangOpts().IncrementalExtensions &&
          "Must be used only in incremental mode");
 
   SourceLocation BeginLoc = Statement->getBeginLoc();
-  DeclContext *DC = C.getTranslationUnitDecl();
 
   return new (C, DC) TopLevelStmtDecl(DC, BeginLoc, Statement);
 }

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -374,7 +374,17 @@ std::unique_ptr<llvm::Module> IncrementalParser::GenModule() {
 void IncrementalParser::CleanUpPTU(PartialTranslationUnit &PTU) {
   TranslationUnitDecl *MostRecentTU = PTU.TUPart;
   TranslationUnitDecl *FirstTU = MostRecentTU->getFirstDecl();
-  if (StoredDeclsMap *Map = FirstTU->getPrimaryContext()->getLookupPtr()) {
+  if (!FirstTU) {
+    return;
+  }
+
+  SmallVector<DeclContext *> contexts;
+  FirstTU->collectAllContexts(contexts);
+  if (contexts.empty()) {
+    return;
+  }
+
+  if (StoredDeclsMap *Map = contexts.back()->getLookupPtr()) {
     for (auto I = Map->begin(); I != Map->end(); ++I) {
       StoredDeclsList &List = I->second;
       DeclContextLookupResult R = List.getLookupResult();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20287,7 +20287,7 @@ Decl *Sema::ActOnFileScopeAsmDecl(Expr *expr,
 }
 
 Decl *Sema::ActOnTopLevelStmtDecl(Stmt *Statement) {
-  DeclContext* NamespaceContext = CurContext->getEnclosingNamespaceContext();
+  DeclContext *NamespaceContext = CurContext->getEnclosingNamespaceContext();
   auto *New = TopLevelStmtDecl::Create(Context, NamespaceContext, Statement);
   NamespaceContext->addDecl(New);
   return New;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20287,8 +20287,9 @@ Decl *Sema::ActOnFileScopeAsmDecl(Expr *expr,
 }
 
 Decl *Sema::ActOnTopLevelStmtDecl(Stmt *Statement) {
-  auto *New = TopLevelStmtDecl::Create(Context, Statement);
-  Context.getTranslationUnitDecl()->addDecl(New);
+  DeclContext* NamespaceContext = CurContext->getEnclosingNamespaceContext();
+  auto *New = TopLevelStmtDecl::Create(Context, NamespaceContext, Statement);
+  NamespaceContext->addDecl(New);
   return New;
 }
 


### PR DESCRIPTION
Change the declaration context where we insert top-level statements to CurrentContext.

Previously, top-level statement declarations were inserted directly into the translation unit. This is incorrect, as it leads to ignoring such statements located inside namespaces.

Fixes: #73632, #72980