### PR TITLE
[docs][NFC] Add usage instructions for FatLTO

### DIFF
--- a/llvm/docs/FatLTO.rst
+++ b/llvm/docs/FatLTO.rst
@@ -89,43 +89,31 @@ Compile and link. Use the object code from the fat object without LTO.
 
 .. code-block:: console
 
-   $ clang -fno-lto -ffat-lto-objects -fuse-ld=lld foo.c
+   $ clang -fno-lto -ffat-lto-objects -fuse-ld=lld example.c
 
 Compile and link. Select full LTO at link time.
 
 .. code-block:: console
 
-   $ clang -flto -ffat-lto-objects -fuse-ld=lld foo.c
+   $ clang -flto -ffat-lto-objects -fuse-ld=lld example.c
 
 Compile and link. Select ThinLTO at link time.
 
 .. code-block:: console
 
-   $ clang -flto=thin -ffat-lto-objects -fuse-ld=lld foo.c
-
-Compile and link. Use ThinLTO with the UnifiedLTO pipeline.
-
-.. code-block:: console
-
-   $ clang -flto=thin -ffat-lto-objects -funified-lto -fuse-ld=lld foo.c
-
-Compile and link. Use full LTO  with the UnifiedLTO pipeline.
-
-.. code-block:: console
-
-   $ clang -flto -ffat-lto-objects -funified-lto -fuse-ld=lld foo.c
+   $ clang -flto=thin -ffat-lto-objects -fuse-ld=lld example.c
 
 Link separately, using ThinLTO.
 
 .. code-block:: console
 
-   $ clang -c -flto=thin -ffat-lto-objects foo.c
+   $ clang -c -flto=thin -ffat-lto-objects example.c
    $ clang -flto=thin -fuse-ld=lld foo.o -ffat-lto-objects  # pass --lto=thin --fat-lto-objects to ld.lld
 
 Link separately, using full LTO.
 
 .. code-block:: console
 
-   $ clang -c -flto -ffat-lto-objects foo.c
+   $ clang -c -flto -ffat-lto-objects example.c
    $ clang -flto -fuse-ld=lld foo.o  # pass --lto=full --fat-lto-objects to ld.lld
 

--- a/llvm/docs/FatLTO.rst
+++ b/llvm/docs/FatLTO.rst
@@ -78,19 +78,19 @@ unclear if it will be useful to support other object file formats like ``COFF``
 or ``Mach-O``.
 
 Usage
-===========
+=====
 
-Users are expected to pass ``-ffat-lto-objects`` to clang in addition to one of
-the ``-flto`` variants. Without the ``-flto`` flag, ``-ffat-lto-objects`` has
-no effect.
+Clang users can specify ``-ffat-lto-objects`` with ``-flto`` or ``-flto=thin``.
+Without the ``-flto`` option, ``-ffat-lto-objects`` has no effect.
 
 Compile an object file using FatLTO:
 
 .. code-block:: console
 
-   $ clang -flto -ffat-lto-objects example.c -o example.o
+   $ clang -flto -ffat-lto-objects example.c -c -o example.o
 
-Link using the object code from the fat object without LTO:
+Link using the object code from the fat object without LTO. This turns
+``-ffat-lto-objects`` into a no-op, when ``-fno-lto`` is specified:
 
 .. code-block:: console
 

--- a/llvm/docs/FatLTO.rst
+++ b/llvm/docs/FatLTO.rst
@@ -76,3 +76,56 @@ Supported File Formats
 The current implementation only supports ELF files. At time of writing, it is
 unclear if it will be useful to support other object file formats like ``COFF``
 or ``Mach-O``.
