### PR TITLE
[mlir][python][cmake] add EXTRA_INCLUDES to `declare_mlir_dialect_python_bindings`

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -286,7 +286,7 @@ function(declare_mlir_dialect_python_bindings)
   cmake_parse_arguments(ARG
     "GEN_ENUM_BINDINGS"
     "ROOT_DIR;ADD_TO_PARENT;TD_FILE;DIALECT_NAME"
-    "SOURCES;SOURCES_GLOB;DEPENDS;GEN_ENUM_BINDINGS_TD_FILE"
+    "SOURCES;SOURCES_GLOB;DEPENDS;GEN_ENUM_BINDINGS_TD_FILE;EXTRA_INCLUDES"
     ${ARGN})
   # Sources.
   set(_dialect_target "${ARG_ADD_TO_PARENT}.${ARG_DIALECT_NAME}")
@@ -307,7 +307,7 @@ function(declare_mlir_dialect_python_bindings)
     set(LLVM_TARGET_DEFINITIONS ${td_file})
     mlir_tablegen("${dialect_filename}"
       -gen-python-op-bindings -bind-dialect=${ARG_DIALECT_NAME}
-      DEPENDS ${ARG_DEPENDS}
+      DEPENDS ${ARG_DEPENDS} EXTRA_INCLUDES ${ARG_EXTRA_INCLUDES}
     )
     add_public_tablegen_target(${tblgen_target})
 
@@ -318,7 +318,7 @@ function(declare_mlir_dialect_python_bindings)
         set(LLVM_TARGET_DEFINITIONS ${td_file})
       endif()
       set(enum_filename "${relative_td_directory}/_${ARG_DIALECT_NAME}_enum_gen.py")
-      mlir_tablegen(${enum_filename} -gen-python-enum-bindings)
+      mlir_tablegen(${enum_filename} -gen-python-enum-bindings EXTRA_INCLUDES ${ARG_EXTRA_INCLUDES})
       list(APPEND _sources ${enum_filename})
     endif()
 

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -403,6 +403,17 @@ declare_mlir_dialect_python_bindings(
   GEN_ENUM_BINDINGS_TD_FILE
     "dialects/VectorAttributes.td")
 
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT MLIRPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/FIROps.td
+  SOURCES dialects/fir.py
+  DIALECT_NAME fir
+  GEN_ENUM_BINDINGS_TD_FILE
+    "dialects/FIRAttrs.td"
+  EXTRA_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/mlir/../../../flang/include"
+)
+
 ################################################################################
 # Python extensions.
 # The sources for these are all in lib/Bindings/Python, but since they have to

--- a/mlir/python/mlir/dialects/FIRAttrs.td
+++ b/mlir/python/mlir/dialects/FIRAttrs.td
@@ -1,0 +1,14 @@
+//===-- ControlFlowOps.td - Python ControlFlowOps bindings -*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef PYTHON_BINDINGS_FIR_ATTRS
+#define PYTHON_BINDINGS_FIR_ATTRS
+
+include "flang/Optimizer/Dialect/FIRAttr.td"
+
+#endif

--- a/mlir/python/mlir/dialects/FIROps.td
+++ b/mlir/python/mlir/dialects/FIROps.td
@@ -1,0 +1,14 @@
+//===-- ControlFlowOps.td - Python ControlFlowOps bindings -*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef PYTHON_BINDINGS_FIR_OPS
+#define PYTHON_BINDINGS_FIR_OPS
+
+include "flang/Optimizer/Dialect/FIROps.td"
+
+#endif

--- a/mlir/python/mlir/dialects/fir.py
+++ b/mlir/python/mlir/dialects/fir.py
@@ -1,0 +1,6 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._fir_ops_gen import *
+from ._fir_enum_gen import *


### PR DESCRIPTION
This PR adds an `EXTRA_INCLUDES` arg to `declare_mlir_dialect_python_bindings` to be forwarded to `mlir_tablegen`. The use case I think is obvious but my personal need was to experiment with generating python bindings for some of flang's dialects. And it worked! How does the adage go? "You can write fortran in any language"? Well now you really can!

Anyway I left the flang cmake target in here as a demo/test  (in a separate commit) but I don't intend to keep it (will drop commit after CI passes).