### PR TITLE
[mlir][QuasiPolynomial] Fixed unused variable error

### DIFF
--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -30,7 +30,7 @@ QuasiPolynomial::QuasiPolynomial(
       assert(aff.size() == getNumInputs() + 1 &&
              "dimensionality of affine functions does not match number of "
              "symbols!");
-      (void) aff;
+      (void)aff;
     }
   }
 }

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -30,6 +30,7 @@ QuasiPolynomial::QuasiPolynomial(
       assert(aff.size() == getNumInputs() + 1 &&
              "dimensionality of affine functions does not match number of "
              "symbols!");
+      (void) aff;
     }
   }
 }


### PR DESCRIPTION
One of the variable `aff` is used inside an assert. When the asserts are removed, the compiler complains of unused variable. This patch should fix this issue.