### PR TITLE
[Support] Resolve symlinks in `getMainExecutable()` on Windows

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -154,7 +154,10 @@ std::string getMainExecutable(const char *argv0, void *MainExecAddr) {
     return "";
 
   llvm::sys::path::make_preferred(PathNameUTF8);
-  return std::string(PathNameUTF8.data());
+
+  SmallString<256> RealPath;
+  sys::fs::real_path(PathNameUTF8, RealPath);
+  return (std::string)RealPath;
 }
 
 UniqueID file_status::getUniqueID() const {

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -157,7 +157,7 @@ std::string getMainExecutable(const char *argv0, void *MainExecAddr) {
 
   SmallString<256> RealPath;
   sys::fs::real_path(PathNameUTF8, RealPath);
-  return RealPath.str().str();
+  return std::string(RealPath);
 }
 
 UniqueID file_status::getUniqueID() const {

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -157,7 +157,7 @@ std::string getMainExecutable(const char *argv0, void *MainExecAddr) {
 
   SmallString<256> RealPath;
   sys::fs::real_path(PathNameUTF8, RealPath);
-  return (std::string)RealPath;
+  return RealPath.str().str();
 }
 
 UniqueID file_status::getUniqueID() const {


### PR DESCRIPTION
This makes the Windows implementation for `getMainExecutable()` behave the same as its Linux counterpart, in regards to symlinks. Previously, when using `cmake ... -DLLVM_USE_SYMLINKS=ON`, calling this function wouldn't resolve to the "real", non-symlinked path.