### PR TITLE
[InstCombine] Simplify `icmp pred (sdiv exact X, C), (sdiv exact Y, C)` into `icmp pred X, Y` when C is positive

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -4966,7 +4966,8 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
       return new ICmpInst(Pred, BO0->getOperand(0), BO1->getOperand(0));
 
     case Instruction::SDiv:
-      if (!I.isEquality() || !BO0->isExact() || !BO1->isExact())
+      if (!(I.isEquality() || match(BO0->getOperand(1), m_NonNegative())) ||
+          !BO0->isExact() || !BO1->isExact())
         break;
       return new ICmpInst(Pred, BO0->getOperand(0), BO1->getOperand(0));
 

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -854,6 +854,123 @@ define i1 @PR32949(i32 %X, i32 %Y, i32 %Z) {
   ret i1 %C
 }
 
+define i1 @test_sdiv_pos_slt(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_slt(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp slt i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_sle(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_sle(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp sle i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_sgt(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_sgt(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp sgt i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_sge(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_sge(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp sge i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_ult(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_ult(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp ult i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_ule(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_ule(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp ule i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_ugt(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_ugt(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp ugt i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_pos_uge(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_pos_uge(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, 40
+  %divy = sdiv exact i32 %y, 40
+  %cmp = icmp uge i32 %divx, %divy
+  ret i1 %cmp
+}
+
+define i1 @test_sdiv_neg_slt(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_sdiv_neg_slt(
+; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], -40
+; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], -40
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %divx = sdiv exact i32 %x, -40
+  %divy = sdiv exact i32 %y, -40
+  %cmp = icmp slt i32 %divx, %divy
+  ret i1 %cmp
+}
+
 ; PR8469
 define <2 x i1> @test49(<2 x i32> %i3) {
 ; CHECK-LABEL: @test49(

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -856,9 +856,7 @@ define i1 @PR32949(i32 %X, i32 %Y, i32 %Z) {
 
 define i1 @test_sdiv_pos_slt(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_slt(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -869,9 +867,7 @@ define i1 @test_sdiv_pos_slt(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_sle(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_sle(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -882,9 +878,7 @@ define i1 @test_sdiv_pos_sle(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_sgt(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_sgt(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -895,9 +889,7 @@ define i1 @test_sdiv_pos_sgt(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_sge(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_sge(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -908,9 +900,7 @@ define i1 @test_sdiv_pos_sge(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_ult(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_ult(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -921,9 +911,7 @@ define i1 @test_sdiv_pos_ult(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_ule(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_ule(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -934,9 +922,7 @@ define i1 @test_sdiv_pos_ule(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_ugt(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_ugt(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40
@@ -947,9 +933,7 @@ define i1 @test_sdiv_pos_ugt(i32 %x, i32 %y) {
 
 define i1 @test_sdiv_pos_uge(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_sdiv_pos_uge(
-; CHECK-NEXT:    [[DIVX:%.*]] = sdiv exact i32 [[X:%.*]], 40
-; CHECK-NEXT:    [[DIVY:%.*]] = sdiv exact i32 [[Y:%.*]], 40
-; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i32 [[DIVX]], [[DIVY]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i32 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %divx = sdiv exact i32 %x, 40


### PR DESCRIPTION
Alive2: https://alive2.llvm.org/ce/z/u49dQ9
It will improve the codegen of `std::_Vector_base<T>::~_Vector_base()` when `sizeof(T)` is not a power of 2.
Related patch: #76384

NOTE: We can also fold `icmp signed-pred (sdiv exact X, C), (sdiv exact Y, C)` into `icmp signed-pred (sdiv exact Y, C), (sdiv exact X, C)` when C is negative. But I don't think it enables more optimizations for real-world applications.
