### PR TITLE
[OpenMP] Reduce the size of heap memory required by the test `malloc_parallel.c`

### DIFF
--- a/openmp/libomptarget/test/offloading/malloc.c
+++ b/openmp/libomptarget/test/offloading/malloc.c
@@ -6,9 +6,9 @@
 
 int main() {
   long unsigned *DP = 0;
-  int N = 128;
-  int Threads = 128;
-  int Teams = 440;
+  int N = 32;
+  int Threads = 64;
+  int Teams = 10;
 
   // Allocate ~55MB on the device.
 #pragma omp target map(from : DP)
@@ -31,7 +31,7 @@ int main() {
     }
   }
 
-  // CHECK: Sum: 203458478080
+  // CHECK: Sum: 6860800
   printf("Sum: %li\n", s);
   return 0;
 }

--- a/openmp/libomptarget/test/offloading/malloc_parallel.c
+++ b/openmp/libomptarget/test/offloading/malloc_parallel.c
@@ -7,9 +7,9 @@
 
 int main() {
   long unsigned **DP = 0;
-  int N = 128;
-  int Threads = 128;
-  int Teams = 440;
+  int N = 32;
+  int Threads = 64;
+  int Teams = 10;
 
 #pragma omp target map(from : DP)
   DP = (long unsigned **)malloc(sizeof(long unsigned *) * Threads * Teams);
@@ -36,7 +36,7 @@ int main() {
     }
   }
 
-  // CHECK: Sum: 203458478080
+  // CHECK: Sum: 6860800
   printf("Sum: %li\n", s);
   return 0;
 }


### PR DESCRIPTION
This patch reduces the size of heap memory required by the test
`malloc_parallel.c` and `malloc.c`. The original size is too large such
that `malloc` returns `nullptr` on many threads, causing illegal
memory access.
