### PR TITLE
[mlir][Quasipolynomials] Fixed type issues in GeneratorFunction.h

### DIFF
--- a/mlir/lib/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/lib/Analysis/Presburger/GeneratingFunction.h
@@ -49,7 +49,7 @@ using Point = SmallVector<Fraction>;
 // g_{ij} \in Q^n are vectors.
 class GeneratingFunction {
 public:
-  GeneratingFunction(unsigned numParam, SmallVector<int, 8> signs,
+  GeneratingFunction(unsigned numParam, SmallVector<int> signs,
                      std::vector<ParamPoint> nums,
                      std::vector<std::vector<Point>> dens)
       : numParam(numParam), signs(signs), numerators(nums), denominators(dens) {
@@ -67,7 +67,7 @@ public:
 
   std::vector<std::vector<Point>> getDenominators() { return denominators; }
 
-  GeneratingFunction operator+(const GeneratingFunction &gf) const {
+  GeneratingFunction operator+(GeneratingFunction &gf) const {
     assert(numParam == gf.getNumParams() &&
            "two generating functions with different numbers of parameters "
            "cannot be added!");
@@ -81,7 +81,7 @@ public:
     std::vector<std::vector<Point>> sumDenominators = denominators;
     sumDenominators.insert(sumDenominators.end(), gf.denominators.begin(),
                            gf.denominators.end());
-    return GeneratingFunction(sumSigns, sumNumerators, sumDenominators);
+    return GeneratingFunction(0, sumSigns, sumNumerators, sumDenominators);
   }
 
   llvm::raw_ostream &print(llvm::raw_ostream &os) const {
@@ -121,7 +121,7 @@ public:
 
 private:
   unsigned numParam;
-  SmallVector<int, 8> signs;
+  SmallVector<int> signs;
   std::vector<ParamPoint> numerators;
   std::vector<std::vector<Point>> denominators;
 };


### PR DESCRIPTION
Fixed two issues: A SmallVector size that caused size-differences issue (8 vs. 12). Thus removed this size restriction. Also a constant parameter was causing an issue in a function not marked constant.