### PR TITLE
[OpenMP] Check for gtest when building libomptarget unit tests

### DIFF
--- a/openmp/libomptarget/CMakeLists.txt
+++ b/openmp/libomptarget/CMakeLists.txt
@@ -153,6 +153,8 @@ add_subdirectory(test)
 
 # Add unit tests if GMock/GTest is present
 if (EXISTS ${LLVM_THIRD_PARTY_DIR}/unittest)
-  add_subdirectory(${LLVM_THIRD_PARTY_DIR}/unittest ${CMAKE_CURRENT_BINARY_DIR}/third-party/unittest)
+  if (NOT TARGET llvm_gtest)
+    add_subdirectory(${LLVM_THIRD_PARTY_DIR}/unittest ${CMAKE_CURRENT_BINARY_DIR}/third-party/unittest)
+  endif()
   add_subdirectory(unittests)
 endif()


### PR DESCRIPTION
This patch addresses an issue introduced in pull request #74398. CMake will attempt to re-build gtest if openmp is enabled as a project (as opposed to being enabled as a runtime). This patch adds a check that prevents this from happening.