### PR TITLE
Replace print-at-pass-number cl::opt with print-before-pass-number

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -65,7 +65,7 @@ private:
   bool shouldPrintBeforePass(StringRef PassID);
   bool shouldPrintAfterPass(StringRef PassID);
   bool shouldPrintPassNumbers();
-  bool shouldPrintAtPassNumber();
+  bool shouldPrintBeforePassNumber();
 
   void pushPassRunDescriptor(StringRef PassID, Any IR,
                              std::string &DumpIRFilename);

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -119,8 +119,8 @@ static cl::opt<bool> PrintPassNumbers(
     cl::desc("Print pass names and their ordinals"));
 
 static cl::opt<unsigned>
-    PrintAtPassNumber("print-at-pass-number", cl::init(0), cl::Hidden,
-                cl::desc("Print IR at pass with this number as "
+    PrintBeforePassNumber("print-before-pass-number", cl::init(0), cl::Hidden,
+                cl::desc("Print IR before the pass with this number as "
                          "reported by print-passes-names"));
 
 static cl::opt<std::string> IRDumpDirectory(
@@ -806,8 +806,7 @@ void PrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
   // Note: here we rely on a fact that we do not change modules while
   // traversing the pipeline, so the latest captured module is good
   // for all print operations that has not happen yet.
-  if (shouldPrintPassNumbers() || shouldPrintAtPassNumber() ||
-      shouldPrintAfterPass(PassID))
+  if (shouldPrintAfterPass(PassID))
     pushPassRunDescriptor(PassID, IR, DumpIRFilename);
 
   if (!shouldPrintIR(IR))
@@ -823,8 +822,10 @@ void PrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
     return;
 
   auto WriteIRToStream = [&](raw_ostream &Stream) {
-    Stream << "; *** IR Dump Before " << PassID << " on " << getIRName(IR)
-           << " ***\n";
+    Stream << "; *** IR Dump Before ";
+    if (shouldPrintBeforePassNumber())
+      Stream << CurrentPassNumber << "-";
+    Stream << PassID << " on " << getIRName(IR) << " ***\n";
     unwrapAndPrint(Stream, IR);
   };
 
@@ -842,8 +843,7 @@ void PrintIRInstrumentation::printAfterPass(StringRef PassID, Any IR) {
   if (isIgnored(PassID))
     return;
 
-  if (!shouldPrintAfterPass(PassID) && !shouldPrintPassNumbers() &&
-      !shouldPrintAtPassNumber())
+  if (!shouldPrintAfterPass(PassID))
     return;
 
   auto [M, DumpIRFilename, IRName, StoredPassID] = popPassRunDescriptor(PassID);
@@ -853,10 +853,7 @@ void PrintIRInstrumentation::printAfterPass(StringRef PassID, Any IR) {
     return;
 
   auto WriteIRToStream = [&](raw_ostream &Stream, const StringRef IRName) {
-    Stream << "; *** IR Dump "
-           << (shouldPrintAtPassNumber()
-                   ? StringRef(formatv("At {0}-{1}", CurrentPassNumber, PassID))
-                   : StringRef(formatv("After {0}", PassID)))
+    Stream << "; *** IR Dump " << StringRef(formatv("After {0}", PassID))
            << " on " << IRName << " ***\n";
     unwrapAndPrint(Stream, IR);
   };
@@ -879,8 +876,7 @@ void PrintIRInstrumentation::printAfterPassInvalidated(StringRef PassID) {
   if (isIgnored(PassID))
     return;
 
-  if (!shouldPrintAfterPass(PassID) && !shouldPrintPassNumbers() &&
-      !shouldPrintAtPassNumber())
+  if (!shouldPrintAfterPass(PassID))
     return;
 
   auto [M, DumpIRFilename, IRName, StoredPassID] = popPassRunDescriptor(PassID);
@@ -893,12 +889,8 @@ void PrintIRInstrumentation::printAfterPassInvalidated(StringRef PassID) {
   auto WriteIRToStream = [&](raw_ostream &Stream, const Module *M,
                              const StringRef IRName) {
     SmallString<20> Banner;
-    if (shouldPrintAtPassNumber())
-      Banner = formatv("; *** IR Dump At {0}-{1} on {2} (invalidated) ***",
-                       CurrentPassNumber, PassID, IRName);
-    else
-      Banner = formatv("; *** IR Dump After {0} on {1} (invalidated) ***",
-                       PassID, IRName);
+    Banner = formatv("; *** IR Dump After {0} on {1} (invalidated) ***",
+                     PassID, IRName);
     Stream << Banner << "\n";
     printIR(Stream, M);
   };
@@ -921,15 +913,16 @@ bool PrintIRInstrumentation::shouldPrintBeforePass(StringRef PassID) {
   if (shouldPrintBeforeAll())
     return true;
 
+  if (shouldPrintBeforePassNumber() &&
+      CurrentPassNumber == PrintBeforePassNumber)
+    return true;
+
   StringRef PassName = PIC->getPassNameForClassName(PassID);
   return is_contained(printBeforePasses(), PassName);
 }
 
 bool PrintIRInstrumentation::shouldPrintAfterPass(StringRef PassID) {
   if (shouldPrintAfterAll())
-    return true;
-
-  if (shouldPrintAtPassNumber() && CurrentPassNumber == PrintAtPassNumber)
     return true;
 
   StringRef PassName = PIC->getPassNameForClassName(PassID);
@@ -940,8 +933,8 @@ bool PrintIRInstrumentation::shouldPrintPassNumbers() {
   return PrintPassNumbers;
 }
 
-bool PrintIRInstrumentation::shouldPrintAtPassNumber() {
-  return PrintAtPassNumber > 0;
+bool PrintIRInstrumentation::shouldPrintBeforePassNumber() {
+  return PrintBeforePassNumber > 0;
 }
 
 void PrintIRInstrumentation::registerCallbacks(
@@ -950,13 +943,12 @@ void PrintIRInstrumentation::registerCallbacks(
 
   // BeforePass callback is not just for printing, it also saves a Module
   // for later use in AfterPassInvalidated.
-  if (shouldPrintPassNumbers() || shouldPrintAtPassNumber() ||
+  if (shouldPrintPassNumbers() || shouldPrintBeforePassNumber() ||
       shouldPrintBeforeSomePass() || shouldPrintAfterSomePass())
     PIC.registerBeforeNonSkippedPassCallback(
         [this](StringRef P, Any IR) { this->printBeforePass(P, IR); });
 
-  if (shouldPrintPassNumbers() || shouldPrintAtPassNumber() ||
-      shouldPrintAfterSomePass()) {
+  if (shouldPrintAfterSomePass()) {
     PIC.registerAfterPassCallback(
         [this](StringRef P, Any IR, const PreservedAnalyses &) {
           this->printAfterPass(P, IR);

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -118,10 +118,10 @@ static cl::opt<bool> PrintPassNumbers(
     "print-pass-numbers", cl::init(false), cl::Hidden,
     cl::desc("Print pass names and their ordinals"));
 
-static cl::opt<unsigned>
-    PrintBeforePassNumber("print-before-pass-number", cl::init(0), cl::Hidden,
-                cl::desc("Print IR before the pass with this number as "
-                         "reported by print-pass-numbers"));
+static cl::opt<unsigned> PrintBeforePassNumber(
+    "print-before-pass-number", cl::init(0), cl::Hidden,
+    cl::desc("Print IR before the pass with this number as "
+             "reported by print-pass-numbers"));
 
 static cl::opt<std::string> IRDumpDirectory(
     "ir-dump-directory",
@@ -889,8 +889,8 @@ void PrintIRInstrumentation::printAfterPassInvalidated(StringRef PassID) {
   auto WriteIRToStream = [&](raw_ostream &Stream, const Module *M,
                              const StringRef IRName) {
     SmallString<20> Banner;
-    Banner = formatv("; *** IR Dump After {0} on {1} (invalidated) ***",
-                     PassID, IRName);
+    Banner = formatv("; *** IR Dump After {0} on {1} (invalidated) ***", PassID,
+                     IRName);
     Stream << Banner << "\n";
     printIR(Stream, M);
   };

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -121,7 +121,7 @@ static cl::opt<bool> PrintPassNumbers(
 static cl::opt<unsigned>
     PrintBeforePassNumber("print-before-pass-number", cl::init(0), cl::Hidden,
                 cl::desc("Print IR before the pass with this number as "
-                         "reported by print-passes-names"));
+                         "reported by print-pass-numbers"));
 
 static cl::opt<std::string> IRDumpDirectory(
     "ir-dump-directory",

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -1,13 +1,9 @@
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-pass-numbers -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=NUMBER
-; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-at-pass-number=3 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=AT
-; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-at-pass-number=4 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=AT-INVALIDATE
+; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-before-pass-number=3 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=BEFORE
 
 define i32 @bar(i32 %arg) {
-; AT: *** IR Dump At 3-IndVarSimplifyPass on bb1 ***
-; AT: define i32 @bar(i32 %arg) {
-
-; AT-INVALIDATE: *** IR Dump At 4-LoopDeletionPass on bb1 (invalidated) ***
-; AT-INVALIDATE: define i32 @bar(i32 %arg) {
+; BEFORE: *** IR Dump Before 3-IndVarSimplifyPass on bb1 ***
+; BEFORE: define i32 @bar(i32 %arg) {
 
 bb:
   br label %bb1


### PR DESCRIPTION
The existing option prints the IR after the pass, but it's not clear from its name. In this patch I change the option to print the IR before the pass and change the name to make the behavior clear.

Printing the IR before the pass is slightly simpler than after as I don't need to worry about printAfterPassInvalidated case. Either before or after the pass would be ok for the original use case this option was introduced for.