### PR TITLE
[ASan][Driver] Add sanitize-target flag to support enabling ASan in device or host compilation

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -224,6 +224,10 @@ ENUM_CODEGENOPT(SanitizeAddressUseAfterReturn,
                 llvm::AsanDetectStackUseAfterReturnMode, 2,
                 llvm::AsanDetectStackUseAfterReturnMode::Runtime
                 ) ///< Set detection mode for stack-use-after-return.
+ENUM_CODEGENOPT(
+    SanitizeTargetsToEnable, llvm::AsanTargetsToEnable, 2,
+    llvm::AsanTargetsToEnable::Both) ///< Set targets to enable sanitizer
+                                     /// passes in offloading scenario.
 CODEGENOPT(SanitizeAddressPoisonCustomArrayCookie, 1,
            0) ///< Enable poisoning operator new[] which is not a replaceable
               ///< global allocation function in AddressSanitizer

--- a/clang/include/clang/Basic/Sanitizers.h
+++ b/clang/include/clang/Basic/Sanitizers.h
@@ -211,6 +211,10 @@ StringRef AsanDetectStackUseAfterReturnModeToString(
 llvm::AsanDetectStackUseAfterReturnMode
 AsanDetectStackUseAfterReturnModeFromString(StringRef modeStr);
 
+llvm::AsanTargetsToEnable
+AsanTargetsToEnableFromString(StringRef asanTargetsStr);
+
+StringRef AsanTargetsToEnableToString(llvm::AsanTargetsToEnable target);
 } // namespace clang
 
 #endif // LLVM_CLANG_BASIC_SANITIZERS_H

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2462,6 +2462,18 @@ def fsanitize_undefined_strip_path_components_EQ : Joined<["-"], "fsanitize-unde
            "when emitting check metadata.">,
   MarshallingInfoInt<CodeGenOpts<"EmitCheckPathComponentsToStrip">, "0", "int">;
 
+def sanitize_targets_EQ
+      : Joined<["-"], "fsanitize-target=">,
+        MetaVarName<"<target>">,
+        Visibility<[ClangOption, CC1Option]>,
+        HelpText<"Select target to enable sanitizer in offloading scenario, "
+                 "valid targets are host, device, both(both host and device "
+                 "enabled).">,
+        Group<f_clang_Group>,
+        Values<"host,device,both">,
+        NormalizedValuesScope<"llvm::AsanTargetsToEnable">,
+        NormalizedValues<["Host", "Device", "Both"]>,
+        MarshallingInfoEnum<CodeGenOpts<"SanitizeTargetsToEnable">, "Both">;
 } // end -f[no-]sanitize* flags
 
 def funsafe_math_optimizations : Flag<["-"], "funsafe-math-optimizations">,

--- a/clang/include/clang/Driver/SanitizerArgs.h
+++ b/clang/include/clang/Driver/SanitizerArgs.h
@@ -67,6 +67,8 @@ class SanitizerArgs {
   bool HwasanUseAliases = false;
   llvm::AsanDetectStackUseAfterReturnMode AsanUseAfterReturn =
       llvm::AsanDetectStackUseAfterReturnMode::Invalid;
+  llvm::AsanTargetsToEnable AsanTargetsToEnable =
+      llvm::AsanTargetsToEnable::Both;
 
   std::string MemtagMode;
 
@@ -79,7 +81,10 @@ public:
   bool needsStableAbi() const { return StableABI; }
 
   bool needsMemProfRt() const { return NeedsMemProfRt; }
-  bool needsAsanRt() const { return Sanitizers.has(SanitizerKind::Address); }
+  bool needsAsanRt() const {
+    bool AsanIsNotDeviceOnly =
+        !(AsanTargetsToEnable == llvm::AsanTargetsToEnable::Device);
+    return Sanitizers.has(SanitizerKind::Address) && AsanIsNotDeviceOnly; }
   bool needsHwasanRt() const {
     return Sanitizers.has(SanitizerKind::HWAddress);
   }

--- a/clang/include/clang/Driver/SanitizerArgs.h
+++ b/clang/include/clang/Driver/SanitizerArgs.h
@@ -84,7 +84,8 @@ public:
   bool needsAsanRt() const {
     bool AsanIsNotDeviceOnly =
         !(AsanTargetsToEnable == llvm::AsanTargetsToEnable::Device);
-    return Sanitizers.has(SanitizerKind::Address) && AsanIsNotDeviceOnly; }
+    return Sanitizers.has(SanitizerKind::Address) && AsanIsNotDeviceOnly;
+  }
   bool needsHwasanRt() const {
     return Sanitizers.has(SanitizerKind::HWAddress);
   }

