### PR TITLE
[libcxx] removes non-customisation-point objects from `__cpo` namespace

### DIFF
--- a/libcxx/include/__algorithm/ranges_adjacent_find.h
+++ b/libcxx/include/__algorithm/ranges_adjacent_find.h
@@ -69,9 +69,7 @@ struct __fn {
 };
 } // namespace __adjacent_find
 
-inline namespace __cpo {
 inline constexpr auto adjacent_find = __adjacent_find::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_all_of.h
+++ b/libcxx/include/__algorithm/ranges_all_of.h
@@ -57,9 +57,7 @@ struct __fn {
 };
 } // namespace __all_of
 
-inline namespace __cpo {
 inline constexpr auto all_of = __all_of::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_any_of.h
+++ b/libcxx/include/__algorithm/ranges_any_of.h
@@ -57,9 +57,7 @@ struct __fn {
 };
 } // namespace __any_of
 
-inline namespace __cpo {
 inline constexpr auto any_of = __any_of::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_binary_search.h
+++ b/libcxx/include/__algorithm/ranges_binary_search.h
@@ -56,9 +56,7 @@ struct __fn {
 };
 } // namespace __binary_search
 
-inline namespace __cpo {
 inline constexpr auto binary_search = __binary_search::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_clamp.h
+++ b/libcxx/include/__algorithm/ranges_clamp.h
@@ -48,9 +48,7 @@ struct __fn {
 };
 } // namespace __clamp
 
-inline namespace __cpo {
 inline constexpr auto clamp = __clamp::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_contains.h
+++ b/libcxx/include/__algorithm/ranges_contains.h
@@ -49,9 +49,7 @@ struct __fn {
 };
 } // namespace __contains
 
-inline namespace __cpo {
 inline constexpr auto contains = __contains::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_copy.h
+++ b/libcxx/include/__algorithm/ranges_copy.h
@@ -54,9 +54,7 @@ struct __fn {
 };
 } // namespace __copy
 
-inline namespace __cpo {
 inline constexpr auto copy = __copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -52,9 +52,7 @@ struct __fn {
 };
 } // namespace __copy_backward
 
-inline namespace __cpo {
 inline constexpr auto copy_backward = __copy_backward::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_copy_if.h
@@ -70,9 +70,7 @@ struct __fn {
 };
 } // namespace __copy_if
 
-inline namespace __cpo {
 inline constexpr auto copy_if = __copy_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_copy_n.h
+++ b/libcxx/include/__algorithm/ranges_copy_n.h
@@ -64,9 +64,7 @@ struct __fn {
 };
 } // namespace __copy_n
 
-inline namespace __cpo {
 inline constexpr auto copy_n = __copy_n::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__algorithm/ranges_count.h
+++ b/libcxx/include/__algorithm/ranges_count.h
@@ -49,9 +49,7 @@ struct __fn {
 };
 } // namespace __count
 
-inline namespace __cpo {
 inline constexpr auto count = __count::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_count_if.h
+++ b/libcxx/include/__algorithm/ranges_count_if.h
@@ -62,9 +62,7 @@ struct __fn {
 };
 } // namespace __count_if
 
-inline namespace __cpo {
 inline constexpr auto count_if = __count_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_ends_with.h
+++ b/libcxx/include/__algorithm/ranges_ends_with.h
@@ -184,9 +184,7 @@ struct __fn {
 };
 } // namespace __ends_with
 
-inline namespace __cpo {
 inline constexpr auto ends_with = __ends_with::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_equal.h
+++ b/libcxx/include/__algorithm/ranges_equal.h
@@ -92,9 +92,7 @@ struct __fn {
 };
 } // namespace __equal
 
