### PR TITLE
Parallel runtime library design doc (PRIF)

### DIFF
--- a/flang/docs/ParallelMultiImageFortranRuntime.md
+++ b/flang/docs/ParallelMultiImageFortranRuntime.md
@@ -1,0 +1,16 @@
+<!--===- docs/ParallelMultiImageFortranRuntime.md
+  
+   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+   See https://llvm.org/LICENSE.txt for license information.
+   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+  
+-->
+
+# Multi-Image Parallel Fortran Runtime
+
+LLVM Flang targets the Parallel Runtime Interface for Fortran (PRIF) for
+runtime support of Fortran's multi-image parallel features.
+
+The current revision of the PRIF specification is here:
+<https://doi.org/10.25344/S4CG6G>
+

--- a/flang/docs/ParallelMultiImageFortranRuntime.md
+++ b/flang/docs/ParallelMultiImageFortranRuntime.md
@@ -8,8 +8,10 @@
 
 # Multi-Image Parallel Fortran Runtime
 
-LLVM Flang targets the Parallel Runtime Interface for Fortran (PRIF) for
-runtime support of Fortran's multi-image parallel features.
+
+The Parallel Runtime Interface for Fortran (PRIF) defines an 
+interface designed for LLVM Flang to target implementations of 
+Fortran's multi-image parallel features.
 
 The current revision of the PRIF specification is here:
 <https://doi.org/10.25344/S4CG6G>

--- a/flang/docs/index.md
+++ b/flang/docs/index.md
@@ -74,6 +74,7 @@ on how to get in touch with us and to learn more about the current status.
    OpenMP-semantics
    OptionComparison
    Overview
+   ParallelMultiImageFortranRuntime
    ParameterizedDerivedTypes
    ParserCombinators
    Parsing


### PR DESCRIPTION
This document specifies the interface design for supporting the parallel features of flang.

For those  interested in reviewing the document, and would like a nicer formatted copy, the following is a link to a PDF version:
https://doi.org/10.25344/S4CG6G