### PR TITLE
[libc++] Fixes valarray proxy type compound assignment operations.

### DIFF
--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -734,6 +734,50 @@ template <class _Tp>
 struct __is_val_expr<valarray<_Tp> > : true_type {};
 
 template <class _Tp>
+struct __is_val_expr<slice_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __is_val_expr<gslice_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __is_val_expr<mask_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __is_val_expr<indirect_array<_Tp> > : true_type {};
+
+// The functions using a __val_expr access the elements by their index.
+// valarray and the libc++ lazy proxies have an operator[]. The
+// Standard proxy array's don't have this operator, instead they have a
+// implementation specific accessor
+//   __get(size_t)
+//
+// The functions use the non-member function
+//   __get(__val_expr, size_t)
+//
+// If the __val_expr is a specialization of __val_expr_use_member_functions it
+// uses the __val_expr's member function
+//   __get(size_t)
+// else it uses the __val_expr's member function
+//   operator[](size_t)
+template <class _ValExpr>
+struct __val_expr_use_member_functions;
+
+template <class>
+struct __val_expr_use_member_functions : false_type {};
+
+template <class _Tp>
+struct __val_expr_use_member_functions<slice_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __val_expr_use_member_functions<gslice_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __val_expr_use_member_functions<mask_array<_Tp> > : true_type {};
+
+template <class _Tp>
+struct __val_expr_use_member_functions<indirect_array<_Tp> > : true_type {};
+
+template <class _Tp>
 class _LIBCPP_TEMPLATE_VIS valarray {
 public:
   typedef _Tp value_type;
@@ -903,6 +947,18 @@ template <class _Tp, size_t _Size>
 valarray(const _Tp (&)[_Size], size_t) -> valarray<_Tp>;
 #endif
 
+template <class _Expr,
+          __enable_if_t<__is_val_expr<_Expr>::value && __val_expr_use_member_functions<_Expr>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI typename _Expr::value_type __get(const _Expr& __v, size_t __i) {
+  return __v.__get(__i);
+}
+
+template <class _Expr,
+          __enable_if_t<__is_val_expr<_Expr>::value && !__val_expr_use_member_functions<_Expr>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI typename _Expr::value_type __get(const _Expr& __v, size_t __i) {
+  return __v[__i];
+}
+
 extern template _LIBCPP_EXPORTED_FROM_ABI void valarray<size_t>::resize(size_t, size_t);
 
 template <class _Op, class _Tp>
@@ -1024,6 +1080,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI void operator=(const value_type& __x) const;
 
   _LIBCPP_HIDE_FROM_ABI void operator=(const valarray<value_type>& __va) const;
+
+  // Behaves like __val_expr::operator[], which returns by value.
+  _LIBCPP_HIDE_FROM_ABI value_type __get(size_t __i) const {
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__i < __size_, "slice_array.__get() index out of bounds");
+    return __vp_[__i * __stride_];
+  }
 
 private:
   _LIBCPP_HIDE_FROM_ABI slice_array(const slice& __sl, const valarray<value_type>& __v)
@@ -1246,6 +1308,12 @@ public:
 
   gslice_array(const gslice_array&) = default;
 
+  // Behaves like __val_expr::operator[], which returns by value.
+  _LIBCPP_HIDE_FROM_ABI value_type __get(size_t __i) const {
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__i < __1d_.size(), "gslice_array.__get() index out of bounds");
+    return __vp_[__1d_[__i]];
+  }
+
 private:
   gslice_array(const gslice& __gs, const valarray<value_type>& __v)
       : __vp_(const_cast<value_type*>(__v.__begin_)), __1d_(__gs.__1d_) {}
@@ -1424,6 +1492,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI const mask_array& operator=(const mask_array& __ma) const;
 
   _LIBCPP_HIDE_FROM_ABI void operator=(const value_type& __x) const;
+
+  // Behaves like __val_expr::operator[], which returns by value.
+  _LIBCPP_HIDE_FROM_ABI value_type __get(size_t __i) const {
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__i < __1d_.size(), "mask_array.__get() index out of bounds");
+    return __vp_[__1d_[__i]];
+  }
 
 private:
   _LIBCPP_HIDE_FROM_ABI mask_array(const valarray<bool>& __vb, const valarray<value_type>& __v)
