### PR TITLE
[mlir][spirv] Use assemblyFormat to define atomic op assembly

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
@@ -18,8 +18,9 @@ include "mlir/Dialect/SPIRV/IR/SPIRVBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class PointeeTypeMatchTrait<string pointer, string name>
-    : TypesMatchWith<"$" # name # " type matches pointee type of " # "$" # pointer, pointer,
-                     name, "$_self.cast<PointerType>().getPointeeType()">;
+    : TypesMatchWith<
+      "$" # name # " type matches pointee type of " # "$" # pointer, pointer,
+      name, "llvm::cast<PointerType>($_self).getPointeeType()">;
 
 // -----
 
@@ -27,12 +28,15 @@ class SPIRV_AtomicUpdateOp<string mnemonic, list<Trait> traits = []>
     : SPIRV_Op<mnemonic,
                !listconcat(traits,
                            [PointeeTypeMatchTrait<"pointer", "result">])> {
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $semantics);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$semantics
+  );
 
-  let results = (outs SPIRV_Integer : $result);
+  let results = (outs
+    SPIRV_Integer:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
@@ -44,13 +48,16 @@ class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []>
                  PointeeTypeMatchTrait<"pointer", "value">,
                  PointeeTypeMatchTrait<"pointer", "result">,
                ])> {
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $semantics, SPIRV_Integer
-                   : $value);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$semantics,
+    SPIRV_Integer:$value
+  );
 
-  let results = (outs SPIRV_Integer : $result);
+  let results = (outs
+    SPIRV_Integer:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
@@ -62,7 +69,7 @@ class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []>
 def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -111,7 +118,7 @@ def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", [
 ]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -159,19 +166,22 @@ def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", [
     ```
   }];
 
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $equal_semantics, SPIRV_MemorySemanticsAttr
-                   : $unequal_semantics, SPIRV_Integer
-                   : $value, SPIRV_Integer
-                   : $comparator);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$equal_semantics,
+    SPIRV_MemorySemanticsAttr:$unequal_semantics,
+    SPIRV_Integer:$value,
+    SPIRV_Integer:$comparator
+  );
 
-  let results = (outs SPIRV_Integer : $result);
+  let results = (outs
+    SPIRV_Integer:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
-    type($pointer)
+      type($pointer)
   }];
 }
 
@@ -208,23 +218,28 @@ def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", [
   }];
 
   let availability = [
-    MinVersion<SPIRV_V_1_0>, MaxVersion<SPIRV_V_1_3>, Extension<[]>,
+    MinVersion<SPIRV_V_1_0>,
+    MaxVersion<SPIRV_V_1_3>,
+    Extension<[]>,
     Capability<[SPIRV_C_Kernel]>
   ];
 
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $equal_semantics, SPIRV_MemorySemanticsAttr
-                   : $unequal_semantics, SPIRV_Integer
-                   : $value, SPIRV_Integer
-                   : $comparator);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$equal_semantics,
+    SPIRV_MemorySemanticsAttr:$unequal_semantics,
+    SPIRV_Integer:$value,
+    SPIRV_Integer:$comparator
+  );
 
-  let results = (outs SPIRV_Integer : $result);
+  let results = (outs
+    SPIRV_Integer:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
-    type($pointer)
+      type($pointer)
   }];
 }
 
@@ -236,7 +251,7 @@ def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", [
 ]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -271,13 +286,16 @@ def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", [
     ```
   }];
 
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $semantics, SPIRV_Numerical
-                   : $value);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$semantics,
+    SPIRV_Numerical:$value
+  );
 
-  let results = (outs SPIRV_Numerical : $result);
+  let results = (outs
+    SPIRV_Numerical:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
@@ -330,20 +348,22 @@ def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", [
   }];
 
   let availability = [
-    MinVersion<SPIRV_V_1_0>, MaxVersion<SPIRV_V_1_6>,
-    Extension<[SPV_EXT_shader_atomic_float_add]>, Capability<[
-      SPIRV_C_AtomicFloat16AddEXT, SPIRV_C_AtomicFloat32AddEXT,
-      SPIRV_C_AtomicFloat64AddEXT
-    ]>
+    MinVersion<SPIRV_V_1_0>,
+    MaxVersion<SPIRV_V_1_6>,
+    Extension<[SPV_EXT_shader_atomic_float_add]>,
+    Capability<[SPIRV_C_AtomicFloat16AddEXT, SPIRV_C_AtomicFloat32AddEXT, SPIRV_C_AtomicFloat64AddEXT]>
   ];
 
-  let arguments = (ins SPIRV_AnyPtr
-                   : $pointer, SPIRV_ScopeAttr
-                   : $memory_scope, SPIRV_MemorySemanticsAttr
-                   : $semantics, SPIRV_Float
-                   : $value);
+  let arguments = (ins
+    SPIRV_AnyPtr:$pointer,
+    SPIRV_ScopeAttr:$memory_scope,
+    SPIRV_MemorySemanticsAttr:$semantics,
+    SPIRV_Float:$value
+  );
 
-  let results = (outs SPIRV_Float : $result);
+  let results = (outs
+    SPIRV_Float:$result
+  );
 
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
@@ -355,7 +375,7 @@ def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", [
 def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -396,7 +416,7 @@ def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
 def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -436,7 +456,7 @@ def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
 def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -475,7 +495,7 @@ def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
 def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -517,7 +537,7 @@ def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
 def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -558,7 +578,7 @@ def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
 def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -600,7 +620,7 @@ def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
 def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -639,11 +659,10 @@ def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
 
 // -----
 
-def SPIRV_AtomicUMaxOp
-    : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp]> {
+def SPIRV_AtomicUMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -682,11 +701,10 @@ def SPIRV_AtomicUMaxOp
 
 // -----
 
-def SPIRV_AtomicUMinOp
-    : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp]> {
+def SPIRV_AtomicUMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -728,7 +746,7 @@ def SPIRV_AtomicUMinOp
 def SPIRV_AtomicXorOp : SPIRV_AtomicUpdateWithValueOp<"AtomicXor", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-        accesses within Scope to the same location:
+    accesses within Scope to the same location:
   }];
 
   let description = [{

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
@@ -14,37 +14,47 @@
 #ifndef MLIR_DIALECT_SPIRV_IR_ATOMIC_OPS
 #define MLIR_DIALECT_SPIRV_IR_ATOMIC_OPS
 
-class SPIRV_AtomicUpdateOp<string mnemonic, list<Trait> traits = []> :
-  SPIRV_Op<mnemonic, traits> {
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$semantics
-  );
+include "mlir/Dialect/SPIRV/IR/SPIRVBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
-  let results = (outs
-    SPIRV_Integer:$result
-  );
+class PointeeTypeMatchTrait<string pointer, string name>
+    : TypesMatchWith<"$" # name # " type matches pointee type of " # "$" # pointer, pointer,
+                     name, "$_self.cast<PointerType>().getPointeeType()">;
+
+// -----
+
+class SPIRV_AtomicUpdateOp<string mnemonic, list<Trait> traits = []>
+    : SPIRV_Op<mnemonic,
+               !listconcat(traits,
+                           [PointeeTypeMatchTrait<"pointer", "result">])> {
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $semantics);
+
+  let results = (outs SPIRV_Integer : $result);
+
+  let assemblyFormat = [{
+    $memory_scope $semantics operands attr-dict `:` type($pointer)
+  }];
 }
 
-class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []> :
-  SPIRV_Op<mnemonic, traits> {
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$semantics,
-    SPIRV_Integer:$value
-  );
+class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []>
+    : SPIRV_Op<mnemonic, !listconcat(traits, [
+                 PointeeTypeMatchTrait<"pointer", "value">,
+                 PointeeTypeMatchTrait<"pointer", "result">,
+               ])> {
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $semantics, SPIRV_Integer
+                   : $value);
 
-  let results = (outs
-    SPIRV_Integer:$result
-  );
+  let results = (outs SPIRV_Integer : $result);
 
-  let builders = [
-    OpBuilder<(ins "Value":$pointer, "::mlir::spirv::Scope":$scope,
-      "::mlir::spirv::MemorySemantics":$memory, "Value":$value),
-    [{build($_builder, $_state, value.getType(), pointer, scope, memory, value);}]>
-  ];
+  let assemblyFormat = [{
+    $memory_scope $semantics operands attr-dict `:` type($pointer)
+  }];
 }
 
 // -----
