### PR TITLE
[libcxx] renames some template type parameters

### DIFF
--- a/libcxx/docs/Contributing.rst
+++ b/libcxx/docs/Contributing.rst
@@ -45,6 +45,22 @@ other implementations (e.g. system headers), the test in
 ``libcxx/test/libcxx/system_reserved_names.gen.py`` contains the list of
 reserved names that can't be used.
 
+We use the following names to refer to various tempalate type parameters:
+
+* ``_Iter``, to refer to an iterator type. Some alterations are used if multiple
+  iterators with different categories appear in the same template:
+  * ``_InIter`` to disambiguate input iterators
+  * ``_ForwardIter`` to disambiguate input iterators
+  * ``_BiIter`` to disambiguate input iterators
+  * ``_RandomIter`` to disambiguate input iterators
+  * ``_ContgiuousIter`` to disambiguate input iterators
+  * ``_OutIter`` to disambiguate output iterators
+* ``_Sent``, to refer to sentinels
+* ``_Func``, to refer to arbitrary invocable objects
+* ``_Pred``, to refer to predicates
+* ``_Comp``, to refer to comparators
+* ``_Proj``, to refer to projections
+
 Unqualified function calls are susceptible to
 `argument-dependent lookup (ADL) <https://en.cppreference.com/w/cpp/language/adl>`_.
 This means calling ``move(UserType)`` might not call ``std::move``. Therefore,

--- a/libcxx/include/__algorithm/fold.h
+++ b/libcxx/include/__algorithm/fold.h
@@ -37,50 +37,53 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 namespace ranges {
-template <class _Ip, class _Tp>
+template <class _Iter, class _Tp>
 struct in_value_result {
-  _LIBCPP_NO_UNIQUE_ADDRESS _Ip in;
+  _LIBCPP_NO_UNIQUE_ADDRESS _Iter in;
   _LIBCPP_NO_UNIQUE_ADDRESS _Tp value;
 
   template <class _I2, class _T2>
-    requires convertible_to<const _Ip&, _I2> && convertible_to<const _Tp&, _T2>
+    requires convertible_to<const _Iter&, _I2> && convertible_to<const _Tp&, _T2>
   _LIBCPP_HIDE_FROM_ABI constexpr operator in_value_result<_I2, _T2>() const& {
     return {in, value};
   }
 
   template <class _I2, class _T2>
-    requires convertible_to<_Ip, _I2> && convertible_to<_Tp, _T2>
+    requires convertible_to<_Iter, _I2> && convertible_to<_Tp, _T2>
   _LIBCPP_HIDE_FROM_ABI constexpr operator in_value_result<_I2, _T2>() && {
     return {std::move(in), std::move(value)};
   }
 };
 
-template <class _Ip, class _Tp>
-using fold_left_with_iter_result = in_value_result<_Ip, _Tp>;
+template <class _Iter, class _Tp>
+using fold_left_with_iter_result = in_value_result<_Iter, _Tp>;
 
-template <class _Fp, class _Tp, class _Ip, class _Rp, class _Up = decay_t<_Rp>>
+template <class _Func, class _Tp, class _Iter, class _Rp, class _Up = decay_t<_Rp>>
 concept __indirectly_binary_left_foldable_impl =
-    convertible_to<_Rp, _Up> &&                    //
-    movable<_Tp> &&                                //
-    movable<_Up> &&                                //
-    convertible_to<_Tp, _Up> &&                    //
-    invocable<_Fp&, _Up, iter_reference_t<_Ip>> && //
-    assignable_from<_Up&, invoke_result_t<_Fp&, _Up, iter_reference_t<_Ip>>>;
+    convertible_to<_Rp, _Up> &&                        //
+    movable<_Tp> &&                                    //
+    movable<_Up> &&                                    //
+    convertible_to<_Tp, _Up> &&                        //
+    invocable<_Func&, _Up, iter_reference_t<_Iter>> && //
+    assignable_from<_Up&, invoke_result_t<_Func&, _Up, iter_reference_t<_Iter>>>;
 
-template <class _Fp, class _Tp, class _Ip>
+template <class _Func, class _Tp, class _Iter>
 concept __indirectly_binary_left_foldable =
-    copy_constructible<_Fp> &&                     //
-    invocable<_Fp&, _Tp, iter_reference_t<_Ip>> && //
-    __indirectly_binary_left_foldable_impl<_Fp, _Tp, _Ip, invoke_result_t<_Fp&, _Tp, iter_reference_t<_Ip>>>;
+    copy_constructible<_Func> &&                       //
+    invocable<_Func&, _Tp, iter_reference_t<_Iter>> && //
+    __indirectly_binary_left_foldable_impl<_Func, _Tp, _Iter, invoke_result_t<_Func&, _Tp, iter_reference_t<_Iter>>>;
 
 struct __fold_left_with_iter {
-  template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, __indirectly_binary_left_foldable<_Tp, _Ip> _Fp>
+  template <input_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
+            class _Tp,
+            __indirectly_binary_left_foldable<_Tp, _Iter> _Func>
   _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
-    using _Up = decay_t<invoke_result_t<_Fp&, _Tp, iter_reference_t<_Ip>>>;
+  operator()(_Iter __first, _Sent __last, _Tp __init, _Func __f) {
+    using _Up = decay_t<invoke_result_t<_Func&, _Tp, iter_reference_t<_Iter>>>;
 
     if (__first == __last) {
-      return fold_left_with_iter_result<_Ip, _Up>{std::move(__first), _Up(std::move(__init))};
+      return fold_left_with_iter_result<_Iter, _Up>{std::move(__first), _Up(std::move(__init))};
     }
 
     _Up __result = std::invoke(__f, std::move(__init), *__first);
@@ -88,14 +91,14 @@ struct __fold_left_with_iter {
       __result = std::invoke(__f, std::move(__result), *__first);
     }
 
-    return fold_left_with_iter_result<_Ip, _Up>{std::move(__first), std::move(__result)};
+    return fold_left_with_iter_result<_Iter, _Up>{std::move(__first), std::move(__result)};
   }
 
-  template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Fp>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
+  template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Func>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Func __f) {
     auto __result = operator()(ranges::begin(__r), ranges::end(__r), std::move(__init), std::ref(__f));
 
-    using _Up = decay_t<invoke_result_t<_Fp&, _Tp, range_reference_t<_Rp>>>;
+    using _Up = decay_t<invoke_result_t<_Func&, _Tp, range_reference_t<_Rp>>>;
     return fold_left_with_iter_result<borrowed_iterator_t<_Rp>, _Up>{std::move(__result.in), std::move(__result.value)};
   }
 };