@@ -1623,6 +1697,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI const indirect_array& operator=(const indirect_array& __ia) const;
 
   _LIBCPP_HIDE_FROM_ABI void operator=(const value_type& __x) const;
+
+  // Behaves like __val_expr::operator[], which returns by value.
+  _LIBCPP_HIDE_FROM_ABI value_type __get(size_t __i) const {
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__i < __1d_.size(), "indirect_array.__get() index out of bounds");
+    return __vp_[__1d_[__i]];
+  }
 
 private:
   _LIBCPP_HIDE_FROM_ABI indirect_array(const valarray<size_t>& __ia, const valarray<value_type>& __v)
@@ -2355,7 +2435,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator*=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t *= __v[__i];
+    *__t *= std::__get(__v,__i);
   return *this;
 }
 
@@ -2364,7 +2444,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator/=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t /= __v[__i];
+    *__t /= std::__get(__v,__i);
   return *this;
 }
 
@@ -2373,7 +2453,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator%=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t %= __v[__i];
+    *__t %= std::__get(__v, __i);
   return *this;
 }
 
@@ -2382,7 +2462,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator+=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t += __v[__i];
+    *__t += std::__get(__v, __i);
   return *this;
 }
 
@@ -2391,7 +2471,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator-=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t -= __v[__i];
+    *__t -= std::__get(__v, __i);
   return *this;
 }
 
@@ -2400,7 +2480,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator^=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t ^= __v[__i];
+    *__t ^= std::__get(__v, __i);
   return *this;
 }
 
@@ -2409,7 +2489,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator|=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t |= __v[__i];
+    *__t |= std::__get(__v, __i);
   return *this;
 }
 
@@ -2418,7 +2498,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator&=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t &= __v[__i];
+    *__t &= std::__get(__v, __i);
   return *this;
 }
 
@@ -2427,7 +2507,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator<<=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t <<= __v[__i];
+    *__t <<= std::__get(__v, __i);
   return *this;
 }
 
@@ -2436,7 +2516,7 @@ template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator>>=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
-    *__t >>= __v[__i];
+    *__t >>= std::__get(__v, __i);
   return *this;
 }
 

--- a/libcxx/test/libcxx/numerics/numarray/class.gslice.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.gslice.array/assert.get.pass.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: has-unix-headers
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
-// XFAIL: availability-verbose_abort-missing
+// XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 
 // <valarray>
 

--- a/libcxx/test/libcxx/numerics/numarray/class.gslice.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.gslice.array/assert.get.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-unix-headers
+// UNSUPPORTED: c++03
+// UNSUPPORTED: libcpp-hardening-mode=none
+// XFAIL: availability-verbose_abort-missing
+
+// <valarray>
+
+// template<class T> class gslice_array;
+
+// T __get(size_t i); // where i is out of bounds
+
+#include <valarray>
+
+#include "check_assertion.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::gslice_array<unsigned> result =
+        array[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(N), "gslice_array.__get() index out of bounds");
+  }
+  {
+    std::valarray<std::size_t> sizes(2);
+    sizes[0] = 2;
+    sizes[1] = 3;
+
+    std::valarray<std::size_t> strides(2);
+    strides[0] = 6;
+    strides[1] = 1;
+
+    std::gslice_array<unsigned> result = array[std::gslice(1, sizes, strides)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(6), "gslice_array.__get() index out of bounds");
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.gslice.array/get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.gslice.array/get.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <valarray>
+
+// template<class T> class gslice_array;
+
+// T __get(size_t i);
+
+#include <valarray>
+#include <cassert>
+
+#include "test_macros.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::gslice_array<unsigned> result =
+        array[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))];
+    for (unsigned i = 0; i < N; ++i)
+      assert(result.__get(i) == i);
+  }
+
+  {
+    std::valarray<std::size_t> sizes(2);
+    sizes[0] = 2;
+    sizes[1] = 3;
+
+    std::valarray<std::size_t> strides(2);
+    strides[0] = 6;
+    strides[1] = 1;
+
+    std::gslice_array<unsigned> result = array[std::gslice(1, sizes, strides)];
+    assert(result.__get(0) == input[1 + 0 * 6 + 0 * 1]);
+    assert(result.__get(1) == input[1 + 0 * 6 + 1 * 1]);
+    assert(result.__get(2) == input[1 + 0 * 6 + 2 * 1]);
+
+    assert(result.__get(3) == input[1 + 1 * 6 + 0 * 1]);
+    assert(result.__get(4) == input[1 + 1 * 6 + 1 * 1]);
+    assert(result.__get(5) == input[1 + 1 * 6 + 2 * 1]);
+  }
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.indirect.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.indirect.array/assert.get.pass.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: has-unix-headers
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
-// XFAIL: availability-verbose_abort-missing
+// XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 
 // <valarray>
 