@@ -52,7 +62,7 @@ class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []> :
 def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -74,9 +84,9 @@ def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
     <!-- End of AutoGen section -->
 
     ```
-    scope ::= `"CrossDevice"` | `"Device"` | `"Workgroup"` | ...
+    scope ::= `<CrossDevice>` | `<Device>` | `<Workgroup>` | ...
 
-    memory-semantics ::= `"None"` | `"Acquire"` | "Release"` | ...
+    memory-semantics ::= `<None>` | `<Acquire>` | <Release>` | ...
 
     atomic-and-op ::=
         `spirv.AtomicAnd` scope memory-semantics
@@ -86,7 +96,7 @@ def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicAnd "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicAnd <Device> <None> %pointer, %value :
                        !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -94,10 +104,14 @@ def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
 
 // -----
 
-def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", []> {
+def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", [
+  PointeeTypeMatchTrait<"pointer", "result">,
+  PointeeTypeMatchTrait<"pointer", "value">,
+  PointeeTypeMatchTrait<"pointer", "comparator">,
+]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -139,29 +153,35 @@ def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", []> {
     #### Example:
 
     ```
-    %0 = spirv.AtomicCompareExchange "Workgroup" "Acquire" "None"
+    %0 = spirv.AtomicCompareExchange <Workgroup> <Acquire> <None>
                                     %pointer, %value, %comparator
                                     : !spirv.ptr<i32, WorkGroup>
     ```
   }];
 
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$equal_semantics,
-    SPIRV_MemorySemanticsAttr:$unequal_semantics,
-    SPIRV_Integer:$value,
-    SPIRV_Integer:$comparator
-  );
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $equal_semantics, SPIRV_MemorySemanticsAttr
+                   : $unequal_semantics, SPIRV_Integer
+                   : $value, SPIRV_Integer
+                   : $comparator);
 
-  let results = (outs
-    SPIRV_Integer:$result
-  );
+  let results = (outs SPIRV_Integer : $result);
+
+  let assemblyFormat = [{
+    $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
+    type($pointer)
+  }];
 }
 
 // -----
 
-def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", []> {
+def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", [
+  PointeeTypeMatchTrait<"pointer", "result">,
+  PointeeTypeMatchTrait<"pointer", "value">,
+  PointeeTypeMatchTrait<"pointer", "comparator">,
+]> {
   let summary = "Deprecated (use OpAtomicCompareExchange).";
 
   let description = [{
@@ -181,39 +201,42 @@ def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", []
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicCompareExchangeWeak "Workgroup" "Acquire" "None"
+    %0 = spirv.AtomicCompareExchangeWeak <Workgroup> <Acquire> <None>
                                        %pointer, %value, %comparator
                                        : !spirv.ptr<i32, WorkGroup>
     ```
   }];
 
   let availability = [
-    MinVersion<SPIRV_V_1_0>,
-    MaxVersion<SPIRV_V_1_3>,
-    Extension<[]>,
+    MinVersion<SPIRV_V_1_0>, MaxVersion<SPIRV_V_1_3>, Extension<[]>,
     Capability<[SPIRV_C_Kernel]>
   ];
 
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$equal_semantics,
-    SPIRV_MemorySemanticsAttr:$unequal_semantics,
-    SPIRV_Integer:$value,
-    SPIRV_Integer:$comparator
-  );
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $equal_semantics, SPIRV_MemorySemanticsAttr
+                   : $unequal_semantics, SPIRV_Integer
+                   : $value, SPIRV_Integer
+                   : $comparator);
 
-  let results = (outs
-    SPIRV_Integer:$result
-  );
+  let results = (outs SPIRV_Integer : $result);
+
+  let assemblyFormat = [{
+    $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
+    type($pointer)
+  }];
 }
 
 // -----
 
-def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", []> {
+def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", [
+  PointeeTypeMatchTrait<"pointer", "value">,
+  PointeeTypeMatchTrait<"pointer", "result">,
+]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -243,26 +266,30 @@ def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicExchange "Workgroup" "Acquire" %pointer, %value,
+    %0 = spirv.AtomicExchange <Workgroup> <Acquire> %pointer, %value,
                             : !spirv.ptr<i32, WorkGroup>
     ```
   }];
 
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$semantics,
-    SPIRV_Numerical:$value
-  );
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $semantics, SPIRV_Numerical
+                   : $value);
 
-  let results = (outs
-    SPIRV_Numerical:$result
-  );
+  let results = (outs SPIRV_Numerical : $result);
+
+  let assemblyFormat = [{
+    $memory_scope $semantics operands attr-dict `:` type($pointer)
+  }];
 }
 
 // -----
 
-def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", []> {
+def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", [
+  PointeeTypeMatchTrait<"pointer", "result">,
+  PointeeTypeMatchTrait<"pointer", "value">,
+]> {
   let summary = "TBD";
 
   let description = [{
@@ -297,28 +324,30 @@ def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.EXT.AtomicFAdd "Device" "None" %pointer, %value :
+    %0 = spirv.EXT.AtomicFAdd <Device> <None> %pointer, %value :
                            !spirv.ptr<f32, StorageBuffer>
     ```
   }];
 
   let availability = [
-    MinVersion<SPIRV_V_1_0>,
-    MaxVersion<SPIRV_V_1_6>,
-    Extension<[SPV_EXT_shader_atomic_float_add]>,
-    Capability<[SPIRV_C_AtomicFloat16AddEXT, SPIRV_C_AtomicFloat32AddEXT, SPIRV_C_AtomicFloat64AddEXT]>
+    MinVersion<SPIRV_V_1_0>, MaxVersion<SPIRV_V_1_6>,
+    Extension<[SPV_EXT_shader_atomic_float_add]>, Capability<[
+      SPIRV_C_AtomicFloat16AddEXT, SPIRV_C_AtomicFloat32AddEXT,
+      SPIRV_C_AtomicFloat64AddEXT
+    ]>
   ];
 
-  let arguments = (ins
-    SPIRV_AnyPtr:$pointer,
-    SPIRV_ScopeAttr:$memory_scope,
-    SPIRV_MemorySemanticsAttr:$semantics,
-    SPIRV_Float:$value
-  );
+  let arguments = (ins SPIRV_AnyPtr
+                   : $pointer, SPIRV_ScopeAttr
+                   : $memory_scope, SPIRV_MemorySemanticsAttr
+                   : $semantics, SPIRV_Float
+                   : $value);
 
