### PR TITLE
[llvm-exegesis] Validate that address annotations are aligned

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-alignment-page-boundary.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-alignment-page-boundary.s
@@ -1,0 +1,14 @@
+# REQUIRES: exegesis-can-measure-latency, x86_64-linux
+
+# Test that we error out if the requested address is not aligned to a page
+# boundary. Here we test out mapping at 2^12+4, which is off from a page
+# boundary by four bytes.
+
+# RUN: not llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess 2>&1 | FileCheck %s
+
+# LLVM-EXEGESIS-MEM-DEF test1 4096 414D47
+# LLVM-EXEGESIS-MEM-MAP test1 65540
+
+nop
+
+# CHECK: invalid comment 'LLVM-EXEGESIS-MEM-MAP  test1 65540', expected <ADDRESS> to be a multiple of the platform page size. 

--- a/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-snippet-alignment-page-boundary.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-snippet-alignment-page-boundary.s
@@ -1,0 +1,13 @@
+# REQUIRES: exegesis-can-measure-latency, x86_64-linux
+
+# Test that we error out if the requested snippet address is not aligned to
+# a page boundary. Here we test out mapping at 2^12+4 which is off from a page
+# boundary by four bytes.
+
+# RUN: not llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess 2>&1 | FileCheck %s
+
+# LLVM-EXEGESIS-SNIPPET-ADDRESS 65540
+
+nop
+
+# CHECK: invalid comment 'LLVM-EXEGESIS-SNIPPET-ADDRESS 65540, expected <ADDRESS> to be a multiple of the platform page size.

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -418,6 +418,12 @@ private:
       exit(ChildProcessExitCodeE::RSeqDisableFailed);
 #endif // GLIBC_INITS_RSEQ
 
+    // The frontend that generates the memory annotation structures should
+    // validate that the address to map the snippet in at is a multiple of
+    // the page size. Assert that this is true here.
+    assert(Key.SnippetAddress % getpagesize() == 0 &&
+           "The snippet address needs to be aligned to a page boundary.");
+
     size_t FunctionDataCopySize = this->Function.FunctionBytes.size();
     void *MapAddress = NULL;
     int MapFlags = MAP_PRIVATE | MAP_ANONYMOUS;


### PR DESCRIPTION
This patch adds in validation at two different levels that address annotations are page aligned. This is necessary as otherwise the mmap calls will fail as MAP_FIXED/MAP_FIXED_NOREPLACE require page aligned addresses. This happens silently in the subprocess. This patch adds validation at snippet parsing time to give feedback to the user and also adds asserts at code generation/address usage time to ensure that other users of the Exegesis APIs conform to the same requirements.