### PR TITLE
[mlir] Remove "Syntax:" parser where it's already provided by `assemblyFormat`

### DIFF
--- a/mlir/include/mlir/Dialect/Math/IR/MathOps.td
+++ b/mlir/include/mlir/Dialect/Math/IR/MathOps.td
@@ -142,12 +142,6 @@ def Math_AbsIOp : Math_IntegerUnaryOp<"absi"> {
 def Math_AtanOp : Math_FloatUnaryOp<"atan">{
   let summary = "arcus tangent of the given value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.atan` ssa-use `:` type
-    ```
-
     The `atan` operation computes the arcus tangent of a given value.  It takes
     one operand of floating point type (i.e., scalar, tensor or vector) and returns
     one result of the same type. It has no standard attributes.
@@ -169,12 +163,6 @@ def Math_AtanOp : Math_FloatUnaryOp<"atan">{
 def Math_Atan2Op : Math_FloatBinaryOp<"atan2">{
   let summary = "2-argument arcus tangent of the given values";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.atan2` ssa-use `,` ssa-use `:` type
-    ```
-
     The `atan2` operation takes two operands and returns one result, all of
     which must be of the same type.  The operands must be of floating point type
     (i.e., scalar, tensor or vector).
@@ -225,12 +213,6 @@ def Math_CbrtOp : Math_FloatUnaryOp<"cbrt"> {
 def Math_CeilOp : Math_FloatUnaryOp<"ceil"> {
   let summary = "ceiling of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.ceil` ssa-use `:` type
-    ```
-
     The `ceil` operation computes the ceiling of a given value. It takes one
     operand of floating point type (i.e., scalar, tensor or vector) and returns one
     result of the same type.  It has no standard attributes.
@@ -252,12 +234,6 @@ def Math_CeilOp : Math_FloatUnaryOp<"ceil"> {
 def Math_CopySignOp : Math_FloatBinaryOp<"copysign"> {
   let summary = "A copysign operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.copysign` ssa-use `,` ssa-use `:` type
-    ```
-
     The `copysign` returns a value with the magnitude of the first operand and
     the sign of the second operand. It takes two operands and returns one result of
     the same type. The operands must be of floating point type (i.e., scalar,
@@ -280,12 +256,6 @@ def Math_CopySignOp : Math_FloatBinaryOp<"copysign"> {
 def Math_CosOp : Math_FloatUnaryOp<"cos"> {
   let summary = "cosine of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.cos` ssa-use `:` type
-    ```
-
     The `cos` operation computes the cosine of a given value. It takes one
     operand of floating point type (i.e., scalar, tensor or vector) and returns one
     result of the same type.  It has no standard attributes.
@@ -307,12 +277,6 @@ def Math_CosOp : Math_FloatUnaryOp<"cos"> {
 def Math_AcosOp : Math_FloatUnaryOp<"acos"> {
   let summary = "arcus cosine of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.acos` ssa-use `:` type
-    ```
-
     The `acos` operation computes the arcus cosine of a given value. It takes one
     operand of floating point type (i.e., scalar, tensor or vector) and returns one
     result of the same type.  It has no standard attributes.
@@ -355,12 +319,6 @@ def Math_CoshOp : Math_FloatUnaryOp<"cosh"> {
 def Math_SinOp : Math_FloatUnaryOp<"sin"> {
   let summary = "sine of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.sin` ssa-use `:` type
-    ```
-
     The `sin` operation computes the sine of a given value. It takes one
     operand of floating point type (i.e., scalar, tensor or vector) and returns one
     result of the same type.  It has no standard attributes.
@@ -463,12 +421,6 @@ def Math_CtPopOp : Math_IntegerUnaryOp<"ctpop"> {
 def Math_ErfOp : Math_FloatUnaryOp<"erf"> {
   let summary = "error function of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.erf` ssa-use `:` type
-    ```
-
     The `erf` operation computes the error function. It takes one operand of
     floating point type (i.e., scalar, tensor or vector) and returns one result of
     the same type. It has no standard attributes.
@@ -491,12 +443,6 @@ def Math_ErfOp : Math_FloatUnaryOp<"erf"> {
 def Math_ExpOp : Math_FloatUnaryOp<"exp"> {
   let summary = "base-e exponential of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.exp` ssa-use `:` type
-    ```
-
     The `exp` operation takes one operand of floating point type (i.e., scalar,
     tensor or vector) and returns one result of the same type. It has no standard
     attributes.
@@ -519,12 +465,6 @@ def Math_Exp2Op : Math_FloatUnaryOp<"exp2"> {
   let summary = "base-2 exponential of the specified value";
 
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.exp2` ssa-use `:` type
-    ```
-
     The `exp` operation takes one operand of floating point type (i.e., scalar,
     tensor or vector) and returns one result of the same type. It has no standard
     attributes.
@@ -546,12 +486,6 @@ def Math_Exp2Op : Math_FloatUnaryOp<"exp2"> {
 def Math_ExpM1Op : Math_FloatUnaryOp<"expm1"> {
   let summary = "base-e exponential of the specified value minus 1";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.expm1` ssa-use `:` type
-    ```
-
     expm1(x) := exp(x) - 1
 
     The `expm1` operation takes one operand of floating point type (i.e.,
@@ -575,12 +509,6 @@ def Math_ExpM1Op : Math_FloatUnaryOp<"expm1"> {
 def Math_FloorOp : Math_FloatUnaryOp<"floor"> {
   let summary = "floor of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.floor` ssa-use `:` type
-    ```
-
     The `floor` operation computes the floor of a given value. It takes one
     operand of floating point type (i.e., scalar, tensor or vector) and returns one
     result of the same type.  It has no standard attributes.
@@ -603,12 +531,6 @@ def Math_FloorOp : Math_FloatUnaryOp<"floor"> {
 def Math_FmaOp : Math_FloatTernaryOp<"fma"> {
   let summary = "floating point fused multipy-add operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.fma` ssa-use `,` ssa-use `,` ssa-use `:` type
-    ```
-
     The `fma` operation takes three operands and returns one result, each of
     these is required to be the same type. Operands must be of floating point type
     (i.e., scalar, tensor or vector).
@@ -634,12 +556,6 @@ def Math_FmaOp : Math_FloatTernaryOp<"fma"> {
 def Math_IPowIOp : Math_IntegerBinaryOp<"ipowi"> {
   let summary = "signed integer raised to the power of operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.ipowi` ssa-use `,` ssa-use `:` type
-    ```
-
     The `ipowi` operation takes two operands of integer type (i.e., scalar,
     tensor or vector) and returns one result of the same type. Operands
     must have the same type.
@@ -751,12 +667,6 @@ def Math_Log2Op : Math_FloatUnaryOp<"log2"> {
 def Math_PowFOp : Math_FloatBinaryOp<"powf"> {
   let summary = "floating point raised to the power of operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.powf` ssa-use `,` ssa-use `:` type
-    ```
-
     The `powf` operation takes two operands of floating point type (i.e.,
     scalar, tensor or vector) and returns one result of the same type. Operands
     must have the same type.
@@ -861,12 +771,6 @@ def Math_TanhOp : Math_FloatUnaryOp<"tanh"> {
 def Math_RoundEvenOp : Math_FloatUnaryOp<"roundeven"> {
   let summary = "round of the specified value with halfway cases to even";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.roundeven` ssa-use `:` type
-    ```
-
     The `roundeven` operation returns the operand rounded to the nearest integer
     value in floating-point format. It takes one operand of floating point type
     (i.e., scalar, tensor or vector) and produces one result of the same type.  The
@@ -891,12 +795,6 @@ def Math_RoundEvenOp : Math_FloatUnaryOp<"roundeven"> {
 def Math_RoundOp : Math_FloatUnaryOp<"round"> {
   let summary = "round of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.round` ssa-use `:` type
-    ```
-
     The `round` operation returns the operand rounded to the nearest integer
     value in floating-point format. It takes one operand of floating point type
     (i.e., scalar, tensor or vector) and produces one result of the same type.  The
@@ -921,12 +819,6 @@ def Math_RoundOp : Math_FloatUnaryOp<"round"> {
 def Math_TruncOp : Math_FloatUnaryOp<"trunc"> {
   let summary = "trunc of the specified value";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.trunc` ssa-use `:` type
-    ```
-
     The `trunc` operation returns the operand rounded to the nearest integer
     value in floating-point format. It takes one operand of floating point type
     (i.e., scalar, tensor or vector) and produces one result of the same type.
@@ -952,12 +844,6 @@ def Math_FPowIOp : Math_Op<"fpowi",
      DeclareOpInterfaceMethods<ArithFastMathInterface>]> {
   let summary = "floating point raised to the signed integer power";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `math.fpowi` ssa-use `,` ssa-use `:` type
-    ```
-
     The `fpowi` operation takes a `base` operand of floating point type
     (i.e. scalar, tensor or vector) and a `power` operand of integer type
     (also scalar, tensor or vector) and returns one result of the same type

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorTypes.td
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorTypes.td
@@ -30,13 +30,6 @@ def SparseTensor_StorageSpecifier : SparseTensor_Type<"StorageSpecifier"> {
   let summary = "Structured metadata for sparse tensor low-level storage scheme";
 
   let description = [{
-    Syntax:
-
-    ```
-    storage_specifier-type ::= `!storage_specifier` `<` encoding `>`
-    encoding ::= attribute-value
-    ```
-
     Values with storage_specifier types represent aggregated storage scheme
     metadata for the given sparse tensor encoding.  It currently holds
     a set of values for level-sizes, coordinate arrays, position arrays,

--- a/mlir/include/mlir/Dialect/UB/IR/UBOps.td
+++ b/mlir/include/mlir/Dialect/UB/IR/UBOps.td
@@ -48,15 +48,6 @@ def PoisonOp : UB_Op<"poison", [ConstantLike, Pure]> {
     semantics (e.g. partially poisoned vectors), default value indicates results
     is fully poisoned.
 
-    Syntax:
-
-    ```
-    poison-op ::= `poison` (`<` value `>`)? `:` type
-    ```
-
-    Examples:
-
-    ```
     // Short form
     %0 = ub.poison : i32
     // Long form

--- a/mlir/include/mlir/Dialect/UB/IR/UBOps.td
+++ b/mlir/include/mlir/Dialect/UB/IR/UBOps.td
@@ -48,6 +48,9 @@ def PoisonOp : UB_Op<"poison", [ConstantLike, Pure]> {
     semantics (e.g. partially poisoned vectors), default value indicates results
     is fully poisoned.
 
+    Examples:
+
+    ```
     // Short form
     %0 = ub.poison : i32
     // Long form


### PR DESCRIPTION
See #73359

Types using `assemblyFormat` to define parsing don't need an additional
handwritten parser. So we should remove the handwritten parsers where one
provided by an `assemblyFormat` already exists to avoid confusion and
de-syncing.