### PR TITLE
[libc++] Remove usage of internal string function in sstream

### DIFF
--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -398,9 +398,9 @@ public:
     typename string_type::size_type __pos           = __view.empty() ? 0 : __view.data() - __str_.data();
     // In C++23, this is just string_type(std::move(__str_), __pos, __view.size(), __str_.get_allocator());
     // But we need something that works in C++20 also.
-    string_type __result(__str_.get_allocator());
-    __result.__move_assign(std::move(__str_), __pos, __view.size());
-    __str_.clear();
+    string_type __result(std::move(__str_), __str_.get_allocator());
+    __result.resize(__pos + __view.size());
+    __result.erase(0, __pos);
     __init_buf_ptrs();
     return __result;
   }


### PR DESCRIPTION
This function replaces a call to `__move_assign` (internal function) with two calls to public member functions (`resize` and `erase`). The order of calls is chosen for the best performance.

This change is required to [turn on ASan string annotations for short strings](https://github.com/llvm/llvm-project/pull/75882) (Short String Optimization - SSO).

The `std::basic_string` class's `void __move_assign(basic_string&& __str, size_type __pos, size_type __len)` function operates on uninitialized strings, where it is reasonable to assume that the memory is not poisoned. However, in `sstream` this function is applied to existing strings that already have poisoned memory.

String ASan annotations turned on here: https://github.com/llvm/llvm-project/pull/72677