### PR TITLE
[mlir][spirv] Convert `bf16` to `spirv` as a `i16`

### DIFF
--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -713,6 +713,9 @@ SPIRVTypeConverter::SPIRVTypeConverter(spirv::TargetEnvAttr targetAttr,
   });
 
   addConversion([this](FloatType floatType) -> std::optional<Type> {
+    if (floatType.isBF16())
+      return convertType(IntegerType::get(floatType.getContext(), 16));
+
     if (auto scalarType = dyn_cast<spirv::ScalarType>(floatType))
       return convertScalarType(this->targetEnv, this->options, scalarType);
     return Type();

--- a/mlir/test/Conversion/FuncToSPIRV/types-to-spirv.mlir
+++ b/mlir/test/Conversion/FuncToSPIRV/types-to-spirv.mlir
@@ -211,7 +211,8 @@ module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [], []>, #spirv.resource_limits<>>
 } {
 
-// CHECK-NOT: spirv.func @bf16_type
+// CHECK: spirv.func @bf16_type
+// CHECK-SAME: i32
 func.func @bf16_type(%arg0: bf16) { return }
 
 } // end module


### PR DESCRIPTION
`bf16` is not support currently in `spirv`. Current conversions treat it as an `i16` with bit-shifting, extending, and other manipulations. Change to `i16` appropriately.