### PR TITLE
[InstCombine] Stop propagating `undef` when element is demanded 

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1378,7 +1378,7 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       if (!Elt) return nullptr;
 
       Elts.push_back(Elt);
-      if (isa<UndefValue>(Elt))   // Already undef or poison.
+      if (isa<PoisonValue>(Elt)) // Already poison.
         UndefElts.setBit(i);
     }
 

--- a/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
+++ b/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
@@ -92,6 +92,7 @@ define <3 x float> @twoShufUses(<3 x float> %x) {
 
 ; The inserted scalar constant index is out-of-bounds for the shuffle vector constant.
 
+; FIXME: This is a miscompilation
 define <5 x i8> @longerMask(<3 x i8> %x) {
 ; CHECK-LABEL: @longerMask(
 ; CHECK-NEXT:    [[SHUF:%.*]] = shufflevector <3 x i8> [[X:%.*]], <3 x i8> <i8 poison, i8 1, i8 poison>, <5 x i32> <i32 2, i32 1, i32 4, i32 poison, i32 poison>

--- a/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
+++ b/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
@@ -92,10 +92,9 @@ define <3 x float> @twoShufUses(<3 x float> %x) {
 
 ; The inserted scalar constant index is out-of-bounds for the shuffle vector constant.
 
-; FIXME: This is a miscompilation
 define <5 x i8> @longerMask(<3 x i8> %x) {
 ; CHECK-LABEL: @longerMask(
-; CHECK-NEXT:    [[SHUF:%.*]] = shufflevector <3 x i8> [[X:%.*]], <3 x i8> <i8 poison, i8 1, i8 poison>, <5 x i32> <i32 2, i32 1, i32 4, i32 poison, i32 poison>
+; CHECK-NEXT:    [[SHUF:%.*]] = shufflevector <3 x i8> [[X:%.*]], <3 x i8> <i8 undef, i8 1, i8 poison>, <5 x i32> <i32 2, i32 1, i32 4, i32 3, i32 poison>
 ; CHECK-NEXT:    [[INS:%.*]] = insertelement <5 x i8> [[SHUF]], i8 42, i64 4
 ; CHECK-NEXT:    ret <5 x i8> [[INS]]
 ;

--- a/llvm/test/Transforms/InstCombine/vec_shuffle.ll
+++ b/llvm/test/Transforms/InstCombine/vec_shuffle.ll
@@ -2332,3 +2332,15 @@ define <2 x float> @uitofp_shuf_narrow(<4 x i32> %x, <4 x i32> %y) {
   %r = shufflevector <4 x float> %nx, <4 x float> %ny, <2 x i32> <i32 3, i32 5>
   ret <2 x float> %r
 }
+
+; FIXME: This is a miscompilation
+define <4 x i16> @blend_elements_from_load(ptr align 8 %_0) {
+; CHECK-LABEL: @blend_elements_from_load(
+; CHECK-NEXT:    [[LOAD:%.*]] = load <3 x i16>, ptr [[_0:%.*]], align 8
+; CHECK-NEXT:    [[RV:%.*]] = shufflevector <3 x i16> <i16 0, i16 poison, i16 poison>, <3 x i16> [[LOAD]], <4 x i32> <i32 0, i32 poison, i32 3, i32 5>
+; CHECK-NEXT:    ret <4 x i16> [[RV]]
+;
+  %load = load <3 x i16>, ptr %_0, align 8
+  %rv = shufflevector <3 x i16> <i16 0, i16 undef, i16 undef>, <3 x i16> %load, <4 x i32> <i32 0, i32 1, i32 3, i32 5>
+  ret <4 x i16> %rv
+}

--- a/llvm/test/Transforms/InstCombine/vec_shuffle.ll
+++ b/llvm/test/Transforms/InstCombine/vec_shuffle.ll
@@ -2333,11 +2333,10 @@ define <2 x float> @uitofp_shuf_narrow(<4 x i32> %x, <4 x i32> %y) {
   ret <2 x float> %r
 }
 
-; FIXME: This is a miscompilation
 define <4 x i16> @blend_elements_from_load(ptr align 8 %_0) {
 ; CHECK-LABEL: @blend_elements_from_load(
 ; CHECK-NEXT:    [[LOAD:%.*]] = load <3 x i16>, ptr [[_0:%.*]], align 8
-; CHECK-NEXT:    [[RV:%.*]] = shufflevector <3 x i16> <i16 0, i16 poison, i16 poison>, <3 x i16> [[LOAD]], <4 x i32> <i32 0, i32 poison, i32 3, i32 5>
+; CHECK-NEXT:    [[RV:%.*]] = shufflevector <3 x i16> <i16 0, i16 undef, i16 poison>, <3 x i16> [[LOAD]], <4 x i32> <i32 0, i32 1, i32 3, i32 5>
 ; CHECK-NEXT:    ret <4 x i16> [[RV]]
 ;
   %load = load <3 x i16>, ptr %_0, align 8


### PR DESCRIPTION
Do not poison `undef` demanded elements in `SimplifyDemandedVectorElts`.

A miscompilation issue has been addressed with refined checking.

Proofs: https://alive2.llvm.org/ce/z/WA5oD5.