### PR TITLE
[flang][driver] Remove Fortain_main static library from linking stages

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1133,15 +1133,14 @@ static bool isWholeArchivePresent(const ArgList &Args) {
   return WholeArchiveActive;
 }
 
+/// Determine if driver is invoked to create a shared object library (-static)
 static bool isSharedLinkage(const ArgList &Args) {
-  bool FoundSharedFlag = false;
-  for (auto *Arg : Args.filtered(options::OPT_shared)) {
-    if (Arg) {
-      FoundSharedFlag = true;
-    }
-  }
+  return Args.hasArg(options::OPT_shared);
+}
 
-  return FoundSharedFlag;
+/// Determine if driver is invoked to create a static object library (-shared)
+static bool isStaticLinkage(const ArgList &Args) {
+  return Args.hasArg(options::OPT_static);
 }
 
 /// Add Fortran runtime libs for MSVC
@@ -1176,13 +1175,12 @@ static void addFortranRuntimeLibsMSVC(const ArgList &Args,
 static void addFortranMain(const ToolChain &TC, const ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) {
   // 0. Shared-library linkage
-  // If we are attempting to link a shared library, we should not add
+  // If we are attempting to link a library, we should not add
   // -lFortran_main.a to the link line, as the `main` symbol is not
-  // required for a shared library and should also be provided by one
-  // of the translation units of the code that this shared library
+  // required for a library and should also be provided by one of
+  // the translation units of the code that this shared library
   // will be linked against eventually.
-  if (isSharedLinkage(Args)) {
-    printf("MK: --> shared linkage, do not add -lFortranMain\n");
+  if (isSharedLinkage(Args) || isStaticLinkage(Args)) {
     return;
   }
 

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -197,6 +197,12 @@ driver) or use Flang with the `-fno-fortran-main` flag.  This flag removes
 `Fortran_main` from the linker stage and hence requires one of the C/C++
 translation units to provide a definition of the `main` function.
 
+When creating shared or static libraries, `Fortran_main` is automatically
+removed from the linker stage.  It is assumed that when creating a static or
+shared library, the generated library does not need a `main` function, as a
+final link stage will occur that will provide the `Fortran_main` library when
+creating the final executable.
+
 ## Frontend Driver
 Flang's frontend driver is the main interface between compiler developers and
 the Flang frontend. The high-level design is similar to Clang's frontend

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -204,7 +204,7 @@ a code that has a Fortran program unit with a C/C++ code that also defines a
 libraries at link time (e.g., via `-lstdc++` for STL)
 
 If the code is C/C++ based and invokes Fortran routines, one can either use Clang
-for Flang as the linker driver.  If Clang is used, it will automatically all
+or Flang as the linker driver.  If Clang is used, it will automatically all
 required runtime libraries needed by C++ (e.g., for STL) to the linker invocation.
 In this case, one has to explicitly provide the Fortran runtime libraries
 `FortranRuntime` and/or `FortranDecimal`.  An alternative is to use Flang to link

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -213,11 +213,12 @@ and use the `-fno-fortran-main` flag.  This flag removes
 translation units to provide a definition of the `main` function. In this case,
 it may be required to explicitly supply C++ runtime libraries as mentioned above.
 
-When creating shared or static libraries, `Fortran_main` is automatically
-removed from the linker stage.  It is assumed that when creating a static or
-shared library, the generated library does not need a `main` function, as a
-final link stage will occur that will provide the `Fortran_main` library when
-creating the final executable.
+When creating shared or static libraries using Flang with -shared or -static
+flag, Fortran_main is automatically removed from the linker stage (i.e.,
+`-fno-fortran-main` is on by default).  It is assumed that when creating a
+static or shared library, the generated library does not need a `main`
+function, as a final link stage will occur that will provide the `Fortran_main`
+library when creating the final executable.
 
 ## Frontend Driver
 Flang's frontend driver is the main interface between compiler developers and

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -172,7 +172,18 @@ translation units supplied as object files.
 By default, the Flang linker driver adds several libraries to the linker
 invocation to make sure that all entrypoints for program start
 (Fortran's program unit) and runtime routines can be resolved by the linker.
-The libraries are:
+
+An abridged example (only showing the Fortran specific linker flags, omission
+indicated by `[...]`) for such a linker invocation on a Linux system would look
+like this:
+
+```
+$ flang -v -o example example.o
+"/usr/bin/ld" [...] example.o [...] "--whole-archive" "-lFortran_main"
+"--no-whole-archive" "-lFortranRuntime" "-lFortranDecimal" [...]
+```
+
+The automatically added libraries are:
 
 * `Fortran_main`: Provides the main entry point `main` that then invokes
   `_QQmain` with the Fortran program unit.  This library has a dependency to
@@ -182,20 +193,25 @@ The libraries are:
 
 The default is that, when using Flang as the linker, one of the Fortran
 translation units provides the program unit and therefore it is assumed that
-Fortran is the main code part (calling into C/C++ routines via `BIND
-(C)` interfaces).  When composing the linker commandline, Flang uses
+Fortran is the main code part (calling into C/C++ routines via `BIND (C)`
+interfaces).  When composing the linker commandline, Flang uses
 `--whole-archive` and `--no-whole-archive` (Windows: `/WHOLEARCHIVE:`,
-Darwin: *not implemented yet*) to make sure that all for `Fortran_main` is
-processed by the linker.  This is done to issue a proper error message when
+Darwin & AIX: *not implemented yet*) to make sure that all for `Fortran_main`
+is processed by the linker.  This is done to issue a proper error message when
 multiple definitions of `main` occur.  This happens, for instance, when linking
 a code that has a Fortran program unit with a C/C++ code that also defines a
-`main` function.
+`main` function.  A user may be required to explicitly provide the C++ runtime
+libraries at link time (e.g., via `-lstdc++` for STL)
 
-If the code is C/C++ based and invokes Fortran routines, either use Clang as the
-linker driver (supplying `FortranRuntime` and/or `FortranDecimal` to the linker
-driver) or use Flang with the `-fno-fortran-main` flag.  This flag removes
+If the code is C/C++ based and invokes Fortran routines, one can either use Clang
+for Flang as the linker driver.  If Clang is used, it will automatically all
+required runtime libraries needed by C++ (e.g., for STL) to the linker invocation.
+In this case, one has to explicitly provide the Fortran runtime libraries
+`FortranRuntime` and/or `FortranDecimal`.  An alternative is to use Flang to link
+and use the `-fno-fortran-main` flag.  This flag removes
 `Fortran_main` from the linker stage and hence requires one of the C/C++
-translation units to provide a definition of the `main` function.
+translation units to provide a definition of the `main` function. In this case,
+it may be required to explicitly supply C++ runtime libraries as mentioned above.
 
 When creating shared or static libraries, `Fortran_main` is automatically
 removed from the linker stage.  It is assumed that when creating a static or

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -213,7 +213,7 @@ and use the `-fno-fortran-main` flag.  This flag removes
 translation units to provide a definition of the `main` function. In this case,
 it may be required to explicitly supply C++ runtime libraries as mentioned above.
 
-When creating shared or static libraries using Flang with -shared or -static
+When creating shared or static libraries using Flang with `-shared` or `-static`
 flag, Fortran_main is automatically removed from the linker stage (i.e.,
 `-fno-fortran-main` is on by default).  It is assumed that when creating a
 static or shared library, the generated library does not need a `main`

--- a/flang/test/Driver/dynamic-linker.f90
+++ b/flang/test/Driver/dynamic-linker.f90
@@ -3,10 +3,12 @@
 
 ! RUN: %flang -### --target=x86_64-linux-gnu -rpath /path/to/dir -shared \
 ! RUN:     -static %s 2>&1 | FileCheck \
-! RUN:     --check-prefixes=GNU-LINKER-OPTIONS %s
+! RUN:     --check-prefixes=GNU-LINKER-OPTIONS \
+! RUN:     --implicit-check-not=GNU-LINKER-OPTIONS-NOT %s
 ! RUN: %flang -### --target=x86_64-windows-msvc -rpath /path/to/dir -shared \
 ! RUN:     -static %s 2>&1 | FileCheck \
 ! RUN:     --check-prefixes=MSVC-LINKER-OPTIONS %s
+! RUN:     --implicit-check-not=MSVC-LINKER-OPTIONS-NOT %s
 ! RUN: %flang -### --target=aarch64-linux-none -rdynamic %s 2>&1 | FileCheck --check-prefixes=RDYNAMIC-LINKER-OPTION %s
 
 ! TODO: Could the linker have an extension or a suffix?
@@ -14,6 +16,7 @@
 ! GNU-LINKER-OPTIONS-SAME: "-shared"
 ! GNU-LINKER-OPTIONS-SAME: "-static"
 ! GNU-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"
+! GNU-LINKER-OPTIONS-NOT: "-lFortran_main.a"
 
 ! RDYNAMIC-LINKER-OPTION: "{{.*}}ld"
 ! RDYNAMIC-LINKER-OPTION-SAME: "-export-dynamic"
@@ -22,3 +25,4 @@
 ! MSVC-LINKER-OPTIONS: "{{.*}}link{{(.exe)?}}"
 ! MSVC-LINKER-OPTIONS-SAME: "-dll"
 ! MSVC-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"
+! MSVC-LINKER-OPTIONS-NOT: "/WHOLEARCHIVE:Fortran_main"

--- a/flang/test/Driver/dynamic-linker.f90
+++ b/flang/test/Driver/dynamic-linker.f90
@@ -7,7 +7,7 @@
 ! RUN:     --implicit-check-not=GNU-LINKER-OPTIONS-NOT %s
 ! RUN: %flang -### --target=x86_64-windows-msvc -rpath /path/to/dir -shared \
 ! RUN:     -static %s 2>&1 | FileCheck \
-! RUN:     --check-prefixes=MSVC-LINKER-OPTIONS %s
+! RUN:     --check-prefixes=MSVC-LINKER-OPTIONS \
 ! RUN:     --implicit-check-not=MSVC-LINKER-OPTIONS-NOT %s
 ! RUN: %flang -### --target=aarch64-linux-none -rdynamic %s 2>&1 | FileCheck --check-prefixes=RDYNAMIC-LINKER-OPTION %s
 


### PR DESCRIPTION
At present, when building static or shared libraries, Flang adds `-lFortran_main.a` (or `/WHOLEARCHIVE:Fortran.*.lib` pon Windows) to the link line.  This leads to the problem that `_QQmain` and `_QQEnvironmentDefaults` (as of the time of this PR) are symbols marked as used, while `main` is being defined.  This should not happen and this PR fixes this by detecting if `-shared` or `-static` is used on the Flang command line and removing the static `Fortran_main` library.