### PR TITLE
[mlir] Check if the stride tensor is empty.

### DIFF
--- a/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
+++ b/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
@@ -271,7 +271,7 @@ bool vector::isContiguousSlice(MemRefType memrefType, VectorType vectorType) {
     return false;
 
   // Cond 1: A contiguous memref will always have a unit trailing stride.
-  if (strides.back() != 1)
+  if (strides.empty() || strides.back() != 1)
     return false;
 
   // Cond 2: Strides of a contiguous memref have to match the flattened dims.

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -356,3 +356,15 @@ func.func @fold_unit_dims_entirely(%arg0 : vector<8xi32>,
 // CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : vector<8xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_2]] : vector<8xi32>
 // CHECK:           return %[[VAL_4]] : vector<8xi32>
+
+// -----
+
+// This test is to make sure there is no crash for empty stride.
+func.func @stride_empty_crash(%1: memref<i16>) -> vector<32x256xi16> {
+  %c0_i16 = arith.constant 0 : i16
+  %3 = vector.transfer_read %1[], %c0_i16 {permutation_map = affine_map<() -> (0, 0)>} : memref<i16>, vector<32x256xi16>
+  return %3 : vector<32x256xi16>
+
+  // CHECK-LABEL: func.func @stride_empty_crash
+  // CHECK: %c0_i16 = arith.constant 0 : i16
+}

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -360,11 +360,14 @@ func.func @fold_unit_dims_entirely(%arg0 : vector<8xi32>,
 // -----
 
 // This test is to make sure there is no crash for empty stride.
-func.func @stride_empty_crash(%1: memref<i16>) -> vector<32x256xi16> {
+func.func @stride_empty_test(%1: memref<i16>) -> vector<32x256xi16> {
   %c0_i16 = arith.constant 0 : i16
   %3 = vector.transfer_read %1[], %c0_i16 {permutation_map = affine_map<() -> (0, 0)>} : memref<i16>, vector<32x256xi16>
   return %3 : vector<32x256xi16>
 
-  // CHECK-LABEL: func.func @stride_empty_crash
-  // CHECK: %c0_i16 = arith.constant 0 : i16
+  // CHECK-LABEL: func.func @stride_empty_test
+  // CHECK: %[[VAL:.*]] = arith.constant 0 : i16
+  // CHECK: %[[RET:.*]] = vector.transfer_read {{.*}} vector<32x256xi16>
+  // CHECK: return %[[RET]]
+  // CHECK-NOT: empty()
 }


### PR DESCRIPTION
Added a check to see if the stride tensor is empty. If so then return false for isContiguousSlice function.

Possible fix for #74463