### PR TITLE
[Libomptarget] Remove remaining global constructors in plugins

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
@@ -49,15 +49,15 @@ struct RecordReplayTy {
 
 private:
   // Memory pointers for recording, replaying memory.
-  void *MemoryStart;
-  void *MemoryPtr;
-  size_t MemorySize;
-  size_t TotalSize;
-  GenericDeviceTy *Device;
-  std::mutex AllocationLock;
+  void *MemoryStart = nullptr;
+  void *MemoryPtr = nullptr;
+  size_t MemorySize = 0;
+  size_t TotalSize = 0;
+  GenericDeviceTy *Device = nullptr;
+  std::mutex AllocationLock{};
 
-  RRStatusTy Status;
-  bool ReplaySaveOutput;
+  RRStatusTy Status = RRDeactivated;
+  bool ReplaySaveOutput = false;
   bool UsedVAMap = false;
   uintptr_t MemoryOffset = 0;
 
@@ -190,7 +190,7 @@ public:
   void setStatus(RRStatusTy Status) { this->Status = Status; }
   bool isSaveOutputEnabled() const { return ReplaySaveOutput; }
 
-  RecordReplayTy()
+  constexpr RecordReplayTy()
       : Status(RRStatusTy::RRDeactivated), ReplaySaveOutput(false) {}
 
   void saveImage(const char *Name, const DeviceImageTy &Image) {
@@ -352,8 +352,9 @@ public:
       Device->free(MemoryStart);
     }
   }
+};
 
-} RecordReplay;
+static RecordReplayTy RecordReplay;
 
 // Extract the mapping of host function pointers to device function pointers
 // from the entry table. Functions marked as 'indirect' in OpenMP will have

--- a/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
@@ -190,9 +190,6 @@ public:
   void setStatus(RRStatusTy Status) { this->Status = Status; }
   bool isSaveOutputEnabled() const { return ReplaySaveOutput; }
 
-  constexpr RecordReplayTy()
-      : Status(RRStatusTy::RRDeactivated), ReplaySaveOutput(false) {}
-
   void saveImage(const char *Name, const DeviceImageTy &Image) {
     SmallString<128> ImageName = {Name, ".image"};
     std::error_code EC;

--- a/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
@@ -54,7 +54,7 @@ private:
   size_t MemorySize = 0;
   size_t TotalSize = 0;
   GenericDeviceTy *Device = nullptr;
-  std::mutex AllocationLock{};
+  std::mutex AllocationLock;
 
   RRStatusTy Status = RRDeactivated;
   bool ReplaySaveOutput = false;


### PR DESCRIPTION
Summary:
This patch fixes the remaining global constructor in the plguins after
addressing the ones in the JIT interface. This struct was mistakenly
using global constructors as not all the members were being initialized
properly. This was almost certainly being optimized out because it's
trivial, but would still be present in debug builds and prevented us
from compiling with `-Werror=global-constructors`. We will want to do
that once offloading is moved to a runtimes only build.
