### PR TITLE
[mlir][Transform] Fix crash with invalid ir for transform libraries

### DIFF
--- a/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
+++ b/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
@@ -109,6 +109,12 @@ LogicalResult transform::detail::parseTransformModuleFromFile(
   sourceMgr.AddNewSourceBuffer(std::move(memoryBuffer), llvm::SMLoc());
   transformModule =
       OwningOpRef<ModuleOp>(parseSourceFile<ModuleOp>(sourceMgr, context));
+  if (!transformModule) {
+    // Failed to parse the transform module.
+    // Don't need to emit an error here as the parsing should have already done
+    // that.
+    return failure();
+  }
   return mlir::verify(*transformModule);
 }
 

--- a/mlir/test/Dialect/Transform/include/test-interpreter-invalid.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-opt %s --verify-diagnostics
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence private @private_helper(%arg0: !transform.any_op {transform.readonly}) {
+    // expected-error @below {{expected ','}}
+    transform.test_print_remark_at_operand %arg0 "message" : !transform.any_op
+  }
+}

--- a/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
@@ -1,5 +1,8 @@
 // RUN: mlir-opt %s --verify-diagnostics
 
+// The only thing we check here is that it should fail to parse. The other
+// check is in the preload test.
+
 module attributes {transform.with_named_sequence} {
   transform.named_sequence private @private_helper(%arg0: !transform.any_op {transform.readonly}) {
     // expected-error @below {{expected ','}}

--- a/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
@@ -6,6 +6,6 @@
 module attributes {transform.with_named_sequence} {
   transform.named_sequence private @private_helper(%arg0: !transform.any_op {transform.readonly}) {
     // expected-error @below {{expected ','}}
-    transform.test_print_remark_at_operand %arg0 "message" : !transform.any_op
+    transform.test_print_remark_at_operand %arg0 "should have ',' prior to this" : !transform.any_op
   }
 }

--- a/mlir/test/Dialect/Transform/preload-library-invalid.mlir
+++ b/mlir/test/Dialect/Transform/preload-library-invalid.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-opt %s \
+// RUN:   -transform-preload-library=transform-library-paths=%p%{fs-sep}include%{fs-sep}test-interpreter-library-invalid \
+// RUN:   -transform-interpreter=entry-point=private_helper \
+// RUN:   -verify-diagnostics
+
+// This test checks if the preload mechanism fails gracefully when passed an
+// invalid transform file.


### PR DESCRIPTION
This patch fixes a crash caused when the transform library interpreter is given an IR that fails to parse.