### PR TITLE
[libc][NFC] Rename `MAX_EXPONENT` to `MAX_BIASED_EXPONENT`

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -97,12 +97,12 @@ public:
   static_assert(sizeof(T) == sizeof(StorageType),
                 "Data type and integral representation have different sizes.");
 
-  static constexpr int MAX_EXPONENT = (1 << EXP_LEN) - 1;
+  static constexpr int MAX_BIASED_EXPONENT = (1 << EXP_LEN) - 1;
   static constexpr StorageType MIN_SUBNORMAL = StorageType(1);
   static constexpr StorageType MAX_SUBNORMAL = FRACTION_MASK;
   static constexpr StorageType MIN_NORMAL = (StorageType(1) << FRACTION_LEN);
   static constexpr StorageType MAX_NORMAL =
-      ((StorageType(MAX_EXPONENT) - 1) << FRACTION_LEN) | MAX_SUBNORMAL;
+      ((StorageType(MAX_BIASED_EXPONENT) - 1) << FRACTION_LEN) | MAX_SUBNORMAL;
 
   // We don't want accidental type promotions/conversions, so we require exact
   // type match.

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -193,7 +193,7 @@ LIBC_INLINE T hypot(T x, T y) {
       sticky_bits = sticky_bits || ((sum & 0x3U) != 0);
       sum >>= 2;
       ++out_exp;
-      if (out_exp >= FPBits_t::MAX_EXPONENT) {
+      if (out_exp >= FPBits_t::MAX_BIASED_EXPONENT) {
         if (int round_mode = quick_get_round();
             round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
           return T(FPBits_t::inf());
@@ -251,7 +251,7 @@ LIBC_INLINE T hypot(T x, T y) {
   if (y_new >= (ONE >> 1)) {
     y_new -= ONE >> 1;
     ++out_exp;
-    if (out_exp >= FPBits_t::MAX_EXPONENT) {
+    if (out_exp >= FPBits_t::MAX_BIASED_EXPONENT) {
       if (round_mode == FE_TONEAREST || round_mode == FE_UPWARD)
         return T(FPBits_t::inf());
       return T(FPBits_t(FPBits_t::MAX_NORMAL));

--- a/libc/src/__support/FPUtil/ManipulationFunctions.h
+++ b/libc/src/__support/FPUtil/ManipulationFunctions.h
@@ -130,7 +130,7 @@ LIBC_INLINE T ldexp(T x, int exp) {
   // early. Because the result of the ldexp operation can be a subnormal number,
   // we need to accommodate the (mantissaWidht + 1) worth of shift in
   // calculating the limit.
-  int exp_limit = FPBits<T>::MAX_EXPONENT + FPBits<T>::FRACTION_LEN + 1;
+  int exp_limit = FPBits<T>::MAX_BIASED_EXPONENT + FPBits<T>::FRACTION_LEN + 1;
   if (exp > exp_limit)
     return bits.get_sign() ? T(FPBits<T>::neg_inf()) : T(FPBits<T>::inf());
 

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -128,9 +128,9 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
   y_exp += y_bits.get_biased_exponent();
   z_exp += z_bits.get_biased_exponent();
 
-  if (LIBC_UNLIKELY(x_exp == FPBits::MAX_EXPONENT ||
-                    y_exp == FPBits::MAX_EXPONENT ||
-                    z_exp == FPBits::MAX_EXPONENT))
+  if (LIBC_UNLIKELY(x_exp == FPBits::MAX_BIASED_EXPONENT ||
+                    y_exp == FPBits::MAX_BIASED_EXPONENT ||
+                    z_exp == FPBits::MAX_BIASED_EXPONENT))
     return x * y + z;
 
   // Extract mantissa and append hidden leading bits.
@@ -255,7 +255,7 @@ template <> LIBC_INLINE double fma<double>(double x, double y, double z) {
 
   // Finalize the result.
   int round_mode = fputil::quick_get_round();
-  if (LIBC_UNLIKELY(r_exp >= FPBits::MAX_EXPONENT)) {
+  if (LIBC_UNLIKELY(r_exp >= FPBits::MAX_BIASED_EXPONENT)) {
     if ((round_mode == FE_TOWARDZERO) ||
         (round_mode == FE_UPWARD && prod_sign) ||
         (round_mode == FE_DOWNWARD && !prod_sign)) {

--- a/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
+++ b/libc/src/__support/FPUtil/x86_64/LongDoubleBits.h
@@ -41,14 +41,14 @@ private:
 public:
   using FloatProperties<long double>::SIGN_MASK;
 
-  static constexpr int MAX_EXPONENT = 0x7FFF;
+  static constexpr int MAX_BIASED_EXPONENT = 0x7FFF;
   static constexpr StorageType MIN_SUBNORMAL = StorageType(1);
   // Subnormal numbers include the implicit bit in x86 long double formats.
   static constexpr StorageType MAX_SUBNORMAL =
       (StorageType(1) << FRACTION_LEN) - 1;
   static constexpr StorageType MIN_NORMAL = (StorageType(3) << FRACTION_LEN);
   static constexpr StorageType MAX_NORMAL =
-      (StorageType(MAX_EXPONENT - 1) << (FRACTION_LEN + 1)) |
+      (StorageType(MAX_BIASED_EXPONENT - 1) << (FRACTION_LEN + 1)) |
       (StorageType(1) << FRACTION_LEN) | MAX_SUBNORMAL;
 
   StorageType bits;
@@ -154,12 +154,12 @@ public:
   }
 
   LIBC_INLINE constexpr bool is_inf() const {
-    return get_biased_exponent() == MAX_EXPONENT && get_mantissa() == 0 &&
-           get_implicit_bit() == 1;
+    return get_biased_exponent() == MAX_BIASED_EXPONENT &&
+           get_mantissa() == 0 && get_implicit_bit() == 1;
   }
 
   LIBC_INLINE constexpr bool is_nan() const {
-    if (get_biased_exponent() == MAX_EXPONENT) {
+    if (get_biased_exponent() == MAX_BIASED_EXPONENT) {
       return (get_implicit_bit() == 0) || get_mantissa() != 0;
     } else if (get_biased_exponent() != 0) {
       return get_implicit_bit() == 0;
@@ -168,7 +168,7 @@ public:
   }
 
   LIBC_INLINE constexpr bool is_inf_or_nan() const {
-    return (get_biased_exponent() == MAX_EXPONENT) ||
+    return (get_biased_exponent() == MAX_BIASED_EXPONENT) ||
            (get_biased_exponent() != 0 && get_implicit_bit() == 0);
   }
 
@@ -180,7 +180,7 @@ public:
 
   LIBC_INLINE static constexpr long double inf(bool sign = false) {
     FPBits<long double> bits(0.0l);
-    bits.set_biased_exponent(MAX_EXPONENT);
+    bits.set_biased_exponent(MAX_BIASED_EXPONENT);
     bits.set_implicit_bit(1);
     if (sign) {
       bits.set_sign(true);
@@ -192,7 +192,7 @@ public:
 
   LIBC_INLINE static constexpr long double build_nan(StorageType v) {
     FPBits<long double> bits(0.0l);
-    bits.set_biased_exponent(MAX_EXPONENT);
+    bits.set_biased_exponent(MAX_BIASED_EXPONENT);
     bits.set_implicit_bit(1);
     bits.set_mantissa(v);
     return bits;

--- a/libc/src/__support/high_precision_decimal.h
+++ b/libc/src/__support/high_precision_decimal.h
@@ -344,8 +344,8 @@ public:
         int64_t temp_exponent = static_cast<int64_t>(this->decimal_point) +
                                 static_cast<int64_t>(add_to_exponent);
 
-        // Theoretically these numbers should be MAX_EXPONENT for long double,
-        // but that should be ~16,000 which is much less than 1 << 30.
+        // Theoretically these numbers should be MAX_BIASED_EXPONENT for long
+        // double, but that should be ~16,000 which is much less than 1 << 30.
         if (temp_exponent > (1 << 30)) {
           temp_exponent = (1 << 30);
         } else if (temp_exponent < -(1 << 30)) {

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -338,7 +338,7 @@ simple_decimal_conversion(const char *__restrict numStart,
   // float, return inf.
   if (hpd.get_decimal_point() > 0 &&
       exp10_to_exp2(hpd.get_decimal_point() - 1) > FloatProp::EXP_BIAS) {
-    output.num = {0, fputil::FPBits<T>::MAX_EXPONENT};
+    output.num = {0, fputil::FPBits<T>::MAX_BIASED_EXPONENT};
     output.error = ERANGE;
     return output;
   }
@@ -388,8 +388,8 @@ simple_decimal_conversion(const char *__restrict numStart,
   exp2 += FloatProp::EXP_BIAS;
 
   // Handle the exponent being too large (and return inf).
-  if (exp2 >= FPBits::MAX_EXPONENT) {
-    output.num = {0, FPBits::MAX_EXPONENT};
+  if (exp2 >= FPBits::MAX_BIASED_EXPONENT) {
+    output.num = {0, FPBits::MAX_BIASED_EXPONENT};
     output.error = ERANGE;
     return output;
   }
@@ -424,7 +424,7 @@ simple_decimal_conversion(const char *__restrict numStart,
     // Check if this rounding causes exp2 to go out of range and make the result
     // INF. If this is the case, then finalMantissa and exp2 are already the
     // correct values for an INF result.
-    if (exp2 >= FPBits::MAX_EXPONENT) {
+    if (exp2 >= FPBits::MAX_BIASED_EXPONENT) {
       output.error = ERANGE;
     }
   }
@@ -658,7 +658,7 @@ decimal_exp_to_float(ExpandedFloat<T> init_num, const char *__restrict numStart,
   // float, return inf. These bounds are relatively loose, but are mostly
   // serving as a first pass. Some close numbers getting through is okay.
   if (exp10 > get_upper_bound<T>()) {
-    output.num = {0, FPBits::MAX_EXPONENT};
+    output.num = {0, FPBits::MAX_BIASED_EXPONENT};
     output.error = ERANGE;
     return output;
   }
@@ -920,10 +920,10 @@ decimal_string_to_float(const char *__restrict src, const char DECIMAL_POINT,
 
       // If the result is in the valid range, then we use it. The valid range is
       // also within the int32 range, so this prevents overflow issues.
-      if (temp_exponent > FPBits::MAX_EXPONENT) {
-        exponent = FPBits::MAX_EXPONENT;
-      } else if (temp_exponent < -FPBits::MAX_EXPONENT) {
-        exponent = -FPBits::MAX_EXPONENT;
+      if (temp_exponent > FPBits::MAX_BIASED_EXPONENT) {
+        exponent = FPBits::MAX_BIASED_EXPONENT;
+      } else if (temp_exponent < -FPBits::MAX_BIASED_EXPONENT) {
+        exponent = -FPBits::MAX_BIASED_EXPONENT;
       } else {
         exponent = static_cast<int32_t>(temp_exponent);
       }
@@ -1034,10 +1034,10 @@ hexadecimal_string_to_float(const char *__restrict src,
 
       // If the result is in the valid range, then we use it. The valid range is
       // also within the int32 range, so this prevents overflow issues.
-      if (temp_exponent > FPBits::MAX_EXPONENT) {
-        exponent = FPBits::MAX_EXPONENT;
-      } else if (temp_exponent < -FPBits::MAX_EXPONENT) {
-        exponent = -FPBits::MAX_EXPONENT;
+      if (temp_exponent > FPBits::MAX_BIASED_EXPONENT) {
+        exponent = FPBits::MAX_BIASED_EXPONENT;
+      } else if (temp_exponent < -FPBits::MAX_BIASED_EXPONENT) {
+        exponent = -FPBits::MAX_BIASED_EXPONENT;
       } else {
         exponent = static_cast<int32_t>(temp_exponent);
       }

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -58,7 +58,8 @@ public:
   }
 
   void testOverflow(LdExpFunc func) {
-    NormalFloat x(FPBits::MAX_EXPONENT - 10, NormalFloat::ONE + 0xF00BA, 0);
+    NormalFloat x(FPBits::MAX_BIASED_EXPONENT - 10, NormalFloat::ONE + 0xF00BA,
+                  0);
     for (int32_t exp = 10; exp < 100; ++exp) {
       ASSERT_FP_EQ(inf, func(T(x), exp));
       ASSERT_FP_EQ(neg_inf, func(-T(x), exp));
@@ -125,7 +126,7 @@ public:
     // Start with a normal number high exponent but pass a very low number for
     // exp. The result should be a subnormal number.
     x = NormalFloat(FPBits::EXP_BIAS, NormalFloat::ONE, 0);
-    int exp = -FPBits::MAX_EXPONENT - 5;
+    int exp = -FPBits::MAX_BIASED_EXPONENT - 5;
     T result = func(x, exp);
     FPBits result_bits(result);
     ASSERT_FALSE(result_bits.is_zero());
@@ -133,17 +134,17 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - FPBits::FRACTION_LEN - 5);
+    result = func(x, -FPBits::MAX_BIASED_EXPONENT - FPBits::FRACTION_LEN - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.
     // The result should not be infinity.
     x = NormalFloat(-FPBits::EXP_BIAS + 1, NormalFloat::ONE >> 10, 0);
-    exp = FPBits::MAX_EXPONENT + 5;
+    exp = FPBits::MAX_BIASED_EXPONENT + 5;
     ASSERT_FALSE(FPBits(func(x, exp)).is_inf());
     // But if the exp is large enough to oversome than the normalization shift,
     // then it should result in infinity.
-    exp = FPBits::MAX_EXPONENT + 15;
+    exp = FPBits::MAX_BIASED_EXPONENT + 15;
     ASSERT_FP_EQ(func(x, exp), inf);
   }
 };

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -58,7 +58,8 @@ public:
   }
 
   void testOverflow(LdExpFunc func) {
-    NormalFloat x(FPBits::MAX_EXPONENT - 10, NormalFloat::ONE + 0xF00BA, 0);
+    NormalFloat x(FPBits::MAX_BIASED_EXPONENT - 10, NormalFloat::ONE + 0xF00BA,
+                  0);
     for (int32_t exp = 10; exp < 100; ++exp) {
       ASSERT_FP_EQ(inf, func(T(x), exp));
       ASSERT_FP_EQ(neg_inf, func(-T(x), exp));
@@ -125,7 +126,7 @@ public:
     // Start with a normal number high exponent but pass a very low number for
     // exp. The result should be a subnormal number.
     x = NormalFloat(FPBits::EXP_BIAS, NormalFloat::ONE, 0);
-    int exp = -FPBits::MAX_EXPONENT - 5;
+    int exp = -FPBits::MAX_BIASED_EXPONENT - 5;
     T result = func(x, exp);
     FPBits result_bits(result);
     ASSERT_FALSE(result_bits.is_zero());
@@ -133,17 +134,17 @@ public:
     ASSERT_EQ(result_bits.get_biased_exponent(), uint16_t(0));
     // But if the exp is so less that normalization leads to zero, then
     // the result should be zero.
-    result = func(x, -FPBits::MAX_EXPONENT - FPBits::FRACTION_LEN - 5);
+    result = func(x, -FPBits::MAX_BIASED_EXPONENT - FPBits::FRACTION_LEN - 5);
     ASSERT_TRUE(FPBits(result).is_zero());
 
     // Start with a subnormal number but pass a very high number for exponent.
     // The result should not be infinity.
     x = NormalFloat(-FPBits::EXP_BIAS + 1, NormalFloat::ONE >> 10, 0);
-    exp = FPBits::MAX_EXPONENT + 5;
+    exp = FPBits::MAX_BIASED_EXPONENT + 5;
     ASSERT_FALSE(FPBits(func(x, exp)).is_inf());
     // But if the exp is large enough to oversome than the normalization shift,
     // then it should result in infinity.
-    exp = FPBits::MAX_EXPONENT + 15;
+    exp = FPBits::MAX_BIASED_EXPONENT + 15;
     ASSERT_FP_EQ(func(x, exp), inf);
   }
 };

--- a/libc/test/utils/FPUtil/x86_long_double_test.cpp
+++ b/libc/test/utils/FPUtil/x86_long_double_test.cpp
@@ -22,7 +22,7 @@ TEST(LlvmLibcX86LongDoubleTest, is_nan) {
   constexpr uint32_t COUNT = 100'000;
 
   FPBits bits(0.0l);
-  bits.set_biased_exponent(FPBits::MAX_EXPONENT);
+  bits.set_biased_exponent(FPBits::MAX_BIASED_EXPONENT);
   for (unsigned int i = 0; i < COUNT; ++i) {
     // If exponent has the max value and the implicit bit is 0,
     // then the number is a NaN for all values of mantissa.


### PR DESCRIPTION
As currently defined `MAX_EXPONENT` actually corresponds to the biased exponent (i.e. an unsigned value).