### PR TITLE
[clangd] don't lower severity of clang-tidy modernize-* checks to remarks

### DIFF
--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -474,8 +474,10 @@ void toLSPDiags(
   // We downgrade severity for certain noisy warnings, like deprecated
   // declartions. These already have visible decorations inside the editor and
   // most users find the extra clutter in the UI (gutter, minimap, diagnostics
-  // views) overwhelming.
-  if (D.Severity == DiagnosticsEngine::Warning) {
+  // views) overwhelming. Because clang-tidy's modernize checks get the
+  // `Deprecated` tag, guard against lowering clang-tidy diagnostic levels.
+  if (D.Severity == DiagnosticsEngine::Warning &&
+      D.Source != Diag::DiagSource::ClangTidy) {
     if (llvm::is_contained(D.Tags, DiagnosticTag::Deprecated))
       Main.severity = getSeverity(DiagnosticsEngine::Remark);
   }

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -1811,10 +1811,10 @@ TEST(ParsedASTTest, ModuleSawDiag) {
   TestTU TU;
 
   auto AST = TU.build();
-        #if 0
+#if 0
   EXPECT_THAT(AST.getDiagnostics(),
               testing::Contains(Diag(Code.range(), KDiagMsg.str())));
-        #endif
+#endif
 }
 
 TEST(Preamble, EndsOnNonEmptyLine) {
@@ -1880,6 +1880,16 @@ TEST(Diagnostics, DeprecatedDiagsAreHints) {
                Diag = std::move(LSPDiag);
              });
   EXPECT_EQ(Diag->severity, getSeverity(DiagnosticsEngine::Remark));
+  Diag.reset();
+
+  // Don't downgrade warnings from clang-tidy that have deprecated tags
+  D.Source = Diag::DiagSource::ClangTidy;
+  toLSPDiags(D, {}, Opts,
+             [&](clangd::Diagnostic LSPDiag, ArrayRef<clangd::Fix>) {
+               Diag = std::move(LSPDiag);
+             });
+  EXPECT_EQ(Diag->severity, getSeverity(DiagnosticsEngine::Warning));
+  D.Source = Diag::DiagSource::Unknown;
   Diag.reset();
 
   // Preserve errors.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -54,6 +54,9 @@ Inlay hints
 Diagnostics
 ^^^^^^^^^^^
 
+- Fixed a bug where the severity of diagnostics from clang-tidy modernize-* checks were
+  lowered to remarks.
+
 Semantic Highlighting
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Starting with a59b24be47ed6263c254d168567b9ebba391fac9, the severity of
diagnostics that have the 'Deprecated' tag is lowered to 'Remark'.
Because the `Deprecated` tag is applied to clang-tidy checks in
the modernize category, this leads to inconsistencies in reported
clang-tidy diagnostics.
