### PR TITLE
[lldb] Add actionable feedback when overwriting a command fails

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1160,9 +1160,11 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
 
   if (UserCommandExists(name)) {
     if (!can_replace) {
-      result.SetErrorString(
-          "user command exists and force replace not set by --overwrite or "
-          "'settings set interpreter.require-overwrite false'");
+      result.SetErrorStringWithFormatv(
+          "user command \"{0}\" already exists and force replace was not set "
+          "by --overwrite or 'settings set interpreter.require-overwrite "
+          "false'",
+          name);
       return result;
     }
     if (cmd_sp->IsMultiwordObject()) {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1160,7 +1160,9 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
 
   if (UserCommandExists(name)) {
     if (!can_replace) {
-      result.SetErrorString("user command exists and force replace not set");
+      result.SetErrorString(
+          "user command exists and force replace not set by --overwrite or "
+          "'settings set interpreter.require-overwrite false'");
       return result;
     }
     if (cmd_sp->IsMultiwordObject()) {

--- a/lldb/test/API/commands/command/script/TestCommandScript.py
+++ b/lldb/test/API/commands/command/script/TestCommandScript.py
@@ -165,9 +165,11 @@ class CmdPythonTestCase(TestBase):
         self.expect(
             "command script add my_command --class welcome.TargetnameCommand",
             substrs=[
-                "cannot add command: user command exists and force replace not set",
-                "--overwrite",
-                "settings set interpreter.require-overwrite false",
+                (
+                    'user command "my_command" already exists and force replace was'
+                    " not set by --overwrite or 'settings set"
+                    " interpreter.require-overwrite false'"
+                ),
             ],
             error=True,
         )

--- a/lldb/test/API/commands/command/script/TestCommandScript.py
+++ b/lldb/test/API/commands/command/script/TestCommandScript.py
@@ -161,6 +161,17 @@ class CmdPythonTestCase(TestBase):
         )
         self.expect("my_command", substrs=["a.out"])
 
+        # Test that without --overwrite we are not allowed to redefine the command.
+        self.expect(
+            "command script add my_command --class welcome.TargetnameCommand",
+            substrs=[
+                "cannot add command: user command exists and force replace not set",
+                "--overwrite",
+                "settings set interpreter.require-overwrite false",
+            ],
+            error=True,
+        )
+
         self.runCmd("command script clear")
 
         self.expect(


### PR DESCRIPTION
If adding a user commands fails because a command with the same name already exists, we only say that "force replace is not set" without telling the user _how_ to set it. There are two ways to do so; this commit changes the error message to mention both.