### PR TITLE
[Clang] Fix a crash when incorrectly calling an explicit object member function template

### DIFF
--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -253,7 +253,7 @@ static void diagnoseInstanceReference(Sema &SemaRef,
     SemaRef.Diag(Loc, diag::err_member_call_without_object)
         << Range << /*static*/ 0;
   else {
-    if (auto *Tpl = dyn_cast<FunctionTemplateDecl>(Rep))
+    if (const auto *Tpl = dyn_cast<FunctionTemplateDecl>(Rep))
       Rep = Tpl->getTemplatedDecl();
     const auto *Callee = cast<CXXMethodDecl>(Rep);
     auto Diag = SemaRef.Diag(Loc, diag::err_member_call_without_object)

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -253,6 +253,8 @@ static void diagnoseInstanceReference(Sema &SemaRef,
     SemaRef.Diag(Loc, diag::err_member_call_without_object)
         << Range << /*static*/ 0;
   else {
+    if (auto *Tpl = dyn_cast<FunctionTemplateDecl>(Rep))
+      Rep = Tpl->getTemplatedDecl();
     const auto *Callee = dyn_cast<CXXMethodDecl>(Rep);
     auto Diag = SemaRef.Diag(Loc, diag::err_member_call_without_object)
                 << Range << Callee->isExplicitObjectMemberFunction();

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -255,7 +255,7 @@ static void diagnoseInstanceReference(Sema &SemaRef,
   else {
     if (auto *Tpl = dyn_cast<FunctionTemplateDecl>(Rep))
       Rep = Tpl->getTemplatedDecl();
-    const auto *Callee = dyn_cast<CXXMethodDecl>(Rep);
+    const auto *Callee = cast<CXXMethodDecl>(Rep);
     auto Diag = SemaRef.Diag(Loc, diag::err_member_call_without_object)
                 << Range << Callee->isExplicitObjectMemberFunction();
     if (!Replacement.empty())

--- a/clang/test/SemaCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this.cpp
@@ -626,3 +626,13 @@ void test() {
 }
 
 }
+
+
+namespace GH75732 {
+auto serialize(auto&& archive, auto&& c){ }
+struct D {
+    auto serialize(this auto&& self, auto&& archive) {
+        serialize(archive, self); // expected-error {{call to explicit member function without an object argument}}
+    }
+};
+}


### PR DESCRIPTION
Fixes #75732