### PR TITLE
[lldb] Fix a quirk in SBValue::GetDescription

### DIFF
--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -24,6 +24,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/DataVisualization.h"
+#include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/Type.h"
@@ -1209,10 +1210,14 @@ bool SBValue::GetDescription(SBStream &description) {
 
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
-  if (value_sp)
-    value_sp->Dump(strm);
-  else
+  if (value_sp) {
+    DumpValueObjectOptions options;
+    options.SetUseDynamicType(m_opaque_sp->GetUseDynamic());
+    options.SetUseSyntheticValue(m_opaque_sp->GetUseSynthetic());
+    value_sp->Dump(strm, options);
+  } else {
     strm.PutCString("No value");
+  }
 
   return true;
 }

--- a/lldb/test/API/python_api/sbvalue_synthetic/Makefile
+++ b/lldb/test/API/python_api/sbvalue_synthetic/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
+++ b/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestSBValueSynthetic(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_str(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        vector = self.frame().FindVariable("vector")
+        has_vector = self.frame().FindVariable("has_vector")
+        self.expect(str(vector), exe=False, substrs=["42", "47"])
+        self.expect(str(has_vector), exe=False, substrs=["42", "47"])

--- a/lldb/test/API/python_api/sbvalue_synthetic/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_synthetic/main.cpp
@@ -1,0 +1,11 @@
+#include <vector>
+
+struct HasVector {
+  std::vector<int> v;
+};
+
+int main() {
+  std::vector<int> vector = {42, 47};
+  HasVector has_vector = {vector};
+  return 0; // break here
+}


### PR DESCRIPTION
The function was using the default version of ValueObject::Dump, which has a default of using the synthetic-ness of the top-level value for determining whether to print _all_ values as synthetic. This resulted in some unusual behavior, where e.g. a std::vector is stringified as synthetic if its dumped as the top level object, but in its raw form if it is a member of a struct without a pretty printer.

The SBValue class already has properties which determine whether one should be looking at the synthetic view of the object (and also whether to use dynamic types), so it seems more natural to use that.