### PR TITLE
[compiler-rt]Mark test compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp as unsupported on Windows

### DIFF
--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -23,13 +23,9 @@
 //
 // XFAIL: system-darwin
 //
-// Mark 32-bit Windows as UNSUPPORTED for now as opposed to XFAIL. This test
-// should fail on many (but not all) 32-bit Windows systems and succeed on the
-// rest. The flexibility in triple string parsing makes it tricky to capture
-// both sets accurately. i[3-9]86 specifies arch as Triple::ArchType::x86, (win32|windows)
-// specifies OS as Triple::OS::Win32
-//
-// UNSUPPORTED: target={{i.86.*windows.*}}
+// FIXME: Fix mangled name matcher on Windows and re-enable test on 64-bit
+// windows.
+// UNSUPPORTED: windows
 
 // RUN: rm -rf %t && split-file %s %t && cd %t
 


### PR DESCRIPTION
The compiler-rt test fails on Windows due to mismatched names (https://lab.llvm.org/buildbot/#/builders/127/builds/59907/steps/8/logs/stdio)
- Given there are name matchers on many lines, mark the test as unsupported on Windows 64-bit for now. Need to get a machine to fix all the names. 