### PR TITLE
[libunwind] Use -nostdlib++ when linking libunwind

### DIFF
--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -66,20 +66,21 @@ set(LIBUNWIND_SOURCES
     ${LIBUNWIND_ASM_SOURCES})
 
 # Generate library list.
-if (LIBUNWIND_USE_COMPILER_RT)
-  add_library_flags("${LIBUNWIND_BUILTINS_LIBRARY}")
+if (CXX_SUPPORTS_NOSTDLIBXX_FLAG)
+  add_link_flags_if_supported(-nostdlib++)
 else()
-  add_library_flags_if(LIBUNWIND_HAS_GCC_S_LIB gcc_s)
-  add_library_flags_if(LIBUNWIND_HAS_GCC_LIB gcc)
-endif()
-if (NOT APPLE) # On Apple platforms, we don't need to link explicitly against system libraries
+  if (LIBUNWIND_USE_COMPILER_RT)
+    add_library_flags("${LIBUNWIND_BUILTINS_LIBRARY}")
+  else()
+    add_library_flags_if(LIBUNWIND_HAS_GCC_S_LIB gcc_s)
+    add_library_flags_if(LIBUNWIND_HAS_GCC_LIB gcc)
+  endif()
   add_library_flags_if(LIBUNWIND_HAS_C_LIB c)
   add_library_flags_if(LIBUNWIND_HAS_DL_LIB dl)
+endif()
 
-  if (LIBUNWIND_ENABLE_THREADS)
+if (LIBUNWIND_ENABLE_THREADS AND NOT APPLE)
     add_library_flags_if(LIBUNWIND_HAS_PTHREAD_LIB pthread)
-    add_compile_flags_if(LIBUNWIND_WEAK_PTHREAD_LIB -DLIBUNWIND_USE_WEAK_PTHREAD=1)
-  endif()
 endif()
 
 if (LIBUNWIND_ENABLE_THREADS)

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -76,6 +76,9 @@ else()
     add_library_flags_if(LIBUNWIND_HAS_GCC_LIB gcc)
   endif()
   add_library_flags_if(LIBUNWIND_HAS_C_LIB c)
+endif()
+
+if (NOT APPLE)
   add_library_flags_if(LIBUNWIND_HAS_DL_LIB dl)
 endif()
 


### PR DESCRIPTION
We shouldn't need to link against libc++ or libc++abi when building libunwind, since that would otherwise be a circular dependency.