### PR TITLE
aarch64: fix testcase

### DIFF
--- a/llvm/test/CodeGen/AArch64/stack-probing-dynamic-no-frame-setup.ll
+++ b/llvm/test/CodeGen/AArch64/stack-probing-dynamic-no-frame-setup.ll
@@ -1,4 +1,4 @@
-; RUN: llc --stop-after=finalize-isel -o - | FileCheck %s
+; RUN: llc < %s --stop-after=finalize-isel -o - | FileCheck %s
 target triple = "aarch64-linux"
 
 ; Check dynamic stack allocation and probing instructions do not have


### PR DESCRIPTION
Add missing < %s to RUN line.

Is there an obvious rule allowing me to just commit this?
