### PR TITLE
[Hexagon] Flip subreg bit for reverse pairs hvx .new

### DIFF
--- a/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
+++ b/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
@@ -512,6 +512,8 @@ DecodeStatus HexagonDisassembler::getSingleInstruction(MCInst &MI, MCInst &MCB,
         const bool Rev = HexagonMCInstrInfo::IsReverseVecRegPair(Producer);
         const unsigned ProdPairIndex =
             Rev ? Producer - Hexagon::WR0 : Producer - Hexagon::W0;
+        if (Rev)
+          SubregBit = !SubregBit;
         Producer = (ProdPairIndex << 1) + SubregBit + Hexagon::V0;
       } else if (SubregBit)
         // Hexagon PRM 10.11 New-value operands

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
@@ -1036,8 +1036,10 @@ unsigned HexagonMCInstrInfo::SubregisterBit(unsigned Consumer,
                                             unsigned Producer2) {
   // If we're a single vector consumer of a double producer, set subreg bit
   // based on if we're accessing the lower or upper register component
-  if (IsVecRegPair(Producer) && IsVecRegSingle(Consumer))
-    return (Consumer - Hexagon::V0) & 0x1;
+  if (IsVecRegPair(Producer) && IsVecRegSingle(Consumer)) {
+    unsigned Rev = IsReverseVecRegPair(Producer);
+    return ((Consumer - Hexagon::V0) & 0x1) ^ Rev;
+  }
   if (Producer2 != Hexagon::NoRegister)
     return Consumer == Producer;
   return 0;

--- a/llvm/test/MC/Hexagon/hvx-nv-pair-reverse.s
+++ b/llvm/test/MC/Hexagon/hvx-nv-pair-reverse.s
@@ -1,0 +1,18 @@
+# RUN: llvm-mc -arch=hexagon -mv69 -mhvx -filetype=obj %s | \
+# RUN:   llvm-objdump --arch=hexagon --mcpu=hexagonv69 --mattr=+hvx -d - | \
+# RUN:   FileCheck %s
+# CHECK: 00000000 <.text>:
+
+{
+  V4:5.w = vadd(V1:0.w, V3:2.w)
+  vmem(r0+#0) = v4.new
+}
+# CHECK-NEXT: 1c6240c5 { 	v4:5.w = vadd(v1:0.w,v3:2.w)
+# CHECK-NEXT: 2820c023   	vmem(r0+#0x0) = v4.new }
+
+{
+  V4:5.w = vadd(V1:0.w, V3:2.w)
+  vmem(r0+#0) = v5.new
+}
+# CHECK-NEXT: 1c6240c5 { 	v4:5.w = vadd(v1:0.w,v3:2.w)
+# CHECK-NEXT: 2820c022   	vmem(r0+#0x0) = v5.new }

--- a/llvm/test/MC/Hexagon/hvx-nv-pair-reverse.s
+++ b/llvm/test/MC/Hexagon/hvx-nv-pair-reverse.s
@@ -1,5 +1,5 @@
-# RUN: llvm-mc -arch=hexagon -mv69 -mhvx -filetype=obj %s | \
-# RUN:   llvm-objdump --arch=hexagon --mcpu=hexagonv69 --mattr=+hvx -d - | \
+# RUN: llvm-mc -triple=hexagon -mv69 -mhvx -filetype=obj %s | \
+# RUN:   llvm-objdump --triple=hexagon --mcpu=hexagonv69 --mattr=+hvx -d - | \
 # RUN:   FileCheck %s
 # CHECK: 00000000 <.text>:
 


### PR DESCRIPTION
In .new instructions, the upper vector of a reverse pair (e.g. V4 in V4:5) should be referenced with an odd sss value.