### PR TITLE
[clang][ASTImporter] import InstantiatedFromMember of ClassTemplateSpecializationDecl

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6141,6 +6141,11 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
                                                   InsertPos))
       // Add this partial specialization to the class template.
       ClassTemplate->AddPartialSpecialization(PartSpec2, InsertPos);
+    if (Expected<ClassTemplatePartialSpecializationDecl *> ToInstOrErr =
+            import(PartialSpec->getInstantiatedFromMember()))
+      PartSpec2->setInstantiatedFromMember(*ToInstOrErr);
+    else
+      return ToInstOrErr.takeError();
 
     updateLookupTableForTemplateParameters(*ToTPList);
   } else { // Not a partial specialization.


### PR DESCRIPTION
import of `ClassTemplateSpecializationDecl` didn't set `InstantiatedFromMember` and this makes ast-dump crash. import and set `InstantiatedFromMember`. fix [issue](https://github.com/llvm/llvm-project/issues/76469)