### PR TITLE
[clangd] Make sure ninja can clean "ClangdXPC.framework"

### DIFF
--- a/clang-tools-extra/clangd/xpc/cmake/modules/CreateClangdXPCFramework.cmake
+++ b/clang-tools-extra/clangd/xpc/cmake/modules/CreateClangdXPCFramework.cmake
@@ -71,6 +71,12 @@ macro(create_clangd_xpc_framework target name)
     ${CLANGD_FRAMEWORK_LOCATION}
   )
 
+  set_property(
+    TARGET ClangdXPC
+    APPEND
+    PROPERTY ADDITIONAL_CLEAN_FILES ${CLANGD_FRAMEWORK_LOCATION}
+  )
+
   # clangd is already signed as a standalone executable, so it must be forced.
   llvm_codesign(ClangdXPC BUNDLE_PATH "${CLANGD_FRAMEWORK_OUT_LOCATION}/XPCServices/${CLANGD_XPC_SERVICE_NAME}.xpc/" FORCE)
   # ClangdXPC library is already signed as a standalone library, so it must be forced.


### PR DESCRIPTION
After building the ClangdXPC target, `ninja clean` fails with the following error:

```
ninja: error: remove(lib/ClangdXPC.framework): Directory not empty
ninja: error: remove(<build>/lib/ClangdXPC.framework): Directory not empty
```

I did not find better way to make this work. I guess we could list all generated files (and directories) in `OUTPUT` of the custom command, but that seems fairly tedious/fragile.