### PR TITLE
[libc++][modules] Adds module testing. 

### DIFF
--- a/libcxx/docs/TestingLibcxx.rst
+++ b/libcxx/docs/TestingLibcxx.rst
@@ -394,7 +394,7 @@ Custom Directives
 ~~~~~~~~~~~~~~~~~
 
 Lit has many directives built in (e.g., ``DEFINE``, ``UNSUPPORTED``). In addition to those directives, libc++ adds two additional libc++-specific directives that makes
-writing tests easier. See `libc++-specific Lit Directives`_ for more information about the ``FILE_DEPENDENCIES`` and ``ADDITIONAL_COMPILE_FLAGS`` libc++-specific directives.
+writing tests easier. See `libc++-specific Lit Directives`_ for more information about the ``FILE_DEPENDENCIES``, ``ADDITIONAL_COMPILE_FLAGS``, and ``MODULE_DEPENDENCIES`` libc++-specific directives.
 
 .. _libc++-specific Lit Directives:
 .. list-table:: libc++-specific Lit Directives
@@ -417,6 +417,13 @@ writing tests easier. See `libc++-specific Lit Directives`_ for more information
      - The additional compiler flags specified by a space-separated list to the ``ADDITIONAL_COMPILE_FLAGS`` libc++-specific Lit directive will be added to the end of the ``%{compile_flags}``
        substitution for the test that contains it. This libc++-specific Lit directive makes it possible to add special compilation flags without having to resort to writing a ``.sh.cpp`` test (see
        `Lit Meaning of libc++ Test Filenames`_), more powerful but perhaps overkill.
+   * - ``MODULE_DEPENDENCIES``
+     - ``// MODULE_DEPENDENCIES: std std.compat``
+     - This directive will build the required C++23 standard library
+       modules and add the additional compiler flags in
+       %{compile_flags}. (Libc++ offers these modules in C++20 as an
+       extension.)
+
 
 Benchmarks
 ==========

--- a/libcxx/test/libcxx/module_std.gen.py
+++ b/libcxx/test/libcxx/module_std.gen.py
@@ -30,6 +30,7 @@ generator = module_test_generator(
     "%{test-tools}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
     "%{flags} %{compile_flags}",
+    "std",
 )
 
 

--- a/libcxx/test/libcxx/module_std_compat.gen.py
+++ b/libcxx/test/libcxx/module_std_compat.gen.py
@@ -30,6 +30,7 @@ generator = module_test_generator(
     "%{test-tools}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
     "%{flags} %{compile_flags}",
+    "std.compat",
 )
 
 

--- a/libcxx/test/libcxx/selftest/modules/no-modules.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/no-modules.sh.cpp
@@ -6,19 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// UNSUPPORTED: clang-modules-build
-// UNSUPPORTED: gcc
+// Make sure that the compile flags contain no module information.
 
-// XFAIL: has-no-cxx-module-support
+// MODULE_DEPENDENCIES:
 
-// A minimal test to validate import works.
-
-// MODULE_DEPENDENCIES: std
-
-import std;
-
-int main(int, char**) {
-  std::println("Hello modular world");
-  return 0;
-}
+// RUN: echo "%{compile_flags}" | grep -v "std.pcm"
+// RUN: echo "%{compile_flags}" | grep -v "std.compat.pcm"

--- a/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
@@ -12,13 +12,11 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// A minimal test to validate import works.
+// Make sure that the compile flags contain the expected elements.
+// The tests only look for the expected components and not the exact flags.
+// Otherwise changing the location of the module would break this test.
 
-// MODULE_DEPENDENCIES: std
+// MODULE_DEPENDENCIES: std std.compat
 
-import std;
-
-int main(int, char**) {
-  std::println("Hello modular world");
-  return 0;
-}
+// RUN: echo "%{compile_flags}" | grep -- "-fmodule-file=std=.*/std.pcm .*/std.pcm"
+// RUN: echo "%{compile_flags}" | grep -- "-fmodule-file=std.compat=.*/std.compat.pcm .*/std.compat.pcm"

--- a/libcxx/test/libcxx/selftest/modules/std-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std-module.sh.cpp
@@ -12,13 +12,13 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// A minimal test to validate import works.
+// Make sure that the compile flags contain the expected elements.
+// The tests only look for the expected components and not the exact flags.
+// Otherwise changing the location of the module would break this test.
 
 // MODULE_DEPENDENCIES: std
 
