### PR TITLE
[Doc] update the usage of opt with mem2reg pass in tutorial

### DIFF
--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
@@ -182,7 +182,7 @@ example through the pass, for example, you'll get:
 
 .. code-block:: bash
 
-    $ llvm-as < example.ll | opt -mem2reg | llvm-dis
+    $ llvm-as < example.ll | opt -passes=mem2reg | llvm-dis
     @G = weak global i32 0
     @H = weak global i32 0
 


### PR DESCRIPTION
The current command will raise an error:

> The `opt -passname` syntax for the new pass manager is not supported, please use `opt -passes=<pipeline>` (or the `-p` alias for a more concise version).

So we should update the usage.