### PR TITLE
[Cygwin] Cygwin X86ISelDAGToDAG.cpp

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -2948,14 +2948,17 @@ bool X86DAGToDAGISel::selectMOV64Imm32(SDValue N, SDValue &Imm) {
   // 32 bit constants.
   if (N->getOpcode() != ISD::TargetGlobalAddress) {
     return TM.getCodeModel() == CodeModel::Small ||
-           TM.getCodeModel() == CodeModel::Medium;
+           (!(Subtarget->isTargetWindowsCygwin() && Subtarget->is64Bit()) &&
+            TM.getCodeModel() == CodeModel::Medium);
   }
 
   const GlobalValue *GV = cast<GlobalAddressSDNode>(N)->getGlobal();
   if (std::optional<ConstantRange> CR = GV->getAbsoluteSymbolRange())
     return CR->getUnsignedMax().ult(1ull << 32);
-
-  return !TM.isLargeGlobalValue(GV);
+  else if (Subtarget->isTargetWindowsCygwin() && Subtarget->is64Bit())
+    return TM.getCodeModel() == CodeModel::Small;
+  else
+    return !TM.isLargeGlobalValue(GV);
 }
 
 bool X86DAGToDAGISel::selectLEA64_32Addr(SDValue N, SDValue &Base,


### PR DESCRIPTION
Fix the regression caused by commit ec92d74a0ef89b9dd46aee6ec8aca6bfd3c66a54 2023-12-14, that, in Cygwin, Clang can't build binutils 2.42.
configure:4686: checking whether we are cross compiling
configure:4694: clang -o conftest.exe -march=x86-64 -O3  -Wl,--strip-all conftest.c  >&5
/cygdrive/c/Users/ADMINI~1/AppData/Local/Temp/conftest-385c4a.o:conftest.c:(.text+0x10): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
/cygdrive/c/Users/ADMINI~1/AppData/Local/Temp/conftest-385c4a.o:conftest.c:(.text+0x15): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
configure:4698: $? = 1
configure:4705: ./conftest.exe
../binutils/configure: line 4707: ./conftest.exe: No such file or directory
configure:4709: $? = 127
configure:4716: error: in `/cygdrive/e/Note/Tool/binutils-release-build':
configure:4718: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
See `config.log' for more details


I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git
