### PR TITLE
[ASan][libc++] Optimize `__annotate_delete` for the default allocator

### DIFF
--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -1012,7 +1012,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
 #ifndef _LIBCPP_HAS_NO_ASAN
     // The default allocator does not require unpoisoning before returning memory.
-    if _LIBCPP_CONSTEXPR (is_same<allocator_type, allocator<_Tp> >::value)
+    if _LIBCPP_CONSTEXPR_SINCE_CXX17 (is_same<allocator_type, allocator<_Tp> >::value)
       return;
     if (empty()) {
       for (size_t __i = 0; __i < __map_.size(); ++__i) {

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -1012,7 +1012,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
 #ifndef _LIBCPP_HAS_NO_ASAN
     // The default allocator does not require unpoisoning before returning memory.
-    if _LIBCPP_CONSTEXPR (is_same<allocator_type, allocator<_Tp>>::value)
+    if _LIBCPP_CONSTEXPR (is_same<allocator_type, allocator<_Tp> >::value)
       return;
     if (empty()) {
       for (size_t __i = 0; __i < __map_.size(); ++__i) {

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -1011,6 +1011,9 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
 #ifndef _LIBCPP_HAS_NO_ASAN
+    // The default allocator does not require unpoisoning before returning memory.
+    if _LIBCPP_CONSTEXPR (is_same<allocator_type, allocator<_Tp>>::value)
+      return;
     if (empty()) {
       for (size_t __i = 0; __i < __map_.size(); ++__i) {
         __annotate_whole_block(__i, __asan_unposion);

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1913,7 +1913,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_delete() const _NOEXCEPT {
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
     // The default allocator does not require unpoisoning before returning memory.
-    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, allocator<__default_allocator_type> >::value)
+    if _LIBCPP_CONSTEXPR_SINCE_CXX17 (!is_same<allocator_type, allocator<__default_allocator_type> >::value)
       if (!__libcpp_is_constant_evaluated() && (__asan_short_string_is_annotated() || __is_long()))
         __annotate_contiguous_container(data() + size() + 1, data() + capacity() + 1);
 #endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1913,7 +1913,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_delete() const _NOEXCEPT {
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
     // The default allocator does not require unpoisoning before returning memory.
-    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, allocator<__default_allocator_type>>::value)
+    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, allocator<__default_allocator_type> >::value)
       if (!__libcpp_is_constant_evaluated() && (__asan_short_string_is_annotated() || __is_long()))
         __annotate_contiguous_container(data() + size() + 1, data() + capacity() + 1);
 #endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1912,8 +1912,10 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_delete() const _NOEXCEPT {
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
-    if (!__libcpp_is_constant_evaluated() && (__asan_short_string_is_annotated() || __is_long()))
-      __annotate_contiguous_container(data() + size() + 1, data() + capacity() + 1);
+    // The default allocator does not require unpoisoning before returning memory.
+    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, allocator<__default_allocator_type>>::value)
+      if (!__libcpp_is_constant_evaluated() && (__asan_short_string_is_annotated() || __is_long()))
+        __annotate_contiguous_container(data() + size() + 1, data() + capacity() + 1);
 #endif
   }
 

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -853,7 +853,9 @@ private:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
 #ifndef _LIBCPP_HAS_NO_ASAN
-    __annotate_contiguous_container(data(), data() + capacity(), data() + size(), data() + capacity());
+    // The default allocator does not require unpoisoning before returning memory.
+    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, __default_allocator_type>::value)
+      __annotate_contiguous_container(data(), data() + capacity(), data() + size(), data() + capacity());
 #endif
   }
 

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -854,7 +854,7 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
 #ifndef _LIBCPP_HAS_NO_ASAN
     // The default allocator does not require unpoisoning before returning memory.
-    if _LIBCPP_CONSTEXPR (!is_same<allocator_type, __default_allocator_type>::value)
+    if _LIBCPP_CONSTEXPR_SINCE_CXX17 (!is_same<allocator_type, __default_allocator_type>::value)
       __annotate_contiguous_container(data(), data() + capacity(), data() + size(), data() + capacity());
 #endif
   }


### PR DESCRIPTION
This commit optimizes the ASan helper functions `__annotate_delete()`, in `std::basic_string`, `std::vector` and `std::deque`, by adding `if` statements to prevent unpoisoning of memory for the default allocator. Unpoisoning is not required by the default allocator, and since it is widely used, this optimization should yield a meaningful performance improvement.

The optimization was suggested by @EricWF.