### PR TITLE
[ORC-RT] Fix ptrauth signing for dlsym return value

### DIFF
--- a/compiler-rt/lib/orc/macho_platform.cpp
+++ b/compiler-rt/lib/orc/macho_platform.cpp
@@ -825,6 +825,10 @@ void *MachOPlatformRuntimeState::dlsym(void *DSOHandle, const char *Symbol) {
     return nullptr;
   }
 
+  // Sign callable symbols as functions, to match dyld.
+  if ((Result.second & MachOExecutorSymbolFlags::Callable) ==
+      MachOExecutorSymbolFlags::Callable)
+    return reinterpret_cast<void *>(Result.first.toPtr<void(void)>());
   return Result.first.toPtr<void *>();
 }
 


### PR DESCRIPTION
dlsym signs text symbols as functions rather than data in dyld, so match that for orc runtime dlsym. This fixes run_program on arm64e.