### PR TITLE
[libc] try fixing LlvmLibcStackChkFail.Smash a third time

### DIFF
--- a/libc/test/src/compiler/CMakeLists.txt
+++ b/libc/test/src/compiler/CMakeLists.txt
@@ -7,6 +7,7 @@ add_libc_unittest(
   SRCS
     stack_chk_guard_test.cpp
   DEPENDS
+    libc.src.__support.macros.sanitizer
     libc.src.compiler.__stack_chk_fail
     libc.src.string.memset
   COMPILE_OPTIONS


### PR DESCRIPTION
Build bots are failing in post submit. Unclear why but can't reproduce locally.
Disable this test for asan for now.
