### PR TITLE
[InstCombine] Fold select with signbit idiom into fabs

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -2767,6 +2767,37 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
     }
   }
 
+  // Match select with (icmp slt (bitcast X to int), 0)
+  //                or (icmp sgt (bitcast X to int), -1)
+  if (ICmpInst::makeCmpResultType(SI.getType()) != CondVal->getType())
+    return ChangedFMF ? &SI : nullptr;
+
+  for (bool Swap : {false, true}) {
+    Value *TrueVal = SI.getTrueValue();
+    Value *X = SI.getFalseValue();
+
+    if (Swap)
+      std::swap(TrueVal, X);
+
+    CmpInst::Predicate Pred;
+    const APInt *C;
+    bool TrueIfSigned;
+    if (!match(CondVal, m_ICmp(Pred, m_BitCast(m_Specific(X)), m_APInt(C))) ||
+        !IC.isSignBitCheck(Pred, *C, TrueIfSigned))
+      continue;
+    if (!match(TrueVal, m_FNeg(m_Specific(X))))
+      return nullptr;
+    if (Swap == TrueIfSigned && !CondVal->hasOneUse() && !TrueVal->hasOneUse())
+      return nullptr;
+
+    // Fold (IsNeg ? -X : X) or (!IsNeg ? X : -X) to fabs(X)
+    // Fold (IsNeg ? X : -X) or (!IsNeg ? -X : X) to -fabs(X)
+    Value *Fabs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X, &SI);
+    if (Swap != TrueIfSigned)
+      return IC.replaceInstUsesWith(SI, Fabs);
+    return UnaryOperator::CreateFNegFMF(Fabs, &SI);
+  }
+
   return ChangedFMF ? &SI : nullptr;
 }
 

