### PR TITLE
[Github] Reformat strings for code format action

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -130,9 +130,10 @@ View the diff from {self.name} here.
 
         if diff is None:
             if should_update_gh:
-                comment_text = f"""
-:white_check_mark: With the latest revision this PR passed the {self.friendly_name}.
-"""
+                comment_text = (
+                    ":white_check_mark: With the latest revision "
+                    f"this PR passed the {self.friendly_name}."
+                )
                 self.update_pr(comment_text, args, create_new=False)
             return True
         elif len(diff) > 0:
@@ -141,15 +142,17 @@ View the diff from {self.name} here.
                 self.update_pr(comment_text, args, create_new=True)
             else:
                 print(
-                    f"Warning: {self.friendly_name}, {self.name} detected some issues with your code formatting..."
+                    f"Warning: {self.friendly_name}, {self.name} detected "
+                    "some issues with your code formatting..."
                 )
             return False
         else:
             # The formatter failed but didn't output a diff (e.g. some sort of
             # infrastructure failure).
-            comment_text = f"""
-:warning: The {self.friendly_name} failed without printing a diff. Check the logs for stderr output. :warning:
-"""
+            comment_text = (
+                f":warning: The {self.friendly_name} failed without printing "
+                "a diff. Check the logs for stderr output. :warning:"
+            )
             self.update_pr(comment_text, args, create_new=False)
             return False
 


### PR DESCRIPTION
Before this patch, there was a regression in comment formatting due to some code formatting in bd3e8eb6e325081bf7cfbe93652aa825de3170e5. This was fixed in 428660cfb986dd0a59cd2a16972c5f7109080522. Github interprets a tab before a string as starting code formatting. The message that indicted the code formatting in a PR had been fixed was refactored to a python multi-line string, but with a tab in front, causing these messages to be rendered as code blocks in Github, instead of as intended. This patch builds upon the original fix to reformat the strings so that they fit within ~80 character lines and are simpler to modify in the future, hopefully removing traps like the one that caused the original issue.