### PR TITLE
[mlir][llvm] Import call site calling conventions

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1439,6 +1439,7 @@ LogicalResult ModuleImport::convertInstruction(llvm::Instruction *inst) {
     } else {
       callOp = builder.create<CallOp>(loc, funcTy, operands);
     }
+    callOp.setCConv(convertCConvFromLLVM(callInst->getCallingConv()));
     setFastmathFlagsAttr(inst, callOp);
     if (!callInst->getType()->isVoidTy())
       mapValue(inst, callOp.getResult());
@@ -1516,6 +1517,7 @@ LogicalResult ModuleImport::convertInstruction(llvm::Instruction *inst) {
           loc, funcTy, /*callee=*/nullptr, operands, directNormalDest,
           ValueRange(), lookupBlock(invokeInst->getUnwindDest()), unwindArgs);
     }
+    invokeOp.setCConv(convertCConvFromLLVM(invokeInst->getCallingConv()));
     if (!invokeInst->getType()->isVoidTy())
       mapValue(inst, invokeOp.getResults().front());
     else

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -191,14 +191,16 @@ module {
 
   // CHECK: llvm.func @test_ccs
   llvm.func @test_ccs() {
+    // CHECK-NEXT: %[[PTR:.*]] = llvm.mlir.addressof @cconv4 : !llvm.ptr
+    %ptr = llvm.mlir.addressof @cconv4 : !llvm.ptr
     // CHECK-NEXT: llvm.call        @cconv1() : () -> ()
     // CHECK-NEXT: llvm.call        @cconv2() : () -> ()
     // CHECK-NEXT: llvm.call fastcc @cconv3() : () -> ()
-    // CHECK-NEXT: llvm.call cc_10  @cconv4() : () -> ()
+    // CHECK-NEXT: llvm.call cc_10  %[[PTR]]() : !llvm.ptr, () -> ()
     llvm.call        @cconv1() : () -> ()
     llvm.call ccc    @cconv2() : () -> ()
     llvm.call fastcc @cconv3() : () -> ()
-    llvm.call cc_10  @cconv4() : () -> ()
+    llvm.call cc_10  %ptr() : !llvm.ptr, () -> ()
     llvm.return
   }
 

--- a/mlir/test/Target/LLVMIR/Import/calling-convention.ll
+++ b/mlir/test/Target/LLVMIR/Import/calling-convention.ll
@@ -1,0 +1,32 @@
+; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
+
+; CHECK: llvm.func fastcc @cconv_fastcc()
+declare fastcc void @cconv_fastcc()
+; CHECK: llvm.func @cconv_ccc()
+declare ccc void @cconv_ccc()
+
+; CHECK-LABEL: @call_cconv
+define void @call_cconv() {
+  ; CHECK: llvm.call fastcc @cconv_fastcc()
+  call fastcc void @cconv_fastcc()
+  ; CHECK: llvm.call @cconv_ccc()
+  call ccc void @cconv_ccc()
+  ret void
+}
+
+; // -----
+
+; CHECK: llvm.func fastcc @cconv_fastcc()
+declare fastcc void @cconv_fastcc()
+declare i32 @__gxx_personality_v0(...)
+
+; CHECK-LABEL: @invoke_cconv
+define i32 @invoke_cconv() personality ptr @__gxx_personality_v0 {
+  ; CHECK: llvm.invoke fastcc @cconv_fastcc() to ^bb2 unwind ^bb1 : () -> ()
+  invoke fastcc void @cconv_fastcc() to label %bb2 unwind label %bb1
+bb1:
+  %1 = landingpad { ptr, i32 } cleanup
+  br label %bb2
+bb2:
+  ret i32 1
+}


### PR DESCRIPTION
This revision adds support for importing call site calling conventions. Additionally, the revision also adds a roundtrip test for an indirect call with a non-standard calling convention.