### PR TITLE
[mlir] Fix support for loop normalization with integer indices

### DIFF
--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -502,9 +502,12 @@ static LoopParams normalizeLoop(OpBuilder &boundsBuilder,
 
   Value newLowerBound =
       isZeroBased ? lowerBound
-                  : boundsBuilder.create<arith::ConstantIndexOp>(loc, 0);
+                  : boundsBuilder.create<arith::ConstantOp>(
+                        loc, boundsBuilder.getZeroAttr(lowerBound.getType()));
   Value newStep =
-      isStepOne ? step : boundsBuilder.create<arith::ConstantIndexOp>(loc, 1);
+      isStepOne ? step
+                : boundsBuilder.create<arith::ConstantOp>(
+                      loc, boundsBuilder.getIntegerAttr(step.getType(), 1));
 
   // Insert code computing the value of the original loop induction variable
   // from the "normalized" one.


### PR DESCRIPTION
Choose correct type for updated loop boundaries after scf loop normalization, do not force chosen type to IndexType