### PR TITLE
[llvm-objcopy] --gap-fill and 0-size sections

### DIFF
--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -2638,7 +2638,7 @@ template <class ELFT> Error ELFWriter<ELFT>::finalize() {
 Error BinaryWriter::write() {
   SmallVector<const SectionBase *, 30> SectionsToWrite;
   for (const SectionBase &Sec : Obj.allocSections()) {
-    if (Sec.Type != SHT_NOBITS)
+    if (Sec.Type != SHT_NOBITS && Sec.Size > 0)
       SectionsToWrite.push_back(&Sec);
   }
 

--- a/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
@@ -108,7 +108,7 @@ Sections:
     Content:         'AABBCCDDFEDCBA'
   - Name:            .zero_size
     Type:            SHT_PROGBITS
-    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Flags:           [ SHF_ALLOC ]
     Address:         0x0110
     Size:            0
   - Name:            .space2

--- a/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/gap-fill.test
@@ -106,6 +106,11 @@ Sections:
     Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
     Address:         0x0108
     Content:         'AABBCCDDFEDCBA'
+  - Name:            .zero_size
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x0110
+    Size:            0
   - Name:            .space2
     Type:            Fill
     Pattern:         'DC'


### PR DESCRIPTION
In the change that added `--gap-fill`, the condition to choose the sections to write in `BinaryWriter::write()` did not exclude zero-size sections. However, zero-size sections did not have correct offsets assigned in `BinaryWriter::finalize()`. The result is either a failed assertion, or memory corruption due to writing to the buffer beyond its size.
To fix this, exclude zero-size sections and add a zero-size section to the test, which would trigger the bug.