### PR TITLE
[SystemZ][z/OS] define HOST_NAME_MAX for z/OS

### DIFF
--- a/third-party/benchmark/src/sysinfo.cc
+++ b/third-party/benchmark/src/sysinfo.cc
@@ -449,6 +449,8 @@ std::string GetSystemName() {
 #define HOST_NAME_MAX 154
 #elif defined(BENCHMARK_OS_RTEMS)
 #define HOST_NAME_MAX 256
+#elif defined(BENCHMARK_OS_ZOS)
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
 #else
 #pragma message("HOST_NAME_MAX not defined. using 64")
 #define HOST_NAME_MAX 64


### PR DESCRIPTION
This copies the change made in google benchmark to define HOST_NAME_MAX for z/OS https://github.com/google/benchmark/commit/7b52bf7346dead5ef4f29d7f98d2a26d6194252f