### PR TITLE
[lld][ELF] Skip finalizeAddressDependentContent if assignAddresses produces errors.

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -677,6 +677,8 @@ void LinkerScript::processSectionCommands() {
 }
 
 void LinkerScript::processSymbolAssignments() {
+  if (errorCount())
+    return;
   // Dot outside an output section still represents a relative address, whose
   // sh_shndx should not be SHN_UNDEF or SHN_ABS. Create a dummy aether section
   // that fills the void outside a section. It has an index of one, which is

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1679,7 +1679,11 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
   ThunkCreator tc;
   AArch64Err843419Patcher a64p;
   ARMErr657417Patcher a32p;
+  unsigned errors = errorHandler().errorCount;
   script->assignAddresses();
+  // Exit out early if the first assignAddresses produced errors.
+  if (errors != errorHandler().errorCount)
+    return;
   // .ARM.exidx and SHF_LINK_ORDER do not require precise addresses, but they
   // do require the relative addresses of OutputSections because linker scripts
   // can assign Virtual Addresses to OutputSections that are not monotonically

--- a/lld/test/ELF/linkerscript/copy-rel-symbol-value-err.s
+++ b/lld/test/ELF/linkerscript/copy-rel-symbol-value-err.s
@@ -5,7 +5,7 @@
 # RUN: echo "SECTIONS { . = . + SIZEOF_HEADERS; foo = bar; }" > %t.script
 # RUN: not ld.lld %t.o %t2.so --script %t.script -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=error:
 
-# CHECK-COUNT-2: error: {{.*}}.script:1: symbol not found: bar
+# CHECK: error: {{.*}}.script:1: symbol not found: bar
 
 .global _start
 _start:

--- a/lld/test/ELF/linkerscript/symbol-assignexpr.s
+++ b/lld/test/ELF/linkerscript/symbol-assignexpr.s
@@ -8,7 +8,7 @@
 # RUN: not ld.lld -o /dev/null --noinhibit-exec -T %t2.script %t.o 2>&1 \
 # RUN:   | FileCheck --check-prefix=ERR %s --implicit-check-not=error:
 
-# ERR-COUNT-3: {{.*}}.script:1: symbol not found: symbol
+# ERR-COUNT-2: {{.*}}.script:1: symbol not found: symbol
 
 # MAP:      VMA              LMA     Size Align Out     In      Symbol
 # MAP-NEXT:   0                0        0     1 symbol2 = symbol

--- a/lld/test/ELF/linkerscript/symbolreferenced.s
+++ b/lld/test/ELF/linkerscript/symbolreferenced.s
@@ -28,7 +28,7 @@
 # CHECK-NEXT: 0000000000001000 A newsym
 
 # RUN: not ld.lld -T chain2.t a.o 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
-# ERR-COUNT-3: error: chain2.t:1: symbol not found: undef
+# ERR-COUNT-2: error: chain2.t:1: symbol not found: undef
 
 #--- a.s
 .global _start


### PR DESCRIPTION
There's no point in running the rest of finalizeAddressDependentContent
if the initial assignAddresses gives an error. Since we will also end
up running it again at least once, we might emit duplicate errors for
no reason.

Remember how many errors we had before we run assignAddresses the
first time, and if it changes, simply return.
