### PR TITLE
[clang-format] Fix bad indentation with attribute and templated type

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -398,7 +398,7 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
   }
   if ((startsNextParameter(Current, Style) || Previous.is(tok::semi) ||
        (Previous.is(TT_TemplateCloser) && Current.is(TT_StartOfName) &&
-        Style.isCpp() &&
+        State.Line->First->isNot(TT_AttributeSquare) && Style.isCpp() &&
         // FIXME: This is a temporary workaround for the case where clang-format
         // sets BreakBeforeParameter to avoid bin packing and this creates a
         // completely unnecessary line break after a template type that isn't

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26492,6 +26492,10 @@ TEST_F(FormatTest, BreakAfterAttributes) {
   verifyFormat("[[nodiscard]]\n"
                "Foo& operator-(Foo&);",
                Style);
+
+  verifyFormat("[[maybe_unused]]\n"
+               "foo<int> f;",
+               Style);
 }
 
 TEST_F(FormatTest, InsertNewlineAtEOF) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26295,6 +26295,8 @@ TEST_F(FormatTest, BreakAfterAttributes) {
   constexpr StringRef Code("[[maybe_unused]] const int i;\n"
                            "[[foo([[]])]] [[maybe_unused]]\n"
                            "int j;\n"
+                           "[[maybe_unused]]\n"
+                           "foo<int> k;\n"
                            "[[nodiscard]] inline int f(int &i);\n"
                            "[[foo([[]])]] [[nodiscard]]\n"
                            "int g(int &i);\n"
@@ -26315,6 +26317,7 @@ TEST_F(FormatTest, BreakAfterAttributes) {
   Style.BreakAfterAttributes = FormatStyle::ABS_Never;
   verifyFormat("[[maybe_unused]] const int i;\n"
                "[[foo([[]])]] [[maybe_unused]] int j;\n"
+               "[[maybe_unused]] foo<int> k;\n"
                "[[nodiscard]] inline int f(int &i);\n"
                "[[foo([[]])]] [[nodiscard]] int g(int &i);\n"
                "[[nodiscard]] inline int f(int &i) {\n"
@@ -26332,6 +26335,8 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "const int i;\n"
                "[[foo([[]])]] [[maybe_unused]]\n"
                "int j;\n"
+               "[[maybe_unused]]\n"
+               "foo<int> k;\n"
                "[[nodiscard]]\n"
                "inline int f(int &i);\n"
                "[[foo([[]])]] [[nodiscard]]\n"
@@ -26491,10 +26496,6 @@ TEST_F(FormatTest, BreakAfterAttributes) {
   Style.ReferenceAlignment = FormatStyle::ReferenceAlignmentStyle::RAS_Left;
   verifyFormat("[[nodiscard]]\n"
                "Foo& operator-(Foo&);",
-               Style);
-
-  verifyFormat("[[maybe_unused]]\n"
-               "foo<int> f;",
                Style);
 }
 


### PR DESCRIPTION
Fixes llvm/llvm-project#76314