### PR TITLE
[libc] lift app's definition out of startup

### DIFF
--- a/libc/config/linux/CMakeLists.txt
+++ b/libc/config/linux/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_header_library(
-  app_h
+add_object_library(
+  app
+  SRCS
+    app.cpp
   HDRS
     app.h
   DEPENDS

--- a/libc/config/linux/app.cpp
+++ b/libc/config/linux/app.cpp
@@ -1,0 +1,13 @@
+//===-- Implementation file for linux applications classes  -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "config/linux/app.h"
+
+namespace LIBC_NAMESPACE {
+AppProperties app;
+}

--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_CONFIG_LINUX_APP_H
 #define LLVM_LIBC_CONFIG_LINUX_APP_H
 
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/properties/architectures.h"
-
 #include <stdint.h>
 
 namespace LIBC_NAMESPACE {
@@ -34,7 +34,7 @@ struct TLSImage {
   // value is a power of 2.
   uintptr_t align = 0;
 
-  constexpr TLSImage() = default;
+  LIBC_INLINE constexpr TLSImage() = default;
 };
 
 #if defined(LIBC_TARGET_ARCH_IS_X86_64) ||                                     \
@@ -94,7 +94,7 @@ struct AppProperties {
   // Auxiliary vector data.
   AuxEntry *auxv_ptr = nullptr;
 
-  constexpr AppProperties() = default;
+  LIBC_INLINE constexpr AppProperties() = default;
 };
 
 extern AppProperties app;
@@ -113,7 +113,7 @@ struct TLSDescriptor {
   // same as |addr| or something else.
   uintptr_t tp = 0;
 
-  constexpr TLSDescriptor() = default;
+  LIBC_INLINE constexpr TLSDescriptor() = default;
 };
 
 // Create and initialize the TLS area for the current thread. Should not

--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -18,21 +18,23 @@ namespace LIBC_NAMESPACE {
 // Data structure to capture properties of the linux/ELF TLS image.
 struct TLSImage {
   // The load address of the TLS.
-  uintptr_t address;
+  uintptr_t address = 0;
 
   // The byte size of the TLS image consisting of both initialized and
   // uninitialized memory. In ELF executables, it is size of .tdata + size of
   // .tbss. Put in another way, it is the memsz field of the PT_TLS header.
-  uintptr_t size;
+  uintptr_t size = 0;
 
   // The byte size of initialized memory in the TLS image. In ELF exectubles,
   // this is the size of .tdata. Put in another way, it is the filesz of the
   // PT_TLS header.
-  uintptr_t init_size;
+  uintptr_t init_size = 0;
 
   // The alignment of the TLS layout. It assumed that the alignment
   // value is a power of 2.
-  uintptr_t align;
+  uintptr_t align = 0;
+
+  constexpr TLSImage() = default;
 };
 
 #if defined(LIBC_TARGET_ARCH_IS_X86_64) ||                                     \
@@ -79,18 +81,20 @@ struct Args {
 // Data structure which captures properties of a linux application.
 struct AppProperties {
   // Page size used for the application.
-  uintptr_t page_size;
+  uintptr_t page_size = 0;
 
-  Args *args;
+  Args *args = nullptr;
 
   // The properties of an application's TLS image.
-  TLSImage tls;
+  TLSImage tls{};
 
   // Environment data.
-  EnvironType *env_ptr;
+  EnvironType *env_ptr = nullptr;
 
   // Auxiliary vector data.
-  AuxEntry *auxv_ptr;
+  AuxEntry *auxv_ptr = nullptr;
+
+  constexpr AppProperties() = default;
 };
 
 extern AppProperties app;

--- a/libc/src/__support/threads/linux/CMakeLists.txt
+++ b/libc/src/__support/threads/linux/CMakeLists.txt
@@ -26,7 +26,7 @@ add_object_library(
     thread.cpp
   DEPENDS
     .futex_word_type
-    libc.config.linux.app_h
+    libc.config.linux.app
     libc.include.sys_syscall
     libc.src.errno.errno
     libc.src.__support.CPP.atomic

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -49,7 +49,7 @@ add_entrypoint_object(
   HDRS
     getenv.h
   DEPENDS
-    libc.config.linux.app_h
+    libc.config.linux.app
 )
 
 add_entrypoint_object(

--- a/libc/startup/linux/aarch64/CMakeLists.txt
+++ b/libc/startup/linux/aarch64/CMakeLists.txt
@@ -3,7 +3,7 @@ add_startup_object(
   SRC
     start.cpp
   DEPENDS
-    libc.config.linux.app_h
+    libc.config.linux.app
     libc.include.sys_mman
     libc.include.sys_syscall
     libc.src.__support.threads.thread

--- a/libc/startup/linux/aarch64/start.cpp
+++ b/libc/startup/linux/aarch64/start.cpp
@@ -37,8 +37,6 @@ static constexpr long MMAP_SYSCALL_NUMBER = SYS_mmap;
 #error "mmap and mmap2 syscalls not available."
 #endif
 
-AppProperties app;
-
 static ThreadAttributes main_thread_attrib;
 
 void init_tls(TLSDescriptor &tls_descriptor) {

--- a/libc/startup/linux/riscv/CMakeLists.txt
+++ b/libc/startup/linux/riscv/CMakeLists.txt
@@ -3,7 +3,7 @@ add_startup_object(
   SRC
     start.cpp
   DEPENDS
-    libc.config.linux.app_h
+    libc.config.linux.app
     libc.include.sys_mman
     libc.include.sys_syscall
     libc.src.__support.threads.thread

--- a/libc/startup/linux/riscv/start.cpp
+++ b/libc/startup/linux/riscv/start.cpp
@@ -32,8 +32,6 @@ static constexpr long MMAP_SYSCALL_NUMBER = SYS_mmap;
 #error "mmap and mmap2 syscalls not available."
 #endif
 
-AppProperties app;
-
 static ThreadAttributes main_thread_attrib;
 
 void init_tls(TLSDescriptor &tls_descriptor) {

--- a/libc/startup/linux/x86_64/CMakeLists.txt
+++ b/libc/startup/linux/x86_64/CMakeLists.txt
@@ -3,7 +3,7 @@ add_startup_object(
   SRC
     start.cpp
   DEPENDS
-    libc.config.linux.app_h
+    libc.config.linux.app
     libc.include.sys_mman
     libc.include.sys_syscall
     libc.include.unistd

--- a/libc/startup/linux/x86_64/start.cpp
+++ b/libc/startup/linux/x86_64/start.cpp
@@ -40,8 +40,6 @@ static constexpr long MMAP_SYSCALL_NUMBER = SYS_mmap;
 #error "mmap and mmap2 syscalls not available."
 #endif
 
-AppProperties app;
-
 static ThreadAttributes main_thread_attrib;
 
 // TODO: The function is x86_64 specific. Move it to config/linux/app.h


### PR DESCRIPTION
AppProperties are not target specific hence this patch lifts app from a header library to an object library. In overlay mode, this also provides a way to check if libc is loaded by its own CRT.