### PR TITLE
[builtins] Fix CPU feature detection for FreeBSD on AArch64

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -34,6 +34,7 @@ _Bool __aarch64_have_lse_atomics
     __attribute__((visibility("hidden"), nocommon)) = false;
 
 #if defined(__FreeBSD__)
+#include <sys/auxv.h>
 #include "aarch64/hwcap.inc"
 #include "aarch64/lse_atomics/freebsd.inc"
 #elif defined(__Fuchsia__)

--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -34,7 +34,9 @@ _Bool __aarch64_have_lse_atomics
     __attribute__((visibility("hidden"), nocommon)) = false;
 
 #if defined(__FreeBSD__)
+// clang-format off: should not reorder sys/auxv.h alphabetically
 #include <sys/auxv.h>
+// clang-format on
 #include "aarch64/hwcap.inc"
 #include "aarch64/lse_atomics/freebsd.inc"
 #elif defined(__Fuchsia__)


### PR DESCRIPTION
This is a follow-up to #75635 which broke the build for FreeBSD on AArch64:

```
compiler-rt/lib/builtins/cpu_model/aarch64/lse_atomics/freebsd.inc:3:16: error: call to undeclared function 'elf_aux_info'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    3 |   int result = elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
      |                ^
```

Using `elf_aux_info()` requires including `<sys/auxv.h>` first. To prevent redeclaration issues with `hwcap.inc` attempting to define `HWCAP_xxx` macros before `<sys/auxv.h>` does so, include `<sys/auxv.h>` before any of the `.inc` files on FreeBSD.