### PR TITLE
asan_static x86-64: Support 64-bit ASAN_SHADOW_OFFSET_CONST

### DIFF
--- a/compiler-rt/lib/asan/asan_rtl_x86_64.S
+++ b/compiler-rt/lib/asan/asan_rtl_x86_64.S
@@ -27,7 +27,12 @@ FNAME(reg, op, s, i): ;\
 #define ASAN_MEMORY_ACCESS_INITIAL_CHECK_ADD(reg, op, s) \
         mov    %##reg,%r10 ;\
         shr    $0x3,%r10 ;\
+        .if ASAN_SHADOW_OFFSET_CONST < 0x80000000   ;\
         movsbl ASAN_SHADOW_OFFSET_CONST(%r10),%r10d ;\
+        .else                                       ;\
+        movabsq $ASAN_SHADOW_OFFSET_CONST,%r11      ;\
+        movsbl (%r10,%r11),%r10d                    ;\
+        .endif                                      ;\
         test   %r10d,%r10d ;\
         jne    CLABEL(reg, op, s, add) ;\
 RLABEL(reg, op, s, add): ;\


### PR DESCRIPTION
Fix #57086: when ASAN_SHADOW_OFFSET_CONST >= 0x80000000 (FreeBSD,
NetBSD, etc), `movsbl ASAN_SHADOW_OFFSET_CONST(%r10),%r10d` has an
invalid displacement (not representable as a signed 32-bit integer),
which will be diagnosed by GNU assembler.

```
% cat a.s
movsbl 0x80000000(%r10),%r10d
% as a.s
a.s: Assembler messages:
a.s:1: Error: 0x80000000 out of range of signed 32bit displacement
% clang -c a.s
```

The integrated assembler after #75747 will diagnose the invalid
displacement as well.
```
% clang -c a.s
a.s:1:19: error: displacement 2147483648 is not within [-2147483648, 2147483647]
movsbl 0x80000000(%r10),%r10d
                  ^
```

If ASAN_SHADOW_OFFSET_CONST cannot be encoded as a displacement, switch
to `movabsq+movsbl`.