--- a/clang/lib/Basic/Sanitizers.cpp
+++ b/clang/lib/Basic/Sanitizers.cpp
@@ -112,4 +112,27 @@ AsanDetectStackUseAfterReturnModeFromString(StringRef modeStr) {
       .Default(llvm::AsanDetectStackUseAfterReturnMode::Invalid);
 }
 
+llvm::AsanTargetsToEnable
+AsanTargetsToEnableFromString(StringRef asanTargetsStr) {
+  return llvm::StringSwitch<llvm::AsanTargetsToEnable>(asanTargetsStr)
+      .Case("host", llvm::AsanTargetsToEnable::Host)
+      .Case("device", llvm::AsanTargetsToEnable::Device)
+      .Case("both", llvm::AsanTargetsToEnable::Both)
+      .Default(llvm::AsanTargetsToEnable::Invalid);
+}
+
+StringRef AsanTargetsToEnableToString(llvm::AsanTargetsToEnable target) {
+  switch (target) {
+  case llvm::AsanTargetsToEnable::Host:
+    return "host";
+  case llvm::AsanTargetsToEnable::Device:
+    return "device";
+  case llvm::AsanTargetsToEnable::Both:
+    return "both";
+  case llvm::AsanTargetsToEnable::Invalid:
+    return "invalid";
+  }
+  return "invalid";
+}
+
 } // namespace clang

--- a/clang/test/Driver/sycl-sanitize-target.cpp
+++ b/clang/test/Driver/sycl-sanitize-target.cpp
@@ -1,0 +1,29 @@
+// UNSUPPORTED: system-windows
+
+// Check whether ASan runtime libraries are linked or not when
+// fsanitize-target=host|device|both. The ASan runtime libraries
+// are NOT needed for device compilation in offloading scenario.
+
+// RUN: %clangxx -fsycl -fsanitize=address %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=SYCL-ASAN-DEFAULT %s
+// SYCL-ASAN-DEFAULT:  "{{.*}}/ld"
+// SYCL-ASAN-DEFAULT-SAME: "{{.*}}/libclang_rt.asan{{.*}}.a"
+
+// RUN: %clangxx -fsycl -fsanitize=address -fsanitize-target=host %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=SYCL-ASAN-HOST %s
+// SYCL-ASAN-HOST:  "{{.*}}/ld"
+// SYCL-ASAN-HOST-SAME: "{{.*}}/libclang_rt.asan{{.*}}.a"
+
+// RUN: %clangxx -fsycl -fsanitize=address -fsanitize-target=both %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=SYCL-ASAN-BOTH %s
+// SYCL-ASAN-BOTH:  "{{.*}}/ld"
+// SYCL-ASAN-BOTH-SAME: "{{.*}}/libclang_rt.asan{{.*}}.a"
+
+// RUN: %clangxx -fsycl -fsanitize=address -fsanitize-target=device %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=SYCL-ASAN-DEVICE %s
+// SYCL-ASAN-DEVICE:  "{{.*}}/ld"
+// SYCL-ASAN-DEVICE-NOT: "{{.*}}/libclang_rt.asan{{.*}}.a"
+
+// RUN: not %clangxx -fsycl -fsanitize=address -fsanitize-target=YYY %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=SYCL-ASAN-INVALID %s
+// SYCL-ASAN-INVALID: error: unsupported argument 'YYY'

--- a/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerOptions.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerOptions.h
@@ -34,6 +34,14 @@ enum class AsanDetectStackUseAfterReturnMode {
   Invalid, ///< Not a valid detect mode.
 };
 
+/// Targets to enable address sanitizer pass in offloading scenario.
+enum class AsanTargetsToEnable {
+  Host,   ///< Only enable AddressSanitizerPass for host compilation.
+  Device, ///< Only enable AddressSanitizerPass for device compilation.
+  Both,   ///< Enable AddressSanitizerPass for both host and device compilation.
+  Invalid ///< Not a valid detect mode.
+};
+
 } // namespace llvm
 
 #endif


### PR DESCRIPTION
In offloading scenario, the whole compiling process consists of device and host compilation phase, device and host code will be bundled together. Address sanitizer can be enabled in either one or both compilation phases via fsanitize-target=host|device|both. The meaning of each value is:
-fsanitize-target=host       AsanPass only enabled in host code
-fsanitize-target=device     AsanPass only enabled in device code
-fsanitize-target=both       AsanPass enabled in both host and device code
The default value is 'both'.