### PR TITLE
[flang] Fix parsing time explosion

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1151,8 +1151,9 @@ TYPE_PARSER(construct<PartRef>(name,
 
 // R913 structure-component -> data-ref
 // The final part-ref in the data-ref is not allowed to have subscripts.
-TYPE_PARSER(construct<StructureComponent>(
-    construct<DataRef>(some(Parser<PartRef>{} / percentOrDot)), name))
+TYPE_CONTEXT_PARSER("component"_en_US,
+    construct<StructureComponent>(
+        construct<DataRef>(some(Parser<PartRef>{} / percentOrDot)), name))
 
 // R919 subscript -> scalar-int-expr
 constexpr auto subscript{scalarIntExpr};


### PR DESCRIPTION
When parsing a deeply-nested expression like
  A1(A2(A3(A4(A5(A6(...A99(i)...))))))
the parser can get into an exponential state due to the need to consider the possibility that each "An(...)" might be the beginning of a reference to a procedure component ("An(...)%PROC(...)") so that alternative has to be attempted first before proceeding to try parsing "An(...)" as a function reference or as an array element designator.  The parser for a structure component, which is used by the procedure designator parser, was not protected with the usual failure memoization technique, leading to exponentially bad behavior parsing a deeply-nested expression.  Fix by exploiting the instrumented() parser combinator so that failed structure component parsers aren't repeated.

Fixes https://github.com/llvm/llvm-project/issues/76477.