### PR TITLE
[libc][NFC] Make `EXP_MANT_MASK` an implementation detail

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -33,7 +33,11 @@ template <typename T> struct FPBits : private FloatProperties<T> {
                 "FPBits instantiated with invalid type.");
   using typename FloatProperties<T>::StorageType;
   using FloatProperties<T>::TOTAL_LEN;
-  using FloatProperties<T>::EXP_MANT_MASK;
+
+private:
+  using FloatProperties<T>::EXP_SIG_MASK;
+
+public:
   using FloatProperties<T>::EXP_MASK;
   using FloatProperties<T>::EXP_BIAS;
   using FloatProperties<T>::EXP_LEN;
@@ -146,15 +150,15 @@ template <typename T> struct FPBits : private FloatProperties<T> {
   }
 
   LIBC_INLINE constexpr bool is_inf() const {
-    return (bits & EXP_MANT_MASK) == EXP_MASK;
+    return (bits & EXP_SIG_MASK) == EXP_MASK;
   }
 
   LIBC_INLINE constexpr bool is_nan() const {
-    return (bits & EXP_MANT_MASK) > EXP_MASK;
+    return (bits & EXP_SIG_MASK) > EXP_MASK;
   }
 
   LIBC_INLINE constexpr bool is_quiet_nan() const {
-    return (bits & EXP_MANT_MASK) == (EXP_MASK | QUIET_NAN_MASK);
+    return (bits & EXP_SIG_MASK) == (EXP_MASK | QUIET_NAN_MASK);
   }
 
   LIBC_INLINE constexpr bool is_inf_or_nan() const {

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -29,7 +29,6 @@ namespace fputil {
 template <> struct FPBits<long double> : private FloatProperties<long double> {
   using typename FloatProperties<long double>::StorageType;
   using FloatProperties<long double>::TOTAL_LEN;
-  using FloatProperties<long double>::EXP_MANT_MASK;
   using FloatProperties<long double>::EXP_MASK;
   using FloatProperties<long double>::EXP_BIAS;
   using FloatProperties<long double>::EXP_LEN;

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -20,6 +20,7 @@ namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
   using FPBits_t = typename fputil::FPBits<float>;
+  using FloatProp = typename fputil::FloatProperties<float>;
   FPBits_t xbits(x);
   uint32_t x_u = xbits.uintval();
 
@@ -34,7 +35,7 @@ LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
 
   if (LIBC_UNLIKELY(x_u >= 0x4f8ffb03)) {
     // Check for exceptional values.
-    uint32_t x_abs = x_u & FPBits_t::EXP_MANT_MASK;
+    uint32_t x_abs = FloatProp::abs(x_u);
     if (LIBC_UNLIKELY(x_abs >= 0x7f80'0000U)) {
       // x is +inf or NaN.
       return x;

--- a/libc/src/math/generic/asinhf.cpp
+++ b/libc/src/math/generic/asinhf.cpp
@@ -19,9 +19,10 @@ namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, asinhf, (float x)) {
   using FPBits_t = typename fputil::FPBits<float>;
+  using FloatProp = typename fputil::FloatProperties<float>;
   FPBits_t xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits_t::EXP_MANT_MASK;
+  uint32_t x_abs = FloatProp::abs(x_u);
 
   // |x| <= 2^-3
   if (LIBC_UNLIKELY(x_abs <= 0x3e80'0000U)) {

--- a/libc/src/math/generic/atanhf.cpp
+++ b/libc/src/math/generic/atanhf.cpp
@@ -15,9 +15,10 @@ namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, atanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
+  using FloatProp = typename fputil::FloatProperties<float>;
   FPBits xbits(x);
-  bool sign = xbits.get_sign();
-  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
+  bool sign = FloatProp::sign(xbits.uintval());
+  uint32_t x_abs = FloatProp::abs(xbits.uintval());
 
   // |x| >= 1.0
   if (LIBC_UNLIKELY(x_abs >= 0x3F80'0000U)) {

--- a/libc/src/math/generic/exp.cpp
+++ b/libc/src/math/generic/exp.cpp
@@ -178,7 +178,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = x_u & FloatProp::EXP_MANT_MASK;
+  uint64_t x_abs = FloatProp::abs(x_u);
 
   // |x| <= 2^-53
   if (x_abs <= 0x3ca0'0000'0000'0000ULL) {

--- a/libc/src/math/generic/exp10.cpp
+++ b/libc/src/math/generic/exp10.cpp
@@ -225,7 +225,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = x_u & FloatProp::EXP_MANT_MASK;
+  uint64_t x_abs = FloatProp::abs( x_u);
 
   // |x| < log10(1 + 2^-53)
   if (x_abs <= 0x3c8bcb7b1526e50e) {

--- a/libc/src/math/generic/exp10.cpp
+++ b/libc/src/math/generic/exp10.cpp
@@ -225,7 +225,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = FloatProp::abs( x_u);
+  uint64_t x_abs = FloatProp::abs(x_u);
 
   // |x| < log10(1 + 2^-53)
   if (x_abs <= 0x3c8bcb7b1526e50e) {

--- a/libc/src/math/generic/exp2.cpp
+++ b/libc/src/math/generic/exp2.cpp
@@ -200,7 +200,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = x_u & FloatProp::EXP_MANT_MASK;
+  uint64_t x_abs = FloatProp::abs(x_u);
 
   // |x| < log2(1 + 2^-53)
   if (x_abs <= 0x3ca71547652b82fd) {

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -223,7 +223,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = x_u & FloatProp::EXP_MANT_MASK;
+  uint64_t x_abs = FloatProp::abs( x_u);
 
   // |x| <= 2^-53.
   if (x_abs <= 0x3ca0'0000'0000'0000ULL) {

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -223,7 +223,7 @@ double set_exceptional(double x) {
   FPBits xbits(x);
 
   uint64_t x_u = xbits.uintval();
-  uint64_t x_abs = FloatProp::abs( x_u);
+  uint64_t x_abs = FloatProp::abs(x_u);
 
   // |x| <= 2^-53.
   if (x_abs <= 0x3ca0'0000'0000'0000ULL) {

--- a/libc/src/math/generic/inv_trigf_utils.h
+++ b/libc/src/math/generic/inv_trigf_utils.h
@@ -38,6 +38,7 @@ extern const double ATAN_K[5];
 // x should be positive, normal finite value
 LIBC_INLINE double atan_eval(double x) {
   using FPB = fputil::FPBits<double>;
+  using FloatProp = fputil::FloatProperties<double>;
   // Added some small value to umin and umax mantissa to avoid possible rounding
   // errors.
   FPB::StorageType umin =
@@ -50,7 +51,7 @@ LIBC_INLINE double atan_eval(double x) {
 
   FPB bs(x);
   bool sign = bs.get_sign();
-  auto x_abs = bs.uintval() & FPB::EXP_MANT_MASK;
+  auto x_abs = FloatProp::abs(bs.uintval());
 
   if (x_abs <= umin) {
     double pe = LIBC_NAMESPACE::fputil::polyeval(

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -517,9 +517,9 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
   FloatBits xbits(x), ybits(y);
 
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FloatProp::EXP_MANT_MASK;
+  uint32_t x_abs = FloatProp::abs(x_u);
   uint32_t y_u = ybits.uintval();
-  uint32_t y_abs = y_u & FloatProp::EXP_MANT_MASK;
+  uint32_t y_abs = FloatProp::abs(y_u);
 
   ///////// BEGIN - Check exceptional cases ////////////////////////////////////
 

--- a/libc/src/math/generic/sinhf.cpp
+++ b/libc/src/math/generic/sinhf.cpp
@@ -16,8 +16,9 @@ namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
+  using FloatProp = typename fputil::FloatProperties<float>;
   FPBits xbits(x);
-  uint32_t x_abs = xbits.uintval() & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = FloatProp::abs(xbits.uintval());
 
   // When |x| >= 90, or x is inf or nan
   if (LIBC_UNLIKELY(x_abs >= 0x42b4'0000U || x_abs <= 0x3da0'0000U)) {

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -22,9 +22,10 @@ constexpr double LOG2_E_EXP2_6 = ExpBase::LOG2_B * 2.0;
 
 LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
   using FPBits = typename fputil::FPBits<float>;
+  using FloatProp = typename fputil::FloatProperties<float>;
   FPBits xbits(x);
   uint32_t x_u = xbits.uintval();
-  uint32_t x_abs = x_u & FPBits::EXP_MANT_MASK;
+  uint32_t x_abs = FloatProp::abs(x_u);
 
   // When |x| >= 15, or x is inf or nan, or |x| <= 0.078125
   if (LIBC_UNLIKELY((x_abs >= 0x4170'0000U) || (x_abs <= 0x3da0'0000U))) {


### PR DESCRIPTION
This mask is an implementation detail of `FPBits` and shouldn't really leak outside of it.
I also used this opportunity to document `FloatProperties`.

For now `FloatProperties` is stateless and works on `StorageType` directly whereas `FPBits` is stateful and allows back and forth between FP type and `StorageType`.
