### PR TITLE
[libcxx][NFC] Rename iterator/sentinel type template parameter names

### DIFF
--- a/libcxx/test/std/ranges/range.adaptors/range.chunk.by/range.chunk.by.iter/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.chunk.by/range.chunk.by.iter/compare.pass.cpp
@@ -25,14 +25,14 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using Underlying      = View<Iterator, Sentinel>;
+  using Underlying      = View<Iter, Sent>;
   using ChunkByView     = std::ranges::chunk_by_view<Underlying, std::ranges::less_equal>;
   using ChunkByIterator = std::ranges::iterator_t<ChunkByView>;
 
   auto make_chunk_by_view = [](auto& arr) {
-    View view{Iterator(arr.data()), Sentinel(Iterator(arr.data() + arr.size()))};
+    View view{Iter(arr.data()), Sent(Iter(arr.data() + arr.size()))};
     return ChunkByView(std::move(view), std::ranges::less_equal{});
   };
 

--- a/libcxx/test/std/ranges/range.adaptors/range.chunk.by/range.chunk.by.iter/decrement.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.chunk.by/range.chunk.by.iter/decrement.pass.cpp
@@ -42,9 +42,9 @@ struct TrackingPred : TrackInitialization {
   constexpr bool operator()(int x, int y) const { return x <= y; }
 };
 
-template <class Iterator, IsConst Constant, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, IsConst Constant, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using Underlying      = View<Iterator, Sentinel>;
+  using Underlying      = View<Iter, Sent>;
   using ChunkByView     = std::ranges::chunk_by_view<Underlying, std::ranges::less_equal>;
   using ChunkByIterator = std::ranges::iterator_t<ChunkByView>;
 
