### PR TITLE
[RISCV] Move Zimop to RISCVInstrInfoZimop.td

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -410,27 +410,6 @@ class RVInstIUnary<bits<12> imm12, bits<3> funct3, RISCVOpcode opcode,
   let Inst{31-20} = imm12;
 }
 
-class RVInstIMopr<bits<7> imm7, bits<5> imm5, bits<3> funct3, RISCVOpcode opcode,
-                   dag outs, dag ins, string opcodestr, string argstr>
-    : RVInstIBase<funct3, opcode, outs, ins, opcodestr, argstr> {
-  let Inst{31} = imm7{6};
-  let Inst{30} = imm5{4};
-  let Inst{29-28} = imm7{5-4};
-  let Inst{27-26} = imm5{3-2};
-  let Inst{25-22} = imm7{3-0};
-  let Inst{21-20} = imm5{1-0};
-}
-
-class RVInstRMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3, RISCVOpcode opcode,
-                   dag outs, dag ins, string opcodestr, string argstr>
-    : RVInstRBase<funct3, opcode, outs, ins, opcodestr, argstr> {
-  let Inst{31} = imm4{3};
-  let Inst{30} = imm3{2};
-  let Inst{29-28} = imm4{2-1};
-  let Inst{27-26} = imm3{1-0};
-  let Inst{25} = imm4{0};
-}
-
 class RVInstS<bits<3> funct3, RISCVOpcode opcode, dag outs, dag ins,
               string opcodestr, string argstr>
     : RVInst<outs, ins, opcodestr, argstr, [], InstFormatS> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -597,18 +597,6 @@ class Priv_rr<string opcodestr, bits<7> funct7>
   let rd = 0;
 }
 
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVMopr<bits<7> imm7, bits<5> imm5, bits<3> funct3,
-             RISCVOpcode opcode, string opcodestr>
-    : RVInstIMopr<imm7, imm5, funct3, opcode, (outs GPR:$rd), (ins GPR:$rs1),
-                   opcodestr, "$rd, $rs1">;
-
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3,
-             RISCVOpcode opcode, string opcodestr>
-    : RVInstRMoprr<imm4, imm3, funct3, opcode, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
-                   opcodestr, "$rd, $rs1, $rs2">;
-
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
@@ -797,22 +785,6 @@ def SRAW  : ALUW_rr<0b0100000, 0b101, "sraw">,
             Sched<[WriteShiftReg32, ReadShiftReg32, ReadShiftReg32]>;
 } // IsSignExtendingOpW = 1
 } // Predicates = [IsRV64]
-
-// Zimop instructions
-
-foreach i = 0...31 in {
-    let Predicates = [HasStdExtZimop] in {
-    def MOPR#i : RVMopr<0b1000111, i, 0b100, OPC_SYSTEM, "mop.r."#i>,
-                 Sched<[]>;
-    } // Predicates = [HasStdExtZimop]
-}
-
-foreach i = 0...7 in {
-    let Predicates = [HasStdExtZimop] in {
-    def MOPRR#i : RVMoprr<0b1001, i, 0b100, OPC_SYSTEM, "mop.rr."#i>,
-                  Sched<[]>;
-    } // Predicates = [HasStdExtZimop]
-}
 
 //===----------------------------------------------------------------------===//
 // Privileged instructions
@@ -2140,6 +2112,7 @@ include "RISCVInstrInfoV.td"
 include "RISCVInstrInfoZvk.td"
 
 // Integer
