### PR TITLE
[BitcodeReader] Add bounds checking on Strtab

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4218,6 +4218,10 @@ Error BitcodeReader::parseGlobalIndirectSymbolRecord(
 
   // Check whether we have enough values to read a partition name.
   if (OpNum + 1 < Record.size()) {
+    // Check Strtab has enough values for the partition.
+    if (Record[OpNum] + Record[OpNum + 1] > Strtab.size()) {
+      return error("Malformed partition, too large.");
+    }
     NewGA->setPartition(
         StringRef(Strtab.data() + Record[OpNum], Record[OpNum + 1]));
     OpNum += 2;

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4219,9 +4219,8 @@ Error BitcodeReader::parseGlobalIndirectSymbolRecord(
   // Check whether we have enough values to read a partition name.
   if (OpNum + 1 < Record.size()) {
     // Check Strtab has enough values for the partition.
-    if (Record[OpNum] + Record[OpNum + 1] > Strtab.size()) {
+    if (Record[OpNum] + Record[OpNum + 1] > Strtab.size())
       return error("Malformed partition, too large.");
-    }
     NewGA->setPartition(
         StringRef(Strtab.data() + Record[OpNum], Record[OpNum + 1]));
     OpNum += 2;


### PR DESCRIPTION
This is needed to protect against global overflows, which was found by a fuzzer recently.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65283