### PR TITLE
[mlir][affine] Remove redundant check in LoopAnalysis

### DIFF
--- a/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
@@ -302,7 +302,7 @@ isVectorizableLoopBodyWithOpCond(AffineForOp loop,
 
   // No vectorization across unknown regions.
   auto regions = matcher::Op([](Operation &op) -> bool {
-    return op.getNumRegions() != 0 && !isa<AffineIfOp, AffineForOp>(op);
+    return op.getNumRegions() != 0 && !isa<AffineForOp>(op);
   });
   SmallVector<NestedMatch, 8> regionsMatched;
   regions.match(forOp, &regionsMatched);


### PR DESCRIPTION
We do not support vectorization across conditionals. We already check it in the beginning of isVectorizableLoopBodyWithOpCond(). There should be no need to check AffineIfOp when checking regions in a loop.