### PR TITLE
[flang] Do not instantiate components in initial targets as objects

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -238,6 +238,10 @@ mlir::Value Fortran::lower::genInitialDataTarget(
         /*nonDeferredParams=*/std::nullopt);
   // Pointer initial data target, and NULL(mold).
   for (const auto &sym : Fortran::evaluate::CollectSymbols(initialTarget)) {
+    // Derived type component symbols should not be instantiated as objects
+    // on their own.
+    if (sym->owner().IsDerivedType())
+      continue;
     // Length parameters processing will need care in global initializer
     // context.
     if (hasDerivedTypeWithLengthParameters(sym))

--- a/flang/test/Lower/HLFIR/initial-target-component.f90
+++ b/flang/test/Lower/HLFIR/initial-target-component.f90
@@ -1,0 +1,17 @@
+! Test https://github.com/llvm/llvm-project/issues/75728 fix.
+! RUN: bbc -emit-hlfir -o - -I nw %s | FileCheck %s
+
+subroutine test()
+  type t
+    complex :: z
+  end type
+  type(t), target, save :: obj
+  real, pointer :: p => obj%z%re
+end subroutine
+! CHECK-LABEL:   fir.global internal @_QFtestEp : !fir.box<!fir.ptr<f32>> {
+! CHECK-NEXT:      %[[VAL_0:.*]] = fir.address_of(@_QFtestEobj) : !fir.ref<!fir.type<_QFtestTt{z:!fir.complex<4>}>>
+! CHECK-NEXT:      %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QFtestTt{z:!fir.complex<4>}>>) -> (!fir.ref<!fir.type<_QFtestTt{z:!fir.complex<4>}>>, !fir.ref<!fir.type<_QFtestTt{z:!fir.complex<4>}>>)
+! CHECK-NEXT:      %[[VAL_2:.*]] = hlfir.designate %[[VAL_1]]#0{"z"}  real : (!fir.ref<!fir.type<_QFtestTt{z:!fir.complex<4>}>>) -> !fir.ref<f32>
+! CHECK-NEXT:      %[[VAL_3:.*]] = fir.embox %[[VAL_2]] : (!fir.ref<f32>) -> !fir.box<f32>
+! CHECK-NEXT:      %[[VAL_4:.*]] = fir.rebox %[[VAL_3]] : (!fir.box<f32>) -> !fir.box<!fir.ptr<f32>>
+! CHECK-NEXT:      fir.has_value %[[VAL_4]] : !fir.box<!fir.ptr<f32>>


### PR DESCRIPTION
Lowering was instantiating component symbols (but the last) in initial target designator as if they were whole objects, leading to collisions and bugs.

Fixes https://github.com/llvm/llvm-project/issues/75728