@@ -103,14 +106,17 @@ struct __fold_left_with_iter {
 inline constexpr auto fold_left_with_iter = __fold_left_with_iter();
 
 struct __fold_left {
-  template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, __indirectly_binary_left_foldable<_Tp, _Ip> _Fp>
+  template <input_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
+            class _Tp,
+            __indirectly_binary_left_foldable<_Tp, _Iter> _Func>
   _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
+  operator()(_Iter __first, _Sent __last, _Tp __init, _Func __f) {
     return fold_left_with_iter(std::move(__first), std::move(__last), std::move(__init), std::ref(__f)).value;
   }
 
-  template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Fp>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
+  template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Func>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Func __f) {
     return fold_left_with_iter(ranges::begin(__r), ranges::end(__r), std::move(__init), std::ref(__f)).value;
   }
 };

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/serial.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/serial.h
@@ -30,9 +30,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace __par_backend {
 inline namespace __serial_cpu_backend {
 
-template <class _RandomAccessIterator, class _Fp>
+template <class _RandomAccessIterator, class _Func>
 _LIBCPP_HIDE_FROM_ABI optional<__empty>
-__parallel_for(_RandomAccessIterator __first, _RandomAccessIterator __last, _Fp __f) {
+__parallel_for(_RandomAccessIterator __first, _RandomAccessIterator __last, _Func __f) {
   __f(__first, __last);
   return __empty{};
 }

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/thread.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/thread.h
@@ -33,9 +33,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace __par_backend {
 inline namespace __thread_cpu_backend {
 
-template <class _RandomAccessIterator, class _Fp>
+template <class _RandomAccessIterator, class _Func>
 _LIBCPP_HIDE_FROM_ABI optional<__empty>
-__parallel_for(_RandomAccessIterator __first, _RandomAccessIterator __last, _Fp __f) {
+__parallel_for(_RandomAccessIterator __first, _RandomAccessIterator __last, _Func __f) {
   __f(__first, __last);
   return __empty{};
 }

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -29,8 +29,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class _Ip, class _Op>
-using copy_backward_result = in_out_result<_Ip, _Op>;
+template <class __InIter, class _OutIter>
+using copy_backward_result = in_out_result<_InIter, _OutIter>;
 
 namespace __copy_backward {
 struct __fn {

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -29,7 +29,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class __InIter, class _OutIter>
+template <class _InIter, class _OutIter>
 using copy_backward_result = in_out_result<_InIter, _OutIter>;
 
 namespace __copy_backward {

--- a/libcxx/include/__algorithm/ranges_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_copy_if.h
@@ -30,8 +30,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class _Ip, class _Op>
-using copy_if_result = in_out_result<_Ip, _Op>;
+template <class _InIter, class _OutIter>
+using copy_if_result = in_out_result<_InIter, _OutIter>;
 
 namespace __copy_if {
 struct __fn {

--- a/libcxx/include/__algorithm/ranges_copy_n.h
+++ b/libcxx/include/__algorithm/ranges_copy_n.h
@@ -31,8 +31,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class _Ip, class _Op>
-using copy_n_result = in_out_result<_Ip, _Op>;
+template <class _InIter, class _OutIter>
+using copy_n_result = in_out_result<_InIter, _OutIter>;
 
 namespace __copy_n {
 struct __fn {
@@ -55,10 +55,10 @@ struct __fn {
     return {__ret.first, __ret.second};
   }
 
-  template <input_iterator _Ip, weakly_incrementable _Op>
-    requires indirectly_copyable<_Ip, _Op>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_n_result<_Ip, _Op>
-  operator()(_Ip __first, iter_difference_t<_Ip> __n, _Op __result) const {
+  template <input_iterator _InIter, weakly_incrementable _OutIter>
+    requires indirectly_copyable<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI constexpr copy_n_result<_InIter, _OutIter>
+  operator()(_InIter __first, iter_difference_t<_InIter> __n, _OutIter __result) const {
     return __go(std::move(__first), __n, std::move(__result));
   }
 };

--- a/libcxx/include/__algorithm/ranges_find.h
+++ b/libcxx/include/__algorithm/ranges_find.h
@@ -47,10 +47,10 @@ struct __fn {
     }
   }
 
-  template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, class _Proj = identity>
-    requires indirect_binary_predicate<ranges::equal_to, projected<_Ip, _Proj>, const _Tp*>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, const _Tp& __value, _Proj __proj = {}) const {
+  template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Tp, class _Proj = identity>
+    requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Tp*>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __first, _Sent __last, const _Tp& __value, _Proj __proj = {}) const {
     return __find_unwrap(std::move(__first), std::move(__last), __value, __proj);
   }
 

--- a/libcxx/include/__algorithm/ranges_find_if.h
+++ b/libcxx/include/__algorithm/ranges_find_if.h
@@ -30,8 +30,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class _Ip, class _Sp, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI constexpr _Ip __find_if_impl(_Ip __first, _Sp __last, _Pred& __pred, _Proj& __proj) {
+template <class _Iter, class _Sent, class _Pred, class _Proj>
+_LIBCPP_HIDE_FROM_ABI constexpr _Iter __find_if_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (std::invoke(__pred, std::invoke(__proj, *__first)))
       break;
@@ -41,12 +41,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Ip __find_if_impl(_Ip __first, _Sp __last, _Pre
 
 namespace __find_if {
 struct __fn {
-  template <input_iterator _Ip,
-            sentinel_for<_Ip> _Sp,
+  template <input_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
             class _Proj = identity,
-            indirect_unary_predicate<projected<_Ip, _Proj>> _Pred>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
+            indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return ranges::__find_if_impl(std::move(__first), std::move(__last), __pred, __proj);
   }
 

--- a/libcxx/include/__algorithm/ranges_find_if_not.h
+++ b/libcxx/include/__algorithm/ranges_find_if_not.h
@@ -33,12 +33,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 namespace __find_if_not {
 struct __fn {
-  template <input_iterator _Ip,
-            sentinel_for<_Ip> _Sp,
+  template <input_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
             class _Proj = identity,
-            indirect_unary_predicate<projected<_Ip, _Proj>> _Pred>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
+            indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     auto __pred2 = [&](auto&& __e) -> bool { return !std::invoke(__pred, std::forward<decltype(__e)>(__e)); };
     return ranges::__find_if_impl(std::move(__first), std::move(__last), __pred2, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_max_element.h
+++ b/libcxx/include/__algorithm/ranges_max_element.h
@@ -31,12 +31,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 namespace __max_element {
 struct __fn {
-  template <forward_iterator _Ip,
-            sentinel_for<_Ip> _Sp,
-            class _Proj                                             = identity,
-            indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  template <forward_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
+            class _Proj                                               = identity,
+            indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __comp_lhs_rhs_swapped = [&](auto&& __lhs, auto&& __rhs) -> bool { return std::invoke(__comp, __rhs, __lhs); };
     return ranges::__min_element_impl(__first, __last, __comp_lhs_rhs_swapped, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_min_element.h
+++ b/libcxx/include/__algorithm/ranges_min_element.h
@@ -31,12 +31,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 // TODO(ranges): `ranges::min_element` can now simply delegate to `std::__min_element`.
-template <class _Ip, class _Sp, class _Proj, class _Comp>
-_LIBCPP_HIDE_FROM_ABI constexpr _Ip __min_element_impl(_Ip __first, _Sp __last, _Comp& __comp, _Proj& __proj) {
+template <class _Iter, class _Sent, class _Proj, class _Comp>
+_LIBCPP_HIDE_FROM_ABI constexpr _Iter __min_element_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
   if (__first == __last)
     return __first;
 
-  _Ip __i = __first;
+  _Iter __i = __first;
   while (++__i != __last)
     if (std::invoke(__comp, std::invoke(__proj, *__i), std::invoke(__proj, *__first)))
       __first = __i;
@@ -45,12 +45,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Ip __min_element_impl(_Ip __first, _Sp __last, 
 
 namespace __min_element {
 struct __fn {
-  template <forward_iterator _Ip,
-            sentinel_for<_Ip> _Sp,
-            class _Proj                                             = identity,
-            indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  template <forward_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
+            class _Proj                                               = identity,
+            indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return ranges::__min_element_impl(__first, __last, __comp, __proj);
   }
 

--- a/libcxx/include/__algorithm/ranges_minmax_element.h
+++ b/libcxx/include/__algorithm/ranges_minmax_element.h
@@ -39,12 +39,12 @@ using minmax_element_result = min_max_result<_T1>;
 
 namespace __minmax_element {
 struct __fn {
-  template <forward_iterator _Ip,
-            sentinel_for<_Ip> _Sp,
-            class _Proj                                             = identity,
-            indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_element_result<_Ip>
-  operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  template <forward_iterator _Iter,
+            sentinel_for<_Iter> _Sent,
+            class _Proj                                               = identity,
+            indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
+  _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_element_result<_Iter>
+  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__minmax_element_impl(std::move(__first), std::move(__last), __comp, __proj);
     return {__ret.first, __ret.second};
   }

--- a/libcxx/include/__algorithm/ranges_transform.h
+++ b/libcxx/include/__algorithm/ranges_transform.h
@@ -32,11 +32,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-template <class _Ip, class _Op>
-using unary_transform_result = in_out_result<_Ip, _Op>;
+template <class _InIter, class _OutIter>
+using unary_transform_result = in_out_result<_InIter, _OutIter>;
 
-template <class _I1, class _I2, class _O1>
-using binary_transform_result = in_in_out_result<_I1, _I2, _O1>;
+template <class _InIter1, class _InIter2, class _OutIter>
+using binary_transform_result = in_in_out_result<_InIter1, _InIter2, _OutIter>;
 
 namespace __transform {
 struct __fn {

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -161,44 +161,47 @@ struct __mu_return
           0 < is_placeholder<_Ti>::value && is_placeholder<_Ti>::value <= tuple_size<_TupleUj>::value,
           _TupleUj> {};
 
-template <class _Fp, class _BoundArgs, class _TupleUj>
+template <class _Func, class _BoundArgs, class _TupleUj>
 struct __is_valid_bind_return {
   static const bool value = false;
 };
 
-template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __is_valid_bind_return<_Fp, tuple<_BoundArgs...>, _TupleUj> {
-  static const bool value = __invokable<_Fp, typename __mu_return<_BoundArgs, _TupleUj>::type...>::value;
+template <class _Func, class... _BoundArgs, class _TupleUj>
+struct __is_valid_bind_return<_Func, tuple<_BoundArgs...>, _TupleUj> {
+  static const bool value = __invokable<_Func, typename __mu_return<_BoundArgs, _TupleUj>::type...>::value;
 };
 
-template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __is_valid_bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj> {
-  static const bool value = __invokable<_Fp, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::value;
+template <class _Func, class... _BoundArgs, class _TupleUj>
+struct __is_valid_bind_return<_Func, const tuple<_BoundArgs...>, _TupleUj> {
+  static const bool value = __invokable<_Func, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::value;
 };
 
-template <class _Fp, class _BoundArgs, class _TupleUj, bool = __is_valid_bind_return<_Fp, _BoundArgs, _TupleUj>::value>
+template <class _Func,
+          class _BoundArgs,
+          class _TupleUj,
+          bool = __is_valid_bind_return<_Func, _BoundArgs, _TupleUj>::value>
 struct __bind_return;
 
-template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __bind_return<_Fp, tuple<_BoundArgs...>, _TupleUj, true> {
-  typedef typename __invoke_of< _Fp&, typename __mu_return< _BoundArgs, _TupleUj >::type... >::type type;
+template <class _Func, class... _BoundArgs, class _TupleUj>
+struct __bind_return<_Func, tuple<_BoundArgs...>, _TupleUj, true> {
+  typedef typename __invoke_of< _Func&, typename __mu_return< _BoundArgs, _TupleUj >::type... >::type type;
 };
 
-template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj, true> {
-  typedef typename __invoke_of< _Fp&, typename __mu_return< const _BoundArgs, _TupleUj >::type... >::type type;
+template <class _Func, class... _BoundArgs, class _TupleUj>
+struct __bind_return<_Func, const tuple<_BoundArgs...>, _TupleUj, true> {
+  typedef typename __invoke_of< _Func&, typename __mu_return< const _BoundArgs, _TupleUj >::type... >::type type;
 };
 
-template <class _Fp, class _BoundArgs, size_t... _Indx, class _Args>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 typename __bind_return<_Fp, _BoundArgs, _Args>::type
-__apply_functor(_Fp& __f, _BoundArgs& __bound_args, __tuple_indices<_Indx...>, _Args&& __args) {
+template <class _Func, class _BoundArgs, size_t... _Indx, class _Args>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 typename __bind_return<_Func, _BoundArgs, _Args>::type
+__apply_functor(_Func& __f, _BoundArgs& __bound_args, __tuple_indices<_Indx...>, _Args&& __args) {
   return std::__invoke(__f, std::__mu(std::get<_Indx>(__bound_args), __args)...);
 }
 
-template <class _Fp, class... _BoundArgs>
-class __bind : public __weak_result_type<__decay_t<_Fp> > {
+template <class _Func, class... _BoundArgs>
+class __bind : public __weak_result_type<__decay_t<_Func> > {
 protected:
-  using _Fd = __decay_t<_Fp>;
+  using _Fd = __decay_t<_Func>;
   typedef tuple<__decay_t<_BoundArgs>...> _Td;
 
 private:
@@ -230,12 +233,12 @@ public:
   }
 };
 
-template <class _Fp, class... _BoundArgs>
-struct is_bind_expression<__bind<_Fp, _BoundArgs...> > : public true_type {};
+template <class _Func, class... _BoundArgs>
+struct is_bind_expression<__bind<_Func, _BoundArgs...> > : public true_type {};
 
-template <class _Rp, class _Fp, class... _BoundArgs>
-class __bind_r : public __bind<_Fp, _BoundArgs...> {
-  typedef __bind<_Fp, _BoundArgs...> base;
+template <class _Rp, class _Func, class... _BoundArgs>
+class __bind_r : public __bind<_Func, _BoundArgs...> {
+  typedef __bind<_Func, _BoundArgs...> base;
   typedef typename base::_Fd _Fd;
   typedef typename base::_Td _Td;
 
@@ -271,21 +274,21 @@ public:
   }
 };
 
-template <class _Rp, class _Fp, class... _BoundArgs>
-struct is_bind_expression<__bind_r<_Rp, _Fp, _BoundArgs...> > : public true_type {};
+template <class _Rp, class _Func, class... _BoundArgs>
+struct is_bind_expression<__bind_r<_Rp, _Func, _BoundArgs...> > : public true_type {};
 
-template <class _Fp, class... _BoundArgs>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bind<_Fp, _BoundArgs...>
-bind(_Fp&& __f, _BoundArgs&&... __bound_args) {
-  typedef __bind<_Fp, _BoundArgs...> type;
-  return type(std::forward<_Fp>(__f), std::forward<_BoundArgs>(__bound_args)...);
+template <class _Func, class... _BoundArgs>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bind<_Func, _BoundArgs...>
+bind(_Func&& __f, _BoundArgs&&... __bound_args) {
+  typedef __bind<_Func, _BoundArgs...> type;
+  return type(std::forward<_Func>(__f), std::forward<_BoundArgs>(__bound_args)...);
 }
 
-template <class _Rp, class _Fp, class... _BoundArgs>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bind_r<_Rp, _Fp, _BoundArgs...>
-bind(_Fp&& __f, _BoundArgs&&... __bound_args) {
-  typedef __bind_r<_Rp, _Fp, _BoundArgs...> type;
-  return type(std::forward<_Fp>(__f), std::forward<_BoundArgs>(__bound_args)...);
+template <class _Rp, class _Func, class... _BoundArgs>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bind_r<_Rp, _Func, _BoundArgs...>
+bind(_Func&& __f, _BoundArgs&&... __bound_args) {
+  typedef __bind_r<_Rp, _Func, _BoundArgs...> type;
+  return type(std::forward<_Func>(__f), std::forward<_BoundArgs>(__bound_args)...);
 }
 
 #endif // _LIBCPP_CXX03_LANG

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -81,7 +81,7 @@ _LIBCPP_NORETURN inline _LIBCPP_HIDE_FROM_ABI void __throw_bad_function_call() {
 #  endif
 }
 
-template <class _Fp>
+template <class _Func>
 class _LIBCPP_TEMPLATE_VIS function; // undefined
 
 namespace __function {
@@ -98,13 +98,13 @@ struct __maybe_derive_from_binary_function {};
 template <class _Rp, class _A1, class _A2>
 struct __maybe_derive_from_binary_function<_Rp(_A1, _A2)> : public __binary_function<_A1, _A2, _Rp> {};
 
-template <class _Fp>
-_LIBCPP_HIDE_FROM_ABI bool __not_null(_Fp const&) {
+template <class _Func>
+_LIBCPP_HIDE_FROM_ABI bool __not_null(_Func const&) {
   return true;
 }
 
-template <class _Fp>
-_LIBCPP_HIDE_FROM_ABI bool __not_null(_Fp* __ptr) {
+template <class _Func>
+_LIBCPP_HIDE_FROM_ABI bool __not_null(_Func* __ptr) {
   return __ptr;
 }
 
@@ -113,8 +113,8 @@ _LIBCPP_HIDE_FROM_ABI bool __not_null(_Ret _Class::*__ptr) {
   return __ptr;
 }
 
-template <class _Fp>
-_LIBCPP_HIDE_FROM_ABI bool __not_null(function<_Fp> const& __f) {
+template <class _Func>
+_LIBCPP_HIDE_FROM_ABI bool __not_null(function<_Func> const& __f) {
   return !!__f;
 }
 
@@ -131,17 +131,17 @@ namespace __function {
 
 // __alloc_func holds a functor and an allocator.
 
-template <class _Fp, class _Ap, class _FB>
+template <class _Func, class _Ap, class _FB>
 class __alloc_func;
-template <class _Fp, class _FB>
+template <class _Func, class _FB>
 class __default_alloc_func;
 
-template <class _Fp, class _Ap, class _Rp, class... _ArgTypes>
-class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)> {
-  __compressed_pair<_Fp, _Ap> __f_;
+template <class _Func, class _Ap, class _Rp, class... _ArgTypes>
+class __alloc_func<_Func, _Ap, _Rp(_ArgTypes...)> {
+  __compressed_pair<_Func, _Ap> __f_;
 
 public:
-  typedef _LIBCPP_NODEBUG _Fp _Target;
+  typedef _LIBCPP_NODEBUG _Func _Target;
   typedef _LIBCPP_NODEBUG _Ap _Alloc;
 
   _LIBCPP_HIDE_FROM_ABI const _Target& __target() const { return __f_.first(); }
@@ -187,12 +187,12 @@ public:
   }
 };
 
-template <class _Fp, class _Rp, class... _ArgTypes>
-class __default_alloc_func<_Fp, _Rp(_ArgTypes...)> {
-  _Fp __f_;
+template <class _Func, class _Rp, class... _ArgTypes>
+class __default_alloc_func<_Func, _Rp(_ArgTypes...)> {
+  _Func __f_;
 
 public:
-  typedef _LIBCPP_NODEBUG _Fp _Target;
+  typedef _LIBCPP_NODEBUG _Func _Target;
 
   _LIBCPP_HIDE_FROM_ABI const _Target& __target() const { return __f_; }
 
@@ -222,7 +222,7 @@ public:
 
 // __base provides an abstract interface for copyable functors.
 
-template <class _Fp>
+template <class _Func>
 class _LIBCPP_TEMPLATE_VIS __base;
 
 template <class _Rp, class... _ArgTypes>
@@ -249,18 +249,18 @@ public:
 template <class _FD, class _Alloc, class _FB>
 class __func;
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-class __func<_Fp, _Alloc, _Rp(_ArgTypes...)> : public __base<_Rp(_ArgTypes...)> {
-  __alloc_func<_Fp, _Alloc, _Rp(_ArgTypes...)> __f_;
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+class __func<_Func, _Alloc, _Rp(_ArgTypes...)> : public __base<_Rp(_ArgTypes...)> {
+  __alloc_func<_Func, _Alloc, _Rp(_ArgTypes...)> __f_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __func(_Fp&& __f) : __f_(std::move(__f)) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __func(_Func&& __f) : __f_(std::move(__f)) {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit __func(const _Fp& __f, const _Alloc& __a) : __f_(__f, __a) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __func(const _Func& __f, const _Alloc& __a) : __f_(__f, __a) {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit __func(const _Fp& __f, _Alloc&& __a) : __f_(__f, std::move(__a)) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __func(const _Func& __f, _Alloc&& __a) : __f_(__f, std::move(__a)) {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit __func(_Fp&& __f, _Alloc&& __a) : __f_(std::move(__f), std::move(__a)) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __func(_Func&& __f, _Alloc&& __a) : __f_(std::move(__f), std::move(__a)) {}
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual __base<_Rp(_ArgTypes...)>* __clone() const;
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __clone(__base<_Rp(_ArgTypes...)>*) const;
@@ -273,8 +273,8 @@ public:
 #  endif // _LIBCPP_HAS_NO_RTTI
 };
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-__base<_Rp(_ArgTypes...)>* __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__clone() const {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+__base<_Rp(_ArgTypes...)>* __func<_Func, _Alloc, _Rp(_ArgTypes...)>::__clone() const {
   typedef allocator_traits<_Alloc> __alloc_traits;
   typedef __rebind_alloc<__alloc_traits, __func> _Ap;
   _Ap __a(__f_.__get_allocator());
@@ -284,18 +284,18 @@ __base<_Rp(_ArgTypes...)>* __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__clone() con
   return __hold.release();
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__clone(__base<_Rp(_ArgTypes...)>* __p) const {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __func<_Func, _Alloc, _Rp(_ArgTypes...)>::__clone(__base<_Rp(_ArgTypes...)>* __p) const {
   ::new ((void*)__p) __func(__f_.__target(), __f_.__get_allocator());
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy() _NOEXCEPT {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __func<_Func, _Alloc, _Rp(_ArgTypes...)>::destroy() _NOEXCEPT {
   __f_.destroy();
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() _NOEXCEPT {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __func<_Func, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() _NOEXCEPT {
   typedef allocator_traits<_Alloc> __alloc_traits;
   typedef __rebind_alloc<__alloc_traits, __func> _Ap;
   _Ap __a(__f_.__get_allocator());
@@ -303,30 +303,30 @@ void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() _NOEXCEPT {
   __a.deallocate(this, 1);
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-_Rp __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&&... __arg) {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+_Rp __func<_Func, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&&... __arg) {
   return __f_(std::forward<_ArgTypes>(__arg)...);
 }
 
 #  ifndef _LIBCPP_HAS_NO_RTTI
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-const void* __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const _NOEXCEPT {
-  if (__ti == typeid(_Fp))
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+const void* __func<_Func, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const _NOEXCEPT {
+  if (__ti == typeid(_Func))
     return std::addressof(__f_.__target());
   return nullptr;
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-const std::type_info& __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target_type() const _NOEXCEPT {
-  return typeid(_Fp);
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+const std::type_info& __func<_Func, _Alloc, _Rp(_ArgTypes...)>::target_type() const _NOEXCEPT {
+  return typeid(_Func);
 }
 
 #  endif // _LIBCPP_HAS_NO_RTTI
 
 // __value_func creates a value-type from a __func.
 
-template <class _Fp>
+template <class _Func>
 class __value_func;
 
 template <class _Rp, class... _ArgTypes>
@@ -343,15 +343,15 @@ class __value_func<_Rp(_ArgTypes...)> {
 public:
   _LIBCPP_HIDE_FROM_ABI __value_func() _NOEXCEPT : __f_(nullptr) {}
 
-  template <class _Fp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI __value_func(_Fp&& __f, const _Alloc& __a) : __f_(nullptr) {
+  template <class _Func, class _Alloc>
+  _LIBCPP_HIDE_FROM_ABI __value_func(_Func&& __f, const _Alloc& __a) : __f_(nullptr) {
     typedef allocator_traits<_Alloc> __alloc_traits;
-    typedef __function::__func<_Fp, _Alloc, _Rp(_ArgTypes...)> _Fun;
+    typedef __function::__func<_Func, _Alloc, _Rp(_ArgTypes...)> _Fun;
     typedef __rebind_alloc<__alloc_traits, _Fun> _FunAlloc;
 
     if (__function::__not_null(__f)) {
       _FunAlloc __af(__a);
-      if (sizeof(_Fun) <= sizeof(__buf_) && is_nothrow_copy_constructible<_Fp>::value &&
+      if (sizeof(_Fun) <= sizeof(__buf_) && is_nothrow_copy_constructible<_Func>::value &&
           is_nothrow_copy_constructible<_FunAlloc>::value) {
         __f_ = ::new ((void*)&__buf_) _Fun(std::move(__f), _Alloc(__af));
       } else {
@@ -363,8 +363,9 @@ public:
     }
   }
 
-  template <class _Fp, __enable_if_t<!is_same<__decay_t<_Fp>, __value_func>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI explicit __value_func(_Fp&& __f) : __value_func(std::forward<_Fp>(__f), allocator<_Fp>()) {}
+  template <class _Func, __enable_if_t<!is_same<__decay_t<_Func>, __value_func>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI explicit __value_func(_Func&& __f)
+      : __value_func(std::forward<_Func>(__f), allocator<_Func>()) {}
 
   _LIBCPP_HIDE_FROM_ABI __value_func(const __value_func& __f) {
     if (__f.__f_ == nullptr)
@@ -574,7 +575,7 @@ using __fast_forward = __conditional_t<is_scalar<_Tp>::value, _Tp, _Tp&&>;
 
 // __policy_invoker calls an instance of __alloc_func held in __policy_storage.
 
-template <class _Fp>
+template <class _Func>
 struct __policy_invoker;
 
 template <class _Rp, class... _ArgTypes>
@@ -609,7 +610,7 @@ private:
 // __policy_func uses a __policy and __policy_invoker to create a type-erased,
 // copyable functor.
 
-template <class _Fp>
+template <class _Func>
 class __policy_func;
 
 template <class _Rp, class... _ArgTypes>
@@ -630,9 +631,9 @@ class __policy_func<_Rp(_ArgTypes...)> {
 public:
   _LIBCPP_HIDE_FROM_ABI __policy_func() : __policy_(__policy::__create_empty()) {}
 
-  template <class _Fp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI __policy_func(_Fp&& __f, const _Alloc& __a) : __policy_(__policy::__create_empty()) {
-    typedef __alloc_func<_Fp, _Alloc, _Rp(_ArgTypes...)> _Fun;
+  template <class _Func, class _Alloc>
+  _LIBCPP_HIDE_FROM_ABI __policy_func(_Func&& __f, const _Alloc& __a) : __policy_(__policy::__create_empty()) {
+    typedef __alloc_func<_Func, _Alloc, _Rp(_ArgTypes...)> _Fun;
     typedef allocator_traits<_Alloc> __alloc_traits;
     typedef __rebind_alloc<__alloc_traits, _Fun> _FunAlloc;
 
@@ -652,9 +653,9 @@ public:
     }
   }
 
-  template <class _Fp, __enable_if_t<!is_same<__decay_t<_Fp>, __policy_func>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI explicit __policy_func(_Fp&& __f) : __policy_(__policy::__create_empty()) {
-    typedef __default_alloc_func<_Fp, _Rp(_ArgTypes...)> _Fun;
+  template <class _Func, __enable_if_t<!is_same<__decay_t<_Func>, __policy_func>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI explicit __policy_func(_Func&& __f) : __policy_(__policy::__create_empty()) {
+    typedef __default_alloc_func<_Func, _Rp(_ArgTypes...)> _Fun;
 
     if (__function::__not_null(__f)) {
       __invoker_ = __invoker::template __create<_Fun>();
@@ -821,21 +822,21 @@ class _LIBCPP_TEMPLATE_VIS function<_Rp(_ArgTypes...)>
 
   __func __f_;
 
-  template <class _Fp,
-            bool = _And< _IsNotSame<__remove_cvref_t<_Fp>, function>, __invokable<_Fp, _ArgTypes...> >::value>
+  template <class _Func,
+            bool = _And< _IsNotSame<__remove_cvref_t<_Func>, function>, __invokable<_Func, _ArgTypes...> >::value>
   struct __callable;
-  template <class _Fp>
-  struct __callable<_Fp, true> {
+  template <class _Func>
+  struct __callable<_Func, true> {
     static const bool value =
-        is_void<_Rp>::value || __is_core_convertible<typename __invoke_of<_Fp, _ArgTypes...>::type, _Rp>::value;
+        is_void<_Rp>::value || __is_core_convertible<typename __invoke_of<_Func, _ArgTypes...>::type, _Rp>::value;
   };
-  template <class _Fp>
-  struct __callable<_Fp, false> {
+  template <class _Func>
+  struct __callable<_Func, false> {
     static const bool value = false;
   };
 
-  template <class _Fp>
-  using _EnableIfLValueCallable = __enable_if_t<__callable<_Fp&>::value>;
+  template <class _Func>
+  using _EnableIfLValueCallable = __enable_if_t<__callable<_Func&>::value>;
 
 public:
   typedef _Rp result_type;
@@ -845,8 +846,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_HIDE_FROM_ABI function(nullptr_t) _NOEXCEPT {}
   _LIBCPP_HIDE_FROM_ABI function(const function&);
   _LIBCPP_HIDE_FROM_ABI function(function&&) _NOEXCEPT;
-  template <class _Fp, class = _EnableIfLValueCallable<_Fp>>
-  _LIBCPP_HIDE_FROM_ABI function(_Fp);
+  template <class _Func, class = _EnableIfLValueCallable<_Func>>
+  _LIBCPP_HIDE_FROM_ABI function(_Func);
 
 #  if _LIBCPP_STD_VER <= 14
   template <class _Alloc>
@@ -857,15 +858,15 @@ public:
   _LIBCPP_HIDE_FROM_ABI function(allocator_arg_t, const _Alloc&, const function&);
   template <class _Alloc>
   _LIBCPP_HIDE_FROM_ABI function(allocator_arg_t, const _Alloc&, function&&);
-  template <class _Fp, class _Alloc, class = _EnableIfLValueCallable<_Fp>>
-  _LIBCPP_HIDE_FROM_ABI function(allocator_arg_t, const _Alloc& __a, _Fp __f);
+  template <class _Func, class _Alloc, class = _EnableIfLValueCallable<_Func>>
+  _LIBCPP_HIDE_FROM_ABI function(allocator_arg_t, const _Alloc& __a, _Func __f);
 #  endif
 
   _LIBCPP_HIDE_FROM_ABI function& operator=(const function&);
   _LIBCPP_HIDE_FROM_ABI function& operator=(function&&) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI function& operator=(nullptr_t) _NOEXCEPT;
-  template <class _Fp, class = _EnableIfLValueCallable<__decay_t<_Fp>>>
-  _LIBCPP_HIDE_FROM_ABI function& operator=(_Fp&&);
+  template <class _Func, class = _EnableIfLValueCallable<__decay_t<_Func>>>
+  _LIBCPP_HIDE_FROM_ABI function& operator=(_Func&&);
 
   _LIBCPP_HIDE_FROM_ABI ~function();
 
@@ -873,9 +874,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI void swap(function&) _NOEXCEPT;
 
 #  if _LIBCPP_STD_VER <= 14
-  template <class _Fp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI void assign(_Fp&& __f, const _Alloc& __a) {
-    function(allocator_arg, __a, std::forward<_Fp>(__f)).swap(*this);
+  template <class _Func, class _Alloc>
+  _LIBCPP_HIDE_FROM_ABI void assign(_Func&& __f, const _Alloc& __a) {
+    function(allocator_arg, __a, std::forward<_Func>(__f)).swap(*this);
   }
 #  endif
 
@@ -908,8 +909,8 @@ public:
 template <class _Rp, class... _Ap>
 function(_Rp (*)(_Ap...)) -> function<_Rp(_Ap...)>;
 
-template <class _Fp, class _Stripped = typename __strip_signature<decltype(&_Fp::operator())>::type>
-function(_Fp) -> function<_Stripped>;
+template <class _Func, class _Stripped = typename __strip_signature<decltype(&_Func::operator())>::type>
+function(_Func) -> function<_Stripped>;
 #  endif // _LIBCPP_STD_VER >= 17
 
 template <class _Rp, class... _ArgTypes>
@@ -931,13 +932,13 @@ function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc&, function&&
 #  endif
 
 template <class _Rp, class... _ArgTypes>
-template <class _Fp, class>
-function<_Rp(_ArgTypes...)>::function(_Fp __f) : __f_(std::move(__f)) {}
+template <class _Func, class>
+function<_Rp(_ArgTypes...)>::function(_Func __f) : __f_(std::move(__f)) {}
 
 #  if _LIBCPP_STD_VER <= 14
 template <class _Rp, class... _ArgTypes>
-template <class _Fp, class _Alloc, class>
-function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc& __a, _Fp __f) : __f_(std::move(__f), __a) {}
+template <class _Func, class _Alloc, class>
+function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc& __a, _Func __f) : __f_(std::move(__f), __a) {}
 #  endif
 
 template <class _Rp, class... _ArgTypes>
@@ -959,9 +960,9 @@ function<_Rp(_ArgTypes...)>& function<_Rp(_ArgTypes...)>::operator=(nullptr_t) _
 }
 
 template <class _Rp, class... _ArgTypes>
-template <class _Fp, class>
-function<_Rp(_ArgTypes...)>& function<_Rp(_ArgTypes...)>::operator=(_Fp&& __f) {
-  function(std::forward<_Fp>(__f)).swap(*this);
+template <class _Func, class>
+function<_Rp(_ArgTypes...)>& function<_Rp(_ArgTypes...)>::operator=(_Func&& __f) {
+  function(std::forward<_Func>(__f)).swap(*this);
   return *this;
 }
 

--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -79,16 +79,16 @@ namespace __advance {
 
 struct __fn {
 private:
-  template <class _Ip>
-  _LIBCPP_HIDE_FROM_ABI static constexpr void __advance_forward(_Ip& __i, iter_difference_t<_Ip> __n) {
+  template <class _Iter>
+  _LIBCPP_HIDE_FROM_ABI static constexpr void __advance_forward(_Iter& __i, iter_difference_t<_Iter> __n) {
     while (__n > 0) {
       --__n;
       ++__i;
     }
   }
 
-  template <class _Ip>
-  _LIBCPP_HIDE_FROM_ABI static constexpr void __advance_backward(_Ip& __i, iter_difference_t<_Ip> __n) {
+  template <class _Iter>
+  _LIBCPP_HIDE_FROM_ABI static constexpr void __advance_backward(_Iter& __i, iter_difference_t<_Iter> __n) {
     while (__n < 0) {
       ++__n;
       --__i;
@@ -97,16 +97,16 @@ private:
 
 public:
   // Preconditions: If `I` does not model `bidirectional_iterator`, `n` is not negative.
-  template <input_or_output_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Ip& __i, iter_difference_t<_Ip> __n) const {
+  template <input_or_output_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Iter& __i, iter_difference_t<_Iter> __n) const {
     _LIBCPP_ASSERT_UNCATEGORIZED(
-        __n >= 0 || bidirectional_iterator<_Ip>, "If `n < 0`, then `bidirectional_iterator<I>` must be true.");
+        __n >= 0 || bidirectional_iterator<_Iter>, "If `n < 0`, then `bidirectional_iterator<I>` must be true.");
 
     // If `I` models `random_access_iterator`, equivalent to `i += n`.
-    if constexpr (random_access_iterator<_Ip>) {
+    if constexpr (random_access_iterator<_Iter>) {
       __i += __n;
       return;
-    } else if constexpr (bidirectional_iterator<_Ip>) {
+    } else if constexpr (bidirectional_iterator<_Iter>) {
       // Otherwise, if `n` is non-negative, increments `i` by `n`.
       __advance_forward(__i, __n);
       // Otherwise, decrements `i` by `-n`.
@@ -121,15 +121,15 @@ public:
 
   // Preconditions: Either `assignable_from<I&, S> || sized_sentinel_for<S, I>` is modeled, or [i, bound_sentinel)
   // denotes a range.
-  template <input_or_output_iterator _Ip, sentinel_for<_Ip> _Sp>
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Ip& __i, _Sp __bound_sentinel) const {
+  template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
+  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Iter& __i, _Sent __bound_sentinel) const {
     // If `I` and `S` model `assignable_from<I&, S>`, equivalent to `i = std::move(bound_sentinel)`.
-    if constexpr (assignable_from<_Ip&, _Sp>) {
+    if constexpr (assignable_from<_Iter&, _Sent>) {
       __i = std::move(__bound_sentinel);
     }
     // Otherwise, if `S` and `I` model `sized_sentinel_for<S, I>`, equivalent to `ranges::advance(i, bound_sentinel -
     // i)`.
-    else if constexpr (sized_sentinel_for<_Sp, _Ip>) {
+    else if constexpr (sized_sentinel_for<_Sent, _Iter>) {
       (*this)(__i, __bound_sentinel - __i);
     }
     // Otherwise, while `bool(i != bound_sentinel)` is true, increments `i`.
@@ -146,13 +146,13 @@ public:
   //   * If `n < 0`, [bound_sentinel, i) denotes a range, `I` models `bidirectional_iterator`, and `I` and `S` model
   //   `same_as<I, S>`.
   // Returns: `n - M`, where `M` is the difference between the ending and starting position.
-  template <input_or_output_iterator _Ip, sentinel_for<_Ip> _Sp>
-  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip>
-  operator()(_Ip& __i, iter_difference_t<_Ip> __n, _Sp __bound_sentinel) const {
-    _LIBCPP_ASSERT_UNCATEGORIZED((__n >= 0) || (bidirectional_iterator<_Ip> && same_as<_Ip, _Sp>),
+  template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
+  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter>
+  operator()(_Iter& __i, iter_difference_t<_Iter> __n, _Sent __bound_sentinel) const {
+    _LIBCPP_ASSERT_UNCATEGORIZED((__n >= 0) || (bidirectional_iterator<_Iter> && same_as<_Iter, _Sent>),
                                  "If `n < 0`, then `bidirectional_iterator<I> && same_as<I, S>` must be true.");
     // If `S` and `I` model `sized_sentinel_for<S, I>`:
-    if constexpr (sized_sentinel_for<_Sp, _Ip>) {
+    if constexpr (sized_sentinel_for<_Sent, _Iter>) {
       // If |n| >= |bound_sentinel - i|, equivalent to `ranges::advance(i, bound_sentinel)`.
       // __magnitude_geq(a, b) returns |a| >= |b|, assuming they have the same sign.
       auto __magnitude_geq = [](auto __a, auto __b) { return __a == 0 ? __b == 0 : __a > 0 ? __a >= __b : __a <= __b; };
@@ -173,7 +173,7 @@ public:
       }
 
       // Otherwise, while `bool(i != bound_sentinel)` is true, decrements `i` but at most `-n` times.
-      if constexpr (bidirectional_iterator<_Ip> && same_as<_Ip, _Sp>) {
+      if constexpr (bidirectional_iterator<_Iter> && same_as<_Iter, _Sent>) {
         while (__i != __bound_sentinel && __n < 0) {
           --__i;
           ++__n;

--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -55,10 +55,10 @@ namespace ranges {
 namespace __distance {
 
 struct __fn {
-  template <class _Ip, sentinel_for<_Ip> _Sp>
-    requires(!sized_sentinel_for<_Sp, _Ip>)
-  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip> operator()(_Ip __first, _Sp __last) const {
-    iter_difference_t<_Ip> __n = 0;
+  template <class _Iter, sentinel_for<_Iter> _Sent>
+    requires(!sized_sentinel_for<_Sent, _Iter>)
+  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter> operator()(_Iter __first, _Sent __last) const {
+    iter_difference_t<_Iter> __n = 0;
     while (__first != __last) {
       ++__first;
       ++__n;
@@ -66,12 +66,12 @@ struct __fn {
     return __n;
   }
 
-  template <class _Ip, sized_sentinel_for<decay_t<_Ip>> _Sp>
-  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip> operator()(_Ip&& __first, _Sp __last) const {
-    if constexpr (sized_sentinel_for<_Sp, __remove_cvref_t<_Ip>>) {
+  template <class _Iter, sized_sentinel_for<decay_t<_Iter>> _Sent>
+  _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter> operator()(_Iter&& __first, _Sent __last) const {
+    if constexpr (sized_sentinel_for<_Sent, __remove_cvref_t<_Iter>>) {
       return __last - __first;
     } else {
-      return __last - decay_t<_Ip>(__first);
+      return __last - decay_t<_Iter>(__first);
     }
   }
 

--- a/libcxx/include/__iterator/incrementable_traits.h
+++ b/libcxx/include/__iterator/incrementable_traits.h
@@ -38,8 +38,8 @@ struct incrementable_traits<_Tp*> {
   using difference_type = ptrdiff_t;
 };
 
-template <class _Ip>
-struct incrementable_traits<const _Ip> : incrementable_traits<_Ip> {};
+template <class _Iter>
+struct incrementable_traits<const _Iter> : incrementable_traits<_Iter> {};
 
 template <class _Tp>
 concept __has_member_difference_type = requires { typename _Tp::difference_type; };
@@ -66,11 +66,11 @@ struct iterator_traits;
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_difference_t<I>` denotes
 // `incrementable_traits<RI>::difference_type` if `iterator_traits<RI>` names a specialization
 // generated from the primary template, and `iterator_traits<RI>::difference_type` otherwise.
-template <class _Ip>
+template <class _Iter>
 using iter_difference_t =
-    typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip> > >::value,
-                           incrementable_traits<remove_cvref_t<_Ip> >,
-                           iterator_traits<remove_cvref_t<_Ip> > >::difference_type;
+    typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Iter> > >::value,
+                           incrementable_traits<remove_cvref_t<_Iter> >,
+                           iterator_traits<remove_cvref_t<_Iter> > >::difference_type;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__iterator/iter_move.h
+++ b/libcxx/include/__iterator/iter_move.h
@@ -59,26 +59,26 @@ concept __just_deref = !__unqualified_iter_move<_Tp> && !__move_deref<_Tp> && re
 
 struct __fn {
   // NOLINTBEGIN(libcpp-robust-against-adl) iter_move ADL calls should only be made through ranges::iter_move
-  template <class _Ip>
-    requires __unqualified_iter_move<_Ip>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator()(_Ip&& __i) const
-      noexcept(noexcept(iter_move(std::forward<_Ip>(__i)))) {
-    return iter_move(std::forward<_Ip>(__i));
+  template <class _Iter>
+    requires __unqualified_iter_move<_Iter>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator()(_Iter&& __i) const
+      noexcept(noexcept(iter_move(std::forward<_Iter>(__i)))) {
+    return iter_move(std::forward<_Iter>(__i));
   }
   // NOLINTEND(libcpp-robust-against-adl)
 
-  template <class _Ip>
-    requires __move_deref<_Ip>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Ip&& __i) const
-      noexcept(noexcept(std::move(*std::forward<_Ip>(__i)))) -> decltype(std::move(*std::forward<_Ip>(__i))) {
-    return std::move(*std::forward<_Ip>(__i));
+  template <class _Iter>
+    requires __move_deref<_Iter>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Iter&& __i) const
+      noexcept(noexcept(std::move(*std::forward<_Iter>(__i)))) -> decltype(std::move(*std::forward<_Iter>(__i))) {
+    return std::move(*std::forward<_Iter>(__i));
   }
 
-  template <class _Ip>
-    requires __just_deref<_Ip>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Ip&& __i) const
-      noexcept(noexcept(*std::forward<_Ip>(__i))) -> decltype(*std::forward<_Ip>(__i)) {
-    return *std::forward<_Ip>(__i);
+  template <class _Iter>
+    requires __just_deref<_Iter>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Iter&& __i) const
+      noexcept(noexcept(*std::forward<_Iter>(__i))) -> decltype(*std::forward<_Iter>(__i)) {
+    return *std::forward<_Iter>(__i);
   }
 };
 } // namespace __iter_move

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -154,67 +154,67 @@ public:
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
 // a "detail" namespace indicating they have a niche use-case.
 namespace __iterator_traits_detail {
-template <class _Ip>
-concept __cpp17_iterator = requires(_Ip __i) {
+template <class _Iter>
+concept __cpp17_iterator = requires(_Iter __i) {
   { *__i } -> __can_reference;
-  { ++__i } -> same_as<_Ip&>;
+  { ++__i } -> same_as<_Iter&>;
   { *__i++ } -> __can_reference;
-} && copyable<_Ip>;
+} && copyable<_Iter>;
 
-template <class _Ip>
-concept __cpp17_input_iterator = __cpp17_iterator<_Ip> && equality_comparable<_Ip> && requires(_Ip __i) {
-  typename incrementable_traits<_Ip>::difference_type;
-  typename indirectly_readable_traits<_Ip>::value_type;
-  typename common_reference_t<iter_reference_t<_Ip>&&, typename indirectly_readable_traits<_Ip>::value_type&>;
-  typename common_reference_t<decltype(*__i++)&&, typename indirectly_readable_traits<_Ip>::value_type&>;
-  requires signed_integral<typename incrementable_traits<_Ip>::difference_type>;
+template <class _Iter>
+concept __cpp17_input_iterator = __cpp17_iterator<_Iter> && equality_comparable<_Iter> && requires(_Iter __i) {
+  typename incrementable_traits<_Iter>::difference_type;
+  typename indirectly_readable_traits<_Iter>::value_type;
+  typename common_reference_t<iter_reference_t<_Iter>&&, typename indirectly_readable_traits<_Iter>::value_type&>;
+  typename common_reference_t<decltype(*__i++)&&, typename indirectly_readable_traits<_Iter>::value_type&>;
+  requires signed_integral<typename incrementable_traits<_Iter>::difference_type>;
 };
 
-template <class _Ip>
+template <class _Iter>
 concept __cpp17_forward_iterator =
-    __cpp17_input_iterator<_Ip> && constructible_from<_Ip> && is_reference_v<iter_reference_t<_Ip>> &&
-    same_as<remove_cvref_t<iter_reference_t<_Ip>>, typename indirectly_readable_traits<_Ip>::value_type> &&
-    requires(_Ip __i) {
-      { __i++ } -> convertible_to<_Ip const&>;
-      { *__i++ } -> same_as<iter_reference_t<_Ip>>;
+    __cpp17_input_iterator<_Iter> && constructible_from<_Iter> && is_reference_v<iter_reference_t<_Iter>> &&
+    same_as<remove_cvref_t<iter_reference_t<_Iter>>, typename indirectly_readable_traits<_Iter>::value_type> &&
+    requires(_Iter __i) {
+      { __i++ } -> convertible_to<_Iter const&>;
+      { *__i++ } -> same_as<iter_reference_t<_Iter>>;
     };
 
-template <class _Ip>
-concept __cpp17_bidirectional_iterator = __cpp17_forward_iterator<_Ip> && requires(_Ip __i) {
-  { --__i } -> same_as<_Ip&>;
-  { __i-- } -> convertible_to<_Ip const&>;
-  { *__i-- } -> same_as<iter_reference_t<_Ip>>;
+template <class _Iter>
+concept __cpp17_bidirectional_iterator = __cpp17_forward_iterator<_Iter> && requires(_Iter __i) {
+  { --__i } -> same_as<_Iter&>;
+  { __i-- } -> convertible_to<_Iter const&>;
+  { *__i-- } -> same_as<iter_reference_t<_Iter>>;
 };
 
-template <class _Ip>
+template <class _Iter>
 concept __cpp17_random_access_iterator =
-    __cpp17_bidirectional_iterator<_Ip> && totally_ordered<_Ip> &&
-    requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n) {
-      { __i += __n } -> same_as<_Ip&>;
-      { __i -= __n } -> same_as<_Ip&>;
-      { __i + __n } -> same_as<_Ip>;
-      { __n + __i } -> same_as<_Ip>;
-      { __i - __n } -> same_as<_Ip>;
+    __cpp17_bidirectional_iterator<_Iter> && totally_ordered<_Iter> &&
+    requires(_Iter __i, typename incrementable_traits<_Iter>::difference_type __n) {
+      { __i += __n } -> same_as<_Iter&>;
+      { __i -= __n } -> same_as<_Iter&>;
+      { __i + __n } -> same_as<_Iter>;
+      { __n + __i } -> same_as<_Iter>;
+      { __i - __n } -> same_as<_Iter>;
       { __i - __i } -> same_as<decltype(__n)>; // NOLINT(misc-redundant-expression) ; This is llvm.org/PR54114
-      { __i[__n] } -> convertible_to<iter_reference_t<_Ip>>;
+      { __i[__n] } -> convertible_to<iter_reference_t<_Iter>>;
     };
 } // namespace __iterator_traits_detail
 
-template <class _Ip>
-concept __has_member_reference = requires { typename _Ip::reference; };
+template <class _Iter>
+concept __has_member_reference = requires { typename _Iter::reference; };
 
-template <class _Ip>
-concept __has_member_pointer = requires { typename _Ip::pointer; };
+template <class _Iter>
+concept __has_member_pointer = requires { typename _Iter::pointer; };
 
-template <class _Ip>
-concept __has_member_iterator_category = requires { typename _Ip::iterator_category; };
+template <class _Iter>
+concept __has_member_iterator_category = requires { typename _Iter::iterator_category; };
 
-template <class _Ip>
+template <class _Iter>
 concept __specifies_members = requires {
-  typename _Ip::value_type;
-  typename _Ip::difference_type;
-  requires __has_member_reference<_Ip>;
-  requires __has_member_iterator_category<_Ip>;
+  typename _Iter::value_type;
+  typename _Iter::difference_type;
+  requires __has_member_reference<_Iter>;
+  requires __has_member_iterator_category<_Iter>;
 };
 
 template <class>
@@ -242,69 +242,69 @@ struct __iterator_traits_member_pointer_or_arrow_or_void {
 
 // [iterator.traits]/3.2.1
 // If the qualified-id `I::pointer` is valid and denotes a type, `pointer` names that type.
-template <__has_member_pointer _Ip>
-struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip> {
-  using type = typename _Ip::pointer;
+template <__has_member_pointer _Iter>
+struct __iterator_traits_member_pointer_or_arrow_or_void<_Iter> {
+  using type = typename _Iter::pointer;
 };
 
 // Otherwise, if `decltype(declval<I&>().operator->())` is well-formed, then `pointer` names that
 // type.
-template <class _Ip>
-  requires requires(_Ip& __i) { __i.operator->(); } && (!__has_member_pointer<_Ip>)
-struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip> {
-  using type = decltype(std::declval<_Ip&>().operator->());
+template <class _Iter>
+  requires requires(_Iter& __i) { __i.operator->(); } && (!__has_member_pointer<_Iter>)
+struct __iterator_traits_member_pointer_or_arrow_or_void<_Iter> {
+  using type = decltype(std::declval<_Iter&>().operator->());
 };
 
 // Otherwise, `reference` names `iter-reference-t<I>`.
-template <class _Ip>
+template <class _Iter>
 struct __iterator_traits_member_reference {
-  using type = iter_reference_t<_Ip>;
+  using type = iter_reference_t<_Iter>;
 };
 
 // [iterator.traits]/3.2.2
 // If the qualified-id `I::reference` is valid and denotes a type, `reference` names that type.
-template <__has_member_reference _Ip>
-struct __iterator_traits_member_reference<_Ip> {
-  using type = typename _Ip::reference;
+template <__has_member_reference _Iter>
+struct __iterator_traits_member_reference<_Iter> {
+  using type = typename _Iter::reference;
 };
 
 // [iterator.traits]/3.2.3.4
 // input_iterator_tag
-template <class _Ip>
+template <class _Iter>
 struct __deduce_iterator_category {
   using type = input_iterator_tag;
 };
 
 // [iterator.traits]/3.2.3.1
 // `random_access_iterator_tag` if `I` satisfies `cpp17-random-access-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_random_access_iterator _Ip>
-struct __deduce_iterator_category<_Ip> {
+template <__iterator_traits_detail::__cpp17_random_access_iterator _Iter>
+struct __deduce_iterator_category<_Iter> {
   using type = random_access_iterator_tag;
 };
 
 // [iterator.traits]/3.2.3.2
 // `bidirectional_iterator_tag` if `I` satisfies `cpp17-bidirectional-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_bidirectional_iterator _Ip>
-struct __deduce_iterator_category<_Ip> {
+template <__iterator_traits_detail::__cpp17_bidirectional_iterator _Iter>
+struct __deduce_iterator_category<_Iter> {
   using type = bidirectional_iterator_tag;
 };
 
 // [iterator.traits]/3.2.3.3
 // `forward_iterator_tag` if `I` satisfies `cpp17-forward-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_forward_iterator _Ip>
-struct __deduce_iterator_category<_Ip> {
+template <__iterator_traits_detail::__cpp17_forward_iterator _Iter>
+struct __deduce_iterator_category<_Iter> {
   using type = forward_iterator_tag;
 };
 
-template <class _Ip>
-struct __iterator_traits_iterator_category : __deduce_iterator_category<_Ip> {};
+template <class _Iter>
+struct __iterator_traits_iterator_category : __deduce_iterator_category<_Iter> {};
 
 // [iterator.traits]/3.2.3
 // If the qualified-id `I::iterator-category` is valid and denotes a type, `iterator-category` names
 // that type.
-template <__has_member_iterator_category _Ip>
-struct __iterator_traits_iterator_category<_Ip> {
-  using type = typename _Ip::iterator_category;
+template <__has_member_iterator_category _Iter>
+struct __iterator_traits_iterator_category<_Iter> {
+  using type = typename _Iter::iterator_category;
 };
 
 // otherwise, it names void.
@@ -315,10 +315,10 @@ struct __iterator_traits_difference_type {
 
 // If the qualified-id `incrementable_traits<I>::difference_type` is valid and denotes a type, then
 // `difference_type` names that type;
-template <class _Ip>
-  requires requires { typename incrementable_traits<_Ip>::difference_type; }
-struct __iterator_traits_difference_type<_Ip> {
-  using type = typename incrementable_traits<_Ip>::difference_type;
+template <class _Iter>
+  requires requires { typename incrementable_traits<_Iter>::difference_type; }
+struct __iterator_traits_difference_type<_Iter> {
+  using type = typename incrementable_traits<_Iter>::difference_type;
 };
 
 // [iterator.traits]/3.4
@@ -329,40 +329,40 @@ struct __iterator_traits {};
 // [iterator.traits]/3.1
 // If `I` has valid ([temp.deduct]) member types `difference-type`, `value-type`, `reference`, and
 // `iterator-category`, then `iterator-traits<I>` has the following publicly accessible members:
-template <__specifies_members _Ip>
-struct __iterator_traits<_Ip> {
-  using iterator_category = typename _Ip::iterator_category;
-  using value_type        = typename _Ip::value_type;
-  using difference_type   = typename _Ip::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_void<_Ip>::type;
-  using reference         = typename _Ip::reference;
+template <__specifies_members _Iter>
+struct __iterator_traits<_Iter> {
+  using iterator_category = typename _Iter::iterator_category;
+  using value_type        = typename _Iter::value_type;
+  using difference_type   = typename _Iter::difference_type;
+  using pointer           = typename __iterator_traits_member_pointer_or_void<_Iter>::type;
+  using reference         = typename _Iter::reference;
 };
 
 // [iterator.traits]/3.2
 // Otherwise, if `I` satisfies the exposition-only concept `cpp17-input-iterator`,
 // `iterator-traits<I>` has the following publicly accessible members:
-template <__cpp17_input_iterator_missing_members _Ip>
-struct __iterator_traits<_Ip> {
-  using iterator_category = typename __iterator_traits_iterator_category<_Ip>::type;
-  using value_type        = typename indirectly_readable_traits<_Ip>::value_type;
-  using difference_type   = typename incrementable_traits<_Ip>::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_arrow_or_void<_Ip>::type;
-  using reference         = typename __iterator_traits_member_reference<_Ip>::type;
+template <__cpp17_input_iterator_missing_members _Iter>
+struct __iterator_traits<_Iter> {
+  using iterator_category = typename __iterator_traits_iterator_category<_Iter>::type;
+  using value_type        = typename indirectly_readable_traits<_Iter>::value_type;
+  using difference_type   = typename incrementable_traits<_Iter>::difference_type;
+  using pointer           = typename __iterator_traits_member_pointer_or_arrow_or_void<_Iter>::type;
+  using reference         = typename __iterator_traits_member_reference<_Iter>::type;
 };
 
 // Otherwise, if `I` satisfies the exposition-only concept `cpp17-iterator`, then
 // `iterator_traits<I>` has the following publicly accessible members:
-template <__cpp17_iterator_missing_members _Ip>
-struct __iterator_traits<_Ip> {
+template <__cpp17_iterator_missing_members _Iter>
+struct __iterator_traits<_Iter> {
   using iterator_category = output_iterator_tag;
   using value_type        = void;
-  using difference_type   = typename __iterator_traits_difference_type<_Ip>::type;
+  using difference_type   = typename __iterator_traits_difference_type<_Iter>::type;
   using pointer           = void;
   using reference         = void;
 };
 
-template <class _Ip>
-struct iterator_traits : __iterator_traits<_Ip> {
+template <class _Iter>
+struct iterator_traits : __iterator_traits<_Iter> {
   using __primary_template = iterator_traits;
 };
 
@@ -516,11 +516,11 @@ using __iter_reference = typename iterator_traits<_Iter>::reference;
 // `indirectly_readable_traits<RI>::value_type` if `iterator_traits<RI>` names a specialization
 // generated from the primary template, and `iterator_traits<RI>::value_type` otherwise.
 // This has to be in this file and not readable_traits.h to break the include cycle between the two.
-template <class _Ip>
+template <class _Iter>
 using iter_value_t =
-    typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip> > >::value,
-                           indirectly_readable_traits<remove_cvref_t<_Ip> >,
-                           iterator_traits<remove_cvref_t<_Ip> > >::value_type;
+    typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Iter> > >::value,
+                           indirectly_readable_traits<remove_cvref_t<_Iter> >,
+                           iterator_traits<remove_cvref_t<_Iter> > >::value_type;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__iterator/next.h
+++ b/libcxx/include/__iterator/next.h
@@ -42,26 +42,27 @@ namespace ranges {
 namespace __next {
 
 struct __fn {
-  template <input_or_output_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x) const {
+  template <input_or_output_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x) const {
     ++__x;
     return __x;
   }
 
-  template <input_or_output_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const {
+  template <input_or_output_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x, iter_difference_t<_Iter> __n) const {
     ranges::advance(__x, __n);
     return __x;
   }
 
-  template <input_or_output_iterator _Ip, sentinel_for<_Ip> _Sp>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x, _Sp __bound_sentinel) const {
+  template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x, _Sent __bound_sentinel) const {
     ranges::advance(__x, __bound_sentinel);
     return __x;
   }
 
-  template <input_or_output_iterator _Ip, sentinel_for<_Ip> _Sp>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Sp __bound_sentinel) const {
+  template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  operator()(_Iter __x, iter_difference_t<_Iter> __n, _Sent __bound_sentinel) const {
     ranges::advance(__x, __n, __bound_sentinel);
     return __x;
   }

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -41,20 +41,20 @@ namespace ranges {
 namespace __prev {
 
 struct __fn {
-  template <bidirectional_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x) const {
+  template <bidirectional_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x) const {
     --__x;
     return __x;
   }
 
-  template <bidirectional_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const {
+  template <bidirectional_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x, iter_difference_t<_Iter> __n) const {
     ranges::advance(__x, -__n);
     return __x;
   }
 
-  template <bidirectional_iterator _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Ip __bound_iter) const {
+  template <bidirectional_iterator _Iter>
+  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __x, iter_difference_t<_Iter> __n, _Iter __bound_iter) const {
     ranges::advance(__x, -__n, __bound_iter);
     return __x;
   }

--- a/libcxx/include/__iterator/readable_traits.h
+++ b/libcxx/include/__iterator/readable_traits.h
@@ -47,14 +47,14 @@ concept __has_member_element_type = requires { typename _Tp::element_type; };
 template <class>
 struct indirectly_readable_traits {};
 
-template <class _Ip>
-  requires is_array_v<_Ip>
-struct indirectly_readable_traits<_Ip> {
-  using value_type = remove_cv_t<remove_extent_t<_Ip>>;
+template <class _Iter>
+  requires is_array_v<_Iter>
+struct indirectly_readable_traits<_Iter> {
+  using value_type = remove_cv_t<remove_extent_t<_Iter>>;
 };
 
-template <class _Ip>
-struct indirectly_readable_traits<const _Ip> : indirectly_readable_traits<_Ip> {};
+template <class _Iter>
+struct indirectly_readable_traits<const _Iter> : indirectly_readable_traits<_Iter> {};
 
 template <class _Tp>
 struct indirectly_readable_traits<_Tp*> : __cond_value_type<_Tp> {};

--- a/libcxx/include/__memory/concepts.h
+++ b/libcxx/include/__memory/concepts.h
@@ -35,21 +35,21 @@ namespace ranges {
 
 // This concept ensures that uninitialized algorithms can construct an object
 // at the address pointed-to by the iterator, which requires an lvalue.
-template <class _Ip>
+template <class _Iter>
 concept __nothrow_input_iterator =
-    input_iterator<_Ip> && is_lvalue_reference_v<iter_reference_t<_Ip>> &&
-    same_as<remove_cvref_t<iter_reference_t<_Ip>>, iter_value_t<_Ip>>;
+    input_iterator<_Iter> && is_lvalue_reference_v<iter_reference_t<_Iter>> &&
+    same_as<remove_cvref_t<iter_reference_t<_Iter>>, iter_value_t<_Iter>>;
 
-template <class _Sp, class _Ip>
-concept __nothrow_sentinel_for = sentinel_for<_Sp, _Ip>;
+template <class _Sent, class _Iter>
+concept __nothrow_sentinel_for = sentinel_for<_Sent, _Iter>;
 
 template <class _Rp>
 concept __nothrow_input_range =
     range<_Rp> && __nothrow_input_iterator<iterator_t<_Rp>> && __nothrow_sentinel_for<sentinel_t<_Rp>, iterator_t<_Rp>>;
 
-template <class _Ip>
+template <class _Iter>
 concept __nothrow_forward_iterator =
-    __nothrow_input_iterator<_Ip> && forward_iterator<_Ip> && __nothrow_sentinel_for<_Ip, _Ip>;
+    __nothrow_input_iterator<_Iter> && forward_iterator<_Iter> && __nothrow_sentinel_for<_Iter, _Iter>;
 
 template <class _Rp>
 concept __nothrow_forward_range = __nothrow_input_range<_Rp> && __nothrow_forward_iterator<iterator_t<_Rp>>;

--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -76,15 +76,15 @@ private:
 
 #ifndef _LIBCPP_CXX03_LANG
 
-template <class _Fp>
+template <class _Func>
 class __call_once_param {
-  _Fp& __f_;
+  _Func& __f_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Func& __f) : __f_(__f) {}
 
   _LIBCPP_HIDE_FROM_ABI void operator()() {
-    typedef typename __make_tuple_indices<tuple_size<_Fp>::value, 1>::type _Index;
+    typedef typename __make_tuple_indices<tuple_size<_Func>::value, 1>::type _Index;
     __execute(_Index());
   }
 
@@ -97,21 +97,21 @@ private:
 
 #else
 
-template <class _Fp>
+template <class _Func>
 class __call_once_param {
-  _Fp& __f_;
+  _Func& __f_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Func& __f) : __f_(__f) {}
 
   _LIBCPP_HIDE_FROM_ABI void operator()() { __f_(); }
 };
 
 #endif
 
-template <class _Fp>
+template <class _Func>
 void _LIBCPP_HIDE_FROM_ABI __call_once_proxy(void* __vp) {
-  __call_once_param<_Fp>* __p = static_cast<__call_once_param<_Fp>*>(__vp);
+  __call_once_param<_Func>* __p = static_cast<__call_once_param<_Func>*>(__vp);
   (*__p)();
 }
 

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -231,8 +231,8 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto get(subrange<_Iter, _Sent, _Kind>&& __subra
     return __subrange.end();
 }
 
-template <class _Ip, class _Sp, subrange_kind _Kp>
-inline constexpr bool enable_borrowed_range<subrange<_Ip, _Sp, _Kp>> = true;
+template <class _Iter, class _Sent, subrange_kind _Kp>
+inline constexpr bool enable_borrowed_range<subrange<_Iter, _Sent, _Kp>> = true;
 
 template <range _Rp>
 using borrowed_subrange_t = _If<borrowed_range<_Rp>, subrange<iterator_t<_Rp>>, dangling>;
@@ -244,27 +244,27 @@ using ranges::get;
 
 // [ranges.syn]
 
-template <class _Ip, class _Sp, ranges::subrange_kind _Kp>
-struct tuple_size<ranges::subrange<_Ip, _Sp, _Kp>> : integral_constant<size_t, 2> {};
+template <class _Iter, class _Sent, ranges::subrange_kind _Kp>
+struct tuple_size<ranges::subrange<_Iter, _Sent, _Kp>> : integral_constant<size_t, 2> {};
 
-template <class _Ip, class _Sp, ranges::subrange_kind _Kp>
-struct tuple_element<0, ranges::subrange<_Ip, _Sp, _Kp>> {
-  using type = _Ip;
+template <class _Iter, class _Sent, ranges::subrange_kind _Kp>
+struct tuple_element<0, ranges::subrange<_Iter, _Sent, _Kp>> {
+  using type = _Iter;
 };
 
-template <class _Ip, class _Sp, ranges::subrange_kind _Kp>
-struct tuple_element<1, ranges::subrange<_Ip, _Sp, _Kp>> {
-  using type = _Sp;
+template <class _Iter, class _Sent, ranges::subrange_kind _Kp>
+struct tuple_element<1, ranges::subrange<_Iter, _Sent, _Kp>> {
+  using type = _Sent;
 };
 
-template <class _Ip, class _Sp, ranges::subrange_kind _Kp>
-struct tuple_element<0, const ranges::subrange<_Ip, _Sp, _Kp>> {
-  using type = _Ip;
+template <class _Iter, class _Sent, ranges::subrange_kind _Kp>
+struct tuple_element<0, const ranges::subrange<_Iter, _Sent, _Kp>> {
+  using type = _Iter;
 };
 
-template <class _Ip, class _Sp, ranges::subrange_kind _Kp>
-struct tuple_element<1, const ranges::subrange<_Ip, _Sp, _Kp>> {
-  using type = _Sp;
+template <class _Iter, class _Sent, ranges::subrange_kind _Kp>
+struct tuple_element<1, const ranges::subrange<_Iter, _Sent, _Kp>> {
+  using type = _Sent;
 };
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -386,8 +386,8 @@ __split_buffer<_Tp, _Allocator>::__split_buffer(__split_buffer&& __c, const __al
     __first_          = __allocation.ptr;
     __begin_ = __end_ = __first_;
     __end_cap()       = __first_ + __allocation.count;
-    typedef move_iterator<iterator> _Ip;
-    __construct_at_end(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    __construct_at_end(_Iter(__c.begin()), _Iter(__c.end()));
   }
 }
 

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -234,22 +234,22 @@ struct __member_pointer_class_type<_Ret _ClassType::*> {
   typedef _ClassType type;
 };
 
-template <class _Fp,
+template <class _Func,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = __decay_t<_Func>,
           class _DecayA0 = __decay_t<_A0>,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet1 =
     __enable_if_t<is_member_function_pointer<_DecayFp>::value &&
                   (is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value)>;
 
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
+template <class _Func, class _A0, class _DecayFp = __decay_t<_Func>, class _DecayA0 = __decay_t<_A0> >
 using __enable_if_bullet2 =
     __enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
 
-template <class _Fp,
+template <class _Func,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = __decay_t<_Func>,
           class _DecayA0 = __decay_t<_A0>,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet3 =
@@ -257,22 +257,22 @@ using __enable_if_bullet3 =
                   !(is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value) &&
                   !__is_reference_wrapper<_DecayA0>::value>;
 
-template <class _Fp,
+template <class _Func,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = __decay_t<_Func>,
           class _DecayA0 = __decay_t<_A0>,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet4 =
     __enable_if_t<is_member_object_pointer<_DecayFp>::value &&
                   (is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value)>;
 
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
+template <class _Func, class _A0, class _DecayFp = __decay_t<_Func>, class _DecayA0 = __decay_t<_A0> >
 using __enable_if_bullet5 =
     __enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
 
-template <class _Fp,
+template <class _Func,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = __decay_t<_Func>,
           class _DecayA0 = __decay_t<_A0>,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet6 =
@@ -290,87 +290,87 @@ __nat __invoke(__any, _Args&&... __args);
 // bullets 1, 2 and 3
 
 // clang-format off
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet1<_Fp, _A0> >
+template <class _Func, class _A0, class... _Args, class = __enable_if_bullet1<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((std::declval<_A0>().*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
+decltype((std::declval<_A0>().*std::declval<_Func>())(std::declval<_Args>()...))
+__invoke(_Func&& __f, _A0&& __a0, _Args&&... __args)
     _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
                { return (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
 
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet2<_Fp, _A0> >
+template <class _Func, class _A0, class... _Args, class = __enable_if_bullet2<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((std::declval<_A0>().get().*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
+decltype((std::declval<_A0>().get().*std::declval<_Func>())(std::declval<_Args>()...))
+__invoke(_Func&& __f, _A0&& __a0, _Args&&... __args)
     _NOEXCEPT_(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
                { return (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
 
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet3<_Fp, _A0> >
+template <class _Func, class _A0, class... _Args, class = __enable_if_bullet3<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(((*std::declval<_A0>()).*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
+decltype(((*std::declval<_A0>()).*std::declval<_Func>())(std::declval<_Args>()...))
+__invoke(_Func&& __f, _A0&& __a0, _Args&&... __args)
     _NOEXCEPT_(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
                { return ((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...); }
 
 // bullets 4, 5 and 6
 
-template <class _Fp, class _A0, class = __enable_if_bullet4<_Fp, _A0> >
+template <class _Func, class _A0, class = __enable_if_bullet4<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_A0>().*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
+decltype(std::declval<_A0>().*std::declval<_Func>())
+__invoke(_Func&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*__f))
                { return static_cast<_A0&&>(__a0).*__f; }
 
-template <class _Fp, class _A0, class = __enable_if_bullet5<_Fp, _A0> >
+template <class _Func, class _A0, class = __enable_if_bullet5<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_A0>().get().*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
+decltype(std::declval<_A0>().get().*std::declval<_Func>())
+__invoke(_Func&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(__a0.get().*__f))
                { return __a0.get().*__f; }
 
-template <class _Fp, class _A0, class = __enable_if_bullet6<_Fp, _A0> >
+template <class _Func, class _A0, class = __enable_if_bullet6<_Func, _A0> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((*std::declval<_A0>()).*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
+decltype((*std::declval<_A0>()).*std::declval<_Func>())
+__invoke(_Func&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept((*static_cast<_A0&&>(__a0)).*__f))
                { return (*static_cast<_A0&&>(__a0)).*__f; }
 
 // bullet 7
 
-template <class _Fp, class... _Args>
+template <class _Func, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_Fp>()(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _Args&&... __args)
-    _NOEXCEPT_(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
-               { return static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...); }
+decltype(std::declval<_Func>()(std::declval<_Args>()...))
+__invoke(_Func&& __f, _Args&&... __args)
+    _NOEXCEPT_(noexcept(static_cast<_Func&&>(__f)(static_cast<_Args&&>(__args)...)))
+               { return static_cast<_Func&&>(__f)(static_cast<_Args&&>(__args)...); }
 // clang-format on
 
 // __invokable
-template <class _Ret, class _Fp, class... _Args>
+template <class _Ret, class _Func, class... _Args>
 struct __invokable_r {
   template <class _XFp, class... _XArgs>
   static decltype(std::__invoke(std::declval<_XFp>(), std::declval<_XArgs>()...)) __try_call(int);
   template <class _XFp, class... _XArgs>
   static __nat __try_call(...);
 
-  // FIXME: Check that _Ret, _Fp, and _Args... are all complete types, cv void,
+  // FIXME: Check that _Ret, _Func, and _Args... are all complete types, cv void,
   // or incomplete array types as required by the standard.
-  using _Result = decltype(__try_call<_Fp, _Args...>(0));
+  using _Result = decltype(__try_call<_Func, _Args...>(0));
 
   using type              = __conditional_t<_IsNotSame<_Result, __nat>::value,
                                __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret> >,
                                false_type>;
   static const bool value = type::value;
 };
-template <class _Fp, class... _Args>
-using __invokable = __invokable_r<void, _Fp, _Args...>;
+template <class _Func, class... _Args>
+using __invokable = __invokable_r<void, _Func, _Args...>;
 
-template <bool _IsInvokable, bool _IsCVVoid, class _Ret, class _Fp, class... _Args>
+template <bool _IsInvokable, bool _IsCVVoid, class _Ret, class _Func, class... _Args>
 struct __nothrow_invokable_r_imp {
   static const bool value = false;
 };
 
-template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...> {
+template <class _Ret, class _Func, class... _Args>
+struct __nothrow_invokable_r_imp<true, false, _Ret, _Func, _Args...> {
   typedef __nothrow_invokable_r_imp _ThisT;
 
   template <class _Tp>
@@ -380,29 +380,29 @@ struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...> {
   static const bool value = false;
 #else
   static const bool value =
-      noexcept(_ThisT::__test_noexcept<_Ret>(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...)));
+      noexcept(_ThisT::__test_noexcept<_Ret>(std::__invoke(std::declval<_Func>(), std::declval<_Args>()...)));
 #endif
 };
 
-template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, true, _Ret, _Fp, _Args...> {
+template <class _Ret, class _Func, class... _Args>
+struct __nothrow_invokable_r_imp<true, true, _Ret, _Func, _Args...> {
 #ifdef _LIBCPP_CXX03_LANG
   static const bool value = false;
 #else
-  static const bool value = noexcept(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...));
+  static const bool value = noexcept(std::__invoke(std::declval<_Func>(), std::declval<_Args>()...));
 #endif
 };
 
-template <class _Ret, class _Fp, class... _Args>
+template <class _Ret, class _Func, class... _Args>
 using __nothrow_invokable_r =
-    __nothrow_invokable_r_imp<__invokable_r<_Ret, _Fp, _Args...>::value, is_void<_Ret>::value, _Ret, _Fp, _Args...>;
+    __nothrow_invokable_r_imp<__invokable_r<_Ret, _Func, _Args...>::value, is_void<_Ret>::value, _Ret, _Func, _Args...>;
 
-template <class _Fp, class... _Args>
-using __nothrow_invokable = __nothrow_invokable_r_imp<__invokable<_Fp, _Args...>::value, true, void, _Fp, _Args...>;
+template <class _Func, class... _Args>
+using __nothrow_invokable = __nothrow_invokable_r_imp<__invokable<_Func, _Args...>::value, true, void, _Func, _Args...>;
 
-template <class _Fp, class... _Args>
+template <class _Func, class... _Args>
 struct __invoke_of
-    : public enable_if<__invokable<_Fp, _Args...>::value, typename __invokable_r<void, _Fp, _Args...>::_Result> {};
+    : public enable_if<__invokable<_Func, _Args...>::value, typename __invokable_r<void, _Func, _Args...>::_Result> {};
 
 template <class _Ret, bool = is_void<_Ret>::value>
 struct __invoke_void_return_wrapper {

--- a/libcxx/include/__type_traits/result_of.h
+++ b/libcxx/include/__type_traits/result_of.h
@@ -24,8 +24,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Callable>
 class _LIBCPP_DEPRECATED_IN_CXX17 result_of;
 
-template <class _Fp, class... _Args>
-class _LIBCPP_TEMPLATE_VIS result_of<_Fp(_Args...)> : public __invoke_of<_Fp, _Args...> {};
+template <class _Func, class... _Args>
+class _LIBCPP_TEMPLATE_VIS result_of<_Func(_Args...)> : public __invoke_of<_Func, _Args...> {};
 
 #  if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/strip_signature.h
+++ b/libcxx/include/__type_traits/strip_signature.h
@@ -19,7 +19,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-template <class _Fp>
+template <class _Func>
 struct __strip_signature;
 
 #  if defined(__cpp_static_call_operator) && __cpp_static_call_operator >= 202207L

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -1348,8 +1348,8 @@ inline deque<_Tp, _Allocator>::deque(deque&& __c, const __type_identity_t<alloca
     __map_.clear();
     __start_ = 0;
     __size() = 0;
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__c.begin()), _Iter(__c.end()));
   }
 }
 
@@ -1363,8 +1363,8 @@ inline deque<_Tp, _Allocator>& deque<_Tp, _Allocator>::operator=(deque&& __c) _N
 template <class _Tp, class _Allocator>
 void deque<_Tp, _Allocator>::__move_assign(deque& __c, false_type) {
   if (__alloc() != __c.__alloc()) {
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__c.begin()), _Iter(__c.end()));
   } else
     __move_assign(__c, true_type());
 }

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -981,8 +981,8 @@ template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a)
     : base(std::move(__x), __a) {
   if (base::__alloc() != __x.__alloc()) {
-    typedef move_iterator<iterator> _Ip;
-    insert_after(cbefore_begin(), _Ip(__x.begin()), _Ip(__x.end()));
+    typedef move_iterator<iterator> _Iter;
+    insert_after(cbefore_begin(), _Iter(__x.begin()), _Iter(__x.end()));
   }
 }
 
@@ -1010,8 +1010,8 @@ void forward_list<_Tp, _Alloc>::__move_assign(forward_list& __x, false_type) {
   if (base::__alloc() == __x.__alloc())
     __move_assign(__x, true_type());
   else {
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__x.begin()), _Ip(__x.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__x.begin()), _Iter(__x.end()));
   }
 }
 
@@ -1489,11 +1489,11 @@ void forward_list<_Tp, _Alloc>::reverse() _NOEXCEPT {
 template <class _Tp, class _Alloc>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const forward_list<_Tp, _Alloc>& __x, const forward_list<_Tp, _Alloc>& __y) {
   typedef forward_list<_Tp, _Alloc> _Cp;
-  typedef typename _Cp::const_iterator _Ip;
-  _Ip __ix = __x.begin();
-  _Ip __ex = __x.end();
-  _Ip __iy = __y.begin();
-  _Ip __ey = __y.end();
+  typedef typename _Cp::const_iterator _Iter;
+  _Iter __ix = __x.begin();
+  _Iter __ex = __x.end();
+  _Iter __iy = __y.begin();
+  _Iter __ey = __y.end();
   for (; __ix != __ex && __iy != __ey; ++__ix, ++__iy)
     if (!(*__ix == *__iy))
       return false;

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -844,7 +844,7 @@ void __async_assoc_state<_Rp, _Func>::__execute() {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
-template <class _Rp, class w_Func>
+template <class _Rp, class _Func>
 void __async_assoc_state<_Rp, _Func>::__on_zero_shared() _NOEXCEPT {
   this->wait();
   base::__on_zero_shared();

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -753,25 +753,25 @@ void __assoc_sub_state_alloc<_Alloc>::__on_zero_shared() _NOEXCEPT {
   __a.deallocate(_PTraits::pointer_to(*this), 1);
 }
 
-template <class _Rp, class _Fp>
+template <class _Rp, class _Func>
 class __deferred_assoc_state : public __assoc_state<_Rp> {
   typedef __assoc_state<_Rp> base;
 
-  _Fp __func_;
+  _Func __func_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __deferred_assoc_state(_Fp&& __f);
+  _LIBCPP_HIDE_FROM_ABI explicit __deferred_assoc_state(_Func&& __f);
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __execute();
 };
 
-template <class _Rp, class _Fp>
-inline __deferred_assoc_state<_Rp, _Fp>::__deferred_assoc_state(_Fp&& __f) : __func_(std::forward<_Fp>(__f)) {
+template <class _Rp, class _Func>
+inline __deferred_assoc_state<_Rp, _Func>::__deferred_assoc_state(_Func&& __f) : __func_(std::forward<_Func>(__f)) {
   this->__set_deferred();
 }
 
-template <class _Rp, class _Fp>
-void __deferred_assoc_state<_Rp, _Fp>::__execute() {
+template <class _Rp, class _Func>
+void __deferred_assoc_state<_Rp, _Func>::__execute() {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -783,25 +783,25 @@ void __deferred_assoc_state<_Rp, _Fp>::__execute() {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
-template <class _Fp>
-class __deferred_assoc_state<void, _Fp> : public __assoc_sub_state {
+template <class _Func>
+class __deferred_assoc_state<void, _Func> : public __assoc_sub_state {
   typedef __assoc_sub_state base;
 
-  _Fp __func_;
+  _Func __func_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __deferred_assoc_state(_Fp&& __f);
+  _LIBCPP_HIDE_FROM_ABI explicit __deferred_assoc_state(_Func&& __f);
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL void __execute() override;
 };
 
-template <class _Fp>
-inline __deferred_assoc_state<void, _Fp>::__deferred_assoc_state(_Fp&& __f) : __func_(std::forward<_Fp>(__f)) {
+template <class _Func>
+inline __deferred_assoc_state<void, _Func>::__deferred_assoc_state(_Func&& __f) : __func_(std::forward<_Func>(__f)) {
   this->__set_deferred();
 }
 
-template <class _Fp>
-void __deferred_assoc_state<void, _Fp>::__execute() {
+template <class _Func>
+void __deferred_assoc_state<void, _Func>::__execute() {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -814,25 +814,25 @@ void __deferred_assoc_state<void, _Fp>::__execute() {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
-template <class _Rp, class _Fp>
+template <class _Rp, class _Func>
 class __async_assoc_state : public __assoc_state<_Rp> {
   typedef __assoc_state<_Rp> base;
 
-  _Fp __func_;
+  _Func __func_;
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __on_zero_shared() _NOEXCEPT;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __async_assoc_state(_Fp&& __f);
+  _LIBCPP_HIDE_FROM_ABI explicit __async_assoc_state(_Func&& __f);
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __execute();
 };
 
-template <class _Rp, class _Fp>
-inline __async_assoc_state<_Rp, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(std::forward<_Fp>(__f)) {}
+template <class _Rp, class _Func>
+inline __async_assoc_state<_Rp, _Func>::__async_assoc_state(_Func&& __f) : __func_(std::forward<_Func>(__f)) {}
 
-template <class _Rp, class _Fp>
-void __async_assoc_state<_Rp, _Fp>::__execute() {
+template <class _Rp, class _Func>
+void __async_assoc_state<_Rp, _Func>::__execute() {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -844,31 +844,31 @@ void __async_assoc_state<_Rp, _Fp>::__execute() {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
-template <class _Rp, class _Fp>
-void __async_assoc_state<_Rp, _Fp>::__on_zero_shared() _NOEXCEPT {
+template <class _Rp, class w_Func>
+void __async_assoc_state<_Rp, _Func>::__on_zero_shared() _NOEXCEPT {
   this->wait();
   base::__on_zero_shared();
 }
 
-template <class _Fp>
-class __async_assoc_state<void, _Fp> : public __assoc_sub_state {
+template <class _Func>
+class __async_assoc_state<void, _Func> : public __assoc_sub_state {
   typedef __assoc_sub_state base;
 
-  _Fp __func_;
+  _Func __func_;
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL void __on_zero_shared() _NOEXCEPT override;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __async_assoc_state(_Fp&& __f);
+  _LIBCPP_HIDE_FROM_ABI explicit __async_assoc_state(_Func&& __f);
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL void __execute() override;
 };
 
-template <class _Fp>
-inline __async_assoc_state<void, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(std::forward<_Fp>(__f)) {}
+template <class _Func>
+inline __async_assoc_state<void, _Func>::__async_assoc_state(_Func&& __f) : __func_(std::forward<_Func>(__f)) {}
 
-template <class _Fp>
-void __async_assoc_state<void, _Fp>::__execute() {
+template <class _Func>
+void __async_assoc_state<void, _Func>::__execute() {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -881,8 +881,8 @@ void __async_assoc_state<void, _Fp>::__execute() {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
-template <class _Fp>
-void __async_assoc_state<void, _Fp>::__on_zero_shared() _NOEXCEPT {
+template <class _Func>
+void __async_assoc_state<void, _Func>::__on_zero_shared() _NOEXCEPT {
   this->wait();
   base::__on_zero_shared();
 }
@@ -897,11 +897,11 @@ class _LIBCPP_TEMPLATE_VIS shared_future;
 template <class _Rp>
 class _LIBCPP_TEMPLATE_VIS future;
 
-template <class _Rp, class _Fp>
-_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Fp&& __f);
+template <class _Rp, class _Func>
+_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Func&& __f);
 
-template <class _Rp, class _Fp>
-_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Fp&& __f);
+template <class _Rp, class _Func>
+_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Func&& __f);
 
 template <class _Rp>
 class _LIBCPP_TEMPLATE_VIS future {
@@ -914,10 +914,10 @@ class _LIBCPP_TEMPLATE_VIS future {
   template <class>
   friend class shared_future;
 
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_deferred_assoc_state(_Fp&& __f);
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_async_assoc_state(_Fp&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_deferred_assoc_state(_Func&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_async_assoc_state(_Func&& __f);
 
 public:
   _LIBCPP_HIDE_FROM_ABI future() _NOEXCEPT : __state_(nullptr) {}
@@ -985,10 +985,10 @@ class _LIBCPP_TEMPLATE_VIS future<_Rp&> {
   template <class>
   friend class shared_future;
 
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_deferred_assoc_state(_Fp&& __f);
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_async_assoc_state(_Fp&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_deferred_assoc_state(_Func&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_async_assoc_state(_Func&& __f);
 
 public:
   _LIBCPP_HIDE_FROM_ABI future() _NOEXCEPT : __state_(nullptr) {}
@@ -1052,10 +1052,10 @@ class _LIBCPP_EXPORTED_FROM_ABI future<void> {
   template <class>
   friend class shared_future;
 
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_deferred_assoc_state(_Fp&& __f);
-  template <class _R1, class _Fp>
-  friend future<_R1> __make_async_assoc_state(_Fp&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_deferred_assoc_state(_Func&& __f);
+  template <class _R1, class _Func>
+  friend future<_R1> __make_async_assoc_state(_Func&& __f);
 
 public:
   _LIBCPP_HIDE_FROM_ABI future() _NOEXCEPT : __state_(nullptr) {}
@@ -1376,7 +1376,7 @@ struct _LIBCPP_TEMPLATE_VIS uses_allocator<promise<_Rp>, _Alloc> : public true_t
 
 // packaged_task
 
-template <class _Fp>
+template <class _Func>
 class __packaged_task_base;
 
 template <class _Rp, class... _ArgTypes>
@@ -1397,44 +1397,44 @@ public:
 template <class _FD, class _Alloc, class _FB>
 class __packaged_task_func;
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-class __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)> : public __packaged_task_base<_Rp(_ArgTypes...)> {
-  __compressed_pair<_Fp, _Alloc> __f_;
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+class __packaged_task_func<_Func, _Alloc, _Rp(_ArgTypes...)> : public __packaged_task_base<_Rp(_ArgTypes...)> {
+  __compressed_pair<_Func, _Alloc> __f_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __packaged_task_func(const _Fp& __f) : __f_(__f, __default_init_tag()) {}
-  _LIBCPP_HIDE_FROM_ABI explicit __packaged_task_func(_Fp&& __f) : __f_(std::move(__f), __default_init_tag()) {}
-  _LIBCPP_HIDE_FROM_ABI __packaged_task_func(const _Fp& __f, const _Alloc& __a) : __f_(__f, __a) {}
-  _LIBCPP_HIDE_FROM_ABI __packaged_task_func(_Fp&& __f, const _Alloc& __a) : __f_(std::move(__f), __a) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __packaged_task_func(const _Func& __f) : __f_(__f, __default_init_tag()) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __packaged_task_func(_Func&& __f) : __f_(std::move(__f), __default_init_tag()) {}
+  _LIBCPP_HIDE_FROM_ABI __packaged_task_func(const _Func& __f, const _Alloc& __a) : __f_(__f, __a) {}
+  _LIBCPP_HIDE_FROM_ABI __packaged_task_func(_Func&& __f, const _Alloc& __a) : __f_(std::move(__f), __a) {}
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __move_to(__packaged_task_base<_Rp(_ArgTypes...)>*) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void destroy();
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void destroy_deallocate();
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual _Rp operator()(_ArgTypes&&... __args);
 };
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__move_to(
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __packaged_task_func<_Func, _Alloc, _Rp(_ArgTypes...)>::__move_to(
     __packaged_task_base<_Rp(_ArgTypes...)>* __p) _NOEXCEPT {
   ::new ((void*)__p) __packaged_task_func(std::move(__f_.first()), std::move(__f_.second()));
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy() {
-  __f_.~__compressed_pair<_Fp, _Alloc>();
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __packaged_task_func<_Func, _Alloc, _Rp(_ArgTypes...)>::destroy() {
+  __f_.~__compressed_pair<_Func, _Alloc>();
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-void __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+void __packaged_task_func<_Func, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() {
   typedef typename __allocator_traits_rebind<_Alloc, __packaged_task_func>::type _Ap;
   typedef allocator_traits<_Ap> _ATraits;
   typedef pointer_traits<typename _ATraits::pointer> _PTraits;
   _Ap __a(__f_.second());
-  __f_.~__compressed_pair<_Fp, _Alloc>();
+  __f_.~__compressed_pair<_Func, _Alloc>();
   __a.deallocate(_PTraits::pointer_to(*this), 1);
 }
 
-template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
-_Rp __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&&... __arg) {
+template <class _Func, class _Alloc, class _Rp, class... _ArgTypes>
+_Rp __packaged_task_func<_Func, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&&... __arg) {
   return std::__invoke(__f_.first(), std::forward<_ArgTypes>(__arg)...);
 }
 
@@ -1457,10 +1457,10 @@ public:
 
   // construct/copy/destroy:
   _LIBCPP_HIDE_FROM_ABI __packaged_task_function() _NOEXCEPT : __f_(nullptr) {}
-  template <class _Fp>
-  _LIBCPP_HIDE_FROM_ABI __packaged_task_function(_Fp&& __f);
-  template <class _Fp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI __packaged_task_function(allocator_arg_t, const _Alloc& __a, _Fp&& __f);
+  template <class _Func>
+  _LIBCPP_HIDE_FROM_ABI __packaged_task_function(_Func&& __f);
+  template <class _Func, class _Alloc>
+  _LIBCPP_HIDE_FROM_ABI __packaged_task_function(allocator_arg_t, const _Alloc& __a, _Func&& __f);
 
   _LIBCPP_HIDE_FROM_ABI __packaged_task_function(__packaged_task_function&&) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI __packaged_task_function& operator=(__packaged_task_function&&) _NOEXCEPT;
@@ -1489,38 +1489,38 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(__packaged
 }
 
 template <class _Rp, class... _ArgTypes>
-template <class _Fp>
-__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(_Fp&& __f) : __f_(nullptr) {
-  typedef __libcpp_remove_reference_t<__decay_t<_Fp> > _FR;
+template <class _Func>
+__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(_Func&& __f) : __f_(nullptr) {
+  typedef __libcpp_remove_reference_t<__decay_t<_Func> > _FR;
   typedef __packaged_task_func<_FR, allocator<_FR>, _Rp(_ArgTypes...)> _FF;
   if (sizeof(_FF) <= sizeof(__buf_)) {
-    ::new ((void*)&__buf_) _FF(std::forward<_Fp>(__f));
+    ::new ((void*)&__buf_) _FF(std::forward<_Func>(__f));
     __f_ = (__base*)&__buf_;
   } else {
     typedef allocator<_FF> _Ap;
     _Ap __a;
     typedef __allocator_destructor<_Ap> _Dp;
     unique_ptr<__base, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
-    ::new ((void*)__hold.get()) _FF(std::forward<_Fp>(__f), allocator<_FR>(__a));
+    ::new ((void*)__hold.get()) _FF(std::forward<_Func>(__f), allocator<_FR>(__a));
     __f_ = __hold.release();
   }
 }
 
 template <class _Rp, class... _ArgTypes>
-template <class _Fp, class _Alloc>
-__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(allocator_arg_t, const _Alloc& __a0, _Fp&& __f)
+template <class _Func, class _Alloc>
+__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(allocator_arg_t, const _Alloc& __a0, _Func&& __f)
     : __f_(nullptr) {
-  typedef __libcpp_remove_reference_t<__decay_t<_Fp> > _FR;
+  typedef __libcpp_remove_reference_t<__decay_t<_Func> > _FR;
   typedef __packaged_task_func<_FR, _Alloc, _Rp(_ArgTypes...)> _FF;
   if (sizeof(_FF) <= sizeof(__buf_)) {
     __f_ = (__base*)&__buf_;
-    ::new ((void*)__f_) _FF(std::forward<_Fp>(__f));
+    ::new ((void*)__f_) _FF(std::forward<_Func>(__f));
   } else {
     typedef typename __allocator_traits_rebind<_Alloc, _FF>::type _Ap;
     _Ap __a(__a0);
     typedef __allocator_destructor<_Ap> _Dp;
     unique_ptr<__base, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
-    ::new ((void*)std::addressof(*__hold.get())) _FF(std::forward<_Fp>(__f), _Alloc(__a));
+    ::new ((void*)std::addressof(*__hold.get())) _FF(std::forward<_Func>(__f), _Alloc(__a));
     __f_ = std::addressof(*__hold.release());
   }
 }
@@ -1601,11 +1601,11 @@ private:
 public:
   // construction and destruction
   _LIBCPP_HIDE_FROM_ABI packaged_task() _NOEXCEPT : __p_(nullptr) {}
-  template <class _Fp, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
-  _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
-  template <class _Fp, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
-  _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
-      : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
+  template <class _Func, class = __enable_if_t<!is_same<__remove_cvref_t<_Func>, packaged_task>::value> >
+  _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Func&& __f) : __f_(std::forward<_Func>(__f)) {}
+  template <class _Func, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Func>, packaged_task>::value> >
+  _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Func&& __f)
+      : __f_(allocator_arg_t(), __a, std::forward<_Func>(__f)), __p_(allocator_arg_t(), __a) {}
   // ~packaged_task() = default;
 
   // no copy
@@ -1691,11 +1691,11 @@ private:
 public:
   // construction and destruction
   _LIBCPP_HIDE_FROM_ABI packaged_task() _NOEXCEPT : __p_(nullptr) {}
-  template <class _Fp, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
-  _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
-  template <class _Fp, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
-  _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
-      : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
+  template <class _Func, class = __enable_if_t<!is_same<__remove_cvref_t<_Func>, packaged_task>::value> >
+  _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Func&& __f) : __f_(std::forward<_Func>(__f)) {}
+  template <class _Func, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Func>, packaged_task>::value> >
+  _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Func&& __f)
+      : __f_(allocator_arg_t(), __a, std::forward<_Func>(__f)), __p_(allocator_arg_t(), __a) {}
   // ~packaged_task() = default;
 
   // no copy
@@ -1733,8 +1733,8 @@ public:
 template <class _Rp, class... _Args>
 packaged_task(_Rp (*)(_Args...)) -> packaged_task<_Rp(_Args...)>;
 
-template <class _Fp, class _Stripped = typename __strip_signature<decltype(&_Fp::operator())>::type>
-packaged_task(_Fp) -> packaged_task<_Stripped>;
+template <class _Func, class _Stripped = typename __strip_signature<decltype(&_Func::operator())>::type>
+packaged_task(_Func) -> packaged_task<_Stripped>;
 
 #endif
 
@@ -1790,31 +1790,31 @@ swap(packaged_task<_Rp(_ArgTypes...)>& __x, packaged_task<_Rp(_ArgTypes...)>& __
 template <class _Callable, class _Alloc>
 struct _LIBCPP_TEMPLATE_VIS uses_allocator<packaged_task<_Callable>, _Alloc> : public true_type {};
 
-template <class _Rp, class _Fp>
-_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Fp&& __f) {
-  unique_ptr<__deferred_assoc_state<_Rp, _Fp>, __release_shared_count> __h(
-      new __deferred_assoc_state<_Rp, _Fp>(std::forward<_Fp>(__f)));
+template <class _Rp, class _Func>
+_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Func&& __f) {
+  unique_ptr<__deferred_assoc_state<_Rp, _Func>, __release_shared_count> __h(
+      new __deferred_assoc_state<_Rp, _Func>(std::forward<_Func>(__f)));
   return future<_Rp>(__h.get());
 }
 
-template <class _Rp, class _Fp>
-_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Fp&& __f) {
-  unique_ptr<__async_assoc_state<_Rp, _Fp>, __release_shared_count> __h(
-      new __async_assoc_state<_Rp, _Fp>(std::forward<_Fp>(__f)));
-  std::thread(&__async_assoc_state<_Rp, _Fp>::__execute, __h.get()).detach();
+template <class _Rp, class _Func>
+_LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Func&& __f) {
+  unique_ptr<__async_assoc_state<_Rp, _Func>, __release_shared_count> __h(
+      new __async_assoc_state<_Rp, _Func>(std::forward<_Func>(__f)));
+  std::thread(&__async_assoc_state<_Rp, _Func>::__execute, __h.get()).detach();
   return future<_Rp>(__h.get());
 }
 
 #ifndef _LIBCPP_CXX03_LANG
 
-template <class _Fp, class... _Args>
+template <class _Func, class... _Args>
 class _LIBCPP_HIDDEN __async_func {
-  tuple<_Fp, _Args...> __f_;
+  tuple<_Func, _Args...> __f_;
 
 public:
-  typedef typename __invoke_of<_Fp, _Args...>::type _Rp;
+  typedef typename __invoke_of<_Func, _Args...>::type _Rp;
 
-  _LIBCPP_HIDE_FROM_ABI explicit __async_func(_Fp&& __f, _Args&&... __args)
+  _LIBCPP_HIDE_FROM_ABI explicit __async_func(_Func&& __f, _Args&&... __args)
       : __f_(std::move(__f), std::move(__args)...) {}
 
   _LIBCPP_HIDE_FROM_ABI __async_func(__async_func&& __f) : __f_(std::move(__f.__f_)) {}
@@ -1835,11 +1835,11 @@ inline _LIBCPP_HIDE_FROM_ABI bool __does_policy_contain(launch __policy, launch 
   return (int(__policy) & int(__value)) != 0;
 }
 
-template <class _Fp, class... _Args>
+template <class _Func, class... _Args>
 _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
-    future<typename __invoke_of<__decay_t<_Fp>, __decay_t<_Args>...>::type>
-    async(launch __policy, _Fp&& __f, _Args&&... __args) {
-  typedef __async_func<__decay_t<_Fp>, __decay_t<_Args>...> _BF;
+    future<typename __invoke_of<__decay_t<_Func>, __decay_t<_Args>...>::type>
+    async(launch __policy, _Func&& __f, _Args&&... __args) {
+  typedef __async_func<__decay_t<_Func>, __decay_t<_Args>...> _BF;
   typedef typename _BF::_Rp _Rp;
 
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
@@ -1847,7 +1847,7 @@ _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
 #  endif
     if (__does_policy_contain(__policy, launch::async))
       return std::__make_async_assoc_state<_Rp>(
-          _BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
+          _BF(_LIBCPP_AUTO_CAST(std::forward<_Func>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     if (__policy == launch::async)
@@ -1857,15 +1857,15 @@ _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
 
   if (__does_policy_contain(__policy, launch::deferred))
     return std::__make_deferred_assoc_state<_Rp>(
-        _BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
+        _BF(_LIBCPP_AUTO_CAST(std::forward<_Func>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
   return future<_Rp>{};
 }
 
-template <class _Fp, class... _Args>
+template <class _Func, class... _Args>
 _LIBCPP_NODISCARD_AFTER_CXX17 inline _LIBCPP_HIDE_FROM_ABI
-    future<typename __invoke_of<__decay_t<_Fp>, __decay_t<_Args>...>::type>
-    async(_Fp&& __f, _Args&&... __args) {
-  return std::async(launch::any, std::forward<_Fp>(__f), std::forward<_Args>(__args)...);
+    future<typename __invoke_of<__decay_t<_Func>, __decay_t<_Args>...>::type>
+    async(_Func&& __f, _Args&&... __args) {
+  return std::async(launch::any, std::forward<_Func>(__f), std::forward<_Args>(__args)...);
 }
 
 #endif // C++03

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -237,11 +237,11 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t7<_MoneyT>& __x) {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
-      typedef istreambuf_iterator<_CharT, _Traits> _Ip;
-      typedef money_get<_CharT, _Ip> _Fp;
+      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
+      typedef money_get<_CharT, _Iter> _Fp;
       ios_base::iostate __err = ios_base::goodbit;
       const _Fp& __mf         = std::use_facet<_Fp>(__is.getloc());
-      __mf.get(_Ip(__is), _Ip(), __x.__intl_, __is, __err, __x.__mon_);
+      __mf.get(_Iter(__is), _Iter(), __x.__intl_, __is, __err, __x.__mon_);
       __is.setstate(__err);
     }
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
@@ -334,11 +334,11 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t9<_CharT>& __x) {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
-      typedef istreambuf_iterator<_CharT, _Traits> _Ip;
-      typedef time_get<_CharT, _Ip> _Fp;
+      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
+      typedef time_get<_CharT, _Iter> _Fp;
       ios_base::iostate __err = ios_base::goodbit;
       const _Fp& __tf         = std::use_facet<_Fp>(__is.getloc());
-      __tf.get(_Ip(__is), _Ip(), __is, __err, __x.__tm_, __x.__fmt_, __x.__fmt_ + _Traits::length(__x.__fmt_));
+      __tf.get(_Iter(__is), _Iter(), __is, __err, __x.__tm_, __x.__fmt_, __x.__fmt_ + _Traits::length(__x.__fmt_));
       __is.setstate(__err);
     }
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -315,10 +315,10 @@ basic_istream<_CharT, _Traits>::sentry::sentry(basic_istream<_CharT, _Traits>& _
     if (__is.tie())
       __is.tie()->flush();
     if (!__noskipws && (__is.flags() & ios_base::skipws)) {
-      typedef istreambuf_iterator<_CharT, _Traits> _Ip;
+      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
-      _Ip __i(__is);
-      _Ip __eof;
+      _Iter __i(__is);
+      _Iter __eof;
       for (; __i != __eof; ++__i)
         if (!__ct.is(__ct.space, *__i))
           break;
@@ -354,9 +354,9 @@ __input_arithmetic(basic_istream<_CharT, _Traits>& __is, _Tp& __n) {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef istreambuf_iterator<_CharT, _Traits> _Ip;
-      typedef num_get<_CharT, _Ip> _Fp;
-      std::use_facet<_Fp>(__is.getloc()).get(_Ip(__is), _Ip(), __is, __state, __n);
+      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
+      typedef num_get<_CharT, _Iter> _Fp;
+      std::use_facet<_Fp>(__is.getloc()).get(_Iter(__is), _Iter(), __is, __state, __n);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
@@ -435,10 +435,10 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef istreambuf_iterator<_CharT, _Traits> _Ip;
-      typedef num_get<_CharT, _Ip> _Fp;
+      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
+      typedef num_get<_CharT, _Iter> _Fp;
       long __temp;
-      std::use_facet<_Fp>(__is.getloc()).get(_Ip(__is), _Ip(), __is, __state, __temp);
+      std::use_facet<_Fp>(__is.getloc()).get(_Iter(__is), _Iter(), __is, __state, __temp);
       if (__temp < numeric_limits<_Tp>::min()) {
         __state |= ios_base::failbit;
         __n = numeric_limits<_Tp>::min();

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -1079,8 +1079,8 @@ inline list<_Tp, _Alloc>::list(list&& __c, const __type_identity_t<allocator_typ
   if (__a == __c.get_allocator())
     splice(end(), __c);
   else {
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__c.begin()), _Iter(__c.end()));
   }
 }
 
@@ -1095,8 +1095,8 @@ inline list<_Tp, _Alloc>& list<_Tp, _Alloc>::operator=(list&& __c)
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::__move_assign(list& __c, false_type) {
   if (base::__node_alloc() != __c.__node_alloc()) {
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__c.begin()), _Iter(__c.end()));
   } else
     __move_assign(__c, true_type());
 }

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -357,10 +357,10 @@ basic_ostream<_CharT, _Traits>::operator<<(basic_streambuf<char_type, traits_typ
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
         try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-          typedef istreambuf_iterator<_CharT, _Traits> _Ip;
+          typedef istreambuf_iterator<_CharT, _Traits> _Iter;
           typedef ostreambuf_iterator<_CharT, _Traits> _Op;
-          _Ip __i(__sb);
-          _Ip __eof;
+          _Iter __i(__sb);
+          _Iter __eof;
           _Op __o(*this);
           size_t __c = 0;
           for (; __i != __eof; ++__i, ++__o, ++__c) {
@@ -668,9 +668,9 @@ __put_character_sequence(basic_ostream<_CharT, _Traits>& __os, const _CharT* __s
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
-      typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
+      typedef ostreambuf_iterator<_CharT, _Traits> _Iter;
       if (std::__pad_and_output(
-              _Ip(__os),
+              _Iter(__os),
               __str,
               (__os.flags() & ios_base::adjustfield) == ios_base::left ? __str + __len : __str,
               __str + __len,
@@ -700,9 +700,9 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       _CharT __c = __os.widen(__cn);
-      typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
+      typedef ostreambuf_iterator<_CharT, _Traits> _Iter;
       if (std::__pad_and_output(
-              _Ip(__os),
+              _Iter(__os),
               &__c,
               (__os.flags() & ios_base::adjustfield) == ios_base::left ? &__c + 1 : &__c,
               &__c + 1,
@@ -748,7 +748,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const char* __strn) {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
-      typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
+      typedef ostreambuf_iterator<_CharT, _Traits> _Iter;
       size_t __len   = char_traits<char>::length(__strn);
       const int __bs = 100;
       _CharT __wbb[__bs];
@@ -763,7 +763,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const char* __strn) {
       for (_CharT* __p = __wb; *__strn != '\0'; ++__strn, ++__p)
         *__p = __os.widen(*__strn);
       if (std::__pad_and_output(
-              _Ip(__os),
+              _Iter(__os),
               __wb,
               (__os.flags() & ios_base::adjustfield) == ios_base::left ? __wb + __len : __wb,
               __wb + __len,
@@ -1047,9 +1047,9 @@ __vprint_nonunicode(ostream& __os, string_view __fmt, format_args __args, bool _
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #  endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef ostreambuf_iterator<char> _Ip;
+      typedef ostreambuf_iterator<char> _Iter;
       if (std::__pad_and_output(
-              _Ip(__os),
+              _Iter(__os),
               __str,
               (__os.flags() & ios_base::adjustfield) == ios_base::left ? __str + __len : __str,
               __str + __len,

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -1262,115 +1262,115 @@ private:
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] = __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator*=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] *= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator/=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] /= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator%=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] %= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator+=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] += __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator-=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] -= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator^=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] ^= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator&=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] &= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator|=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] |= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator<<=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] <<= __v[__j];
 }
 
 template <class _Tp>
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
 inline void gslice_array<_Tp>::operator>>=(const _Expr& __v) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   size_t __j = 0;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i, ++__j)
     __vp_[*__i] >>= __v[__j];
 }
 
 template <class _Tp>
 inline const gslice_array<_Tp>& gslice_array<_Tp>::operator=(const gslice_array& __ga) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   const value_type* __s = __ga.__vp_;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_, __j = __ga.__1d_.__begin_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_, __j = __ga.__1d_.__begin_; __i != __e; ++__i, ++__j)
     __vp_[*__i] = __s[*__j];
   return *this;
 }
 
 template <class _Tp>
 inline void gslice_array<_Tp>::operator=(const value_type& __x) const {
-  typedef const size_t* _Ip;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i)
+  typedef const size_t* _Iter;
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i)
     __vp_[*__i] = __x;
 }
 
@@ -1729,17 +1729,17 @@ inline void indirect_array<_Tp>::operator>>=(const _Expr& __v) const {
 
 template <class _Tp>
 inline const indirect_array<_Tp>& indirect_array<_Tp>::operator=(const indirect_array& __ia) const {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   const value_type* __s = __ia.__vp_;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_, __j = __ia.__1d_.__begin_; __i != __e; ++__i, ++__j)
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_, __j = __ia.__1d_.__begin_; __i != __e; ++__i, ++__j)
     __vp_[*__i] = __s[*__j];
   return *this;
 }
 
 template <class _Tp>
 inline void indirect_array<_Tp>::operator=(const value_type& __x) const {
-  typedef const size_t* _Ip;
-  for (_Ip __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i)
+  typedef const size_t* _Iter;
+  for (_Iter __i = __1d_.__begin_, __e = __1d_.__end_; __i != __e; ++__i)
     __vp_[*__i] = __x;
 }
 
@@ -2016,9 +2016,9 @@ valarray<_Tp>::valarray(const gslice_array<value_type>& __ga) : __begin_(nullptr
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef const size_t* _Ip;
+      typedef const size_t* _Iter;
       const value_type* __s = __ga.__vp_;
-      for (_Ip __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__end_)
+      for (_Iter __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
@@ -2037,9 +2037,9 @@ valarray<_Tp>::valarray(const mask_array<value_type>& __ma) : __begin_(nullptr),
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef const size_t* _Ip;
+      typedef const size_t* _Iter;
       const value_type* __s = __ma.__vp_;
-      for (_Ip __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__end_)
+      for (_Iter __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
@@ -2058,9 +2058,9 @@ valarray<_Tp>::valarray(const indirect_array<value_type>& __ia) : __begin_(nullp
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-      typedef const size_t* _Ip;
+      typedef const size_t* _Iter;
       const value_type* __s = __ia.__vp_;
-      for (_Ip __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__end_)
+      for (_Iter __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
@@ -2133,30 +2133,30 @@ inline valarray<_Tp>& valarray<_Tp>::operator=(const slice_array<value_type>& __
 
 template <class _Tp>
 inline valarray<_Tp>& valarray<_Tp>::operator=(const gslice_array<value_type>& __ga) {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   value_type* __t       = __begin_;
   const value_type* __s = __ga.__vp_;
-  for (_Ip __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__t)
+  for (_Iter __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__t)
     *__t = __s[*__i];
   return *this;
 }
 
 template <class _Tp>
 inline valarray<_Tp>& valarray<_Tp>::operator=(const mask_array<value_type>& __ma) {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   value_type* __t       = __begin_;
   const value_type* __s = __ma.__vp_;
-  for (_Ip __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__t)
+  for (_Iter __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__t)
     *__t = __s[*__i];
   return *this;
 }
 
 template <class _Tp>
 inline valarray<_Tp>& valarray<_Tp>::operator=(const indirect_array<value_type>& __ia) {
-  typedef const size_t* _Ip;
+  typedef const size_t* _Iter;
   value_type* __t       = __begin_;
   const value_type* __s = __ia.__vp_;
-  for (_Ip __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__t)
+  for (_Iter __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__t)
     *__t = __s[*__i];
   return *this;
 }

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -506,63 +506,63 @@ private:
     return __at(__elems[__index], __indices...);
   }
 
-  template <class _Fp, class... _Fs>
+  template <class _Func, class... _Fs>
   static _LIBCPP_HIDE_FROM_ABI constexpr void __std_visit_visitor_return_type_check() {
     static_assert(
-        __all<is_same_v<_Fp, _Fs>...>::value, "`std::visit` requires the visitor to have a single return type.");
+        __all<is_same_v<_Func, _Fs>...>::value, "`std::visit` requires the visitor to have a single return type.");
   }
 
-  template <class... _Fs>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_farray(_Fs&&... __fs) {
-    __std_visit_visitor_return_type_check<__remove_cvref_t<_Fs>...>();
-    using __result = __farray<common_type_t<__remove_cvref_t<_Fs>...>, sizeof...(_Fs)>;
-    return __result{{std::forward<_Fs>(__fs)...}};
+  template <class... _Funcs>
+  _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_farray(_Funcs&&... __fs) {
+    __std_visit_visitor_return_type_check<__remove_cvref_t<_Funcs>...>();
+    using __result = __farray<common_type_t<__remove_cvref_t<_Funcs>...>, sizeof...(_Funcs)>;
+    return __result{{std::forward<_Funcs>(__fs)...}};
   }
 
   template <size_t... _Is>
   struct __dispatcher {
-    template <class _Fp, class... _Vs>
-    _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto) __dispatch(_Fp __f, _Vs... __vs) {
-      return std::__invoke(static_cast<_Fp>(__f), __access::__base::__get_alt<_Is>(static_cast<_Vs>(__vs))...);
+    template <class _Func, class... _Vs>
+    _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto) __dispatch(_Func __f, _Vs... __vs) {
+      return std::__invoke(static_cast<_Func>(__f), __access::__base::__get_alt<_Is>(static_cast<_Vs>(__vs))...);
     }
   };
 
-  template <class _Fp, class... _Vs, size_t... _Is>
+  template <class _Func, class... _Vs, size_t... _Is>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_dispatch(index_sequence<_Is...>) {
-    return __dispatcher<_Is...>::template __dispatch<_Fp, _Vs...>;
+    return __dispatcher<_Is...>::template __dispatch<_Func, _Vs...>;
   }
 
-  template <size_t _Ip, class _Fp, class... _Vs>
+  template <size_t _Ip, class _Func, class... _Vs>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_fdiagonal_impl() {
-    return __make_dispatch<_Fp, _Vs...>(index_sequence<((void)__type_identity<_Vs>{}, _Ip)...>{});
+    return __make_dispatch<_Func, _Vs...>(index_sequence<((void)__type_identity<_Vs>{}, _Ip)...>{});
   }
 
-  template <class _Fp, class... _Vs, size_t... _Is>
+  template <class _Func, class... _Vs, size_t... _Is>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_fdiagonal_impl(index_sequence<_Is...>) {
-    return __base::__make_farray(__make_fdiagonal_impl<_Is, _Fp, _Vs...>()...);
+    return __base::__make_farray(__make_fdiagonal_impl<_Is, _Func, _Vs...>()...);
   }
 
-  template <class _Fp, class _Vp, class... _Vs>
+  template <class _Func, class _Vp, class... _Vs>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_fdiagonal() {
     constexpr size_t __np = __remove_cvref_t<_Vp>::__size();
     static_assert(__all<(__np == __remove_cvref_t<_Vs>::__size())...>::value);
-    return __make_fdiagonal_impl<_Fp, _Vp, _Vs...>(make_index_sequence<__np>{});
+    return __make_fdiagonal_impl<_Func, _Vp, _Vs...>(make_index_sequence<__np>{});
   }
 
-  template <class _Fp, class... _Vs, size_t... _Is>
+  template <class _Func, class... _Vs, size_t... _Is>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_fmatrix_impl(index_sequence<_Is...> __is) {
-    return __make_dispatch<_Fp, _Vs...>(__is);
+    return __make_dispatch<_Func, _Vs...>(__is);
   }
 
-  template <class _Fp, class... _Vs, size_t... _Is, size_t... _Js, class... _Ls>
+  template <class _Func, class... _Vs, size_t... _Is, size_t... _Js, class... _Ls>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto
   __make_fmatrix_impl(index_sequence<_Is...>, index_sequence<_Js...>, _Ls... __ls) {
-    return __base::__make_farray(__make_fmatrix_impl<_Fp, _Vs...>(index_sequence<_Is..., _Js>{}, __ls...)...);
+    return __base::__make_farray(__make_fmatrix_impl<_Func, _Vs...>(index_sequence<_Is..., _Js>{}, __ls...)...);
   }
 
-  template <class _Fp, class... _Vs>
+  template <class _Func, class... _Vs>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_fmatrix() {
-    return __make_fmatrix_impl<_Fp, _Vs...>(
+    return __make_fmatrix_impl<_Func, _Vs...>(
         index_sequence<>{}, make_index_sequence<__remove_cvref_t<_Vs>::__size()>{}...);
   }
 };

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -1226,9 +1226,9 @@ vector<_Tp, _Allocator>::vector(vector&& __x, const __type_identity_t<allocator_
     this->__end_cap() = __x.__end_cap();
     __x.__begin_ = __x.__end_ = __x.__end_cap() = nullptr;
   } else {
-    typedef move_iterator<iterator> _Ip;
+    typedef move_iterator<iterator> _Iter;
     auto __guard = std::__make_exception_guard(__destroy_vector(*this));
-    assign(_Ip(__x.begin()), _Ip(__x.end()));
+    assign(_Iter(__x.begin()), _Iter(__x.end()));
     __guard.__complete();
   }
 }
@@ -1272,8 +1272,8 @@ template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__move_assign(vector& __c, false_type)
     _NOEXCEPT_(__alloc_traits::is_always_equal::value) {
   if (__alloc() != __c.__alloc()) {
-    typedef move_iterator<iterator> _Ip;
-    assign(_Ip(__c.begin()), _Ip(__c.end()));
+    typedef move_iterator<iterator> _Iter;
+    assign(_Iter(__c.begin()), _Iter(__c.end()));
   } else
     __move_assign(__c, true_type());
 }

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.constr/constr.compile.fail.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.constr/constr.compile.fail.cpp
@@ -9,11 +9,10 @@
 // <thread>
 
 // class thread
-//     template <class _Fp, class ..._Args,
-//         explicit thread(_Fp&& __f, _Args&&... __args);
+//     template <class _Func, class ..._Args,
+//         explicit thread(_Func&& __f, _Args&&... __args);
 //  This constructor shall not participate in overload resolution
 //       if decay<F>::type is the same type as std::thread.
-
 
 #include <thread>
 


### PR DESCRIPTION
Sweeps through the libc++ headers to rename the following template type paramters:

* Iterators are renamed to `_Iter` unless the category is ambiguous. When it is ambiguous:
  * Input iterators are renamed to `_InIter`
  * Output iterators are renamed to `_OutIter`
* Sentinels are renamed to `_Sent`
* General invocable objects are renamed to `_Func`