### PR TITLE
[Support] Adjust .note.GNU-stack guard in Support/BLAKE3/blake3_*_x86…

### DIFF
--- a/llvm/lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
+#if defined(__ELF__) && !(defined(__sun__) && defined(__svr4__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
+#if defined(__ELF__) && !(defined(__sun__) && defined(__svr4__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_sse2_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_sse2_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_sse2_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_sse2_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
+#if defined(__ELF__) && !(defined(__sun__) && defined(__svr4__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_sse41_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_sse41_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/llvm/lib/Support/BLAKE3/blake3_sse41_x86-64_unix.S
+++ b/llvm/lib/Support/BLAKE3/blake3_sse41_x86-64_unix.S
@@ -2,7 +2,7 @@
 
 #include "llvm_blake3_prefix.h"
 
-#if defined(__ELF__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__))
+#if defined(__ELF__) && !(defined(__sun__) && defined(__svr4__))
 .section .note.GNU-stack,"",%progbits
 #endif
 


### PR DESCRIPTION
…-64_unix.S

When using GNU ld 2.41 on FreeBSD 14.0/amd64, there are linker warnings like
```
/vol/gcc/bin/gld-2.41: warning: blake3_avx512_x86-64_unix.S.o: missing .note.GNU-stack section implies executable stack
/vol/gcc/bin/gld-2.41: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```
This can be fixed by adjusting the guard of the `.note.GNU-stack` sections in `blake3_*_x86-64_unix.S` to match other instances.

Tested on `amd64-pc-freebsd14.0`.