### PR TITLE
[CodeGen] Use `MachinePassKey` for machine passes

### DIFF
--- a/llvm/include/llvm/CodeGen/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/CodeGen/CodeGenPassBuilder.h
@@ -85,7 +85,7 @@ namespace llvm {
     }                                                                          \
   };
 #define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  struct PASS_NAME : public PassInfoMixin<PASS_NAME> {                         \
+  struct PASS_NAME : public MachinePassInfoMixin<PASS_NAME> {                  \
     template <typename... Ts> PASS_NAME(Ts &&...) {}                           \
     Error run(Module &, MachineFunctionAnalysisManager &) {                    \
       return Error::success();                                                 \
@@ -94,16 +94,16 @@ namespace llvm {
                           MachineFunctionAnalysisManager &) {                  \
       llvm_unreachable("this api is to make new PM api happy");                \
     }                                                                          \
-    static AnalysisKey Key;                                                    \
+    static MachinePassKey Key;                                                 \
   };
 #define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)              \
-  struct PASS_NAME : public PassInfoMixin<PASS_NAME> {                         \
+  struct PASS_NAME : public MachinePassInfoMixin<PASS_NAME> {                  \
     template <typename... Ts> PASS_NAME(Ts &&...) {}                           \
     PreservedAnalyses run(MachineFunction &,                                   \
                           MachineFunctionAnalysisManager &) {                  \
       return PreservedAnalyses::all();                                         \
     }                                                                          \
-    static AnalysisKey Key;                                                    \
+    static MachinePassKey Key;                                                 \
   };
 #define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
   struct PASS_NAME : public AnalysisInfoMixin<PASS_NAME> {                     \

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -37,6 +37,22 @@ class MachineFunction;
 
 extern template class AnalysisManager<MachineFunction>;
 
+/// Like \c AnalysisKey, but only for machine passes.
+struct alignas(8) MachinePassKey {};
+
+/// A CRTP mix-in that provides informational APIs needed for machine passes.
+///
+/// This provides some boilerplate for types that are machine passes. It
+/// automatically mixes in \c PassInfoMixin.
+template <typename DerivedT>
+struct MachinePassInfoMixin : public PassInfoMixin<DerivedT> {
+  static MachinePassKey *ID() {
+    static_assert(std::is_base_of<MachinePassInfoMixin, DerivedT>::value,
+                  "Must pass the derived type as the template argument!");
+    return &DerivedT::Key;
+  }
+};
+
 /// An AnalysisManager<MachineFunction> that also exposes IR analysis results.
 class MachineFunctionAnalysisManager : public AnalysisManager<MachineFunction> {
 public:

--- a/llvm/lib/CodeGen/CodeGenPassBuilder.cpp
+++ b/llvm/lib/CodeGen/CodeGenPassBuilder.cpp
@@ -17,10 +17,10 @@ using namespace llvm;
 
 namespace llvm {
 #define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  AnalysisKey PASS_NAME::Key;
+  MachinePassKey PASS_NAME::Key;
 #include "llvm/CodeGen/MachinePassRegistry.def"
 #define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)              \
-  AnalysisKey PASS_NAME::Key;
+  MachinePassKey PASS_NAME::Key;
 #define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
   AnalysisKey PASS_NAME::Key;
 #include "llvm/CodeGen/MachinePassRegistry.def"


### PR DESCRIPTION
Machine passes define `AnalysisKey`, it is counterintuitive. Add `MachinePassKey` and `MachinePassInfoMixin` to avoid this.