### PR TITLE
[builtins] Avoid using long double in FreeBSD standalone environment

### DIFF
--- a/compiler-rt/lib/builtins/int_types.h
+++ b/compiler-rt/lib/builtins/int_types.h
@@ -139,7 +139,6 @@ typedef union {
   udwords u;
   double f;
 } double_bits;
-#endif
 
 typedef struct {
 #if _YUGA_LITTLE_ENDIAN
@@ -220,7 +219,6 @@ typedef union {
 #define CRT_HAS_TF_MODE
 #endif
 
-#if CRT_HAS_FLOATING_POINT
 #if __STDC_VERSION__ >= 199901L
 typedef float _Complex Fcomplex;
 typedef double _Complex Dcomplex;
@@ -270,5 +268,5 @@ typedef struct {
 #define COMPLEXTF_IMAGINARY(x) (x).imaginary
 #endif
 
-#endif
+#endif // CRT_HAS_FLOATING_POINT
 #endif // INT_TYPES_H


### PR DESCRIPTION
After 05a4212cc76d a number of long double related declarations are enabled in `int_types.h`, whenever the CPU architecture and platform support it. However, this does not work with FreeBSD's standalone environment, which disallows any use of floating point.

In add98b246290 this was made conditional with `CRT_HAS_FLOATING_POINT`, so use that macro to also determine whether `HAS_80_BIT_LONG_DOUBLE` can be turned on.
