### PR TITLE
[CommandLine] Add subcommand groups

### DIFF
--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -243,6 +243,15 @@ extern ManagedStatic<SubCommand> TopLevelSubCommand;
 // A special subcommand that can be used to put an option into all subcommands.
 extern ManagedStatic<SubCommand> AllSubCommands;
 
+class SubCommandGroup {
+  SmallVector<SubCommand *, 4> Subs;
+
+public:
+  SubCommandGroup(std::initializer_list<SubCommand *> IL) : Subs(IL) {}
+
+  ArrayRef<SubCommand *> getSubCommands() const { return Subs; }
+};
+
 //===----------------------------------------------------------------------===//
 //
 class Option {
@@ -477,11 +486,19 @@ struct cat {
 
 // Specify the subcommand that this option belongs to.
 struct sub {
-  SubCommand &Sub;
+  SubCommand *Sub = nullptr;
+  SubCommandGroup *Group = nullptr;
 
-  sub(SubCommand &S) : Sub(S) {}
+  sub(SubCommand &S) : Sub(&S) {}
+  sub(SubCommandGroup &G) : Group(&G) {}
 
-  template <class Opt> void apply(Opt &O) const { O.addSubCommand(Sub); }
+  template <class Opt> void apply(Opt &O) const {
+    if (Sub)
+      O.addSubCommand(*Sub);
+    else if (Group)
+      for (SubCommand *SC : Group->getSubCommands())
+        O.addSubCommand(*SC);
+  }
 };
 
 // Specify a callback function to be called when an option is seen.

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -2274,4 +2274,67 @@ TEST(CommandLineTest, UnknownCommands) {
   EXPECT_EQ(Errs, "prog: Unknown subcommand 'faz'.  Try: 'prog --help'\n");
 }
 
+TEST(CommandLineTest, SubCommandGroups) {
+  cl::ResetCommandLineParser();
+
+  StackSubCommand SC1("sc1", "SC1 subcommand");
+  StackSubCommand SC2("sc2", "SC2 subcommand");
+  StackSubCommand SC3("sc3", "SC3 subcommand");
+  cl::SubCommandGroup Group12 = {&SC1, &SC2};
+  cl::SubCommandGroup Group23 = {&SC2, &SC3};
+
+  StackOption<bool> Opt1("opt1", cl::sub(SC1), cl::init(false));
+  StackOption<bool> Opt2("opt2", cl::sub(SC2), cl::init(false));
+  StackOption<bool> Opt3("opt3", cl::sub(SC3), cl::init(false));
+  StackOption<bool> Opt12("opt12", cl::sub(Group12), cl::init(false));
+  StackOption<bool> Opt23("opt23", cl::sub(Group23), cl::init(false));
+
+  EXPECT_EQ(2, SC1.OptionsMap.size());
+  EXPECT_TRUE(SC1.OptionsMap.contains("opt1"));
+  EXPECT_TRUE(SC1.OptionsMap.contains("opt12"));
+
+  EXPECT_EQ(3, SC2.OptionsMap.size());
+  EXPECT_TRUE(SC2.OptionsMap.contains("opt2"));
+  EXPECT_TRUE(SC2.OptionsMap.contains("opt12"));
+  EXPECT_TRUE(SC2.OptionsMap.contains("opt23"));
+
+  EXPECT_EQ(2, SC3.OptionsMap.size());
+  EXPECT_TRUE(SC3.OptionsMap.contains("opt3"));
+  EXPECT_TRUE(SC3.OptionsMap.contains("opt23"));
+
+  const char *Args1[] = {"prog", "--opt1"};
+  EXPECT_FALSE(cl::ParseCommandLineOptions(std::size(Args1), Args1, StringRef(),
+                                           &llvm::nulls()));
+
+  cl::ResetAllOptionOccurrences();
+
+  const char *Args2[] = {"prog", "sc2", "--opt2"};
+  EXPECT_TRUE(cl::ParseCommandLineOptions(std::size(Args2), Args2, StringRef(),
+                                          &llvm::nulls()));
+  EXPECT_FALSE(SC1);
+  EXPECT_TRUE(SC2);
+  EXPECT_FALSE(SC3);
+
+  EXPECT_FALSE(Opt1);
+  EXPECT_TRUE(Opt2);
+  EXPECT_FALSE(Opt3);
+  EXPECT_FALSE(Opt12);
+  EXPECT_FALSE(Opt23);
+
+  cl::ResetAllOptionOccurrences();
+
+  const char *Args3[] = {"prog", "sc3", "--opt23"};
+  EXPECT_TRUE(cl::ParseCommandLineOptions(std::size(Args3), Args3, StringRef(),
+                                          &llvm::nulls()));
+  EXPECT_FALSE(SC1);
+  EXPECT_FALSE(SC2);
+  EXPECT_TRUE(SC3);
+
+  EXPECT_FALSE(Opt1);
+  EXPECT_FALSE(Opt2);
+  EXPECT_FALSE(Opt3);
+  EXPECT_FALSE(Opt12);
+  EXPECT_TRUE(Opt23);
+}
+
 } // anonymous namespace


### PR DESCRIPTION
The patch introduces a `SubCommandGroup` class which represents a list of subcommands. An option can be added to all these subcommands using one `cl::sub(group)` command. This simplifies the declaration of options that are shared across multiple subcommands of a tool.