### PR TITLE
Add support for renaming objc methods, even those with multiple selector pieces

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -844,14 +844,17 @@ void ClangdLSPServer::onWorkspaceSymbol(
 }
 
 void ClangdLSPServer::onPrepareRename(const TextDocumentPositionParams &Params,
-                                      Callback<std::optional<Range>> Reply) {
+                                      Callback<PrepareRenameResult> Reply) {
   Server->prepareRename(
       Params.textDocument.uri.file(), Params.position, /*NewName*/ std::nullopt,
       Opts.Rename,
       [Reply = std::move(Reply)](llvm::Expected<RenameResult> Result) mutable {
         if (!Result)
           return Reply(Result.takeError());
-        return Reply(std::move(Result->Target));
+        PrepareRenameResult PrepareResult;
+        PrepareResult.range = Result->Target;
+        PrepareResult.placeholder = Result->Placeholder;
+        return Reply(std::move(PrepareResult));
       });
 }
 

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -134,7 +134,7 @@ private:
   void onWorkspaceSymbol(const WorkspaceSymbolParams &,
                          Callback<std::vector<SymbolInformation>>);
   void onPrepareRename(const TextDocumentPositionParams &,
-                       Callback<std::optional<Range>>);
+                       Callback<PrepareRenameResult>);
   void onRename(const RenameParams &, Callback<WorkspaceEdit>);
   void onHover(const TextDocumentPositionParams &,
                Callback<std::optional<Hover>>);

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1187,6 +1187,15 @@ bool fromJSON(const llvm::json::Value &Params, RenameParams &R,
          O.map("position", R.position) && O.map("newName", R.newName);
 }
 
