### PR TITLE
[libc] `__stack_chk_fail` baremetal dependencies

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -74,6 +74,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.vsnprintf
 
     # stdlib.h entrypoints
+    libc.src.stdlib.abort
     libc.src.stdlib.abs
     libc.src.stdlib.atoi
     libc.src.stdlib.atof

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -74,6 +74,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.vsnprintf
 
     # stdlib.h entrypoints
+    libc.src.stdlib.abort
     libc.src.stdlib.abs
     libc.src.stdlib.atoi
     libc.src.stdlib.atol

--- a/libc/src/__support/OSUtil/baremetal/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/baremetal/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_header_library(
+  baremetal_util
+  HDRS
+    io.h
+    quick_exit.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.CPP.string_view
+)

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -1,0 +1,25 @@
+//===---------- Baremetal implementation of IO utils ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
+
+#include "src/__support/CPP/string_view.h"
+
+namespace LIBC_NAMESPACE {
+
+// This is intended to be provided by the vendor.
+extern "C" void __llvm_libc_log_write(const char* msg, size_t len);
+
+void write_to_stderr(cpp::string_view msg) {
+  __llvm_libc_log_write(msg.data(), msg.size());
+}
+
+} // namespace LIBC_NAMESPACE
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H

--- a/libc/src/__support/OSUtil/baremetal/quick_exit.h
+++ b/libc/src/__support/OSUtil/baremetal/quick_exit.h
@@ -1,0 +1,23 @@
+//===----- Baremetal implementation of a quick exit function ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_QUICK_EXIT_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_QUICK_EXIT_H
+
+namespace LIBC_NAMESPACE {
+
+// This is intended to be provided by the vendor.
+extern "C" void __llvm_libc_quick_exit(int status);
+
+void quick_exit(int status) {
+  __llvm_libc_quick_exit(status);
+}
+
+} // namespace LIBC_NAMESPACE
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_QUICK_EXIT_H

--- a/libc/src/__support/OSUtil/io.h
+++ b/libc/src/__support/OSUtil/io.h
@@ -19,6 +19,9 @@
 #include "linux/io.h"
 #elif defined(__Fuchsia__)
 #include "fuchsia/io.h"
+#elif defined(__ELF__)
+// TODO: Ideally we would have LIBC_TARGET_OS_IS_BAREMETAL.
+#include "baremetal/io.h"
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_IO_H

--- a/libc/src/__support/OSUtil/quick_exit.h
+++ b/libc/src/__support/OSUtil/quick_exit.h
@@ -17,6 +17,9 @@
 #include "darwin/quick_exit.h"
 #elif defined(__linux__)
 #include "linux/quick_exit.h"
+#elif defined(__ELF__)
+// TODO: Ideally we would have LIBC_TARGET_OS_IS_BAREMETAL.
+#include "baremetal/quick_exit.h"
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_QUICK_EXIT_H


### PR DESCRIPTION
`__stack_chk_fail` uses `write_to_stderr` and `abort` but these currently aren't included in baremetal targets resulting in a CMake build error:

```
CMake Error at /llvm-project/libc/cmake/modules/LLVMLibCObjectRules.cmake:693 (target_link_libraries):
  Target "libc.src.stdlib.abort" of type UTILITY may not be linked into
  another target.  One may link only to INTERFACE, OBJECT, STATIC or SHARED
  libraries, or to executables with the ENABLE_EXPORTS property set.
Call Stack (most recent call first):
  /llvm-project/libc/cmake/modules/LLVMLibCObjectRules.cmake:811 (create_entrypoint_object)
  /llvm-project/libc/cmake/modules/LLVMLibCObjectRules.cmake:891 (expand_flags_for_entrypoint_object)
  /llvm-project/libc/src/compiler/generic/CMakeLists.txt:1 (add_entrypoint_object)

CMake Error at /llvm-project/libc/cmake/modules/LLVMLibCLibraryRules.cmake:5 (get_target_property):
  get_target_property() called with non-existent target
  "libc.src.__support.OSUtil.osutil".
Call Stack (most recent call first):
  /llvm-project/libc/cmake/modules/LLVMLibCLibraryRules.cmake:36 (collect_object_file_deps)
  /llvm-project/libc/cmake/modules/LLVMLibCLibraryRules.cmake:36 (collect_object_file_deps)
  /llvm-project/libc/cmake/modules/LLVMLibCLibraryRules.cmake:85 (collect_object_file_deps)
  /llvm-project/libc/lib/CMakeLists.txt:26 (add_entrypoint_library)
```

To address these errors, we need to include `abort` in the list of baremetal entrypoints. We also need to provide `write_to_stderr` baremetal implementation, but this is challenging since there is no uniform way to print a message on these platforms (sometimes there may not be any way to print a message). We instead defer to `__libc_log_write` which can be provided by the underlying platform. We use a similar approach for `quick_exit`, defering to `__libc_quick_exit`.