### PR TITLE
[Serialization] Fix instantiated default arguments

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -5293,8 +5293,10 @@ void ASTWriter::WriteDeclUpdatesBlocks(RecordDataImpl &OffsetsRecord) {
         break;
 
       case UPD_CXX_INSTANTIATED_DEFAULT_ARGUMENT:
-        Record.AddStmt(const_cast<Expr *>(
-            cast<ParmVarDecl>(Update.getDecl())->getDefaultArg()));
+        // Do not use ParmVarDecl::getDefaultArg(): It strips the outermost
+        // FullExpr, such as ExprWithCleanups.
+        Record.AddStmt(
+            const_cast<Expr *>(cast<ParmVarDecl>(Update.getDecl())->getInit()));
         break;
 
       case UPD_CXX_INSTANTIATED_DEFAULT_MEMBER_INITIALIZER:

--- a/clang/test/Modules/pr68702.cpp
+++ b/clang/test/Modules/pr68702.cpp
@@ -1,0 +1,65 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t %t/main.cpp -o %t/main.o
+
+//--- V.h
+#ifndef V_H
+#define V_H
+
+class A {
+public:
+  constexpr A() { }
+  constexpr ~A() { }
+};
+
+template <typename T>
+class V {
+public:
+  V() = default;
+
+  constexpr V(int n, const A& a = A()) {}
+};
+
+#endif
+
+//--- inst1.h
+#include "V.h"
+
+static void inst1() {
+  V<int> v;
+}
+
+//--- inst2.h
+#include "V.h"
+
+static void inst2() {
+  V<int> v(100);
+}
+
+//--- module.modulemap
+module "M" {
+  export *
+  module "V.h" {
+    export *
+    header "V.h"
+  }
+  module "inst1.h" {
+    export *
+    header "inst1.h"
+  }
+}
+
+module "inst2.h" {
+  export *
+  header "inst2.h"
+}
+
+//--- main.cpp
+#include "V.h"
+#include "inst2.h"
+
+static void m() {
+  static V<int> v(100);
+}


### PR DESCRIPTION
`ParmVarDecl::getDefaultArg()` strips the outermost `FullExpr`, such as `ExprWithCleanups`. This leads to an `llvm_unreachable` being executed with the added test `clang/test/Modules/pr68702.cpp`; instead use the more generic `VarDecl::getInit()` which also returns `FullExpr`'s.

Closes https://github.com/llvm/llvm-project/issues/68702