### PR TITLE
[libc++][format] Improves tests.

### DIFF
--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
@@ -37,7 +37,7 @@ void test(StringT expected, StringViewT fmt, bool arg, std::size_t offset) {
   std::formatter<bool, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
@@ -37,7 +37,7 @@ void test(StringT expected, StringViewT fmt, const CharT* a, std::size_t offset)
   std::formatter<T, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
@@ -38,7 +38,7 @@ void test(StringT expected, StringViewT fmt, ArgumentT arg, std::size_t offset) 
   std::formatter<ArgumentT, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -50,7 +50,7 @@ struct Tester {
     std::formatter<Str, CharT> formatter;
     static_assert(std::semiregular<decltype(formatter)>);
 
-    auto it = formatter.parse(parse_ctx);
+    std::same_as<typename std::basic_string_view<CharT>::iterator> auto it = formatter.parse(parse_ctx);
     assert(it == fmt.end() - offset);
 
     std::basic_string<CharT> result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp
@@ -48,7 +48,7 @@ void test(std::basic_string_view<CharT> fmt, ArithmeticT arg, std::basic_string<
   std::formatter<ArithmeticT, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename std::basic_string_view<CharT>::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   std::basic_string<CharT> result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
@@ -42,7 +42,7 @@ void test(std::string expected, std::string_view fmt, color arg, std::size_t off
   std::formatter<color, char> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename std::string_view::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   std::string result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -43,7 +43,7 @@ void test(StringT expected, StringViewT fmt, PointerT arg, std::size_t offset) {
   std::formatter<PointerT, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
@@ -45,7 +45,7 @@ void test(StringT expected, StringViewT fmt, ArithmeticT arg, std::size_t offset
   std::formatter<ArithmeticT, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
@@ -45,7 +45,7 @@ void test(StringT expected, StringViewT fmt, StringT a, std::size_t offset) {
   std::formatter<T, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
@@ -45,7 +45,7 @@ void test(StringT expected, StringViewT fmt, ArithmeticT arg, std::size_t offset
   std::formatter<ArithmeticT, CharT> formatter;
   static_assert(std::semiregular<decltype(formatter)>);
 
-  auto it = formatter.parse(parse_ctx);
+  std::same_as<typename StringViewT::iterator> auto it = formatter.parse(parse_ctx);
   assert(it == fmt.end() - offset);
 
   StringT result;


### PR DESCRIPTION
Tests the returned type. This was first done for the vector<bool> formatters. This adds it to the other formatters where it wasn't done yet.