### PR TITLE
[lldb][Type] Add TypeQuery::SetLanguages API

### DIFF
--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -247,6 +247,10 @@ public:
   /// match.
   void AddLanguage(lldb::LanguageType language);
 
+  /// Set the list of languages that should produce a match to only the ones
+  /// specified in \ref languages.
+  void SetLanguages(LanguageSet languages);
+
   /// Check if the language matches any languages that have been added to this
   /// match object.
   ///

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -145,6 +145,10 @@ void TypeQuery::AddLanguage(LanguageType language) {
   m_languages->Insert(language);
 }
 
+void TypeQuery::SetLanguages(LanguageSet languages) {
+  m_languages = std::move(languages);
+}
+
 bool TypeQuery::ContextMatches(
     llvm::ArrayRef<CompilerContext> context_chain) const {
   if (GetExactMatch() || context_chain.size() == m_context.size())


### PR DESCRIPTION
This is required for users of `TypeQuery` that limit the set of languages of the query using APIs such as `GetSupportedLanguagesForTypes` or `GetSupportedLanguagesForExpressions`.

Example usage: https://github.com/apple/llvm-project/pull/7885