### PR TITLE
[clang-tidy] Invalid Fix-It generated for implicit-widening-multiplication-result

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -222,6 +222,10 @@ Changes in existing checks
   casting during type conversions at variable initialization, now with improved
   compatibility for C++17 and later versions.
 
+- Improved :doc:`bugprone-implicit-widening-of-multiplication-result
+  <clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result>` check
+  to correctly emit fixes.
+
 - Improved :doc:`bugprone-lambda-function-name
   <clang-tidy/checks/bugprone/lambda-function-name>` check by adding option
   `IgnoreMacros` to ignore warnings in macros.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-array-subscript-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-array-subscript-expression.cpp
@@ -18,7 +18,7 @@ char *t0(char *base, int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:16: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (ptrdiff_t)
-  // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>()
+  // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>( )
 }
 void *t1(char *base, int a, int b) {
   return &((a * b)[base]);
@@ -35,7 +35,7 @@ char *t2(char *base, unsigned int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<size_t>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:16: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (size_t)
-  // CHECK-NOTES-CXX:                  static_cast<size_t>()
+  // CHECK-NOTES-CXX:                  static_cast<size_t>( )
 }
 
 char *t3(char *base, int a, unsigned int b) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-int.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-int.cpp
@@ -18,7 +18,7 @@ long t0(int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<long>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:10: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (long)
-  // CHECK-NOTES-CXX:                  static_cast<long>()
+  // CHECK-NOTES-CXX:                  static_cast<long>( )
 }
 unsigned long t1(int a, int b) {
   return a * b;
@@ -28,7 +28,7 @@ unsigned long t1(int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<unsigned long>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:10: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (long)
-  // CHECK-NOTES-CXX:                  static_cast<long>()
+  // CHECK-NOTES-CXX:                  static_cast<long>( )
 }
 
 long t2(unsigned int a, int b) {
@@ -39,7 +39,7 @@ long t2(unsigned int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<long>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:10: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (unsigned long)
-  // CHECK-NOTES-CXX:                  static_cast<unsigned long>()
+  // CHECK-NOTES-CXX:                  static_cast<unsigned long>( )
 }
 unsigned long t3(unsigned int a, int b) {
   return a * b;
@@ -49,7 +49,7 @@ unsigned long t3(unsigned int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<unsigned long>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:10: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (unsigned long)
-  // CHECK-NOTES-CXX:                  static_cast<unsigned long>()
+  // CHECK-NOTES-CXX:                  static_cast<unsigned long>( )
 }
 
 long t4(int a, unsigned int b) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-pointer-offset.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-pointer-offset.cpp
@@ -18,7 +18,7 @@ char *t0(char *base, int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:17: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (ptrdiff_t)
-  // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>()
+  // CHECK-NOTES-CXX:                  static_cast<ptrdiff_t>( )
 }
 char *t1(char *base, int a, int b) {
   return a * b + base;
@@ -35,7 +35,7 @@ char *t2(char *base, unsigned int a, int b) {
   // CHECK-NOTES-CXX:                  static_cast<size_t>( )
   // CHECK-NOTES-ALL: :[[@LINE-5]]:17: note: perform multiplication in a wider type
   // CHECK-NOTES-C:                    (size_t)
-  // CHECK-NOTES-CXX:                  static_cast<size_t>()
+  // CHECK-NOTES-CXX:                  static_cast<size_t>( )
 }
 
 char *t3(char *base, int a, unsigned int b) {


### PR DESCRIPTION
The check currently emits warnings for the following code:
    `uint64_t fn() { return 1024 * 1024; }`

But the code generated after applying the notes will look like this:
    `uint64_t fn() { return static_cast<uint64_t>(1024 * )1024; }`
```
[<source>:5:12: warning: performing an implicit widening conversion to type 'uint64_t' (aka 'unsigned long') of a multiplication performed in type 'int' [bugprone-implicit-widening-of-multiplication-result]](javascript:;)
    5 |     return 1024 * 1024;
      |            ^
[<source>:5:12: note: make conversion explicit to silence this warning](javascript:;)
    1 | #include <cstdint>
    2 | 
    3 | uint64_t fn()
    4 | {
    5 |     return 1024 * 1024;
      |            ^~~~~~~~~~~
      |            static_cast<uint64_t>( )
[<source>:5:12: note: perform multiplication in a wider type](javascript:;)
    5 |     return 1024 * 1024;
      |            ^~~~
      |            static_cast<long>()
1 warning generated.
```

This is because when generating the notes the check will use the beginLoc() and EndLoc() of the subexpr of the implicit cast.
But in some cases the AST Node might not have a beginLoc and EndLoc. This seems to be true when the Node is composed of only 1 token (for example an integer literal). Calling the getEndLoc() on this type of node will simply return the known location which is, in this case, the beginLoc.

Fixes #63070 #56728


I was not able to add tests for this commit and this is because the check currently emits two notes for every detection. 
The first suggestion is to silence the warning by casting the whole operation.
The second suggestion is there to fix the issue (And I think the suggested code is invalid, but I've opened another issue for that: https://github.com/llvm/llvm-project/issues/76311).

Since both suggestions are overlapping clang-tidy refuses to apply them and I was not able to add new tests.

The first suggestion seems useless since we should not suggest a fix-it to silence an issue (the message seems sufficient to me). 
But this requires more discussion and the change is not trivial so I've left it how it is for now.

 