### PR TITLE
[lldb] Fix TestSBValueSynthetic on windows

### DIFF
--- a/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
+++ b/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
@@ -12,8 +12,10 @@ class TestSBValueSynthetic(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
+        self.runCmd("command script import formatter.py")
+        self.runCmd("type synthetic add --python-class formatter.FooSyntheticProvider Foo")
 
-        vector = self.frame().FindVariable("vector")
-        has_vector = self.frame().FindVariable("has_vector")
-        self.expect(str(vector), exe=False, substrs=["42", "47"])
-        self.expect(str(has_vector), exe=False, substrs=["42", "47"])
+        formatted = self.frame().FindVariable("foo")
+        has_formatted = self.frame().FindVariable("has_foo")
+        self.expect(str(formatted), exe=False, substrs=["synth_child"])
+        self.expect(str(has_formatted), exe=False, substrs=["synth_child"])

--- a/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
+++ b/lldb/test/API/python_api/sbvalue_synthetic/TestSBValueSynthetic.py
@@ -13,7 +13,9 @@ class TestSBValueSynthetic(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
         self.runCmd("command script import formatter.py")
-        self.runCmd("type synthetic add --python-class formatter.FooSyntheticProvider Foo")
+        self.runCmd(
+            "type synthetic add --python-class formatter.FooSyntheticProvider Foo"
+        )
 
         formatted = self.frame().FindVariable("foo")
         has_formatted = self.frame().FindVariable("has_foo")

--- a/lldb/test/API/python_api/sbvalue_synthetic/formatter.py
+++ b/lldb/test/API/python_api/sbvalue_synthetic/formatter.py
@@ -1,0 +1,23 @@
+import lldb
+
+
+class FooSyntheticProvider:
+    def __init__(self, valobj, dict):
+        target = valobj.GetTarget()
+        data = lldb.SBData.CreateDataFromCString(lldb.eByteOrderLittle, 8, "S")
+        self._child = valobj.CreateValueFromData(
+                "synth_child", data, target.GetBasicType(lldb.eBasicTypeChar)
+        )
+
+    def num_children(self):
+        return 1
+
+    def get_child_at_index(self, index):
+        if index != 0:
+            return None
+        return self._child
+
+    def get_child_index(self, name):
+        if name == "synth_child":
+            return 0
+        return None

--- a/lldb/test/API/python_api/sbvalue_synthetic/formatter.py
+++ b/lldb/test/API/python_api/sbvalue_synthetic/formatter.py
@@ -6,7 +6,7 @@ class FooSyntheticProvider:
         target = valobj.GetTarget()
         data = lldb.SBData.CreateDataFromCString(lldb.eByteOrderLittle, 8, "S")
         self._child = valobj.CreateValueFromData(
-                "synth_child", data, target.GetBasicType(lldb.eBasicTypeChar)
+            "synth_child", data, target.GetBasicType(lldb.eBasicTypeChar)
         )
 
     def num_children(self):

--- a/lldb/test/API/python_api/sbvalue_synthetic/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_synthetic/main.cpp
@@ -1,11 +1,13 @@
-#include <vector>
+struct Foo {
+  int real_child = 47;
+};
 
-struct HasVector {
-  std::vector<int> v;
+struct HasFoo {
+  Foo f;
 };
 
 int main() {
-  std::vector<int> vector = {42, 47};
-  HasVector has_vector = {vector};
+  Foo foo;
+  HasFoo has_foo;
   return 0; // break here
 }


### PR DESCRIPTION
We don't have a std::vector formatter on windows, so use a custom formatter in this test to avoid relying on std::vector.