### PR TITLE
[compiler-rt][test]Mark thinlto icp test as UNSUPPORTED on ppc.

### DIFF
--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -15,6 +15,10 @@
 
 // REQUIRES: windows || linux || darwin
 
+// The test failed on ppc when building the instrumented binary.
+// ld.lld: error: /lib/../lib64/Scrt1.o: ABI version 1 is not supported
+// UNSUPPORTED: ppc
+
 // This test and IR test llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
 // are complementary to each other; a compiler-rt test has better test coverage
 // on different platforms, and the IR test is less restrictive in terms of

--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -13,12 +13,7 @@
 // - Generate ThinLTO summary file with LLVM bitcodes, and run `function-import` pass.
 // - Run `pgo-icall-prom` pass for the IR module which needs to import callees.
 
-
 // REQUIRES: windows || linux || darwin
-
-// The test failed on ppc when building the instrumented binary.
-// ld.lld: error: /lib/../lib64/Scrt1.o: ABI version 1 is not supported
-// UNSUPPORTED: ppc
 
 // This test and IR test llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
 // are complementary to each other; a compiler-rt test has better test coverage

--- a/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
+++ b/compiler-rt/test/profile/instrprof-thinlto-indirect-call-promotion.cpp
@@ -13,7 +13,12 @@
 // - Generate ThinLTO summary file with LLVM bitcodes, and run `function-import` pass.
 // - Run `pgo-icall-prom` pass for the IR module which needs to import callees.
 
+
 // REQUIRES: windows || linux || darwin
+
+// The test failed on ppc when building the instrumented binary.
+// ld.lld: error: /lib/../lib64/Scrt1.o: ABI version 1 is not supported
+// UNSUPPORTED: ppc
 
 // This test and IR test llvm/test/Transforms/PGOProfile/thinlto_indirect_call_promotion.ll
 // are complementary to each other; a compiler-rt test has better test coverage


### PR DESCRIPTION
The test failure is about failed to build instrumented binary on ppc (https://lab.llvm.org/buildbot/#/builders/18/builds/13228). Not sure how to fix this for now. Mark the test unsupported on ppc.

```
RUN: at line 46: /home/buildbots/ppc64be-sanitizer/sanitizer-ppc64be/build/build_gcc/./bin/clang  --driver-mode=g++  -m64  -ldl  -fprofile-generate -fuse-ld=lld -O2 lib.cpp main.cpp -o main
+ /home/buildbots/ppc64be-sanitizer/sanitizer-ppc64be/build/build_gcc/./bin/clang --driver-mode=g++ -m64 -ldl -fprofile-generate -fuse-ld=lld -O2 lib.cpp main.cpp -o main
ld.lld: error: /lib/../lib64/Scrt1.o: ABI version 1 is not supported
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```