+llvm::json::Value toJSON(const PrepareRenameResult &PRR) {
+  if (PRR.placeholder.empty())
+    return toJSON(PRR.range);
+  return llvm::json::Object{
+      {"range", toJSON(PRR.range)},
+      {"placeholder", PRR.placeholder},
+  };
+}
+
 llvm::json::Value toJSON(const DocumentHighlight &DH) {
   return llvm::json::Object{
       {"range", toJSON(DH.range)},

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1436,6 +1436,14 @@ struct RenameParams {
 };
 bool fromJSON(const llvm::json::Value &, RenameParams &, llvm::json::Path);
 
+struct PrepareRenameResult {
+  /// Range of the string to rename.
+  Range range;
+  /// Placeholder text to use in the editor if non-empty.
+  std::string placeholder;
+};
+llvm::json::Value toJSON(const PrepareRenameResult &PRR);
+
 enum class DocumentHighlightKind { Text = 1, Read = 2, Write = 3 };
 
 /// A document highlight is a range inside a text document which deserves

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1977,6 +1977,28 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ASTNode &);
 } // namespace clang
 
 namespace llvm {
+
+template <> struct DenseMapInfo<clang::clangd::Range> {
+  using Range = clang::clangd::Range;
+  static inline Range getEmptyKey() {
+    static clang::clangd::Position Tomb{-1, -1};
+    static Range R{Tomb, Tomb};
+    return R;
+  }
+  static inline Range getTombstoneKey() {
+    static clang::clangd::Position Tomb{-2, -2};
+    static Range R{Tomb, Tomb};
+    return R;
+  }
+  static unsigned getHashValue(const Range &Val) {
+    return llvm::hash_combine(
+        Val.start.line, Val.start.character, Val.end.line, Val.end.character);
+  }
+  static bool isEqual(const Range &LHS, const Range &RHS) {
+    return std::tie(LHS.start, LHS.end) == std::tie(RHS.start, RHS.end);
+  }
+};
+
 template <> struct format_provider<clang::clangd::Position> {
   static void format(const clang::clangd::Position &Pos, raw_ostream &OS,
                      StringRef Style) {

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1991,8 +1991,8 @@ template <> struct DenseMapInfo<clang::clangd::Range> {
     return R;
   }
   static unsigned getHashValue(const Range &Val) {
-    return llvm::hash_combine(
-        Val.start.line, Val.start.character, Val.end.line, Val.end.character);
+    return llvm::hash_combine(Val.start.line, Val.start.character, Val.end.line,
+                              Val.end.character);
   }
   static bool isEqual(const Range &LHS, const Range &RHS) {
     return std::tie(LHS.start, LHS.end) == std::tie(RHS.start, RHS.end);

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -174,7 +174,9 @@ bool isSpelled(SourceLocation Loc, const NamedDecl &ND) {
   auto Name = ND.getDeclName();
   const auto NameKind = Name.getNameKind();
   if (NameKind != DeclarationName::Identifier &&
-      NameKind != DeclarationName::CXXConstructorName)
+      NameKind != DeclarationName::CXXConstructorName &&
+      NameKind != DeclarationName::ObjCZeroArgSelector &&
+      NameKind != DeclarationName::ObjCOneArgSelector)
     return false;
   const auto &AST = ND.getASTContext();
   const auto &SM = AST.getSourceManager();
@@ -183,6 +185,8 @@ bool isSpelled(SourceLocation Loc, const NamedDecl &ND) {
   if (clang::Lexer::getRawToken(Loc, Tok, SM, LO))
     return false;
   auto StrName = Name.getAsString();
+  if (const auto *MD = dyn_cast<ObjCMethodDecl>(&ND))
+    StrName = MD->getSelector().getNameForSlot(0).str();
   return clang::Lexer::getSpelling(Tok, SM, LO) == StrName;
 }
 } // namespace

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -176,7 +176,8 @@ bool isSpelled(SourceLocation Loc, const NamedDecl &ND) {
   if (NameKind != DeclarationName::Identifier &&
       NameKind != DeclarationName::CXXConstructorName &&
       NameKind != DeclarationName::ObjCZeroArgSelector &&
-      NameKind != DeclarationName::ObjCOneArgSelector)
+      NameKind != DeclarationName::ObjCOneArgSelector &&
+      NameKind != DeclarationName::ObjCMultiArgSelector)
     return false;
   const auto &AST = ND.getASTContext();
   const auto &SM = AST.getSourceManager();
@@ -184,10 +185,10 @@ bool isSpelled(SourceLocation Loc, const NamedDecl &ND) {
   clang::Token Tok;
   if (clang::Lexer::getRawToken(Loc, Tok, SM, LO))
     return false;
-  auto StrName = Name.getAsString();
+  auto TokSpelling = clang::Lexer::getSpelling(Tok, SM, LO);
   if (const auto *MD = dyn_cast<ObjCMethodDecl>(&ND))
-    StrName = MD->getSelector().getNameForSlot(0).str();
-  return clang::Lexer::getSpelling(Tok, SM, LO) == StrName;
+    return TokSpelling == MD->getSelector().getNameForSlot(0);
+  return TokSpelling == Name.getAsString();
 }
 } // namespace
 

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -1028,22 +1028,19 @@ llvm::Expected<Edit> buildRenameEdit(llvm::StringRef AbsFilePath,
 
   std::vector<OccurrenceOffset> OccurrencesOffsets;
   for (const auto &SR : Occurrences) {
-    for (auto It = SR.Ranges.begin(); It != SR.Ranges.end(); ++It) {
-      const auto &R = *It;
-      auto StartOffset = Offset(R.start);
+    for (auto [Range, NewName] : llvm::zip(SR.Ranges, NewNames)) {
+      auto StartOffset = Offset(Range.start);
       if (!StartOffset)
         return StartOffset.takeError();
-      auto EndOffset = Offset(R.end);
+      auto EndOffset = Offset(Range.end);
       if (!EndOffset)
         return EndOffset.takeError();
-      auto Index = It - SR.Ranges.begin();
       // Nothing to do if the token/name hasn't changed.
       auto CurName =
           InitialCode.substr(*StartOffset, *EndOffset - *StartOffset);
-      if (CurName == NewNames[Index])
+      if (CurName == NewName)
         continue;
-      OccurrencesOffsets.emplace_back(*StartOffset, *EndOffset,
-                                      NewNames[Index]);
+      OccurrencesOffsets.emplace_back(*StartOffset, *EndOffset, NewName);
     }
   }
 

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -1112,21 +1112,6 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs) {
     // TODO: Insert the ranges from the ObjCMethodDecl/ObjCMessageExpr selector
     // pieces which are being renamed. This will require us to make changes to
     // locateDeclAt to preserve this AST node.
-    //
-    // if (RInputs.NewName != "__clangd_rename_placeholder") {
-    //   llvm::StringRef NewName = RInputs.NewName;
-    //   llvm::SmallVector<llvm::StringRef, 8> NewNames;
-    //   NewName.split(NewNames, ":");
-
-    //   const auto Sel = MD->getSelector();
-    //   unsigned NumSelectorLocs = MD->getNumSelectorLocs();
-    //   for (unsigned I = 0; I < NumSelectorLocs; ++I) {
-    //     if (Sel.getNameForSlot(I) != NewNames[I]) {
-    //       RenamedRanges.insert(
-    //           tokenRangeForLoc(AST, MD->getSelectorLoc(I), SM, LangOpts));
-    //     }
-    //   }
-    // }
   } else {
     RenamedRanges.insert(CurrentIdentifier);
   }

--- a/clang-tools-extra/clangd/refactor/Rename.h
+++ b/clang-tools-extra/clangd/refactor/Rename.h
@@ -11,7 +11,9 @@
 
 #include "Protocol.h"
 #include "SourceCode.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LangOptions.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 #include <optional>
 
@@ -53,12 +55,35 @@ struct RenameInputs {
 struct RenameResult {
   // The range of the symbol that the user can attempt to rename.
   Range Target;
+  // Placeholder text for the rename operation if non-empty.
+  std::string Placeholder;
   // Rename occurrences for the current main file.
   std::vector<Range> LocalChanges;
   // Complete edits for the rename, including LocalChanges.
   // If the full set of changes is unknown, this field is empty.
   FileEdits GlobalChanges;
 };
+
+/// Represents a symbol range where the symbol can potentially have multiple
+/// tokens.
+struct SymbolRange {
+  /// Ranges for the tokens that make up the symbol's name.
+  /// Usually a single range, but there can be multiple ranges if the tokens for
+  /// the symbol are split, e.g. ObjC selectors.
+  std::vector<Range> Ranges;
+
+  SymbolRange(Range R);
+  SymbolRange(std::vector<Range> Ranges);
+
+  /// Returns the first range.
+  Range range() const;
+
+  friend bool operator==(const SymbolRange &LHS, const SymbolRange &RHS);
+  friend bool operator!=(const SymbolRange &LHS, const SymbolRange &RHS);
+  friend bool operator<(const SymbolRange &LHS, const SymbolRange &RHS);
+};
+
+std::vector<SymbolRange> symbolRanges(const std::vector<Range> Ranges);
 
 /// Renames all occurrences of the symbol. The result edits are unformatted.
 /// If AllowCrossFile is false, returns an error if rename a symbol that's used
@@ -71,8 +96,8 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs);
 /// REQUIRED: Occurrences is sorted and doesn't have duplicated ranges.
 llvm::Expected<Edit> buildRenameEdit(llvm::StringRef AbsFilePath,
                                      llvm::StringRef InitialCode,
-                                     std::vector<Range> Occurrences,
-                                     llvm::StringRef NewName);
+                                     std::vector<SymbolRange> Occurrences,
+                                     llvm::ArrayRef<llvm::StringRef> NewNames);
 
 /// Adjusts indexed occurrences to match the current state of the file.
 ///
@@ -84,9 +109,10 @@ llvm::Expected<Edit> buildRenameEdit(llvm::StringRef AbsFilePath,
 /// The API assumes that Indexed contains only named occurrences (each
 /// occurrence has the same length).
 /// REQUIRED: Indexed is sorted.
-std::optional<std::vector<Range>>
+std::optional<std::vector<SymbolRange>>
 adjustRenameRanges(llvm::StringRef DraftCode, llvm::StringRef Identifier,
-                   std::vector<Range> Indexed, const LangOptions &LangOpts);
+                   std::vector<Range> Indexed, const LangOptions &LangOpts,
+                   std::optional<Selector> Selector);
 
 /// Calculates the lexed occurrences that the given indexed occurrences map to.
 /// Returns std::nullopt if we don't find a mapping.
@@ -94,15 +120,16 @@ adjustRenameRanges(llvm::StringRef DraftCode, llvm::StringRef Identifier,
 /// Exposed for testing only.
 ///
 /// REQUIRED: Indexed and Lexed are sorted.
-std::optional<std::vector<Range>> getMappedRanges(ArrayRef<Range> Indexed,
-                                                  ArrayRef<Range> Lexed);
+std::optional<std::vector<SymbolRange>>
+getMappedRanges(ArrayRef<Range> Indexed, ArrayRef<SymbolRange> Lexed);
 /// Evaluates how good the mapped result is. 0 indicates a perfect match.
 ///
 /// Exposed for testing only.
 ///
 /// REQUIRED: Indexed and Lexed are sorted, Indexed and MappedIndex have the
 /// same size.
-size_t renameRangeAdjustmentCost(ArrayRef<Range> Indexed, ArrayRef<Range> Lexed,
+size_t renameRangeAdjustmentCost(ArrayRef<Range> Indexed,
+                                 ArrayRef<SymbolRange> Lexed,
                                  ArrayRef<size_t> MappedIndex);
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/refactor/Rename.h
+++ b/clang-tools-extra/clangd/refactor/Rename.h
@@ -83,8 +83,6 @@ struct SymbolRange {
   friend bool operator<(const SymbolRange &LHS, const SymbolRange &RHS);
 };
 
-std::vector<SymbolRange> symbolRanges(const std::vector<Range> Ranges);
-
 /// Renames all occurrences of the symbol. The result edits are unformatted.
 /// If AllowCrossFile is false, returns an error if rename a symbol that's used
 /// in another file (per the index).

--- a/clang-tools-extra/clangd/test/rename.test
+++ b/clang-tools-extra/clangd/test/rename.test
@@ -10,6 +10,8 @@
 #      CHECK:  "id": 1,
 # CHECK-NEXT:  "jsonrpc": "2.0",
 # CHECK-NEXT:  "result": {
+# CHECK-NEXT:    "placeholder": "foo",
+# CHECK-NEXT:    "range": {
 # CHECK-NEXT:      "end": {
 # CHECK-NEXT:        "character": 7,
 # CHECK-NEXT:        "line": 0
@@ -18,6 +20,7 @@
 # CHECK-NEXT:        "character": 4,
 # CHECK-NEXT:        "line": 0
 # CHECK-NEXT:      }
+# CHECK-NEXT:    }
 # CHECK-NEXT:  }
 ---
 {"jsonrpc":"2.0","id":2,"method":"textDocument/prepareRename","params":{"textDocument":{"uri":"test:///foo.cpp"},"position":{"line":0,"character":2}}}

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -894,11 +894,10 @@ TEST(RenameTest, ObjCWithinFileRename) {
     /// fail.
     std::optional<llvm::StringRef> Expected;
   };
-  TestCase Tests[] = {
-    // Simple rename
-    {
-      // Input
-      R"cpp(
+  TestCase Tests[] = {// Simple rename
+                      {
+                          // Input
+                          R"cpp(
         @interface Foo
         - (int)performA^ction:(int)action w^ith:(int)value;
         @end
@@ -908,10 +907,10 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-      // New name
-      "performNewAction:by:",
-      // Expected
-      R"cpp(
+                          // New name
+                          "performNewAction:by:",
+                          // Expected
+                          R"cpp(
         @interface Foo
         - (int)performNewAction:(int)action by:(int)value;
         @end
@@ -921,11 +920,11 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-    },
-    // Rename selector with macro
-    {
-      // Input
-      R"cpp(
+                      },
+                      // Rename selector with macro
+                      {
+                          // Input
+                          R"cpp(
         #define mySelector - (int)performAction:(int)action with:(int)value
         @interface Foo
         ^mySelector;
@@ -936,15 +935,15 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-      // New name
-      "performNewAction:by:",
-      // Expected error
-      std::nullopt,
-    },
-    // Rename selector in macro definition
-    {
-      // Input
-      R"cpp(
+                          // New name
+                          "performNewAction:by:",
+                          // Expected error
+                          std::nullopt,
+                      },
+                      // Rename selector in macro definition
+                      {
+                          // Input
+                          R"cpp(
         #define mySelector - (int)perform^Action:(int)action with:(int)value
         @interface Foo
         mySelector;
@@ -955,18 +954,20 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-      // New name
-      "performNewAction:by:",
-      // Expected error
-      std::nullopt,
-    },
-    // Don't rename `@selector`
-    // `@selector` is not tied to a single selector. Eg. there might be multiple
-    // classes in the codebase that implement that selector. It's thus more like
-    // a string literal and we shouldn't rename it.
-    {
-      // Input
-      R"cpp(
+                          // New name
+                          "performNewAction:by:",
+                          // Expected error
+                          std::nullopt,
+                      },
+                      // Don't rename `@selector`
+                      // `@selector` is not tied to a single selector. Eg. there
+                      // might be multiple
+                      // classes in the codebase that implement that selector.
+                      // It's thus more like
+                      // a string literal and we shouldn't rename it.
+                      {
+                          // Input
+                          R"cpp(
         @interface Foo
         - (void)performA^ction:(int)action with:(int)value;
         @end
@@ -976,10 +977,10 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-      // New name
-      "performNewAction:by:",
-      // Expected
-      R"cpp(
+                          // New name
+                          "performNewAction:by:",
+                          // Expected
+                          R"cpp(
         @interface Foo
         - (void)performNewAction:(int)action by:(int)value;
         @end
@@ -989,11 +990,11 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-    },
-    // Fail if rename initiated inside @selector
-    {
-      // Input
-      R"cpp(
+                      },
+                      // Fail if rename initiated inside @selector
+                      {
+                          // Input
+                          R"cpp(
         @interface Foo
         - (void)performAction:(int)action with:(int)value;
         @end
@@ -1003,12 +1004,11 @@ TEST(RenameTest, ObjCWithinFileRename) {
         }
         @end
       )cpp",
-      // New name
-      "performNewAction:by:",
-      // Expected
-      std::nullopt,
-    }
-  };
+                          // New name
+                          "performNewAction:by:",
+                          // Expected
+                          std::nullopt,
+                      }};
   for (TestCase T : Tests) {
     SCOPED_TRACE(T.Input);
     Annotations Code(T.Input);
@@ -1024,8 +1024,8 @@ TEST(RenameTest, ObjCWithinFileRename) {
         ASSERT_TRUE(bool(RenameResult)) << RenameResult.takeError();
         ASSERT_EQ(1u, RenameResult->GlobalChanges.size());
         EXPECT_EQ(
-                  applyEdits(std::move(RenameResult->GlobalChanges)).front().second,
-                  *Expected);
+            applyEdits(std::move(RenameResult->GlobalChanges)).front().second,
+            *Expected);
       } else {
         ASSERT_FALSE(bool(RenameResult));
         consumeError(RenameResult.takeError());

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -103,6 +103,13 @@ std::string expectedResult(Annotations Test, llvm::StringRef NewName) {
   return Result;
 }
 
+std::vector<SymbolRange> symbolRanges(llvm::ArrayRef<Range> Ranges) {
+  std::vector<SymbolRange> Result;
+  for (const auto &R : Ranges)
+    Result.emplace_back(R);
+  return Result;
+}
+
 TEST(RenameTest, WithinFileRename) {
   // For each "^" this test moves cursor to its location and applies renaming
   // while checking that all identifiers in [[]] ranges are also renamed.

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -560,10 +560,12 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
                                   haveRanges(Main.ranges("talk")))));
   EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::say:").ID,
                                   haveRanges(Main.ranges("say")))));
