### PR TITLE
[mlir][python][nfc] Test `-print-ir-after-all`

### DIFF
--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -281,3 +281,26 @@ def testPostPassOpInvalidation():
         # CHECK:   return
         # CHECK: }
         log(module)
+
+
+# Test -print-ir-after-all.
+# CHECK-LABEL: TEST: testPrintIrAfterAll
+@run
+def testPrintIrAfterAll():
+    with Context() as ctx:
+        module = ModuleOp.parse(
+            """
+          module {
+            func.func @main() {
+              %0 = arith.constant 10
+              return
+            }
+          }
+        """
+        )
+        pm = PassManager.parse("builtin.module(canonicalize)")
+        ctx.enable_multithreading(False)
+        pm.enable_ir_printing()
+        pm.run(module)
+        log(module)
+        # CHECK: IR Dump After Canonicalizer

--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -283,7 +283,6 @@ def testPostPassOpInvalidation():
         log(module)
 
 
-# Test -print-ir-after-all.
 # CHECK-LABEL: TEST: testPrintIrAfterAll
 @run
 def testPrintIrAfterAll():
@@ -308,8 +307,6 @@ def testPrintIrAfterAll():
         # CHECK:     return
         # CHECK:   }
         # CHECK: }
-        # CHECK: 
-        # CHECK: 
         # CHECK: // -----// IR Dump After Canonicalizer (canonicalize) ('builtin.module' operation) //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
@@ -317,4 +314,3 @@ def testPrintIrAfterAll():
         # CHECK:   }
         # CHECK: }
         pm.run(module)
-        # CHECK: IR Dump After Canonicalizer

--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -301,6 +301,20 @@ def testPrintIrAfterAll():
         pm = PassManager.parse("builtin.module(canonicalize)")
         ctx.enable_multithreading(False)
         pm.enable_ir_printing()
+        # CHECK: // -----// IR Dump Before Canonicalizer (canonicalize) ('builtin.module' operation) //----- //
+        # CHECK: module {
+        # CHECK:   func.func @main() {
+        # CHECK:     %[[C10:.*]] = arith.constant 10 : i64
+        # CHECK:     return
+        # CHECK:   }
+        # CHECK: }
+        # CHECK: 
+        # CHECK: 
+        # CHECK: // -----// IR Dump After Canonicalizer (canonicalize) ('builtin.module' operation) //----- //
+        # CHECK: module {
+        # CHECK:   func.func @main() {
+        # CHECK:     return
+        # CHECK:   }
+        # CHECK: }
         pm.run(module)
-        log(module)
         # CHECK: IR Dump After Canonicalizer


### PR DESCRIPTION
The functionality to `-print-ir-after-all` was added in https://github.com/llvm/llvm-project/commit/caa159f044a05f782701a525d8b0e8f346abbd64. This PR adds a test and, with that, some documentation.