### PR TITLE
[llvm-objdump] --disassemble-symbols: skip inline relocs from symbols that are not dumped

### DIFF
--- a/llvm/test/tools/llvm-objdump/X86/disassemble-zeroes-relocations.test
+++ b/llvm/test/tools/llvm-objdump/X86/disassemble-zeroes-relocations.test
@@ -35,6 +35,11 @@
 # CHECK2-EMPTY:
 # CHECK2-NEXT: 0000000000000037 <rodata3>:
 # CHECK2-NEXT:                 ...
+# CHECK2-NEXT:      3f:       00 00   addb    %al, (%rax)
+# CHECK2-NEXT:                000000000000003f:  R_X86_64_64  x3
+# CHECK2-NEXT:      41:       00 00   addb    %al, (%rax)
+# CHECK2-NEXT:      43:       00 00   addb    %al, (%rax)
+# CHECK2-NEXT:      45:       00 00   addb    %al, (%rax)
 # CHECK2-NOT:  {{.}}
 
 ## Check that without -reloc all zeroes would be omitted.

--- a/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs-exec.test
+++ b/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs-exec.test
@@ -22,7 +22,6 @@
 # CHECK-NEXT:		000000000040000d:  R_X86_64_32	.rodata
 # CHECK-NOT: {{.}}
 
-## FIXME: --disassemble-symbols: remove inline relocs from skipped functions
 #     CHECK2:000000000040000c <text1>:
 #CHECK2-NEXT:  40000c: bf 10 00 40 00               	movl	$4194320, %edi          # imm = 0x400010
 #CHECK2-NEXT:		000000000040000d:  R_X86_64_32	.rodata

--- a/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs-exec.test
+++ b/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs-exec.test
@@ -25,8 +25,6 @@
 ## FIXME: --disassemble-symbols: remove inline relocs from skipped functions
 #     CHECK2:000000000040000c <text1>:
 #CHECK2-NEXT:  40000c: bf 10 00 40 00               	movl	$4194320, %edi          # imm = 0x400010
-#CHECK2-NEXT:		0000000000400002:  R_X86_64_32	.rodata
-#CHECK2-NEXT:		0000000000400007:  R_X86_64_PLT32	puts-0x4
 #CHECK2-NEXT:		000000000040000d:  R_X86_64_32	.rodata
 #CHECK2-NOT: {{.}}
 

--- a/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs.test
+++ b/llvm/test/tools/llvm-objdump/X86/elf-disassemble-relocs.test
@@ -28,19 +28,15 @@
 # CHECK-NEXT:             000000000000001a:  R_X86_64_REX_GOTPCRELX       var-0x4
 # CHECK-NOT:   {{.}}
 
-## FIXME: --disassemble-symbols: remove inline relocs from skipped functions
 # CHECK2:      000000000000000a <x2>:
 # CHECK2-NEXT:   a: 90                            nop
-# CHECK2-NEXT:           0000000000000001:  R_X86_64_PC32        foo-0x4
-# CHECK2-NEXT:           0000000000000002:  R_X86_64_NONE        bar+0x8
-# CHECK2-NEXT:           0000000000000006:  R_X86_64_PLT32       foo+0x1
 # CHECK2-NEXT:   b: 48 8b 05 00 00 00 00          movq    (%rip), %rax            # 0x12 <x3>
 # CHECK2-NEXT:           000000000000000e:  R_X86_64_REX_GOTPCRELX       var-0x4
 # CHECK2-EMPTY:
 # CHECK2-NEXT: 0000000000000017 <x4>:
 # CHECK2-NEXT:  17: 48 8b 05 00 00 00 00          movq    (%rip), %rax            # 0x1e <x4+0x7>
-# CHECK2-NEXT:            0000000000000013:  R_X86_64_PLT32       foo-0x4
 # CHECK2-NEXT:            000000000000001a:  R_X86_64_REX_GOTPCRELX       var-0x4
+# CHECK2-NOT:  {{.}}
 
 .globl x1, x2, x3, x4
 x1:

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1948,6 +1948,13 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
         continue;
       }
 
+      // Skip relocations from symbols that are not dumped.
+      for (; RelCur != RelEnd; ++RelCur) {
+        uint64_t Offset = RelCur->getOffset() - RelAdjustment;
+        if (Index <= Offset)
+          break;
+      }
+
       bool DumpARMELFData = false;
       bool DumpTracebackTableForXCOFFFunction =
           Obj.isXCOFF() && Section.isText() && TracebackTable &&
@@ -2214,7 +2221,7 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           while (RelCur != RelEnd) {
             uint64_t Offset = RelCur->getOffset() - RelAdjustment;
             // If this relocation is hidden, skip it.
-            if (getHidden(*RelCur) || SectionAddr + Offset < StartAddress) {
+            if (getHidden(*RelCur)) {
               ++RelCur;
               continue;
             }


### PR DESCRIPTION
When a section contains two functions x1 and x2, we incorrectly display
x1's relocations when dumping x2 for `--disassemble-symbols=x2 -r`.
Fix #75539 by ignoring these relocations.
