### PR TITLE
[mlir][vector] Refactor parts of `VectorToSCF.cpp` (NFC)

### DIFF
--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -870,7 +870,6 @@ struct TransferOpConversion : public VectorToSCFPattern<OpTy> {
                             Value iv, ValueRange loopState,
                             Value castedMaskBuffer, PatternRewriter &rewriter,
                             Location loc) const {
-    // Create new transfer op.
     OpTy newXfer = Strategy<OpTy>::rewriteOp(b, this->options, xferOp,
                                              castedDataBuffer, iv, loopState);
 

--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -595,8 +595,7 @@ struct PrepareTransferReadConversion
     auto *newXfer = rewriter.clone(*xferOp.getOperation());
     newXfer->setAttr(kPassLabel, rewriter.getUnitAttr());
     if (xferOp.getMask()) {
-      cast<TransferReadOp>(newXfer).getMaskMutable().assign(
-          buffers.maskBuffer);
+      cast<TransferReadOp>(newXfer).getMaskMutable().assign(buffers.maskBuffer);
     }
 
     Location loc = xferOp.getLoc();
@@ -724,15 +723,12 @@ struct DecomposePrintOpConversion : public VectorToSCFPattern<vector::PrintOp> {
       VectorType signlessTarget =
           vectorType.cloneWith({}, getIntTypeWithSignlessSemantics(legalIntTy));
       VectorType target = vectorType.cloneWith({}, legalIntTy);
-      value = rewriter.create<vector::BitCastOp>(loc, signlessSource,
-                                                 value);
+      value = rewriter.create<vector::BitCastOp>(loc, signlessSource, value);
       if (value.getType() != signlessTarget) {
         if (width == 1 || intTy.isUnsigned())
-          value = rewriter.create<arith::ExtUIOp>(loc, signlessTarget,
-                                                  value);
+          value = rewriter.create<arith::ExtUIOp>(loc, signlessTarget, value);
         else
-          value = rewriter.create<arith::ExtSIOp>(loc, signlessTarget,
-                                                  value);
+          value = rewriter.create<arith::ExtSIOp>(loc, signlessTarget, value);
       }
       value = rewriter.create<vector::BitCastOp>(loc, target, value);
       vectorType = target;
@@ -749,7 +745,7 @@ struct DecomposePrintOpConversion : public VectorToSCFPattern<vector::PrintOp> {
       // non-constant value (which can currently only be done via
       // vector.extractelement for 1D vectors).
       int flatLength = std::accumulate(shape.begin(), shape.end(), 1,
-                                        std::multiplies<int64_t>());
+                                       std::multiplies<int64_t>());
       VectorType flat =
           VectorType::get({flatLength}, vectorType.getElementType());
       value = rewriter.create<vector::ShapeCastOp>(loc, flat, value);


### PR DESCRIPTION
I'm trying to work on https://github.com/llvm/llvm-project/issues/71326. However, the code in `VectorToSCF.cpp` is quite complex. This PR suggests the following refactorings to make it slightly simpler to read:

- Specify the type explicitly instead of using `auto`, except when the type is obvious (https://llvm.org/docs/CodingStandards.html#use-auto-type-deduction-to-make-code-more-readable).
- Replace a few Systems Hungarian namings by less verbose ones (related to the previous point). For example, `auto signlessSourceVectorType` to `VectorType signlessSource`.
-  Use `cast` instead of `dyn_cast` when the result is not tested.
- Extracted one method. The code is still complex, but (in my opinion) it is now slightly more clear which variables are used where.