-inline namespace __cpo {
 inline constexpr auto equal = __equal::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_equal_range.h
+++ b/libcxx/include/__algorithm/ranges_equal_range.h
@@ -63,9 +63,7 @@ struct __fn {
 
 } // namespace __equal_range
 
-inline namespace __cpo {
 inline constexpr auto equal_range = __equal_range::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_fill.h
+++ b/libcxx/include/__algorithm/ranges_fill.h
@@ -45,9 +45,7 @@ struct __fn {
 };
 } // namespace __fill
 
-inline namespace __cpo {
 inline constexpr auto fill = __fill::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_fill_n.h
+++ b/libcxx/include/__algorithm/ranges_fill_n.h
@@ -36,9 +36,7 @@ struct __fn {
 };
 } // namespace __fill_n
 
-inline namespace __cpo {
 inline constexpr auto fill_n = __fill_n::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_find.h
+++ b/libcxx/include/__algorithm/ranges_find.h
@@ -63,9 +63,7 @@ struct __fn {
 };
 } // namespace __find
 
-inline namespace __cpo {
 inline constexpr auto find = __find::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_find_end.h
+++ b/libcxx/include/__algorithm/ranges_find_end.h
@@ -86,9 +86,7 @@ struct __fn {
 };
 } // namespace __find_end
 
-inline namespace __cpo {
 inline constexpr auto find_end = __find_end::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_find_first_of.h
+++ b/libcxx/include/__algorithm/ranges_find_first_of.h
@@ -89,9 +89,7 @@ struct __fn {
 };
 } // namespace __find_first_of
 
-inline namespace __cpo {
 inline constexpr auto find_first_of = __find_first_of::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_find_if.h
+++ b/libcxx/include/__algorithm/ranges_find_if.h
@@ -58,9 +58,7 @@ struct __fn {
 };
 } // namespace __find_if
 
-inline namespace __cpo {
 inline constexpr auto find_if = __find_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_find_if_not.h
+++ b/libcxx/include/__algorithm/ranges_find_if_not.h
@@ -52,9 +52,7 @@ struct __fn {
 };
 } // namespace __find_if_not
 
-inline namespace __cpo {
 inline constexpr auto find_if_not = __find_if_not::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_for_each.h
+++ b/libcxx/include/__algorithm/ranges_for_each.h
@@ -64,9 +64,7 @@ public:
 };
 } // namespace __for_each
 
-inline namespace __cpo {
 inline constexpr auto for_each = __for_each::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_for_each_n.h
+++ b/libcxx/include/__algorithm/ranges_for_each_n.h
@@ -47,9 +47,7 @@ struct __fn {
 };
 } // namespace __for_each_n
 
