### PR TITLE
[mlir][EmitC] Use declarative assembly format for opaque types and attributes

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCAttributes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCAttributes.td
@@ -57,8 +57,7 @@ def EmitC_OpaqueAttr : EmitC_Attr<"Opaque", "opaque"> {
   }];
 
   let parameters = (ins StringRefParameter<"the opaque value">:$value);
-
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "`<` $value `>`";
 }
 
 def EmitC_OpaqueOrTypedAttr : AnyAttrOf<[EmitC_OpaqueAttr, TypedAttrInterface]>;

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
@@ -42,7 +42,8 @@ def EmitC_OpaqueType : EmitC_Type<"Opaque", "opaque"> {
   }];
 
   let parameters = (ins StringRefParameter<"the opaque value">:$value);
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "`<` $value `>`";
+  let genVerifyDecl = 1;
 }
 
 def EmitC_PointerType : EmitC_Type<"Pointer", "ptr"> {


### PR DESCRIPTION
The parser and printer of string attributes were changed to handle escape sequences. Therefore, we no longer require a custom parser and printer. Verification is moved from the parser to the verifier accordingly.