### PR TITLE
[MLIR][Doc] fix incorrect syntax for gpu.launch

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -713,7 +713,7 @@ def GPU_LaunchOp : GPU_Op<"launch", [
 
     ```
     operation ::= `gpu.launch` (`async` (`[` ssa-id-list `]`)? )?
-                             `block` `(` ssa-id-list `)` `in` ssa-reassignment
+                             `blocks` `(` ssa-id-list `)` `in` ssa-reassignment
                              `threads` `(` ssa-id-list `)` `in` ssa-reassignment
                              (dynamic_shared_memory_size ssa-use)?
                              memory-attribution


### PR DESCRIPTION
Per the code:

https://github.com/llvm/llvm-project/blob/5c39b8d1a86cc0c92acd438d4799d19e67ae70db/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td#L805

And the usage:

https://github.com/llvm/llvm-project/blob/5c39b8d1a86cc0c92acd438d4799d19e67ae70db/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp#L869

The keyword should be `blocks` rather than `block`. The documentation of the syntax is out of date.