### PR TITLE
[mlir][Quasipolynomial] Fixed -Wunused-variable in GeneratorFunction.h

### DIFF
--- a/mlir/lib/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/lib/Analysis/Presburger/GeneratingFunction.h
@@ -53,10 +53,12 @@ public:
                      std::vector<ParamPoint> nums,
                      std::vector<std::vector<Point>> dens)
       : numParam(numParam), signs(signs), numerators(nums), denominators(dens) {
+#ifndef NDEBUG
     for (const ParamPoint &term : numerators)
       assert(term.getNumColumns() == numParam + 1 &&
              "dimensionality of numerator exponents does not match number of "
              "parameters!");
+#endif // NDEBUG
   }
 
   unsigned getNumParams() { return numParam; }


### PR DESCRIPTION
```
llvm-project/mlir/lib/Analysis/Presburger/GeneratingFunction.h:56:28:
error: unused variable 'term' [-Werror,-Wunused-variable]
   56 |     for (const ParamPoint &term : numerators)
      |                            ^~~~
1 error generated.
```