### PR TITLE
[libc++][modules] Increase clang-tidy version used.

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -5,9 +5,9 @@
 set(LLVM_DIR_SAVE ${LLVM_DIR})
 set(Clang_DIR_SAVE ${Clang_DIR})
 
-find_package(Clang 17)
+find_package(Clang 18)
 if (NOT Clang_FOUND)
-  find_package(Clang 18)
+  find_package(Clang 17)
 endif()
 
 set(SOURCES

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -31,8 +31,8 @@ def _getSuitableClangTidy(cfg):
             return None
 
         # TODO MODULES require ToT due module specific fixes.
-        if runScriptExitCode(cfg, ['clang-tidy-17 --version']) == 0:
-          return 'clang-tidy-17'
+        if runScriptExitCode(cfg, ['clang-tidy-18 --version']) == 0:
+          return 'clang-tidy-18'
 
         # TODO This should be the last stable release.
         # LLVM RELEASE bump to latest stable version


### PR DESCRIPTION
As suggested in #71438 we should use
  export import std;
in the std.compat module.

Testing this locally failed when building with the clang-tidy-17 plugin. The std module was considered corrupt in the test
  libcxx/test/libcxx/module_std_compat.gen.py
however the test
  libcxx/test/libcxx/module_std.gen.py
passed. Both test generated identical std.pcm files. Using the clang-tidy-18 plugin solves the issue.