### PR TITLE
Add tests for driver to propagate module map flags for layering check

### DIFF
--- a/clang/test/Driver/modules.m
+++ b/clang/test/Driver/modules.m
@@ -57,6 +57,14 @@
 // CHECK-MODULE-MAP-FILES: "-fmodule-map-file=foo.map"
 // CHECK-MODULE-MAP-FILES: "-fmodule-map-file=bar.map"
 
+// Verify that the driver propagates -fmodule-name and -fmodule-map-file flags even with
+// -fno-modules.  We rely on this behavior for layering check.
+// RUN: %clang -fno-modules -fmodule-name=foo -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-PROPAGATE-MODULE-NAME %s
+// CHECK-PROPAGATE-MODULE-NAME: -fmodule-name=foo
+
+// RUN: %clang -fno-modules -fmodule-map-file=foo.map -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-PROPAGATE-MODULE-MAPS %s
+// CHECK-PROPAGATE-MODULE-MAPS: -fmodule-map-file=foo.map
+
 // RUN: %clang -fmodules -fbuiltin-module-map -### %s 2>&1 | FileCheck -check-prefix=CHECK-BUILTIN-MODULE-MAP %s
 // CHECK-BUILTIN-MODULE-MAP: "-fmodules"
 // CHECK-BUILTIN-MODULE-MAP: "-fmodule-map-file={{.*}}include{{/|\\\\}}module.modulemap"

--- a/clang/test/Driver/modules.m
+++ b/clang/test/Driver/modules.m
@@ -57,15 +57,21 @@
 // CHECK-MODULE-MAP-FILES: "-fmodule-map-file=foo.map"
 // CHECK-MODULE-MAP-FILES: "-fmodule-map-file=bar.map"
 
-// Verify that the driver propagates -fmodule-name and -fmodule-map-file flags even with
-// -fno-modules.  We rely on this behavior for layering check.
-// RUN: %clang -fno-modules -fmodule-name=foo -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-PROPAGATE-MODULE-NAME %s
-// CHECK-PROPAGATE-MODULE-NAME: -fmodule-name=foo
+// Verify that the driver propagates -fmodule-name and -fmodule-map-file flags when
+// -fmodules-decluse or -fmodules-strict-decluse, as used for layering check.
+// RUN: %clang -fmodules-decluse -fmodule-name=foo -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-DECLUSE-PROPAGATE-MODULE-NAME %s
+// CHECK-DECLUSE-PROPAGATE-MODULE-NAME: -fmodule-name=foo
 
-// RUN: %clang -fno-modules -fmodule-map-file=foo.map -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-PROPAGATE-MODULE-MAPS %s
-// CHECK-PROPAGATE-MODULE-MAPS: -fmodule-map-file=foo.map
+// RUN: %clang -fmodules-decluse -fmodule-map-file=foo.map -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-DECLUSE-PROPAGATE-MODULE-MAPS %s
+// CHECK-DECLUSE-PROPAGATE-MODULE-MAPS: -fmodule-map-file=foo.map
 
-// RUN: %clang -fmodules -fbuiltin-module-map -### %s 2>&1 | FileCheck -check-prefix=CHECK-BUILTIN-MODULE-MAP %s
+// RUN: %clang -fmodules-strict-decluse -fmodule-name=foo -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-STRICT-DECLUSE-PROPAGATE-MODULE-NAME %s
+// CHECK-STRICT-DECLUSE-PROPAGATE-MODULE-NAME: -fmodule-name=foo
+
+// RUN: %clang -fmodules-strict-decluse -fmodule-map-file=foo.map -c -### %s 2>&1 | FileCheck -check-prefix=CHECK-STRICT-DECLUSE-PROPAGATE-MODULE-MAPS %s
+// CHECK-STRICT-DECLUSE-PROPAGATE-MODULE-MAPS: -fmodule-map-file=foo.map
+
+    // RUN: %clang -fmodules -fbuiltin-module-map -### %s 2>&1 | FileCheck -check-prefix=CHECK-BUILTIN-MODULE-MAP %s
 // CHECK-BUILTIN-MODULE-MAP: "-fmodules"
 // CHECK-BUILTIN-MODULE-MAP: "-fmodule-map-file={{.*}}include{{/|\\\\}}module.modulemap"
 


### PR DESCRIPTION
…ules

We use this to verify properties of our build graph, even when modules are off.  Xcode 14.3.1 seems to have dropped these flags so we are creating a unit test to reproduce the issue.