### PR TITLE
[CodeGen] Don't codegen the weak function when there is a defined non-weak symbol

### DIFF
--- a/llvm/include/llvm/MC/MCSymbol.h
+++ b/llvm/include/llvm/MC/MCSymbol.h
@@ -104,6 +104,9 @@ protected:
   /// This symbol is weak external.
   mutable unsigned IsWeakExternal : 1;
 
+  /// This symbol is weak.
+  mutable unsigned IsWeak : 1;
+
   /// LLVM RTTI discriminator. This is actually a SymbolKind enumerator, but is
   /// unsigned to avoid sign extension and achieve better bitpacking with MSVC.
   unsigned Kind : 3;
@@ -163,7 +166,7 @@ protected:
   MCSymbol(SymbolKind Kind, const StringMapEntry<bool> *Name, bool isTemporary)
       : IsTemporary(isTemporary), IsRedefinable(false), IsUsed(false),
         IsRegistered(false), IsExternal(false), IsPrivateExtern(false),
-        IsWeakExternal(false), Kind(Kind), IsUsedInReloc(false),
+        IsWeakExternal(false), IsWeak(false), Kind(Kind), IsUsedInReloc(false),
         SymbolContents(SymContentsUnset), CommonAlignLog2(0), Flags(0) {
     Offset = 0;
     HasName = !!Name;
@@ -410,6 +413,9 @@ public:
   void setPrivateExtern(bool Value) { IsPrivateExtern = Value; }
 
   bool isWeakExternal() const { return IsWeakExternal; }
+
+  bool isWeak() const { return IsWeak; }
+  void setWeak(bool Value) const { IsWeak = Value; }
 
   /// print - Print the value to the stream \p OS.
   void print(raw_ostream &OS, const MCAsmInfo *MAI) const;

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -189,6 +189,8 @@ bool ELFAsmParser::ParseDirectiveSymbolAttribute(StringRef Directive, SMLoc) {
 
       MCSymbol *Sym = getContext().getOrCreateSymbol(Name);
 
+      if (Attr == MCSA_Weak)
+        Sym->setWeak(true);
       getStreamer().emitSymbolAttribute(Sym, Attr);
 
       if (getLexer().is(AsmToken::EndOfStatement))

--- a/llvm/test/CodeGen/Thumb/asm-fn-weak.ll
+++ b/llvm/test/CodeGen/Thumb/asm-fn-weak.ll
@@ -1,14 +1,17 @@
-; RUN: not llc -mtriple=thumbv6m-none-unknown-eabi < %s 2>&1 | FileCheck %s
+; RUN: llc -mtriple=thumbv6m-none-unknown-eabi < %s | FileCheck %s
 
-; CHECK: error: symbol '__aeabi_uidivmod' is already defined
-; FIXME: We want to discard the weak function.
-
+; CHECK: .globl	__aeabi_uidivmod
+; CHECK-NEXT: .type	__aeabi_uidivmod,%function
+; CHECK-NEXT: __aeabi_uidivmod:
+; CHECK-NEXT: str	r0, [r2, #96]
+; CHECK-NEXT: str	r1, [r2, #100]
 module asm ".global __aeabi_uidivmod"
 module asm ".type __aeabi_uidivmod, %function"
 module asm "__aeabi_uidivmod:"
 module asm "str    r0, [r2, #0x060]"
 module asm "str    r1, [r2, #0x064]"
 
+; CHECK-NOT: __aeabi_uidivmod
 define weak void @__aeabi_uidivmod() #0 {
   tail call void asm sideeffect alignstack "push {lr}\0Asub sp, sp, #4\0Amov r2, sp\0Abl __udivmodsi4\0Aldr r1, [sp]\0Aadd sp, sp, #4\0Apop {pc}", "~{cc},~{memory}"()
   unreachable

--- a/llvm/test/CodeGen/Thumb/asm-fn-weak.ll
+++ b/llvm/test/CodeGen/Thumb/asm-fn-weak.ll
@@ -1,0 +1,17 @@
+; RUN: not llc -mtriple=thumbv6m-none-unknown-eabi < %s 2>&1 | FileCheck %s
+
+; CHECK: error: symbol '__aeabi_uidivmod' is already defined
+; FIXME: We want to discard the weak function.
+
+module asm ".global __aeabi_uidivmod"
+module asm ".type __aeabi_uidivmod, %function"
+module asm "__aeabi_uidivmod:"
+module asm "str    r0, [r2, #0x060]"
+module asm "str    r1, [r2, #0x064]"
+
+define weak void @__aeabi_uidivmod() #0 {
+  tail call void asm sideeffect alignstack "push {lr}\0Asub sp, sp, #4\0Amov r2, sp\0Abl __udivmodsi4\0Aldr r1, [sp]\0Aadd sp, sp, #4\0Apop {pc}", "~{cc},~{memory}"()
+  unreachable
+}
+
+attributes #0 = { naked }

--- a/llvm/test/CodeGen/Thumb/asm-fn.ll
+++ b/llvm/test/CodeGen/Thumb/asm-fn.ll
@@ -1,0 +1,16 @@
+; RUN: not llc -mtriple=thumbv6m-none-unknown-eabi < %s 2>&1 | FileCheck %s
+
+; CHECK: error: symbol '__aeabi_uidivmod' is already defined
+
+module asm ".global __aeabi_uidivmod"
+module asm ".type __aeabi_uidivmod, %function"
+module asm "__aeabi_uidivmod:"
+module asm "str    r0, [r2, #0x060]"
+module asm "str    r1, [r2, #0x064]"
+
+define void @__aeabi_uidivmod() #0 {
+  tail call void asm sideeffect alignstack "push {lr}\0Asub sp, sp, #4\0Amov r2, sp\0Abl __udivmodsi4\0Aldr r1, [sp]\0Aadd sp, sp, #4\0Apop {pc}", "~{cc},~{memory}"()
+  unreachable
+}
+
+attributes #0 = { naked }

--- a/llvm/test/CodeGen/Thumb/asm-weak-fn-weak.ll
+++ b/llvm/test/CodeGen/Thumb/asm-weak-fn-weak.ll
@@ -1,0 +1,16 @@
+; RUN: not llc -mtriple=thumbv6m-none-unknown-eabi < %s 2>&1 | FileCheck %s
+
+; CHECK: error: symbol '__aeabi_uidivmod' is already defined
+
+module asm ".weak __aeabi_uidivmod"
+module asm ".type __aeabi_uidivmod, %function"
+module asm "__aeabi_uidivmod:"
+module asm "str    r0, [r2, #0x060]"
+module asm "str    r1, [r2, #0x064]"
+
+define weak void @__aeabi_uidivmod() #0 {
+  tail call void asm sideeffect alignstack "push {lr}\0Asub sp, sp, #4\0Amov r2, sp\0Abl __udivmodsi4\0Aldr r1, [sp]\0Aadd sp, sp, #4\0Apop {pc}", "~{cc},~{memory}"()
+  unreachable
+}
+
+attributes #0 = { naked }

--- a/llvm/test/CodeGen/Thumb/asm-weak-fn.ll
+++ b/llvm/test/CodeGen/Thumb/asm-weak-fn.ll
@@ -1,0 +1,17 @@
+; RUN: not llc -mtriple=thumbv6m-none-unknown-eabi < %s 2>&1 | FileCheck %s
+
+; CHECK: error: symbol '__aeabi_uidivmod' is already defined
+; FIXME: We want to discard the weak asm function.
+
+module asm ".weak __aeabi_uidivmod"
+module asm ".type __aeabi_uidivmod, %function"
+module asm "__aeabi_uidivmod:"
+module asm "str    r0, [r2, #0x060]"
+module asm "str    r1, [r2, #0x064]"
+
+define void @__aeabi_uidivmod() #0 {
+  tail call void asm sideeffect alignstack "push {lr}\0Asub sp, sp, #4\0Amov r2, sp\0Abl __udivmodsi4\0Aldr r1, [sp]\0Aadd sp, sp, #4\0Apop {pc}", "~{cc},~{memory}"()
+  unreachable
+}
+
+attributes #0 = { naked }


### PR DESCRIPTION
When there is an IR with inline asm modules and another with a weak function, LTO can lead to multiple symbol definition issue. The weak function can be correctly discarded without using LTO.
I found that the LLVM IR can't understand the asm content and can only handle it in codegen.
Currently I've only solved the weak function under ELF.