### PR TITLE
[scudo] limit VMA size for riscv64 for DefaultConfig

### DIFF
--- a/compiler-rt/lib/scudo/standalone/allocator_config.h
+++ b/compiler-rt/lib/scudo/standalone/allocator_config.h
@@ -124,8 +124,14 @@ struct DefaultConfig {
   struct Primary {
     using SizeClassMap = DefaultSizeClassMap;
 #if SCUDO_CAN_USE_PRIMARY64
+#if SCUDO_RISCV64
+    // Support 39-bit VMA for riscv-64
+    static const uptr RegionSizeLog = 30U;
+    static const uptr GroupSizeLog = 19U;
+#else
     static const uptr RegionSizeLog = 32U;
     static const uptr GroupSizeLog = 21U;
+#endif
     typedef uptr CompactPtrT;
     static const uptr CompactPtrScale = 0;
     static const bool EnableRandomOffset = true;


### PR DESCRIPTION
The VMA size for RISC-V 64-bit Sv39 virtual address map is currently only defined in FuchsiaConfig, which leads to scudo failure on RISC-V Linux Sv39 systems, and most current available RISC-V Linux systems support only Sv39 in hardware.

Copy the reduced VMA size definition to DefaultConfig.