-import std;
+// RUN: echo "%{compile_flags}" | grep -- "-fmodule-file=std=.*/std.pcm .*/std.pcm"
 
-int main(int, char**) {
-  std::println("Hello modular world");
-  return 0;
-}
+// The std module should not provide the std.compat module
+// RUN: echo "%{compile_flags}" | grep -v "std.compat.pcm"

--- a/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
@@ -12,13 +12,13 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// A minimal test to validate import works.
+// Make sure that the compile flags contain the expected elements.
+// The tests only look for the expected components and not the exact flags.
+// Otherwise changing the location of the module would break this test.
 
-// MODULE_DEPENDENCIES: std
+// MODULE_DEPENDENCIES: std.compat
 
-import std;
+// RUN: echo "%{compile_flags}" | grep -- "-fmodule-file=std.compat=.*/std.compat.pcm .*/std.compat.pcm"
 
-int main(int, char**) {
-  std::println("Hello modular world");
-  return 0;
-}
+// It's unspecified whether std.compat is built on the std module.
+// Therefore don't test its presence

--- a/libcxx/test/std/modules/std.compat.pass.cpp
+++ b/libcxx/test/std/modules/std.compat.pass.cpp
@@ -8,10 +8,13 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: clang-modules-build
+// UNSUPPORTED: gcc
 
-// XFAIL: *
+// XFAIL: has-no-cxx-module-support
 
 // A minimal test to validate import works.
+
+// MODULE_DEPENDENCIES: std.compat
 
 import std.compat;
 

--- a/libcxx/utils/libcxx/test/config.py
+++ b/libcxx/utils/libcxx/test/config.py
@@ -16,6 +16,10 @@ def _getSubstitution(substitution, config):
     raise ValueError("Substitution {} is not in the config.".format(substitution))
 
 
+def _appendToSubstitution(substitutions, key, value):
+    return [(k, v + " " + value) if k == key else (k, v) for (k, v) in substitutions]
+
+
 def configure(parameters, features, config, lit_config):
     note = lambda s: lit_config.note("({}) {}".format(config.name, s))
     config.environment = dict(os.environ)

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -317,6 +317,18 @@ DEFAULT_FEATURES = [
             AddSubstitution("%{clang-tidy}", lambda cfg: _getSuitableClangTidy(cfg))
         ],
     ),
+    # Whether module support for the platform is available.
+    Feature(
+        name="has-no-cxx-module-support",
+        # The libc of these platforms have functions with internal linkage.
+        # This is not allowed per C11 7.1.2 Standard headers/6
+        #  Any declaration of a library function shall have external linkage.
+        when=lambda cfg: "__ANDROID__" in compilerMacros(cfg)
+        or "__PICOLIBC__" in compilerMacros(cfg)
+        or platform.system().lower().startswith("aix")
+        # Avoid building on platforms that don't support modules properly.
+        or not hasCompileFlag(cfg, "-Wno-reserved-module-identifier"),
+    ),
 ]
 
 # Deduce and add the test features that that are implied by the #defines in

--- a/libcxx/utils/libcxx/test/modules.py
+++ b/libcxx/utils/libcxx/test/modules.py
@@ -113,6 +113,7 @@ class module_test_generator:
     clang_tidy_plugin: str
     compiler: str
     compiler_flags: str
+    module: str
 
     def write_lit_configuration(self):
         print(
@@ -120,12 +121,12 @@ class module_test_generator:
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: clang-modules-build
 
-// XFAIL: *
-
 // REQUIRES: has-clang-tidy
 
 // The GCC compiler flags are not always compatible with clang-tidy.
 // UNSUPPORTED: gcc
+
+// MODULE_DEPENDENCIES: {self.module}
 
 // RUN: echo -n > {self.tmp_prefix}.all_partitions
 """


### PR DESCRIPTION
This adds a new module test infrastructure. This requires tagging tests
using modules. The test runner uses this information to determine the
compiler flags needed to build and use the module.

Currently modules are build per test, which allows testing them for
tests with ADDITIONAL_COMPILE_FLAGS. At the moment only 4 tests use
modules. Therefore the performance penalty is not measurable. If in the
future more tests use modules it would be good to measure the overhead
and determine whether it's acceptable.