### PR TITLE
Add ability to pass in a clang-tidy config file to clang-tidy-diff

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -227,7 +227,7 @@ def main():
         "-config",
         dest="config",
         default=None,
-        help="Specifies a clang-tidy config file"
+        help="Specifies a clang-tidy config file",
     )
 
     clang_tidy_args = []

--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -223,6 +223,12 @@ def main():
         default=[],
         help="Load the specified plugin in clang-tidy.",
     )
+    parser.add_argument(
+        "-config",
+        dest="config",
+        default=None,
+        help="Specifies a clang-tidy config file"
+    )
 
     clang_tidy_args = []
     argv = sys.argv[1:]
@@ -309,6 +315,8 @@ def main():
 
     # Form the common args list.
     common_clang_tidy_args = []
+    if args.config is not None:
+        common_clang_tidy_args.append("--config-file=" + args.config)
     if args.fix:
         common_clang_tidy_args.append("-fix")
     if args.checks != "":

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -124,6 +124,10 @@ Improvements to clang-tidy
   exporting fixes fails. It now accepts a directory as a value for
   `-export-fixes` to export individual yaml files for each compilation unit.
 
+- Improved :program:`clang-tidy-diff.py` script. It now accepts a `-config` option
+  to pass in a configuration file to :program:`clang-tidy`. This option corresponds
+  to the `--config-file` option in :program:`clang-tidy`.
+
 - Improved :program:`run-clang-tidy.py` script. It now accepts a directory
   as a value for `-export-fixes` to export individual yaml files for each
   compilation unit.


### PR DESCRIPTION
I found this handy for situations where you want to pass in a config file and not rely on a default `.clang-tidy` file.


The new option is `-config` and will expect something that can be passed into the `--config-file=` parameter of `clang-tidy`