### PR TITLE
[asan] Ignore vDSO on FreeBSD

### DIFF
--- a/compiler-rt/lib/asan/asan_linux.cpp
+++ b/compiler-rt/lib/asan/asan_linux.cpp
@@ -148,11 +148,11 @@ static int FindFirstDSOCallback(struct dl_phdr_info *info, size_t size,
       internal_strncmp(info->dlpi_name, "linux-", sizeof("linux-") - 1) == 0)
     return 0;
 #    endif
-#   if SANITIZER_FREEBSD
+#    if SANITIZER_FREEBSD
   // Ignore vDSO.
   if (internal_strcmp(info->dlpi_name, "[vdso]") == 0)
     return 0;
-#   endif
+#    endif
 
   *name = info->dlpi_name;
   return 1;

--- a/compiler-rt/lib/asan/asan_linux.cpp
+++ b/compiler-rt/lib/asan/asan_linux.cpp
@@ -148,6 +148,11 @@ static int FindFirstDSOCallback(struct dl_phdr_info *info, size_t size,
       internal_strncmp(info->dlpi_name, "linux-", sizeof("linux-") - 1) == 0)
     return 0;
 #    endif
+#   if SANITIZER_FREEBSD
+  // Ignore vDSO.
+  if (internal_strcmp(info->dlpi_name, "[vdso]") == 0)
+    return 0;
+#   endif
 
   *name = info->dlpi_name;
   return 1;


### PR DESCRIPTION
Most asan tests `FAIL` on FreeBSD 14.0/amd64 with
```
==17651==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
```
With `ASAN_OPTIONS=verbosity=2` one sees:
```
==4880==info->dlpi_name = [vdso]	info->dlpi_addr = 0xffffe780
==4880==info->dlpi_name = lib/clang/18/lib/freebsd/libclang_rt.asan-i386.so	info->dlpi_addr = 0x2808a000
```
Ignoring the vDSO as on Linux fixes this.

Tested on `amd64-pc-freebsd14.0`.