### PR TITLE
[lldb] Remove unused GetChildAtIndexPath(...) methods from ValueObject.cpp

### DIFF
--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -469,14 +469,6 @@ public:
                                               bool can_create = true);
 
   // The method always creates missing children in the path, if necessary.
-  lldb::ValueObjectSP GetChildAtIndexPath(llvm::ArrayRef<size_t> idxs,
-                                          size_t *index_of_error = nullptr);
-
-  lldb::ValueObjectSP
-  GetChildAtIndexPath(llvm::ArrayRef<std::pair<size_t, bool>> idxs,
-                      size_t *index_of_error = nullptr);
-
-  // The method always creates missing children in the path, if necessary.
   lldb::ValueObjectSP GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names);
 
   virtual lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -393,46 +393,6 @@ ValueObjectSP ValueObject::GetChildAtIndex(size_t idx, bool can_create) {
 }
 
 lldb::ValueObjectSP
-ValueObject::GetChildAtIndexPath(llvm::ArrayRef<size_t> idxs,
-                                 size_t *index_of_error) {
-  if (idxs.size() == 0)
-    return GetSP();
-  ValueObjectSP root(GetSP());
-
-  size_t current_index = 0;
-  for (size_t idx : idxs) {
-    root = root->GetChildAtIndex(idx);
-    if (!root) {
-      if (index_of_error)
-        *index_of_error = current_index;
-      return root;
-    }
-    current_index += 1;
-  }
-  return root;
-}
-
-lldb::ValueObjectSP ValueObject::GetChildAtIndexPath(
-  llvm::ArrayRef<std::pair<size_t, bool>> idxs, size_t *index_of_error) {
-  if (idxs.size() == 0)
-    return GetSP();
-  ValueObjectSP root(GetSP());
-
-  size_t current_index = 0;
-  for (std::pair<size_t, bool> idx : idxs) {
-    root = root->GetChildAtIndex(idx.first, idx.second);
-    if (!root) {
-      if (index_of_error)
-        *index_of_error = current_index;
-      return root;
-    }
-
-    current_index += 1;
-  }
-  return root;
-}
-
-lldb::ValueObjectSP
 ValueObject::GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names) {
   if (names.size() == 0)
     return GetSP();


### PR DESCRIPTION
This a follow-up PR from this other one:
https://github.com/llvm/llvm-project/pull/74413

Nothing calls into these two methods, so we (@DavidSpickett, @adrian-prantl, and I) agreed to remove them once we merged the previous PR.