### PR TITLE
[mlir][python] Fixup the constantTypes of pdl.TypesOp

### DIFF
--- a/mlir/python/mlir/dialects/pdl.py
+++ b/mlir/python/mlir/dialects/pdl.py
@@ -216,7 +216,5 @@ class TypesOp(TypesOp):
         loc=None,
         ip=None,
     ):
-        if constantTypes is None:
-            constantTypes = []
         result = pdl.RangeType.get(pdl.TypeType.get())
         super().__init__(result, constantTypes=constantTypes, loc=loc, ip=ip)


### PR DESCRIPTION
The default value of `constantTypes` in `pdl.TypesOp` should be `None` instead of `[]`, because if it's `[]`, it may cause PDL interpreter failure.