### PR TITLE
[libc++][modules] Adds CMake 3.28 support.

### DIFF
--- a/libcxx/modules/CMakeLists.txt.in
+++ b/libcxx/modules/CMakeLists.txt.in
@@ -3,12 +3,16 @@ cmake_minimum_required(VERSION 3.26)
 project(libc++-modules LANGUAGES CXX)
 
 # Enable CMake's module support
-if(CMAKE_VERSION VERSION_LESS "3.27.0")
-  set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API "2182bf5c-ef0d-489a-91da-49dbc3090d2a")
+if(CMAKE_VERSION VERSION_LESS "3.28.0")
+  if(CMAKE_VERSION VERSION_LESS "3.27.0")
+    set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API "2182bf5c-ef0d-489a-91da-49dbc3090d2a")
+  else()
+    set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API "aa1f7df0-828a-4fcd-9afc-2dc80491aca7")
+  endif()
+  set(CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP 1)
 else()
-  set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API "aa1f7df0-828a-4fcd-9afc-2dc80491aca7")
+  cmake_policy(VERSION 3.28)
 endif()
-set(CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP 1)
 
 # Default to C++ extensions being off. Libc++'s modules support have trouble
 # with extensions right now.


### PR DESCRIPTION
This is a preparation to start using CMake 3.28 in the CI.