### PR TITLE
[libc] expose aux vector

### DIFF
--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -49,10 +49,19 @@ typedef uintptr_t ArgcType;
 typedef uintptr_t ArgVEntryType;
 
 typedef uintptr_t EnvironType;
-typedef uintptr_t AuxEntryType;
 #else
 #error "argc and argv types are not defined for the target platform."
 #endif
+
+// Linux manpage on `proc(5)` says that the aux vector is an array of
+// unsigned long pairs.
+// (see: https://man7.org/linux/man-pages/man5/proc.5.html)
+using AuxEntryType = unsigned long;
+// Using the naming convention from `proc(5)`.
+struct AuxEntry {
+  AuxEntryType id;
+  AuxEntryType value;
+};
 
 struct Args {
   ArgcType argc;
@@ -78,6 +87,9 @@ struct AppProperties {
 
   // Environment data.
   EnvironType *env_ptr;
+
+  // Auxiliary vector data.
+  AuxEntry *auxv_ptr;
 };
 
 extern AppProperties app;

--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -58,6 +58,7 @@ typedef uintptr_t EnvironType;
 // (see: https://man7.org/linux/man-pages/man5/proc.5.html)
 using AuxEntryType = unsigned long;
 // Using the naming convention from `proc(5)`.
+// TODO: Would be nice to use the aux entry structure from elf.h when available.
 struct AuxEntry {
   AuxEntryType id;
   AuxEntryType value;

--- a/libc/startup/linux/aarch64/start.cpp
+++ b/libc/startup/linux/aarch64/start.cpp
@@ -126,12 +126,7 @@ static void call_fini_array_callbacks() {
 } // namespace LIBC_NAMESPACE
 
 using LIBC_NAMESPACE::app;
-
-// TODO: Would be nice to use the aux entry structure from elf.h when available.
-struct AuxEntry {
-  uint64_t type;
-  uint64_t value;
-};
+using LIBC_NAMESPACE::AuxEntry;
 
 __attribute__((noinline)) static void do_start() {
   auto tid = LIBC_NAMESPACE::syscall_impl<long>(SYS_gettid);
@@ -155,9 +150,9 @@ __attribute__((noinline)) static void do_start() {
   // denoted by an AT_NULL entry.
   Elf64_Phdr *program_hdr_table = nullptr;
   uintptr_t program_hdr_count;
-  for (AuxEntry *aux_entry = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
-       aux_entry->type != AT_NULL; ++aux_entry) {
-    switch (aux_entry->type) {
+  app.auxv_ptr = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
+  for (auto *aux_entry = app.auxv_ptr; aux_entry->id != AT_NULL; ++aux_entry) {
+    switch (aux_entry->id) {
     case AT_PHDR:
       program_hdr_table = reinterpret_cast<Elf64_Phdr *>(aux_entry->value);
       break;

--- a/libc/startup/linux/riscv/start.cpp
+++ b/libc/startup/linux/riscv/start.cpp
@@ -115,12 +115,7 @@ static void call_fini_array_callbacks() {
 } // namespace LIBC_NAMESPACE
 
 using LIBC_NAMESPACE::app;
-
-// TODO: Would be nice to use the aux entry structure from elf.h when available.
-struct AuxEntry {
-  LIBC_NAMESPACE::AuxEntryType type;
-  LIBC_NAMESPACE::AuxEntryType value;
-};
+using LIBC_NAMESPACE::AuxEntry;
 
 #if defined(LIBC_TARGET_ARCH_IS_X86_64) ||                                     \
     defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                    \
@@ -158,9 +153,9 @@ __attribute__((noinline)) static void do_start() {
   // denoted by an AT_NULL entry.
   PgrHdrTableType *program_hdr_table = nullptr;
   uintptr_t program_hdr_count;
-  for (AuxEntry *aux_entry = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
-       aux_entry->type != AT_NULL; ++aux_entry) {
-    switch (aux_entry->type) {
+  app.auxv_ptr = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
+  for (auto *aux_entry = app.auxv_ptr; aux_entry->id != AT_NULL; ++aux_entry) {
+    switch (aux_entry->id) {
     case AT_PHDR:
       program_hdr_table = reinterpret_cast<PgrHdrTableType *>(aux_entry->value);
       break;

--- a/libc/startup/linux/x86_64/start.cpp
+++ b/libc/startup/linux/x86_64/start.cpp
@@ -144,12 +144,7 @@ static void call_fini_array_callbacks() {
 } // namespace LIBC_NAMESPACE
 
 using LIBC_NAMESPACE::app;
-
-// TODO: Would be nice to use the aux entry structure from elf.h when available.
-struct AuxEntry {
-  uint64_t type;
-  uint64_t value;
-};
+using LIBC_NAMESPACE::AuxEntry;
 
 extern "C" void _start() {
   // This TU is compiled with -fno-omit-frame-pointer. Hence, the previous value
@@ -193,9 +188,9 @@ extern "C" void _start() {
   // denoted by an AT_NULL entry.
   Elf64_Phdr *program_hdr_table = nullptr;
   uintptr_t program_hdr_count = 0;
-  for (AuxEntry *aux_entry = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
-       aux_entry->type != AT_NULL; ++aux_entry) {
-    switch (aux_entry->type) {
+  app.auxv_ptr = reinterpret_cast<AuxEntry *>(env_end_marker + 1);
+  for (auto *aux_entry = app.auxv_ptr; aux_entry->id != AT_NULL; ++aux_entry) {
+    switch (aux_entry->id) {
     case AT_PHDR:
       program_hdr_table = reinterpret_cast<Elf64_Phdr *>(aux_entry->value);
       break;


### PR DESCRIPTION
This patch lifts aux vector related definitions to app.h. Because startup's refactoring is in progress, this patch still contains duplicated changes. This problem will be addressed very soon in an incoming patch.