### PR TITLE
[clang-repl] fix segfault in CleanUpPTU()

### DIFF
--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -377,9 +377,8 @@ void IncrementalParser::CleanUpPTU(PartialTranslationUnit &PTU) {
     return;
 
   TranslationUnitDecl *FirstTU = MostRecentTU->getFirstDecl();
-  if (!FirstTU) {
+  if (!FirstTU)
     return;
-  }
 
   if (StoredDeclsMap *Map = FirstTU->getPrimaryContext()->getLookupPtr()) {
     for (auto I = Map->begin(); I != Map->end(); ++I) {

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -373,9 +373,8 @@ std::unique_ptr<llvm::Module> IncrementalParser::GenModule() {
 
 void IncrementalParser::CleanUpPTU(PartialTranslationUnit &PTU) {
   TranslationUnitDecl *MostRecentTU = PTU.TUPart;
-  if (!MostRecentTU) {
+  if (!MostRecentTU)
     return;
-  }
 
   TranslationUnitDecl *FirstTU = MostRecentTU->getFirstDecl();
   if (!FirstTU) {

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -373,7 +373,15 @@ std::unique_ptr<llvm::Module> IncrementalParser::GenModule() {
 
 void IncrementalParser::CleanUpPTU(PartialTranslationUnit &PTU) {
   TranslationUnitDecl *MostRecentTU = PTU.TUPart;
+  if (!MostRecentTU) {
+    return;
+  }
+
   TranslationUnitDecl *FirstTU = MostRecentTU->getFirstDecl();
+  if (!FirstTU) {
+    return;
+  }
+
   if (StoredDeclsMap *Map = FirstTU->getPrimaryContext()->getLookupPtr()) {
     for (auto I = Map->begin(); I != Map->end(); ++I) {
       StoredDeclsList &List = I->second;

--- a/clang/test/Interpreter/anonymous-scope-fail.cpp
+++ b/clang/test/Interpreter/anonymous-scope-fail.cpp
@@ -1,0 +1,10 @@
+// RUN: clang-repl "int x = 10;" "{ int t; a::b(t); }" "int y = 10;"
+// REQUIRES: host-supports-jit
+// UNSUPPORTED: system-aix
+// RUN: cat %s | not clang-repl | FileCheck %s
+{ int t; a::b(t); }
+extern "C" int printf(const char *, ...);
+int i = 42;
+auto r1 = printf("i = %d\n", i);
+// CHECK: i = 42
+%quit


### PR DESCRIPTION
Check if the last translation unit or its first declaration are actually empty and do not nead cleanup.

Previously this caused segmentation fault on empty PTUs.

Add a regression test.

Fixes: #72980