### PR TITLE
[test]Mark thinlto icp test as unsupported on powerpc

### DIFF
--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -35,6 +35,8 @@
 // specifies OS as Triple::OS::Win32
 //
 // UNSUPPORTED: target={{i.86.*windows.*}}
+// FIXME: Re-enable the test on powerpc.
+// UNSUPPORTED: powerpc-registered-target
 
 // RUN: rm -rf %t && split-file %s %t && cd %t
 

--- a/llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
+++ b/llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
@@ -9,6 +9,8 @@
 ; The raw profiles storesd compressed function names, so profile reader should
 ; be built with zlib support to decompress them.
 ; REQUIRES: zlib
+; FIXME: Re-enable the test on powerpc.
+; UNSUPPORTED: powerpc-registered-target
 
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 


### PR DESCRIPTION
Test failed on ppc (https://lab.llvm.org/buildbot/#/builders/231/builds/18902), and logs shows missed import.

Cannot reproduce this with machines I could access so far. https://gcc.gnu.org/wiki/CompileFarm seems to provide ppc64 machine. Mark the thinlto icp test as unsupported for now.