### PR TITLE
[RISCV] Collect function features in AsmPrinter before emission (#76231)

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -491,6 +491,8 @@ void validate(const Triple &TT, const FeatureBitset &FeatureBits);
 llvm::Expected<std::unique_ptr<RISCVISAInfo>>
 parseFeatureBits(bool IsRV64, const FeatureBitset &FeatureBits);
 
+void filterOffIncompatibleFeatureBits(MCSubtargetInfo *STI);
+
 } // namespace RISCVFeatures
 
 namespace RISCVVType {

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -408,6 +408,9 @@ void RISCVAsmPrinter::emitEndOfAsmFile(Module &M) {
       static_cast<RISCVTargetStreamer &>(*OutStreamer->getTargetStreamer());
 
   if (TM.getTargetTriple().isOSBinFormatELF()) {
+    // We are interested only in the set of common and compatible
+    // flags accross all functions.
+    RISCVFeatures::filterOffIncompatibleFeatureBits(CommonSTI.get());
     emitAttributes();
     RTS.finishAttributeSection();
   }

--- a/llvm/test/CodeGen/RISCV/flags-collect-asmprinter-incompatible.ll
+++ b/llvm/test/CodeGen/RISCV/flags-collect-asmprinter-incompatible.ll
@@ -1,0 +1,34 @@
+; RUN: llc -mtriple=riscv32  -verify-machineinstrs < %s -filetype=obj -o %t
+; RUN: llvm-readelf -A %t | FileCheck %s
+
+; CHECK: Value:  rv32i2p1_a2p1_zicsr2p0_zca1p0
+define dso_local i32 @func0() #0 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func1() #1 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func2() #2 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func3() #3 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func4() #4 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind "target-features"="+32bit,+d" }
+attributes #1 = { nounwind "target-features"="+32bit,+c" }
+attributes #2 = { nounwind "target-features"="+32bit,+f,+zcmp" }
+attributes #3 = { nounwind "target-features"="+32bit,+a,+zfinx" }
+attributes #4 = { nounwind "target-features"="+32bit,+a,+zcmt" }

--- a/llvm/test/CodeGen/RISCV/flags-collect-asmprinter.ll
+++ b/llvm/test/CodeGen/RISCV/flags-collect-asmprinter.ll
@@ -1,0 +1,28 @@
+; RUN: llc -mtriple=riscv32  -verify-machineinstrs < %s -filetype=obj -o %t
+; RUN: llvm-readelf -A %t | FileCheck %s
+
+; CHECK: Value: rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0
+define dso_local i32 @func0() #0 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func1() #1 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func2() #2 {
+entry:
+  ret i32 0
+}
+
+define dso_local i32 @func3() #3 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind "target-features"="+32bit,+d,+zicsr" }
+attributes #1 = { nounwind "target-features"="+32bit,+d,+f,+m" }
+attributes #2 = { nounwind "target-features"="+32bit,+f,+c" }
+attributes #3 = { nounwind "target-features"="+32bit,+a" }


### PR DESCRIPTION
When performing LTO, if we use just TM MCSubtargetInfo feature flags, it will be incomplete because these informations will be in function's Subtarget. In this way, we collect the flags of all functions and postpone the attribute emission to the end of the file emission.