### PR TITLE
[mlir][scf] Improve `scf.parallel` fusion pass

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
@@ -34,7 +34,7 @@ class ParallelOp;
 /// Fuses all adjacent scf.parallel operations with identical bounds and step
 /// into one scf.parallel operations. Uses a naive aliasing and dependency
 /// analysis.
-/// User can additioanlly customize alias checking with `mayAlias` hook.
+/// User can additionally customize alias checking with `mayAlias` hook.
 /// `mayAlias` must return false if 2 values are guaranteed to not alias.
 void naivelyFuseParallelOps(Region &region,
                             llvm::function_ref<bool(Value, Value)> mayAlias);

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
@@ -34,7 +34,10 @@ class ParallelOp;
 /// Fuses all adjacent scf.parallel operations with identical bounds and step
 /// into one scf.parallel operations. Uses a naive aliasing and dependency
 /// analysis.
-void naivelyFuseParallelOps(Region &region);
+/// User can additioanlly customize alias checking with `mayAlias` hook.
+/// `mayAlias` must return false if 2 values are guaranteed to no alias.
+void naivelyFuseParallelOps(Region &region,
+                            llvm::function_ref<bool(Value, Value)> mayAlias);
 
 /// Rewrite a for loop with bounds/step that potentially do not divide evenly
 /// into a for loop where the step divides the iteration space evenly, followed

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
@@ -35,7 +35,7 @@ class ParallelOp;
 /// into one scf.parallel operations. Uses a naive aliasing and dependency
 /// analysis.
 /// User can additioanlly customize alias checking with `mayAlias` hook.
-/// `mayAlias` must return false if 2 values are guaranteed to no alias.
+/// `mayAlias` must return false if 2 values are guaranteed to not alias.
 void naivelyFuseParallelOps(Region &region,
                             llvm::function_ref<bool(Value, Value)> mayAlias);
 

--- a/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
+++ b/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
@@ -383,7 +383,7 @@ func.func @do_not_fuse_alias(%A: memref<2x2xf32>, %B: memref<2x2xf32>,
   return
 }
 
-// %sum and %result may alias, do not fuse loops
+// %sum and %result may alias with other args, do not fuse loops
 // CHECK-LABEL: func @do_not_fuse_alias
 // CHECK:      scf.parallel
 // CHECK:      scf.parallel

--- a/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
+++ b/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
@@ -357,3 +357,33 @@ func.func @nested_fuse(%A: memref<2x2xf32>, %B: memref<2x2xf32>,
 // CHECK:        }
 // CHECK:      }
 // CHECK:      memref.dealloc [[SUM]]
+
+// -----
+
+func.func @do_not_fuse_alias(%A: memref<2x2xf32>, %B: memref<2x2xf32>,
+                             %C: memref<2x2xf32>, %result: memref<2x2xf32>,
+                             %sum: memref<2x2xf32>) {
+  %c2 = arith.constant 2 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.parallel (%i, %j) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+    %B_elem = memref.load %B[%i, %j] : memref<2x2xf32>
+    %C_elem = memref.load %C[%i, %j] : memref<2x2xf32>
+    %sum_elem = arith.addf %B_elem, %C_elem : f32
+    memref.store %sum_elem, %sum[%i, %j] : memref<2x2xf32>
+    scf.yield
+  }
+  scf.parallel (%i, %j) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+    %sum_elem = memref.load %sum[%i, %j] : memref<2x2xf32>
+    %A_elem = memref.load %A[%i, %j] : memref<2x2xf32>
+    %product_elem = arith.mulf %sum_elem, %A_elem : f32
+    memref.store %product_elem, %result[%i, %j] : memref<2x2xf32>
+    scf.yield
+  }
+  return
+}
+
+// %sum and %result may alias, do not fuse loops
+// CHECK-LABEL: func @do_not_fuse_alias
+// CHECK:      scf.parallel
+// CHECK:      scf.parallel


### PR DESCRIPTION
Abort fusion if memref load may alias write, but not the exact alias. 
Add alias check hook to `naivelyFuseParallelOps`, so user can customize alias checking. 
Use builtin alias analysis in `ParallelLoopFusion` pass.