### PR TITLE
Remove unused FileSPec::IsResolved() functionality.

### DIFF
--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -386,21 +386,6 @@ public:
   ///     The triple which is used to set the Path style.
   void SetFile(llvm::StringRef path, const llvm::Triple &triple);
 
-  bool IsResolved() const { return m_is_resolved; }
-
-  /// Set if the file path has been resolved or not.
-  ///
-  /// If you know a file path is already resolved and avoided passing a \b
-  /// true parameter for any functions that take a "bool resolve_path"
-  /// parameter, you can set the value manually using this call to make sure
-  /// we don't try and resolve it later, or try and resolve a path that has
-  /// already been resolved.
-  ///
-  /// \param[in] is_resolved
-  ///     A boolean value that will replace the current value that
-  ///     indicates if the paths in this object have been resolved.
-  void SetIsResolved(bool is_resolved) { m_is_resolved = is_resolved; }
-
   FileSpec CopyByAppendingPathComponent(llvm::StringRef component) const;
   FileSpec CopyByRemovingLastPathComponent() const;
 
@@ -440,7 +425,6 @@ protected:
   /// state in this object.
   void PathWasModified() {
     m_checksum = Checksum();
-    m_is_resolved = false;
     m_absolute = Absolute::Calculate;
   }
 
@@ -458,9 +442,6 @@ protected:
 
   /// The optional MD5 checksum of the file.
   Checksum m_checksum;
-
-  /// True if this path has been resolved.
-  mutable bool m_is_resolved = false;
 
   /// Cache whether this path is absolute.
   mutable Absolute m_absolute = Absolute::Calculate;

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -259,7 +259,6 @@ void FileSystem::Resolve(FileSpec &file_spec) {
     file_spec.SetDirectory(path);
   else
     file_spec.SetPath(path);
-  file_spec.SetIsResolved(true);
 }
 
 template <typename T>


### PR DESCRIPTION
This API seems to be completely unused. Should we just remove it?