### PR TITLE
[test] Restrict thinlto icp IR test to little endian systems, and the compiler-rt test to three tested platforms.

### DIFF
--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -13,6 +13,8 @@
 // - Generate ThinLTO summary file with LLVM bitcodes, and run `function-import` pass.
 // - Run `pgo-icall-prom` pass for the IR module which needs to import callees.
 
+// REQUIRES: windows || linux || darwin
+
 // This test and IR test llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
 // are complementary to each other; a compiler-rt test has better test coverage
 // on different platforms, and the IR test is less restrictive in terms of
@@ -35,8 +37,6 @@
 // specifies OS as Triple::OS::Win32
 //
 // UNSUPPORTED: target={{i.86.*windows.*}}
-// FIXME: Re-enable the test on powerpc.
-// UNSUPPORTED: powerpc-registered-target
 
 // RUN: rm -rf %t && split-file %s %t && cd %t
 

--- a/llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
+++ b/llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
@@ -9,8 +9,7 @@
 ; The raw profiles storesd compressed function names, so profile reader should
 ; be built with zlib support to decompress them.
 ; REQUIRES: zlib
-; FIXME: Re-enable the test on powerpc.
-; UNSUPPORTED: powerpc-registered-target
+; REQUIRES: host-byteorder-little-endian
 
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 


### PR DESCRIPTION
- The IR test failed to import indirect callees on big-endian systems. The raw profiles are generated on little-endian systems. Going to require little-endian.
- Limit the compiler-rt test to three tested platforms. 