### PR TITLE
True fixpoint algorithm in RS4GC

### DIFF
--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1031,13 +1031,13 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
         NewState.meet(OpState);
       });
 
-      // if the instruction has known base, but should in fact be marked as 
-      // conflict because of incompatible in/out types, we mark it as such 
+      // if the instruction has known base, but should in fact be marked as
+      // conflict because of incompatible in/out types, we mark it as such
       // ensuring that it will propagate through the fixpoint iteration
       auto I = cast<Instruction>(BDV);
       auto BV = NewState.getBaseValue();
       if (BV && MarkConflict(I, BV))
-          NewState = BDVState(I, BDVState::Conflict);
+        NewState = BDVState(I, BDVState::Conflict);
 
       BDVState OldState = Pair.second;
       if (OldState != NewState) {
@@ -1058,8 +1058,8 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
   }
 #endif
 
-  // since we do the conflict marking as part of the fixpoint iteration this loop
-  // only asserts that invariants are met
+  // since we do the conflict marking as part of the fixpoint iteration this
+  // loop only asserts that invariants are met
   for (auto Pair : States) {
     Instruction *I = cast<Instruction>(Pair.first);
     BDVState State = Pair.second;

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -967,51 +967,6 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
     return BDVState(BaseValue, BDVState::Base, BaseValue);
   };
 
-  bool Progress = true;
-  while (Progress) {
-#ifndef NDEBUG
-    const size_t OldSize = States.size();
-#endif
-    Progress = false;
-    // We're only changing values in this loop, thus safe to keep iterators.
-    // Since this is computing a fixed point, the order of visit does not
-    // effect the result.  TODO: We could use a worklist here and make this run
-    // much faster.
-    for (auto Pair : States) {
-      Value *BDV = Pair.first;
-      // Only values that do not have known bases or those that have differing
-      // type (scalar versus vector) from a possible known base should be in the
-      // lattice.
-      assert((!isKnownBase(BDV, KnownBases) ||
-             !areBothVectorOrScalar(BDV, Pair.second.getBaseValue())) &&
-                 "why did it get added?");
-
-      BDVState NewState(BDV);
-      visitBDVOperands(BDV, [&](Value *Op) {
-        Value *BDV = findBaseOrBDV(Op, Cache, KnownBases);
-        auto OpState = GetStateForBDV(BDV, Op);
-        NewState.meet(OpState);
-      });
-
-      BDVState OldState = Pair.second;
-      if (OldState != NewState) {
-        Progress = true;
-        States[BDV] = NewState;
-      }
-    }
-
-    assert(OldSize == States.size() &&
-           "fixed point shouldn't be adding any new nodes to state");
-  }
-
-#ifndef NDEBUG
-  VerifyStates();
-  LLVM_DEBUG(dbgs() << "States after meet iteration:\n");
-  for (const auto &Pair : States) {
-    LLVM_DEBUG(dbgs() << " " << Pair.second << " for " << *Pair.first << "\n");
-  }
-#endif
-
   // Even though we have identified a concrete base (or a conflict) for all live
   // pointers at this point, there are cases where the base is of an
   // incompatible type compared to the original instruction. We conservatively
@@ -1023,7 +978,7 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
   // the BDVs.
   // TODO: in many cases the instructions emited for the conflicting states
   // will be identical to the I itself (if the I's operate on their BDVs
-  // themselves). We should expoit this, but can't do it here since it would
+  // themselves). We should exploit this, but can't do it here since it would
   // break the invariant about the BDVs not being known to be a base.
   // TODO: the code also does not handle constants at all - the algorithm relies
   // on all constants having the same BDV and therefore constant-only insns
@@ -1050,6 +1005,61 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
     return false;
   };
 
+  bool Progress = true;
+  while (Progress) {
+#ifndef NDEBUG
+    const size_t OldSize = States.size();
+#endif
+    Progress = false;
+    // We're only changing values in this loop, thus safe to keep iterators.
+    // Since this is computing a fixed point, the order of visit does not
+    // effect the result.  TODO: We could use a worklist here and make this run
+    // much faster.
+    for (auto Pair : States) {
+      Value *BDV = Pair.first;
+      // Only values that do not have known bases or those that have differing
+      // type (scalar versus vector) from a possible known base should be in the
+      // lattice.
+      assert((!isKnownBase(BDV, KnownBases) ||
+             !areBothVectorOrScalar(BDV, Pair.second.getBaseValue())) &&
+                 "why did it get added?");
+
+      BDVState NewState(BDV);
+      visitBDVOperands(BDV, [&](Value *Op) {
+        Value *BDV = findBaseOrBDV(Op, Cache, KnownBases);
+        auto OpState = GetStateForBDV(BDV, Op);
+        NewState.meet(OpState);
+      });
+
+      // if the instruction has known base, but should in fact be marked as 
+      // conflict because of incompatible in/out types, we mark it as such 
+      // ensuring that it will propagate through the fixpoint iteration
+      auto I = cast<Instruction>(BDV);
+      auto BV = NewState.getBaseValue();
+      if (BV && MarkConflict(I, BV))
+          NewState = BDVState(I, BDVState::Conflict);
+
+      BDVState OldState = Pair.second;
+      if (OldState != NewState) {
+        Progress = true;
+        States[BDV] = NewState;
+      }
+    }
+
+    assert(OldSize == States.size() &&
+           "fixed point shouldn't be adding any new nodes to state");
+  }
+
+#ifndef NDEBUG
+  VerifyStates();
+  LLVM_DEBUG(dbgs() << "States after meet iteration:\n");
+  for (const auto &Pair : States) {
+    LLVM_DEBUG(dbgs() << " " << Pair.second << " for " << *Pair.first << "\n");
+  }
+#endif
+
+  // since we do the conflict marking as part of the fixpoint iteration this loop
+  // only asserts that invariants are met
   for (auto Pair : States) {
     Instruction *I = cast<Instruction>(Pair.first);
     BDVState State = Pair.second;
@@ -1061,14 +1071,6 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
         (!isKnownBase(I, KnownBases) || !areBothVectorOrScalar(I, BaseValue)) &&
         "why did it get added?");
     assert(!State.isUnknown() && "Optimistic algorithm didn't complete!");
-
-    // since we only mark vec-scalar insns as conflicts in the pass, our work is
-    // done if the instruction already conflicts
-    if (State.isConflict())
-      continue;
-
-    if (MarkConflict(I, BaseValue))
-      States[I] = BDVState(I, BDVState::Conflict);
   }
 
 #ifndef NDEBUG


### PR DESCRIPTION
Fixes a problem where the explicit marking of various instructions as conflicts did not propagate to their users. An example of this:

```
%getelementptr = getelementptr i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i64> <i64 888, i64 908>
%shufflevector = shufflevector <2 x ptr addrspace(1)> %getelementptr, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
%shufflevector1 = shufflevector <2 x ptr addrspace(1)> %getelementptr, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
%select = select i1 false, <4 x ptr addrspace(1)> %shufflevector1, <4 x ptr addrspace(1)> %shufflevector
```

Here the vector shuffles will get single base (gep) during the fixpoint and therefore the select will get a known base (gep). We later mark the shuffles as conflicts, but this does not change the base of select. This gets caught by an assert where the select's type will differ from its (wrong) base later on.

The solution in the MR is to move the explicit conflict marking into the fixpoint phase.