-  let results = (outs
-    SPIRV_Float:$result
-  );
+  let results = (outs SPIRV_Float : $result);
+
+  let assemblyFormat = [{
+    $memory_scope $semantics operands attr-dict `:` type($pointer)
+  }];
 }
 
 // -----
@@ -326,7 +355,7 @@ def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", []> {
 def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -356,7 +385,7 @@ def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicIAdd "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicIAdd <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -367,7 +396,7 @@ def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
 def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -396,7 +425,7 @@ def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicIDecrement "Device" "None" %pointer :
+    %0 = spirv.AtomicIDecrement <Device> <None> %pointer :
                               !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -407,7 +436,7 @@ def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
 def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -435,7 +464,7 @@ def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicIncrement "Device" "None" %pointer :
+    %0 = spirv.AtomicIncrement <Device> <None> %pointer :
                              !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -446,7 +475,7 @@ def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
 def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -477,7 +506,7 @@ def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicISub "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicISub <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -488,7 +517,7 @@ def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
 def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -518,7 +547,7 @@ def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicOr "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicOr <Device> <None> %pointer, %value :
                       !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -529,7 +558,7 @@ def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
 def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -560,7 +589,7 @@ def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicSMax "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicSMax <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -571,7 +600,7 @@ def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
 def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -602,7 +631,7 @@ def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicSMin "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicSMin <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -610,10 +639,11 @@ def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
 
 // -----
 
-def SPIRV_AtomicUMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp]> {
+def SPIRV_AtomicUMaxOp
+    : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -644,7 +674,7 @@ def SPIRV_AtomicUMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicUMax "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicUMax <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -652,10 +682,11 @@ def SPIRV_AtomicUMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp
 
 // -----
 
-def SPIRV_AtomicUMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp]> {
+def SPIRV_AtomicUMinOp
+    : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp]> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -686,7 +717,7 @@ def SPIRV_AtomicUMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicUMin "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicUMin <Device> <None> %pointer, %value :
                         !spirv.ptr<i32, StorageBuffer>
     ```
   }];
@@ -697,7 +728,7 @@ def SPIRV_AtomicUMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp
 def SPIRV_AtomicXorOp : SPIRV_AtomicUpdateWithValueOp<"AtomicXor", []> {
   let summary = [{
     Perform the following steps atomically with respect to any other atomic
-    accesses within Scope to the same location:
+        accesses within Scope to the same location:
   }];
 
   let description = [{
@@ -728,7 +759,7 @@ def SPIRV_AtomicXorOp : SPIRV_AtomicUpdateWithValueOp<"AtomicXor", []> {
     #### Example:
 
     ```mlir
