### PR TITLE
Add settings and code that limits the number of progress events.

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 
+#include <condition_variable>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -365,6 +366,10 @@ public:
 
   lldb::DWIMPrintVerbosity GetDWIMPrintVerbosity() const;
 
+  uint64_t GetProgressUpdateFrequency() const;
+
+  uint64_t GetProgressMinDuration() const;
+
   bool GetEscapeNonPrintables() const;
 
   bool GetNotifyVoid() const;
@@ -588,6 +593,9 @@ public:
     return m_source_file_cache;
   }
 
+  /// Notify the progress thread that there is new progress data.
+  void NotifyProgress(std::unique_ptr<ProgressEventData> &data_up);
+
 protected:
   friend class CommandInterpreter;
   friend class REPL;
@@ -659,6 +667,12 @@ protected:
 
   lldb::thread_result_t DefaultEventHandler();
 
+  bool StartProgressThread();
+
+  void StopProgressThread();
+
+  lldb::thread_result_t ProgressThread();
+
   void HandleBreakpointEvent(const lldb::EventSP &event_sp);
 
   void HandleProcessEvent(const lldb::EventSP &event_sp);
@@ -721,6 +735,30 @@ protected:
   LoadedPluginsList m_loaded_plugins;
   HostThread m_event_handler_thread;
   HostThread m_io_handler_thread;
+  HostThread m_progress_thread;
+  std::mutex m_progress_mutex;
+  std::condition_variable m_progress_condition;
+  bool m_progress_thread_running = false;
+  using ProgressClock = std::chrono::system_clock;
+  using ProgressTimePoint = std::chrono::time_point<ProgressClock>;
+  using ProgressDuration = ProgressTimePoint::duration;
+  struct ProgressInfo {
+    ProgressInfo(ProgressEventData *data_ptr, uint64_t min_duration_ms) :
+      data_up(data_ptr), start(ProgressClock::now()) {
+      next_event_time = start + std::chrono::milliseconds(min_duration_ms);
+    }
+
+    std::unique_ptr<ProgressEventData> data_up;
+    /// The time the first progress was reported.
+    ProgressTimePoint start;
+    /// Only broadcast an event if the current time is >= this time.
+    ProgressTimePoint next_event_time;
+    /// If valid, the last time a notification was sent out for this progress.
+    std::optional<ProgressTimePoint> last_notification_time;
+  };
+  std::map<uint64_t, ProgressInfo> m_progress_map;
+  ///< Each time m_progress_map is updated, this gets incremented.
+  uint64_t m_progress_update_id = 0;
   Broadcaster m_sync_broadcaster; ///< Private debugger synchronization.
   Broadcaster m_broadcaster;      ///< Public Debugger event broadcaster.
   lldb::ListenerSP m_forward_listener_sp;

--- a/lldb/include/lldb/Core/DebuggerEvents.h
+++ b/lldb/include/lldb/Core/DebuggerEvents.h
@@ -41,6 +41,7 @@ public:
   bool IsFinite() const { return m_total != UINT64_MAX; }
   uint64_t GetCompleted() const { return m_completed; }
   uint64_t GetTotal() const { return m_total; }
+  bool IsDone() const { return m_completed == m_total; }
   std::string GetMessage() const {
     std::string message = m_title;
     if (!m_details.empty()) {

--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -49,7 +49,8 @@ enum class LLDBLog : Log::MaskType {
   Watchpoints = Log::ChannelFlag<30>,
   OnDemand = Log::ChannelFlag<31>,
   Source = Log::ChannelFlag<32>,
-  LLVM_MARK_AS_BITMASK_ENUM(OnDemand),
+  Progress = Log::ChannelFlag<33>,
+  LLVM_MARK_AS_BITMASK_ENUM(Progress),
 };
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -220,4 +220,12 @@ let Definition = "debugger" in {
     DefaultEnumValue<"eDWIMPrintVerbosityNone">,
     EnumValues<"OptionEnumValues(g_dwim_print_verbosities)">,
     Desc<"The verbosity level used by dwim-print.">;
+  def ProgressUpdateFrequency: Property<"progress-update-frequency", "UInt64">,
+    Global,
+    DefaultUnsignedValue<1000>,
+    Desc<"The minimum time in milliseconds between progress updates for progress notifications that have a valid count.">;
+  def ProgressMinDuration: Property<"progress-minimum-duration", "UInt64">,
+    Global,
+    DefaultUnsignedValue<500>,
+    Desc<"The minimum time in milliseconds required for a progress to get reported. If a progress starts and completes and the elapsed time is under this threshold, then no progress will get reported.">;
 }

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -64,6 +64,7 @@ static constexpr Log::Category g_categories[] = {
      {"log symbol on-demand related activities"},
      LLDBLog::OnDemand},
     {{"source"}, {"log source related activities"}, LLDBLog::Source},
+    {{"progress"}, {"log the progress event thread"}, LLDBLog::Progress},
 };
 
 static Log::Channel g_log_channel(g_categories,


### PR DESCRIPTION
Currently in LLDB if clients listen for Debugger::eBroadcastBitProgress events, this can cause too many progress events to get sent to clients which makes the feature a bit less useful that originally planned.

This patch fixes this by adding two new settings in LLDB:
```
(lldb) apropos progress
The following settings variables may relate to 'progress':
  progress-minimum-duration -- The minimum time in milliseconds required for a
                               progress to get reported. If a progress starts
                               and completes and the elapsed time is under this
                               threshold, then no progress will get reported.
  progress-update-frequency -- The minimum time in milliseconds between
                               progress updates for progress notifications that
                               have a valid count.
```

This patch also adds code that spawns a progress thread in each debugger that manages all of the incoming events and only sends out progress events if they meet the setting requirements. The default settings are:
```
(lldb) settings show progress-minimum-duration progress-update-frequency
progress-minimum-duration (unsigned) = 500
progress-update-frequency (unsigned) = 1000
```
The `progress-minimum-duration` setting is the number of milliseconds that we wait before broadcasting any events for a progress. If the progress start and end events happen quicker than this number, no progress events get broadcast. This keeps the progress events from becoming too cumbersome on clients and makes sure that if we have thousands of very quick internal progress reports, we don't have to show any of them. The default of 500ms value is open to suggestions, maybe 250ms would be better?

The `progress-update-frequency` setting is for progress dialogs with finite amounts of work. When we index DWARF, we create progress dialogs with thousands and thousands of compile units and each time we manually index a compile unit, previously we would send thousands and thousands of progress updates for each compile unit no matter how quickly we would index them. With this new setting, will first wait `progress-minimum-duration` milliseconds before broadcasting any progress events, and then after that we will broadcast update progress events only every 1000 ms, or 1 second. This really keeps the number of progress notifications down to a minimum.

Posting this as a solution to the RFC:

https://discourse.llvm.org/t/rfc-improve-lldb-progress-reporting/75717