### PR TITLE
[CodeGen][MISched] Handle empty sized resource usage.

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -4270,7 +4270,7 @@ unsigned ResourceSegments::getFirstAvailableAt(
   // Zero resource usage is allowed by TargetSchedule.td but we do not construct
   // a ResourceSegment interval for that situation.
   if (AcquireAtCycle == Cycle)
-    return Cycle;
+    return CurrCycle;
 
   unsigned RetCycle = CurrCycle;
   ResourceSegments::IntervalTy NewInterval =

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -4292,13 +4292,13 @@ unsigned ResourceSegments::getFirstAvailableAt(
 void ResourceSegments::add(ResourceSegments::IntervalTy A,
                            const unsigned CutOff) {
   assert(A.first <= A.second && "Cannot add negative resource usage");
-
+  assert(CutOff > 0 && "0-size interval history has no use.");
   // Zero resource usage is allowed by TargetSchedule.td, in the case that the
   // instruction needed the resource to be available but does not use it.
   // However, ResourceSegment represents an interval that is closed on the left
   // and open on the right. It is impossible to represent an empty interval when
   // the left is closed. Do not add it to Intervals.
-  if (A.first == A.second || CutOff == 0)
+  if (A.first == A.second)
     return;
 
   assert(all_of(_Intervals,

--- a/llvm/unittests/CodeGen/SchedBoundary.cpp
+++ b/llvm/unittests/CodeGen/SchedBoundary.cpp
@@ -20,9 +20,10 @@ TEST(ResourceSegmentsDeath, FullOverwrite) {
   EXPECT_DEATH(X.add({15, 18}), "A resource is being overwritten");
 }
 
-TEST(ResourceSegmentsDeath, ZeroSizeIntervalsNotAllowed) {
+TEST(ResourceSegmentsDeath, ZeroSizeCuttoffAllowed) {
   auto X = ResourceSegments({{10, 20}});
-  EXPECT_DEATH(X.add({20, 30}, 0), "0-size interval history has no use.");
+  X.add({20, 30}, 0);
+  EXPECT_EQ(X, ResourceSegments({{10, 20}}));
 }
 #endif // NDEBUG
 
@@ -85,7 +86,8 @@ TEST(ResourceSegments, add_02) {
 #ifndef NDEBUG
 TEST(ResourceSegmentsDeath, add_empty) {
   auto X = ResourceSegments({{10, 20}, {30, 40}});
-  EXPECT_DEATH(X.add({22, 22}), "Cannot add empty resource usage");
+  X.add({22, 22});
+  EXPECT_EQ(X, ResourceSegments({{10, 20}, {30, 40}}));
 }
 #endif
 

--- a/llvm/unittests/CodeGen/SchedBoundary.cpp
+++ b/llvm/unittests/CodeGen/SchedBoundary.cpp
@@ -20,10 +20,9 @@ TEST(ResourceSegmentsDeath, FullOverwrite) {
   EXPECT_DEATH(X.add({15, 18}), "A resource is being overwritten");
 }
 
-TEST(ResourceSegmentsDeath, ZeroSizeCuttoffAllowed) {
+TEST(ResourceSegmentsDeath, ZeroSizeIntervalsNotAllowed) {
   auto X = ResourceSegments({{10, 20}});
-  X.add({20, 30}, 0);
-  EXPECT_EQ(X, ResourceSegments({{10, 20}}));
+  EXPECT_DEATH(X.add({20, 30}, 0), "0-size interval history has no use.");
 }
 #endif // NDEBUG
 


### PR DESCRIPTION
TargetSchedule.td explicitly allows the usage of a ProcResource for zero cycles, in order to represent that the ProcResource must be available but is not consumed by the instruction. On the other hand, ResourceSegments explicitly does not allow for a zero sized interval. In order to remedy this, this patch handles the special case of when there is an empty interval usage of a resource by not adding an empty interval.

No test was added since there is no upstream CPU that does this currently. We ran into this issue downstream, but it makes sense to have this upstream since it is explicitly allowed by TargetSchedule.td.