### PR TITLE
[OpenMP] [OMPT] A pointer to HostOpId should be passed in EMI callbacks.

### DIFF
--- a/openmp/libomptarget/include/OpenMP/OMPT/Interface.h
+++ b/openmp/libomptarget/include/OpenMP/OMPT/Interface.h
@@ -195,9 +195,6 @@ private:
   /// Target task data representing the target task region
   ompt_data_t *TargetTaskData = nullptr;
 
-  /// Correlation id that is incremented with target operations
-  uint64_t TargetRegionOpId = 1;
-
   /// Used for marking begin of a data operation
   void beginTargetDataOperation();
 

--- a/openmp/libomptarget/src/OpenMP/OMPT/Callback.cpp
+++ b/openmp/libomptarget/src/OpenMP/OMPT/Callback.cpp
@@ -86,7 +86,7 @@ void Interface::beginTargetDataAlloc(int64_t DeviceId, void *HstPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_begin, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_begin, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_alloc, HstPtrBegin,
         /* SrcDeviceNum */ omp_get_initial_device(), *TgtPtrBegin,
         /* TgtDeviceNum */ DeviceId, Size, Code);
@@ -109,7 +109,7 @@ void Interface::endTargetDataAlloc(int64_t DeviceId, void *HstPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_end, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_end, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_alloc, HstPtrBegin,
         /* SrcDeviceNum */ omp_get_initial_device(), *TgtPtrBegin,
         /* TgtDeviceNum */ DeviceId, Size, Code);
@@ -125,7 +125,7 @@ void Interface::beginTargetDataSubmit(int64_t DeviceId, void *TgtPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_begin, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_begin, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_transfer_to_device, HstPtrBegin,
         /* SrcDeviceNum */ omp_get_initial_device(), TgtPtrBegin, DeviceId,
         Size, Code);
@@ -148,7 +148,7 @@ void Interface::endTargetDataSubmit(int64_t DeviceId, void *TgtPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_end, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_end, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_transfer_to_device, HstPtrBegin,
         /* SrcDeviceNum */ omp_get_initial_device(), TgtPtrBegin, DeviceId,
         Size, Code);
@@ -163,7 +163,7 @@ void Interface::beginTargetDataDelete(int64_t DeviceId, void *TgtPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_begin, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_begin, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_delete, TgtPtrBegin, DeviceId,
         /* TgtPtrBegin */ nullptr, /* TgtDeviceNum */ -1, /* Bytes */ 0, Code);
   } else if (ompt_callback_target_data_op_fn) {
@@ -184,7 +184,7 @@ void Interface::endTargetDataDelete(int64_t DeviceId, void *TgtPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_end, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_end, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_delete, TgtPtrBegin, DeviceId,
         /* TgtPtrBegin */ nullptr, /* TgtDeviceNum */ -1, /* Bytes */ 0, Code);
   }
@@ -199,7 +199,7 @@ void Interface::beginTargetDataRetrieve(int64_t DeviceId, void *HstPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_begin, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_begin, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_transfer_from_device, TgtPtrBegin, DeviceId,
         HstPtrBegin,
         /* TgtDeviceNum */ omp_get_initial_device(), Size, Code);
@@ -222,7 +222,7 @@ void Interface::endTargetDataRetrieve(int64_t DeviceId, void *HstPtrBegin,
     // HostOpId will be set by the tool. Invoke the tool supplied data op EMI
     // callback
     ompt_callback_target_data_op_emi_fn(
-        ompt_scope_end, TargetTaskData, &TargetData, &TargetRegionOpId,
+        ompt_scope_end, TargetTaskData, &TargetData, &HostOpId,
         ompt_target_data_transfer_from_device, TgtPtrBegin, DeviceId,
         HstPtrBegin,
         /* TgtDeviceNum */ omp_get_initial_device(), Size, Code);
@@ -364,12 +364,11 @@ void Interface::endTarget(int64_t DeviceId, void *Code) {
 }
 
 void Interface::beginTargetDataOperation() {
-  DP("in ompt_target_region_begin (TargetRegionOpId = %lu)\n",
-     TargetData.value);
+  DP("in ompt_target_region_begin (TargetRegionId = %lu)\n", TargetData.value);
 }
 
 void Interface::endTargetDataOperation() {
-  DP("in ompt_target_region_end (TargetRegionOpId = %lu)\n", TargetData.value);
+  DP("in ompt_target_region_end (TargetRegionId = %lu)\n", TargetData.value);
 }
 
 void Interface::beginTargetRegion() {


### PR DESCRIPTION
With this change, TargetRegionOpId is no more used and hence deleted.