### PR TITLE
[llvm-objcopy] Fix gap-fill/pad-to tests

### DIFF
--- a/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
@@ -24,65 +24,65 @@
 ## Test no gap fill with all allocatable output sections.
 # RUN: llvm-objcopy -O binary %t %t-default
 # RUN: od -v -Ax -t x1 %t-default | FileCheck %s --check-prefix=DEFAULT --match-full-lines
-# DEFAULT:      000000 ee ff 11 22 33 44 aa bb cc dd fe dc ba 00 a1 b2
-# DEFAULT-NEXT: 000010 c3 d4 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000020 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000030 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000040 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000050 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000060 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000070 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000080 00 00 89 ab cd ef
-# DEFAULT-NEXT: 000086
+# DEFAULT:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba 00 a1 b2
+# DEFAULT-NEXT: {{0*}}10 c3 d4 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}50 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}70 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}80 00 00 89 ab cd ef
+# DEFAULT-NEXT: {{0*}}86
 
 ## Test gap fill with all allocatable output sections.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 %t %t-filled
 # RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=FULL --match-full-lines
-# FULL:      000000 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
-# FULL-NEXT: 000010 c3 d4 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000020 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000030 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000040 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000050 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000060 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000070 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FULL-NEXT: 000080 e9 e9 89 ab cd ef
-# FULL-NEXT: 000086
+# FULL:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
+# FULL-NEXT: {{0*}}10 c3 d4 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}20 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}30 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}40 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}50 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}60 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}70 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FULL-NEXT: {{0*}}80 e9 e9 89 ab cd ef
+# FULL-NEXT: {{0*}}86
 
 ## Test gap fill with a decimal value.
 # RUN: llvm-objcopy -O binary --gap-fill=99 %t %t-filled-decimal
 # RUN: od -v -Ax -t x1 %t-filled-decimal | FileCheck %s --check-prefix=DEC --match-full-lines
-# DEC:      000000 ee ff 11 22 33 44 aa bb cc dd fe dc ba 63 a1 b2
-# DEC-NEXT: 000010 c3 d4 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000020 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000030 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000040 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000050 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000060 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000070 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
-# DEC-NEXT: 000080 63 63 89 ab cd ef
-# DEC-NEXT: 000086
+# DEC:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba 63 a1 b2
+# DEC-NEXT: {{0*}}10 c3 d4 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}20 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}30 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}40 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}50 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}60 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}70 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
+# DEC-NEXT: {{0*}}80 63 63 89 ab cd ef
+# DEC-NEXT: {{0*}}86
 
 ## Test gap fill with the last section removed, should be truncated.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 --remove-section=.foo %t %t-filled
 # RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-LAST-SECTION --match-full-lines
-# REMOVE-LAST-SECTION: 000000 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
-# REMOVE-LAST-SECTION-NEXT: 000010 c3 d4
-# REMOVE-LAST-SECTION-NEXT: 000012
+# REMOVE-LAST-SECTION: {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
+# REMOVE-LAST-SECTION-NEXT: {{0*}}10 c3 d4
+# REMOVE-LAST-SECTION-NEXT: {{0*}}12
 
 ## Test gap fill with the middle section removed, should be filled.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 --remove-section=.gap2 %t %t-filled
 # RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-MIDDLE-SECTION --match-full-lines
-# REMOVE-MIDDLE-SECTION:      000000 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000010 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000020 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000030 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000040 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000050 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000060 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000070 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-MIDDLE-SECTION-NEXT: 000080 e9 e9 89 ab cd ef
-# REMOVE-MIDDLE-SECTION-NEXT: 000086
+# REMOVE-MIDDLE-SECTION:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}10 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}20 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}30 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}40 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}50 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}60 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}70 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}80 e9 e9 89 ab cd ef
+# REMOVE-MIDDLE-SECTION-NEXT: {{0*}}86
 
 --- !ELF
 FileHeader:
@@ -150,7 +150,7 @@ Sections:
 # RUN: yaml2obj --docnum=2 %s -o %t.2
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 %t.2 %t.2.filled
 # RUN: od -v -Ax -t x1 %t.2.filled | FileCheck --match-full-lines %s
-# CHECK: 000000 aa bb cc dd e9 e9 e9 e9 11 22 33 44
+# CHECK: {{0*}}00 aa bb cc dd e9 e9 e9 e9 11 22 33 44
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
@@ -23,7 +23,7 @@
 
 ## Test no gap fill with all allocatable output sections.
 # RUN: llvm-objcopy -O binary %t %t-default
