### PR TITLE
[Libomptarget] Only initialize a plugin if a device image needs it

### DIFF
--- a/openmp/libomptarget/include/PluginManager.h
+++ b/openmp/libomptarget/include/PluginManager.h
@@ -49,6 +49,10 @@ struct PluginAdaptorTy {
   /// that fail to initialize are ignored.
   void initDevices(PluginManager &PM);
 
+  /// Initialize as many devices as possible for this plugin adaptor. Devices
+  /// that fail to initialize are ignored.
+  llvm::Error initPlugin();
+
   bool isUsed() const { return DeviceOffset >= 0; }
 
   /// Return the number of devices visible to the underlying plugin.

--- a/openmp/libomptarget/include/Shared/PluginAPI.h
+++ b/openmp/libomptarget/include/Shared/PluginAPI.h
@@ -20,13 +20,19 @@
 #include "Shared/APITypes.h"
 
 extern "C" {
-
 // First method called on the plugin
 int32_t __tgt_rtl_init_plugin();
+
+// Returns non-zero if the plugin has been initialized.
+int32_t __tgt_rtl_is_plugin_active();
 
 // Return the number of available devices of the type supported by the
 // target RTL.
 int32_t __tgt_rtl_number_of_devices(void);
+
+// Returns a non-zero integer if the given Image is capable of being run by the
+// plugin. This is intended to be called without initializing the plugin.
+int32_t __tgt_rtl_is_binary_compatible(__tgt_device_image *Image);
 
 // Return an integer different from zero if the provided device image can be
 // supported by the runtime. The functionality is similar to comparing the

--- a/openmp/libomptarget/include/Shared/PluginAPI.inc
+++ b/openmp/libomptarget/include/Shared/PluginAPI.inc
@@ -14,6 +14,8 @@
 // No include guards!
 
 PLUGIN_API_HANDLE(init_plugin, true);
+PLUGIN_API_HANDLE(is_plugin_active, true);
+PLUGIN_API_HANDLE(is_binary_compatible, true);
 PLUGIN_API_HANDLE(is_valid_binary, true);
 PLUGIN_API_HANDLE(is_data_exchangable, false);
 PLUGIN_API_HANDLE(number_of_devices, true);

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -56,6 +56,8 @@
 #include "hsa/hsa_ext_amd.h"
 #endif
 
+extern const uint16_t llvm::omp::target::plugin::ELFMachine = ELF::EM_AMDGPU;
+
 namespace llvm {
 namespace omp {
 namespace target {
@@ -3013,7 +3015,7 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
   Triple::ArchType getTripleArch() const override { return Triple::amdgcn; }
 
   /// Get the ELF code for recognizing the compatible image binary.
-  uint16_t getMagicElfBits() const override { return ELF::EM_AMDGPU; }
+  uint16_t getMagicElfBits() const override { return ELFMachine; }
 
   /// Check whether the image is compatible with an AMDGPU device.
   Expected<bool> isELFCompatible(StringRef Image) const override {

--- a/openmp/libomptarget/plugins-nextgen/common/include/JIT.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/JIT.h
@@ -57,7 +57,7 @@ struct JITEngine {
 
   /// Return true if \p Image is a bitcode image that can be JITed for the given
   /// architecture.
-  bool checkBitcodeImage(const __tgt_device_image &Image);
+  Expected<bool> checkBitcodeImage(StringRef Buffer) const;
 
 private:
   /// Compile the bitcode image \p Image and generate the binary image that can

--- a/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
@@ -1067,7 +1067,7 @@ struct GenericPluginTy {
 
   /// Top level interface to verify if a given ELF image can be executed on a
   /// given target. Returns true if the \p Image is compatible with the plugin.
-  Expected<bool> checkELFImage(__tgt_device_image &Image) const;
+  Expected<bool> checkELFImage(StringRef Image) const;
 
   /// Indicate if an image is compatible with the plugin devices. Notice that
   /// this function may be called before actually initializing the devices. So

--- a/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
@@ -48,8 +48,11 @@
 namespace llvm {
 namespace omp {
 namespace target {
-
 namespace plugin {
+
+/// The plugin's native ELF architecture. This should be defined individually
+/// by each plugin, and ELF:EM_NONE if the ELF target is not applicable.
+extern const uint16_t ELFMachine;
 
 struct GenericPluginTy;
 struct GenericKernelTy;

--- a/openmp/libomptarget/plugins-nextgen/common/src/Utils/ELF.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/Utils/ELF.cpp
@@ -37,8 +37,7 @@ bool utils::elf::isELF(StringRef Buffer) {
 }
 
 Expected<bool> utils::elf::checkMachine(StringRef Object, uint16_t EMachine) {
-  if (!isELF(Object))
-    return createError("Input is not an ELF.");
+  assert(isELF(Object) && "Input is not an ELF!");
 
   Expected<ELF64LEObjectFile> ElfOrErr =
       ELF64LEObjectFile::create(MemoryBufferRef(Object, /*Identifier=*/""),

--- a/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
@@ -29,6 +29,8 @@
 #include "llvm/Frontend/OpenMP/OMPGridValues.h"
 #include "llvm/Support/Error.h"
 
+extern const uint16_t llvm::omp::target::plugin::ELFMachine = ELF::EM_CUDA;
+
 namespace llvm {
 namespace omp {
 namespace target {
@@ -1275,7 +1277,7 @@ struct CUDAPluginTy final : public GenericPluginTy {
   Error deinitImpl() override { return Plugin::success(); }
 
   /// Get the ELF code for recognizing the compatible image binary.
-  uint16_t getMagicElfBits() const override { return ELF::EM_CUDA; }
+  uint16_t getMagicElfBits() const override { return ELFMachine; }
 
   Triple::ArchType getTripleArch() const override {
     // TODO: I think we can drop the support for 32-bit NVPTX devices.

--- a/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
@@ -38,6 +38,8 @@
 #define TARGET_ELF_ID ELF::EM_NONE
 #endif
 
+extern const uint16_t llvm::omp::target::plugin::ELFMachine = TARGET_ELF_ID;
+
 namespace llvm {
 namespace omp {
 namespace target {
@@ -389,7 +391,7 @@ struct GenELF64PluginTy final : public GenericPluginTy {
   Error deinitImpl() override { return Plugin::success(); }
 
   /// Get the ELF code to recognize the compatible binary images.
-  uint16_t getMagicElfBits() const override { return TARGET_ELF_ID; }
+  uint16_t getMagicElfBits() const override { return ELFMachine; }
 
   /// This plugin does not support exchanging data between two devices.
   bool isDataExchangable(int32_t SrcDeviceId, int32_t DstDeviceId) override {


### PR DESCRIPTION
    Summary:
    This patch changes the image registration logic. Currently, we
    initialize every single plugin even if no images will end up using it.
    This patch adds a new pair of runtime calls. The first one checks if the
    plugin has been initialized or is active. The second does a light-weight
    check on the ELF machine to prevent it from needing to initialize a
    plugin with a trivially incompatible image.
    
    My machine has CUDA and AMDGPU installed. This patch saves roughly 20ms
    when compiling only for the AMDGPU device with a trivial program. and
    roughly 30ms when compiling only for the NVPTX device with a trivial
    program.
