### PR TITLE
[emacs] Fix Emacs library formatting

### DIFF
--- a/clang-tools-extra/clang-include-fixer/tool/clang-include-fixer.el
+++ b/clang-tools-extra/clang-include-fixer/tool/clang-include-fixer.el
@@ -1,5 +1,6 @@
 ;;; clang-include-fixer.el --- Emacs integration of the clang include fixer  -*- lexical-binding: t; -*-
 
+;; Version: 0.1.0
 ;; Keywords: tools, c
 ;; Package-Requires: ((cl-lib "0.5") (json "1.2") (let-alist "1.0.4"))
 

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -1,5 +1,6 @@
 ;;; clang-format.el --- Format code using clang-format  -*- lexical-binding: t; -*-
 
+;; Version: 0.1.0
 ;; Keywords: tools, c
 ;; Package-Requires: ((cl-lib "0.3"))
 ;; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/clang/tools/clang-rename/clang-rename.el
+++ b/clang/tools/clang-rename/clang-rename.el
@@ -1,5 +1,6 @@
 ;;; clang-rename.el --- Renames every occurrence of a symbol found at <offset>.  -*- lexical-binding: t; -*-
 
+;; Version: 0.1.0
 ;; Keywords: tools, c
 
 ;;; Commentary:

--- a/llvm/utils/emacs/tablegen-mode.el
+++ b/llvm/utils/emacs/tablegen-mode.el
@@ -1,6 +1,7 @@
 ;;; tablegen-mode.el --- Major mode for TableGen description files (part of LLVM project)
 
 ;; Maintainer:  The LLVM team, http://llvm.org/
+;; Version: 1.0
 
 ;;; Commentary:
 ;; A major mode for TableGen description files in LLVM.

--- a/mlir/utils/emacs/mlir-lsp-client.el
+++ b/mlir/utils/emacs/mlir-lsp-client.el
@@ -14,6 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
+;; Version: 0.1.0
+
 ;;; Commentary:
 
 ;; LSP clinet to use with `mlir-mode' that uses `mlir-lsp-server' or any

--- a/mlir/utils/emacs/mlir-mode.el
+++ b/mlir/utils/emacs/mlir-mode.el
@@ -14,6 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
+;; Version: 0.1.0
+
 ;;; Commentary:
 
 ;; Major mode for editing MLIR files.
@@ -96,5 +98,4 @@
 (add-to-list 'auto-mode-alist (cons "\\.mlirbc\\'" 'mlir-mode))
 
 (provide 'mlir-mode)
-
 ;;; mlir-mode.el ends here


### PR DESCRIPTION
This makes it easier to ship/install these using the builtin Emacs package format (in particular, a Version is required).