### PR TITLE
[libc++][modules] Fixes clang-tidy exports.

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -252,8 +252,12 @@ static bool is_global_name_exported_by_std_module(std::string_view name) {
 
 static bool is_valid_declaration_context(
     const clang::NamedDecl& decl, std::string_view name, header_exportable_declarations::FileType file_type) {
-  if (decl.getDeclContext()->isNamespace())
+  const clang::DeclContext& context = *decl.getDeclContext();
+  if (context.isNamespace())
     return true;
+
+  if (context.isFunctionOrMethod() || context.isRecord())
+    return false;
 
   if (is_global_name_exported_by_std_module(name))
     return true;


### PR DESCRIPTION
As suggested in #71438 we should use
  export import std;
in the std.compat module.

Using this exports some named declarations from functions and records, adding them to the global namespace. Clang correctly does not export these and it's an issue in the declaration filtering. Declarations in function or record context are not considered a global named declaration.