### PR TITLE
[lldb] Remove redundant severity substring within a diagnostic message.

### DIFF
--- a/lldb/source/Expression/DiagnosticManager.cpp
+++ b/lldb/source/Expression/DiagnosticManager.cpp
@@ -46,11 +46,20 @@ static const char *StringForSeverity(DiagnosticSeverity severity) {
 
 std::string DiagnosticManager::GetString(char separator) {
   std::string ret;
+  llvm::raw_string_ostream stream(ret);
 
   for (const auto &diagnostic : Diagnostics()) {
-    ret.append(StringForSeverity(diagnostic->GetSeverity()));
-    ret.append(std::string(diagnostic->GetMessage()));
-    ret.push_back(separator);
+    llvm::StringRef severity = StringForSeverity(diagnostic->GetSeverity());
+    stream << severity;
+
+    llvm::StringRef message = diagnostic->GetMessage();
+    std::string searchable_message = message.lower();
+    auto severity_pos = message.find(severity);
+    stream << message.take_front(severity_pos);
+
+    if (severity_pos != llvm::StringRef::npos)
+      stream << message.drop_front(severity_pos + severity.size());
+    stream << separator;
   }
 
   return ret;

--- a/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
+++ b/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             "expr @import LLDBTestModule",
             error=True,
             substrs=[
-                "module.h:4:1: error: use of undeclared identifier 'syntax_error_for_lldb_to_find'",
+                "module.h:4:1: use of undeclared identifier 'syntax_error_for_lldb_to_find'",
                 "syntax_error_for_lldb_to_find // comment that tests source printing",
                 "could not build module 'LLDBTestModule'",
             ],


### PR DESCRIPTION
For example, the following message has the severity string "error: " twice.
> "error: <EXPR>:3:1: error: cannot find 'bogus' in scope

This method already appends the severity string in the beginning, but with this fix, it also removes a secondary instance, if applicable.

Note that this change only removes the *first* redundant substring. I considered putting the removal logic in a loop, but I decided that if something is generating more than one redundant severity substring, then that's a problem the message's source should probably fix.

rdar://114203423