-inline namespace __cpo {
 inline constexpr auto for_each_n = __for_each_n::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_generate.h
+++ b/libcxx/include/__algorithm/ranges_generate.h
@@ -56,9 +56,7 @@ struct __fn {
 
 } // namespace __generate
 
-inline namespace __cpo {
 inline constexpr auto generate = __generate::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_generate_n.h
+++ b/libcxx/include/__algorithm/ranges_generate_n.h
@@ -48,9 +48,7 @@ struct __fn {
 
 } // namespace __generate_n
 
-inline namespace __cpo {
 inline constexpr auto generate_n = __generate_n::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_includes.h
+++ b/libcxx/include/__algorithm/ranges_includes.h
@@ -81,9 +81,7 @@ struct __fn {
 
 } // namespace __includes
 
-inline namespace __cpo {
 inline constexpr auto includes = __includes::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_inplace_merge.h
+++ b/libcxx/include/__algorithm/ranges_inplace_merge.h
@@ -67,9 +67,7 @@ struct __fn {
 
 } // namespace __inplace_merge
 
-inline namespace __cpo {
 inline constexpr auto inplace_merge = __inplace_merge::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_heap.h
+++ b/libcxx/include/__algorithm/ranges_is_heap.h
@@ -64,9 +64,7 @@ struct __fn {
 
 } // namespace __is_heap
 
-inline namespace __cpo {
 inline constexpr auto is_heap = __is_heap::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_heap_until.h
+++ b/libcxx/include/__algorithm/ranges_is_heap_until.h
@@ -64,9 +64,7 @@ struct __fn {
 
 } // namespace __is_heap_until
 
-inline namespace __cpo {
 inline constexpr auto is_heap_until = __is_heap_until::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_partitioned.h
+++ b/libcxx/include/__algorithm/ranges_is_partitioned.h
@@ -69,9 +69,7 @@ struct __fn {
 };
 } // namespace __is_partitioned
 
-inline namespace __cpo {
 inline constexpr auto is_partitioned = __is_partitioned::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_permutation.h
+++ b/libcxx/include/__algorithm/ranges_is_permutation.h
@@ -90,9 +90,7 @@ struct __fn {
 };
 } // namespace __is_permutation
 
-inline namespace __cpo {
 inline constexpr auto is_permutation = __is_permutation::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_sorted.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted.h
@@ -50,9 +50,7 @@ struct __fn {
 };
 } // namespace __is_sorted
 
-inline namespace __cpo {
 inline constexpr auto is_sorted = __is_sorted::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_is_sorted_until.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted_until.h
@@ -65,9 +65,7 @@ struct __fn {
 };
 } // namespace __is_sorted_until
 
-inline namespace __cpo {
 inline constexpr auto is_sorted_until = __is_sorted_until::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_lexicographical_compare.h
+++ b/libcxx/include/__algorithm/ranges_lexicographical_compare.h
@@ -89,9 +89,7 @@ struct __fn {
 };
 } // namespace __lexicographical_compare
 
-inline namespace __cpo {
 inline constexpr auto lexicographical_compare = __lexicographical_compare::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_lower_bound.h
+++ b/libcxx/include/__algorithm/ranges_lower_bound.h
@@ -56,9 +56,7 @@ struct __fn {
 };
 } // namespace __lower_bound
 
-inline namespace __cpo {
 inline constexpr auto lower_bound = __lower_bound::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_make_heap.h
+++ b/libcxx/include/__algorithm/ranges_make_heap.h
@@ -68,9 +68,7 @@ struct __fn {
 
 } // namespace __make_heap
 
-inline namespace __cpo {
 inline constexpr auto make_heap = __make_heap::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_max.h
+++ b/libcxx/include/__algorithm/ranges_max.h
@@ -89,9 +89,7 @@ struct __fn {
 };
 } // namespace __max
 
-inline namespace __cpo {
 inline constexpr auto max = __max::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_max_element.h
+++ b/libcxx/include/__algorithm/ranges_max_element.h
@@ -52,9 +52,7 @@ struct __fn {
 };
 } // namespace __max_element
 
-inline namespace __cpo {
 inline constexpr auto max_element = __max_element::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_merge.h
+++ b/libcxx/include/__algorithm/ranges_merge.h
@@ -121,9 +121,7 @@ struct __fn {
 
 } // namespace __merge
 
-inline namespace __cpo {
 inline constexpr auto merge = __merge::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_min.h
+++ b/libcxx/include/__algorithm/ranges_min.h
@@ -81,9 +81,7 @@ struct __fn {
 };
 } // namespace __min
 
-inline namespace __cpo {
 inline constexpr auto min = __min::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_min_element.h
+++ b/libcxx/include/__algorithm/ranges_min_element.h
@@ -64,9 +64,7 @@ struct __fn {
 };
 } // namespace __min_element
 
-inline namespace __cpo {
 inline constexpr auto min_element = __min_element::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_minmax.h
+++ b/libcxx/include/__algorithm/ranges_minmax.h
@@ -146,9 +146,7 @@ struct __fn {
 };
 } // namespace __minmax
 
-inline namespace __cpo {
 inline constexpr auto minmax = __minmax::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_minmax_element.h
+++ b/libcxx/include/__algorithm/ranges_minmax_element.h
@@ -60,9 +60,7 @@ struct __fn {
 };
 } // namespace __minmax_element
 
-inline namespace __cpo {
 inline constexpr auto minmax_element = __minmax_element::__fn{};
-} // namespace __cpo
 
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_mismatch.h
+++ b/libcxx/include/__algorithm/ranges_mismatch.h
@@ -77,9 +77,7 @@ struct __fn {
 };
 } // namespace __mismatch
 
-inline namespace __cpo {
 constexpr inline auto mismatch = __mismatch::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__algorithm/ranges_move.h
+++ b/libcxx/include/__algorithm/ranges_move.h
@@ -57,9 +57,7 @@ struct __fn {
 };
 } // namespace __move
 
-inline namespace __cpo {
 inline constexpr auto move = __move::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_move_backward.h
+++ b/libcxx/include/__algorithm/ranges_move_backward.h
@@ -59,9 +59,7 @@ struct __fn {
 };
 } // namespace __move_backward
 
-inline namespace __cpo {
 inline constexpr auto move_backward = __move_backward::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_next_permutation.h
+++ b/libcxx/include/__algorithm/ranges_next_permutation.h
@@ -61,9 +61,7 @@ struct __fn {
 
 } // namespace __next_permutation
 
-inline namespace __cpo {
 constexpr inline auto next_permutation = __next_permutation::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_none_of.h
+++ b/libcxx/include/__algorithm/ranges_none_of.h
@@ -58,9 +58,7 @@ struct __fn {
 };
 } // namespace __none_of
 
-inline namespace __cpo {
 inline constexpr auto none_of = __none_of::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_nth_element.h
+++ b/libcxx/include/__algorithm/ranges_nth_element.h
@@ -67,9 +67,7 @@ struct __fn {
 
 } // namespace __nth_element
 
-inline namespace __cpo {
 inline constexpr auto nth_element = __nth_element::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_partial_sort.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort.h
@@ -65,9 +65,7 @@ struct __fn {
 
 } // namespace __partial_sort
 
-inline namespace __cpo {
 inline constexpr auto partial_sort = __partial_sort::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_partial_sort_copy.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort_copy.h
@@ -97,9 +97,7 @@ struct __fn {
 
 } // namespace __partial_sort_copy
 
-inline namespace __cpo {
 inline constexpr auto partial_sort_copy = __partial_sort_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_partition.h
+++ b/libcxx/include/__algorithm/ranges_partition.h
@@ -71,9 +71,7 @@ struct __fn {
 
 } // namespace __partition
 
-inline namespace __cpo {
 inline constexpr auto partition = __partition::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_partition_copy.h
+++ b/libcxx/include/__algorithm/ranges_partition_copy.h
@@ -93,9 +93,7 @@ struct __fn {
 
 } // namespace __partition_copy
 
-inline namespace __cpo {
 inline constexpr auto partition_copy = __partition_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_partition_point.h
+++ b/libcxx/include/__algorithm/ranges_partition_point.h
@@ -76,9 +76,7 @@ struct __fn {
 
 } // namespace __partition_point
 
-inline namespace __cpo {
 inline constexpr auto partition_point = __partition_point::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_pop_heap.h
+++ b/libcxx/include/__algorithm/ranges_pop_heap.h
@@ -69,9 +69,7 @@ struct __fn {
 
 } // namespace __pop_heap
 
-inline namespace __cpo {
 inline constexpr auto pop_heap = __pop_heap::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_prev_permutation.h
+++ b/libcxx/include/__algorithm/ranges_prev_permutation.h
@@ -61,9 +61,7 @@ struct __fn {
 
 } // namespace __prev_permutation
 
-inline namespace __cpo {
 constexpr inline auto prev_permutation = __prev_permutation::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_push_heap.h
+++ b/libcxx/include/__algorithm/ranges_push_heap.h
@@ -68,9 +68,7 @@ struct __fn {
 
 } // namespace __push_heap
 
-inline namespace __cpo {
 inline constexpr auto push_heap = __push_heap::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_remove.h
+++ b/libcxx/include/__algorithm/ranges_remove.h
@@ -51,9 +51,7 @@ struct __fn {
 };
 } // namespace __remove
 
-inline namespace __cpo {
 inline constexpr auto remove = __remove::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_remove_copy.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy.h
@@ -64,9 +64,7 @@ struct __fn {
 
 } // namespace __remove_copy
 
-inline namespace __cpo {
 inline constexpr auto remove_copy = __remove_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_remove_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy_if.h
@@ -78,9 +78,7 @@ struct __fn {
 
 } // namespace __remove_copy_if
 
-inline namespace __cpo {
 inline constexpr auto remove_copy_if = __remove_copy_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_remove_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_if.h
@@ -72,9 +72,7 @@ struct __fn {
 };
 } // namespace __remove_if
 
-inline namespace __cpo {
 inline constexpr auto remove_if = __remove_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_replace.h
+++ b/libcxx/include/__algorithm/ranges_replace.h
@@ -51,9 +51,7 @@ struct __fn {
 };
 } // namespace __replace
 
-inline namespace __cpo {
 inline constexpr auto replace = __replace::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_replace_copy.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy.h
@@ -76,9 +76,7 @@ struct __fn {
 
 } // namespace __replace_copy
 
-inline namespace __cpo {
 inline constexpr auto replace_copy = __replace_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_replace_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy_if.h
@@ -81,9 +81,7 @@ struct __fn {
 
 } // namespace __replace_copy_if
 
-inline namespace __cpo {
 inline constexpr auto replace_copy_if = __replace_copy_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_replace_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_if.h
@@ -64,9 +64,7 @@ struct __fn {
 };
 } // namespace __replace_if
 
-inline namespace __cpo {
 inline constexpr auto replace_if = __replace_if::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_reverse.h
+++ b/libcxx/include/__algorithm/ranges_reverse.h
@@ -67,9 +67,7 @@ struct __fn {
 };
 } // namespace __reverse
 
-inline namespace __cpo {
 inline constexpr auto reverse = __reverse::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_reverse_copy.h
+++ b/libcxx/include/__algorithm/ranges_reverse_copy.h
@@ -53,9 +53,7 @@ struct __fn {
 };
 } // namespace __reverse_copy
 
-inline namespace __cpo {
 inline constexpr auto reverse_copy = __reverse_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_rotate.h
+++ b/libcxx/include/__algorithm/ranges_rotate.h
@@ -54,9 +54,7 @@ struct __fn {
 
 } // namespace __rotate
 
-inline namespace __cpo {
 inline constexpr auto rotate = __rotate::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_rotate_copy.h
+++ b/libcxx/include/__algorithm/ranges_rotate_copy.h
@@ -51,9 +51,7 @@ struct __fn {
 };
 } // namespace __rotate_copy
 
-inline namespace __cpo {
 inline constexpr auto rotate_copy = __rotate_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_sample.h
+++ b/libcxx/include/__algorithm/ranges_sample.h
@@ -57,9 +57,7 @@ struct __fn {
 
 } // namespace __sample
 
-inline namespace __cpo {
 inline constexpr auto sample = __sample::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_search.h
+++ b/libcxx/include/__algorithm/ranges_search.h
@@ -122,9 +122,7 @@ struct __fn {
 };
 } // namespace __search
 
-inline namespace __cpo {
 inline constexpr auto search = __search::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_search_n.h
+++ b/libcxx/include/__algorithm/ranges_search_n.h
@@ -99,9 +99,7 @@ struct __fn {
 };
 } // namespace __search_n
 
-inline namespace __cpo {
 inline constexpr auto search_n = __search_n::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_set_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_difference.h
@@ -92,9 +92,7 @@ struct __fn {
 
 } // namespace __set_difference
 
-inline namespace __cpo {
 inline constexpr auto set_difference = __set_difference::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_set_intersection.h
+++ b/libcxx/include/__algorithm/ranges_set_intersection.h
@@ -97,9 +97,7 @@ struct __fn {
 
 } // namespace __set_intersection
 
-inline namespace __cpo {
 inline constexpr auto set_intersection = __set_intersection::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
@@ -97,9 +97,7 @@ struct __fn {
 
 } // namespace __set_symmetric_difference
 
-inline namespace __cpo {
 inline constexpr auto set_symmetric_difference = __set_symmetric_difference::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_set_union.h
+++ b/libcxx/include/__algorithm/ranges_set_union.h
@@ -98,9 +98,7 @@ struct __fn {
 
 } // namespace __set_union
 
-inline namespace __cpo {
 inline constexpr auto set_union = __set_union::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_shuffle.h
+++ b/libcxx/include/__algorithm/ranges_shuffle.h
@@ -55,9 +55,7 @@ struct __fn {
 
 } // namespace __shuffle
 
-inline namespace __cpo {
 inline constexpr auto shuffle = __shuffle::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_sort.h
+++ b/libcxx/include/__algorithm/ranges_sort.h
@@ -67,9 +67,7 @@ struct __fn {
 
 } // namespace __sort
 
-inline namespace __cpo {
 inline constexpr auto sort = __sort::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_sort_heap.h
+++ b/libcxx/include/__algorithm/ranges_sort_heap.h
@@ -68,9 +68,7 @@ struct __fn {
 
 } // namespace __sort_heap
 
-inline namespace __cpo {
 inline constexpr auto sort_heap = __sort_heap::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_stable_partition.h
+++ b/libcxx/include/__algorithm/ranges_stable_partition.h
@@ -75,9 +75,7 @@ struct __fn {
 
 } // namespace __stable_partition
 
-inline namespace __cpo {
 inline constexpr auto stable_partition = __stable_partition::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_stable_sort.h
+++ b/libcxx/include/__algorithm/ranges_stable_sort.h
@@ -65,9 +65,7 @@ struct __fn {
 
 } // namespace __stable_sort
 
-inline namespace __cpo {
 inline constexpr auto stable_sort = __stable_sort::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_starts_with.h
+++ b/libcxx/include/__algorithm/ranges_starts_with.h
@@ -78,9 +78,7 @@ struct __fn {
   }
 };
 } // namespace __starts_with
-inline namespace __cpo {
 inline constexpr auto starts_with = __starts_with::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_swap_ranges.h
+++ b/libcxx/include/__algorithm/ranges_swap_ranges.h
@@ -53,9 +53,7 @@ struct __fn {
 };
 } // namespace __swap_ranges
 
-inline namespace __cpo {
 inline constexpr auto swap_ranges = __swap_ranges::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_transform.h
+++ b/libcxx/include/__algorithm/ranges_transform.h
@@ -160,9 +160,7 @@ public:
 };
 } // namespace __transform
 
-inline namespace __cpo {
 inline constexpr auto transform = __transform::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -65,9 +65,7 @@ struct __fn {
 
 } // namespace __unique
 
-inline namespace __cpo {
 inline constexpr auto unique = __unique::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_unique_copy.h
+++ b/libcxx/include/__algorithm/ranges_unique_copy.h
@@ -103,9 +103,7 @@ struct __fn {
 
 } // namespace __unique_copy
 
-inline namespace __cpo {
 inline constexpr auto unique_copy = __unique_copy::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_upper_bound.h
+++ b/libcxx/include/__algorithm/ranges_upper_bound.h
@@ -62,9 +62,7 @@ struct __fn {
 };
 } // namespace __upper_bound
 
-inline namespace __cpo {
 inline constexpr auto upper_bound = __upper_bound::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -188,9 +188,7 @@ public:
 
 } // namespace __advance
 
-inline namespace __cpo {
 inline constexpr auto advance = __advance::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -87,9 +87,7 @@ struct __fn {
 
 } // namespace __distance
 
-inline namespace __cpo {
 inline constexpr auto distance = __distance::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/next.h
+++ b/libcxx/include/__iterator/next.h
@@ -69,9 +69,7 @@ struct __fn {
 
 } // namespace __next
 
-inline namespace __cpo {
 inline constexpr auto next = __next::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -62,9 +62,7 @@ struct __fn {
 
 } // namespace __prev
 
-inline namespace __cpo {
 inline constexpr auto prev = __prev::__fn{};
-} // namespace __cpo
 } // namespace ranges
 
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__memory/ranges_construct_at.h
+++ b/libcxx/include/__memory/ranges_construct_at.h
@@ -49,9 +49,7 @@ struct __fn {
 
 } // namespace __construct_at
 
-inline namespace __cpo {
 inline constexpr auto construct_at = __construct_at::__fn{};
-} // namespace __cpo
 
 // destroy_at
 
@@ -66,9 +64,7 @@ struct __fn {
 
 } // namespace __destroy_at
 
-inline namespace __cpo {
 inline constexpr auto destroy_at = __destroy_at::__fn{};
-} // namespace __cpo
 
 // destroy
 
@@ -90,9 +86,7 @@ struct __fn {
 
 } // namespace __destroy
 
-inline namespace __cpo {
 inline constexpr auto destroy = __destroy::__fn{};
-} // namespace __cpo
 
 // destroy_n
 
@@ -109,9 +103,7 @@ struct __fn {
 
 } // namespace __destroy_n
 
-inline namespace __cpo {
 inline constexpr auto destroy_n = __destroy_n::__fn{};
-} // namespace __cpo
 
 } // namespace ranges
 

--- a/libcxx/include/__memory/ranges_uninitialized_algorithms.h
+++ b/libcxx/include/__memory/ranges_uninitialized_algorithms.h
@@ -58,9 +58,7 @@ struct __fn {
 
 } // namespace __uninitialized_default_construct
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_default_construct = __uninitialized_default_construct::__fn{};
-} // namespace __cpo
 
 // uninitialized_default_construct_n
 
@@ -78,9 +76,7 @@ struct __fn {
 
 } // namespace __uninitialized_default_construct_n
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_default_construct_n = __uninitialized_default_construct_n::__fn{};
-} // namespace __cpo
 
 // uninitialized_value_construct
 
@@ -103,9 +99,7 @@ struct __fn {
 
 } // namespace __uninitialized_value_construct
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_value_construct = __uninitialized_value_construct::__fn{};
-} // namespace __cpo
 
 // uninitialized_value_construct_n
 
@@ -123,9 +117,7 @@ struct __fn {
 
 } // namespace __uninitialized_value_construct_n
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_value_construct_n = __uninitialized_value_construct_n::__fn{};
-} // namespace __cpo
 
 // uninitialized_fill
 
@@ -148,9 +140,7 @@ struct __fn {
 
 } // namespace __uninitialized_fill
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_fill = __uninitialized_fill::__fn{};
-} // namespace __cpo
 
 // uninitialized_fill_n
 
@@ -168,9 +158,7 @@ struct __fn {
 
 } // namespace __uninitialized_fill_n
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_fill_n = __uninitialized_fill_n::__fn{};
-} // namespace __cpo
 
 // uninitialized_copy
 
@@ -206,9 +194,7 @@ struct __fn {
 
 } // namespace __uninitialized_copy
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_copy = __uninitialized_copy::__fn{};
-} // namespace __cpo
 
 // uninitialized_copy_n
 
@@ -237,9 +223,7 @@ struct __fn {
 
 } // namespace __uninitialized_copy_n
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_copy_n = __uninitialized_copy_n::__fn{};
-} // namespace __cpo
 
 // uninitialized_move
 
@@ -275,9 +259,7 @@ struct __fn {
 
 } // namespace __uninitialized_move
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_move = __uninitialized_move::__fn{};
-} // namespace __cpo
 
 // uninitialized_move_n
 
@@ -307,9 +289,7 @@ struct __fn {
 
 } // namespace __uninitialized_move_n
 
-inline namespace __cpo {
 inline constexpr auto uninitialized_move_n = __uninitialized_move_n::__fn{};
-} // namespace __cpo
 
 } // namespace ranges
 


### PR DESCRIPTION
Customisation-point objects often rely on ADL as a hook for users to customise their behaviour. This requires a function declaration with the same name as the CPO (which is a function object) in the same scope as the CPO. The technique for getting around having both a function and a function object in the same scope is to put the CPO inside an inline namespace: the function is declared as deleted, and so only the CPO can be called.

The iterator primitive functions and algorithms in `std::ranges` are not CPOs and thus do not need to be in the `__cpo` namespace.