### PR TITLE
[libc++] Fix the handling of `views::take` for `iota_view`

### DIFF
--- a/libcxx/include/__ranges/take_view.h
+++ b/libcxx/include/__ranges/take_view.h
@@ -282,15 +282,16 @@ struct __fn {
             class _Dist     = range_difference_t<_Range>>
     requires(!__is_empty_view<_RawRange> && random_access_range<_RawRange> && sized_range<_RawRange> &&
              __is_iota_specialization<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
-  operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(ranges::iota_view(
-      *ranges::begin(__rng), *ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))))
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(
+      ranges::iota_view(*ranges::begin(__rng),
+                        *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))))
       -> decltype(ranges::iota_view(
           // Note: deliberately not forwarding `__rng` to guard against double moves.
           *ranges::begin(__rng),
-          *ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))) {
-    return ranges::iota_view(*ranges::begin(__rng),
-                             *ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)));
+          *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))) {
+    return ranges::iota_view(
+        *ranges::begin(__rng),
+        *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))));
   }
   // clang-format off
 #if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/__ranges/take_view.h
+++ b/libcxx/include/__ranges/take_view.h
@@ -276,24 +276,31 @@ struct __fn {
   }
 
   // [range.take.overview]: the `iota_view` case.
+  // clang-format off
   template <class _Range,
             convertible_to<range_difference_t<_Range>> _Np,
             class _RawRange = remove_cvref_t<_Range>,
             class _Dist     = range_difference_t<_Range>>
-    requires(!__is_empty_view<_RawRange> && random_access_range<_RawRange> && sized_range<_RawRange> &&
-             __is_iota_specialization<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(
-      ranges::iota_view(*ranges::begin(__rng),
-                        *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))))
-      -> decltype(ranges::iota_view(
-          // Note: deliberately not forwarding `__rng` to guard against double moves.
-          *ranges::begin(__rng),
-          *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))) {
-    return ranges::iota_view(
-        *ranges::begin(__rng),
-        *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))));
-  }
-  // clang-format off
+    requires (!__is_empty_view<_RawRange> &&
+              random_access_range<_RawRange> &&
+              sized_range<_RawRange> &&
+              __is_iota_specialization<_RawRange>)
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI
+  constexpr auto operator()(_Range&& __rng, _Np&& __n) const
+    noexcept(noexcept(ranges::iota_view(
+                              *ranges::begin(__rng),
+                              *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))
+                              )))
+    -> decltype(      ranges::iota_view(
+                              // Note: deliberately not forwarding `__rng` to guard against double moves.
+                              *ranges::begin(__rng),
+                              *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))
+                              ))
+    { return          ranges::iota_view(
+                              *ranges::begin(__rng),
+                              *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))
+                              ); }
+
 #if _LIBCPP_STD_VER >= 23
   // [range.take.overview]: the `repeat_view` "_RawRange models sized_range" case.
   template <class _Range,

--- a/libcxx/test/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
@@ -172,9 +172,8 @@ constexpr bool test() {
   // `views::take(iota_view, n)` returns an `iota_view`.
   {
     auto iota = std::views::iota(1, 8);
-    // The second template argument of the resulting `iota_view` is different because it has to be able to hold
-    // the `range_difference_t` of the input `iota_view`.
-    using Result = std::ranges::iota_view<int, std::ranges::range_difference_t<decltype(iota)>>;
+    // The second template argument of the resulting `iota_view` is same as the first.
+    using Result = std::ranges::iota_view<int, int>;
     std::same_as<Result> decltype(auto) result = iota | std::views::take(3);
     assert(result.size() == 3);
   }

--- a/libcxx/test/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
@@ -173,7 +173,7 @@ constexpr bool test() {
   {
     auto iota = std::views::iota(1, 8);
     // The second template argument of the resulting `iota_view` is same as the first.
-    using Result = std::ranges::iota_view<int, int>;
+    using Result                               = std::ranges::iota_view<int, int>;
     std::same_as<Result> decltype(auto) result = iota | std::views::take(3);
     assert(result.size() == 3);
   }


### PR DESCRIPTION
Currently, when libc++'s views::take specially handles an iota_view, the
addition is done after dereferencing the beginning iterator. However, in 
[range.take.overview]/2.3, the addition is done before the dereferencing, 
which means that the standard requires the returned iota_view to have the 
same W and Bound type in such cases.

This patch fixes that, and also fixes a test that was testing the 
incorrect behavior.

Fixes #75611