### PR TITLE
[clang][AVR] Restrict range of assembly constraint 'G'

### DIFF
--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -146,7 +146,9 @@ public:
     case 'R': // Integer constant (Range: -6 to 5)
       Info.setRequiresImmediate(-6, 5);
       return true;
-    case 'G': // Floating point constant
+    case 'G': // Floating point constant 0.0
+      Info.setRequiresImmediate(0);
+      return true;
     case 'Q': // A memory address based on Y or Z pointer with displacement.
       return true;
     }

--- a/clang/test/CodeGen/avr/avr-inline-asm-constraints.c
+++ b/clang/test/CodeGen/avr/avr-inline-asm-constraints.c
@@ -109,8 +109,8 @@ void R() {
 }
 
 void G() {
-  // CHECK: call addrspace(0) void asm sideeffect "subi r30, $0", "G"(i16 50)
-  asm("subi r30, %0" :: "G"(50));
+  // CHECK: call addrspace(0) void asm sideeffect "subi r30, $0", "G"(i16 0)
+  asm("subi r30, %0" :: "G"(0));
 }
 
 void Q() {

--- a/clang/test/CodeGen/avr/avr-unsupported-inline-asm-constraints.c
+++ b/clang/test/CodeGen/avr/avr-unsupported-inline-asm-constraints.c
@@ -5,4 +5,5 @@ const unsigned char val = 0;
 int foo(void) {
   __asm__ volatile("foo %0, 1" : : "fo" (val)); // expected-error {{invalid input constraint 'fo' in asm}}
   __asm__ volatile("foo %0, 1" : : "Nd" (val)); // expected-error {{invalid input constraint 'Nd' in asm}}
+  __asm__ volatile("subi r30, %0" : : "G" (1)); // expected-error {{value '1' out of range for constraint 'G'}}
 }


### PR DESCRIPTION
According to https://www.nongnu.org/avr-libc/user-manual/inline_asm.html, "G" only represents floating point constant '0.0'. And avr-gcc also rejects other non-zero FP values.