### PR TITLE
asan_static x86-64: Support 64-bit ASAN_SHADOW_OFFSET_CONST redux

### DIFF
--- a/compiler-rt/lib/asan/asan_rtl_x86_64.S
+++ b/compiler-rt/lib/asan/asan_rtl_x86_64.S
@@ -89,7 +89,12 @@ ENDF
 #define ASAN_MEMORY_ACCESS_CHECK_ADD(reg, op, s, c) \
         mov    %##reg,%r10 ;\
         shr    $0x3,%r10 ;\
+        .if ASAN_SHADOW_OFFSET_CONST < 0x80000000  ;\
         ##c    $0x0,ASAN_SHADOW_OFFSET_CONST(%r10) ;\
+        .else                                      ;\
+        movabsq $ASAN_SHADOW_OFFSET_CONST,%r11     ;\
+        ##c    $0x0,(%r10,%r11)                    ;\
+        .endif                                     ;\
         jne    FLABEL(reg, op, s, add) ;\
         retq  ;\
 


### PR DESCRIPTION
Similar to b9935bb02a50, but also apply a similar change to ACCESS_CHECK_ADD.

If ASAN_SHADOW_OFFSET_CONST cannot be encoded as a displacement, switch to `movabsq` and the register offset variant of cmp.