### PR TITLE
[MLIR][Presburger] Fix bug in Identifier::isEqual assert

### DIFF
--- a/mlir/lib/Analysis/Presburger/PresburgerSpace.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerSpace.cpp
@@ -18,8 +18,9 @@ using namespace presburger;
 bool Identifier::isEqual(const Identifier &other) const {
   if (value == nullptr || other.value == nullptr)
     return false;
-  assert(value == other.value && idType == other.idType &&
-         "Values of Identifiers are equal but their types do not match.");
+  assert(value != other.value ||
+         (value == other.value && idType == other.idType &&
+          "Values of Identifiers are equal but their types do not match."));
   return value == other.value;
 }
 

--- a/mlir/unittests/Analysis/Presburger/PresburgerSpaceTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/PresburgerSpaceTest.cpp
@@ -110,6 +110,20 @@ TEST(PresburgerSpaceTest, removeVarRangeIdentifier) {
   EXPECT_EQ(space.getId(VarKind::Range, 1), Identifier(&identifiers[5]));
 }
 
+TEST(PresburgerSpaceTest, IdentifierIsEqual) {
+  PresburgerSpace space = PresburgerSpace::getRelationSpace(1, 2, 0, 0);
+  space.resetIds();
+
+  int identifiers[2] = {0, 1};
+  space.getId(VarKind::Domain, 0) = Identifier(&identifiers[0]);
+  space.getId(VarKind::Range, 0) = Identifier(&identifiers[0]);
+  space.getId(VarKind::Range, 1) = Identifier(&identifiers[1]);
+
+  EXPECT_EQ(space.getId(VarKind::Domain, 0), space.getId(VarKind::Range, 0));
+  EXPECT_FALSE(
+      space.getId(VarKind::Range, 0).isEqual(space.getId(VarKind::Range, 1)));
+}
+
 TEST(PresburgerSpaceTest, convertVarKind) {
   PresburgerSpace space = PresburgerSpace::getRelationSpace(2, 2, 0, 0);
   space.resetIds();


### PR DESCRIPTION
Make identifiers::isEqual return false instead of failing assertion when identifiers are not equal.