### PR TITLE
[OpenMP][libomptarget][Fix] Disable test on NVIDIA platforms

### DIFF
--- a/openmp/libomptarget/test/offloading/struct_mapping_with_pointers.cpp
+++ b/openmp/libomptarget/test/offloading/struct_mapping_with_pointers.cpp
@@ -4,6 +4,9 @@
 
 // REQUIRES: libomptarget-debug
 
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The tests doesn't seem to work for NVIDIA so disabling it for now.