### PR TITLE
[llvm-link] Add the `--ignore-if-conflict` option

### DIFF
--- a/llvm/docs/CommandGuide/llvm-link.rst
+++ b/llvm/docs/CommandGuide/llvm-link.rst
@@ -57,6 +57,14 @@ OPTIONS
   a symbol is declared more than twice, the definition from the file declared
   last takes precedence.
 
+.. option:: --ignore-if-conflict <filename>
+
+  Adds the passed-in file to the link and ignores symbols that have already
+  been declared with the definitions in the file that is passed in. This flag
+  can be specified multiple times to have multiple files act as ignores. If
+  a symbol is declared more than twice, the definition from the file declared
+  first takes precedence.
+
 .. option:: --import <function:filename>
 
   Specify a function that should be imported from the specified file for

--- a/llvm/include/llvm/Linker/Linker.h
+++ b/llvm/include/llvm/Linker/Linker.h
@@ -27,6 +27,7 @@ public:
     None = 0,
     OverrideFromSrc = (1 << 0),
     LinkOnlyNeeded = (1 << 1),
+    IgnoreFromSrcIfConflict = (1 << 2),
   };
 
   Linker(Module &M);

--- a/llvm/lib/Linker/LinkModules.cpp
+++ b/llvm/lib/Linker/LinkModules.cpp
@@ -52,6 +52,9 @@ class ModuleLinker {
 
   bool shouldOverrideFromSrc() { return Flags & Linker::OverrideFromSrc; }
   bool shouldLinkOnlyNeeded() { return Flags & Linker::LinkOnlyNeeded; }
+  bool shouldIgnoreFromSrcIfConflict() {
+    return Flags & Linker::IgnoreFromSrcIfConflict;
+  }
 
   bool shouldLinkFromSource(bool &LinkFromSrc, const GlobalValue &Dest,
                             const GlobalValue &Src);
@@ -314,6 +317,11 @@ bool ModuleLinker::shouldLinkFromSource(bool &LinkFromSrc,
   if (Dest.isWeakForLinker()) {
     assert(Src.hasExternalLinkage());
     LinkFromSrc = true;
+    return false;
+  }
+
+  if (shouldIgnoreFromSrcIfConflict()) {
+    LinkFromSrc = false;
     return false;
   }
 

--- a/llvm/test/tools/llvm-link/Inputs/f_1.ll
+++ b/llvm/test/tools/llvm-link/Inputs/f_1.ll
@@ -1,0 +1,9 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @f() {
+entry:
+  call void @f_1();
+  ret void
+}
+
+declare void @f_1();

--- a/llvm/test/tools/llvm-link/ignore.test
+++ b/llvm/test/tools/llvm-link/ignore.test
@@ -1,0 +1,8 @@
+# RUN: not llvm-link %S/Inputs/f.ll %S/Inputs/f_1.ll 2>&1 | FileCheck %s
+# RUN: llvm-link %S/Inputs/f.ll --ignore-if-conflict %S/Inputs/f_1.ll -S | FileCheck -check-prefix=IGNORE %s
+
+# CHECK: error: Linking globals named 'f': symbol multiply defined!
+
+# IGNORE: define void @f() {
+# IGNORE-NEXT: entry:
+# IGNORE-NEXT: ret void

--- a/llvm/unittests/Linker/LinkModulesTest.cpp
+++ b/llvm/unittests/Linker/LinkModulesTest.cpp
@@ -233,6 +233,16 @@ TEST_F(LinkModuleTest, NewCAPIFailure) {
   EXPECT_EQ("Linking globals named 'foo': symbol multiply defined!", Err);
 }
 
+TEST_F(LinkModuleTest, IgnoreFromSrcIfConflict) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> DestM(getExternal(Ctx, "foo"));
+  std::unique_ptr<Module> SourceM(getExternal(Ctx, "foo"));
+  Ctx.setDiagnosticHandlerCallBack(expectNoDiags);
+  bool Failed = Linker::linkModules(*DestM, std::move(SourceM),
+                                    Linker::Flags::IgnoreFromSrcIfConflict);
+  ASSERT_FALSE(Failed);
+}
+
 TEST_F(LinkModuleTest, MoveDistinctMDs) {
   LLVMContext C;
   SMDiagnostic Err;


### PR DESCRIPTION
Adding the `--ignore-if-conflict` option supports the following usage case.

The user code (user.ll):
```llvm
define void __addsf3() { ... }
define void foo() { ... }
```

The builtin function provided by the compiler (builtin.ll):
```llvm
define void __addsf3() { ... }
```

I want to allow user to override builtin functions under LTO. I can't use `--override`, which might cause the `foo` symbol to accidentally override a symbol of the same name.