### PR TITLE
[X86][MC] Support Enc/Dec for EGPR for promoted CET instruction

### DIFF
--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -520,6 +520,7 @@ let SchedRW = [WriteSystem] in {
     } // Defs SSP
   } // Uses SSP
 
+let Predicates = [NoEGPR] in {
   def WRSSD : I<0xF6, MRMDestMem, (outs), (ins i32mem:$dst, GR32:$src),
                 "wrssd\t{$src, $dst|$dst, $src}",
                 [(int_x86_wrssd GR32:$src, addr:$dst)]>, T8PS;
@@ -532,6 +533,22 @@ let SchedRW = [WriteSystem] in {
   def WRUSSQ : RI<0xF5, MRMDestMem, (outs), (ins i64mem:$dst, GR64:$src),
                   "wrussq\t{$src, $dst|$dst, $src}",
                   [(int_x86_wrussq GR64:$src, addr:$dst)]>, T8PD;
+}
+
+let Predicates = [HasEGPR, In64BitMode] in {
+  def WRSSD_EVEX : I<0x66, MRMDestMem, (outs), (ins i32mem:$dst, GR32:$src),
+                     "wrssd\t{$src, $dst|$dst, $src}",
+                     [(int_x86_wrssd GR32:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PS;
+  def WRSSQ_EVEX : RI<0x66, MRMDestMem, (outs), (ins i64mem:$dst, GR64:$src),
+                      "wrssq\t{$src, $dst|$dst, $src}",
+                      [(int_x86_wrssq GR64:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PS;
+  def WRUSSD_EVEX : I<0x65, MRMDestMem, (outs), (ins i32mem:$dst, GR32:$src),
+                      "wrussd\t{$src, $dst|$dst, $src}",
+                      [(int_x86_wrussd GR32:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PD;
+  def WRUSSQ_EVEX : RI<0x65, MRMDestMem, (outs), (ins i64mem:$dst, GR64:$src),
+                       "wrussq\t{$src, $dst|$dst, $src}",
+                       [(int_x86_wrussq GR64:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PD;
+}
 
   let Defs = [SSP] in {
     let Uses = [SSP] in {

--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -538,16 +538,16 @@ let Predicates = [NoEGPR] in {
 let Predicates = [HasEGPR, In64BitMode] in {
   def WRSSD_EVEX : I<0x66, MRMDestMem, (outs), (ins i32mem:$dst, GR32:$src),
                      "wrssd\t{$src, $dst|$dst, $src}",
-                     [(int_x86_wrssd GR32:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PS;
+                     [(int_x86_wrssd GR32:$src, addr:$dst)]>, EVEX, NoCD8, T_MAP4PS;
   def WRSSQ_EVEX : RI<0x66, MRMDestMem, (outs), (ins i64mem:$dst, GR64:$src),
                       "wrssq\t{$src, $dst|$dst, $src}",
-                      [(int_x86_wrssq GR64:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PS;
+                      [(int_x86_wrssq GR64:$src, addr:$dst)]>, EVEX, NoCD8, T_MAP4PS;
   def WRUSSD_EVEX : I<0x65, MRMDestMem, (outs), (ins i32mem:$dst, GR32:$src),
                       "wrussd\t{$src, $dst|$dst, $src}",
-                      [(int_x86_wrussd GR32:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PD;
+                      [(int_x86_wrussd GR32:$src, addr:$dst)]>, EVEX, NoCD8, T_MAP4PD;
   def WRUSSQ_EVEX : RI<0x65, MRMDestMem, (outs), (ins i64mem:$dst, GR64:$src),
                        "wrussq\t{$src, $dst|$dst, $src}",
-                       [(int_x86_wrussq GR64:$src, addr:$dst)]>, EVEX_NoCD8, T_MAP4PD;
+                       [(int_x86_wrussq GR64:$src, addr:$dst)]>, EVEX, NoCD8, T_MAP4PD;
 }
 
   let Defs = [SSP] in {

--- a/llvm/test/MC/Disassembler/X86/apx/wrssd.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/wrssd.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   wrssd	%r18d, 291(%r28,%r29,4)
+# INTEL: wrssd	dword ptr [r28 + 4*r29 + 291], r18d
+0x62,0x8c,0x78,0x08,0x66,0x94,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/Disassembler/X86/apx/wrssq.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/wrssq.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   wrssq	%r19, 291(%r28,%r29,4)
+# INTEL: wrssq	qword ptr [r28 + 4*r29 + 291], r19
+0x62,0x8c,0xf8,0x08,0x66,0x9c,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/Disassembler/X86/apx/wrussd.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/wrussd.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   wrussd	%r18d, 291(%r28,%r29,4)
+# INTEL: wrussd	dword ptr [r28 + 4*r29 + 291], r18d
+0x62,0x8c,0x79,0x08,0x65,0x94,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/Disassembler/X86/apx/wrussq.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/wrussq.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
+# RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
+
+# ATT:   wrussq	%r19, 291(%r28,%r29,4)
+# INTEL: wrussq	qword ptr [r28 + 4*r29 + 291], r19
+0x62,0x8c,0xf9,0x08,0x65,0x9c,0xac,0x23,0x01,0x00,0x00

--- a/llvm/test/MC/X86/apx/wrssd-att.s
+++ b/llvm/test/MC/X86/apx/wrssd-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: wrssd	%r18d, 291(%r28,%r29,4)
+# CHECK: encoding: [0x62,0x8c,0x78,0x08,0x66,0x94,0xac,0x23,0x01,0x00,0x00]
+         wrssd	%r18d, 291(%r28,%r29,4)

--- a/llvm/test/MC/X86/apx/wrssd-intel.s
+++ b/llvm/test/MC/X86/apx/wrssd-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: wrssd	dword ptr [r28 + 4*r29 + 291], r18d
+# CHECK: encoding: [0x62,0x8c,0x78,0x08,0x66,0x94,0xac,0x23,0x01,0x00,0x00]
+         wrssd	dword ptr [r28 + 4*r29 + 291], r18d

--- a/llvm/test/MC/X86/apx/wrssq-att.s
+++ b/llvm/test/MC/X86/apx/wrssq-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: wrssq	%r19, 291(%r28,%r29,4)
+# CHECK: encoding: [0x62,0x8c,0xf8,0x08,0x66,0x9c,0xac,0x23,0x01,0x00,0x00]
+         wrssq	%r19, 291(%r28,%r29,4)

--- a/llvm/test/MC/X86/apx/wrssq-intel.s
+++ b/llvm/test/MC/X86/apx/wrssq-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: wrssq	qword ptr [r28 + 4*r29 + 291], r19
+# CHECK: encoding: [0x62,0x8c,0xf8,0x08,0x66,0x9c,0xac,0x23,0x01,0x00,0x00]
+         wrssq	qword ptr [r28 + 4*r29 + 291], r19

--- a/llvm/test/MC/X86/apx/wrussd-att.s
+++ b/llvm/test/MC/X86/apx/wrussd-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: wrussd	%r18d, 291(%r28,%r29,4)
+# CHECK: encoding: [0x62,0x8c,0x79,0x08,0x65,0x94,0xac,0x23,0x01,0x00,0x00]
+         wrussd	%r18d, 291(%r28,%r29,4)

--- a/llvm/test/MC/X86/apx/wrussd-intel.s
+++ b/llvm/test/MC/X86/apx/wrussd-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: wrussd	dword ptr [r28 + 4*r29 + 291], r18d
+# CHECK: encoding: [0x62,0x8c,0x79,0x08,0x65,0x94,0xac,0x23,0x01,0x00,0x00]
+         wrussd	dword ptr [r28 + 4*r29 + 291], r18d

--- a/llvm/test/MC/X86/apx/wrussq-att.s
+++ b/llvm/test/MC/X86/apx/wrussq-att.s
@@ -1,0 +1,8 @@
+# RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
+# RUN: not llvm-mc -triple i386 -show-encoding %s 2>&1 | FileCheck %s --check-prefix=ERROR
+
+# ERROR-COUNT-1: error:
+# ERROR-NOT: error:
+# CHECK: wrussq	%r19, 291(%r28,%r29,4)
+# CHECK: encoding: [0x62,0x8c,0xf9,0x08,0x65,0x9c,0xac,0x23,0x01,0x00,0x00]
+         wrussq	%r19, 291(%r28,%r29,4)

--- a/llvm/test/MC/X86/apx/wrussq-intel.s
+++ b/llvm/test/MC/X86/apx/wrussq-intel.s
@@ -1,0 +1,5 @@
+# RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
+
+# CHECK: wrussq	qword ptr [r28 + 4*r29 + 291], r19
+# CHECK: encoding: [0x62,0x8c,0xf9,0x08,0x65,0x9c,0xac,0x23,0x01,0x00,0x00]
+         wrussq	qword ptr [r28 + 4*r29 + 291], r19


### PR DESCRIPTION
R16-R31 was added into GPRs in https://github.com/llvm/llvm-project/pull/70958,
This patch supports the encoding/decoding for promoted CET instruction in EVEX space.

RFC: https://discourse.llvm.org/t/rfc-design-for-apx-feature-egpr-and-ndd-support/73031/4