-    %0 = spirv.AtomicXor "Device" "None" %pointer, %value :
+    %0 = spirv.AtomicXor <Device> <None> %pointer, %value :
                        !spirv.ptr<i32, StorageBuffer>
     ```
   }];

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
@@ -41,6 +41,8 @@ class SPIRV_AtomicUpdateOp<string mnemonic, list<Trait> traits = []>
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
   }];
+
+  let hasCustomAssemblyFormat = 0;
 }
 
 class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []>
@@ -62,6 +64,8 @@ class SPIRV_AtomicUpdateWithValueOp<string mnemonic, list<Trait> traits = []>
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
   }];
+
+  let hasCustomAssemblyFormat = 0;
 }
 
 // -----
@@ -183,6 +187,9 @@ def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", [
     $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
       type($pointer)
   }];
+
+  let hasCustomAssemblyFormat = 0;
+  let hasVerifier = 0;
 }
 
 // -----
@@ -241,6 +248,9 @@ def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", [
     $memory_scope $equal_semantics $unequal_semantics operands attr-dict `:`
       type($pointer)
   }];
+
+  let hasCustomAssemblyFormat = 0;
+  let hasVerifier = 0;
 }
 
 // -----
@@ -300,6 +310,9 @@ def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", [
   let assemblyFormat = [{
     $memory_scope $semantics operands attr-dict `:` type($pointer)
   }];
+
+  let hasCustomAssemblyFormat = 0;
+  let hasVerifier = 0;
 }
 
 // -----

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
@@ -94,16 +94,6 @@ def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
 
     <!-- End of AutoGen section -->
 
-    ```
-    scopae ::= `<CrossDevice>` | `<Device>` | `<Workgroup>` | ...
-
-    memory-semantics ::= `<None>` | `<Acquire>` | <Release>` | ...
-
-    atomic-and-op ::=
-        `spirv.AtomicAnd` scope memory-semantics
-                        ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -154,13 +144,6 @@ def SPIRV_AtomicCompareExchangeOp : SPIRV_Op<"AtomicCompareExchange", [
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-compare-exchange-op ::=
-        `spirv.AtomicCompareExchange` scope memory-semantics memory-semantics
-                                    ssa-use `,` ssa-use `,` ssa-use
-                                    `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```
@@ -207,13 +190,6 @@ def SPIRV_AtomicCompareExchangeWeakOp : SPIRV_Op<"AtomicCompareExchangeWeak", [
     Memory must be a valid memory Scope.
 
     <!-- End of AutoGen section -->
-
-    ```
-    atomic-compare-exchange-weak-op ::=
-        `spirv.AtomicCompareExchangeWeak` scope memory-semantics memory-semantics
-                                        ssa-use `,` ssa-use `,` ssa-use
-                                        `:` spv-pointer-type
-    ```
 
     #### Example:
 
@@ -282,12 +258,6 @@ def SPIRV_AtomicExchangeOp : SPIRV_Op<"AtomicExchange", [
 
     <!-- End of AutoGen section -->
 
-     ```
-    atomic-exchange-op ::=
-        `spirv.AtomicCompareExchange` scope memory-semantics
-                                    ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -346,12 +316,6 @@ def SPIRV_EXTAtomicFAddOp : SPIRV_ExtVendorOp<"AtomicFAdd", [
 
     Memory must be a valid memory Scope.
 
-    ```
-    atomic-fadd-op ::=
-        `spirv.EXT.AtomicFAdd` scope memory-semantics
-                            ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -409,12 +373,6 @@ def SPIRV_AtomicIAddOp : SPIRV_AtomicUpdateWithValueOp<"AtomicIAdd", []> {
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-iadd-op ::=
-        `spirv.AtomicIAdd` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -449,12 +407,6 @@ def SPIRV_AtomicIDecrementOp : SPIRV_AtomicUpdateOp<"AtomicIDecrement", []> {
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-idecrement-op ::=
-        `spirv.AtomicIDecrement` scope memory-semantics ssa-use
-                               `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -487,12 +439,6 @@ def SPIRV_AtomicIIncrementOp : SPIRV_AtomicUpdateOp<"AtomicIIncrement", []> {
     Memory must be a valid memory Scope.
 
     <!-- End of AutoGen section -->
-
-    ```
-    atomic-iincrement-op ::=
-        `spirv.AtomicIIncrement` scope memory-semantics ssa-use
-                               `:` spv-pointer-type
-    ```
 
     #### Example:
 
@@ -530,12 +476,6 @@ def SPIRV_AtomicISubOp : SPIRV_AtomicUpdateWithValueOp<"AtomicISub", []> {
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-isub-op ::=
-        `spirv.AtomicISub` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -570,12 +510,6 @@ def SPIRV_AtomicOrOp : SPIRV_AtomicUpdateWithValueOp<"AtomicOr", []> {
     Memory must be a valid memory Scope.
 
     <!-- End of AutoGen section -->
-
-    ```
-    atomic-or-op ::=
-        `spirv.AtomicOr` scope memory-semantics
-                       ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
 
     #### Example:
 
@@ -613,12 +547,6 @@ def SPIRV_AtomicSMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMax", []> {
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-smax-op ::=
-        `spirv.AtomicSMax` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -654,12 +582,6 @@ def SPIRV_AtomicSMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicSMin", []> {
     Memory must be a valid memory Scope.
 
     <!-- End of AutoGen section -->
-
-    ```
-    atomic-smin-op ::=
-        `spirv.AtomicSMin` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
 
     #### Example:
 
@@ -697,12 +619,6 @@ def SPIRV_AtomicUMaxOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMax", [UnsignedOp
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-umax-op ::=
-        `spirv.AtomicUMax` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -739,12 +655,6 @@ def SPIRV_AtomicUMinOp : SPIRV_AtomicUpdateWithValueOp<"AtomicUMin", [UnsignedOp
 
     <!-- End of AutoGen section -->
 
-    ```
-    atomic-umin-op ::=
-        `spirv.AtomicUMin` scope memory-semantics
-                         ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -780,12 +690,6 @@ def SPIRV_AtomicXorOp : SPIRV_AtomicUpdateWithValueOp<"AtomicXor", []> {
     Memory must be a valid memory Scope.
 
     <!-- End of AutoGen section -->
-
-    ```
-    atomic-xor-op ::=
-        `spirv.AtomicXor` scope memory-semantics
-                        ssa-use `,` ssa-use `:` spv-pointer-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAtomicOps.td
@@ -19,8 +19,8 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class PointeeTypeMatchTrait<string pointer, string name>
     : TypesMatchWith<
-      "$" # name # " type matches pointee type of " # "$" # pointer, pointer,
-      name, "llvm::cast<PointerType>($_self).getPointeeType()">;
+      "`" # name # "` type matches pointee type of " # "`" # pointer # "`",
+      pointer, name, "llvm::cast<PointerType>($_self).getPointeeType()">;
 
 // -----
 
@@ -95,7 +95,7 @@ def SPIRV_AtomicAndOp : SPIRV_AtomicUpdateWithValueOp<"AtomicAnd", []> {
     <!-- End of AutoGen section -->
 
     ```
-    scope ::= `<CrossDevice>` | `<Device>` | `<Workgroup>` | ...
+    scopae ::= `<CrossDevice>` | `<Device>` | `<Workgroup>` | ...
 
     memory-semantics ::= `<None>` | `<Acquire>` | <Release>` | ...
 

--- a/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
@@ -42,13 +42,6 @@ static LogicalResult verifyAtomicUpdateOp(Operation *op) {
                              << stringifyTypeName<ExpectedElementType>()
                              << " value, found " << elementType;
 
-  if (op->getNumOperands() > 1) {
-    auto valueType = op->getOperand(1).getType();
-    if (valueType != elementType)
-      return op->emitOpError("expected value to have the same type as the "
-                             "pointer operand's pointee type ")
-             << elementType << ", but found " << valueType;
-  }
   auto memorySemantics =
       op->getAttrOfType<spirv::MemorySemanticsAttr>(kSemanticsAttrName)
           .getValue();
@@ -58,60 +51,12 @@ static LogicalResult verifyAtomicUpdateOp(Operation *op) {
   return success();
 }
 
-template <typename T>
-static LogicalResult verifyAtomicCompareExchangeImpl(T atomOp) {
-  // According to the spec:
-  // "The type of Value must be the same as Result Type. The type of the value
-  // pointed to by Pointer must be the same as Result Type. This type must also
-  // match the type of Comparator."
-  if (atomOp.getType() != atomOp.getValue().getType())
-    return atomOp.emitOpError("value operand must have the same type as the op "
-                              "result, but found ")
-           << atomOp.getValue().getType() << " vs " << atomOp.getType();
-
-  if (atomOp.getType() != atomOp.getComparator().getType())
-    return atomOp.emitOpError(
-               "comparator operand must have the same type as the op "
-               "result, but found ")
-           << atomOp.getComparator().getType() << " vs " << atomOp.getType();
-
-  Type pointeeType =
-      llvm::cast<spirv::PointerType>(atomOp.getPointer().getType())
-          .getPointeeType();
-  if (atomOp.getType() != pointeeType)
-    return atomOp.emitOpError(
-               "pointer operand's pointee type must have the same "
-               "as the op result type, but found ")
-           << pointeeType << " vs " << atomOp.getType();
-
-  // TODO: Unequal cannot be set to Release or Acquire and Release.
-  // In addition, Unequal cannot be set to a stronger memory-order then Equal.
-
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // spirv.AtomicAndOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult AtomicAndOp::verify() {
   return verifyAtomicUpdateOp<IntegerType>(getOperation());
-}
-
-//===----------------------------------------------------------------------===//
-// spirv.AtomicCompareExchangeOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult AtomicCompareExchangeOp::verify() {
-  return verifyAtomicCompareExchangeImpl(*this);
-}
-
-//===----------------------------------------------------------------------===//
-// spirv.AtomicCompareExchangeWeakOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult AtomicCompareExchangeWeakOp::verify() {
-  return verifyAtomicCompareExchangeImpl(*this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
@@ -60,26 +60,6 @@ LogicalResult AtomicAndOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// spirv.AtomicExchange
-//===----------------------------------------------------------------------===//
-
-LogicalResult AtomicExchangeOp::verify() {
-  if (getType() != getValue().getType())
-    return emitOpError("value operand must have the same type as the op "
-                       "result, but found ")
-           << getValue().getType() << " vs " << getType();
-
-  Type pointeeType =
-      llvm::cast<spirv::PointerType>(getPointer().getType()).getPointeeType();
-  if (getType() != pointeeType)
-    return emitOpError("pointer operand's pointee type must have the same "
-                       "as the op result type, but found ")
-           << pointeeType << " vs " << getType();
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // spirv.AtomicIAddOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Conversion/MemRefToSPIRV/alloc.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/alloc.mlir
@@ -48,8 +48,8 @@ module attributes {
 //       CHECK:   %{{.+}} = spirv.Load "Workgroup" %[[PTR]] : i32
 //       CHECK:   %[[LOC:.+]] = spirv.SDiv
 //       CHECK:   %[[PTR:.+]] = spirv.AccessChain %[[VAR]][%{{.+}}, %[[LOC]]]
-//       CHECK:   %{{.+}} = spirv.AtomicAnd "Workgroup" "AcquireRelease" %[[PTR]], %{{.+}} : !spirv.ptr<i32, Workgroup>
-//       CHECK:   %{{.+}} = spirv.AtomicOr "Workgroup" "AcquireRelease" %[[PTR]], %{{.+}} : !spirv.ptr<i32, Workgroup>
+//       CHECK:   %{{.+}} = spirv.AtomicAnd <Workgroup> <AcquireRelease> %[[PTR]], %{{.+}} : !spirv.ptr<i32, Workgroup>
+//       CHECK:   %{{.+}} = spirv.AtomicOr <Workgroup> <AcquireRelease> %[[PTR]], %{{.+}} : !spirv.ptr<i32, Workgroup>
 
 // -----
 

--- a/mlir/test/Conversion/MemRefToSPIRV/atomic.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/atomic.mlir
@@ -6,7 +6,7 @@ module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_addi_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicIAdd "Device" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicIAdd <Device> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "addi" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>) -> i32
   return %0: i32
@@ -16,7 +16,7 @@ func.func @atomic_addi_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #s
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_maxs_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<Workgroup>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicSMax "Workgroup" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicSMax <Workgroup> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "maxs" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<Workgroup>>) -> i32
   return %0: i32
@@ -26,7 +26,7 @@ func.func @atomic_maxs_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_maxu_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicUMax "Device" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicUMax <Device> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "maxu" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>) -> i32
   return %0: i32
@@ -36,7 +36,7 @@ func.func @atomic_maxu_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #s
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_mins_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<Workgroup>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicSMin "Workgroup" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicSMin <Workgroup> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "mins" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<Workgroup>>) -> i32
   return %0: i32
@@ -46,7 +46,7 @@ func.func @atomic_mins_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_minu_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicUMin "Device" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicUMin <Device> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "minu" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>) -> i32
   return %0: i32
@@ -56,7 +56,7 @@ func.func @atomic_minu_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #s
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_ori_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<Workgroup>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicOr "Workgroup" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicOr <Workgroup> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, Workgroup>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "ori" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<Workgroup>>) -> i32
   return %0: i32
@@ -66,7 +66,7 @@ func.func @atomic_ori_workgroup(%value: i32, %memref: memref<2x3x4xi32, #spirv.s
 // CHECK-SAME: (%[[VAL:.+]]: i32,
 func.func @atomic_andi_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>, %i0: index, %i1: index, %i2: index) -> i32 {
   // CHECK: %[[AC:.+]] = spirv.AccessChain
-  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicAnd "Device" "AcquireRelease" %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: %[[ATOMIC:.+]] = spirv.AtomicAnd <Device> <AcquireRelease> %[[AC]], %[[VAL]] : !spirv.ptr<i32, StorageBuffer>
   // CHECK: return %[[ATOMIC]]
   %0 = memref.atomic_rmw "andi" %value, %memref[%i0, %i1, %i2] : (i32, memref<2x3x4xi32, #spirv.storage_class<StorageBuffer>>) -> i32
   return %0: i32

--- a/mlir/test/Conversion/MemRefToSPIRV/bitwidth-emulation.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/bitwidth-emulation.mlir
@@ -122,8 +122,8 @@ func.func @store_i1(%arg0: memref<i1, #spirv.storage_class<StorageBuffer>>, %val
   //     CHECK: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CASTED_ARG1]], %[[OFFSET]] : i32, i32
   //     CHECK: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[ZERO]], %[[FOUR]] : i32
   //     CHECK: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]]
-  //     CHECK: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //     CHECK: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //     CHECK: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //     CHECK: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
   memref.store %value, %arg0[] : memref<i1, #spirv.storage_class<StorageBuffer>>
   return
 }
@@ -147,8 +147,8 @@ func.func @store_i8(%arg0: memref<i8, #spirv.storage_class<StorageBuffer>>, %val
   //     CHECK: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[OFFSET]] : i32, i32
   //     CHECK: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[ZERO]], %[[FOUR]] : i32
   //     CHECK: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]]
-  //     CHECK: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //     CHECK: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //     CHECK: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //     CHECK: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
 
   //   INDEX64-DAG: %[[ARG1_CAST:.+]] = builtin.unrealized_conversion_cast %[[ARG1]] : i8 to i32
   //   INDEX64-DAG: %[[ARG0_CAST:.+]] = builtin.unrealized_conversion_cast %[[ARG0]]
@@ -164,8 +164,8 @@ func.func @store_i8(%arg0: memref<i8, #spirv.storage_class<StorageBuffer>>, %val
   //   INDEX64: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[OFFSET]] : i32, i64
   //   INDEX64: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[ZERO]], %[[FOUR]] : i64
   //   INDEX64: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]] : {{.+}}, i64, i64
-  //   INDEX64: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //   INDEX64: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //   INDEX64: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //   INDEX64: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
   memref.store %value, %arg0[] : memref<i8, #spirv.storage_class<StorageBuffer>>
   return
 }
@@ -191,8 +191,8 @@ func.func @store_i16(%arg0: memref<10xi16, #spirv.storage_class<StorageBuffer>>,
   //     CHECK: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[OFFSET]] : i32, i32
   //     CHECK: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[FLAT_IDX]], %[[TWO]] : i32
   //     CHECK: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]]
-  //     CHECK: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //     CHECK: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //     CHECK: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //     CHECK: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
   memref.store %value, %arg0[%index] : memref<10xi16, #spirv.storage_class<StorageBuffer>>
   return
 }
@@ -262,8 +262,8 @@ func.func @store_i4(%arg0: memref<?xi4, #spirv.storage_class<StorageBuffer>>, %v
   // CHECK: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[BITS]] : i32, i32
   // CHECK: %[[ACCESS_INDEX:.+]] = spirv.SDiv %[[OFFSET]], %[[EIGHT]] : i32
   // CHECK: %[[PTR:.+]] = spirv.AccessChain %{{.+}}[%[[ZERO]], %[[ACCESS_INDEX]]]
-  // CHECK: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK2]]
-  // CHECK: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  // CHECK: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK2]]
+  // CHECK: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
   memref.store %value, %arg0[%i] : memref<?xi4, #spirv.storage_class<StorageBuffer>>
   return
 }
@@ -338,8 +338,8 @@ func.func @store_i8(%arg0: memref<i8, #spirv.storage_class<StorageBuffer>>, %val
   //     CHECK: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[OFFSET]] : i32, i32
   //     CHECK: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[ZERO]], %[[FOUR]] : i32
   //     CHECK: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]]
-  //     CHECK: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //     CHECK: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //     CHECK: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //     CHECK: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
 
   //   INDEX64-DAG: %[[ARG0_CAST:.+]] = builtin.unrealized_conversion_cast %[[ARG0]]
   //   INDEX64: %[[ZERO:.+]] = spirv.Constant 0 : i64
@@ -355,8 +355,8 @@ func.func @store_i8(%arg0: memref<i8, #spirv.storage_class<StorageBuffer>>, %val
   //   INDEX64: %[[STORE_VAL:.+]] = spirv.ShiftLeftLogical %[[CLAMPED_VAL]], %[[OFFSET]] : i32, i64
   //   INDEX64: %[[ACCESS_IDX:.+]] = spirv.SDiv %[[ZERO]], %[[FOUR]] : i64
   //   INDEX64: %[[PTR:.+]] = spirv.AccessChain %[[ARG0_CAST]][%[[ZERO]], %[[ACCESS_IDX]]] : {{.+}}, i64, i64
-  //   INDEX64: spirv.AtomicAnd "Device" "AcquireRelease" %[[PTR]], %[[MASK]]
-  //   INDEX64: spirv.AtomicOr "Device" "AcquireRelease" %[[PTR]], %[[STORE_VAL]]
+  //   INDEX64: spirv.AtomicAnd <Device> <AcquireRelease> %[[PTR]], %[[MASK]]
+  //   INDEX64: spirv.AtomicOr <Device> <AcquireRelease> %[[PTR]], %[[STORE_VAL]]
   memref.store %value, %arg0[] : memref<i8, #spirv.storage_class<StorageBuffer>>
   return
 }

--- a/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
@@ -5,15 +5,15 @@
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicAnd "Device" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicAnd "Device" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicAnd <Device> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicAnd <Device> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
 // -----
 
 func.func @atomic_and(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : i32) -> i32 {
-  // expected-error @+1 {{pointer operand must point to an integer value, found 'f32'}}
+  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicAnd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<f32, StorageBuffer>, i32) -> (i32)
   return %0 : i32
 }
@@ -22,7 +22,7 @@ func.func @atomic_and(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : i32) -> i3
 // -----
 
 func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i64) -> i64 {
-  // expected-error @+1 {{expected value to have the same type as the pointer operand's pointee type 'i32', but found 'i64'}}
+  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicAnd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, StorageBuffer>, i64) -> (i64)
   return %0 : i64
 }
@@ -31,7 +31,7 @@ func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i64) -> i6
 
 func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
   // expected-error @+1 {{expected at most one of these four memory constraints to be set: `Acquire`, `Release`,`AcquireRelease` or `SequentiallyConsistent`}}
-  %0 = spirv.AtomicAnd "Device" "Acquire|Release" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicAnd <Device> <Acquire|Release> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -42,15 +42,15 @@ func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i3
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // CHECK: spirv.AtomicCompareExchange "Workgroup" "Release" "Acquire" %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-  %0 = spirv.AtomicCompareExchange "Workgroup" "Release" "Acquire" %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
+  // CHECK: spirv.AtomicCompareExchange <Workgroup> <Release> <Acquire> %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+  %0 = spirv.AtomicCompareExchange <Workgroup> <Release> <Acquire> %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
   return %0: i32
 }
 
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64, %comparator: i32) -> i32 {
-  // expected-error @+1 {{value operand must have the same type as the op result, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64, i32) -> (i32)
   return %0: i32
 }
@@ -58,7 +58,7 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i16) -> i32 {
-  // expected-error @+1 {{comparator operand must have the same type as the op result, but found 'i16' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that $comparator type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i32, i16) -> (i32)
   return %0: i32
 }
