### PR TITLE
[CommandLine][NFC] Replace 'std::function' with 'function_ref'

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -175,8 +175,7 @@ public:
                                StringRef Overview, raw_ostream *Errs = nullptr,
                                bool LongOptionsUseDoubleDash = false);
 
-  void forEachSubCommand(Option &Opt,
-                         std::function<void(SubCommand &)> Action) {
+  void forEachSubCommand(Option &Opt, function_ref<void(SubCommand &)> Action) {
     if (Opt.Subs.empty()) {
       Action(SubCommand::getTopLevel());
       return;


### PR DESCRIPTION
This implements a post-commit suggestion for #75679.