### PR TITLE
[lldb][DWARF] Search for symbols in all external modules

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -175,7 +175,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromClangModule(const SymbolContext &sc,
         *sc.comp_unit, results.GetSearchedSymbolFiles(), [&](Module &module) {
           module.FindTypes(query, results);
           pcm_type_sp = results.GetTypeMap().FirstType();
-          return !pcm_type_sp;
+          return (bool)pcm_type_sp;
         });
   }
 


### PR DESCRIPTION
The way this code was updated in dd9587795811ba21e6ca6ad52b4531e17e6babd6 meant that if the first module did not have the symbol, the iteration stopped as returning true means stop. So only if every module had the symbol would we find it, in the last module.

Invert the condition to break when we find the first instance, which is what the previous code did.