### PR TITLE
[libc] disable asan for LlvmLibcStackChkFail.Smash

### DIFF
--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -17,7 +17,7 @@ TEST(LlvmLibcStackChkFail, Death) {
 
 TEST(LlvmLibcStackChkFail, Smash) {
   EXPECT_DEATH(
-      [] {
+      [] [[gnu::no_sanitize]] {
         int arr[20];
         LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
       },


### PR DESCRIPTION
Otherwise for ASAN configured runs of the test, the test will fail due to the
sanitizer rather than via SIGABRT.
