### PR TITLE
[clang-format] Stop aligning the to continuation lines

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -95,7 +95,7 @@ public:
   /// level to the same indent.
   /// Note that \c nextLine must have been called before this method.
   void adjustToUnmodifiedLine(const AnnotatedLine &Line) {
-    if (Line.InPPDirective)
+    if (Line.InPPDirective || Line.IsContinuation)
       return;
     assert(Line.Level < IndentForLevel.size());
     if (Line.First->is(tok::comment) && IndentForLevel[Line.Level] != -1)

--- a/clang/unittests/Format/FormatTestCSharp.cpp
+++ b/clang/unittests/Format/FormatTestCSharp.cpp
@@ -1304,6 +1304,18 @@ TEST_F(FormatTestCSharp, CSharpGenericTypeConstraints) {
                "}",
                Style);
 
+  // When the where line is not to be formatted, following lines should not take
+  // on its indentation.
+  verifyFormat("class ItemFactory<T>\n"
+               "    where T : new() {\n"
+               "  int f() {}\n"
+               "}",
+               "class ItemFactory<T>\n"
+               "    where T : new() {\n"
+               "  int f() {}\n"
+               "}",
+               Style, {tooling::Range(43, 13)});
+
   verifyFormat("class Dictionary<TKey, TVal>\n"
                "    where TKey : IComparable<TKey>\n"
                "    where TVal : IMyInterface {\n"

--- a/clang/unittests/Format/FormatTestCSharp.cpp
+++ b/clang/unittests/Format/FormatTestCSharp.cpp
@@ -1304,8 +1304,8 @@ TEST_F(FormatTestCSharp, CSharpGenericTypeConstraints) {
                "}",
                Style);
 
-  // When the where line is not to be formatted, following lines should not take
-  // on its indentation.
+  // When the "where" line is not to be formatted, following lines should not
+  // take on its indentation.
   verifyFormat("class ItemFactory<T>\n"
                "    where T : new() {\n"
                "  int f() {}\n"

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -613,6 +613,17 @@ TEST_F(FormatTestVerilog, Headers) {
                "      (input var x aaaaaaaaaaaaaaa``x, \\\n"
                "                   b);",
                Style);
+  // When the ports line is not to be formatted, following lines should not take
+  // on its indentation.
+  verifyFormat("module x\n"
+               "    (output x);\n"
+               "  assign x = 0;\n"
+               "endmodule",
+               "module x\n"
+               "    (output x);\n"
+               "    assign x = 0;\n"
+               "endmodule",
+               getDefaultStyle(), {tooling::Range(25, 18)});
 }
 
 TEST_F(FormatTestVerilog, Hierarchy) {


### PR DESCRIPTION
Some unwrapped lines are marked as continuations of the previous lines, for example the ports in a Verilog module header.  Previously, if the first line following the ports lines was changed, and git-clang-format was run, the changed line would be indented by an extra continuation indentation.