+include "RISCVInstrInfoZimop.td"
 include "RISCVInstrInfoZicbo.td"
 include "RISCVInstrInfoZicond.td"
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
@@ -1,0 +1,61 @@
+//===-- RISCVInstrInfoZimop.td -----------------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file describes the RISC-V instructions from the standard
+// May-Be-Operations Extension (Zimop).
+// This version is still experimental as the 'Zimop' extension hasn't been
+// ratified yet. It is based on v0.1 of the specification.
+//
+//===----------------------------------------------------------------------===//
+
+class RVInstIMopr<bits<7> imm7, bits<5> imm5, bits<3> funct3, RISCVOpcode opcode,
+                   dag outs, dag ins, string opcodestr, string argstr>
+    : RVInstIBase<funct3, opcode, outs, ins, opcodestr, argstr> {
+  let Inst{31} = imm7{6};
+  let Inst{30} = imm5{4};
+  let Inst{29-28} = imm7{5-4};
+  let Inst{27-26} = imm5{3-2};
+  let Inst{25-22} = imm7{3-0};
+  let Inst{21-20} = imm5{1-0};
+}
+
+class RVInstRMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3, RISCVOpcode opcode,
+                   dag outs, dag ins, string opcodestr, string argstr>
+    : RVInstRBase<funct3, opcode, outs, ins, opcodestr, argstr> {
+  let Inst{31} = imm4{3};
+  let Inst{30} = imm3{2};
+  let Inst{29-28} = imm4{2-1};
+  let Inst{27-26} = imm3{1-0};
+  let Inst{25} = imm4{0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVMopr<bits<7> imm7, bits<5> imm5, bits<3> funct3,
+             RISCVOpcode opcode, string opcodestr>
+    : RVInstIMopr<imm7, imm5, funct3, opcode, (outs GPR:$rd), (ins GPR:$rs1),
+                   opcodestr, "$rd, $rs1">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3,
+             RISCVOpcode opcode, string opcodestr>
+    : RVInstRMoprr<imm4, imm3, funct3, opcode, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
+                   opcodestr, "$rd, $rs1, $rs2">;
+
+foreach i = 0...31 in {
+    let Predicates = [HasStdExtZimop] in {
+    def MOPR#i : RVMopr<0b1000111, i, 0b100, OPC_SYSTEM, "mop.r."#i>,
+                 Sched<[]>;
+    } // Predicates = [HasStdExtZimop]
+}
+
+foreach i = 0...7 in {
+    let Predicates = [HasStdExtZimop] in {
+    def MOPRR#i : RVMoprr<0b1001, i, 0b100, OPC_SYSTEM, "mop.rr."#i>,
+                  Sched<[]>;
+    } // Predicates = [HasStdExtZimop]
+}

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
@@ -47,15 +47,13 @@ class RVMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3,
                    opcodestr, "$rd, $rs1, $rs2">;
 
 foreach i = 0...31 in {
-  let Predicates = [HasStdExtZimop] in {
+  let Predicates = [HasStdExtZimop] in
   def MOPR#i : RVMopr<0b1000111, i, 0b100, OPC_SYSTEM, "mop.r."#i>,
                Sched<[]>;
-  } // Predicates = [HasStdExtZimop]
 }
 
 foreach i = 0...7 in {
-  let Predicates = [HasStdExtZimop] in {
+  let Predicates = [HasStdExtZimop] in
   def MOPRR#i : RVMoprr<0b1001, i, 0b100, OPC_SYSTEM, "mop.rr."#i>,
                 Sched<[]>;
-  } // Predicates = [HasStdExtZimop]
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZimop.td
@@ -47,15 +47,15 @@ class RVMoprr<bits<4> imm4, bits<3> imm3, bits<3> funct3,
                    opcodestr, "$rd, $rs1, $rs2">;
 
 foreach i = 0...31 in {
-    let Predicates = [HasStdExtZimop] in {
-    def MOPR#i : RVMopr<0b1000111, i, 0b100, OPC_SYSTEM, "mop.r."#i>,
-                 Sched<[]>;
-    } // Predicates = [HasStdExtZimop]
+  let Predicates = [HasStdExtZimop] in {
+  def MOPR#i : RVMopr<0b1000111, i, 0b100, OPC_SYSTEM, "mop.r."#i>,
+               Sched<[]>;
+  } // Predicates = [HasStdExtZimop]
 }
 
 foreach i = 0...7 in {
-    let Predicates = [HasStdExtZimop] in {
-    def MOPRR#i : RVMoprr<0b1001, i, 0b100, OPC_SYSTEM, "mop.rr."#i>,
-                  Sched<[]>;
-    } // Predicates = [HasStdExtZimop]
+  let Predicates = [HasStdExtZimop] in {
+  def MOPRR#i : RVMoprr<0b1001, i, 0b100, OPC_SYSTEM, "mop.rr."#i>,
+                Sched<[]>;
+  } // Predicates = [HasStdExtZimop]
 }


### PR DESCRIPTION
So the structure of TableGen files is still clear.