@@ -52,7 +52,7 @@ constexpr void test() {
   static_assert(HasPreDecrement<ChunkByIterator>);
 
   auto make_chunk_by_view = [](auto& arr) {
-    View view{Iterator{arr.data()}, Sentinel{Iterator{arr.data() + arr.size()}}};
+    View view{Iter{arr.data()}, Sent{Iter{arr.data() + arr.size()}}};
     return ChunkByView{std::move(view), std::ranges::less_equal{}};
   };
 
@@ -125,7 +125,7 @@ constexpr void test() {
   // Test with a predicate that takes by non-const reference
   if constexpr (!std::to_underlying(Constant)) {
     std::array array{1, 2, 3, -3, -2, -1};
-    View v{Iterator{array.data()}, Sentinel{Iterator{array.data() + array.size()}}};
+    View v{Iter{array.data()}, Sent{Iter{array.data() + array.size()}}};
     auto view = std::views::chunk_by(std::move(v), [](int& x, int& y) { return x <= y; });
 
     auto it = std::ranges::next(view.begin());
@@ -137,7 +137,7 @@ constexpr void test() {
   // Test with a predicate that is invocable but not callable (i.e. cannot be called like regular function 'f()')
   {
     std::array array = {1, 2, 3, -3, -2, -1};
-    auto v           = View{Iterator{array.data()}, Sentinel{Iterator{array.data() + array.size()}}} |
+    auto v           = View{Iter{array.data()}, Sent{Iter{array.data() + array.size()}}} |
              std::views::transform([](int x) { return IntWrapper{x}; });
     auto view = std::views::chunk_by(std::move(v), &IntWrapper::lessEqual);
 
@@ -151,7 +151,7 @@ constexpr void test() {
   if constexpr (std::ranges::common_range<Underlying>) {
     bool moved = false, copied = false;
     std::array array{1, 2, 1, 3};
-    View v{Iterator(array.data()), Sentinel(Iterator(array.data() + array.size()))};
+    View v{Iter(array.data()), Sent(Iter(array.data() + array.size()))};
     auto view = std::views::chunk_by(std::move(v), TrackingPred(&moved, &copied));
     assert(std::exchange(moved, false));
     auto it = view.end();

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
@@ -73,22 +73,22 @@ struct WithNonCopyableIterator : std::ranges::view_base {
 };
 static_assert(std::ranges::input_range<WithNonCopyableIterator>);
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
   std::array<XYPoint, 5> array{{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}}};
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 
   for (std::ptrdiff_t n = 0; n != 5; ++n) {
     FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
-    FilterIterator const iter(view, Iterator(array.data() + n));
-    std::same_as<Iterator> decltype(auto) result = iter.operator->();
+    FilterIterator const iter(view, Iter(array.data() + n));
+    std::same_as<Iter> decltype(auto) result = iter.operator->();
     assert(base(result) == array.data() + n);
     assert(iter->x == n);
     assert(iter->y == n);

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
@@ -21,14 +21,14 @@
 #include "test_macros.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 
@@ -37,18 +37,18 @@ constexpr void test() {
 
   // Test the const& version
   {
-    FilterIterator const iter(view, Iterator(array.data()));
-    Iterator const& result = iter.base();
-    ASSERT_SAME_TYPE(Iterator const&, decltype(iter.base()));
+    FilterIterator const iter(view, Iter(array.data()));
+    Iter const& result = iter.base();
+    ASSERT_SAME_TYPE(Iter const&, decltype(iter.base()));
     ASSERT_NOEXCEPT(iter.base());
     assert(base(result) == array.data());
   }
 
   // Test the && version
   {
-    FilterIterator iter(view, Iterator(array.data()));
-    Iterator result = std::move(iter).base();
-    ASSERT_SAME_TYPE(Iterator, decltype(std::move(iter).base()));
+    FilterIterator iter(view, Iter(array.data()));
+    Iter result = std::move(iter).base();
+    ASSERT_SAME_TYPE(Iter, decltype(std::move(iter).base()));
     assert(base(result) == array.data());
   }
 }

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
@@ -18,15 +18,15 @@
 #include "test_iterators.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   std::array<int, 10> array{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  View view(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
-  Iterator iter = view.begin();
+  View view(Iter(array.data()), Sent(Iter(array.data() + array.size())));
+  Iter iter = view.begin();
 
   FilterView filter_view(std::move(view), AlwaysTrue{});
   FilterIterator filter_iter(filter_view, std::move(iter));

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
@@ -38,14 +38,14 @@ using FilterIteratorFor = std::ranges::iterator_t<
   std::ranges::filter_view<minimal_view<Iterator, sentinel_wrapper<Iterator>>, EqualTo>
 >;
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, EqualTo>;
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
@@ -21,14 +21,14 @@
 #include "test_macros.h"
 #include "../types.h"
 
-template <class Iterator, class ValueType = int, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class ValueType = int, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 
@@ -36,7 +36,7 @@ constexpr void test() {
   FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   for (std::size_t n = 0; n != array.size(); ++n) {
-    FilterIterator const iter(view, Iterator(array.data() + n));
+    FilterIterator const iter(view, Iter(array.data() + n));
     ValueType& result = *iter;
     ASSERT_SAME_TYPE(ValueType&, decltype(*iter));
     assert(&result == array.data() + n);

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
@@ -19,14 +19,14 @@
 #include "test_iterators.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterSentinel = std::ranges::sentinel_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 
@@ -34,7 +34,7 @@ constexpr void test() {
   FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   FilterSentinel const sent = view.end();
-  std::same_as<Sentinel> decltype(auto) result = sent.base();
+  std::same_as<Sent> decltype(auto) result = sent.base();
   assert(base(base(result)) == array.data() + array.size());
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
@@ -19,14 +19,14 @@
 #include "test_iterators.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
 
   std::array<int, 5> array{0, 1, 2, 3, 4};
 
   {
-    View v(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
+    View v(Iter(array.data()), Sent(Iter(array.data() + array.size())));
     std::ranges::filter_view view(std::move(v), AlwaysTrue{});
     auto const it = view.begin();
     auto const sent = view.end();
@@ -34,7 +34,7 @@ constexpr void test() {
     assert(!result);
   }
   {
-    View v(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
+    View v(Iter(array.data()), Sent(Iter(array.data() + array.size())));
     std::ranges::filter_view view(std::move(v), [](auto) { return false; });
     auto const it = view.begin();
     auto const sent = view.end();

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.default.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.default.pass.cpp
@@ -16,9 +16,9 @@
 #include "test_iterators.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterSentinel = std::ranges::sentinel_t<FilterView>;
   FilterSentinel sent1{};

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
@@ -19,14 +19,14 @@
 #include "test_iterators.h"
 #include "../types.h"
 
-template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
+template <class Iter, class Sent = sentinel_wrapper<Iter>>
 constexpr void test() {
-  using View = minimal_view<Iterator, Sentinel>;
+  using View = minimal_view<Iter, Sent>;
   using FilterView = std::ranges::filter_view<View, AlwaysTrue>;
   using FilterSentinel = std::ranges::sentinel_t<FilterView>;
 
   auto make_filter_view = [](auto begin, auto end, auto pred) {
-    View view{Iterator(begin), Sentinel(Iterator(end))};
+    View view{Iter(begin), Sent(Iter(end))};
     return FilterView(std::move(view), pred);
   };
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/types.h
@@ -31,9 +31,9 @@ struct AlwaysTrue {
   constexpr bool operator()(T const&) const { return true; }
 };
 
-template <class Iterator, class Sentinel>
+template <class Iter, class Sent>
 struct minimal_view : std::ranges::view_base {
-  constexpr explicit minimal_view(Iterator it, Sentinel sent)
+  constexpr explicit minimal_view(Iter it, Sent sent)
     : it_(base(std::move(it)))
     , sent_(base(std::move(sent)))
   { }
@@ -41,12 +41,12 @@ struct minimal_view : std::ranges::view_base {
   minimal_view(minimal_view&&) = default;
   minimal_view& operator=(minimal_view&&) = default;
 
-  constexpr Iterator begin() const { return Iterator(it_); }
-  constexpr Sentinel end() const { return Sentinel(sent_); }
+  constexpr Iter begin() const { return Iter(it_); }
+  constexpr Sent end() const { return Sent(sent_); }
 
 private:
-  decltype(base(std::declval<Iterator>())) it_;
-  decltype(base(std::declval<Sentinel>())) sent_;
+  decltype(base(std::declval<Iter>())) it_;
+  decltype(base(std::declval<Sent>())) sent_;
 };
 
 template <bool IsNoexcept>


### PR DESCRIPTION
According to internally agreed upon best practices, type template parameter names representing iterator types should be named `Iter`. For type template parameters representing sentinel types, they should be named `Sent`.