-# RUN: od -v -Ax -t x1 %t-default | FileCheck %s --check-prefix=DEFAULT --match-full-lines
+# RUN: od -v -Ax -t x1 %t-default | FileCheck %s --check-prefix=DEFAULT --ignore-case --match-full-lines
 # DEFAULT:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba 00 a1 b2
 # DEFAULT-NEXT: {{0*}}10 c3 d4 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 # DEFAULT-NEXT: {{0*}}20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -37,7 +37,7 @@
 
 ## Test gap fill with all allocatable output sections.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 %t %t-filled
-# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=FULL --match-full-lines
+# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=FULL --ignore-case --match-full-lines
 # FULL:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
 # FULL-NEXT: {{0*}}10 c3 d4 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
 # FULL-NEXT: {{0*}}20 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
@@ -51,7 +51,7 @@
 
 ## Test gap fill with a decimal value.
 # RUN: llvm-objcopy -O binary --gap-fill=99 %t %t-filled-decimal
-# RUN: od -v -Ax -t x1 %t-filled-decimal | FileCheck %s --check-prefix=DEC --match-full-lines
+# RUN: od -v -Ax -t x1 %t-filled-decimal | FileCheck %s --check-prefix=DEC --ignore-case --match-full-lines
 # DEC:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba 63 a1 b2
 # DEC-NEXT: {{0*}}10 c3 d4 63 63 63 63 63 63 63 63 63 63 63 63 63 63
 # DEC-NEXT: {{0*}}20 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63 63
@@ -65,14 +65,14 @@
 
 ## Test gap fill with the last section removed, should be truncated.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 --remove-section=.foo %t %t-filled
-# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-LAST-SECTION --match-full-lines
+# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-LAST-SECTION --ignore-case --match-full-lines
 # REMOVE-LAST-SECTION: {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 a1 b2
 # REMOVE-LAST-SECTION-NEXT: {{0*}}10 c3 d4
 # REMOVE-LAST-SECTION-NEXT: {{0*}}12
 
 ## Test gap fill with the middle section removed, should be filled.
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 --remove-section=.gap2 %t %t-filled
-# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-MIDDLE-SECTION --match-full-lines
+# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-MIDDLE-SECTION --ignore-case --match-full-lines
 # REMOVE-MIDDLE-SECTION:      {{0*}}00 ee ff 11 22 33 44 aa bb cc dd fe dc ba e9 e9 e9
 # REMOVE-MIDDLE-SECTION-NEXT: {{0*}}10 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
 # REMOVE-MIDDLE-SECTION-NEXT: {{0*}}20 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
@@ -149,7 +149,7 @@ Sections:
 
 # RUN: yaml2obj --docnum=2 %s -o %t.2
 # RUN: llvm-objcopy -O binary --gap-fill=0xe9 %t.2 %t.2.filled
-# RUN: od -v -Ax -t x1 %t.2.filled | FileCheck --match-full-lines %s
+# RUN: od -v -Ax -t x1 %t.2.filled | FileCheck --ignore-case --match-full-lines %s
 # CHECK: {{0*}}00 aa bb cc dd e9 e9 e9 e9 11 22 33 44
 
 --- !ELF

--- a/llvm/test/tools/llvm-objcopy/ELF/pad-to.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/pad-to.test
@@ -29,28 +29,28 @@
 
 ## Pad all allocatable sections to a valid address.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 %t %t-pad-default
-# RUN: od -v -Ax -t x1 %t-pad-default | FileCheck %s --check-prefix=DEFAULT --match-full-lines
+# RUN: od -v -Ax -t x1 %t-pad-default | FileCheck %s --check-prefix=DEFAULT --ignore-case --match-full-lines
 # DEFAULT:      {{0*}}00 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
 # DEFAULT-NEXT: {{0*}}10 77 88 99 aa 00 00 00 00
 # DEFAULT-NEXT: {{0*}}18
 
 ## Use a decimal number for the padding address and verify it is not misunderstood.
 # RUN: llvm-objcopy -O binary --pad-to=536 %t %t-pad-decimal
