### PR TITLE
[flang] Add option to skip struct argument rewrite in target-rewrite

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -63,7 +63,10 @@ def TargetRewritePass : Pass<"target-rewrite", "mlir::ModuleOp"> {
            "Disable target-specific conversion of CHARACTER.">,
     Option<"noComplexConversion", "no-complex-conversion",
            "bool", /*default=*/"false",
-           "Disable target-specific conversion of COMPLEX.">
+           "Disable target-specific conversion of COMPLEX.">,
+    Option<"noStructConversion", "no-struct-conversion",
+           "bool", /*default=*/"false",
+           "Disable target-specific conversion of derived type value.">
   ];
 }
 

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -34,6 +34,7 @@ std::unique_ptr<mlir::Pass> createFirCodeGenRewritePass();
 struct TargetRewriteOptions {
   bool noCharacterConversion{};
   bool noComplexConversion{};
+  bool noStructConversion{};
 };
 
 /// Prerequiste pass for code gen. Perform intermediate rewrites to tailor the

--- a/flang/test/Fir/target-rewrite-selective-no-struct.fir
+++ b/flang/test/Fir/target-rewrite-selective-no-struct.fir
@@ -1,0 +1,25 @@
+// Test no-struct-conversion of target-rewrite pass.
+// RUN: fir-opt -target-rewrite="no-struct-conversion" %s | FileCheck %s
+
+func.func @test(%arg0: !fir.type<t{i:i32}>) {
+  return
+}
+
+func.func @test_call(%arg0: !fir.type<t{i:i32}>) {
+  fir.call @test(%arg0) : (!fir.type<t{i:i32}>) -> ()
+  return
+}
+
+func.func @test_addr_off() {
+  %0 = fir.address_of(@test) : (!fir.type<t{i:i32}>) -> ()
+  return
+}
+
+// CHECK-LABEL:  func.func @test(%{{.*}}: !fir.type<t{i:i32}>) {
+
+// CHECK-LABEL:  func.func @test_call(
+// CHECK-SAME:                        %[[ARG0:.*]]: !fir.type<t{i:i32}>) {
+// CHECK:    fir.call @test(%[[ARG0]]) : (!fir.type<t{i:i32}>) -> ()
+
+// CHECK-LABEL:  func.func @test_addr_off() {
+// CHECK:    fir.address_of(@test) : (!fir.type<t{i:i32}>) -> ()


### PR DESCRIPTION
Be consistent with complex and character rewrite so that the pass can be run selectively.