### PR TITLE
[flang][runtime] Fix RU/RD results when rounding to least nonzero

### DIFF
--- a/flang/lib/Decimal/decimal-to-binary.cpp
+++ b/flang/lib/Decimal/decimal-to-binary.cpp
@@ -270,6 +270,7 @@ ConversionToBinaryResult<PREC> IntermediateFloat<PREC>::ToBinary(
       if ((!isNegative && rounding == RoundUp) ||
           (isNegative && rounding == RoundDown)) {
         // round to least nonzero value
+        expo = 0;
       } else { // round to zero
         if (guard != 0) {
           flags |= Underflow;

--- a/flang/unittests/Runtime/NumericalFormatTest.cpp
+++ b/flang/unittests/Runtime/NumericalFormatTest.cpp
@@ -914,6 +914,10 @@ TEST(IOApiTests, EditDoubleInputValues) {
       {"(RZ,F7.0)", "-1.e999", 0xffefffffffffffff, 0}, // -HUGE()
       {"(RD,F7.0)", "-1.e999", 0xfff0000000000000, ovf}, // -Inf
       {"(RU,F7.0)", "-1.e999", 0xffefffffffffffff, 0}, // -HUGE()
+      {"(E9.1)", " 1.0E-325", 0x0, 0},
+      {"(RU,E9.1)", " 1.0E-325", 0x1, 0},
+      {"(E9.1)", "-1.0E-325", 0x0, 0},
+      {"(RD,E9.1)", "-1.0E-325", 0x8000000000000001, 0},
   };
   for (auto const &[format, data, want, iostat] : testCases) {
     auto cookie{IONAME(BeginInternalFormattedInput)(


### PR DESCRIPTION
When rounding what otherwise would have been a result that underflowed to zero up (RU) or down (RD) to the least magnitude nonzero subnormal number, ensure that the original exponent value doesn't perturb the result.