-  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::categoryMethod").ID,
-                                  ElementsAre(isSpelled()))));
-  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
-                                  ElementsAre(Not(isSpelled())))));
+  EXPECT_THAT(Refs,
+              Contains(Pair(findSymbol(Symbols, "Person::categoryMethod").ID,
+                            ElementsAre(isSpelled()))));
+  EXPECT_THAT(Refs,
+              Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
+                            ElementsAre(Not(isSpelled())))));
 }
 
 TEST_F(SymbolCollectorTest, ObjCSymbols) {

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -105,6 +105,9 @@ MATCHER(refRange, "") {
 MATCHER_P2(OverriddenBy, Subject, Object, "") {
   return arg == Relation{Subject.ID, RelationKind::OverriddenBy, Object.ID};
 }
+MATCHER(isSpelled, "") {
+  return static_cast<bool>(arg.Kind & RefKind::Spelled);
+}
 ::testing::Matcher<const std::vector<Ref> &>
 haveRanges(const std::vector<Range> Ranges) {
   return ::testing::UnorderedPointwise(refRange(), Ranges);
@@ -522,6 +525,45 @@ TEST_F(SymbolCollectorTest, templateArgs) {
           Contains(AllOf(qName("Foz"), templateArgs("<T, T>"),
                          declRange(Header.range("parampacktempltemplpartial")),
                          forCodeCompletion(false)))));
+}
+
+TEST_F(SymbolCollectorTest, ObjCRefs) {
+  Annotations Header(R"(
+  @interface Person
+  - (void)$talk[[talk]];
+  - (void)$say[[say]]:(id)something;
+  @end
+  @interface Person (Category)
+  - (void)categoryMethod;
+  - (void)multiArg:(id)a method:(id)b;
+  @end
+  )");
+  Annotations Main(R"(
+  @implementation Person
+  - (void)$talk[[talk]] {}
+  - (void)$say[[say]]:(id)something {}
+  @end
+
+  void fff(Person *p) {
+    [p $talk[[talk]]];
+    [p $say[[say]]:0];
+    [p categoryMethod];
+    [p multiArg:0 method:0];
+  }
+  )");
+  CollectorOpts.RefFilter = RefKind::All;
+  CollectorOpts.CollectMainFileRefs = true;
+  TestFileName = testPath("test.m");
+  runSymbolCollector(Header.code(), Main.code(),
+                     {"-fblocks", "-xobjective-c++", "-Wno-objc-root-class"});
+  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::talk").ID,
+                                  haveRanges(Main.ranges("talk")))));
+  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::say:").ID,
+                                  haveRanges(Main.ranges("say")))));
+  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::categoryMethod").ID,
+                                  ElementsAre(isSpelled()))));
+  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
+                                  ElementsAre(Not(isSpelled())))));
 }
 
 TEST_F(SymbolCollectorTest, ObjCSymbols) {

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -565,7 +565,7 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
                             ElementsAre(isSpelled()))));
   EXPECT_THAT(Refs,
               Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
-                            ElementsAre(Not(isSpelled())))));
+                            ElementsAre(isSpelled()))));
 }
 
 TEST_F(SymbolCollectorTest, ObjCSymbols) {


### PR DESCRIPTION
This is based on  top of #76410 