### PR TITLE
[X86] Don't use rip-relative lea to get a function address in medium static mode

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -18329,13 +18329,6 @@ unsigned X86TargetLowering::getGlobalWrapperKind(
        OpFlags == X86II::MO_DLLIMPORT))
     return X86ISD::WrapperRIP;
 
-  // In the medium model, functions can always be referenced RIP-relatively,
-  // since they must be within 2GiB. This is also possible in non-PIC mode, and
-  // shorter than the 64-bit absolute immediate that would otherwise be emitted.
-  if (getTargetMachine().getCodeModel() == CodeModel::Medium &&
-      isa_and_nonnull<Function>(GV))
-    return X86ISD::WrapperRIP;
-
   // GOTPCREL references must always use RIP.
   if (OpFlags == X86II::MO_GOTPCREL || OpFlags == X86II::MO_GOTPCREL_NORELAX)
     return X86ISD::WrapperRIP;

--- a/llvm/test/CodeGen/X86/code-model-elf.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf.ll
@@ -829,7 +829,7 @@ define dso_local ptr @lea_static_fn() #0 {
 ;
 ; MEDIUM-STATIC-LABEL: lea_static_fn:
 ; MEDIUM-STATIC:       # %bb.0:
-; MEDIUM-STATIC-NEXT:    leaq static_fn(%rip), %rax
+; MEDIUM-STATIC-NEXT:    movl $static_fn, %eax
 ; MEDIUM-STATIC-NEXT:    retq
 ;
 ; LARGE-STATIC-LABEL: lea_static_fn:
@@ -882,7 +882,7 @@ define dso_local ptr @lea_global_fn() #0 {
 ;
 ; MEDIUM-STATIC-LABEL: lea_global_fn:
 ; MEDIUM-STATIC:       # %bb.0:
-; MEDIUM-STATIC-NEXT:    leaq global_fn(%rip), %rax
+; MEDIUM-STATIC-NEXT:    movl $global_fn, %eax
 ; MEDIUM-STATIC-NEXT:    retq
 ;
 ; LARGE-STATIC-LABEL: lea_global_fn:


### PR DESCRIPTION
This essentially reverts https://reviews.llvm.org/D140593. Somewhere
along the line we properly fixed the medium code model to assume
functions are small, so now we get a 32-bit movl as desired.
