### PR TITLE
[ConstraintElim] Drop invalid rows instead of failing the elimination

### DIFF
--- a/llvm/lib/Analysis/ConstraintSystem.cpp
+++ b/llvm/lib/Analysis/ConstraintSystem.cpp
@@ -95,17 +95,19 @@ bool ConstraintSystem::eliminateUsingFM() {
           IdxUpper++;
         }
 
-        if (MulOverflow(UpperV, -1 * LowerLast, M1))
-          return false;
+        if (MulOverflow(UpperV, -1 * LowerLast, M1)) {
+          NR.clear();
+          break;
+        }
         if (IdxLower < LowerRow.size() && LowerRow[IdxLower].Id == CurrentId) {
           LowerV = LowerRow[IdxLower].Coefficient;
           IdxLower++;
         }
 
-        if (MulOverflow(LowerV, UpperLast, M2))
-          return false;
-        if (AddOverflow(M1, M2, N))
-          return false;
+        if (MulOverflow(LowerV, UpperLast, M2) || AddOverflow(M1, M2, N)) {
+          NR.clear();
+          break;
+        }
         if (N == 0)
           continue;
         NR.emplace_back(N, CurrentId);

--- a/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
+++ b/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
@@ -13,8 +13,7 @@ define i32 @f(i64 %a3, i64 %numElements) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i64 [[A1]], [[A3]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF_END_I:%.*]], label [[ABORT:%.*]]
 ; CHECK:       if.end.i:
-; CHECK-NEXT:    [[CMP2_NOT_I:%.*]] = icmp ult i64 [[A1]], [[A3]]
-; CHECK-NEXT:    br i1 [[CMP2_NOT_I]], label [[ABORT]], label [[EXIT:%.*]]
+; CHECK-NEXT:    br i1 false, label [[ABORT]], label [[EXIT:%.*]]
 ; CHECK:       abort:
 ; CHECK-NEXT:    ret i32 -1
 ; CHECK:       exit:


### PR DESCRIPTION
This patch tries to drop invalid rows when overflow occurs instead of failing the elimination immediately.
Fixes the regression in [velox/buffer/Buffer.h](https://github.com/facebookincubator/velox/blob/50187434e32bffcbebcd6501898763c56de40065/velox/buffer/Buffer.h#L347-L350), which was introduced by #76262.

See also https://github.com/dtcxzyw/llvm-opt-benchmark/issues/35#issuecomment-1868362725.
