### PR TITLE
[LLDB] Fix write permission error in TestGlobalModuleCache.py

### DIFF
--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -26,6 +26,9 @@ class GlobalModuleCacheTestCase(TestBase):
         # a previous build, so sleep a bit here to ensure that the touch is later.
         time.sleep(2)
         try:
+            # Make sure dst is writeable before trying to write to it.
+            subprocess.run(['chmod', '777', dst], stdin=None,
+                           capture_output=False, encoding='utf-8')
             shutil.copy(src, dst)
         except:
             self.fail(f"Could not copy {src} to {dst}")

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -27,8 +27,12 @@ class GlobalModuleCacheTestCase(TestBase):
         time.sleep(2)
         try:
             # Make sure dst is writeable before trying to write to it.
-            subprocess.run(['chmod', '777', dst], stdin=None,
-                           capture_output=False, encoding='utf-8')
+            subprocess.run(
+                ['chmod', '777', dst],
+                stdin=None,
+                capture_output=False,
+                encoding='utf-8'
+            )
             shutil.copy(src, dst)
         except:
             self.fail(f"Could not copy {src} to {dst}")

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -28,10 +28,10 @@ class GlobalModuleCacheTestCase(TestBase):
         try:
             # Make sure dst is writeable before trying to write to it.
             subprocess.run(
-                ['chmod', '777', dst],
+                ["chmod", "777", dst],
                 stdin=None,
                 capture_output=False,
-                encoding='utf-8'
+                encoding="utf-8"
             )
             shutil.copy(src, dst)
         except:

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -31,7 +31,7 @@ class GlobalModuleCacheTestCase(TestBase):
                 ["chmod", "777", dst],
                 stdin=None,
                 capture_output=False,
-                encoding="utf-8"
+                encoding="utf-8",
             )
             shutil.copy(src, dst)
         except:


### PR DESCRIPTION
TestGlobalModuleCache.py, a recently added test, tries to update a source file in the build directory, but it assumes the file is writable. In our distributed build and test system, this is not always true, so the test often fails with a write permissions error.

This change fixes that by setting the permissions on the file to be writable before attempting to write to it.