### PR TITLE
[libc] Adds AMDGPU gfx941 and gfx942 to archs

### DIFF
--- a/libc/cmake/modules/prepare_libc_gpu_build.cmake
+++ b/libc/cmake/modules/prepare_libc_gpu_build.cmake
@@ -5,8 +5,9 @@ endif()
 
 # Set up the target architectures to build the GPU libc for.
 set(all_amdgpu_architectures "gfx700;gfx701;gfx801;gfx803;gfx900;gfx902;gfx906"
-                             "gfx908;gfx90a;gfx90c;gfx940;gfx1010;gfx1030"
-                             "gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
+                             "gfx908;gfx90a;gfx90c;gfx940;gfx941;gfx942"
+                             "gfx1010;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034"
+                             "gfx1035;gfx1036"
                              "gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151")
 set(all_nvptx_architectures "sm_35;sm_37;sm_50;sm_52;sm_53;sm_60;sm_61;sm_62"
                             "sm_70;sm_72;sm_75;sm_80;sm_86;sm_89;sm_90")

--- a/libc/src/math/gpu/vendor/amdgpu/platform.h
+++ b/libc/src/math/gpu/vendor/amdgpu/platform.h
@@ -72,6 +72,10 @@ extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 9010;
 extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 9012;
 #elif defined(__gfx940__)
 extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 9400;
+#elif defined(__gfx941__)
+extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 9401;
+#elif defined(__gfx942__)
+extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 9402;
 #elif defined(__gfx1010__)
 extern const LIBC_INLINE_VAR uint32_t __oclc_ISA_version = 10100;
 #elif defined(__gfx1011__)

--- a/libc/src/time/gpu/time_utils.h
+++ b/libc/src/time/gpu/time_utils.h
@@ -17,7 +17,8 @@ namespace LIBC_NAMESPACE {
 // AMDGPU does not have a single set frequency. Different architectures and
 // cards can have vary values. Here we default to a few known values, but for
 // complete support the frequency needs to be read from the kernel driver.
-#if defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) ||    \
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) ||       \
+    defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) ||    \
     defined(__gfx1013__) || defined(__gfx1030__) || defined(__gfx1031__) ||    \
     defined(__gfx1032__) || defined(__gfx1033__) || defined(__gfx1034__) ||    \
     defined(__gfx1035__) || defined(__gfx1036__) || defined(__gfx1100__) ||    \
@@ -27,7 +28,7 @@ namespace LIBC_NAMESPACE {
 constexpr uint64_t clock_freq = 100000000;
 #elif defined(__gfx900__) || defined(__gfx902__) || defined(__gfx904__) ||     \
     defined(__gfx906__) || defined(__gfx908__) || defined(__gfx909__) ||       \
-    defined(__gfx90a__) || defined(__gfx90c__) || defined(__gfx940__)
+    defined(__gfx90a__) || defined(__gfx90c__)
 // These architectures use a 25 MHz fixed frequency clock expect for Vega 10
 // which is actually 27 Mhz. We default to 25 MHz in all cases anyway.
 constexpr uint64_t clock_freq = 25000000;


### PR DESCRIPTION
This adds the ROCm device libs defines for both target architectures so that we an compile libc on such GPUs.