@@ -66,7 +66,7 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // expected-error @+1 {{pointer operand's pointee type must have the same as the op result type, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{spirv.AtomicCompareExchange' op failed to verify that $result type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32, i32) -> (i32)
   return %0: i32
 }
@@ -78,15 +78,15 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // CHECK: spirv.AtomicCompareExchangeWeak "Workgroup" "Release" "Acquire" %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-  %0 = spirv.AtomicCompareExchangeWeak "Workgroup" "Release" "Acquire" %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
+  // CHECK: spirv.AtomicCompareExchangeWeak <Workgroup> <Release> <Acquire> %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+  %0 = spirv.AtomicCompareExchangeWeak <Workgroup> <Release> <Acquire> %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
   return %0: i32
 }
 
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64, %comparator: i32) -> i32 {
-  // expected-error @+1 {{value operand must have the same type as the op result, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64, i32) -> (i32)
   return %0: i32
 }
@@ -94,7 +94,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i16) -> i32 {
-  // expected-error @+1 {{comparator operand must have the same type as the op result, but found 'i16' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $comparator type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i32, i16) -> (i32)
   return %0: i32
 }
@@ -102,7 +102,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // expected-error @+1 {{pointer operand's pointee type must have the same as the op result type, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $result type matches pointee type of $pointer}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32, i32) -> (i32)
   return %0: i32
 }
