### PR TITLE
[DWARFLibrary] Add bounds check to Contrib index

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -157,6 +157,9 @@ bool DWARFUnitIndex::parseImpl(DataExtractor IndexData) {
     auto Index = IndexData.getU32(&Offset);
     if (!Index)
       continue;
+    // Ensure Index is in valid range
+    if (Index > Header.NumUnits)
+      return false;
     Rows[i].Index = this;
     Rows[i].Contributions =
         std::make_unique<Entry::SectionContribution[]>(Header.NumColumns);


### PR DESCRIPTION
Index should be within the range of Contrib before being used as an index.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30308