### PR TITLE
[clang] Fix unexpected warnings after a01307a

### DIFF
--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -864,6 +864,14 @@ InitListChecker::FillInEmptyInitializations(const InitializedEntity &Entity,
       WarnIfMissingField &=
           SemaRef.getLangOpts().CPlusPlus || !hasAnyDesignatedInits(SForm);
 
+      if (OuterILE) {
+        InitListExpr *OuterSForm = OuterILE->isSyntacticForm()
+                                       ? OuterILE
+                                       : OuterILE->getSyntacticForm();
+        WarnIfMissingField &= SemaRef.getLangOpts().CPlusPlus ||
+                              !hasAnyDesignatedInits(OuterSForm);
+      }
+
       unsigned NumElems = numStructUnionElements(ILE->getType());
       if (!RDecl->isUnion() && RDecl->hasFlexibleArrayMember())
         ++NumElems;

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -865,6 +865,9 @@ InitListChecker::FillInEmptyInitializations(const InitializedEntity &Entity,
           SemaRef.getLangOpts().CPlusPlus || !hasAnyDesignatedInits(SForm);
 
       if (OuterILE) {
+        // When nested designators are present, there might be two nested init
+        // lists created and only outer will contain designated initializer
+        // expression, so check outer list as well.
         InitListExpr *OuterSForm = OuterILE->isSyntacticForm()
                                        ? OuterILE
                                        : OuterILE->getSyntacticForm();

--- a/clang/test/Sema/missing-field-initializers.c
+++ b/clang/test/Sema/missing-field-initializers.c
@@ -61,3 +61,26 @@ struct S {
 // f1, now we no longer issue that warning (note, this code is still unsafe
 // because of the buffer overrun).
 struct S s = {1, {1, 2}};
+
+struct S1 {
+  long int l;
+  struct  { int a, b; } d1;
+};
+
+struct S1 s01 = { 1, {1} }; // expected-warning {{missing field 'b' initializer}}
+struct S1 s02 = { .d1.a = 1 }; // designator avoids MFI warning
+
+union U1 {
+  long int l;
+  struct  { int a, b; } d1;
+};
+
+union U1 u01 = { 1 };
+union U1 u02 = { .d1.a = 1 }; // designator avoids MFI warning
+
+struct S2 {
+  long int l;
+  struct { int a, b; struct {int c; } d2; } d1;
+};
+
+struct S2 s22 = { .d1.d2.c = 1 }; // designator avoids MFI warning


### PR DESCRIPTION
a01307a broke silencing of -Wmissing-field-initializers warnings in C for nested designators. This fixes the issue.