### PR TITLE
[SystemZ][z/OS] Add guard for dl_info and dladdr

### DIFF
--- a/clang/tools/libclang/CIndexer.cpp
+++ b/clang/tools/libclang/CIndexer.cpp
@@ -126,18 +126,18 @@ const std::string &CIndexer::getClangResourcesPath() {
 #elif defined(_AIX)
   getClangResourcesPathImplAIX(LibClangPath);
 #else
-  bool pathFound = false;
+  bool PathFound = false;
 #if defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR)
   Dl_info info;
   // This silly cast below avoids a C++ warning.
   if (dladdr((void *)(uintptr_t)clang_createTranslationUnit, &info) != 0) {
     // We now have the CIndex directory, locate clang relative to it.
     LibClangPath += info.dli_fname;
-    pathFound = true;
+    PathFound = true;
   }
 #endif
   std::string Path;
-  if (!pathFound) {
+  if (!PathFound) {
     if (!(Path = llvm::sys::fs::getMainExecutable(nullptr, nullptr)).empty()) {
       // If we can't get the path using dladdr, try to get the main executable
       // path. This may be needed when we're statically linking libclang with

--- a/clang/tools/libclang/CIndexer.cpp
+++ b/clang/tools/libclang/CIndexer.cpp
@@ -17,6 +17,7 @@
 #include "clang/Driver/Driver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/Path.h"
@@ -125,21 +126,28 @@ const std::string &CIndexer::getClangResourcesPath() {
 #elif defined(_AIX)
   getClangResourcesPathImplAIX(LibClangPath);
 #else
+  bool pathFound = false;
+#if defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR)
   Dl_info info;
-  std::string Path;
   // This silly cast below avoids a C++ warning.
   if (dladdr((void *)(uintptr_t)clang_createTranslationUnit, &info) != 0) {
     // We now have the CIndex directory, locate clang relative to it.
     LibClangPath += info.dli_fname;
-  } else if (!(Path = llvm::sys::fs::getMainExecutable(nullptr, nullptr)).empty()) {
-    // If we can't get the path using dladdr, try to get the main executable
-    // path. This may be needed when we're statically linking libclang with
-    // musl libc, for example.
-    LibClangPath += Path;
-  } else {
-    // It's rather unlikely we end up here. But it could happen, so report an
-    // error instead of crashing.
-    llvm::report_fatal_error("could not locate Clang resource path");
+    pathFound = true;
+  }
+#endif
+  std::string Path;
+  if (!pathFound) {
+    if (!(Path = llvm::sys::fs::getMainExecutable(nullptr, nullptr)).empty()) {
+      // If we can't get the path using dladdr, try to get the main executable
+      // path. This may be needed when we're statically linking libclang with
+      // musl libc, for example.
+      LibClangPath += Path;
+    } else {
+      // It's rather unlikely we end up here. But it could happen, so report an
+      // error instead of crashing.
+      llvm::report_fatal_error("could not locate Clang resource path");
+    }
   }
 
 #endif


### PR DESCRIPTION
This patch fixes the following build error on z/OS `error: unknown type name 'Dl_info'` by adding a guard to check if we have dladdr.