### PR TITLE
[CoverageMapping] Avoid use of pow() resulting in solaris build fail

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -281,7 +281,7 @@ public:
       : ExecutedTestVectorBitmap(Bitmap), Region(Region), Branches(Branches),
         NumConditions(Region.MCDCParams.NumConditions),
         Folded(NumConditions, false), IndependencePairs(NumConditions),
-        TestVectors(pow(2, NumConditions)) {}
+        TestVectors((size_t)1 << NumConditions) {}
 
 private:
   void recordTestVector(MCDCRecord::TestVector &TV,


### PR DESCRIPTION
Fixes a build failure introduced by
commit 8ecbb0404d74 ("Reland [Coverage][llvm-cov]
Enable MC/DC Support in LLVM Source-based Code Coverage (2/3)")

Use of pow() is not necessary.