### PR TITLE
[lld][NFC] Revert commit ccec22b675195bf.

### DIFF
--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -560,7 +560,7 @@ void Writer::createECCodeMap() {
   codeMap.clear();
 
   std::optional<chpe_range_type> lastType;
-  Chunk *first = nullptr, *last = nullptr;
+  Chunk *first, *last;
 
   auto closeRange = [&]() {
     if (lastType) {


### PR DESCRIPTION
This reverts commit ccec22b675195bf45a5e34583a866ab881f94dde (#75183). It's no longer needed with #76251.