### PR TITLE
[llvm-dwarfdump-fuzzer] fix out of bounds potential

### DIFF
--- a/llvm/tools/llvm-dwarfdump/fuzzer/llvm-dwarfdump-fuzzer.cpp
+++ b/llvm/tools/llvm-dwarfdump/fuzzer/llvm-dwarfdump-fuzzer.cpp
@@ -20,8 +20,8 @@ using namespace llvm;
 using namespace object;
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
-  std::unique_ptr<MemoryBuffer> Buff = MemoryBuffer::getMemBuffer(
-      StringRef((const char *)data, size), "", false);
+  std::string Payload(reinterpret_cast<const char *>(data), size);
+  std::unique_ptr<MemoryBuffer> Buff = MemoryBuffer::getMemBuffer(Payload);
 
   Expected<std::unique_ptr<ObjectFile>> ObjOrErr =
       ObjectFile::createObjectFile(Buff->getMemBufferRef());


### PR DESCRIPTION
The fuzzer relies on MemoryBuffer to hold fuzz data, and MemoryBuffer guarantees that "In addition to basic access to the characters in the file, this interface guarantees you can read one character past the end of the file, and that this character will read as '\0'." [Ref](https://llvm.org/doxygen/classllvm_1_1MemoryBuffer.html#details). The current fuzzing set up does not support this, which causes potential false positives. This PR fixes it.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65114