--- a/libcxx/test/libcxx/numerics/numarray/class.indirect.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.indirect.array/assert.get.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-unix-headers
+// UNSUPPORTED: c++03
+// UNSUPPORTED: libcpp-hardening-mode=none
+// XFAIL: availability-verbose_abort-missing
+
+// <valarray>
+
+// template<class T> class indirect_array;
+
+// T __get(size_t i); // where i is out of bounds
+
+#include <valarray>
+
+#include "check_assertion.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::indirect_array<unsigned> result = array[std::valarray<std::size_t>()];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(0), "indirect_array.__get() index out of bounds");
+  }
+  {
+    std::indirect_array<unsigned> result = array[std::valarray<std::size_t>(std::size_t(0), std::size_t(N))];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(N), "indirect_array.__get() index out of bounds");
+  }
+
+  {
+    std::valarray<std::size_t> indirect(std::size_t(0), std::size_t(3));
+    std::indirect_array<unsigned> result = array[indirect];
+    indirect[0]                          = 4;
+    indirect[1]                          = 1;
+    indirect[2]                          = 3;
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(3), "indirect_array.__get() index out of bounds");
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.indirect.array/get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.indirect.array/get.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <valarray>
+
+// template<class T> class indirect_array;
+
+// T __get(size_t i);
+
+#include <valarray>
+#include <cassert>
+
+#include "test_macros.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::indirect_array<unsigned> result = array[std::valarray<std::size_t>(std::size_t(0), std::size_t(N))];
+    for (unsigned i = 0; i < N; ++i)
+      assert(result.__get(i) == 0);
+  }
+
+  {
+    std::valarray<std::size_t> indirect(std::size_t(0), std::size_t(3));
+    indirect[0]                          = 4;
+    indirect[1]                          = 1;
+    indirect[2]                          = 3;
+    std::indirect_array<unsigned> result = array[indirect];
+    assert(result.__get(0) == 4);
+    assert(result.__get(1) == 1);
+    assert(result.__get(2) == 3);
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.mask.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.mask.array/assert.get.pass.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: has-unix-headers
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
-// XFAIL: availability-verbose_abort-missing
+// XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 
 // <valarray>
 

--- a/libcxx/test/libcxx/numerics/numarray/class.mask.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.mask.array/assert.get.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-unix-headers
+// UNSUPPORTED: c++03
+// UNSUPPORTED: libcpp-hardening-mode=none
+// XFAIL: availability-verbose_abort-missing
+
+// <valarray>
+
+// template<class T> class mask_array;
+
+// T __get(size_t i); // where i is out of bounds
+
+#include <valarray>
+
+#include "check_assertion.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::mask_array<unsigned> result = array[std::valarray<bool>(false, N)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(0), "mask_array.__get() index out of bounds");
+  }
+  {
+    std::mask_array<unsigned> result = array[std::valarray<bool>(true, N)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(N), "mask_array.__get() index out of bounds");
+  }
+
+  {
+    std::valarray<bool> mask(false, N);
+    mask[1]                          = true;
+    mask[3]                          = true;
+    std::mask_array<unsigned> result = array[mask];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(2), "mask_array.__get() index out of bounds");
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.mask.array/get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.mask.array/get.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <valarray>
+
+// template<class T> class mask_array;
+
+// T __get(size_t i);
+
+#include <valarray>
+#include <cassert>
+
+#include "test_macros.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::mask_array<unsigned> result = array[std::valarray<bool>(true, N)];
+    for (unsigned i = 0; i < N; ++i)
+      assert(result.__get(i) == i);
+  }
+
+  {
+    std::valarray<bool> mask(false, N);
+    mask[1]                          = true;
+    mask[3]                          = true;
+    std::mask_array<unsigned> result = array[mask];
+    assert(result.__get(0) == 1);
+    assert(result.__get(1) == 3);
+  }
+
+  {
+    std::valarray<bool> mask(false, N);
+    mask[0]                          = true;
+    mask[4]                          = true;
+    std::mask_array<unsigned> result = array[mask];
+    assert(result.__get(0) == 0);
+    assert(result.__get(1) == 4);
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.slice.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.slice.array/assert.get.pass.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: has-unix-headers
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
-// XFAIL: availability-verbose_abort-missing
+// XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 
 // <valarray>
 

--- a/libcxx/test/libcxx/numerics/numarray/class.slice.array/assert.get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.slice.array/assert.get.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-unix-headers
+// UNSUPPORTED: c++03
+// UNSUPPORTED: libcpp-hardening-mode=none
+// XFAIL: availability-verbose_abort-missing
+
+// <valarray>
+
+// template<class T> class slice_array;
+
+// T __get(size_t i); // where i is out of bounds
+
+#include <valarray>
+
+#include "check_assertion.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::slice_array<unsigned> result = array[std::slice(0, 0, 0)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(0), "slice_array.__get() index out of bounds");
+  }
+  {
+    std::slice_array<unsigned> result = array[std::slice(0, N, 1)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(N), "slice_array.__get() index out of bounds");
+  }
+  {
+    std::slice_array<unsigned> result = array[std::slice(3, 2, 2)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(2), "slice_array.__get() index out of bounds");
+  }
+
+  {
+    std::slice_array<unsigned> result = array[std::slice(1, 3, 4)];
+    TEST_LIBCPP_ASSERT_FAILURE(result.__get(3), "slice_array.__get() index out of bounds");
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/numerics/numarray/class.slice.array/get.pass.cpp
+++ b/libcxx/test/libcxx/numerics/numarray/class.slice.array/get.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <valarray>
+
+// template<class T> class slice_array;
+
+// T __get(size_t i);
+
+#include <valarray>
+#include <cassert>
+
+#include "test_macros.h"
+
+int main(int, char**) {
+  unsigned input[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<unsigned> array(input, N);
+
+  {
+    std::slice_array<unsigned> result = array[std::slice(0, N, 1)];
+    for (unsigned i = 0; i < N; ++i)
+      assert(result.__get(i) == i);
+  }
+
+  {
+    std::slice_array<unsigned> result = array[std::slice(3, 2, 2)];
+    assert(result.__get(0) == 3);
+    assert(result.__get(1) == 5);
+  }
+
+  {
+    std::slice_array<unsigned> result = array[std::slice(1, 3, 4)];
+    assert(result.__get(0) == 1);
+    assert(result.__get(1) == 5);
+    assert(result.__get(2) == 9);
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/and_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/and_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator&=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {0,  2,  0,  0,  0};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 &= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {0, 2, 0, 0, 0};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value &= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/divide_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/divide_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator/=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {6, 14, 24, 36, 50};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v3 /= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {6, 14, 24, 36, 50};
+  int expected[]   = {1, 2, 3, 4, 5};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value /= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/minus_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/minus_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator-=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {7,  9, 11, 13, 15};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v3 -= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {7, 9, 11, 13, 15};
+  int expected[]   = {1, 2, 3, 4, 5};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value -= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/modulo_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/modulo_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator%=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {0,  1,  2,  1,  0};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v2 %= v1;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v2[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {6, 7, 8, 9, 10};
+  int expected[]   = {0, 1, 2, 1, 0};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value %= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {1, 2, 3, 4, 5};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/or_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/or_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator|=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {7,  7, 11, 13, 15};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 |= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {7, 7, 11, 13, 15};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value |= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/plus_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/plus_valarray.pass.cpp
@@ -12,29 +12,71 @@
 
 // valarray& operator+=(const valarray& v);
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+
 #include <valarray>
 #include <cassert>
 #include <cstddef>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {7,  9, 11, 13, 15};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 += v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {7, 9, 11, 13, 15};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value += rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/shift_left_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/shift_left_valarray.pass.cpp
@@ -10,6 +10,20 @@
 
 // template<class T> class valarray;
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
+// Validate the function works for valarray, the proxies, and __val_expr.
+//
 // valarray& operator<<=(const valarray& v);
 
 #include <valarray>
@@ -18,23 +32,51 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = { 1,   2,   3,    4,    5};
-        T a2[] = { 6,   7,   8,    9,   10};
-        T a3[] = {64, 256, 768, 2048, 5120};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 <<= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {64, 256, 768, 2048, 5120};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value <<= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/shift_right_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/shift_right_valarray.pass.cpp
@@ -10,6 +10,18 @@
 
 // template<class T> class valarray;
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
 // valarray& operator>>=(const valarray& v);
 
 #include <valarray>
@@ -18,23 +30,51 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = { 1,   2,   3,    4,    5};
-        T a2[] = { 6,   7,   8,    9,   10};
-        T a3[] = {64, 256, 768, 2048, 5120};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v3 >>= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {64, 256, 768, 2048, 5120};
+  int expected[]   = {1, 2, 3, 4, 5};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value >>= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/times_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/times_valarray.pass.cpp
@@ -10,6 +10,18 @@
 
 // template<class T> class valarray;
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
 // valarray& operator*=(const valarray& v);
 
 #include <valarray>
@@ -18,23 +30,51 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {6, 14, 24, 36, 50};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 *= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {6, 14, 24, 36, 50};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value *= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/xor_valarray.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cassign/xor_valarray.pass.cpp
@@ -10,6 +10,18 @@
 
 // template<class T> class valarray;
 
+// [valarray.syn]/3
+//   Any function returning a valarray<T> is permitted to return an object of
+//   another type, provided all the const member functions of valarray<T> are
+//   also applicable to this type.
+//
+// Libc++ uses this and returns __val_expr<_Expr> for several operations.
+//
+// The const overloads of
+//   valarray::operator[](...) const
+// return propxy objects. These proxies are implicitly convertible to
+// std::valarray.
+//
 // valarray& operator^=(const valarray& v);
 
 #include <valarray>
@@ -18,23 +30,51 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        T a1[] = {1,  2,  3,  4,  5};
-        T a2[] = {6,  7,  8,  9, 10};
-        T a3[] = {7,  5, 11, 13, 15};
-        const unsigned N = sizeof(a1)/sizeof(a1[0]);
-        std::valarray<T> v1(a1, N);
-        std::valarray<T> v2(a2, N);
-        std::valarray<T> v3(a3, N);
-        v1 ^= v2;
-        assert(v1.size() == v2.size());
-        assert(v1.size() == v3.size());
-        for (std::size_t i = 0; i < v1.size(); ++i)
-            assert(v1[i] == v3[i]);
-    }
+template <class A>
+void test(const A& rhs) {
+  int input[]      = {1, 2, 3, 4, 5};
+  int expected[]   = {7, 5, 11, 13, 15};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+  std::valarray<int> value(input, N);
+
+  value ^= rhs;
+
+  assert(value.size() == N);
+  for (std::size_t i = 0; i < value.size(); ++i)
+    assert(value[i] == expected[i]);
+}
+
+int main(int, char**) {
+  int input[]      = {6, 7, 8, 9, 10};
+  const unsigned N = sizeof(input) / sizeof(input[0]);
+
+  std::valarray<bool> mask(true, N);
+  std::size_t indices[] = {0, 1, 2, 3, 4};
+  std::valarray<std::size_t> indirect(indices, N);
+
+  std::valarray<int> zero(0, N);
+
+  {
+    std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
+
+  {
+    const std::valarray<int> value(input, N);
+
+    test(value);
+    test(value[std::slice(0, N, 1)]);
+    test(value[std::gslice(0, std::valarray<std::size_t>(N, 1), std::valarray<std::size_t>(1, 1))]);
+    test(value[mask]);
+    test(value[indirect]);
+    test(value + zero);
+  }
 
   return 0;
 }


### PR DESCRIPTION
The valarray<>::operator[](...) const functions return proxy objects. The valarray<>::operator[](...) functions return valarray objects.

However the standard allows functions returning valarray objects to return custom proxy objects instead. Libc++ returns __val_expr proxies. Functions taking a valarray object must work with the custom proxies too. Therefore several operations have a custom proxy overload instead of valarray overloads.

Libc++ doesn't specify a valarray overload. This is an issue with the standard proxy types; these can implicitly be converted to a valarray.

The solution is to allow the standard proxies to behave as-if they are custom proxies.

This patch fixes the valarray compound assignments. Other operations, like the binary non-member functions are not fixed. These will be done in a followup patch.

Fixes: https://github.com/llvm/llvm-project/issues/21320