### PR TITLE
[MC][x86] Allow non-MCTargetExpr RHS when the LHS of a MCBinaryExpr is MCTargetExpr

### DIFF
--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -942,16 +942,17 @@ bool MCExpr::evaluateAsRelocatableImpl(MCValue &Res, const MCAssembler *Asm,
                                                   Addrs, InSet)) {
       // Check if both are Target Expressions, see if we can compare them.
       if (const MCTargetExpr *L = dyn_cast<MCTargetExpr>(ABE->getLHS())) {
-        const MCTargetExpr *R = cast<MCTargetExpr>(ABE->getRHS());
-        switch (ABE->getOpcode()) {
-        case MCBinaryExpr::EQ:
-          Res = MCValue::get(L->isEqualTo(R) ? -1 : 0);
-          return true;
-        case MCBinaryExpr::NE:
-          Res = MCValue::get(L->isEqualTo(R) ? 0 : -1);
-          return true;
-        default:
-          break;
+        if (const MCTargetExpr *R = dyn_cast<MCTargetExpr>(ABE->getRHS())) {
+          switch (ABE->getOpcode()) {
+          case MCBinaryExpr::EQ:
+            Res = MCValue::get(L->isEqualTo(R) ? -1 : 0);
+            return true;
+          case MCBinaryExpr::NE:
+            Res = MCValue::get(L->isEqualTo(R) ? 0 : -1);
+            return true;
+          default:
+            break;
+          }
         }
       }
       return false;

--- a/llvm/test/MC/X86/register-assignment-error.s
+++ b/llvm/test/MC/X86/register-assignment-error.s
@@ -1,0 +1,8 @@
+// RUN: not llvm-mc -triple x86_64 %s -o /dev/null 2>&1 | FileCheck %s
+
+var_xdata = %rcx
+
+// This used to crash.
+.if var_xdata == 1
+.endif
+// CHECK: error: expected absolute expression


### PR DESCRIPTION
This fixes #73109.
In instruction `addl %eax %rax`, because there is a missing comma in the middle of two registers, the asm parser will treat it as a binary expression.
```
%rax  %  rax --> register mod identifier
```
However, In `MCExpr::evaluateAsRelocatableImpl`, it only checks the left side of the expression. This patch ensures the right side will also be checked.