### PR TITLE
[sanitizer] Disable InstallAtForkHandler on Solaris, NetBSD

### DIFF
--- a/compiler-rt/lib/asan/asan_posix.cpp
+++ b/compiler-rt/lib/asan/asan_posix.cpp
@@ -149,6 +149,9 @@ void PlatformTSDDtor(void *tsd) {
 #endif
 
 void InstallAtForkHandler() {
+#  if SANITIZER_SOLARIS || SANITIZER_NETBSD
+  return;  // FIXME: Implement FutexWait.
+#  endif
   auto before = []() {
     if (CAN_SANITIZE_LEAKS) {
       __lsan::LockGlobal();

--- a/compiler-rt/lib/lsan/lsan_posix.cpp
+++ b/compiler-rt/lib/lsan/lsan_posix.cpp
@@ -101,6 +101,9 @@ void InstallAtExitCheckLeaks() {
 }
 
 void InstallAtForkHandler() {
+#  if SANITIZER_SOLARIS || SANITIZER_NETBSD
+  return;  // FIXME: Implement FutexWait.
+#  endif
   auto before = []() {
     LockGlobal();
     LockThreads();

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/fork_threaded.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/fork_threaded.c
@@ -12,6 +12,10 @@
 // FIXME: False stack overflow report
 // UNSUPPORTED: android && asan
 
+// FIXME: Requires `FutexWait` implementation. See __asan::InstallAtForkHandler.
+// UNSUPPORTED: target={{.*solaris.*}}
+// UNSUPPORTED: target={{.*netbsd.*}}
+
 // Forking in multithread environment is unsupported. However we already have
 // some workarounds, and will add more, so this is the test.
 // The test try to check two things:


### PR DESCRIPTION
Handlers need missing FutexWait implementation.

Reported in #75290.
