### PR TITLE
[clangd] Handle lambda scopes inside Node::getDeclContext()

### DIFF
--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -1113,9 +1113,9 @@ const DeclContext &SelectionTree::Node::getDeclContext() const {
           return *DC;
       return *Current->getLexicalDeclContext();
     }
-    if (auto *LE = CurrentNode->ASTNode.get<LambdaExpr>())
+    if (const auto *LE = CurrentNode->ASTNode.get<LambdaExpr>())
       if (CurrentNode != this)
-        return *LE->getLambdaClass();
+        return *LE->getCallOperator();
   }
   llvm_unreachable("A tree must always be rooted at TranslationUnitDecl.");
 }

--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -1113,6 +1113,9 @@ const DeclContext &SelectionTree::Node::getDeclContext() const {
           return *DC;
       return *Current->getLexicalDeclContext();
     }
+    if (auto *LE = CurrentNode->ASTNode.get<LambdaExpr>())
+      if (CurrentNode != this)
+        return *LE->getLambdaClass();
   }
   llvm_unreachable("A tree must always be rooted at TranslationUnitDecl.");
 }

--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -890,7 +890,7 @@ TEST(SelectionTest, DeclContextLambda) {
   auto AST = TestTU::withCode(Test.code()).build();
   auto ST = SelectionTree::createRight(AST.getASTContext(), AST.getTokens(),
                                        Test.point("1"), Test.point("1"));
-  EXPECT_FALSE(ST.commonAncestor()->getDeclContext().isTranslationUnit());
+  EXPECT_TRUE(ST.commonAncestor()->getDeclContext().isFunctionOrMethod());
 }
 
 } // namespace

--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -880,6 +880,19 @@ TEST(SelectionTest, DeclContextIsLexical) {
   }
 }
 
+TEST(SelectionTest, DeclContextLambda) {
+  llvm::Annotations Test(R"cpp(
+    void foo();
+    auto lambda = [] {
+      return $1^foo();
+    };
+  )cpp");
+  auto AST = TestTU::withCode(Test.code()).build();
+  auto ST = SelectionTree::createRight(AST.getASTContext(), AST.getTokens(),
+                                       Test.point("1"), Test.point("1"));
+  EXPECT_FALSE(ST.commonAncestor()->getDeclContext().isTranslationUnit());
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/tweaks/AddUsingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/AddUsingTests.cpp
@@ -309,6 +309,29 @@ namespace foo { void fun(); }
 void foo::fun() {
   ff();
 })cpp"},
+      // Inside a lambda.
+      {
+          R"cpp(
+namespace NS {
+void unrelated();
+void foo();
+}
+
+auto L = [] {
+  using NS::unrelated;
+  NS::f^oo();
+};)cpp",
+          R"cpp(
+namespace NS {
+void unrelated();
+void foo();
+}
+
+auto L = [] {
+  using NS::foo;using NS::unrelated;
+  foo();
+};)cpp",
+      },
       // If all other using are fully qualified, add ::
       {R"cpp(
 #include "test.hpp"


### PR DESCRIPTION
We used to consider the `DeclContext` for selection nodes inside a lambda as the enclosing scope of the lambda expression, rather than the lambda itself.

For example,

```cpp
void foo();
auto lambda = [] {
  return ^foo();
};
```

where `N` is the selection node for the expression `foo()`, `N.getDeclContext()` returns the `TranslationUnitDecl` previously, which IMO is wrong, since the method `operator()` of the lambda is closer.

Incidentally, this fixes a glitch in add-using-declaration tweaks. (Thanks @HighCommander4 for the test case.)