### PR TITLE
[LLDB] Define _BSD_SOURCE globally, to get optreset available in mingw's getopt.h

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -44,6 +44,10 @@ endif()
 
 if (WIN32)
   add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+  if (NOT MSVC)
+    # _BSD_SOURCE is required for MinGW's getopt.h to define optreset
+    add_definitions(-D_BSD_SOURCE)
+  endif()
 endif()
 
 if (LLDB_ENABLE_PYTHON)

--- a/lldb/include/lldb/Host/HostGetOpt.h
+++ b/lldb/include/lldb/Host/HostGetOpt.h
@@ -11,10 +11,6 @@
 
 #if !defined(_MSC_VER) && !defined(__NetBSD__)
 
-#ifdef _WIN32
-#define _BSD_SOURCE // Required so that getopt.h defines optreset
-#endif
-
 #include <getopt.h>
 #include <unistd.h>
 


### PR DESCRIPTION
We previously were defining _BSD_SOURCE right before including getopt.h. However, on mingw-w64, getopt.h is also transitively included by unistd.h, and unistd.h can be transitively included by many headers (recently, by some libc++ headers).

Therefore, to be safe, we need to define _BSD_SOURCE before including any header. Thus do this in CMake.

This fixes https://github.com/llvm/llvm-project/issues/76050.