### PR TITLE
[llvm-cov] format cells in code coverage report with 0/0 branches/functions/lines differently

### DIFF
--- a/llvm/test/tools/llvm-cov/coverage_watermark.test
+++ b/llvm/test/tools/llvm-cov/coverage_watermark.test
@@ -13,29 +13,47 @@ INVALID-ARRANGE: error: -coverage-watermark: invalid number range '10,20', must 
 RUN: llvm-cov show %S/Inputs/templateInstantiations.covmapping -instr-profile %S/Inputs/templateInstantiations.profdata -format html -show-region-summary -show-instantiation-summary -o %t.html.dir -path-equivalence=/tmp,%S %S/showTemplateInstantiations.cpp
 RUN: FileCheck -check-prefix=ORIGIN %s -input-file %t.html.dir/index.html
 
+ORIGIN: Totals
+ORIGIN: <td class='column-entry-green'>
+ORIGIN: 100.00% (2/2)
 ORIGIN: <td class='column-entry-green'>
 ORIGIN: 100.00% (3/3)
 ORIGIN: <td class='column-entry-red'>
 ORIGIN: 75.00% (9/12)
 ORIGIN: <td class='column-entry-red'>
 ORIGIN: 66.67% (4/6)
+ORIGIN: <td class='column-entry-gray'>
+ORIGIN: - (0/0)
+ORIGIN: </tr>
 
-RUN: llvm-cov show %S/Inputs/templateInstantiations.covmapping -instr-profile %S/Inputs/templateInstantiations.profdata -format html -show-region-summary -show-instantiation-summary -o %t.html.dir -path-equivalence=/tmp,%S -coverage-watermark 80,60 %S/showTemplateInstantiations.cpp
+RUN: llvm-cov show %S/Inputs/templateInstantiations.covmapping -instr-profile %S/Inputs/templateInstantiations.profdata -format html -show-region-summary -show-instantiation-summary -o %t.html.dir -path-equivalence=/tmp,%S -coverage-watermark 80,70 %S/showTemplateInstantiations.cpp
 RUN: FileCheck -check-prefix=DOWNGRADE1 %s -input-file %t.html.dir/index.html
 
+DOWNGRADE:1 Totals
+DOWNGRADE1: <td class='column-entry-green'>
+DOWNGRADE1: 100.00% (2/2)
 DOWNGRADE1: <td class='column-entry-green'>
 DOWNGRADE1: 100.00% (3/3)
 DOWNGRADE1: <td class='column-entry-yellow'>
 DOWNGRADE1: 75.00% (9/12)
 DOWNGRADE1: <td class='column-entry-red'>
 DOWNGRADE1: 66.67% (4/6)
+DOWNGRADE1: <td class='column-entry-gray'>
+DOWNGRADE1: - (0/0)
+DOWNGRADE1: </tr>
 
 RUN: llvm-cov show %S/Inputs/templateInstantiations.covmapping -instr-profile %S/Inputs/templateInstantiations.profdata -format html -show-region-summary -show-instantiation-summary -o %t.html.dir -path-equivalence=/tmp,%S -coverage-watermark 70,50 %S/showTemplateInstantiations.cpp
 RUN: FileCheck -check-prefix=DOWNGRADE2 %s -input-file %t.html.dir/index.html
 
+DOWNGRADE:1 Totals
+DOWNGRADE2: <td class='column-entry-green'>
+DOWNGRADE2: 100.00% (2/2)
 DOWNGRADE2: <td class='column-entry-green'>
 DOWNGRADE2: 100.00% (3/3)
 DOWNGRADE2: <td class='column-entry-green'>
 DOWNGRADE2: 75.00% (9/12)
 DOWNGRADE2: <td class='column-entry-yellow'>
 DOWNGRADE2: 66.67% (4/6)
+DOWNGRADE1: <td class='column-entry-gray'>
+DOWNGRADE1: - (0/0)
+DOWNGRADE1: </tr>

--- a/llvm/tools/llvm-cov/SourceCoverageViewHTML.cpp
+++ b/llvm/tools/llvm-cov/SourceCoverageViewHTML.cpp
@@ -130,10 +130,14 @@ table {
 .light-row {
   background: #ffffff;
   border: 1px solid #dbdbdb;
+  border-left: none;
+  border-right: none;
 }
 .light-row-bold {
   background: #ffffff;
   border: 1px solid #dbdbdb;
+  border-left: none;
+  border-right: none;
   font-weight: bold;
 }
 .column-entry {
@@ -147,21 +151,28 @@ table {
   text-align: left;
   background-color: #ffffd0;
 }
-.column-entry-yellow:hover {
+.column-entry-yellow:hover, tr:hover .column-entry-yellow {
   background-color: #fffff0;
 }
 .column-entry-red {
   text-align: left;
   background-color: #ffd0d0;
 }
-.column-entry-red:hover {
+.column-entry-red:hover, tr:hover .column-entry-red {
   background-color: #fff0f0;
+}
+.column-entry-gray {
+  text-align: left;
+  background-color: #fbfbfb;
+}
+.column-entry-gray:hover, tr:hover .column-entry-gray {
+  background-color: #f0f0f0;
 }
 .column-entry-green {
   text-align: left;
   background-color: #d0ffd0;
 }
-.column-entry-green:hover {
+.column-entry-green:hover, tr:hover .column-entry-green {
   background-color: #f0fff0;
 }
 .line-number {
@@ -231,6 +242,9 @@ td:last-child {
 }
 tr:hover {
   background-color: #f0f0f0;
+}
+tr:last-child {
+  border-bottom: none;
 }
 )";
 
@@ -309,7 +323,9 @@ void emitTableRow(raw_ostream &OS, const CoverageViewOptions &Opts,
           RSO << '(' << Hit << '/' << Total << ')';
         }
         const char *CellClass = "column-entry-yellow";
-        if (Pctg >= Opts.HighCovWatermark)
+        if (!Total)
+          CellClass = "column-entry-gray";
+        else if (Pctg >= Opts.HighCovWatermark)
           CellClass = "column-entry-green";
         else if (Pctg < Opts.LowCovWatermark)
           CellClass = "column-entry-red";


### PR DESCRIPTION
Currently such cells in the report are formatted as red. Which screams "problem" but with more and more rangefied code, there can be whole files without any branch inside them. 

Before:
<img width="916" alt="Screenshot 2023-12-18 at 11 09 07" src="https://github.com/llvm/llvm-project/assets/6557263/d0e79c75-7f34-471f-a1f6-a2fd2bd111f2">

After:
<img width="920" alt="Screenshot 2023-12-18 at 11 08 29" src="https://github.com/llvm/llvm-project/assets/6557263/7db3278f-ad6d-4421-967a-cf72b67c5760">

Things to notice:
-  highlighted line which is result of cursor hover (now whole line is highlighted)
-  before there were some borders doubled (fixed)
-  cells with `- 0/0` coverage are no longer red


