### PR TITLE
[mlir][SCF] Remove unused `fail_if_already_divisible` from the .td file

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/TransformOps/SCFTransformOps.td
+++ b/mlir/include/mlir/Dialect/SCF/TransformOps/SCFTransformOps.td
@@ -139,8 +139,7 @@ def LoopPeelOp : Op<Transform_Dialect, "loop.peel",
 
   let arguments =
       (ins Transform_ScfForOp:$target,
-           DefaultValuedAttr<BoolAttr, "false">:$peel_front,
-           DefaultValuedAttr<BoolAttr, "false">:$fail_if_already_divisible);
+           DefaultValuedAttr<BoolAttr, "false">:$peel_front);
   let results = (outs TransformHandleTypeInterface:$peeled_loop,
                       TransformHandleTypeInterface:$remainder_loop);
 


### PR DESCRIPTION
Unless I'm missing something, the `fail_if_already_divisible` attribute in the `LoopPeelOp` is doing nothing. It seems like the logic was removed in 5230710, but the option was not removed in the .td file. This is confusing because users (e.g.: myself a few days ago) may think that this is doing something while actually it does nothing.