### PR TITLE
[RISCV][GISEL] Fix legalization for G_MERGE/UNMERGE_VALUES

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -85,13 +85,12 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST)
 
   // Merge/Unmerge
   for (unsigned Op : {G_MERGE_VALUES, G_UNMERGE_VALUES}) {
-    unsigned BigTyIdx = (Op == G_MERGE_VALUES) ? 0 : 1;
-    unsigned LitTyIdx = (Op == G_MERGE_VALUES) ? 1 : 0;
     auto &MergeUnmergeActions = getActionDefinitionsBuilder(Op);
+    unsigned BigTyIdx = Op == G_MERGE_VALUES ? 0 : 1;
+    unsigned LitTyIdx = Op == G_MERGE_VALUES ? 1 : 0;
     if (XLen == 32 && ST.hasStdExtD()) {
-      LLT IdxZeroTy = (Op == G_MERGE_VALUES) ? s64 : s32;
-      LLT IdxOneTy = (Op == G_MERGE_VALUES) ? s32 : s64;
-      MergeUnmergeActions.legalFor({{IdxZeroTy, IdxOneTy}});
+      MergeUnmergeActions.legalIf(
+          all(typeIs(BigTyIdx, s64), typeIs(LitTyIdx, s32)));
     }
     MergeUnmergeActions.widenScalarToNextPow2(LitTyIdx, XLen)
         .widenScalarToNextPow2(BigTyIdx, XLen)


### PR DESCRIPTION
There are two bugs fixed by this patch:

  1. G_MERGE_VALUES is always true, causing IdxZeroTy and IdxOneTy to always be s64 and s32 respectively.
  2. The legalFor check was for the type in index 0, instead of for index 0 and index 1, so we were allowing s64 or s32 in type 0 to be legal for both G_MERGE_VALUES and G_UNMERGE_VALUES.

The existing test was passing because (2) covered up (1). 