### PR TITLE
[libc++] Fixes istream::sync.

### DIFF
--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -1009,17 +1009,18 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::unget() {
 template <class _CharT, class _Traits>
 int basic_istream<_CharT, _Traits>::sync() {
   ios_base::iostate __state = ios_base::goodbit;
-  int __r                   = 0;
   sentry __sen(*this, true);
+  if (this->rdbuf() == nullptr)
+    return -1;
+
+  int __r = 0;
   if (__sen) {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      if (this->rdbuf() == nullptr)
-        return -1;
       if (this->rdbuf()->pubsync() == -1) {
         __state |= ios_base::badbit;
-        return -1;
+        __r = -1;
       }
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
@@ -13,7 +13,7 @@
 // The fix for bug 51497 and bug 51499 require and updated dylib due to
 // explicit instantiations. That means Apple backdeployment targets remain
 // broken.
-// UNSUPPORTED: using-built-library-before-llvm-19
+// XFAIL: using-built-library-before-llvm-19
 
 #include <istream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
@@ -13,7 +13,8 @@
 // The fix for bug 51497 and bug 51499 require and updated dylib due to
 // explicit instantiations. That means Apple backdeployment targets remain
 // broken.
-// XFAIL: using-built-library-before-llvm-19
+// TODO(#82107) Enable XFAIL.
+// UNSUPPORTED: using-built-library-before-llvm-19
 
 #include <istream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/sync.pass.cpp
@@ -10,6 +10,11 @@
 
 // int sync();
 
+// The fix for bug 51497 and bug 51499 require and updated dylib due to
+// explicit instantiations. That means Apple backdeployment targets remain
+// broken.
+// UNSUPPORTED: using-built-library-before-llvm-19
+
 #include <istream>
 #include <cassert>
 
@@ -47,6 +52,18 @@ protected:
         return 5;
     }
 };
+
+template <class CharT>
+struct testbuf_pubsync_error
+    : public std::basic_streambuf<CharT>
+{
+public:
+
+    testbuf_pubsync_error() {}
+protected:
+    virtual int sync() { return -1; }
+};
+
 
 #ifndef TEST_HAS_NO_EXCEPTIONS
 struct testbuf_exception { };
@@ -86,20 +103,61 @@ protected:
 int main(int, char**)
 {
     {
+        std::istream is(nullptr);
+        assert(is.sync() == -1);
+    }
+    {
         testbuf<char> sb(" 123456789");
         std::istream is(&sb);
         assert(is.sync() == 0);
         assert(sync_called == 1);
     }
+    {
+        testbuf_pubsync_error<char> sb;
+        std::istream is(&sb);
+        is.exceptions(std::ios_base::failbit | std::ios_base::eofbit);
+        assert(is.sync() == -1);
+        assert( is.bad());
+        assert(!is.eof());
+        assert( is.fail());
+    }
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
+    {
+        std::wistream is(nullptr);
+        assert(is.sync() == -1);
+    }
     {
         testbuf<wchar_t> sb(L" 123456789");
         std::wistream is(&sb);
         assert(is.sync() == 0);
         assert(sync_called == 2);
     }
+    {
+        testbuf_pubsync_error<wchar_t> sb;
+        std::wistream is(&sb);
+        is.exceptions(std::ios_base::failbit | std::ios_base::eofbit);
+        assert(is.sync() == -1);
+        assert( is.bad());
+        assert(!is.eof());
+        assert( is.fail());
+    }
 #endif
 #ifndef TEST_HAS_NO_EXCEPTIONS
+    {
+        testbuf_pubsync_error<char> sb;
+        std::istream is(&sb);
+        is.exceptions(std::ios_base::badbit);
+        bool threw = false;
+        try {
+            is.sync();
+        } catch (std::ios_base::failure const&) {
+            threw = true;
+        }
+        assert( is.bad());
+        assert(!is.eof());
+        assert( is.fail());
+        assert(threw);
+    }
     {
         throwing_testbuf<char> sb(" 123456789");
         std::basic_istream<char> is(&sb);
@@ -117,6 +175,21 @@ int main(int, char**)
     }
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     {
+        testbuf_pubsync_error<wchar_t> sb;
+        std::wistream is(&sb);
+        is.exceptions(std::ios_base::badbit);
+        bool threw = false;
+        try {
+            is.sync();
+        } catch (std::ios_base::failure const&) {
+            threw = true;
+        }
+        assert( is.bad());
+        assert(!is.eof());
+        assert( is.fail());
+        assert(threw);
+    }
+    {
         throwing_testbuf<wchar_t> sb(L" 123456789");
         std::basic_istream<wchar_t> is(&sb);
         is.exceptions(std::ios_base::badbit);
@@ -131,7 +204,7 @@ int main(int, char**)
         assert( is.fail());
         assert(threw);
     }
-#endif
+#endif // TEST_HAS_NO_WIDE_CHARACTERS
 #endif // TEST_HAS_NO_EXCEPTIONS
 
     return 0;


### PR DESCRIPTION
This fixes two issues.

The return value
----------------

Based on the wording

[istream.unformatted]/37
  Effects: Behaves as an unformatted input function (as described above),
  except that it does not count the number of characters extracted and
  does not affect the value returned by subsequent calls to gcount().
  After constructing a sentry object, if rdbuf() is a null pointer,
  returns -1.

[istream.unformatted]/1
  ... It then creates an object of class sentry with the default argument
  noskipws (second) argument true. If the sentry object returns true, when
  converted to a value of type bool, the function endeavors to obtain the
  requested input. ...

It could be argued the current behaviour is correct, however constructing a istream rdbuf() == nullptr creates a sentry that returns false; its state is always bad in this case.

As mentioned in the bug report, after this change the 3 major implementations behave the same.

The setting of the state
------------------------

When pubsync returned -1 it updated the local __state variable and returned. This early return caused the state up the istream not to be updated to the new state.

Fixes: https://github.com/llvm/llvm-project/issues/51497
Fixes: https://github.com/llvm/llvm-project/issues/51499