@@ -114,15 +114,15 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i64, Workgroup>, %value
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32) -> i32 {
-  // CHECK: spirv.AtomicExchange "Workgroup" "Release" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-  %0 = spirv.AtomicExchange "Workgroup" "Release" %ptr, %value: !spirv.ptr<i32, Workgroup>
+  // CHECK: spirv.AtomicExchange <Workgroup> <Release> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+  %0 = spirv.AtomicExchange <Workgroup> <Release> %ptr, %value: !spirv.ptr<i32, Workgroup>
   return %0: i32
 }
 
 // -----
 
 func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64) -> i32 {
-  // expected-error @+1 {{value operand must have the same type as the op result, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicExchange"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64) -> (i32)
   return %0: i32
 }
@@ -130,7 +130,7 @@ func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64) -> i32
 // -----
 
 func.func @atomic_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32) -> i32 {
-  // expected-error @+1 {{pointer operand's pointee type must have the same as the op result type, but found 'i64' vs 'i32'}}
+  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that $value type matches pointee type of $pointer}}
   %0 = "spirv.AtomicExchange"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32) -> (i32)
   return %0: i32
 }
@@ -142,8 +142,8 @@ func.func @atomic_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32) -> i32
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_iadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicIAdd "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicIAdd "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicIAdd <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicIAdd <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -152,8 +152,8 @@ func.func @atomic_iadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_idecrement(%ptr : !spirv.ptr<i32, StorageBuffer>) -> i32 {
-  // CHECK: spirv.AtomicIDecrement "Workgroup" "None" %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicIDecrement "Workgroup" "None" %ptr : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicIDecrement <Workgroup> <None> %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicIDecrement <Workgroup> <None> %ptr : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -162,8 +162,8 @@ func.func @atomic_idecrement(%ptr : !spirv.ptr<i32, StorageBuffer>) -> i32 {
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_iincrement(%ptr : !spirv.ptr<i32, StorageBuffer>) -> i32 {
-  // CHECK: spirv.AtomicIIncrement "Workgroup" "None" %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicIIncrement "Workgroup" "None" %ptr : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicIIncrement <Workgroup> <None> %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicIIncrement <Workgroup> <None> %ptr : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -172,8 +172,8 @@ func.func @atomic_iincrement(%ptr : !spirv.ptr<i32, StorageBuffer>) -> i32 {
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_isub(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicISub "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicISub "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicISub <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicISub <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -182,8 +182,8 @@ func.func @atomic_isub(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_or(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicOr "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicOr "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicOr <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicOr <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -192,8 +192,8 @@ func.func @atomic_or(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_smax(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicSMax "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicSMax "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicSMax <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicSMax <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -202,8 +202,8 @@ func.func @atomic_smax(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_smin(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicSMin "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicSMin "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicSMin <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicSMin <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -212,8 +212,8 @@ func.func @atomic_smin(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_umax(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicUMax "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicUMax "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicUMax <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicUMax <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -222,8 +222,8 @@ func.func @atomic_umax(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_umin(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicUMin "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicUMin "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicUMin <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicUMin <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -232,8 +232,8 @@ func.func @atomic_umin(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_xor(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i32 {
-  // CHECK: spirv.AtomicXor "Workgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
-  %0 = spirv.AtomicXor "Workgroup" "None" %ptr, %value : !spirv.ptr<i32, StorageBuffer>
+  // CHECK: spirv.AtomicXor <Workgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, StorageBuffer>
+  %0 = spirv.AtomicXor <Workgroup> <None> %ptr, %value : !spirv.ptr<i32, StorageBuffer>
   return %0 : i32
 }
 
@@ -244,15 +244,15 @@ func.func @atomic_xor(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i3
 //===----------------------------------------------------------------------===//
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f32) -> f32 {
-  // CHECK: spirv.EXT.AtomicFAdd "Device" "None" %{{.*}}, %{{.*}} : !spirv.ptr<f32, StorageBuffer>
-  %0 = spirv.EXT.AtomicFAdd "Device" "None" %ptr, %value : !spirv.ptr<f32, StorageBuffer>
+  // CHECK: spirv.EXT.AtomicFAdd <Device> <None> %{{.*}}, %{{.*}} : !spirv.ptr<f32, StorageBuffer>
+  %0 = spirv.EXT.AtomicFAdd <Device> <None> %ptr, %value : !spirv.ptr<f32, StorageBuffer>
   return %0 : f32
 }
 
 // -----
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : f32) -> f32 {
-  // expected-error @+1 {{pointer operand must point to an float value, found 'i32'}}
+  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that $result type matches pointee type of $pointer}}
   %0 = "spirv.EXT.AtomicFAdd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, StorageBuffer>, f32) -> (f32)
   return %0 : f32
 }
@@ -260,7 +260,7 @@ func.func @atomic_fadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : f32) -> f
 // -----
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f64) -> f64 {
-  // expected-error @+1 {{expected value to have the same type as the pointer operand's pointee type 'f32', but found 'f64'}}
+  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that $result type matches pointee type of $pointer}}
   %0 = "spirv.EXT.AtomicFAdd"(%ptr, %value) {memory_scope = #spirv.scope<Device>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<f32, StorageBuffer>, f64) -> (f64)
   return %0 : f64
 }
@@ -269,6 +269,6 @@ func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f64) -> f
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f32) -> f32 {
   // expected-error @+1 {{expected at most one of these four memory constraints to be set: `Acquire`, `Release`,`AcquireRelease` or `SequentiallyConsistent`}}
-  %0 = spirv.EXT.AtomicFAdd "Device" "Acquire|Release" %ptr, %value : !spirv.ptr<f32, StorageBuffer>
+  %0 = spirv.EXT.AtomicFAdd <Device> <Acquire|Release> %ptr, %value : !spirv.ptr<f32, StorageBuffer>
   return %0 : f32
 }

--- a/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
@@ -13,7 +13,7 @@ func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i32) -> i3
 // -----
 
 func.func @atomic_and(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : i32) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicAnd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<f32, StorageBuffer>, i32) -> (i32)
   return %0 : i32
 }
@@ -22,7 +22,7 @@ func.func @atomic_and(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : i32) -> i3
 // -----
 
 func.func @atomic_and(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : i64) -> i64 {
-  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicAnd' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicAnd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, StorageBuffer>, i64) -> (i64)
   return %0 : i64
 }
@@ -50,7 +50,7 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64, %comparator: i32) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64, i32) -> (i32)
   return %0: i32
 }
@@ -58,7 +58,7 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i16) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that $comparator type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchange' op failed to verify that `comparator` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i32, i16) -> (i32)
   return %0: i32
 }