+
+Usage
+===========
+
+Users are expected to pass ``-ffat-lto-objects`` to clang in addition to one of
+the ``-flto`` variants. Without the ``-flto`` flag, ``-ffat-lto-objects`` has
+no effect.
+
+
+Compile and link. Use the object code from the fat object without LTO.
+
+.. code-block:: console
+
+   $ clang -fno-lto -ffat-lto-objects -fuse-ld=lld foo.c
+
+Compile and link. Select full LTO at link time.
+
+.. code-block:: console
+
+   $ clang -flto -ffat-lto-objects -fuse-ld=lld foo.c
+
+Compile and link. Select ThinLTO at link time.
+
+.. code-block:: console
+
+   $ clang -flto=thin -ffat-lto-objects -fuse-ld=lld foo.c
+
+Compile and link. Use ThinLTO with the UnifiedLTO pipeline.
+
+.. code-block:: console
+
+   $ clang -flto=thin -ffat-lto-objects -funified-lto -fuse-ld=lld foo.c
+
+Compile and link. Use full LTO  with the UnifiedLTO pipeline.
+
+.. code-block:: console
+
+   $ clang -flto -ffat-lto-objects -funified-lto -fuse-ld=lld foo.c
+
+Link separately, using ThinLTO.
+
+.. code-block:: console
+
+   $ clang -c -flto=thin -ffat-lto-objects foo.c
+   $ clang -flto=thin -fuse-ld=lld foo.o -ffat-lto-objects  # pass --lto=thin --fat-lto-objects to ld.lld
+
+Link separately, using full LTO.
+
+.. code-block:: console
+
+   $ clang -c -flto -ffat-lto-objects foo.c
+   $ clang -flto -fuse-ld=lld foo.o  # pass --lto=full --fat-lto-objects to ld.lld
+

--- a/llvm/docs/FatLTO.rst
+++ b/llvm/docs/FatLTO.rst
@@ -84,36 +84,32 @@ Users are expected to pass ``-ffat-lto-objects`` to clang in addition to one of
 the ``-flto`` variants. Without the ``-flto`` flag, ``-ffat-lto-objects`` has
 no effect.
 
-
-Compile and link. Use the object code from the fat object without LTO.
-
-.. code-block:: console
-
-   $ clang -fno-lto -ffat-lto-objects -fuse-ld=lld example.c
-
-Compile and link. Select full LTO at link time.
+Compile an object file using FatLTO:
 
 .. code-block:: console
 
-   $ clang -flto -ffat-lto-objects -fuse-ld=lld example.c
+   $ clang -flto -ffat-lto-objects example.c -o example.o
 
-Compile and link. Select ThinLTO at link time.
-
-.. code-block:: console
-
-   $ clang -flto=thin -ffat-lto-objects -fuse-ld=lld example.c
-
-Link separately, using ThinLTO.
+Link using the object code from the fat object without LTO:
 
 .. code-block:: console
 
-   $ clang -c -flto=thin -ffat-lto-objects example.c
-   $ clang -flto=thin -fuse-ld=lld foo.o -ffat-lto-objects  # pass --lto=thin --fat-lto-objects to ld.lld
+   $ clang -fno-lto -ffat-lto-objects -fuse-ld=lld example.o
 
-Link separately, using full LTO.
+Alternatively, you can omit any references to LTO with fat objects and retain standard linker behavior:
 
 .. code-block:: console
 
-   $ clang -c -flto -ffat-lto-objects example.c
-   $ clang -flto -fuse-ld=lld foo.o  # pass --lto=full --fat-lto-objects to ld.lld
+   $ clang -fuse-ld=lld example.o
 
+Link using the LLVM bitcode from the fat object with Full LTO:
+
+.. code-block:: console
+
+   $ clang -flto -ffat-lto-objects -fuse-ld=lld example.o  # clang will pass --lto=full --fat-lto-objects to ld.lld
+
+Link using the LLVM bitcode from the fat object with Thin LTO:
+
+.. code-block:: console
+
+   $ clang -flto=thin -ffat-lto-objects -fuse-ld=lld example.o  # clang will pass --lto=thin --fat-lto-objects to ld.lld


### PR DESCRIPTION
We included these in the commit message when we added `-ffat-lto-objects`, but they should be in the documentation as well.