--- a/llvm/test/Transforms/InstCombine/fabs.ll
+++ b/llvm/test/Transforms/InstCombine/fabs.ll
@@ -1038,10 +1038,7 @@ define <2 x float> @select_fneg_vec(<2 x i1> %c, <2 x float> %x) {
 
 define float @test_select_neg_negx_x(float %value) {
 ; CHECK-LABEL: @test_select_neg_negx_x(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call float @llvm.fabs.f32(float [[VALUE:%.*]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1053,10 +1050,8 @@ define float @test_select_neg_negx_x(float %value) {
 
 define float @test_select_nneg_negx_x(float %value) {
 ; CHECK-LABEL: @test_select_nneg_negx_x(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A11]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[VALUE:%.*]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = fneg float [[TMP1]]
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1068,10 +1063,8 @@ define float @test_select_nneg_negx_x(float %value) {
 
 define float @test_select_neg_x_negx(float %value) {
 ; CHECK-LABEL: @test_select_neg_x_negx(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[VALUE:%.*]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = fneg float [[TMP1]]
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1083,10 +1076,7 @@ define float @test_select_neg_x_negx(float %value) {
 
 define float @test_select_nneg_x_negx(float %value) {
 ; CHECK-LABEL: @test_select_nneg_x_negx(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A11]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call float @llvm.fabs.f32(float [[VALUE:%.*]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1101,8 +1091,7 @@ define float @test_select_neg_negx_x_multiuse1(float %value) {
 ; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
 ; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
 ; CHECK-NEXT:    call void @usebool(i1 [[A1]])
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call float @llvm.fabs.f32(float [[VALUE]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1115,11 +1104,9 @@ define float @test_select_neg_negx_x_multiuse1(float %value) {
 
 define float @test_select_neg_negx_x_multiuse2(float %value) {
 ; CHECK-LABEL: @test_select_neg_negx_x_multiuse2(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE:%.*]]
 ; CHECK-NEXT:    call void @use(float [[FNEG_I]])
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call float @llvm.fabs.f32(float [[VALUE]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1137,7 +1124,7 @@ define float @test_select_neg_negx_x_multiuse3(float %value) {
 ; CHECK-NEXT:    call void @usebool(i1 [[A1]])
 ; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
 ; CHECK-NEXT:    call void @use(float [[FNEG_I]])
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call float @llvm.fabs.f32(float [[VALUE]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1151,10 +1138,7 @@ define float @test_select_neg_negx_x_multiuse3(float %value) {
 
 define float @test_select_neg_negx_x_fmf(float %value) {
 ; CHECK-LABEL: @test_select_neg_negx_x_fmf(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select nnan ninf nsz i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = call nnan ninf nsz float @llvm.fabs.f32(float [[VALUE:%.*]])
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32
@@ -1166,10 +1150,8 @@ define float @test_select_neg_negx_x_fmf(float %value) {
 
 define float @test_select_nneg_negx_x_fmf(float %value) {
 ; CHECK-LABEL: @test_select_nneg_negx_x_fmf(
-; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
-; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
-; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
-; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select nnan ninf nsz i1 [[A11]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    [[TMP1:%.*]] = call nnan ninf nsz float @llvm.fabs.f32(float [[VALUE:%.*]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = fneg nnan ninf nsz float [[TMP1]]
 ; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
 ;
   %a0 = bitcast float %value to i32

--- a/llvm/test/Transforms/InstCombine/fabs.ll
+++ b/llvm/test/Transforms/InstCombine/fabs.ll
@@ -15,6 +15,7 @@ declare float @llvm.fma.f32(float, float, float)
 declare float @llvm.fmuladd.f32(float, float, float)
 
 declare void @use(float)
+declare void @usebool(i1)
 
 define float @replace_fabs_call_f32(float %x) {
 ; CHECK-LABEL: @replace_fabs_call_f32(
@@ -1033,4 +1034,228 @@ define <2 x float> @select_fneg_vec(<2 x i1> %c, <2 x float> %x) {
   %s = select fast <2 x i1> %c, <2 x float> %x, <2 x float> %n
   %fabs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %s)
   ret <2 x float> %fabs
+}
+
+define float @test_select_neg_negx_x(float %value) {
+; CHECK-LABEL: @test_select_neg_negx_x(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_nneg_negx_x(float %value) {
+; CHECK-LABEL: @test_select_nneg_negx_x(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A11]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp sgt i32 %a0, -1
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_x_negx(float %value) {
+; CHECK-LABEL: @test_select_neg_x_negx(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %value, float %fneg.i
+  ret float %value.addr.0.i
+}
+
+define float @test_select_nneg_x_negx(float %value) {
+; CHECK-LABEL: @test_select_nneg_x_negx(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A11]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp sgt i32 %a0, -1
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %value, float %fneg.i
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_multiuse1(float %value) {
+; CHECK-LABEL: @test_select_neg_negx_x_multiuse1(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    call void @usebool(i1 [[A1]])
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  call void @usebool(i1 %a1)
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_multiuse2(float %value) {
+; CHECK-LABEL: @test_select_neg_negx_x_multiuse2(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    call void @use(float [[FNEG_I]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  call void @use(float %fneg.i)
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_multiuse3(float %value) {
+; CHECK-LABEL: @test_select_neg_negx_x_multiuse3(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    call void @usebool(i1 [[A1]])
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    call void @use(float [[FNEG_I]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  call void @usebool(i1 %a1)
+  %fneg.i = fneg float %value
+  call void @use(float %fneg.i)
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_fmf(float %value) {
+; CHECK-LABEL: @test_select_neg_negx_x_fmf(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select nnan ninf nsz i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select nsz nnan ninf i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_nneg_negx_x_fmf(float %value) {
+; CHECK-LABEL: @test_select_nneg_negx_x_fmf(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[A11:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select nnan ninf nsz i1 [[A11]], float [[VALUE]], float [[FNEG_I]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp sgt i32 %a0, -1
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select nsz nnan ninf i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+; Negative tests
+
+define float @test_select_nneg_negx_x_multiuse4(float %value) {
+; CHECK-LABEL: @test_select_nneg_negx_x_multiuse4(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp sgt i32 [[A0]], -1
+; CHECK-NEXT:    call void @usebool(i1 [[A1]])
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    call void @use(float [[FNEG_I]])
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp sgt i32 %a0, -1
+  call void @usebool(i1 %a1)
+  %fneg.i = fneg float %value
+  call void @use(float %fneg.i)
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_mismatched1(float %value, float %y) {
+; CHECK-LABEL: @test_select_neg_negx_x_mismatched1(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[Y:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE:%.*]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %y to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_mismatched2(float %value, float %y) {
+; CHECK-LABEL: @test_select_neg_negx_x_mismatched2(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[Y:%.*]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[VALUE]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %y
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %value
+  ret float %value.addr.0.i
+}
+
+define float @test_select_neg_negx_x_mismatched3(float %value, float %y) {
+; CHECK-LABEL: @test_select_neg_negx_x_mismatched3(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast float [[VALUE:%.*]] to i32
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i32 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg float [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], float [[FNEG_I]], float [[Y:%.*]]
+; CHECK-NEXT:    ret float [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast float %value to i32
+  %a1 = icmp slt i32 %a0, 0
+  %fneg.i = fneg float %value
+  %value.addr.0.i = select i1 %a1, float %fneg.i, float %y
+  ret float %value.addr.0.i
+}
+
+define <2 x float> @test_select_neg_negx_x_wrong_type(<2 x float> %value) {
+; CHECK-LABEL: @test_select_neg_negx_x_wrong_type(
+; CHECK-NEXT:    [[A0:%.*]] = bitcast <2 x float> [[VALUE:%.*]] to i64
+; CHECK-NEXT:    [[A1:%.*]] = icmp slt i64 [[A0]], 0
+; CHECK-NEXT:    [[FNEG_I:%.*]] = fneg <2 x float> [[VALUE]]
+; CHECK-NEXT:    [[VALUE_ADDR_0_I:%.*]] = select i1 [[A1]], <2 x float> [[FNEG_I]], <2 x float> [[VALUE]]
+; CHECK-NEXT:    ret <2 x float> [[VALUE_ADDR_0_I]]
+;
+  %a0 = bitcast <2 x float> %value to i64
+  %a1 = icmp slt i64 %a0, 0
+  %fneg.i = fneg <2 x float> %value
+  %value.addr.0.i = select i1 %a1, <2 x float> %fneg.i, <2 x float> %value
+  ret <2 x float> %value.addr.0.i
 }


### PR DESCRIPTION
This patch folds:
```
((bitcast X to int) <s 0 ? -X : X) -> fabs(X)
((bitcast X to int) >s -1 ? X : -X) -> fabs(X)
((bitcast X to int) <s 0 ? X : -X) -> -fabs(X)
((bitcast X to int) >s -1 ? -X : X) -> -fabs(X)
```
Alive2: https://alive2.llvm.org/ce/z/rGepow