-# RUN: od -v -Ax -t x1 %t-pad-decimal | FileCheck %s --check-prefix=DECIMAL --match-full-lines
+# RUN: od -v -Ax -t x1 %t-pad-decimal | FileCheck %s --check-prefix=DECIMAL --ignore-case --match-full-lines
 # DECIMAL:      {{0*}}00 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
 # DECIMAL-NEXT: {{0*}}10 77 88 99 aa 00 00 00 00
 # DECIMAL-NEXT: {{0*}}18
 
 ## Pad all allocatable sections to a valid address, using --gap-fill.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 --gap-fill=0xe9 %t %t-pad-fill
-# RUN: od -v -Ax -t x1 %t-pad-fill | FileCheck %s --check-prefix=FILL --match-full-lines
+# RUN: od -v -Ax -t x1 %t-pad-fill | FileCheck %s --check-prefix=FILL --ignore-case --match-full-lines
 # FILL:      {{0*}}00 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
 # FILL-NEXT: {{0*}}10 77 88 99 aa e9 e9 e9 e9
 # FILL-NEXT: {{0*}}18
 
 ## Remove the last section containing data and test that the padded space is gap filled.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 --gap-fill=0xe9 --remove-section=.section2 %t %t-filled
-# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-SECTION --match-full-lines
+# RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-SECTION --ignore-case --match-full-lines
 # REMOVE-SECTION: {{0*}}00 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
 # REMOVE-SECTION-NEXT: {{0*}}10 e9 e9 e9 e9 e9 e9 e9 e9
 # REMOVE-SECTION-NEXT: {{0*}}18

--- a/llvm/test/tools/llvm-objcopy/ELF/pad-to.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/pad-to.test
@@ -30,30 +30,30 @@
 ## Pad all allocatable sections to a valid address.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 %t %t-pad-default
 # RUN: od -v -Ax -t x1 %t-pad-default | FileCheck %s --check-prefix=DEFAULT --match-full-lines
-# DEFAULT:      000000 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
-# DEFAULT-NEXT: 000010 77 88 99 aa 00 00 00 00
-# DEFAULT-NEXT: 000018
+# DEFAULT:      {{0*}}00 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
+# DEFAULT-NEXT: {{0*}}10 77 88 99 aa 00 00 00 00
+# DEFAULT-NEXT: {{0*}}18
 
 ## Use a decimal number for the padding address and verify it is not misunderstood.
 # RUN: llvm-objcopy -O binary --pad-to=536 %t %t-pad-decimal
 # RUN: od -v -Ax -t x1 %t-pad-decimal | FileCheck %s --check-prefix=DECIMAL --match-full-lines
-# DECIMAL:      000000 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
-# DECIMAL-NEXT: 000010 77 88 99 aa 00 00 00 00
-# DECIMAL-NEXT: 000018
+# DECIMAL:      {{0*}}00 11 22 33 44 55 66 00 00 00 00 00 00 00 00 00 00
+# DECIMAL-NEXT: {{0*}}10 77 88 99 aa 00 00 00 00
+# DECIMAL-NEXT: {{0*}}18
 
 ## Pad all allocatable sections to a valid address, using --gap-fill.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 --gap-fill=0xe9 %t %t-pad-fill
 # RUN: od -v -Ax -t x1 %t-pad-fill | FileCheck %s --check-prefix=FILL --match-full-lines
-# FILL:      000000 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# FILL-NEXT: 000010 77 88 99 aa e9 e9 e9 e9
-# FILL-NEXT: 000018
+# FILL:      {{0*}}00 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# FILL-NEXT: {{0*}}10 77 88 99 aa e9 e9 e9 e9
+# FILL-NEXT: {{0*}}18
 
 ## Remove the last section containing data and test that the padded space is gap filled.
 # RUN: llvm-objcopy -O binary --pad-to=0x218 --gap-fill=0xe9 --remove-section=.section2 %t %t-filled
 # RUN: od -v -Ax -t x1 %t-filled | FileCheck %s --check-prefix=REMOVE-SECTION --match-full-lines
-# REMOVE-SECTION: 000000 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-SECTION-NEXT: 000010 e9 e9 e9 e9 e9 e9 e9 e9
-# REMOVE-SECTION-NEXT: 000018
+# REMOVE-SECTION: {{0*}}00 11 22 33 44 55 66 e9 e9 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-SECTION-NEXT: {{0*}}10 e9 e9 e9 e9 e9 e9 e9 e9
+# REMOVE-SECTION-NEXT: {{0*}}18
 
 --- !ELF
 FileHeader:


### PR DESCRIPTION
The tests added in PR #65815 fail on Apple buildbot because the `od` printed addresses have a different number of leading zeroes. Mask leading zeroes with a regex.