### PR TITLE
[TLI] Add getLibFunc that accepts an Opcode and scalar Type.

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -158,7 +158,7 @@ public:
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  bool getLibFunc(unsigned int Opcode, Type *ScalarTy, LibFunc &F) const;
+  bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const;
 
   /// Forces a function to be marked as unavailable.
   void setUnavailable(LibFunc F) {
@@ -366,8 +366,8 @@ public:
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  bool getLibFunc(unsigned int Opcode, Type *ScalarTy, LibFunc &F) const {
-    return Impl->getLibFunc(Opcode, ScalarTy, F);
+  bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const {
+    return Impl->getLibFunc(Opcode, Ty, F);
   }
 
   /// Disables all builtins.

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -156,6 +156,10 @@ public:
   /// FDecl is assumed to have a parent Module when using this function.
   bool getLibFunc(const Function &FDecl, LibFunc &F) const;
 
+  /// Searches for a function name using the opcode of \p I. Currently, only the
+  /// frem instruction is supported.
+  bool getLibFunc(const Instruction &I, LibFunc &F) const;
+
   /// Forces a function to be marked as unavailable.
   void setUnavailable(LibFunc F) {
     setState(F, Unavailable);
@@ -358,6 +362,12 @@ public:
   bool getLibFunc(const CallBase &CB, LibFunc &F) const {
     return !CB.isNoBuiltin() && CB.getCalledFunction() &&
            getLibFunc(*(CB.getCalledFunction()), F);
+  }
+
+  /// Searches for a function name using the opcode of \p I. Currently, only the
+  /// frem instruction is supported.
+  bool getLibFunc(const Instruction &I, LibFunc &F) const {
+    return Impl->getLibFunc(I, F);
   }
 
   /// Disables all builtins.

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -156,9 +156,9 @@ public:
   /// FDecl is assumed to have a parent Module when using this function.
   bool getLibFunc(const Function &FDecl, LibFunc &F) const;
 
-  /// Searches for a function name using the opcode of \p I. Currently, only the
-  /// frem instruction is supported.
-  bool getLibFunc(const Instruction &I, LibFunc &F) const;
+  /// Searches for a function name using an Instruction \p Opcode.
+  /// Currently, only the frem instruction is supported.
+  bool getLibFunc(unsigned int Opcode, Type *ScalarTy, LibFunc &F) const;
 
   /// Forces a function to be marked as unavailable.
   void setUnavailable(LibFunc F) {
@@ -364,10 +364,10 @@ public:
            getLibFunc(*(CB.getCalledFunction()), F);
   }
 
-  /// Searches for a function name using the opcode of \p I. Currently, only the
-  /// frem instruction is supported.
-  bool getLibFunc(const Instruction &I, LibFunc &F) const {
-    return Impl->getLibFunc(I, F);
+  /// Searches for a function name using an Instruction \p Opcode.
+  /// Currently, only the frem instruction is supported.
+  bool getLibFunc(unsigned int Opcode, Type *ScalarTy, LibFunc &F) const {
+    return Impl->getLibFunc(Opcode, ScalarTy, F);
   }
 
   /// Disables all builtins.

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1149,14 +1149,13 @@ bool TargetLibraryInfoImpl::getLibFunc(const Function &FDecl,
   return isValidProtoForLibFunc(*FDecl.getFunctionType(), F, *M);
 }
 
-bool TargetLibraryInfoImpl::getLibFunc(unsigned int Opcode, Type *ScalarTy,
+bool TargetLibraryInfoImpl::getLibFunc(unsigned int Opcode, Type *Ty,
                                        LibFunc &F) const {
-  // Must be a double or a float frem instruction.
-  if (Opcode != Instruction::FRem ||
-      (!ScalarTy->isDoubleTy() && !ScalarTy->isFloatTy()))
+  // Must be a frem instruction with float or double arguments.
+  if (Opcode != Instruction::FRem || (!Ty->isDoubleTy() && !Ty->isFloatTy()))
     return false;
 
-  F = ScalarTy->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;
+  F = Ty->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;
   return true;
 }
 

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1149,6 +1149,22 @@ bool TargetLibraryInfoImpl::getLibFunc(const Function &FDecl,
   return isValidProtoForLibFunc(*FDecl.getFunctionType(), F, *M);
 }
 
+bool TargetLibraryInfoImpl::getLibFunc(const Instruction &I, LibFunc &F) const {
+  if (I.getOpcode() != Instruction::FRem)
+    return false;
+
+  Type *ScalarTy = I.getType()->getScalarType();
+  if (ScalarTy->isDoubleTy())
+    F = LibFunc_fmod;
+  else if (ScalarTy->isFloatTy())
+    F = LibFunc_fmodf;
+  else if (ScalarTy->isFP128Ty())
+    F = LibFunc_fmodl;
+  else
+    return false;
+  return true;
+}
+
 void TargetLibraryInfoImpl::disableAllFunctions() {
   memset(AvailableArray, 0, sizeof(AvailableArray));
 }

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1154,12 +1154,10 @@ bool TargetLibraryInfoImpl::getLibFunc(const Instruction &I, LibFunc &F) const {
     return false;
 
   Type *ScalarTy = I.getType()->getScalarType();
-  if (ScalarTy->isDoubleTy())
-    F = LibFunc_fmod;
-  else if (ScalarTy->isFloatTy())
-    F = LibFunc_fmodf;
-  else
+  if (!ScalarTy->isDoubleTy() && !ScalarTy->isFloatTy())
     return false;
+
+  F = ScalarTy->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;
   return true;
 }
 

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1158,8 +1158,6 @@ bool TargetLibraryInfoImpl::getLibFunc(const Instruction &I, LibFunc &F) const {
     F = LibFunc_fmod;
   else if (ScalarTy->isFloatTy())
     F = LibFunc_fmodf;
-  else if (ScalarTy->isFP128Ty())
-    F = LibFunc_fmodl;
   else
     return false;
   return true;

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1149,12 +1149,11 @@ bool TargetLibraryInfoImpl::getLibFunc(const Function &FDecl,
   return isValidProtoForLibFunc(*FDecl.getFunctionType(), F, *M);
 }
 
-bool TargetLibraryInfoImpl::getLibFunc(const Instruction &I, LibFunc &F) const {
-  if (I.getOpcode() != Instruction::FRem)
-    return false;
-
-  Type *ScalarTy = I.getType()->getScalarType();
-  if (!ScalarTy->isDoubleTy() && !ScalarTy->isFloatTy())
+bool TargetLibraryInfoImpl::getLibFunc(unsigned int Opcode, Type *ScalarTy,
+                                       LibFunc &F) const {
+  // Must be a double or a float frem instruction.
+  if (Opcode != Instruction::FRem ||
+      (!ScalarTy->isDoubleTy() && !ScalarTy->isFloatTy()))
     return false;
 
   F = ScalarTy->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -624,8 +624,8 @@ TEST_F(TargetLibraryInfoTest, ValidProto) {
 
 namespace {
 
-/// Creates TLI for AArch64 and uses it to get the LibFunc names for the FRem
-/// Instruction.
+/// Creates TLI for AArch64 and uses it to get the LibFunc names for the given
+/// Instruction opcode and Type.
 class TLITestAarch64 : public ::testing::Test {
 private:
   const Triple TargetTriple;
@@ -642,21 +642,17 @@ protected:
     TLI = std::make_unique<TargetLibraryInfo>(TargetLibraryInfo(*TLII));
   }
 
-  /// Creates an FRem Instruction of Type \p Ty, and uses it to get the TLI
-  /// function name.
-  StringRef getFremScalarName(Type *Ty) {
-    Value *V = Constant::getNullValue(Ty);
-    Instruction *FRem = BinaryOperator::Create(Instruction::FRem, V, V);
+  /// Returns the TLI function name for the given \p Opcode and type \p Ty.
+  StringRef getScalarName(unsigned int Opcode, Type *Ty) {
     LibFunc Func;
-    if (!TLI->getLibFunc(FRem->getOpcode(), FRem->getType(), Func))
+    if (!TLI->getLibFunc(Opcode, Ty, Func))
       return "";
-    FRem->deleteValue();
     return TLI->getName(Func);
   }
 };
 } // end anonymous namespace
 
 TEST_F(TLITestAarch64, TestFrem) {
-  EXPECT_EQ(getFremScalarName(Type::getDoubleTy(Ctx)), "fmod");
-  EXPECT_EQ(getFremScalarName(Type::getFloatTy(Ctx)), "fmodf");
+  EXPECT_EQ(getScalarName(Instruction::FRem, Type::getDoubleTy(Ctx)), "fmod");
+  EXPECT_EQ(getScalarName(Instruction::FRem, Type::getFloatTy(Ctx)), "fmodf");
 }

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -680,5 +680,4 @@ protected:
 TEST_F(TLITestAarch64ArmPl, TestFrem) {
   EXPECT_EQ(getFremScalarName(Type::getDoubleTy(Ctx)), "fmod");
   EXPECT_EQ(getFremScalarName(Type::getFloatTy(Ctx)), "fmodf");
-  EXPECT_EQ(getFremScalarName(Type::getFP128Ty(Ctx)), "fmodl");
 }

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/AsmParser/Parser.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
@@ -625,59 +624,41 @@ TEST_F(TargetLibraryInfoTest, ValidProto) {
 
 namespace {
 
-// Creates TLI for AArch64 and VecLibrary ARmPL, and uses it to get the TLI
-// names for different FRem Instructions.
-class TLITestAarch64ArmPl : public ::testing::Test {
+/// Creates TLI for AArch64 and uses it to get the LibFunc names for the FRem
+/// Instruction.
+class TLITestAarch64 : public ::testing::Test {
 private:
-  SMDiagnostic Err;
   const Triple TargetTriple;
-  const TargetLibraryInfoImpl::VectorLibrary VecLib;
 
 protected:
   LLVMContext Ctx;
-  std::unique_ptr<Module> M;
   std::unique_ptr<TargetLibraryInfoImpl> TLII;
   std::unique_ptr<TargetLibraryInfo> TLI;
 
-  /// Create TLI for AArch64 with VecLib ArmPL.
-  TLITestAarch64ArmPl()
-      : TargetTriple(Triple("aarch64-unknown-linux-gnu")),
-        VecLib(TargetLibraryInfoImpl::ArmPL) {
+  /// Create TLI for AArch64
+  TLITestAarch64() : TargetTriple(Triple("aarch64-unknown-linux-gnu")) {
     TLII = std::make_unique<TargetLibraryInfoImpl>(
         TargetLibraryInfoImpl(TargetTriple));
-    TLII->addVectorizableFunctionsFromVecLib(VecLib, TargetTriple);
+    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::NoLibrary,
+                                             TargetTriple);
     TLI = std::make_unique<TargetLibraryInfo>(TargetLibraryInfo(*TLII));
-    // Create a dummy module needed for tests.
-    M = parseAssemblyString("declare void @dummy()", Err, Ctx);
-    EXPECT_NE(M.get(), nullptr)
-        << "Loading an invalid module.\n " << Err.getMessage() << "\n";
   }
 
   /// Creates an FRem Instruction of Type \p Ty, and uses it to get the TLI
   /// function name.
   StringRef getFremScalarName(Type *Ty) {
-    // Use a dummy function and a BB to create an FRem Instruction.
-    FunctionType *FTy = FunctionType::get(Ty, {Ty, Ty}, false);
-    Function *F = Function::Create(FTy, Function::ExternalLinkage, "foo", *M);
-    BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
-    IRBuilder<> Builder(BB);
-    Builder.SetInsertPoint(BB);
-    auto *FRem =
-        dyn_cast<Instruction>(Builder.CreateFRem(F->getArg(0), F->getArg(1)));
-
-    // Use TLI to get LibFunc and then the TLI name.
+    Value *V = Constant::getNullValue(Ty);
+    Instruction *FRem = BinaryOperator::Create(Instruction::FRem, V, V);
     LibFunc Func;
     if (!TLI->getLibFunc(*FRem, Func))
       return "";
-    auto FuncName = TLI->getName(Func);
-    // Erase tmp function to prepare for the next test.
-    F->eraseFromParent();
-    return FuncName;
+    FRem->deleteValue();
+    return TLI->getName(Func);
   }
 };
 } // end anonymous namespace
 
-TEST_F(TLITestAarch64ArmPl, TestFrem) {
+TEST_F(TLITestAarch64, TestFrem) {
   EXPECT_EQ(getFremScalarName(Type::getDoubleTy(Ctx)), "fmod");
   EXPECT_EQ(getFremScalarName(Type::getFloatTy(Ctx)), "fmodf");
 }

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -639,8 +639,6 @@ protected:
   TLITestAarch64() : TargetTriple(Triple("aarch64-unknown-linux-gnu")) {
     TLII = std::make_unique<TargetLibraryInfoImpl>(
         TargetLibraryInfoImpl(TargetTriple));
-    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::NoLibrary,
-                                             TargetTriple);
     TLI = std::make_unique<TargetLibraryInfo>(TargetLibraryInfo(*TLII));
   }
 
@@ -650,7 +648,7 @@ protected:
     Value *V = Constant::getNullValue(Ty);
     Instruction *FRem = BinaryOperator::Create(Instruction::FRem, V, V);
     LibFunc Func;
-    if (!TLI->getLibFunc(*FRem, Func))
+    if (!TLI->getLibFunc(FRem->getOpcode(), FRem->getType(), Func))
       return "";
     FRem->deleteValue();
     return TLI->getName(Func);


### PR DESCRIPTION
It sets a LibFunc similarly with the other two getLibFunc methods. Currently, it supports only the FRem Instruction.

Add tests for FRem.

# Motivation:
Almost all libm functions are represented in LLVM as intrinsics with the exception of `fmod` that is transformed into the `FREM` Instruction. This difference means existing code to map scalar calls to vector functions (as used by `LoopVectorize` and `ReplaceWithVecLib`) does not work and so first we want to map the instruction back to it’s representative scalar function. 

Given variants of getLibFunc exist to map an intrinsic to such functions it seems reasonable to have a variant for instructions as well.