### PR TITLE
[-Wunsafe-buffer-usage] Add a subgroup `-Wunsafe-buffer-usage-in-container`

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1488,4 +1488,5 @@ def DXILValidation : DiagGroup<"dxil-validation">;
 def ReadOnlyPlacementChecks : DiagGroup<"read-only-types">;
 
 // Warnings and fixes to support the "safe buffers" programming model.
-def UnsafeBufferUsage : DiagGroup<"unsafe-buffer-usage">;
+def UnsafeBufferUsageInContainer : DiagGroup<"unsafe-buffer-usage-in-container">;
+def UnsafeBufferUsage : DiagGroup<"unsafe-buffer-usage", [UnsafeBufferUsageInContainer]>;


### PR DESCRIPTION
Add a sub diagnostic group under `-Wunsafe-buffer-usage` controlled by `-Wunsafe-buffer-usage-in-container`.  The subgroup will include warnings on misuses of `std::span`, `std::vector`, and `std::array`.