### PR TITLE
[clang] Add basic support for #embed

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -165,6 +165,8 @@ def ext_c99_feature : Extension<
   "'%0' is a C99 extension">, InGroup<C99>;
 def ext_c11_feature : Extension<
   "'%0' is a C11 extension">, InGroup<C11>;
+def ext_c23_feature : Extension<
+  "'%0' is a C23 extension">, InGroup<C23>;
 def warn_c23_compat_keyword : Warning<
  "'%0' is incompatible with C standards before C23">,
  InGroup<CPre23Compat>, DefaultIgnore;

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -113,6 +113,9 @@ PPKEYWORD(defined)
 PPKEYWORD(include)
 PPKEYWORD(__include_macros)
 
+// C23 6.10.2 - Binary resource inclusion
+PPKEYWORD(embed)
+
 // C99 6.10.3 - Macro Replacement.
 PPKEYWORD(define)
 PPKEYWORD(undef)

--- a/clang/include/clang/Lex/DependencyDirectivesScanner.h
+++ b/clang/include/clang/Lex/DependencyDirectivesScanner.h
@@ -70,6 +70,7 @@ enum DirectiveKind : uint8_t {
   pp_pragma_include_alias,
   pp_pragma_system_header,
   pp_include_next,
+  pp_embed,
   pp_if,
   pp_ifdef,
   pp_ifndef,

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -2689,6 +2689,9 @@ private:
   void HandleIncludeMacrosDirective(SourceLocation HashLoc, Token &Tok);
   void HandleImportDirective(SourceLocation HashLoc, Token &Tok);
   void HandleMicrosoftImportDirective(Token &Tok);
+  void HandleEmbedDirective(SourceLocation HashLoc, Token &Tok,
+                            ConstSearchDirIterator LookupFrom = nullptr,
+                            const FileEntry *LookupFromFile = nullptr);
 
 public:
   /// Check that the given module is available, producing a diagnostic if not.

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -446,6 +446,7 @@ tok::PPKeywordKind IdentifierInfo::getPPKeywordID() const {
   CASE( 5, 'i', 'e', ident);
   CASE( 5, 'i', 'd', ifdef);
   CASE( 5, 'u', 'd', undef);
+  CASE(5, 'e', 'b', embed);
 
   CASE( 6, 'a', 's', assert);
   CASE( 6, 'd', 'f', define);

--- a/clang/lib/Lex/DependencyDirectivesScanner.cpp
+++ b/clang/lib/Lex/DependencyDirectivesScanner.cpp
@@ -91,6 +91,9 @@ private:
   dependency_directives_scan::Token &lexIncludeFilename(const char *&First,
                                                         const char *const End);
 
+  dependency_directives_scan::Token &lexEmbedFilename(const char *&First,
+                                                      const char *const End);
+
   void skipLine(const char *&First, const char *const End);
   void skipDirective(StringRef Name, const char *&First, const char *const End);
 
@@ -541,6 +544,11 @@ Scanner::lexIncludeFilename(const char *&First, const char *const End) {
   return CurDirToks.back();
 }
 
+dependency_directives_scan::Token &
+Scanner::lexEmbedFilename(const char *&First, const char *const End) {
+  return lexIncludeFilename(First, End);
+}
+
 void Scanner::lexPPDirectiveBody(const char *&First, const char *const End) {
   while (true) {
     const dependency_directives_scan::Token &Tok = lexToken(First, End);
@@ -875,6 +883,7 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
   auto Kind = llvm::StringSwitch<DirectiveKind>(Id)
                   .Case("include", pp_include)
                   .Case("__include_macros", pp___include_macros)
+                  .Case("embed", pp_embed)
                   .Case("define", pp_define)
                   .Case("undef", pp_undef)
                   .Case("import", pp_import)
@@ -902,6 +911,9 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
   case pp_include_next:
   case pp_import:
     lexIncludeFilename(First, End);
+    break;
+  case pp_embed:
+    lexEmbedFilename(First, End);
     break;
   default:
     break;

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -4541,6 +4541,7 @@ bool Lexer::LexDependencyDirectiveTokenWhileSkipping(Token &Result) {
       llvm_unreachable("unexpected 'pp_none'");
     case pp_include:
     case pp___include_macros:
+    case pp_embed:
     case pp_define:
     case pp_undef:
     case pp_import:


### PR DESCRIPTION
This patch takes the first steps toward C23 #embed support. We can include binary files, but embed-parameter-sequences are not implemented. Adding the embedded file to the -M dependency array is also not implemented.