### PR TITLE
[clang-cl] document correct defaults for `-fms-compatibility-version` / `-fmsc-version`

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -302,7 +302,7 @@ Language Selection and Mode Options
 .. option:: -fmsc-version=
 
  Set ``_MSC_VER``. When on Windows, this defaults to either the same value as
- the currently installed version of cl.exe, or ``1920``. Not set otherwise.
+ the currently installed version of cl.exe, or ``1933``. Not set otherwise.
 
 .. option:: -fborland-extensions
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -4382,11 +4382,11 @@ Execute ``clang-cl /?`` to see a list of supported options:
       -fmerge-all-constants   Allow merging of constants
       -fms-compatibility-version=<value>
                               Dot-separated value representing the Microsoft compiler version
-                              number to report in _MSC_VER (0 = don't define it (default))
+                              number to report in _MSC_VER (0 = don't define it; default is same value as installed cl.exe, or 1933)
       -fms-compatibility      Enable full Microsoft Visual C++ compatibility
       -fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
       -fmsc-version=<value>   Microsoft compiler version number to report in _MSC_VER
-                              (0 = don't define it (default))
+                              (0 = don't define it; default is same value as installed cl.exe, or 1933)
       -fno-addrsig            Don't emit an address-significance table
       -fno-builtin-<value>    Disable implicit builtin knowledge of a specific function
       -fno-builtin            Disable implicit builtin knowledge of functions


### PR DESCRIPTION
The UserManual states wrongly (AFAICT) that these default are not being defined for clang-cl, whereas further up the opposite is stated:

https://github.com/llvm/llvm-project/blob/c86fe3ee0b92934f5d18394d9a0cdc1d3f0eef64/clang/docs/UsersManual.rst#L3375-L3382

I've chosen to follow that wording, as it's the latest related update.

CC @RIscRIpt who recently touched this in b3e6ff331925dde24a4707452d657da0fdf7f588
CC @AaronBallman who cared about this, c.f. 8fc0dcf036bf199b2af2e10a4f81215dbd706daf