### PR TITLE
[libc] Remove unnecessary call in memfunction dispatchers

### DIFF
--- a/libc/src/string/memory_utils/inline_bcmp.h
+++ b/libc/src/string/memory_utils/inline_bcmp.h
@@ -32,8 +32,8 @@
 
 namespace LIBC_NAMESPACE {
 
-__attribute__((flatten)) LIBC_INLINE int
-inline_bcmp(const void *p1, const void *p2, size_t count) {
+[[gnu::flatten]] LIBC_INLINE int inline_bcmp(const void *p1, const void *p2,
+                                             size_t count) {
   return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_BCMP(
       reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
 }

--- a/libc/src/string/memory_utils/inline_bcmp.h
+++ b/libc/src/string/memory_utils/inline_bcmp.h
@@ -32,7 +32,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LIBC_INLINE int inline_bcmp(const void *p1, const void *p2, size_t count) {
+__attribute__((flatten)) LIBC_INLINE int
+inline_bcmp(const void *p1, const void *p2, size_t count) {
   return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_BCMP(
       reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
 }

--- a/libc/src/string/memory_utils/inline_bzero.h
+++ b/libc/src/string/memory_utils/inline_bzero.h
@@ -16,11 +16,13 @@
 
 namespace LIBC_NAMESPACE {
 
-LIBC_INLINE static void inline_bzero(Ptr dst, size_t count) {
+__attribute__((flatten)) LIBC_INLINE static void inline_bzero(Ptr dst,
+                                                              size_t count) {
   inline_memset(dst, 0, count);
 }
 
-LIBC_INLINE static void inline_bzero(void *dst, size_t count) {
+__attribute__((flatten)) LIBC_INLINE static void inline_bzero(void *dst,
+                                                              size_t count) {
   inline_bzero(reinterpret_cast<Ptr>(dst), count);
 }
 

--- a/libc/src/string/memory_utils/inline_bzero.h
+++ b/libc/src/string/memory_utils/inline_bzero.h
@@ -16,13 +16,11 @@
 
 namespace LIBC_NAMESPACE {
 
-__attribute__((flatten)) LIBC_INLINE static void inline_bzero(Ptr dst,
-                                                              size_t count) {
+[[gnu::flatten]] LIBC_INLINE static void inline_bzero(Ptr dst, size_t count) {
   inline_memset(dst, 0, count);
 }
 
-__attribute__((flatten)) LIBC_INLINE static void inline_bzero(void *dst,
-                                                              size_t count) {
+[[gnu::flatten]] LIBC_INLINE static void inline_bzero(void *dst, size_t count) {
   inline_bzero(reinterpret_cast<Ptr>(dst), count);
 }
 

--- a/libc/src/string/memory_utils/inline_memcmp.h
+++ b/libc/src/string/memory_utils/inline_memcmp.h
@@ -33,7 +33,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LIBC_INLINE int inline_memcmp(const void *p1, const void *p2, size_t count) {
+__attribute__((flatten)) LIBC_INLINE int
+inline_memcmp(const void *p1, const void *p2, size_t count) {
   return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP(
       reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
 }

--- a/libc/src/string/memory_utils/inline_memcmp.h
+++ b/libc/src/string/memory_utils/inline_memcmp.h
@@ -33,8 +33,8 @@
 
 namespace LIBC_NAMESPACE {
 
-__attribute__((flatten)) LIBC_INLINE int
-inline_memcmp(const void *p1, const void *p2, size_t count) {
+[[gnu::flatten]] LIBC_INLINE int inline_memcmp(const void *p1, const void *p2,
+                                               size_t count) {
   return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP(
       reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
 }

--- a/libc/src/string/memory_utils/inline_memcpy.h
+++ b/libc/src/string/memory_utils/inline_memcpy.h
@@ -40,7 +40,7 @@
 
 namespace LIBC_NAMESPACE {
 
-__attribute__((flatten)) LIBC_INLINE void
+[[gnu::flatten]] LIBC_INLINE void
 inline_memcpy(void *__restrict dst, const void *__restrict src, size_t count) {
   LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY(reinterpret_cast<Ptr>(dst),
                                       reinterpret_cast<CPtr>(src), count);

--- a/libc/src/string/memory_utils/inline_memcpy.h
+++ b/libc/src/string/memory_utils/inline_memcpy.h
@@ -40,8 +40,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LIBC_INLINE void inline_memcpy(void *__restrict dst, const void *__restrict src,
-                               size_t count) {
+__attribute__((flatten)) LIBC_INLINE void
+inline_memcpy(void *__restrict dst, const void *__restrict src, size_t count) {
   LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY(reinterpret_cast<Ptr>(dst),
                                       reinterpret_cast<CPtr>(src), count);
 }

--- a/libc/src/string/memory_utils/inline_memmove.h
+++ b/libc/src/string/memory_utils/inline_memmove.h
@@ -49,14 +49,14 @@ LIBC_INLINE constexpr bool inline_memmove_no_small_size(void *, const void *,
   return false;
 }
 
-LIBC_INLINE bool inline_memmove_small_size(void *dst, const void *src,
-                                           size_t count) {
+__attribute__((flatten)) LIBC_INLINE bool
+inline_memmove_small_size(void *dst, const void *src, size_t count) {
   return LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE(
       reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);
 }
 
-LIBC_INLINE void inline_memmove_follow_up(void *dst, const void *src,
-                                          size_t count) {
+__attribute__((flatten)) LIBC_INLINE void
+inline_memmove_follow_up(void *dst, const void *src, size_t count) {
   LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP(
       reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);
 }

--- a/libc/src/string/memory_utils/inline_memmove.h
+++ b/libc/src/string/memory_utils/inline_memmove.h
@@ -49,13 +49,13 @@ LIBC_INLINE constexpr bool inline_memmove_no_small_size(void *, const void *,
   return false;
 }
 
-__attribute__((flatten)) LIBC_INLINE bool
+[[gnu::flatten]] LIBC_INLINE bool
 inline_memmove_small_size(void *dst, const void *src, size_t count) {
   return LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE(
       reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);
 }
 
-__attribute__((flatten)) LIBC_INLINE void
+[[gnu::flatten]] LIBC_INLINE void
 inline_memmove_follow_up(void *dst, const void *src, size_t count) {
   LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP(
       reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);


### PR DESCRIPTION
Before this patch the compiler could generate unnecessary calls to the selected implementation.
https://clang.llvm.org/docs/AttributeReference.html#flatten
