### PR TITLE
[OpenMP] Remove unnecessary dependencies from plugin unit tests

### DIFF
--- a/openmp/libomptarget/unittests/Plugins/CMakeLists.txt
+++ b/openmp/libomptarget/unittests/Plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PLUGINS_TEST_COMMON omptarget OMPT omptarget.devicertl)
+set(PLUGINS_TEST_COMMON omptarget)
 set(PLUGINS_TEST_SOURCES NextgenPluginsTest.cpp)
 set(PLUGINS_TEST_INCLUDE ${LIBOMPTARGET_INCLUDE_DIR})
 


### PR DESCRIPTION
This was an oversight that seems to be causing problems on certain builds. This PR should fix #76225.