### PR TITLE
[CodeGen] Emit a more accurate alignment for non-temporal loads/stores

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -232,19 +232,19 @@ static Value *MakeBinaryAtomicValue(
 
 static Value *EmitNontemporalStore(CodeGenFunction &CGF, const CallExpr *E) {
   Value *Val = CGF.EmitScalarExpr(E->getArg(0));
-  Value *Address = CGF.EmitScalarExpr(E->getArg(1));
+  Address Addr = CGF.EmitPointerWithAlignment(E->getArg(1));
 
   Val = CGF.EmitToMemory(Val, E->getArg(0)->getType());
-  LValue LV = CGF.MakeNaturalAlignAddrLValue(Address, E->getArg(0)->getType());
+  LValue LV = CGF.MakeAddrLValue(Addr, E->getArg(0)->getType());
   LV.setNontemporal(true);
   CGF.EmitStoreOfScalar(Val, LV, false);
   return nullptr;
 }
 
 static Value *EmitNontemporalLoad(CodeGenFunction &CGF, const CallExpr *E) {
-  Value *Address = CGF.EmitScalarExpr(E->getArg(0));
+  Address Addr = CGF.EmitPointerWithAlignment(E->getArg(0));
 
-  LValue LV = CGF.MakeNaturalAlignAddrLValue(Address, E->getType());
+  LValue LV = CGF.MakeAddrLValue(Addr, E->getType());
   LV.setNontemporal(true);
   return CGF.EmitLoadOfScalar(LV, E->getExprLoc());
 }

--- a/clang/test/CodeGen/Nontemporal.cpp
+++ b/clang/test/CodeGen/Nontemporal.cpp
@@ -46,3 +46,17 @@ void test_all_sizes(void)                 // CHECK-LABEL: test_all_sizes
   vf2 = __builtin_nontemporal_load(&vf1); // CHECK: load <4 x float>{{.*}}align 16, !nontemporal
   vc2 = __builtin_nontemporal_load(&vc1); // CHECK: load <8 x i8>{{.*}}align 8, !nontemporal
 }
+
+struct S { char c[16]; };
+S x;
+
+typedef int v4si __attribute__ ((vector_size(16)));
+
+// CHECK-LABEL: define void @_Z14test_alignmentv()
+// CHECK: load <4 x i32>, ptr @x, align 1, !nontemporal
+// CHECK: store <4 x i32> %1, ptr @x, align 1, !nontemporal
+
+void test_alignment() {
+ auto t =  __builtin_nontemporal_load((v4si*)x.c);
+ __builtin_nontemporal_store(t, (v4si*)x.c);
+}


### PR DESCRIPTION
Call EmitPointerWithAlignment to compute the alignment based on the underlying lvalue's alignment when it's available.