### PR TITLE
[LoopInfo][NewPM] Print function name in LoopPrinterPass

### DIFF
--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -969,7 +969,9 @@ LoopInfo LoopAnalysis::run(Function &F, FunctionAnalysisManager &AM) {
 
 PreservedAnalyses LoopPrinterPass::run(Function &F,
                                        FunctionAnalysisManager &AM) {
-  AM.getResult<LoopAnalysis>(F).print(OS);
+  auto &LI = AM.getResult<LoopAnalysis>(F);
+  OS << "Loop info for function '" << F.getName() << "':\n";
+  LI.print(OS);
   return PreservedAnalyses::all();
 }
 

--- a/llvm/test/Analysis/LoopInfo/annotated-parallel-simple.ll
+++ b/llvm/test/Analysis/LoopInfo/annotated-parallel-simple.ll
@@ -33,5 +33,5 @@ for.end:
 !7 = distinct !{!7, !9} ; LoopID
 !9 = !{!"llvm.loop.parallel_accesses", !6}
 
-
-; CHECK: Parallel Loop
+; CHECK: Loop info for function 'func':
+; CHECK: Parallel Loop at depth 1 containing:


### PR DESCRIPTION
The legacy pass manager printed the function name when printing
loop info (via -analyze option). Like this:

Printing analysis 'Natural Loop Information' for function 'func':
Loop at depth 1 containing: ...
    Loop at depth 2 containing: ...

Make sure we print such a first line including the function name
also when using the new pass manager version of LoopPrinterPass.

The format of the string is changed slightly, so now we say:

Loop info for function 'func':
Loop at depth 1 containing: ...
    Loop at depth 2 containing: ...

This was originally requested in
  https://discourse.llvm.org/t/need-usage-help-w-new-pass-manager-for-opt-analysis-natural-loop-information/75874/7
and also mentioned in
  https://github.com/llvm/llvm-project/issues/76762