### PR TITLE
[llvm-ifs] Treat unknown symbol types as error.

### DIFF
--- a/llvm/lib/InterfaceStub/IFSHandler.cpp
+++ b/llvm/lib/InterfaceStub/IFSHandler.cpp
@@ -201,11 +201,11 @@ Expected<std::unique_ptr<IFSStub>> ifs::readIFSFromBuffer(StringRef Buf) {
           "IFS arch '" + *Stub->Target.ArchString + "' is unsupported");
     Stub->Target.Arch = eMachine;
   }
-  for (const auto &item : Stub->Symbols) {
-    if (item.Type == IFSSymbolType::Unknown)
+  for (const auto &Item : Stub->Symbols) {
+    if (Item.Type == IFSSymbolType::Unknown)
       return createStringError(
           std::make_error_code(std::errc::invalid_argument),
-          "IFS symbol type for symbol '" + item.Name + "' is unsupported");
+          "IFS symbol type for symbol '" + Item.Name + "' is unsupported");
   }
   return std::move(Stub);
 }

--- a/llvm/lib/InterfaceStub/IFSHandler.cpp
+++ b/llvm/lib/InterfaceStub/IFSHandler.cpp
@@ -201,6 +201,12 @@ Expected<std::unique_ptr<IFSStub>> ifs::readIFSFromBuffer(StringRef Buf) {
           "IFS arch '" + *Stub->Target.ArchString + "' is unsupported");
     Stub->Target.Arch = eMachine;
   }
+  for (const auto &item : Stub->Symbols) {
+    if (item.Type == IFSSymbolType::Unknown)
+      return createStringError(
+          std::make_error_code(std::errc::invalid_argument),
+          "IFS symbol type for symbol '" + item.Name + "' is unsupported");
+  }
   return std::move(Stub);
 }
 

--- a/llvm/lib/InterfaceStub/IFSStub.cpp
+++ b/llvm/lib/InterfaceStub/IFSStub.cpp
@@ -89,8 +89,9 @@ uint8_t ifs::convertIFSSymbolTypeToELF(IFSSymbolType SymbolType) {
   case IFSSymbolType::TLS:
     return ELF::STT_TLS;
   case IFSSymbolType::NoType:
-  default:
     return ELF::STT_NOTYPE;
+  default:
+    llvm_unreachable("unknown symbol type");
   }
 }
 

--- a/llvm/test/tools/llvm-ifs/ifs-read-invalid-symbol-type.test
+++ b/llvm/test/tools/llvm-ifs/ifs-read-invalid-symbol-type.test
@@ -5,10 +5,6 @@ SoName: somelib.so
 IfsVersion: 3.0
 Target: { ObjectFormat: ELF, Arch: Aarch64, Endianness: little, BitWidth: 64 }
 Symbols:
-  - { Name: foo, Type: Func }
-  - { Name: bar, Type: Object, Size: 42 }
-  - { Name: baz, Type: Object, Size: 8 }
-  - { Name: not, Type: Object, Size: 128, Undefined: true }
   - { Name: nor, Type: bogus, Undefined: true }
 ...
 

--- a/llvm/test/tools/llvm-ifs/ifs-read-invalid-symbol-type.test
+++ b/llvm/test/tools/llvm-ifs/ifs-read-invalid-symbol-type.test
@@ -1,0 +1,15 @@
+# RUN: not llvm-ifs --output-ifs=- %s 2>&1 | FileCheck %s
+
+--- !ifs-v1
+SoName: somelib.so
+IfsVersion: 3.0
+Target: { ObjectFormat: ELF, Arch: Aarch64, Endianness: little, BitWidth: 64 }
+Symbols:
+  - { Name: foo, Type: Func }
+  - { Name: bar, Type: Object, Size: 42 }
+  - { Name: baz, Type: Object, Size: 8 }
+  - { Name: not, Type: Object, Size: 128, Undefined: true }
+  - { Name: nor, Type: bogus, Undefined: true }
+...
+
+# CHECK: error: IFS symbol type for symbol 'nor' is unsupported

--- a/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
+++ b/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
@@ -68,7 +68,9 @@ TEST(ElfYamlTextAPI, YAMLReadsInvalidSymbols) {
       "Weak: true, Warning: \'All fields populated!\' }\n"
       "...\n";
   Expected<std::unique_ptr<IFSStub>> StubOrErr = readIFSFromBuffer(Data);
-  ASSERT_THAT_ERROR(StubOrErr.takeError(), Failed());
+  ASSERT_THAT_ERROR(
+      StubOrErr.takeError(),
+      FailedWithMessage("IFS symbol type for symbol 'not' is unsupported"));
 }
 
 TEST(ElfYamlTextAPI, YAMLReadsTBESymbols) {

--- a/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
+++ b/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
@@ -68,7 +68,7 @@ TEST(ElfYamlTextAPI, YAMLReadsTBESymbols) {
       "  - { Name: baz, Type: TLS, Size: 3 }\n"
       "  - { Name: foo, Type: Func, Warning: \"Deprecated!\" }\n"
       "  - { Name: nor, Type: NoType, Undefined: true }\n"
-      "  - { Name: not, Type: File, Undefined: true, Size: 111, "
+      "  - { Name: not, Type: NoType, Undefined: true, Size: 111, "
       "Weak: true, Warning: \'All fields populated!\' }\n"
       "...\n";
   Expected<std::unique_ptr<IFSStub>> StubOrErr = readIFSFromBuffer(Data);
@@ -116,7 +116,7 @@ TEST(ElfYamlTextAPI, YAMLReadsTBESymbols) {
   IFSSymbol const &SymNot = *Iterator++;
   EXPECT_STREQ(SymNot.Name.c_str(), "not");
   EXPECT_EQ(*SymNot.Size, 111u);
-  EXPECT_EQ(SymNot.Type, IFSSymbolType::Unknown);
+  EXPECT_EQ(SymNot.Type, IFSSymbolType::NoType);
   EXPECT_TRUE(SymNot.Undefined);
   EXPECT_TRUE(SymNot.Weak);
   EXPECT_TRUE(SymNot.Warning);

--- a/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
+++ b/llvm/unittests/InterfaceStub/ELFYAMLTest.cpp
@@ -56,6 +56,21 @@ TEST(ElfYamlTextAPI, YAMLReadableTBE) {
   EXPECT_STREQ(Stub->NeededLibs[2].c_str(), "libbar.so");
 }
 
+TEST(ElfYamlTextAPI, YAMLReadsInvalidSymbols) {
+  const char Data[] =
+      "--- !ifs-v1\n"
+      "IfsVersion: 1.0\n"
+      "SoName: test.so\n"
+      "Target: { ObjectFormat: ELF, Arch: x86_64, Endianness: little, "
+      "BitWidth: 64 }\n"
+      "Symbols:\n"
+      "  - { Name: not, Type: File, Undefined: true, Size: 111, "
+      "Weak: true, Warning: \'All fields populated!\' }\n"
+      "...\n";
+  Expected<std::unique_ptr<IFSStub>> StubOrErr = readIFSFromBuffer(Data);
+  ASSERT_THAT_ERROR(StubOrErr.takeError(), Failed());
+}
+
 TEST(ElfYamlTextAPI, YAMLReadsTBESymbols) {
   const char Data[] =
       "--- !ifs-v1\n"


### PR DESCRIPTION
Before this patch, when an unknown symbol type is used in IFS stub, it will be treated as a NO_TYPE and parsed without error. This patch makes llvm-ifs throw an error when this scenario happens.