### PR TITLE
[LLD] Fix llvm-driver cmake integration for LLD

### DIFF
--- a/lld/cmake/modules/AddLLD.cmake
+++ b/lld/cmake/modules/AddLLD.cmake
@@ -37,30 +37,48 @@ macro(add_lld_executable name)
 endmacro(add_lld_executable)
 
 macro(add_lld_tool name)
+  cmake_parse_arguments(ARG "DEPENDS;GENERATE_DRIVER" "" "" ${ARGN})
   if (NOT LLD_BUILD_TOOLS)
     set(EXCLUDE_FROM_ALL ON)
   endif()
+  if(ARG_GENERATE_DRIVER
+    AND LLVM_TOOL_LLVM_DRIVER_BUILD
+    AND (NOT LLVM_DISTRIBUTION_COMPONENTS OR ${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS)
+  )
+    set(get_obj_args ${ARGN})
+    list(FILTER get_obj_args EXCLUDE REGEX "^SUPPORT_PLUGINS$")
+    generate_llvm_objects(${name} ${get_obj_args})
+    add_custom_target(${name} DEPENDS llvm-driver)
+  else()
+    add_lld_executable(${name} ${ARGN})
 
-  add_lld_executable(${name} ${ARGN})
-
-  if (LLD_BUILD_TOOLS)
-    get_target_export_arg(${name} LLD export_to_lldtargets)
-    install(TARGETS ${name}
-      ${export_to_lldtargets}
-      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-      COMPONENT ${name})
-
-    if(NOT CMAKE_CONFIGURATION_TYPES)
-      add_llvm_install_targets(install-${name}
-        DEPENDS ${name}
+    if (LLD_BUILD_TOOLS)
+      get_target_export_arg(${name} LLD export_to_lldtargets)
+      install(TARGETS ${name}
+        ${export_to_lldtargets}
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         COMPONENT ${name})
+
+      if(NOT CMAKE_CONFIGURATION_TYPES)
+        add_llvm_install_targets(install-${name}
+          DEPENDS ${name}
+          COMPONENT ${name})
+      endif()
+      set_property(GLOBAL APPEND PROPERTY LLD_EXPORTS ${name})
     endif()
-    set_property(GLOBAL APPEND PROPERTY LLD_EXPORTS ${name})
   endif()
 endmacro()
 
 macro(add_lld_symlink name dest)
-  llvm_add_tool_symlink(LLD ${name} ${dest} ALWAYS_GENERATE)
-  # Always generate install targets
-  llvm_install_symlink(LLD ${name} ${dest} ALWAYS_GENERATE)
+  get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)
+  if(LLVM_TOOL_LLVM_DRIVER_BUILD
+     AND ${dest} IN_LIST LLVM_DRIVER_TOOLS
+     AND (NOT LLVM_DISTRIBUTION_COMPONENTS OR ${dest} IN_LIST LLVM_DISTRIBUTION_COMPONENTS)
+    )
+    set_property(GLOBAL APPEND PROPERTY LLVM_DRIVER_TOOL_ALIASES_${dest} ${name})
+  else()
+    llvm_add_tool_symlink(LLD ${name} ${dest} ALWAYS_GENERATE)
+    # Always generate install targets
+    llvm_install_symlink(LLD ${name} ${dest} ALWAYS_GENERATE)
+  endif()
 endmacro()

--- a/lld/test/CMakeLists.txt
+++ b/lld/test/CMakeLists.txt
@@ -7,6 +7,7 @@ llvm_canonicalize_cmake_booleans(
   LLVM_BUILD_EXAMPLES
   LLVM_ENABLE_PLUGINS
   LLVM_BYE_LINK_INTO_TOOLS
+  LLVM_TOOL_LLVM_DRIVER_BUILD
   )
 
 configure_lit_site_cfg(

--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -12,10 +12,16 @@ add_lld_tool(lld
 export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)
-  target_link_libraries(${target} ${type} ${ARGN})
   if (TARGET obj.${target})
     target_link_libraries(obj.${target} ${ARGN})
   endif()
+
+  get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)
+  if(LLVM_TOOL_LLVM_DRIVER_BUILD AND ${target} IN_LIST LLVM_DRIVER_TOOLS)
+    set(target llvm-driver)
+  endif()
+
+  target_link_libraries(${target} ${type} ${ARGN})
 endfunction()
 
 lld_target_link_libraries(lld
@@ -27,9 +33,6 @@ lld_target_link_libraries(lld
   lldMinGW
   lldWasm
   )
-
-install(TARGETS lld
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 if(NOT LLD_SYMLINKS_TO_CREATE)
   set(LLD_SYMLINKS_TO_CREATE


### PR DESCRIPTION
Previously, even though LLD was linked as part of llvm-driver when using `cmake ... -DLLVM_TOOL_LLVM_DRIVER_BUILD=ON`, there were build issues when compiling incrementally. Sometimes link errors when linking LLD, other times, the `llvm.exe` would be impropely be replaced by `lld.exe`.