### PR TITLE
[libc++] Mark a few functions as _LIBCPP_CONSTEVAL_EXT

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -985,6 +985,12 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_EXPLICIT_SINCE_CXX23
 #  endif
 
+#  if _LIBCPP_STD_VER >= 20
+#    define _LIBCPP_CONSTEVAL_EXT consteval
+#  else
+#    define _LIBCPP_CONSTEVAL_EXT _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
+#  endif
+
 #  if _LIBCPP_STD_VER >= 14
 #    define _LIBCPP_CONSTEXPR_SINCE_CXX14 constexpr
 #  else

--- a/libcxx/include/experimental/__simd/simd.h
+++ b/libcxx/include/experimental/__simd/simd.h
@@ -42,7 +42,7 @@ public:
   using mask_type  = simd_mask<_Tp, _Abi>;
   using abi_type   = _Abi;
 
-  static _LIBCPP_HIDE_FROM_ABI constexpr size_t size() noexcept { return simd_size_v<value_type, abi_type>; }
+  static _LIBCPP_CONSTEVAL_EXT size_t size() noexcept { return simd_size_v<value_type, abi_type>; }
 
   _LIBCPP_HIDE_FROM_ABI simd() noexcept = default;
 

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -206,15 +206,15 @@ protected:
     static _LIBCPP_CONSTEXPR const int  max_digits10 = 0;
     static _LIBCPP_CONSTEXPR const type __min = __libcpp_compute_min<type, digits, is_signed>::value;
     static _LIBCPP_CONSTEXPR const type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type min() _NOEXCEPT {return __min;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type max() _NOEXCEPT {return __max;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type lowest() _NOEXCEPT {return min();}
+    static _LIBCPP_CONSTEVAL_EXT type min() _NOEXCEPT {return __min;}
+    static _LIBCPP_CONSTEVAL_EXT type max() _NOEXCEPT {return __max;}
+    static _LIBCPP_CONSTEVAL_EXT type lowest() _NOEXCEPT {return min();}
 
     static _LIBCPP_CONSTEXPR const bool is_integer = true;
     static _LIBCPP_CONSTEXPR const bool is_exact = true;
     static _LIBCPP_CONSTEXPR const int  radix = 2;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type epsilon() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type round_error() _NOEXCEPT {return type(0);}
 
     static _LIBCPP_CONSTEXPR const int  min_exponent = 0;
     static _LIBCPP_CONSTEXPR const int  min_exponent10 = 0;
@@ -226,10 +226,10 @@ protected:
     static _LIBCPP_CONSTEXPR const bool has_signaling_NaN = false;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type infinity() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type quiet_NaN() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type signaling_NaN() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type denorm_min() _NOEXCEPT {return type(0);}
 
     static _LIBCPP_CONSTEXPR const bool is_iec559 = false;
     static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -259,15 +259,15 @@ protected:
     static _LIBCPP_CONSTEXPR const int  max_digits10 = 0;
     static _LIBCPP_CONSTEXPR const type __min = false;
     static _LIBCPP_CONSTEXPR const type __max = true;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type min() _NOEXCEPT {return __min;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type max() _NOEXCEPT {return __max;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type lowest() _NOEXCEPT {return min();}
+    static _LIBCPP_CONSTEVAL_EXT type min() _NOEXCEPT {return __min;}
+    static _LIBCPP_CONSTEVAL_EXT type max() _NOEXCEPT {return __max;}
+    static _LIBCPP_CONSTEVAL_EXT type lowest() _NOEXCEPT {return min();}
 
     static _LIBCPP_CONSTEXPR const bool is_integer = true;
     static _LIBCPP_CONSTEXPR const bool is_exact = true;
     static _LIBCPP_CONSTEXPR const int  radix = 2;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type epsilon() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type round_error() _NOEXCEPT {return type(0);}
 
     static _LIBCPP_CONSTEXPR const int  min_exponent = 0;
     static _LIBCPP_CONSTEXPR const int  min_exponent10 = 0;
@@ -279,10 +279,10 @@ protected:
     static _LIBCPP_CONSTEXPR const bool has_signaling_NaN = false;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {return type(0);}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type infinity() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type quiet_NaN() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type signaling_NaN() _NOEXCEPT {return type(0);}
+    static _LIBCPP_CONSTEVAL_EXT type denorm_min() _NOEXCEPT {return type(0);}
 
     static _LIBCPP_CONSTEXPR const bool is_iec559 = false;
     static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -305,15 +305,15 @@ protected:
     static _LIBCPP_CONSTEXPR const int  digits = __FLT_MANT_DIG__;
     static _LIBCPP_CONSTEXPR const int  digits10 = __FLT_DIG__;
     static _LIBCPP_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type min() _NOEXCEPT {return __FLT_MIN__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type max() _NOEXCEPT {return __FLT_MAX__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    static _LIBCPP_CONSTEVAL_EXT type min() _NOEXCEPT {return __FLT_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type max() _NOEXCEPT {return __FLT_MAX__;}
+    static _LIBCPP_CONSTEVAL_EXT type lowest() _NOEXCEPT {return -max();}
 
     static _LIBCPP_CONSTEXPR const bool is_integer = false;
     static _LIBCPP_CONSTEXPR const bool is_exact = false;
     static _LIBCPP_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {return __FLT_EPSILON__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {return 0.5F;}
+    static _LIBCPP_CONSTEVAL_EXT type epsilon() _NOEXCEPT {return __FLT_EPSILON__;}
+    static _LIBCPP_CONSTEVAL_EXT type round_error() _NOEXCEPT {return 0.5F;}
 
     static _LIBCPP_CONSTEXPR const int  min_exponent = __FLT_MIN_EXP__;
     static _LIBCPP_CONSTEXPR const int  min_exponent10 = __FLT_MIN_10_EXP__;
@@ -325,10 +325,10 @@ protected:
     static _LIBCPP_CONSTEXPR const bool has_signaling_NaN = true;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_valf();}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nanf("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nansf("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {return __FLT_DENORM_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type infinity() _NOEXCEPT {return __builtin_huge_valf();}
+    static _LIBCPP_CONSTEVAL_EXT type quiet_NaN() _NOEXCEPT {return __builtin_nanf("");}
+    static _LIBCPP_CONSTEVAL_EXT type signaling_NaN() _NOEXCEPT {return __builtin_nansf("");}
+    static _LIBCPP_CONSTEVAL_EXT type denorm_min() _NOEXCEPT {return __FLT_DENORM_MIN__;}
 
     static _LIBCPP_CONSTEXPR const bool is_iec559 = true;
     static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -355,15 +355,15 @@ protected:
     static _LIBCPP_CONSTEXPR const int  digits = __DBL_MANT_DIG__;
     static _LIBCPP_CONSTEXPR const int  digits10 = __DBL_DIG__;
     static _LIBCPP_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type min() _NOEXCEPT {return __DBL_MIN__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type max() _NOEXCEPT {return __DBL_MAX__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    static _LIBCPP_CONSTEVAL_EXT type min() _NOEXCEPT {return __DBL_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type max() _NOEXCEPT {return __DBL_MAX__;}
+    static _LIBCPP_CONSTEVAL_EXT type lowest() _NOEXCEPT {return -max();}
 
     static _LIBCPP_CONSTEXPR const bool is_integer = false;
     static _LIBCPP_CONSTEXPR const bool is_exact = false;
     static _LIBCPP_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {return __DBL_EPSILON__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {return 0.5;}
+    static _LIBCPP_CONSTEVAL_EXT type epsilon() _NOEXCEPT {return __DBL_EPSILON__;}
+    static _LIBCPP_CONSTEVAL_EXT type round_error() _NOEXCEPT {return 0.5;}
 
     static _LIBCPP_CONSTEXPR const int  min_exponent = __DBL_MIN_EXP__;
     static _LIBCPP_CONSTEXPR const int  min_exponent10 = __DBL_MIN_10_EXP__;
@@ -375,10 +375,10 @@ protected:
     static _LIBCPP_CONSTEXPR const bool has_signaling_NaN = true;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_val();}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nan("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nans("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {return __DBL_DENORM_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type infinity() _NOEXCEPT {return __builtin_huge_val();}
+    static _LIBCPP_CONSTEVAL_EXT type quiet_NaN() _NOEXCEPT {return __builtin_nan("");}
+    static _LIBCPP_CONSTEVAL_EXT type signaling_NaN() _NOEXCEPT {return __builtin_nans("");}
+    static _LIBCPP_CONSTEVAL_EXT type denorm_min() _NOEXCEPT {return __DBL_DENORM_MIN__;}
 
     static _LIBCPP_CONSTEXPR const bool is_iec559 = true;
     static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -405,15 +405,15 @@ protected:
     static _LIBCPP_CONSTEXPR const int  digits = __LDBL_MANT_DIG__;
     static _LIBCPP_CONSTEXPR const int  digits10 = __LDBL_DIG__;
     static _LIBCPP_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type min() _NOEXCEPT {return __LDBL_MIN__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type max() _NOEXCEPT {return __LDBL_MAX__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    static _LIBCPP_CONSTEVAL_EXT type min() _NOEXCEPT {return __LDBL_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type max() _NOEXCEPT {return __LDBL_MAX__;}
+    static _LIBCPP_CONSTEVAL_EXT type lowest() _NOEXCEPT {return -max();}
 
     static _LIBCPP_CONSTEXPR const bool is_integer = false;
     static _LIBCPP_CONSTEXPR const bool is_exact = false;
     static _LIBCPP_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {return __LDBL_EPSILON__;}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {return 0.5L;}
+    static _LIBCPP_CONSTEVAL_EXT type epsilon() _NOEXCEPT {return __LDBL_EPSILON__;}
+    static _LIBCPP_CONSTEVAL_EXT type round_error() _NOEXCEPT {return 0.5L;}
 
     static _LIBCPP_CONSTEXPR const int  min_exponent = __LDBL_MIN_EXP__;
     static _LIBCPP_CONSTEXPR const int  min_exponent10 = __LDBL_MIN_10_EXP__;
@@ -425,10 +425,10 @@ protected:
     static _LIBCPP_CONSTEXPR const bool has_signaling_NaN = true;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_vall();}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nanl("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nansl("");}
-    _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {return __LDBL_DENORM_MIN__;}
+    static _LIBCPP_CONSTEVAL_EXT type infinity() _NOEXCEPT {return __builtin_huge_vall();}
+    static _LIBCPP_CONSTEVAL_EXT type quiet_NaN() _NOEXCEPT {return __builtin_nanl("");}
+    static _LIBCPP_CONSTEVAL_EXT type signaling_NaN() _NOEXCEPT {return __builtin_nansl("");}
+    static _LIBCPP_CONSTEVAL_EXT type denorm_min() _NOEXCEPT {return __LDBL_DENORM_MIN__;}
 
 #if defined(__powerpc__) && defined(__LONG_DOUBLE_IBM128__)
     static _LIBCPP_CONSTEXPR const bool is_iec559 = false;


### PR DESCRIPTION
This should not be observable by the user and generates a bit better code sometimes.
