### PR TITLE
[libc++][print] Enables it on Apple backdeployment.

### DIFF
--- a/libcxx/include/__availability
+++ b/libcxx/include/__availability
@@ -264,6 +264,10 @@
 #  define _LIBCPP_AVAILABILITY_HAS_TZDB 0
 #  define _LIBCPP_AVAILABILITY_TZDB __attribute__((unavailable))
 
+// Warning: This availability macro works differently as the other macros.
+// The dylib part of print is not needed on Apple platforms. Therefore when
+// the macro is not available the code calling the dylib is commented out.
+// The macro _LIBCPP_AVAILABILITY_PRINT is not used.
 #  define _LIBCPP_AVAILABILITY_HAS_PRINT 0
 #  define _LIBCPP_AVAILABILITY_PRINT __attribute__((unavailable))
 

--- a/libcxx/include/__availability
+++ b/libcxx/include/__availability
@@ -264,7 +264,7 @@
 #  define _LIBCPP_AVAILABILITY_HAS_TZDB 0
 #  define _LIBCPP_AVAILABILITY_TZDB __attribute__((unavailable))
 
-// Warning: This availability macro works differently as the other macros.
+// Warning: This availability macro works differently than the other macros.
 // The dylib part of print is not needed on Apple platforms. Therefore when
 // the macro is not available the code calling the dylib is commented out.
 // The macro _LIBCPP_AVAILABILITY_PRINT is not used.

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -1084,12 +1084,15 @@ _LIBCPP_HIDE_FROM_ABI inline void vprint_nonunicode(ostream& __os, string_view _
 //   native Unicode API;
 // Whether the returned FILE* is "a terminal capable of displaying Unicode"
 // is determined in the same way as the print(FILE*, ...) overloads.
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_EXPORTED_FROM_ABI FILE* __get_ostream_file(ostream& __os);
+_LIBCPP_EXPORTED_FROM_ABI FILE* __get_ostream_file(ostream& __os);
 
 #  ifndef _LIBCPP_HAS_NO_UNICODE
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_HIDE_FROM_ABI void
+_LIBCPP_HIDE_FROM_ABI void
 __vprint_unicode(ostream& __os, string_view __fmt, format_args __args, bool __write_nl) {
+#if _LIBCPP_AVAILABILITY_HAS_PRINT == 0
+  return std::__vprint_nonunicode(__os, __fmt, __args, __write_nl);
+#else
   FILE* __file = std::__get_ostream_file(__os);
   if (!__file || !__print::__is_terminal(__file))
     return std::__vprint_nonunicode(__os, __fmt, __args, __write_nl);
@@ -1124,17 +1127,18 @@ __vprint_unicode(ostream& __os, string_view __fmt, format_args __args, bool __wr
     __os.__set_badbit_and_consider_rethrow();
   }
 #    endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#endif // _LIBCPP_AVAILABILITY_HAS_PRINT
 }
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_HIDE_FROM_ABI inline void
+_LIBCPP_HIDE_FROM_ABI inline void
 vprint_unicode(ostream& __os, string_view __fmt, format_args __args) {
   std::__vprint_unicode(__os, __fmt, __args, false);
 }
 #  endif // _LIBCPP_HAS_NO_UNICODE
 
 template <class... _Args>
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_HIDE_FROM_ABI void
+_LIBCPP_HIDE_FROM_ABI void
 print(ostream& __os, format_string<_Args...> __fmt, _Args&&... __args) {
 #  ifndef _LIBCPP_HAS_NO_UNICODE
   if constexpr (__print::__use_unicode)
@@ -1147,7 +1151,7 @@ print(ostream& __os, format_string<_Args...> __fmt, _Args&&... __args) {
 }
 
 template <class... _Args>
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_HIDE_FROM_ABI void
+_LIBCPP_HIDE_FROM_ABI void
 println(ostream& __os, format_string<_Args...> __fmt, _Args&&... __args) {
 #  ifndef _LIBCPP_HAS_NO_UNICODE
   // Note the wording in the Standard is inefficient. The output of

--- a/libcxx/src/ostream.cpp
+++ b/libcxx/src/ostream.cpp
@@ -17,7 +17,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-_LIBCPP_AVAILABILITY_PRINT _LIBCPP_EXPORTED_FROM_ABI FILE* __get_ostream_file(ostream& __os) {
+_LIBCPP_EXPORTED_FROM_ABI FILE* __get_ostream_file(ostream& __os) {
   // dynamic_cast requires RTTI, this only affects users whose vendor builds
   // the dylib with RTTI disabled. It does not affect users who build with RTTI
   // disabled but use a dylib where the RTTI is enabled.

--- a/libcxx/test/libcxx/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
@@ -10,7 +10,6 @@
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // Clang modules do not work with the definiton of _LIBCPP_TESTING_PRINT_IS_TERMINAL
 // XFAIL: clang-modules-build

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/locale-specific_form.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/locale-specific_form.pass.cpp
@@ -13,7 +13,6 @@
 // UNSUPPORTED: no-filesystem
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // Bionic has minimal locale support, investigate this later.
 // XFAIL: LIBCXX-ANDROID-FIXME

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/print.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/print.pass.cpp
@@ -12,7 +12,6 @@
 // UNSUPPORTED: no-filesystem
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // <ostream>
 

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/println.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/println.pass.cpp
@@ -12,7 +12,6 @@
 // UNSUPPORTED: no-filesystem
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // <ostream>
 

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_nonunicode.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_nonunicode.pass.cpp
@@ -12,7 +12,6 @@
 // UNSUPPORTED: no-filesystem
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // <ostream>
 

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
@@ -12,7 +12,6 @@
 // UNSUPPORTED: no-filesystem
 
 // XFAIL: availability-fp_to_chars-missing
-// XFAIL: availability-print-missing
 
 // <ostream>
 

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -586,13 +586,4 @@ DEFAULT_FEATURES += [
             cfg.available_features,
         ),
     ),
-    # Tests that require support for <print> and std::print in <ostream> in the built library.
-    Feature(
-        name="availability-print-missing",
-        when=lambda cfg: BooleanExpression.evaluate(
-            # TODO(ldionne) Please provide the correct value.
-            "stdlib=apple-libc++ && target={{.+}}-apple-macosx{{(10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0|13.0)(.0)?}}",
-            cfg.available_features,
-        ),
-    ),
 ]


### PR DESCRIPTION
As suggested in #73262 this enable the stream printing on Apple backdeployment targets. This omits the check whether the file is a terminal. This is not entirely conforming, but the differences should be minor and are typically not observable.

Fixes https://github.com/llvm/llvm-project/issues/75225