### PR TITLE
[lit] add `LIT_MAX_WORKERS` env variable

### DIFF
--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -36,7 +36,7 @@ def parse_args():
         metavar="N",
         help="Number of workers used for testing",
         type=_positive_int,
-        default=lit.util.usable_core_count(),
+        default=os.getenv("LIT_MAX_WORKERS", lit.util.usable_core_count()),
     )
     parser.add_argument(
         "--config-prefix",


### PR DESCRIPTION
I find myself fiddling with `ARGS "-j"` very frequently when switching between groups of tests with `LIT_FILTER`. Then invariably I accidentally commit `ARGS "-j1"` or something like that. This env variable (analogous to `LIT_FILTER`) resolves the issue. 

Not sure how to test but I'm pretty sure this is "correct code".