### PR TITLE
[libcxx] removes dedicated namespaces for ranges stuff

### DIFF
--- a/libcxx/include/__algorithm/ranges_adjacent_find.h
+++ b/libcxx/include/__algorithm/ranges_adjacent_find.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __adjacent_find {
-struct __fn {
+struct __adjacent_find {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __adjacent_find_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
@@ -67,10 +66,9 @@ struct __fn {
     return __adjacent_find_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __adjacent_find
 
 inline namespace __cpo {
-inline constexpr auto adjacent_find = __adjacent_find::__fn{};
+inline constexpr auto adjacent_find = __adjacent_find{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_all_of.h
+++ b/libcxx/include/__algorithm/ranges_all_of.h
@@ -30,8 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __all_of {
-struct __fn {
+struct __all_of {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool __all_of_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
     for (; __first != __last; ++__first) {
@@ -58,10 +57,9 @@ struct __fn {
     return __all_of_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __all_of
 
 inline namespace __cpo {
-inline constexpr auto all_of = __all_of::__fn{};
+inline constexpr auto all_of = __all_of{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_any_of.h
+++ b/libcxx/include/__algorithm/ranges_any_of.h
@@ -30,8 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __any_of {
-struct __fn {
+struct __any_of {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool __any_of_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
     for (; __first != __last; ++__first) {
@@ -58,10 +57,9 @@ struct __fn {
     return __any_of_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __any_of
 
 inline namespace __cpo {
-inline constexpr auto any_of = __any_of::__fn{};
+inline constexpr auto any_of = __any_of{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_binary_search.h
+++ b/libcxx/include/__algorithm/ranges_binary_search.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __binary_search {
-struct __fn {
+struct __binary_search {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Type,
@@ -57,10 +56,9 @@ struct __fn {
     return __ret != __last && !std::invoke(__comp, __value, std::invoke(__proj, *__ret));
   }
 };
-} // namespace __binary_search
 
 inline namespace __cpo {
-inline constexpr auto binary_search = __binary_search::__fn{};
+inline constexpr auto binary_search = __binary_search{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_clamp.h
+++ b/libcxx/include/__algorithm/ranges_clamp.h
@@ -30,8 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __clamp {
-struct __fn {
+struct __clamp {
   template <class _Type,
             class _Proj                                                      = identity,
             indirect_strict_weak_order<projected<const _Type*, _Proj>> _Comp = ranges::less>
@@ -50,10 +49,9 @@ struct __fn {
       return __value;
   }
 };
-} // namespace __clamp
 
 inline namespace __cpo {
-inline constexpr auto clamp = __clamp::__fn{};
+inline constexpr auto clamp = __clamp{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_contains.h
+++ b/libcxx/include/__algorithm/ranges_contains.h
@@ -33,8 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __contains {
-struct __fn {
+struct __contains {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool static
@@ -50,10 +49,9 @@ struct __fn {
            ranges::end(__range);
   }
 };
-} // namespace __contains
 
 inline namespace __cpo {
-inline constexpr auto contains = __contains::__fn{};
+inline constexpr auto contains = __contains{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_contains_subrange.h
+++ b/libcxx/include/__algorithm/ranges_contains_subrange.h
@@ -35,8 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __contains_subrange {
-struct __fn {
+struct __contains_subrange {
   template <forward_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             forward_iterator _Iter2,
@@ -81,10 +80,9 @@ struct __fn {
     return __ret.empty() == false;
   }
 };
-} // namespace __contains_subrange
 
 inline namespace __cpo {
-inline constexpr auto contains_subrange = __contains_subrange::__fn{};
+inline constexpr auto contains_subrange = __contains_subrange{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_copy.h
+++ b/libcxx/include/__algorithm/ranges_copy.h
@@ -37,8 +37,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __copy {
-struct __fn {
+struct __copy {
   template <input_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_result<_InIter, _OutIter>
@@ -55,10 +54,9 @@ struct __fn {
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 };
-} // namespace __copy
 
 inline namespace __cpo {
-inline constexpr auto copy = __copy::__fn{};
+inline constexpr auto copy = __copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -35,8 +35,7 @@ namespace ranges {
 template <class _Ip, class _Op>
 using copy_backward_result = in_out_result<_Ip, _Op>;
 
-namespace __copy_backward {
-struct __fn {
+struct __copy_backward {
   template <bidirectional_iterator _InIter1, sentinel_for<_InIter1> _Sent1, bidirectional_iterator _InIter2>
     requires indirectly_copyable<_InIter1, _InIter2>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_backward_result<_InIter1, _InIter2>
@@ -53,10 +52,9 @@ struct __fn {
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 };
-} // namespace __copy_backward
 
 inline namespace __cpo {
-inline constexpr auto copy_backward = __copy_backward::__fn{};
+inline constexpr auto copy_backward = __copy_backward{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_copy_if.h
@@ -36,8 +36,7 @@ namespace ranges {
 template <class _Ip, class _Op>
 using copy_if_result = in_out_result<_Ip, _Op>;
 
-namespace __copy_if {
-struct __fn {
+struct __copy_if {
   template <class _InIter, class _Sent, class _OutIter, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI static constexpr copy_if_result<_InIter, _OutIter>
   __copy_if_impl(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj& __proj) {
@@ -71,10 +70,9 @@ struct __fn {
     return __copy_if_impl(ranges::begin(__r), ranges::end(__r), std::move(__result), __pred, __proj);
   }
 };
-} // namespace __copy_if
 
 inline namespace __cpo {
-inline constexpr auto copy_if = __copy_if::__fn{};
+inline constexpr auto copy_if = __copy_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_copy_n.h
+++ b/libcxx/include/__algorithm/ranges_copy_n.h
@@ -37,8 +37,7 @@ namespace ranges {
 template <class _Ip, class _Op>
 using copy_n_result = in_out_result<_Ip, _Op>;
 
-namespace __copy_n {
-struct __fn {
+struct __copy_n {
   template <class _InIter, class _DiffType, class _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr static copy_n_result<_InIter, _OutIter>
   __go(_InIter __first, _DiffType __n, _OutIter __result) {
@@ -65,10 +64,9 @@ struct __fn {
     return __go(std::move(__first), __n, std::move(__result));
   }
 };
-} // namespace __copy_n
 
 inline namespace __cpo {
-inline constexpr auto copy_n = __copy_n::__fn{};
+inline constexpr auto copy_n = __copy_n{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_count.h
+++ b/libcxx/include/__algorithm/ranges_count.h
@@ -34,8 +34,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __count {
-struct __fn {
+struct __count {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter>
@@ -50,10 +49,9 @@ struct __fn {
     return std::__count<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), __value, __proj);
   }
 };
-} // namespace __count
 
 inline namespace __cpo {
-inline constexpr auto count = __count::__fn{};
+inline constexpr auto count = __count{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_count_if.h
+++ b/libcxx/include/__algorithm/ranges_count_if.h
@@ -44,8 +44,7 @@ __count_if_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   return __counter;
 }
 
-namespace __count_if {
-struct __fn {
+struct __count_if {
   template <input_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
@@ -63,10 +62,9 @@ struct __fn {
     return ranges::__count_if_impl(ranges::begin(__r), ranges::end(__r), __pred, __proj);
   }
 };
-} // namespace __count_if
 
 inline namespace __cpo {
-inline constexpr auto count_if = __count_if::__fn{};
+inline constexpr auto count_if = __count_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_ends_with.h
+++ b/libcxx/include/__algorithm/ranges_ends_with.h
@@ -36,8 +36,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __ends_with {
-struct __fn {
+struct __ends_with {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
   _LIBCPP_HIDE_FROM_ABI static constexpr bool __ends_with_fn_impl_bidirectional(
       _Iter1 __first1,
@@ -185,10 +184,9 @@ struct __fn {
     }
   }
 };
-} // namespace __ends_with
 
 inline namespace __cpo {
-inline constexpr auto ends_with = __ends_with::__fn{};
+inline constexpr auto ends_with = __ends_with{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_equal.h
+++ b/libcxx/include/__algorithm/ranges_equal.h
@@ -34,8 +34,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __equal {
-struct __fn {
+struct __equal {
   template <input_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             input_iterator _Iter2,
@@ -93,10 +92,9 @@ struct __fn {
     return false;
   }
 };
-} // namespace __equal
 
 inline namespace __cpo {
-inline constexpr auto equal = __equal::__fn{};
+inline constexpr auto equal = __equal{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_equal_range.h
+++ b/libcxx/include/__algorithm/ranges_equal_range.h
@@ -38,9 +38,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __equal_range {
-
-struct __fn {
+struct __equal_range {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Tp,
@@ -64,10 +62,8 @@ struct __fn {
   }
 };
 
-} // namespace __equal_range
-
 inline namespace __cpo {
-inline constexpr auto equal_range = __equal_range::__fn{};
+inline constexpr auto equal_range = __equal_range{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_fill.h
+++ b/libcxx/include/__algorithm/ranges_fill.h
@@ -28,8 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __fill {
-struct __fn {
+struct __fill {
   template <class _Type, output_iterator<const _Type&> _Iter, sentinel_for<_Iter> _Sent>
   _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __first, _Sent __last, const _Type& __value) const {
     if constexpr (random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>) {
@@ -46,10 +45,9 @@ struct __fn {
     return (*this)(ranges::begin(__range), ranges::end(__range), __value);
   }
 };
-} // namespace __fill
 
 inline namespace __cpo {
-inline constexpr auto fill = __fill::__fn{};
+inline constexpr auto fill = __fill{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_fill_n.h
+++ b/libcxx/include/__algorithm/ranges_fill_n.h
@@ -25,8 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __fill_n {
-struct __fn {
+struct __fill_n {
   template <class _Type, output_iterator<const _Type&> _Iter>
   _LIBCPP_HIDE_FROM_ABI constexpr _Iter
   operator()(_Iter __first, iter_difference_t<_Iter> __n, const _Type& __value) const {
@@ -37,10 +36,9 @@ struct __fn {
     return __first;
   }
 };
-} // namespace __fill_n
 
 inline namespace __cpo {
-inline constexpr auto fill_n = __fill_n::__fn{};
+inline constexpr auto fill_n = __fill_n{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find.h
+++ b/libcxx/include/__algorithm/ranges_find.h
@@ -36,8 +36,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __find {
-struct __fn {
+struct __find {
   template <class _Iter, class _Sent, class _Tp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI static constexpr _Iter
   __find_unwrap(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
@@ -64,10 +63,9 @@ struct __fn {
     return __find_unwrap(ranges::begin(__r), ranges::end(__r), __value, __proj);
   }
 };
-} // namespace __find
 
 inline namespace __cpo {
-inline constexpr auto find = __find::__fn{};
+inline constexpr auto find = __find{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find_end.h
+++ b/libcxx/include/__algorithm/ranges_find_end.h
@@ -35,8 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __find_end {
-struct __fn {
+struct __find_end {
   template <forward_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             forward_iterator _Iter2,
@@ -87,10 +86,9 @@ struct __fn {
     return {__ret.first, __ret.second};
   }
 };
-} // namespace __find_end
 
 inline namespace __cpo {
-inline constexpr auto find_end = __find_end::__fn{};
+inline constexpr auto find_end = __find_end{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find_first_of.h
+++ b/libcxx/include/__algorithm/ranges_find_first_of.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __find_first_of {
-struct __fn {
+struct __find_first_of {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter1 __find_first_of_impl(
       _Iter1 __first1,
@@ -90,10 +89,9 @@ struct __fn {
         __proj2);
   }
 };
-} // namespace __find_first_of
 
 inline namespace __cpo {
-inline constexpr auto find_first_of = __find_first_of::__fn{};
+inline constexpr auto find_first_of = __find_first_of{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find_if.h
+++ b/libcxx/include/__algorithm/ranges_find_if.h
@@ -42,8 +42,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Ip __find_if_impl(_Ip __first, _Sp __last, _Pre
   return __first;
 }
 
-namespace __find_if {
-struct __fn {
+struct __find_if {
   template <input_iterator _Ip,
             sentinel_for<_Ip> _Sp,
             class _Proj = identity,
@@ -59,10 +58,9 @@ struct __fn {
     return ranges::__find_if_impl(ranges::begin(__r), ranges::end(__r), __pred, __proj);
   }
 };
-} // namespace __find_if
 
 inline namespace __cpo {
-inline constexpr auto find_if = __find_if::__fn{};
+inline constexpr auto find_if = __find_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find_if_not.h
+++ b/libcxx/include/__algorithm/ranges_find_if_not.h
@@ -34,8 +34,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __find_if_not {
-struct __fn {
+struct __find_if_not {
   template <input_iterator _Ip,
             sentinel_for<_Ip> _Sp,
             class _Proj = identity,
@@ -53,10 +52,9 @@ struct __fn {
     return ranges::__find_if_impl(ranges::begin(__r), ranges::end(__r), __pred2, __proj);
   }
 };
-} // namespace __find_if_not
 
 inline namespace __cpo {
-inline constexpr auto find_if_not = __find_if_not::__fn{};
+inline constexpr auto find_if_not = __find_if_not{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_find_last.h
+++ b/libcxx/include/__algorithm/ranges_find_last.h
@@ -72,8 +72,7 @@ __find_last_impl(_Iter __first, _Sent __last, _Pred __pred, _Proj& __proj) {
   }
 }
 
-namespace __find_last {
-struct __fn {
+struct __find_last {
   template <class _Type>
   struct __op {
     const _Type& __value;
@@ -97,10 +96,8 @@ struct __fn {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Type>{__value}, __proj);
   }
 };
-} // namespace __find_last
 
-namespace __find_last_if {
-struct __fn {
+struct __find_last_if {
   template <class _Pred>
   struct __op {
     _Pred& __pred;
@@ -127,10 +124,8 @@ struct __fn {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Pred>{__pred}, __proj);
   }
 };
-} // namespace __find_last_if
 
-namespace __find_last_if_not {
-struct __fn {
+struct __find_last_if_not {
   template <class _Pred>
   struct __op {
     _Pred& __pred;
@@ -157,12 +152,11 @@ struct __fn {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Pred>{__pred}, __proj);
   }
 };
-} // namespace __find_last_if_not
 
 inline namespace __cpo {
-inline constexpr auto find_last        = __find_last::__fn{};
-inline constexpr auto find_last_if     = __find_last_if::__fn{};
-inline constexpr auto find_last_if_not = __find_last_if_not::__fn{};
+inline constexpr auto find_last        = __find_last{};
+inline constexpr auto find_last_if     = __find_last_if{};
+inline constexpr auto find_last_if_not = __find_last_if_not{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_for_each.h
+++ b/libcxx/include/__algorithm/ranges_for_each.h
@@ -36,8 +36,7 @@ namespace ranges {
 template <class _Iter, class _Func>
 using for_each_result = in_fun_result<_Iter, _Func>;
 
-namespace __for_each {
-struct __fn {
+struct __for_each {
 private:
   template <class _Iter, class _Sent, class _Proj, class _Func>
   _LIBCPP_HIDE_FROM_ABI constexpr static for_each_result<_Iter, _Func>
@@ -65,10 +64,9 @@ public:
     return __for_each_impl(ranges::begin(__range), ranges::end(__range), __func, __proj);
   }
 };
-} // namespace __for_each
 
 inline namespace __cpo {
-inline constexpr auto for_each = __for_each::__fn{};
+inline constexpr auto for_each = __for_each{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_for_each_n.h
+++ b/libcxx/include/__algorithm/ranges_for_each_n.h
@@ -36,8 +36,7 @@ namespace ranges {
 template <class _Iter, class _Func>
 using for_each_n_result = in_fun_result<_Iter, _Func>;
 
-namespace __for_each_n {
-struct __fn {
+struct __for_each_n {
   template <input_iterator _Iter, class _Proj = identity, indirectly_unary_invocable<projected<_Iter, _Proj>> _Func>
   _LIBCPP_HIDE_FROM_ABI constexpr for_each_n_result<_Iter, _Func>
   operator()(_Iter __first, iter_difference_t<_Iter> __count, _Func __func, _Proj __proj = {}) const {
@@ -48,10 +47,9 @@ struct __fn {
     return {std::move(__first), std::move(__func)};
   }
 };
-} // namespace __for_each_n
 
 inline namespace __cpo {
-inline constexpr auto for_each_n = __for_each_n::__fn{};
+inline constexpr auto for_each_n = __for_each_n{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_generate.h
+++ b/libcxx/include/__algorithm/ranges_generate.h
@@ -32,9 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __generate {
-
-struct __fn {
+struct __generate {
   template <class _OutIter, class _Sent, class _Func>
   _LIBCPP_HIDE_FROM_ABI constexpr static _OutIter __generate_fn_impl(_OutIter __first, _Sent __last, _Func& __gen) {
     for (; __first != __last; ++__first) {
@@ -57,10 +55,8 @@ struct __fn {
   }
 };
 
-} // namespace __generate
-
 inline namespace __cpo {
-inline constexpr auto generate = __generate::__fn{};
+inline constexpr auto generate = __generate{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_generate_n.h
+++ b/libcxx/include/__algorithm/ranges_generate_n.h
@@ -33,9 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __generate_n {
-
-struct __fn {
+struct __generate_n {
   template <input_or_output_iterator _OutIter, copy_constructible _Func>
     requires invocable<_Func&> && indirectly_writable<_OutIter, invoke_result_t<_Func&>>
   _LIBCPP_HIDE_FROM_ABI constexpr _OutIter
@@ -49,10 +47,8 @@ struct __fn {
   }
 };
 
-} // namespace __generate_n
-
 inline namespace __cpo {
-inline constexpr auto generate_n = __generate_n::__fn{};
+inline constexpr auto generate_n = __generate_n{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_includes.h
+++ b/libcxx/include/__algorithm/ranges_includes.h
@@ -35,9 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __includes {
-
-struct __fn {
+struct __includes {
   template <input_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             input_iterator _Iter2,
@@ -82,10 +80,8 @@ struct __fn {
   }
 };
 
-} // namespace __includes
-
 inline namespace __cpo {
-inline constexpr auto includes = __includes::__fn{};
+inline constexpr auto includes = __includes{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_inplace_merge.h
+++ b/libcxx/include/__algorithm/ranges_inplace_merge.h
@@ -39,9 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __inplace_merge {
-
-struct __fn {
+struct __inplace_merge {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto
   __inplace_merge_impl(_Iter __first, _Iter __middle, _Sent __last, _Comp&& __comp, _Proj&& __proj) {
@@ -68,10 +66,8 @@ struct __fn {
   }
 };
 
-} // namespace __inplace_merge
-
 inline namespace __cpo {
-inline constexpr auto inplace_merge = __inplace_merge::__fn{};
+inline constexpr auto inplace_merge = __inplace_merge{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_heap.h
+++ b/libcxx/include/__algorithm/ranges_is_heap.h
@@ -34,9 +34,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __is_heap {
-
-struct __fn {
+struct __is_heap {
   template <class _Iter, class _Sent, class _Proj, class _Comp>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool
   __is_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -65,10 +63,8 @@ struct __fn {
   }
 };
 
-} // namespace __is_heap
-
 inline namespace __cpo {
-inline constexpr auto is_heap = __is_heap::__fn{};
+inline constexpr auto is_heap = __is_heap{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_heap_until.h
+++ b/libcxx/include/__algorithm/ranges_is_heap_until.h
@@ -35,9 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __is_heap_until {
-
-struct __fn {
+struct __is_heap_until {
   template <class _Iter, class _Sent, class _Proj, class _Comp>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __is_heap_until_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -65,10 +63,8 @@ struct __fn {
   }
 };
 
-} // namespace __is_heap_until
-
 inline namespace __cpo {
-inline constexpr auto is_heap_until = __is_heap_until::__fn{};
+inline constexpr auto is_heap_until = __is_heap_until{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_partitioned.h
+++ b/libcxx/include/__algorithm/ranges_is_partitioned.h
@@ -31,8 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __is_partitioned {
-struct __fn {
+struct __is_partitioned {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool
   __is_partitioned_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
@@ -70,10 +69,9 @@ struct __fn {
     return __is_partitioned_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __is_partitioned
 
 inline namespace __cpo {
-inline constexpr auto is_partitioned = __is_partitioned::__fn{};
+inline constexpr auto is_partitioned = __is_partitioned{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_permutation.h
+++ b/libcxx/include/__algorithm/ranges_is_permutation.h
@@ -33,8 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __is_permutation {
-struct __fn {
+struct __is_permutation {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Proj1, class _Proj2, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool __is_permutation_func_impl(
       _Iter1 __first1,
@@ -91,10 +90,9 @@ struct __fn {
         __proj2);
   }
 };
-} // namespace __is_permutation
 
 inline namespace __cpo {
-inline constexpr auto is_permutation = __is_permutation::__fn{};
+inline constexpr auto is_permutation = __is_permutation{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_sorted.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted.h
@@ -31,8 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __is_sorted {
-struct __fn {
+struct __is_sorted {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
@@ -51,10 +50,9 @@ struct __fn {
     return ranges::__is_sorted_until_impl(ranges::begin(__range), __last, __comp, __proj) == __last;
   }
 };
-} // namespace __is_sorted
 
 inline namespace __cpo {
-inline constexpr auto is_sorted = __is_sorted::__fn{};
+inline constexpr auto is_sorted = __is_sorted{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_is_sorted_until.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted_until.h
@@ -47,8 +47,7 @@ __is_sorted_until_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj
   return __i;
 }
 
-namespace __is_sorted_until {
-struct __fn {
+struct __is_sorted_until {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
@@ -66,10 +65,9 @@ struct __fn {
     return ranges::__is_sorted_until_impl(ranges::begin(__range), ranges::end(__range), __comp, __proj);
   }
 };
-} // namespace __is_sorted_until
 
 inline namespace __cpo {
-inline constexpr auto is_sorted_until = __is_sorted_until::__fn{};
+inline constexpr auto is_sorted_until = __is_sorted_until{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_lexicographical_compare.h
+++ b/libcxx/include/__algorithm/ranges_lexicographical_compare.h
@@ -31,8 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __lexicographical_compare {
-struct __fn {
+struct __lexicographical_compare {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Proj1, class _Proj2, class _Comp>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool __lexicographical_compare_impl(
       _Iter1 __first1,
@@ -90,10 +89,9 @@ struct __fn {
         __proj2);
   }
 };
-} // namespace __lexicographical_compare
 
 inline namespace __cpo {
-inline constexpr auto lexicographical_compare = __lexicographical_compare::__fn{};
+inline constexpr auto lexicographical_compare = __lexicographical_compare{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_lower_bound.h
+++ b/libcxx/include/__algorithm/ranges_lower_bound.h
@@ -36,8 +36,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
 
-namespace __lower_bound {
-struct __fn {
+struct __lower_bound {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Type,
@@ -57,10 +56,9 @@ struct __fn {
     return std::__lower_bound<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), __value, __comp, __proj);
   }
 };
-} // namespace __lower_bound
 
 inline namespace __cpo {
-inline constexpr auto lower_bound = __lower_bound::__fn{};
+inline constexpr auto lower_bound = __lower_bound{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_make_heap.h
+++ b/libcxx/include/__algorithm/ranges_make_heap.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __make_heap {
-
-struct __fn {
+struct __make_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __make_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -69,10 +67,8 @@ struct __fn {
   }
 };
 
-} // namespace __make_heap
-
 inline namespace __cpo {
-inline constexpr auto make_heap = __make_heap::__fn{};
+inline constexpr auto make_heap = __make_heap{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_max.h
+++ b/libcxx/include/__algorithm/ranges_max.h
@@ -36,8 +36,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __max {
-struct __fn {
+struct __max {
   template <class _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
@@ -87,10 +86,9 @@ struct __fn {
     }
   }
 };
-} // namespace __max
 
 inline namespace __cpo {
-inline constexpr auto max = __max::__fn{};
+inline constexpr auto max = __max{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_max_element.h
+++ b/libcxx/include/__algorithm/ranges_max_element.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __max_element {
-struct __fn {
+struct __max_element {
   template <forward_iterator _Ip,
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
@@ -53,10 +52,9 @@ struct __fn {
     return ranges::__min_element_impl(ranges::begin(__r), ranges::end(__r), __comp_lhs_rhs_swapped, __proj);
   }
 };
-} // namespace __max_element
 
 inline namespace __cpo {
-inline constexpr auto max_element = __max_element::__fn{};
+inline constexpr auto max_element = __max_element{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_merge.h
+++ b/libcxx/include/__algorithm/ranges_merge.h
@@ -39,42 +39,7 @@ namespace ranges {
 template <class _InIter1, class _InIter2, class _OutIter>
 using merge_result = in_in_out_result<_InIter1, _InIter2, _OutIter>;
 
-namespace __merge {
-
-template < class _InIter1,
-           class _Sent1,
-           class _InIter2,
-           class _Sent2,
-           class _OutIter,
-           class _Comp,
-           class _Proj1,
-           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI constexpr merge_result<__remove_cvref_t<_InIter1>,
-                                             __remove_cvref_t<_InIter2>,
-                                             __remove_cvref_t<_OutIter>>
-__merge_impl(_InIter1&& __first1,
-             _Sent1&& __last1,
-             _InIter2&& __first2,
-             _Sent2&& __last2,
-             _OutIter&& __result,
-             _Comp&& __comp,
-             _Proj1&& __proj1,
-             _Proj2&& __proj2) {
-  for (; __first1 != __last1 && __first2 != __last2; ++__result) {
-    if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))) {
-      *__result = *__first2;
-      ++__first2;
-    } else {
-      *__result = *__first1;
-      ++__first1;
-    }
-  }
-  auto __ret1 = ranges::copy(std::move(__first1), std::move(__last1), std::move(__result));
-  auto __ret2 = ranges::copy(std::move(__first2), std::move(__last2), std::move(__ret1.out));
-  return {std::move(__ret1.in), std::move(__ret2.in), std::move(__ret2.out)};
-}
-
-struct __fn {
+struct __merge {
   template <input_iterator _InIter1,
             sentinel_for<_InIter1> _Sent1,
             input_iterator _InIter2,
@@ -120,12 +85,43 @@ struct __fn {
         __proj1,
         __proj2);
   }
+
+  template < class _InIter1,
+             class _Sent1,
+             class _InIter2,
+             class _Sent2,
+             class _OutIter,
+             class _Comp,
+             class _Proj1,
+             class _Proj2>
+  _LIBCPP_HIDE_FROM_ABI static constexpr merge_result<__remove_cvref_t<_InIter1>,
+                                                      __remove_cvref_t<_InIter2>,
+                                                      __remove_cvref_t<_OutIter>>
+  __merge_impl(_InIter1&& __first1,
+               _Sent1&& __last1,
+               _InIter2&& __first2,
+               _Sent2&& __last2,
+               _OutIter&& __result,
+               _Comp&& __comp,
+               _Proj1&& __proj1,
+               _Proj2&& __proj2) {
+    for (; __first1 != __last1 && __first2 != __last2; ++__result) {
+      if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))) {
+        *__result = *__first2;
+        ++__first2;
+      } else {
+        *__result = *__first1;
+        ++__first1;
+      }
+    }
+    auto __ret1 = ranges::copy(std::move(__first1), std::move(__last1), std::move(__result));
+    auto __ret2 = ranges::copy(std::move(__first2), std::move(__last2), std::move(__ret1.out));
+    return {std::move(__ret1.in), std::move(__ret2.in), std::move(__ret2.out)};
+  }
 };
 
-} // namespace __merge
-
 inline namespace __cpo {
-inline constexpr auto merge = __merge::__fn{};
+inline constexpr auto merge = __merge{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_min.h
+++ b/libcxx/include/__algorithm/ranges_min.h
@@ -35,8 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __min {
-struct __fn {
+struct __min {
   template <class _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
@@ -79,10 +78,9 @@ struct __fn {
     }
   }
 };
-} // namespace __min
 
 inline namespace __cpo {
-inline constexpr auto min = __min::__fn{};
+inline constexpr auto min = __min{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_min_element.h
+++ b/libcxx/include/__algorithm/ranges_min_element.h
@@ -46,8 +46,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Ip __min_element_impl(_Ip __first, _Sp __last, 
   return __first;
 }
 
-namespace __min_element {
-struct __fn {
+struct __min_element {
   template <forward_iterator _Ip,
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
@@ -65,10 +64,9 @@ struct __fn {
     return ranges::__min_element_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };
-} // namespace __min_element
 
 inline namespace __cpo {
-inline constexpr auto min_element = __min_element::__fn{};
+inline constexpr auto min_element = __min_element{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_minmax.h
+++ b/libcxx/include/__algorithm/ranges_minmax.h
@@ -47,8 +47,7 @@ namespace ranges {
 template <class _T1>
 using minmax_result = min_max_result<_T1>;
 
-namespace __minmax {
-struct __fn {
+struct __minmax {
   template <class _Type,
             class _Proj                                                      = identity,
             indirect_strict_weak_order<projected<const _Type*, _Proj>> _Comp = ranges::less>
@@ -159,10 +158,9 @@ struct __fn {
     }
   }
 };
-} // namespace __minmax
 
 inline namespace __cpo {
-inline constexpr auto minmax = __minmax::__fn{};
+inline constexpr auto minmax = __minmax{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_minmax_element.h
+++ b/libcxx/include/__algorithm/ranges_minmax_element.h
@@ -40,8 +40,7 @@ namespace ranges {
 template <class _T1>
 using minmax_element_result = min_max_result<_T1>;
 
-namespace __minmax_element {
-struct __fn {
+struct __minmax_element {
   template <forward_iterator _Ip,
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
@@ -61,10 +60,9 @@ struct __fn {
     return {__ret.first, __ret.second};
   }
 };
-} // namespace __minmax_element
 
 inline namespace __cpo {
-inline constexpr auto minmax_element = __minmax_element::__fn{};
+inline constexpr auto minmax_element = __minmax_element{};
 } // namespace __cpo
 
 } // namespace ranges

--- a/libcxx/include/__algorithm/ranges_mismatch.h
+++ b/libcxx/include/__algorithm/ranges_mismatch.h
@@ -39,8 +39,7 @@ namespace ranges {
 template <class _I1, class _I2>
 using mismatch_result = in_in_result<_I1, _I2>;
 
-namespace __mismatch {
-struct __fn {
+struct __mismatch {
   template <class _I1, class _S1, class _I2, class _S2, class _Pred, class _Proj1, class _Proj2>
   static _LIBCPP_HIDE_FROM_ABI constexpr mismatch_result<_I1, _I2>
   __go(_I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
@@ -84,10 +83,9 @@ struct __fn {
         ranges::begin(__r1), ranges::end(__r1), ranges::begin(__r2), ranges::end(__r2), __pred, __proj1, __proj2);
   }
 };
-} // namespace __mismatch
 
 inline namespace __cpo {
-constexpr inline auto mismatch = __mismatch::__fn{};
+constexpr inline auto mismatch = __mismatch{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_move.h
+++ b/libcxx/include/__algorithm/ranges_move.h
@@ -35,8 +35,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using move_result = in_out_result<_InIter, _OutIter>;
 
-namespace __move {
-struct __fn {
+struct __move {
   template <class _InIter, class _Sent, class _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr static move_result<_InIter, _OutIter>
   __move_impl(_InIter __first, _Sent __last, _OutIter __result) {
@@ -58,10 +57,9 @@ struct __fn {
     return __move_impl(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }
 };
-} // namespace __move
 
 inline namespace __cpo {
-inline constexpr auto move = __move::__fn{};
+inline constexpr auto move = __move{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_move_backward.h
+++ b/libcxx/include/__algorithm/ranges_move_backward.h
@@ -37,8 +37,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using move_backward_result = in_out_result<_InIter, _OutIter>;
 
-namespace __move_backward {
-struct __fn {
+struct __move_backward {
   template <class _InIter, class _Sent, class _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr static move_backward_result<_InIter, _OutIter>
   __move_backward_impl(_InIter __first, _Sent __last, _OutIter __result) {
@@ -60,10 +59,9 @@ struct __fn {
     return __move_backward_impl(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }
 };
-} // namespace __move_backward
 
 inline namespace __cpo {
-inline constexpr auto move_backward = __move_backward::__fn{};
+inline constexpr auto move_backward = __move_backward{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_next_permutation.h
+++ b/libcxx/include/__algorithm/ranges_next_permutation.h
@@ -40,9 +40,7 @@ namespace ranges {
 template <class _InIter>
 using next_permutation_result = in_found_result<_InIter>;
 
-namespace __next_permutation {
-
-struct __fn {
+struct __next_permutation {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr next_permutation_result<_Iter>
@@ -62,10 +60,8 @@ struct __fn {
   }
 };
 
-} // namespace __next_permutation
-
 inline namespace __cpo {
-constexpr inline auto next_permutation = __next_permutation::__fn{};
+constexpr inline auto next_permutation = __next_permutation{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_none_of.h
+++ b/libcxx/include/__algorithm/ranges_none_of.h
@@ -30,8 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __none_of {
-struct __fn {
+struct __none_of {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static bool
   __none_of_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
@@ -59,10 +58,9 @@ struct __fn {
     return __none_of_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __none_of
 
 inline namespace __cpo {
-inline constexpr auto none_of = __none_of::__fn{};
+inline constexpr auto none_of = __none_of{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_nth_element.h
+++ b/libcxx/include/__algorithm/ranges_nth_element.h
@@ -39,9 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __nth_element {
-
-struct __fn {
+struct __nth_element {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __nth_element_fn_impl(_Iter __first, _Iter __nth, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -68,10 +66,8 @@ struct __fn {
   }
 };
 
-} // namespace __nth_element
-
 inline namespace __cpo {
-inline constexpr auto nth_element = __nth_element::__fn{};
+inline constexpr auto nth_element = __nth_element{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_partial_sort.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort.h
@@ -41,9 +41,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __partial_sort {
-
-struct __fn {
+struct __partial_sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __partial_sort_fn_impl(_Iter __first, _Iter __middle, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -66,10 +64,8 @@ struct __fn {
   }
 };
 
-} // namespace __partial_sort
-
 inline namespace __cpo {
-inline constexpr auto partial_sort = __partial_sort::__fn{};
+inline constexpr auto partial_sort = __partial_sort{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_partial_sort_copy.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort_copy.h
@@ -42,9 +42,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using partial_sort_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __partial_sort_copy {
-
-struct __fn {
+struct __partial_sort_copy {
   template <input_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             random_access_iterator _Iter2,
@@ -98,10 +96,8 @@ struct __fn {
   }
 };
 
-} // namespace __partial_sort_copy
-
 inline namespace __cpo {
-inline constexpr auto partial_sort_copy = __partial_sort_copy::__fn{};
+inline constexpr auto partial_sort_copy = __partial_sort_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_partition.h
+++ b/libcxx/include/__algorithm/ranges_partition.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __partition {
-
-struct __fn {
+struct __partition {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI static constexpr subrange<__remove_cvref_t<_Iter>>
   __partition_fn_impl(_Iter&& __first, _Sent&& __last, _Pred&& __pred, _Proj&& __proj) {
@@ -72,10 +70,8 @@ struct __fn {
   }
 };
 
-} // namespace __partition
-
 inline namespace __cpo {
-inline constexpr auto partition = __partition::__fn{};
+inline constexpr auto partition = __partition{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_partition_copy.h
+++ b/libcxx/include/__algorithm/ranges_partition_copy.h
@@ -38,9 +38,7 @@ namespace ranges {
 template <class _InIter, class _OutIter1, class _OutIter2>
 using partition_copy_result = in_out_out_result<_InIter, _OutIter1, _OutIter2>;
 
-namespace __partition_copy {
-
-struct __fn {
+struct __partition_copy {
   // TODO(ranges): delegate to the classic algorithm.
   template <class _InIter, class _Sent, class _OutIter1, class _OutIter2, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static partition_copy_result<__remove_cvref_t<_InIter>,
@@ -94,10 +92,8 @@ struct __fn {
   }
 };
 
-} // namespace __partition_copy
-
 inline namespace __cpo {
-inline constexpr auto partition_copy = __partition_copy::__fn{};
+inline constexpr auto partition_copy = __partition_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_partition_point.h
+++ b/libcxx/include/__algorithm/ranges_partition_point.h
@@ -35,9 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __partition_point {
-
-struct __fn {
+struct __partition_point {
   // TODO(ranges): delegate to the classic algorithm.
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
@@ -77,10 +75,8 @@ struct __fn {
   }
 };
 
-} // namespace __partition_point
-
 inline namespace __cpo {
-inline constexpr auto partition_point = __partition_point::__fn{};
+inline constexpr auto partition_point = __partition_point{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_pop_heap.h
+++ b/libcxx/include/__algorithm/ranges_pop_heap.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __pop_heap {
-
-struct __fn {
+struct __pop_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __pop_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -70,10 +68,8 @@ struct __fn {
   }
 };
 
-} // namespace __pop_heap
-
 inline namespace __cpo {
-inline constexpr auto pop_heap = __pop_heap::__fn{};
+inline constexpr auto pop_heap = __pop_heap{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_prev_permutation.h
+++ b/libcxx/include/__algorithm/ranges_prev_permutation.h
@@ -40,9 +40,7 @@ namespace ranges {
 template <class _InIter>
 using prev_permutation_result = in_found_result<_InIter>;
 
-namespace __prev_permutation {
-
-struct __fn {
+struct __prev_permutation {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr prev_permutation_result<_Iter>
@@ -62,10 +60,8 @@ struct __fn {
   }
 };
 
-} // namespace __prev_permutation
-
 inline namespace __cpo {
-constexpr inline auto prev_permutation = __prev_permutation::__fn{};
+constexpr inline auto prev_permutation = __prev_permutation{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_push_heap.h
+++ b/libcxx/include/__algorithm/ranges_push_heap.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __push_heap {
-
-struct __fn {
+struct __push_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __push_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -69,10 +67,8 @@ struct __fn {
   }
 };
 
-} // namespace __push_heap
-
 inline namespace __cpo {
-inline constexpr auto push_heap = __push_heap::__fn{};
+inline constexpr auto push_heap = __push_heap{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_remove.h
+++ b/libcxx/include/__algorithm/ranges_remove.h
@@ -33,8 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __remove {
-struct __fn {
+struct __remove {
   template <permutable _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
@@ -52,10 +51,9 @@ struct __fn {
     return ranges::__remove_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __remove
 
 inline namespace __cpo {
-inline constexpr auto remove = __remove::__fn{};
+inline constexpr auto remove = __remove{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_remove_copy.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy.h
@@ -38,9 +38,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using remove_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __remove_copy {
-
-struct __fn {
+struct __remove_copy {
   template <input_iterator _InIter,
             sentinel_for<_InIter> _Sent,
             weakly_incrementable _OutIter,
@@ -65,10 +63,8 @@ struct __fn {
   }
 };
 
-} // namespace __remove_copy
-
 inline namespace __cpo {
-inline constexpr auto remove_copy = __remove_copy::__fn{};
+inline constexpr auto remove_copy = __remove_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_remove_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy_if.h
@@ -53,9 +53,7 @@ __remove_copy_if_impl(_InIter __first, _Sent __last, _OutIter __result, _Pred& _
   return {std::move(__first), std::move(__result)};
 }
 
-namespace __remove_copy_if {
-
-struct __fn {
+struct __remove_copy_if {
   template <input_iterator _InIter,
             sentinel_for<_InIter> _Sent,
             weakly_incrementable _OutIter,
@@ -79,10 +77,8 @@ struct __fn {
   }
 };
 
-} // namespace __remove_copy_if
-
 inline namespace __cpo {
-inline constexpr auto remove_copy_if = __remove_copy_if::__fn{};
+inline constexpr auto remove_copy_if = __remove_copy_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_remove_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_if.h
@@ -53,8 +53,7 @@ __remove_if_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   return {__new_end, __i};
 }
 
-namespace __remove_if {
-struct __fn {
+struct __remove_if {
   template <permutable _Iter,
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
@@ -73,10 +72,9 @@ struct __fn {
     return ranges::__remove_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };
-} // namespace __remove_if
 
 inline namespace __cpo {
-inline constexpr auto remove_if = __remove_if::__fn{};
+inline constexpr auto remove_if = __remove_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_replace.h
+++ b/libcxx/include/__algorithm/ranges_replace.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __replace {
-struct __fn {
+struct __replace {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type1, class _Type2, class _Proj = identity>
     requires indirectly_writable<_Iter, const _Type2&> &&
              indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type1*>
@@ -52,10 +51,9 @@ struct __fn {
     return ranges::__replace_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __new_value, __proj);
   }
 };
-} // namespace __replace
 
 inline namespace __cpo {
-inline constexpr auto replace = __replace::__fn{};
+inline constexpr auto replace = __replace{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_replace_copy.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy.h
@@ -38,9 +38,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using replace_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __replace_copy {
-
-struct __fn {
+struct __replace_copy {
   template <input_iterator _InIter,
             sentinel_for<_InIter> _Sent,
             class _OldType,
@@ -77,10 +75,8 @@ struct __fn {
   }
 };
 
-} // namespace __replace_copy
-
 inline namespace __cpo {
-inline constexpr auto replace_copy = __replace_copy::__fn{};
+inline constexpr auto replace_copy = __replace_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_replace_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy_if.h
@@ -52,9 +52,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_if_result<_InIter, _OutIter> __repl
   return {std::move(__first), std::move(__result)};
 }
 
-namespace __replace_copy_if {
-
-struct __fn {
+struct __replace_copy_if {
   template <input_iterator _InIter,
             sentinel_for<_InIter> _Sent,
             class _Type,
@@ -82,10 +80,8 @@ struct __fn {
   }
 };
 
-} // namespace __replace_copy_if
-
 inline namespace __cpo {
-inline constexpr auto replace_copy_if = __replace_copy_if::__fn{};
+inline constexpr auto replace_copy_if = __replace_copy_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_replace_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_if.h
@@ -42,8 +42,7 @@ __replace_if_impl(_Iter __first, _Sent __last, _Pred& __pred, const _Type& __new
   return __first;
 }
 
-namespace __replace_if {
-struct __fn {
+struct __replace_if {
   template <input_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Type,
@@ -65,10 +64,9 @@ struct __fn {
     return ranges::__replace_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __new_value, __proj);
   }
 };
-} // namespace __replace_if
 
 inline namespace __cpo {
-inline constexpr auto replace_if = __replace_if::__fn{};
+inline constexpr auto replace_if = __replace_if{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_reverse.h
+++ b/libcxx/include/__algorithm/ranges_reverse.h
@@ -27,8 +27,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __reverse {
-struct __fn {
+struct __reverse {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent>
     requires permutable<_Iter>
   _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __first, _Sent __last) const {
@@ -65,10 +64,9 @@ struct __fn {
     return (*this)(ranges::begin(__range), ranges::end(__range));
   }
 };
-} // namespace __reverse
 
 inline namespace __cpo {
-inline constexpr auto reverse = __reverse::__fn{};
+inline constexpr auto reverse = __reverse{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_reverse_copy.h
+++ b/libcxx/include/__algorithm/ranges_reverse_copy.h
@@ -37,8 +37,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using reverse_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __reverse_copy {
-struct __fn {
+struct __reverse_copy {
   template <bidirectional_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_copy_result<_InIter, _OutIter>
@@ -54,10 +53,9 @@ struct __fn {
     return {ranges::next(ranges::begin(__range), ranges::end(__range)), std::move(__ret.out)};
   }
 };
-} // namespace __reverse_copy
 
 inline namespace __cpo {
-inline constexpr auto reverse_copy = __reverse_copy::__fn{};
+inline constexpr auto reverse_copy = __reverse_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_rotate.h
+++ b/libcxx/include/__algorithm/ranges_rotate.h
@@ -33,9 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __rotate {
-
-struct __fn {
+struct __rotate {
   template <class _Iter, class _Sent>
   _LIBCPP_HIDE_FROM_ABI constexpr static subrange<_Iter> __rotate_fn_impl(_Iter __first, _Iter __middle, _Sent __last) {
     auto __ret = std::__rotate<_RangeAlgPolicy>(std::move(__first), std::move(__middle), std::move(__last));
@@ -55,10 +53,8 @@ struct __fn {
   }
 };
 
-} // namespace __rotate
-
 inline namespace __cpo {
-inline constexpr auto rotate = __rotate::__fn{};
+inline constexpr auto rotate = __rotate{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_rotate_copy.h
+++ b/libcxx/include/__algorithm/ranges_rotate_copy.h
@@ -34,8 +34,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using rotate_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __rotate_copy {
-struct __fn {
+struct __rotate_copy {
   template <forward_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr rotate_copy_result<_InIter, _OutIter>
@@ -52,10 +51,9 @@ struct __fn {
     return (*this)(ranges::begin(__range), std::move(__middle), ranges::end(__range), std::move(__result));
   }
 };
-} // namespace __rotate_copy
 
 inline namespace __cpo {
-inline constexpr auto rotate_copy = __rotate_copy::__fn{};
+inline constexpr auto rotate_copy = __rotate_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_sample.h
+++ b/libcxx/include/__algorithm/ranges_sample.h
@@ -35,9 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __sample {
-
-struct __fn {
+struct __sample {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, weakly_incrementable _OutIter, class _Gen>
     requires(forward_iterator<_Iter> || random_access_iterator<_OutIter>) && indirectly_copyable<_Iter, _OutIter> &&
             uniform_random_bit_generator<remove_reference_t<_Gen>>
@@ -58,10 +56,8 @@ struct __fn {
   }
 };
 
-} // namespace __sample
-
 inline namespace __cpo {
-inline constexpr auto sample = __sample::__fn{};
+inline constexpr auto sample = __sample{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_search.h
+++ b/libcxx/include/__algorithm/ranges_search.h
@@ -33,8 +33,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __search {
-struct __fn {
+struct __search {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
   _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter1> __ranges_search_impl(
       _Iter1 __first1,
@@ -120,10 +119,9 @@ struct __fn {
         __proj2);
   }
 };
-} // namespace __search
 
 inline namespace __cpo {
-inline constexpr auto search = __search::__fn{};
+inline constexpr auto search = __search{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_search_n.h
+++ b/libcxx/include/__algorithm/ranges_search_n.h
@@ -39,8 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __search_n {
-struct __fn {
+struct __search_n {
   template <class _Iter1, class _Sent1, class _SizeT, class _Type, class _Pred, class _Proj>
   _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter1> __ranges_search_n_impl(
       _Iter1 __first, _Sent1 __last, _SizeT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
@@ -100,10 +99,9 @@ struct __fn {
     return __ranges_search_n_impl(ranges::begin(__range), ranges::end(__range), __count, __value, __pred, __proj);
   }
 };
-} // namespace __search_n
 
 inline namespace __cpo {
-inline constexpr auto search_n = __search_n::__fn{};
+inline constexpr auto search_n = __search_n{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_set_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_difference.h
@@ -42,9 +42,7 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using set_difference_result = in_out_result<_InIter, _OutIter>;
 
-namespace __set_difference {
-
-struct __fn {
+struct __set_difference {
   template <input_iterator _InIter1,
             sentinel_for<_InIter1> _Sent1,
             input_iterator _InIter2,
@@ -93,10 +91,8 @@ struct __fn {
   }
 };
 
-} // namespace __set_difference
-
 inline namespace __cpo {
-inline constexpr auto set_difference = __set_difference::__fn{};
+inline constexpr auto set_difference = __set_difference{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_set_intersection.h
+++ b/libcxx/include/__algorithm/ranges_set_intersection.h
@@ -40,9 +40,7 @@ namespace ranges {
 template <class _InIter1, class _InIter2, class _OutIter>
 using set_intersection_result = in_in_out_result<_InIter1, _InIter2, _OutIter>;
 
-namespace __set_intersection {
-
-struct __fn {
+struct __set_intersection {
   template <input_iterator _InIter1,
             sentinel_for<_InIter1> _Sent1,
             input_iterator _InIter2,
@@ -98,10 +96,8 @@ struct __fn {
   }
 };
 
-} // namespace __set_intersection
-
 inline namespace __cpo {
-inline constexpr auto set_intersection = __set_intersection::__fn{};
+inline constexpr auto set_intersection = __set_intersection{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
@@ -40,9 +40,7 @@ namespace ranges {
 template <class _InIter1, class _InIter2, class _OutIter>
 using set_symmetric_difference_result = in_in_out_result<_InIter1, _InIter2, _OutIter>;
 
-namespace __set_symmetric_difference {
-
-struct __fn {
+struct __set_symmetric_difference {
   template <input_iterator _InIter1,
             sentinel_for<_InIter1> _Sent1,
             input_iterator _InIter2,
@@ -98,10 +96,8 @@ struct __fn {
   }
 };
 
-} // namespace __set_symmetric_difference
-
 inline namespace __cpo {
-inline constexpr auto set_symmetric_difference = __set_symmetric_difference::__fn{};
+inline constexpr auto set_symmetric_difference = __set_symmetric_difference{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_set_union.h
+++ b/libcxx/include/__algorithm/ranges_set_union.h
@@ -43,9 +43,7 @@ namespace ranges {
 template <class _InIter1, class _InIter2, class _OutIter>
 using set_union_result = in_in_out_result<_InIter1, _InIter2, _OutIter>;
 
-namespace __set_union {
-
-struct __fn {
+struct __set_union {
   template <input_iterator _InIter1,
             sentinel_for<_InIter1> _Sent1,
             input_iterator _InIter2,
@@ -99,10 +97,8 @@ struct __fn {
   }
 };
 
-} // namespace __set_union
-
 inline namespace __cpo {
-inline constexpr auto set_union = __set_union::__fn{};
+inline constexpr auto set_union = __set_union{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_shuffle.h
+++ b/libcxx/include/__algorithm/ranges_shuffle.h
@@ -39,9 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __shuffle {
-
-struct __fn {
+struct __shuffle {
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Gen>
     requires permutable<_Iter> && uniform_random_bit_generator<remove_reference_t<_Gen>>
   _LIBCPP_HIDE_FROM_ABI _Iter operator()(_Iter __first, _Sent __last, _Gen&& __gen) const {
@@ -56,10 +54,8 @@ struct __fn {
   }
 };
 
-} // namespace __shuffle
-
 inline namespace __cpo {
-inline constexpr auto shuffle = __shuffle::__fn{};
+inline constexpr auto shuffle = __shuffle{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_sort.h
+++ b/libcxx/include/__algorithm/ranges_sort.h
@@ -39,9 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __sort {
-
-struct __fn {
+struct __sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __sort_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -68,10 +66,8 @@ struct __fn {
   }
 };
 
-} // namespace __sort
-
 inline namespace __cpo {
-inline constexpr auto sort = __sort::__fn{};
+inline constexpr auto sort = __sort{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_sort_heap.h
+++ b/libcxx/include/__algorithm/ranges_sort_heap.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __sort_heap {
-
-struct __fn {
+struct __sort_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
   __sort_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
@@ -69,10 +67,8 @@ struct __fn {
   }
 };
 
-} // namespace __sort_heap
-
 inline namespace __cpo {
-inline constexpr auto sort_heap = __sort_heap::__fn{};
+inline constexpr auto sort_heap = __sort_heap{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_stable_partition.h
+++ b/libcxx/include/__algorithm/ranges_stable_partition.h
@@ -42,9 +42,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __stable_partition {
-
-struct __fn {
+struct __stable_partition {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
   _LIBCPP_HIDE_FROM_ABI static subrange<__remove_cvref_t<_Iter>>
   __stable_partition_fn_impl(_Iter&& __first, _Sent&& __last, _Pred&& __pred, _Proj&& __proj) {
@@ -76,10 +74,8 @@ struct __fn {
   }
 };
 
-} // namespace __stable_partition
-
 inline namespace __cpo {
-inline constexpr auto stable_partition = __stable_partition::__fn{};
+inline constexpr auto stable_partition = __stable_partition{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_stable_sort.h
+++ b/libcxx/include/__algorithm/ranges_stable_sort.h
@@ -39,9 +39,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __stable_sort {
-
-struct __fn {
+struct __stable_sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
   _LIBCPP_HIDE_FROM_ABI static _Iter __stable_sort_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
@@ -66,10 +64,8 @@ struct __fn {
   }
 };
 
-} // namespace __stable_sort
-
 inline namespace __cpo {
-inline constexpr auto stable_sort = __stable_sort::__fn{};
+inline constexpr auto stable_sort = __stable_sort{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_starts_with.h
+++ b/libcxx/include/__algorithm/ranges_starts_with.h
@@ -32,8 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __starts_with {
-struct __fn {
+struct __starts_with {
   template <input_iterator _Iter1,
             sentinel_for<_Iter1> _Sent1,
             input_iterator _Iter2,
@@ -50,7 +49,7 @@ struct __fn {
       _Pred __pred   = {},
       _Proj1 __proj1 = {},
       _Proj2 __proj2 = {}) {
-    return __mismatch::__fn::__go(
+    return __mismatch::__go(
                std::move(__first1),
                std::move(__last1),
                std::move(__first2),
@@ -69,7 +68,7 @@ struct __fn {
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr bool
   operator()(_Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) {
-    return __mismatch::__fn::__go(
+    return __mismatch::__go(
                ranges::begin(__range1),
                ranges::end(__range1),
                ranges::begin(__range2),
@@ -80,9 +79,8 @@ struct __fn {
                .in2 == ranges::end(__range2);
   }
 };
-} // namespace __starts_with
 inline namespace __cpo {
-inline constexpr auto starts_with = __starts_with::__fn{};
+inline constexpr auto starts_with = __starts_with{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_swap_ranges.h
+++ b/libcxx/include/__algorithm/ranges_swap_ranges.h
@@ -36,8 +36,7 @@ namespace ranges {
 template <class _I1, class _I2>
 using swap_ranges_result = in_in_result<_I1, _I2>;
 
-namespace __swap_ranges {
-struct __fn {
+struct __swap_ranges {
   template <input_iterator _I1, sentinel_for<_I1> _S1, input_iterator _I2, sentinel_for<_I2> _S2>
     requires indirectly_swappable<_I1, _I2>
   _LIBCPP_HIDE_FROM_ABI constexpr swap_ranges_result<_I1, _I2>
@@ -54,10 +53,9 @@ struct __fn {
     return operator()(ranges::begin(__r1), ranges::end(__r1), ranges::begin(__r2), ranges::end(__r2));
   }
 };
-} // namespace __swap_ranges
 
 inline namespace __cpo {
-inline constexpr auto swap_ranges = __swap_ranges::__fn{};
+inline constexpr auto swap_ranges = __swap_ranges{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_transform.h
+++ b/libcxx/include/__algorithm/ranges_transform.h
@@ -41,8 +41,7 @@ using unary_transform_result = in_out_result<_Ip, _Op>;
 template <class _I1, class _I2, class _O1>
 using binary_transform_result = in_in_out_result<_I1, _I2, _O1>;
 
-namespace __transform {
-struct __fn {
+struct __transform {
 private:
   template <class _InIter, class _Sent, class _OutIter, class _Func, class _Proj>
   _LIBCPP_HIDE_FROM_ABI static constexpr unary_transform_result<_InIter, _OutIter>
@@ -161,10 +160,9 @@ public:
         __projection2);
   }
 };
-} // namespace __transform
 
 inline namespace __cpo {
-inline constexpr auto transform = __transform::__fn{};
+inline constexpr auto transform = __transform{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -40,9 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __unique {
-
-struct __fn {
+struct __unique {
   template <permutable _Iter,
             sentinel_for<_Iter> _Sent,
             class _Proj                                                  = identity,
@@ -66,10 +64,8 @@ struct __fn {
   }
 };
 
-} // namespace __unique
-
 inline namespace __cpo {
-inline constexpr auto unique = __unique::__fn{};
+inline constexpr auto unique = __unique{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_unique_copy.h
+++ b/libcxx/include/__algorithm/ranges_unique_copy.h
@@ -44,12 +44,10 @@ namespace ranges {
 template <class _InIter, class _OutIter>
 using unique_copy_result = in_out_result<_InIter, _OutIter>;
 
-namespace __unique_copy {
-
 template <class _InIter, class _OutIter>
 concept __can_reread_from_output = (input_iterator<_OutIter> && same_as<iter_value_t<_InIter>, iter_value_t<_OutIter>>);
 
-struct __fn {
+struct __unique_copy {
   template <class _InIter, class _OutIter>
   static consteval auto __get_algo_tag() {
     if constexpr (forward_iterator<_InIter>) {
@@ -104,10 +102,8 @@ struct __fn {
   }
 };
 
-} // namespace __unique_copy
-
 inline namespace __cpo {
-inline constexpr auto unique_copy = __unique_copy::__fn{};
+inline constexpr auto unique_copy = __unique_copy{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__algorithm/ranges_upper_bound.h
+++ b/libcxx/include/__algorithm/ranges_upper_bound.h
@@ -30,8 +30,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace ranges {
-namespace __upper_bound {
-struct __fn {
+struct __upper_bound {
   template <forward_iterator _Iter,
             sentinel_for<_Iter> _Sent,
             class _Type,
@@ -60,10 +59,9 @@ struct __fn {
         ranges::begin(__r), ranges::end(__r), __value, __comp_lhs_rhs_swapped, __proj);
   }
 };
-} // namespace __upper_bound
 
 inline namespace __cpo {
-inline constexpr auto upper_bound = __upper_bound::__fn{};
+inline constexpr auto upper_bound = __upper_bound{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -76,9 +76,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 void advance(_InputIter& __i
 // [range.iter.op.advance]
 
 namespace ranges {
-namespace __advance {
-
-struct __fn {
+struct __advance {
 private:
   template <class _Ip>
   _LIBCPP_HIDE_FROM_ABI static constexpr void __advance_forward(_Ip& __i, iter_difference_t<_Ip> __n) {
@@ -189,10 +187,8 @@ public:
   }
 };
 
-} // namespace __advance
-
 inline namespace __cpo {
-inline constexpr auto advance = __advance::__fn{};
+inline constexpr auto advance = __advance{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -52,9 +52,7 @@ distance(_InputIter __first, _InputIter __last) {
 // [range.iter.op.distance]
 
 namespace ranges {
-namespace __distance {
-
-struct __fn {
+struct __distance {
   template <class _Ip, sentinel_for<_Ip> _Sp>
     requires(!sized_sentinel_for<_Sp, _Ip>)
   _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip> operator()(_Ip __first, _Sp __last) const {
@@ -85,10 +83,8 @@ struct __fn {
   }
 };
 
-} // namespace __distance
-
 inline namespace __cpo {
-inline constexpr auto distance = __distance::__fn{};
+inline constexpr auto distance = __distance{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__iterator/next.h
+++ b/libcxx/include/__iterator/next.h
@@ -41,9 +41,7 @@ next(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n =
 // [range.iter.op.next]
 
 namespace ranges {
-namespace __next {
-
-struct __fn {
+struct __next {
   template <input_or_output_iterator _Ip>
   _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x) const {
     ++__x;
@@ -69,10 +67,8 @@ struct __fn {
   }
 };
 
-} // namespace __next
-
 inline namespace __cpo {
-inline constexpr auto next = __next::__fn{};
+inline constexpr auto next = __next{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -40,9 +40,7 @@ prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n =
 // [range.iter.op.prev]
 
 namespace ranges {
-namespace __prev {
-
-struct __fn {
+struct __prev {
   template <bidirectional_iterator _Ip>
   _LIBCPP_HIDE_FROM_ABI constexpr _Ip operator()(_Ip __x) const {
     --__x;
@@ -62,10 +60,8 @@ struct __fn {
   }
 };
 
-} // namespace __prev
-
 inline namespace __cpo {
-inline constexpr auto prev = __prev::__fn{};
+inline constexpr auto prev = __prev{};
 } // namespace __cpo
 } // namespace ranges
 

--- a/libcxx/include/__memory/ranges_construct_at.h
+++ b/libcxx/include/__memory/ranges_construct_at.h
@@ -38,43 +38,33 @@ namespace ranges {
 
 // construct_at
 
-namespace __construct_at {
-
-struct __fn {
+struct __construct_at {
   template <class _Tp, class... _Args, class = decltype(::new(std::declval<void*>()) _Tp(std::declval<_Args>()...))>
   _LIBCPP_HIDE_FROM_ABI constexpr _Tp* operator()(_Tp* __location, _Args&&... __args) const {
     return std::construct_at(__location, std::forward<_Args>(__args)...);
   }
 };
 
-} // namespace __construct_at
-
 inline namespace __cpo {
-inline constexpr auto construct_at = __construct_at::__fn{};
+inline constexpr auto construct_at = __construct_at{};
 } // namespace __cpo
 
 // destroy_at
 
-namespace __destroy_at {
-
-struct __fn {
+struct __destroy_at {
   template <destructible _Tp>
   _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp* __location) const noexcept {
     std::destroy_at(__location);
   }
 };
 
-} // namespace __destroy_at
-
 inline namespace __cpo {
-inline constexpr auto destroy_at = __destroy_at::__fn{};
+inline constexpr auto destroy_at = __destroy_at{};
 } // namespace __cpo
 
 // destroy
 
-namespace __destroy {
-
-struct __fn {
+struct __destroy {
   template <__nothrow_input_iterator _InputIterator, __nothrow_sentinel_for<_InputIterator> _Sentinel>
     requires destructible<iter_value_t<_InputIterator>>
   _LIBCPP_HIDE_FROM_ABI constexpr _InputIterator operator()(_InputIterator __first, _Sentinel __last) const noexcept {
@@ -88,17 +78,13 @@ struct __fn {
   }
 };
 
-} // namespace __destroy
-
 inline namespace __cpo {
-inline constexpr auto destroy = __destroy::__fn{};
+inline constexpr auto destroy = __destroy{};
 } // namespace __cpo
 
 // destroy_n
 
-namespace __destroy_n {
-
-struct __fn {
+struct __destroy_n {
   template <__nothrow_input_iterator _InputIterator>
     requires destructible<iter_value_t<_InputIterator>>
   _LIBCPP_HIDE_FROM_ABI constexpr _InputIterator
@@ -107,10 +93,8 @@ struct __fn {
   }
 };
 
-} // namespace __destroy_n
-
 inline namespace __cpo {
-inline constexpr auto destroy_n = __destroy_n::__fn{};
+inline constexpr auto destroy_n = __destroy_n{};
 } // namespace __cpo
 
 } // namespace ranges

--- a/libcxx/include/__memory/ranges_uninitialized_algorithms.h
+++ b/libcxx/include/__memory/ranges_uninitialized_algorithms.h
@@ -42,9 +42,7 @@ namespace ranges {
 
 // uninitialized_default_construct
 
-namespace __uninitialized_default_construct {
-
-struct __fn {
+struct __uninitialized_default_construct {
   template <__nothrow_forward_iterator _ForwardIterator, __nothrow_sentinel_for<_ForwardIterator> _Sentinel>
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last) const {
@@ -59,17 +57,13 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_default_construct
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_default_construct = __uninitialized_default_construct::__fn{};
+inline constexpr auto uninitialized_default_construct = __uninitialized_default_construct{};
 } // namespace __cpo
 
 // uninitialized_default_construct_n
 
-namespace __uninitialized_default_construct_n {
-
-struct __fn {
+struct __uninitialized_default_construct_n {
   template <__nothrow_forward_iterator _ForwardIterator>
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator
@@ -79,17 +73,13 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_default_construct_n
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_default_construct_n = __uninitialized_default_construct_n::__fn{};
+inline constexpr auto uninitialized_default_construct_n = __uninitialized_default_construct_n{};
 } // namespace __cpo
 
 // uninitialized_value_construct
 
-namespace __uninitialized_value_construct {
-
-struct __fn {
+struct __uninitialized_value_construct {
   template <__nothrow_forward_iterator _ForwardIterator, __nothrow_sentinel_for<_ForwardIterator> _Sentinel>
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last) const {
@@ -104,17 +94,13 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_value_construct
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_value_construct = __uninitialized_value_construct::__fn{};
+inline constexpr auto uninitialized_value_construct = __uninitialized_value_construct{};
 } // namespace __cpo
 
 // uninitialized_value_construct_n
 
-namespace __uninitialized_value_construct_n {
-
-struct __fn {
+struct __uninitialized_value_construct_n {
   template <__nothrow_forward_iterator _ForwardIterator>
     requires default_initializable<iter_value_t<_ForwardIterator>>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator
@@ -124,17 +110,13 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_value_construct_n
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_value_construct_n = __uninitialized_value_construct_n::__fn{};
+inline constexpr auto uninitialized_value_construct_n = __uninitialized_value_construct_n{};
 } // namespace __cpo
 
 // uninitialized_fill
 
-namespace __uninitialized_fill {
-
-struct __fn {
+struct __uninitialized_fill {
   template <__nothrow_forward_iterator _ForwardIterator, __nothrow_sentinel_for<_ForwardIterator> _Sentinel, class _Tp>
     requires constructible_from<iter_value_t<_ForwardIterator>, const _Tp&>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator operator()(_ForwardIterator __first, _Sentinel __last, const _Tp& __x) const {
@@ -149,17 +131,13 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_fill
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_fill = __uninitialized_fill::__fn{};
+inline constexpr auto uninitialized_fill = __uninitialized_fill{};
 } // namespace __cpo
 
 // uninitialized_fill_n
 
-namespace __uninitialized_fill_n {
-
-struct __fn {
+struct __uninitialized_fill_n {
   template <__nothrow_forward_iterator _ForwardIterator, class _Tp>
     requires constructible_from<iter_value_t<_ForwardIterator>, const _Tp&>
   _LIBCPP_HIDE_FROM_ABI _ForwardIterator
@@ -169,10 +147,8 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_fill_n
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_fill_n = __uninitialized_fill_n::__fn{};
+inline constexpr auto uninitialized_fill_n = __uninitialized_fill_n{};
 } // namespace __cpo
 
 // uninitialized_copy
@@ -180,9 +156,7 @@ inline constexpr auto uninitialized_fill_n = __uninitialized_fill_n::__fn{};
 template <class _InputIterator, class _OutputIterator>
 using uninitialized_copy_result = in_out_result<_InputIterator, _OutputIterator>;
 
-namespace __uninitialized_copy {
-
-struct __fn {
+struct __uninitialized_copy {
   template <input_iterator _InputIterator,
             sentinel_for<_InputIterator> _Sentinel1,
             __nothrow_forward_iterator _OutputIterator,
@@ -207,10 +181,8 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_copy
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_copy = __uninitialized_copy::__fn{};
+inline constexpr auto uninitialized_copy = __uninitialized_copy{};
 } // namespace __cpo
 
 // uninitialized_copy_n
@@ -218,9 +190,7 @@ inline constexpr auto uninitialized_copy = __uninitialized_copy::__fn{};
 template <class _InputIterator, class _OutputIterator>
 using uninitialized_copy_n_result = in_out_result<_InputIterator, _OutputIterator>;
 
-namespace __uninitialized_copy_n {
-
-struct __fn {
+struct __uninitialized_copy_n {
   template <input_iterator _InputIterator,
             __nothrow_forward_iterator _OutputIterator,
             __nothrow_sentinel_for<_OutputIterator> _Sentinel>
@@ -238,10 +208,8 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_copy_n
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_copy_n = __uninitialized_copy_n::__fn{};
+inline constexpr auto uninitialized_copy_n = __uninitialized_copy_n{};
 } // namespace __cpo
 
 // uninitialized_move
@@ -249,9 +217,7 @@ inline constexpr auto uninitialized_copy_n = __uninitialized_copy_n::__fn{};
 template <class _InputIterator, class _OutputIterator>
 using uninitialized_move_result = in_out_result<_InputIterator, _OutputIterator>;
 
-namespace __uninitialized_move {
-
-struct __fn {
+struct __uninitialized_move {
   template <input_iterator _InputIterator,
             sentinel_for<_InputIterator> _Sentinel1,
             __nothrow_forward_iterator _OutputIterator,
@@ -276,10 +242,8 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_move
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_move = __uninitialized_move::__fn{};
+inline constexpr auto uninitialized_move = __uninitialized_move{};
 } // namespace __cpo
 
 // uninitialized_move_n
@@ -287,9 +251,7 @@ inline constexpr auto uninitialized_move = __uninitialized_move::__fn{};
 template <class _InputIterator, class _OutputIterator>
 using uninitialized_move_n_result = in_out_result<_InputIterator, _OutputIterator>;
 
-namespace __uninitialized_move_n {
-
-struct __fn {
+struct __uninitialized_move_n {
   template <input_iterator _InputIterator,
             __nothrow_forward_iterator _OutputIterator,
             __nothrow_sentinel_for<_OutputIterator> _Sentinel>
@@ -308,10 +270,8 @@ struct __fn {
   }
 };
 
-} // namespace __uninitialized_move_n
-
 inline namespace __cpo {
-inline constexpr auto uninitialized_move_n = __uninitialized_move_n::__fn{};
+inline constexpr auto uninitialized_move_n = __uninitialized_move_n{};
 } // namespace __cpo
 
 } // namespace ranges


### PR DESCRIPTION
I originally put implementation-detail function objects into individual namespaces for `std::ranges` without a good reason for doing so. This practice was continued after I left libc++, presumably because there was prior art. Since there's no reason to keep these namespaces, this commit removes them, which will slightly impact binary size.

This commit does not apply to CPOs, some of which need additional work.