### PR TITLE
[libc] Fix improper initialization of `StorageType`

### DIFF
--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_UTILS_UNITTEST_FPMATCHER_H
 #define LLVM_LIBC_UTILS_UNITTEST_FPMATCHER_H
 
+#include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/fpbits_str.h"
@@ -62,6 +63,8 @@ template <TestCond C, typename T> FPMatcher<T, C> getMatcher(T expectedValue) {
 template <typename T> struct FPTest : public Test {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
+  static constexpr StorageType STORAGE_MAX =
+      LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();
   static constexpr T zero = FPBits::zero();
   static constexpr T neg_zero = FPBits::neg_zero();
   static constexpr T aNaN = FPBits::build_quiet_nan(1);
@@ -88,6 +91,8 @@ template <typename T> struct FPTest : public Test {
 #define DECLARE_SPECIAL_CONSTANTS(T)                                           \
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;                            \
   using StorageType = typename FPBits::StorageType;                            \
+  static constexpr StorageType STORAGE_MAX =                                   \
+      LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();                 \
   const T zero = FPBits::zero();                                               \
   const T neg_zero = FPBits::neg_zero();                                       \
   const T aNaN = FPBits::build_quiet_nan(1);                                   \

--- a/libc/test/src/math/CeilTest.h
+++ b/libc/test/src/math/CeilTest.h
@@ -65,7 +65,7 @@ public:
 
   void testRange(CeilFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/CopySignTest.h
+++ b/libc/test/src/math/CopySignTest.h
@@ -35,7 +35,7 @@ public:
 
   void testRange(CopySignFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FAbsTest.h
+++ b/libc/test/src/math/FAbsTest.h
@@ -33,7 +33,7 @@ public:
 
   void testRange(FabsFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FDimTest.h
+++ b/libc/test/src/math/FDimTest.h
@@ -53,9 +53,11 @@ public:
   }
 
   void test_in_range(FuncPtr func) {
+    constexpr StorageType STORAGE_MAX =
+        LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FMaxTest.h
+++ b/libc/test/src/math/FMaxTest.h
@@ -56,8 +56,8 @@ public:
 
   void testRange(FMaxFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FMinTest.h
+++ b/libc/test/src/math/FMinTest.h
@@ -56,8 +56,8 @@ public:
 
   void testRange(FMinFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FloorTest.h
+++ b/libc/test/src/math/FloorTest.h
@@ -65,7 +65,7 @@ public:
 
   void testRange(FloorFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/FrexpTest.h
+++ b/libc/test/src/math/FrexpTest.h
@@ -95,7 +95,7 @@ public:
   void testRange(FrexpFunc func) {
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)

--- a/libc/test/src/math/LogbTest.h
+++ b/libc/test/src/math/LogbTest.h
@@ -74,7 +74,7 @@ public:
   void testRange(LogbFunc func) {
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)

--- a/libc/test/src/math/ModfTest.h
+++ b/libc/test/src/math/ModfTest.h
@@ -85,7 +85,7 @@ public:
 
   void testRange(ModfFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == T(0.0))

--- a/libc/test/src/math/RoundTest.h
+++ b/libc/test/src/math/RoundTest.h
@@ -65,7 +65,7 @@ public:
 
   void testRange(RoundFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/SqrtTest.h
+++ b/libc/test/src/math/SqrtTest.h
@@ -56,7 +56,7 @@ public:
 
   void test_normal_range(SqrtFunc func) {
     constexpr StorageType COUNT = 200'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = LIBC_NAMESPACE::cpp::bit_cast<T>(v);
       if (isnan(x) || (x < 0)) {

--- a/libc/test/src/math/TruncTest.h
+++ b/libc/test/src/math/TruncTest.h
@@ -65,7 +65,7 @@ public:
 
   void testRange(TruncFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/cos_test.cpp
+++ b/libc/test/src/math/cos_test.cpp
@@ -20,7 +20,7 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 TEST_F(LlvmLibcCosTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
   constexpr StorageType COUNT = 100'000;
-  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  constexpr StorageType STEP = STORAGE_MAX / COUNT;
   for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.

--- a/libc/test/src/math/sin_test.cpp
+++ b/libc/test/src/math/sin_test.cpp
@@ -21,7 +21,7 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 TEST_F(LlvmLibcSinTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
   constexpr StorageType COUNT = 100'000;
-  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  constexpr StorageType STEP = STORAGE_MAX / COUNT;
   for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.

--- a/libc/test/src/math/smoke/CopySignTest.h
+++ b/libc/test/src/math/smoke/CopySignTest.h
@@ -32,7 +32,7 @@ public:
 
   void testRange(CopySignFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       FPBits x_bits = FPBits(v);
       T x = T(v);

--- a/libc/test/src/math/smoke/FDimTest.h
+++ b/libc/test/src/math/smoke/FDimTest.h
@@ -53,9 +53,11 @@ public:
   }
 
   void test_in_range(FuncPtr func) {
+    constexpr StorageType STORAGE_MAX =
+        LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/FMaxTest.h
+++ b/libc/test/src/math/smoke/FMaxTest.h
@@ -53,8 +53,8 @@ public:
 
   void testRange(FMaxFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/FMinTest.h
+++ b/libc/test/src/math/smoke/FMinTest.h
@@ -53,8 +53,8 @@ public:
 
   void testRange(FMinFunc func) {
     constexpr StorageType COUNT = 100'001;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
-    for (StorageType i = 0, v = 0, w = StorageType(-1); i <= COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
+    for (StorageType i = 0, v = 0, w = STORAGE_MAX; i <= COUNT;
          ++i, v += STEP, w -= STEP) {
       T x = T(FPBits(v)), y = T(FPBits(w));
       if (isnan(x) || isinf(x))

--- a/libc/test/src/math/smoke/LogbTest.h
+++ b/libc/test/src/math/smoke/LogbTest.h
@@ -71,7 +71,7 @@ public:
   void testRange(LogbFunc func) {
     using StorageType = typename FPBits::StorageType;
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = static_cast<T>(FPBits(v));
       if (isnan(x) || isinf(x) || x == 0.0l)

--- a/libc/test/src/math/smoke/ModfTest.h
+++ b/libc/test/src/math/smoke/ModfTest.h
@@ -82,7 +82,7 @@ public:
 
   void testRange(ModfFunc func) {
     constexpr StorageType COUNT = 100'000;
-    constexpr StorageType STEP = StorageType(-1) / COUNT;
+    constexpr StorageType STEP = STORAGE_MAX / COUNT;
     for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
       T x = T(FPBits(v));
       if (isnan(x) || isinf(x) || x == T(0.0))

--- a/libc/test/src/math/tan_test.cpp
+++ b/libc/test/src/math/tan_test.cpp
@@ -20,7 +20,7 @@ namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 TEST_F(LlvmLibcTanTest, Range) {
   static constexpr double _2pi = 6.283185307179586;
   constexpr StorageType COUNT = 100'000;
-  constexpr StorageType STEP = StorageType(-1) / COUNT;
+  constexpr StorageType STEP = STORAGE_MAX / COUNT;
   for (StorageType i = 0, v = 0; i <= COUNT; ++i, v += STEP) {
     double x = double(FPBits(v));
     // TODO: Expand the range of testing after range reduction is implemented.


### PR DESCRIPTION
`StorageType` may be a `BigInt` under the hood. Initializing it with `-1` does not yields the maximum value.
