### PR TITLE
[libc] __stack_chk_fail post submit test failures

### DIFF
--- a/libc/src/compiler/__stack_chk_fail.h
+++ b/libc/src/compiler/__stack_chk_fail.h
@@ -9,10 +9,8 @@
 #ifndef LLVM_LIBC_SRC_COMPILER___STACK_CHK_FAIL_H
 #define LLVM_LIBC_SRC_COMPILER___STACK_CHK_FAIL_H
 
-namespace LIBC_NAMESPACE {
-
+extern "C" {
 [[noreturn]] void __stack_chk_fail();
-
-} // namespace LIBC_NAMESPACE
+} // extern "C"
 
 #endif // LLVM_LIBC_SRC_COMPILER___STACK_CHK_FAIL_H

--- a/libc/src/compiler/__stack_chk_fail.h
+++ b/libc/src/compiler/__stack_chk_fail.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_SRC_COMPILER___STACK_CHK_FAIL_H
 #define LLVM_LIBC_SRC_COMPILER___STACK_CHK_FAIL_H
 
+// The compiler will emit calls implicitly to a non-namespaced version.
+// TODO: can we additionally provide a namespaced alias so that tests can
+// explicitly call the namespaced variant rather than the non-namespaced
+// definition?
 extern "C" {
 [[noreturn]] void __stack_chk_fail();
 } // extern "C"

--- a/libc/src/compiler/generic/__stack_chk_fail.cpp
+++ b/libc/src/compiler/generic/__stack_chk_fail.cpp
@@ -10,11 +10,11 @@
 #include "src/__support/OSUtil/io.h"
 #include "src/stdlib/abort.h"
 
-namespace LIBC_NAMESPACE {
+extern "C" {
 
-LLVM_LIBC_FUNCTION(void, __stack_chk_fail, (void)) {
+void __stack_chk_fail(void) {
   LIBC_NAMESPACE::write_to_stderr("stack smashing detected");
   LIBC_NAMESPACE::abort();
 }
 
-} // namespace LIBC_NAMESPACE
+} // extern "C"

--- a/libc/test/integration/src/unistd/CMakeLists.txt
+++ b/libc/test/integration/src/unistd/CMakeLists.txt
@@ -45,6 +45,7 @@ if((${LIBC_TARGET_OS} STREQUAL "linux") AND (${LIBC_TARGET_ARCHITECTURE_IS_X86})
       libc.include.signal
       libc.include.sys_wait
       libc.include.unistd
+      libc.src.compiler.__stack_chk_fail
       libc.src.pthread.pthread_atfork
       libc.src.signal.raise
       libc.src.sys.wait.wait

--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -12,8 +12,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStackChkFail, Death) {
-  EXPECT_DEATH([] { __stack_chk_fail(); },
-               WITH_SIGNAL(SIGABRT));
+  EXPECT_DEATH([] { __stack_chk_fail(); }, WITH_SIGNAL(SIGABRT));
 }
 
 TEST(LlvmLibcStackChkFail, Smash) {

--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -12,7 +12,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStackChkFail, Death) {
-  EXPECT_DEATH([] { LIBC_NAMESPACE::__stack_chk_fail(); },
+  EXPECT_DEATH([] { __stack_chk_fail(); },
                WITH_SIGNAL(SIGABRT));
 }
 

--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -20,7 +20,7 @@ TEST(LlvmLibcStackChkFail, Smash) {
   EXPECT_DEATH(
       [] {
         int arr[20];
-        LIBC_NAMESPACE::memset(arr, 0xAA, 9001);
+        LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
       },
       WITH_SIGNAL(SIGABRT));
 }


### PR DESCRIPTION
Use a size smaller than the smallest supported page size so that we don't
clobber over any guard pages, which may result in a segfault before
__stack_chk_fail can be called.
