### PR TITLE
Fix `__float128` only available on Linux for x86_64

### DIFF
--- a/libc/src/__support/macros/properties/float.h
+++ b/libc/src/__support/macros/properties/float.h
@@ -59,11 +59,6 @@ using float16 = _Float16;
      defined(LIBC_TARGET_ARCH_IS_X86_64))
 #define LIBC_COMPILER_HAS_C23_FLOAT128
 #endif
-#if (defined(LIBC_COMPILER_CLANG_VER) && (LIBC_COMPILER_CLANG_VER >= 500)) &&  \
-    (defined(LIBC_TARGET_ARCH_IS_X86_64) &&                                    \
-     !defined(LIBC_TARGET_OS_IS_FUCHSIA))
-#define LIBC_COMPILER_HAS_FLOAT128_EXTENSION
-#endif
 
 #if defined(LIBC_COMPILER_HAS_C23_FLOAT128)
 using float128 = _Float128;

--- a/libc/src/__support/macros/properties/float.h
+++ b/libc/src/__support/macros/properties/float.h
@@ -59,6 +59,11 @@ using float16 = _Float16;
      defined(LIBC_TARGET_ARCH_IS_X86_64))
 #define LIBC_COMPILER_HAS_C23_FLOAT128
 #endif
+#if (defined(LIBC_COMPILER_CLANG_VER) && (LIBC_COMPILER_CLANG_VER >= 600)) &&  \
+    (defined(LIBC_TARGET_ARCH_IS_X86_64) &&                                    \
+     defined(LIBC_TARGET_OS_IS_LINUX) && !defined(LIBC_TARGET_OS_IS_FUCHSIA))
+#define LIBC_COMPILER_HAS_FLOAT128_EXTENSION
+#endif
 
 #if defined(LIBC_COMPILER_HAS_C23_FLOAT128)
 using float128 = _Float128;


### PR DESCRIPTION
Hello

It seems that CLang does not support float-128 extension, at least for x86-64 architecture.
For any OS, not only for fuchsia. So, following code causes a compilation error and should be removed.

#if (defined(LIBC_COMPILER_CLANG_VER) && (LIBC_COMPILER_CLANG_VER >= 500)) &&  \
    (defined(LIBC_TARGET_ARCH_IS_X86_64) &&                                    \
     !defined(LIBC_TARGET_OS_IS_FUCHSIA))
#define LIBC_COMPILER_HAS_FLOAT128_EXTENSION
#endif