### PR TITLE
Allow the use of `if constexpr` in dialects after C++11.

### DIFF
--- a/libcxx/docs/DesignDocs/ExtendedCXXSupport.rst
+++ b/libcxx/docs/DesignDocs/ExtendedCXXSupport.rst
@@ -1,6 +1,6 @@
-=======================
-Extended C++03 Support
-=======================
+===================================
+Language and Library C++ Extensions
+===================================
 
 .. contents::
    :local:
@@ -10,11 +10,14 @@ Overview
 
 libc++ is an implementation of the C++ standard library targeting C++11 or later.
 
-In C++03, the library implements the C++11 standard using C++11 language extensions provided
+In C++03, the library provides the C++11 standard using C++11 language extensions provided
 by Clang.
 
-This document tracks the C++11 extensions libc++ requires, the C++11 extensions it provides,
-and how to write minimal C++11 inside libc++.
+In other dialects, the library may depend on language extensions provided by the compiler.
+
+This document tracks the C++ extensions libc++ requires from the compiler, and in what dialect.
+Additionally this documents the C++11 extensions libc++ provides, and how to write
+minimal C++11 inside libc++.
 
 Required C++11 Compiler Extensions
 ==================================
@@ -36,6 +39,15 @@ mode. These include:
 *  Trailing return types.
 * ``>>`` without a space.
 
+Required C++17 Compiler Extensions
+==================================
+
+Clang and GCC provide some language extensions in C++11 and later.
+The features libc++ expects Clang & GCC to provide are:
+
+* `if constexpr`
+
+This extension is not available in C++03.
 
 Provided C++11 Library Extensions
 =================================

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -186,7 +186,7 @@ Design Documents
    DesignDocs/AtomicDesign
    DesignDocs/CapturingConfigInfo
    DesignDocs/ExperimentalFeatures
-   DesignDocs/ExtendedCXX03Support
+   DesignDocs/ExtendedCXXSupport
    DesignDocs/FeatureTestMacros
    DesignDocs/FileTimeType
    DesignDocs/HeaderRemovalPolicy

--- a/libcxx/test/libcxx/extensions/test-cxx17-extensions.pass.cpp
+++ b/libcxx/test/libcxx/extensions/test-cxx17-extensions.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+
+// Test that `if constexpr` is provided as an extension by supported compilers
+// in all language dialects after C++03. Also further test that the test suite
+// has disabled -Wc++17-extension because we also disable system headers.
+
+#include <cassert>
+
+// if constexpr doesn't need to be used in a constexpr function, nor a dependent
+// one.
+bool CheckIfConstexpr() {
+  if constexpr (false) {
+    return false;
+  }
+  if constexpr (true) {
+    return true;
+  }
+}
+
+int main(int, char**) {
+  assert(CheckIfConstexpr());
+  return 0;
+}

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -57,6 +57,8 @@ _warningFlags = [
     # Disable warnings for extensions used in C++03
     "-Wno-local-type-template-args",
     "-Wno-c++11-extensions",
+    # Allow the use of C++17 `if constexpr` as an extension after C++03
+    "-Wno-c++17-extensions",
 
     # TODO(philnik) This fails with the PSTL.
     "-Wno-unknown-pragmas",


### PR DESCRIPTION
This change enables that by disabling the C++17 extensions warning
in the test suite and by adding documentation and testing for the use of
this extension.