@@ -66,7 +66,7 @@ func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32
 // -----
 
 func.func @atomic_compare_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // expected-error @+1 {{spirv.AtomicCompareExchange' op failed to verify that $result type matches pointee type of $pointer}}
+  // expected-error @+1 {{spirv.AtomicCompareExchange' op failed to verify that `result` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchange"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32, i32) -> (i32)
   return %0: i32
 }
@@ -86,7 +86,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64, %comparator: i32) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64, i32) -> (i32)
   return %0: i32
 }
@@ -94,7 +94,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i16) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $comparator type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that `comparator` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i32, i16) -> (i32)
   return %0: i32
 }
@@ -102,7 +102,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
 // -----
 
 func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32, %comparator: i32) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that $result type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicCompareExchangeWeak' op failed to verify that `result` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicCompareExchangeWeak"(%ptr, %value, %comparator) {memory_scope = #spirv.scope<Workgroup>, equal_semantics = #spirv.memory_semantics<AcquireRelease>, unequal_semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32, i32) -> (i32)
   return %0: i32
 }
@@ -122,7 +122,7 @@ func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32) -> i32
 // -----
 
 func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicExchange"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64) -> (i32)
   return %0: i32
 }
@@ -130,7 +130,7 @@ func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64) -> i32
 // -----
 
 func.func @atomic_exchange(%ptr: !spirv.ptr<i64, Workgroup>, %value: i32) -> i32 {
-  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that $value type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicExchange"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i64, Workgroup>, i32) -> (i32)
   return %0: i32
 }
@@ -252,7 +252,7 @@ func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f32) -> f
 // -----
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : f32) -> f32 {
-  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that $result type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that `result` type matches pointee type of `pointer`}}
   %0 = "spirv.EXT.AtomicFAdd"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, StorageBuffer>, f32) -> (f32)
   return %0 : f32
 }
@@ -260,7 +260,7 @@ func.func @atomic_fadd(%ptr : !spirv.ptr<i32, StorageBuffer>, %value : f32) -> f
 // -----
 
 func.func @atomic_fadd(%ptr : !spirv.ptr<f32, StorageBuffer>, %value : f64) -> f64 {
-  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that $result type matches pointee type of $pointer}}
+  // expected-error @+1 {{'spirv.EXT.AtomicFAdd' op failed to verify that `result` type matches pointee type of `pointer`}}
   %0 = "spirv.EXT.AtomicFAdd"(%ptr, %value) {memory_scope = #spirv.scope<Device>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<f32, StorageBuffer>, f64) -> (f64)
   return %0 : f64
 }

--- a/mlir/test/Dialect/SPIRV/IR/availability.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/availability.mlir
@@ -16,7 +16,7 @@ func.func @atomic_compare_exchange_weak(%ptr: !spirv.ptr<i32, Workgroup>, %value
   // CHECK: max version: v1.3
   // CHECK: extensions: [ ]
   // CHECK: capabilities: [ [Kernel] ]
-  %0 = spirv.AtomicCompareExchangeWeak "Workgroup" "Release" "Acquire" %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
+  %0 = spirv.AtomicCompareExchangeWeak <Workgroup> <Release> <Acquire> %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
   return %0: i32
 }
 

--- a/mlir/test/Dialect/SPIRV/IR/target-env.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/target-env.mlir
@@ -49,7 +49,7 @@ func.func @main() {
 func.func @cmp_exchange_weak_suitable_version_capabilities(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i32) -> i32 attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.1, [Kernel, AtomicStorage], []>, #spirv.resource_limits<>>
 } {
-  // CHECK: spirv.AtomicCompareExchangeWeak "Workgroup" "AcquireRelease|AtomicCounterMemory" "Acquire"
+  // CHECK: spirv.AtomicCompareExchangeWeak <Workgroup> <AcquireRelease|AtomicCounterMemory> <Acquire>
   %0 = "test.convert_to_atomic_compare_exchange_weak_op"(%ptr, %value, %comparator): (!spirv.ptr<i32, Workgroup>, i32, i32) -> (i32)
   return %0: i32
 }

