### PR TITLE
[mlir][spirv] Enable CAPI and Python binding for the SPIR-V dialect

### DIFF
--- a/mlir/include/mlir-c/Dialect/SPIRV.h
+++ b/mlir/include/mlir-c/Dialect/SPIRV.h
@@ -1,0 +1,26 @@
+//===-- mlir-c/Dialect/SPIRV.h - C API for SPIRV dialect -------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef MLIR_C_DIALECT_SPIRV_H
+#define MLIR_C_DIALECT_SPIRV_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(SPIRV, spirv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_DIALECT_SPIRV_H

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -171,6 +171,15 @@ add_mlir_upstream_c_api_library(MLIRCAPIFunc
   MLIRFuncDialect
 )
 
+add_mlir_upstream_c_api_library(MLIRCAPISPIRV
+  SPIRV.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  MLIRSPIRVDialect
+)
+
 add_mlir_upstream_c_api_library(MLIRCAPITensor
   Tensor.cpp
 

--- a/mlir/lib/CAPI/Dialect/SPIRV.cpp
+++ b/mlir/lib/CAPI/Dialect/SPIRV.cpp
@@ -1,0 +1,13 @@
+//===- SPIRV.cpp - C Interface for SPIRV dialect ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/Dialect/SPIRV.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SPIRV, spirv, mlir::spirv::SPIRVDialect)

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -372,6 +372,13 @@ declare_mlir_dialect_python_bindings(
 )
 
 declare_mlir_dialect_python_bindings(
+    ADD_TO_PARENT MLIRPythonSources.Dialects
+    ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+    TD_FILE dialects/SPIRVOps.td
+    SOURCES dialects/spirv.py
+    DIALECT_NAME spirv)
+
+declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT MLIRPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
   TD_FILE dialects/TensorOps.td

--- a/mlir/python/mlir/dialects/SPIRVOps.td
+++ b/mlir/python/mlir/dialects/SPIRVOps.td
@@ -1,0 +1,14 @@
+//===-- SPIRVOps.td - Entry point for SPIRVOps bind ------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PYTHON_BINDINGS_SPIRV_OPS
+#define PYTHON_BINDINGS_SPIRV_OPS
+
+include "mlir/Dialect/SPIRV/IR/SPIRVOps.td"
+
+#endif

--- a/mlir/python/mlir/dialects/spirv.py
+++ b/mlir/python/mlir/dialects/spirv.py
@@ -1,0 +1,5 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._spirv_ops_gen import *

--- a/mlir/test/python/dialects/spirv_dialect.py
+++ b/mlir/test/python/dialects/spirv_dialect.py
@@ -1,0 +1,22 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir.ir import *
+import mlir.dialects.spirv as spirv
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+
+
+# CHECK-LABEL: TEST: testConstantOp
+@run
+def testConstantOps():
+    with Context() as ctx, Location.unknown():
+        module = Module.create()
+        with InsertionPoint(module.body):
+            spirv.ConstantOp(
+                value=FloatAttr.get(F32Type.get(), 42.42), constant=F32Type.get()
+            )
+        # CHECK:         %cst_f32 = spirv.Constant 4.242000e+01 : f32
+        print(module)


### PR DESCRIPTION
Add support for
- C-API
- Python binding