### PR TITLE
[llvm-exegesis] Add support for loading X86 segment registers

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/latency/segment-registers-subprocess.asm
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/segment-registers-subprocess.asm
@@ -1,0 +1,29 @@
+# REQUIRES: exegesis-can-measure-latency, x86_64-linux
+
+# Check that the value of the segment registers is set properly when in
+# subprocess mode.
+
+# RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess | FileCheck %s
+
+# LLVM-EXEGESIS-DEFREG FS 12345600
+# LLVM-EXEGESIS-DEFREG GS 2468ac00
+# LLVM-EXEGESIS-DEFREG R13 0
+# LLVM-EXEGESIS-DEFREG R14 127
+# LLVM-EXEGESIS-DEFREG R15 0
+# LLVM-EXEGESIS-MEM-DEF MEM1 4096 0000000012345600
+# LLVM-EXEGESIS-MEM-DEF MEM2 4096 000000002468ac00
+# LLVM-EXEGESIS-MEM-MAP MEM1 305418240
+# LLVM-EXEGESIS-MEM-MAP MEM2 610836480
+
+movq %fs:0, %r13
+cmpq $0x12345600, %r13
+cmovneq %r14, %r15
+movq %gs:0, %r13
+cmpq $0x2468ac00, %r13
+cmovneq %r14, %r15
+
+movq $60, %rax
+movq %r15, %rdi
+syscall
+
+# CHECK-NOT: error:           'Child benchmarking process exited with non-zero exit code: Child process returned with unknown exit code'

--- a/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
@@ -929,7 +929,7 @@ constexpr std::array<unsigned, 6> SyscallArgumentRegisters{
 
 static void saveSyscallRegisters(std::vector<MCInst> &GeneratedCode,
                                  unsigned ArgumentCount) {
-  assert(ArgumentCount < 6 &&
+  assert(ArgumentCount <= 6 &&
          "System calls only X86-64 Linux can only take six arguments");
   // Preserve RCX and R11 (Clobbered by the system call).
   generateRegisterStackPush(X86::RCX, GeneratedCode);
@@ -943,7 +943,7 @@ static void saveSyscallRegisters(std::vector<MCInst> &GeneratedCode,
 
 static void restoreSyscallRegisters(std::vector<MCInst> &GeneratedCode,
                                     unsigned ArgumentCount) {
-  assert(ArgumentCount < 6 &&
+  assert(ArgumentCount <= 6 &&
          "System calls only X86-64 Linux can only take six arguments");
   // Restore the argument registers, in the opposite order of the way they are
   // saved.


### PR DESCRIPTION
This patch adds support for setting the X86 segment registers. These registers are used in quite a few basic blocks in BHive and similar datasets, so being able to set them is necessary to ensure consistent runs as the live-in values of fs and gs can change across runs.

Fixes #76340.