--- a/mlir/test/Dialect/SPIRV/Transforms/inlining.mlir
+++ b/mlir/test/Dialect/SPIRV/Transforms/inlining.mlir
@@ -206,7 +206,7 @@ spirv.module Logical GLSL450 {
       // CHECK: [[STOREPTR:%.*]] = spirv.AccessChain [[ADDRESS_ARG1]]
       %7 = spirv.AccessChain %3[%1] : !spirv.ptr<!spirv.struct<(i32 [0])>, StorageBuffer>, i32
       // CHECK-NOT: spirv.FunctionCall
-      // CHECK: spirv.AtomicIAdd "Device" "AcquireRelease" [[STOREPTR]], [[VAL]]
+      // CHECK: spirv.AtomicIAdd <Device> <AcquireRelease> [[STOREPTR]], [[VAL]]
       // CHECK: spirv.Branch
       spirv.FunctionCall @atomic_add(%5, %7) : (i32, !spirv.ptr<i32, StorageBuffer>) -> ()
       spirv.Branch ^bb2
@@ -217,7 +217,7 @@ spirv.module Logical GLSL450 {
     spirv.Return
   }
   spirv.func @atomic_add(%arg0: i32, %arg1: !spirv.ptr<i32, StorageBuffer>) "None" {
-    %0 = spirv.AtomicIAdd "Device" "AcquireRelease" %arg1, %arg0 : !spirv.ptr<i32, StorageBuffer>
+    %0 = spirv.AtomicIAdd <Device> <AcquireRelease> %arg1, %arg0 : !spirv.ptr<i32, StorageBuffer>
     spirv.Return
   }
   spirv.EntryPoint "GLCompute" @inline_into_selection_region

--- a/mlir/test/Target/SPIRV/atomic-ops.mlir
+++ b/mlir/test/Target/SPIRV/atomic-ops.mlir
@@ -3,41 +3,41 @@
 spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader], []> {
   // CHECK-LABEL: @test_int_atomics
   spirv.func @test_int_atomics(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i32) -> i32 "None" {
-    // CHECK: spirv.AtomicCompareExchangeWeak "Workgroup" "Release" "Acquire" %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %0 = spirv.AtomicCompareExchangeWeak "Workgroup" "Release" "Acquire" %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicAnd "Device" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %1 = spirv.AtomicAnd "Device" "None" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicIAdd "Workgroup" "Acquire" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %2 = spirv.AtomicIAdd "Workgroup" "Acquire" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicIDecrement "Workgroup" "Acquire" %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %3 = spirv.AtomicIDecrement "Workgroup" "Acquire" %ptr : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicIIncrement "Device" "Release" %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %4 = spirv.AtomicIIncrement "Device" "Release" %ptr : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicISub "Workgroup" "Acquire" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %5 = spirv.AtomicISub "Workgroup" "Acquire" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicOr "Workgroup" "AcquireRelease" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %6 = spirv.AtomicOr "Workgroup" "AcquireRelease" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicSMax "Subgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %7 = spirv.AtomicSMax "Subgroup" "None" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicSMin "Device" "Release" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %8 = spirv.AtomicSMin "Device" "Release" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicUMax "Subgroup" "None" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %9 = spirv.AtomicUMax "Subgroup" "None" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicUMin "Device" "Release" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %10 = spirv.AtomicUMin "Device" "Release" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicXor "Workgroup" "AcquireRelease" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %11 = spirv.AtomicXor "Workgroup" "AcquireRelease" %ptr, %value : !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicCompareExchange "Workgroup" "Release" "Acquire" %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %12 = spirv.AtomicCompareExchange "Workgroup" "Release" "Acquire" %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
-    // CHECK: spirv.AtomicExchange "Workgroup" "Release" %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
-    %13 = spirv.AtomicExchange "Workgroup" "Release" %ptr, %value: !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicCompareExchangeWeak <Workgroup> <Release> <Acquire> %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %0 = spirv.AtomicCompareExchangeWeak <Workgroup> <Release> <Acquire> %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicAnd <Device> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %1 = spirv.AtomicAnd <Device> <None> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicIAdd <Workgroup> <Acquire> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %2 = spirv.AtomicIAdd <Workgroup> <Acquire> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicIDecrement <Workgroup> <Acquire> %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %3 = spirv.AtomicIDecrement <Workgroup> <Acquire> %ptr : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicIIncrement <Device> <Release> %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %4 = spirv.AtomicIIncrement <Device> <Release> %ptr : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicISub <Workgroup> <Acquire> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %5 = spirv.AtomicISub <Workgroup> <Acquire> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicOr <Workgroup> <AcquireRelease> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %6 = spirv.AtomicOr <Workgroup> <AcquireRelease> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicSMax <Subgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %7 = spirv.AtomicSMax <Subgroup> <None> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicSMin <Device> <Release> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %8 = spirv.AtomicSMin <Device> <Release> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicUMax <Subgroup> <None> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %9 = spirv.AtomicUMax <Subgroup> <None> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicUMin <Device> <Release> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %10 = spirv.AtomicUMin <Device> <Release> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicXor <Workgroup> <AcquireRelease> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %11 = spirv.AtomicXor <Workgroup> <AcquireRelease> %ptr, %value : !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicCompareExchange <Workgroup> <Release> <Acquire> %{{.*}}, %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %12 = spirv.AtomicCompareExchange <Workgroup> <Release> <Acquire> %ptr, %value, %comparator: !spirv.ptr<i32, Workgroup>
+    // CHECK: spirv.AtomicExchange <Workgroup> <Release> %{{.*}}, %{{.*}} : !spirv.ptr<i32, Workgroup>
+    %13 = spirv.AtomicExchange <Workgroup> <Release> %ptr, %value: !spirv.ptr<i32, Workgroup>
     spirv.ReturnValue %0: i32
   }
 
   // CHECK-LABEL: @test_float_atomics
   spirv.func @test_float_atomics(%ptr: !spirv.ptr<f32, Workgroup>, %value: f32) -> f32 "None" {
-    // CHECK: spirv.EXT.AtomicFAdd "Workgroup" "Acquire" %{{.*}}, %{{.*}} : !spirv.ptr<f32, Workgroup>
-    %0 = spirv.EXT.AtomicFAdd "Workgroup" "Acquire" %ptr, %value : !spirv.ptr<f32, Workgroup>
+    // CHECK: spirv.EXT.AtomicFAdd <Workgroup> <Acquire> %{{.*}}, %{{.*}} : !spirv.ptr<f32, Workgroup>
+    %0 = spirv.EXT.AtomicFAdd <Workgroup> <Acquire> %ptr, %value : !spirv.ptr<f32, Workgroup>
     spirv.ReturnValue %0: f32
   }
 }

--- a/mlir/test/Target/SPIRV/debug.mlir
+++ b/mlir/test/Target/SPIRV/debug.mlir
@@ -13,7 +13,7 @@ spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader], []> {
 
   spirv.func @atomic(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32, %comparator: i32) "None" {
     // CHECK: loc({{".*debug.mlir"}}:16:10)
-    %1 = spirv.AtomicAnd "Device" "None" %ptr, %value : !spirv.ptr<i32, Workgroup>
+    %1 = spirv.AtomicAnd <Device> <None> %ptr, %value : !spirv.ptr<i32, Workgroup>
     spirv.Return
   }
 


### PR DESCRIPTION
see #73359

Declarative assemblyFormat ODS is more concise and requires less boilerplate than filling out CPP interfaces.

Changes:
* updates the Ops defined in `SPIRVAtomicOps.td` to use assemblyFormat.
* Removes print/parse from`AtomcOps.cpp` which is now generated by assemblyFormat
* Adds `Trait` to verify that a pointer operand `foo`'s pointee type matches operand `bar`'s type
* * Updates error message expected in tests from new Trait
* Updates tests to updated format (largely using <operand> in place of "operand")


