### PR TITLE
[mlir] Make TypedValue::getType() const

### DIFF
--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -443,7 +443,7 @@ struct TypedValue : Value {
   static bool classof(Value value) { return llvm::isa<Ty>(value.getType()); }
 
   /// Return the known Type
-  Ty getType() { return llvm::cast<Ty>(Value::getType()); }
+  Ty getType() const { return llvm::cast<Ty>(Value::getType()); }
   void setType(Ty ty) { Value::setType(ty); }
 };
 


### PR DESCRIPTION
The TypedValue::getType() essentially forwards the return value of Value::getType() which is a const method. Somehow, at TypedValue level the method's constness is lost, so restore it.

Originally done by: Nikita Kudriavtsev <nikita.kudriavtsev@intel.com>