### PR TITLE
[analyzer] Add std::any checker

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -2095,6 +2095,27 @@ This checker is a part of ``core.StackAddressEscape``, but is temporarily disabl
                  //       returned block
  }
 
+.. _alpha-core-StdAny:
+
+alpha.core.StdAny (C++)
+"""""""""""""""""""""""
+Check if a value of active type is retrieved from an ``std::any`` instance with ``std::any_cats``
+or if the ``std::any`` instance holds type. In case of bad any type access
+(the accessed type differs from the active type, or the instance has no stored value)
+a warning is emitted. Currently, this checker does not take exception handling into account.
+
+.. code-block:: cpp
+
+ void anyCast() {
+  std::any a = 5;
+  char c = std::any_cast<char>(a); // // warn: "int" is the active alternative
+ }
+
+ void noTypeHeld() {
+  std::any a;
+  int i = std::any_cast<int>(a); // warn: any 'a' is empty
+ }
+
 .. _alpha-core-StdVariant:
 
 alpha.core.StdVariant (C++)

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -2099,10 +2099,12 @@ This checker is a part of ``core.StackAddressEscape``, but is temporarily disabl
 
 alpha.core.StdAny (C++)
 """""""""""""""""""""""
-Check if a value of active type is retrieved from an ``std::any`` instance with ``std::any_cats``
-or if the ``std::any`` instance holds type. In case of bad any type access
-(the accessed type differs from the active type, or the instance has no stored value)
-a warning is emitted. Currently, this checker does not take exception handling into account.
+Check if a value of active type is retrieved from a ``std::any`` instance with ``std::any_cast``
+or if the instance holds a value. In case of bad access
+(the accessed type differs from the active type, or the instance is empty)
+a warning is emitted.
+
+**Limitation:** The checker does not take exception handling into account.
 
 .. code-block:: cpp
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -321,6 +321,10 @@ def C11LockChecker : Checker<"C11Lock">,
   Dependencies<[PthreadLockBase]>,
   Documentation<HasDocumentation>;
 
+def StdAnyChecker : Checker<"StdAny">,
+  HelpText<"Check for bad type access for std::any.">,
+  Documentation<HasDocumentation>;
+
 def StdVariantChecker : Checker<"StdVariant">,
   HelpText<"Check for bad type access for std::variant.">,
   Documentation<HasDocumentation>;

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -107,6 +107,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   SmartPtrChecker.cpp
   SmartPtrModeling.cpp
   StackAddrEscapeChecker.cpp
+  StdAnyChecker.cpp
   StdLibraryFunctionsChecker.cpp
   StdVariantChecker.cpp
   STLAlgorithmModeling.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -105,8 +105,8 @@ public:
   }
 
 private:
-  // When an std::any is rested or default constructed it has a null type.
-  // We represent it by storing a null QualType.
+  // When a std::any is reset or default constructed it has a null type.
+  // We represent it by storing an empty QualType.
   ProgramStateRef setNullTypeAny(const MemRegion *Mem, CheckerContext &C) const {
     auto State = C.getState();
     return State->set<AnyHeldTypeMap>(Mem, QualType{});

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -149,7 +149,7 @@ private:
     auto TypeOut = FirstTemplateArgument.getAsType();
     const auto *TypeStored = State->get<AnyHeldTypeMap>(AnyMemRegion);
 
-    // Report when we try to use std::any_cast on an std::any that held a null
+    // Report when we try to use std::any_cast on a std::any that held a null
     // type.
     if (TypeStored->isNull()) {
       ExplodedNode *ErrNode = C.generateNonFatalErrorNode();

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -13,6 +13,7 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramState_Fwd.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #include "TaggedUnionModeling.h"
@@ -63,7 +64,7 @@ public:
       if (!ThisMemRegion)
         return false;
 
-      setNullTypeAny(ThisMemRegion, C);
+      C.addTransition(setNullTypeAny(ThisMemRegion, C));
       return true;
     }
 
@@ -90,7 +91,7 @@ public:
       // In this case the any holds a null type.
       if (Call.getNumArgs() == 0) {
         const auto *ThisMemRegion = ThisSVal.getAsRegion();
-        setNullTypeAny(ThisMemRegion, C);
+        C.addTransition(setNullTypeAny(ThisMemRegion, C));
         return true;
       }
 
@@ -106,10 +107,10 @@ public:
 private:
   // When an std::any is rested or default constructed it has a null type.
   // We represent it by storing a null QualType.
-  void setNullTypeAny(const MemRegion *Mem, CheckerContext &C) const {
+  ProgramStateRef setNullTypeAny(const MemRegion *Mem, CheckerContext &C) const {
     auto State = C.getState();
-    State = State->set<AnyHeldTypeMap>(Mem, QualType{});
-    C.addTransition(State);
+    return State->set<AnyHeldTypeMap>(Mem, QualType{});
+    //C.addTransition(State);
   }
 
   bool handleAnyCastCall(const CallEvent &Call, CheckerContext &C) const {

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -1,0 +1,201 @@
+//===- StdAnyChecker.cpp -------------------------------------*- C++ -*----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include "TaggedUnionModeling.h"
+
+using namespace clang;
+using namespace ento;
+using namespace tagged_union_modeling;
+
+REGISTER_MAP_WITH_PROGRAMSTATE(AnyHeldTypeMap, const MemRegion *, QualType)
+
+class StdAnyChecker : public Checker<eval::Call, check::RegionChanges> {
+  CallDescription AnyConstructor{{"std", "any", "any"}};
+  CallDescription AnyAsOp{{"std", "any", "operator="}};
+  CallDescription AnyReset{{"std", "any", "reset"}, 0, 0};
+  CallDescription AnyCast{{"std", "any_cast"}, 1, 1};
+
+  BugType BadAnyType{this, "BadAnyType", "BadAnyType"};
+  BugType NullAnyType{this, "NullAnyType", "NullAnyType"};
+
+public:
+  ProgramStateRef
+  checkRegionChanges(ProgramStateRef State,
+                     const InvalidatedSymbols *Invalidated,
+                     ArrayRef<const MemRegion *> ExplicitRegions,
+                     ArrayRef<const MemRegion *> Regions,
+                     const LocationContext *LCtx, const CallEvent *Call) const {
+    if (!Call)
+      return State;
+
+    return removeInformationStoredForDeadInstances<AnyHeldTypeMap>(*Call, State,
+                                                                   Regions);
+  }
+
+  bool evalCall(const CallEvent &Call, CheckerContext &C) const {
+    // Do not take implementation details into consideration
+    if (Call.isCalledFromSystemHeader())
+      return false;
+
+    if (AnyCast.matches(Call))
+      return handleAnyCastCall(Call, C);
+
+    if (AnyReset.matches(Call)) {
+      const auto *AsMemberCall = dyn_cast<CXXMemberCall>(&Call);
+      if (!AsMemberCall)
+        return false;
+
+      const auto *ThisMemRegion = AsMemberCall->getCXXThisVal().getAsRegion();
+      if (!ThisMemRegion)
+        return false;
+
+      setNullTypeAny(ThisMemRegion, C);
+      return true;
+    }
+
+    bool IsAnyConstructor =
+        isa<CXXConstructorCall>(Call) && AnyConstructor.matches(Call);
+    bool IsAnyAssignmentOperatorCall =
+        isa<CXXMemberOperatorCall>(Call) && AnyAsOp.matches(Call);
+
+    if (IsAnyConstructor || IsAnyAssignmentOperatorCall) {
+      auto State = C.getState();
+      SVal ThisSVal = [&]() {
+        if (IsAnyConstructor) {
+          const auto *AsConstructorCall = dyn_cast<CXXConstructorCall>(&Call);
+          return AsConstructorCall->getCXXThisVal();
+        }
+        if (IsAnyAssignmentOperatorCall) {
+          const auto *AsMemberOpCall = dyn_cast<CXXMemberOperatorCall>(&Call);
+          return AsMemberOpCall->getCXXThisVal();
+        }
+        llvm_unreachable("We must have an assignment operator or constructor");
+      }();
+
+      // default constructor call
+      // in this case the any holds a null type
+      if (Call.getNumArgs() == 0) {
+        const auto *ThisMemRegion = ThisSVal.getAsRegion();
+        setNullTypeAny(ThisMemRegion, C);
+        return true;
+      }
+
+      if (Call.getNumArgs() != 1)
+        return false;
+
+      handleConstructorAndAssignment<AnyHeldTypeMap>(Call, C, ThisSVal);
+      return true;
+    }
+    return false;
+  }
+
+private:
+  // When an std::any is rested or default constructed it has a null type.
+  // We represent it by storing a null QualType.
+  void setNullTypeAny(const MemRegion *Mem, CheckerContext &C) const {
+    auto State = C.getState();
+    State = State->set<AnyHeldTypeMap>(Mem, QualType{});
+    C.addTransition(State);
+  }
+
+  // this function name is terrible
+  bool handleAnyCastCall(const CallEvent &Call, CheckerContext &C) const {
+    auto State = C.getState();
+
+    if (Call.getNumArgs() != 1)
+      return false;
+
+    auto ArgSVal = Call.getArgSVal(0);
+
+    // The argument is aether a const reference or a right value reference
+    //  We need the type referred
+    const auto *ArgType = ArgSVal.getType(C.getASTContext())
+                              .getTypePtr()
+                              ->getPointeeType()
+                              .getTypePtr();
+    if (!isStdAny(ArgType))
+      return false;
+
+    const auto *AnyMemRegion = ArgSVal.getAsRegion();
+
+    if (!State->contains<AnyHeldTypeMap>(AnyMemRegion))
+      return false;
+
+    // get the type we are trying to get from any
+    const CallExpr *CE = cast<CallExpr>(Call.getOriginExpr());
+    const FunctionDecl *FD = CE->getDirectCallee();
+    if (FD->getTemplateSpecializationArgs()->size() < 1)
+      return false;
+
+    const auto &FirstTemplateArgument =
+        FD->getTemplateSpecializationArgs()->asArray()[0];
+    if (FirstTemplateArgument.getKind() != TemplateArgument::ArgKind::Type)
+      return false;
+
+    auto TypeOut = FirstTemplateArgument.getAsType();
+    const auto *TypeStored = State->get<AnyHeldTypeMap>(AnyMemRegion);
+
+    // Report when we try to use std::any_cast on an std::any that held a null
+    // type
+    if (TypeStored->isNull()) {
+      ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+      if (!ErrNode)
+        return false;
+      llvm::SmallString<128> Str;
+      llvm::raw_svector_ostream OS(Str);
+      OS << "std::any " << AnyMemRegion->getDescriptiveName() << " is empty.";
+      auto R = std::make_unique<PathSensitiveBugReport>(NullAnyType, OS.str(),
+                                                        ErrNode);
+      C.emitReport(std::move(R));
+      return true;
+    }
+
+    // Check if the right type is being accessed
+    // There is spacial case for object types.
+    QualType RetrievedCanonicalType = TypeOut.getCanonicalType();
+    QualType StoredCanonicalType = TypeStored->getCanonicalType();
+    if (RetrievedCanonicalType == StoredCanonicalType)
+      return true;
+
+    // Report when the type we want to get out of std::any is wrong
+    ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+    if (!ErrNode)
+      return false;
+    llvm::SmallString<128> Str;
+    llvm::raw_svector_ostream OS(Str);
+    std::string StoredTypeName = StoredCanonicalType.getAsString();
+    std::string RetrievedTypeName = RetrievedCanonicalType.getAsString();
+    OS << "std::any " << AnyMemRegion->getDescriptiveName() << " held "
+       << indefiniteArticleBasedOnVowel(StoredTypeName[0]) << " \'"
+       << StoredTypeName << "\', not "
+       << indefiniteArticleBasedOnVowel(RetrievedTypeName[0]) << " \'"
+       << RetrievedTypeName << "\'";
+    auto R =
+        std::make_unique<PathSensitiveBugReport>(BadAnyType, OS.str(), ErrNode);
+    C.emitReport(std::move(R));
+    return true;
+  }
+};
+
+bool clang::ento::shouldRegisterStdAnyChecker(
+    clang::ento::CheckerManager const &mgr) {
+  return true;
+}
+
+void clang::ento::registerStdAnyChecker(clang::ento::CheckerManager &mgr) {
+  mgr.registerChecker<StdAnyChecker>();
+}

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -137,7 +137,7 @@ private:
     // Get the type we are trying to retrieve from any.
     const CallExpr *CE = cast<CallExpr>(Call.getOriginExpr());
     const FunctionDecl *FD = CE->getDirectCallee();
-    if (FD->getTemplateSpecializationArgs()->size() < 1)
+    if (FD->getTemplateSpecializationArgs()->size() != 1)
       return false;
 
     const auto &FirstTemplateArgument =

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -142,7 +142,7 @@ private:
       return false;
 
     const auto &FirstTemplateArgument =
-        FD->getTemplateSpecializationArgs()->asArray()[0];
+        FD->getTemplateSpecializationArgs()->get(0);
     if (FirstTemplateArgument.getKind() != TemplateArgument::ArgKind::Type)
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -152,7 +152,7 @@ private:
     // Report when we try to use std::any_cast on a std::any that held a null
     // type.
     if (TypeStored->isNull()) {
-      ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+      ExplodedNode *ErrNode = C.generateErrorNode();
       if (!ErrNode)
         return false;
       llvm::SmallString<128> Str;

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -132,7 +132,8 @@ private:
 
     const auto *AnyMemRegion = ArgSVal.getAsRegion();
 
-    if (!State->contains<AnyHeldTypeMap>(AnyMemRegion))
+    const auto *TypeStored = State->get<AnyHeldTypeMap>(AnyMemRegion);
+    if (!TypeStored)
       return false;
 
     // Get the type we are trying to retrieve from any.
@@ -147,7 +148,6 @@ private:
       return false;
 
     auto TypeOut = FirstTemplateArgument.getAsType();
-    const auto *TypeStored = State->get<AnyHeldTypeMap>(AnyMemRegion);
 
     // Report when we try to use std::any_cast on a std::any that held a null
     // type.

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -86,8 +86,8 @@ public:
         llvm_unreachable("We must have an assignment operator or constructor");
       }();
 
-      // default constructor call
-      // in this case the any holds a null type
+      // Default constructor call.
+      // In this case the any holds a null type.
       if (Call.getNumArgs() == 0) {
         const auto *ThisMemRegion = ThisSVal.getAsRegion();
         setNullTypeAny(ThisMemRegion, C);
@@ -112,7 +112,6 @@ private:
     C.addTransition(State);
   }
 
-  // this function name is terrible
   bool handleAnyCastCall(const CallEvent &Call, CheckerContext &C) const {
     auto State = C.getState();
 
@@ -121,8 +120,8 @@ private:
 
     auto ArgSVal = Call.getArgSVal(0);
 
-    // The argument is aether a const reference or a right value reference
-    //  We need the type referred
+    // The argument is ether a const reference or a right value reference.
+    // We need the type referred.
     const auto *ArgType = ArgSVal.getType(C.getASTContext())
                               .getTypePtr()
                               ->getPointeeType()
@@ -135,7 +134,7 @@ private:
     if (!State->contains<AnyHeldTypeMap>(AnyMemRegion))
       return false;
 
-    // get the type we are trying to get from any
+    // Get the type we are trying to retrieve from any.
     const CallExpr *CE = cast<CallExpr>(Call.getOriginExpr());
     const FunctionDecl *FD = CE->getDirectCallee();
     if (FD->getTemplateSpecializationArgs()->size() < 1)
@@ -150,7 +149,7 @@ private:
     const auto *TypeStored = State->get<AnyHeldTypeMap>(AnyMemRegion);
 
     // Report when we try to use std::any_cast on an std::any that held a null
-    // type
+    // type.
     if (TypeStored->isNull()) {
       ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
       if (!ErrNode)
@@ -164,14 +163,13 @@ private:
       return true;
     }
 
-    // Check if the right type is being accessed
-    // There is spacial case for object types.
+    // Check if the right type is being accessed.
     QualType RetrievedCanonicalType = TypeOut.getCanonicalType();
     QualType StoredCanonicalType = TypeStored->getCanonicalType();
     if (RetrievedCanonicalType == StoredCanonicalType)
       return true;
 
-    // Report when the type we want to get out of std::any is wrong
+    // Report when the type we want to get out of std::any is wrong.
     ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
     if (!ErrNode)
       return false;

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -121,7 +121,7 @@ private:
 
     auto ArgSVal = Call.getArgSVal(0);
 
-    // The argument is ether a const reference or a right value reference.
+    // The argument is either a const reference or a right value reference.
     // We need the type referred.
     const auto *ArgType = ArgSVal.getType(C.getASTContext())
                               .getTypePtr()

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -29,8 +29,8 @@ class StdAnyChecker : public Checker<eval::Call, check::RegionChanges> {
   CallDescription AnyReset{{"std", "any", "reset"}, 0, 0};
   CallDescription AnyCast{{"std", "any_cast"}, 1, 1};
 
-  BugType BadAnyType{this, "BadAnyType", "BadAnyType"};
-  BugType NullAnyType{this, "NullAnyType", "NullAnyType"};
+  const BugType BadAnyType{this, "Bad std::any type access.", "BadAnyType"};
+  const BugType NullAnyType{this, "std::any has no value", "NullAnyType"};
 
 public:
   ProgramStateRef checkRegionChanges(ProgramStateRef State,

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -33,12 +33,12 @@ class StdAnyChecker : public Checker<eval::Call, check::RegionChanges> {
   BugType NullAnyType{this, "NullAnyType", "NullAnyType"};
 
 public:
-  ProgramStateRef
-  checkRegionChanges(ProgramStateRef State,
-                     const InvalidatedSymbols *Invalidated,
-                     ArrayRef<const MemRegion *> ExplicitRegions,
-                     ArrayRef<const MemRegion *> Regions,
-                     const LocationContext *LCtx, const CallEvent *Call) const {
+  ProgramStateRef checkRegionChanges(ProgramStateRef State,
+                                     const InvalidatedSymbols *,
+                                     ArrayRef<const MemRegion *>,
+                                     ArrayRef<const MemRegion *> Regions,
+                                     const LocationContext *,
+                                     const CallEvent *Call) const {
     if (!Call)
       return State;
 

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -107,10 +107,10 @@ public:
 private:
   // When a std::any is reset or default constructed it has a null type.
   // We represent it by storing an empty QualType.
-  ProgramStateRef setNullTypeAny(const MemRegion *Mem, CheckerContext &C) const {
+  ProgramStateRef setNullTypeAny(const MemRegion *Mem,
+                                 CheckerContext &C) const {
     auto State = C.getState();
     return State->set<AnyHeldTypeMap>(Mem, QualType{});
-    //C.addTransition(State);
   }
 
   bool handleAnyCastCall(const CallEvent &Call, CheckerContext &C) const {

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -179,10 +179,10 @@ private:
     std::string StoredTypeName = StoredCanonicalType.getAsString();
     std::string RetrievedTypeName = RetrievedCanonicalType.getAsString();
     OS << "std::any " << AnyMemRegion->getDescriptiveName() << " held "
-       << indefiniteArticleBasedOnVowel(StoredTypeName[0]) << " \'"
-       << StoredTypeName << "\', not "
-       << indefiniteArticleBasedOnVowel(RetrievedTypeName[0]) << " \'"
-       << RetrievedTypeName << "\'";
+       << indefiniteArticleBasedOnVowel(StoredTypeName[0]) << " '"
+       << StoredTypeName << "', not "
+       << indefiniteArticleBasedOnVowel(RetrievedTypeName[0]) << " '"
+       << RetrievedTypeName << "'";
     auto R =
         std::make_unique<PathSensitiveBugReport>(BadAnyType, OS.str(), ErrNode);
     C.emitReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdAnyChecker.cpp
@@ -102,13 +102,11 @@ private:
       return false;
 
     auto ArgSVal = Call.getArgSVal(0);
+    const auto *ArgExpr = Call.getArgExpr(0);
+    if (!ArgExpr)
+      return false;
 
-    // The argument is either a const reference or a right value reference.
-    // We need the type referred.
-    const auto *ArgType = ArgSVal.getType(C.getASTContext())
-                              .getTypePtr()
-                              ->getPointeeType()
-                              .getTypePtr();
+    const auto *ArgType = ArgExpr->getType().getTypePtr();
     if (!isStdAny(ArgType))
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -269,7 +269,7 @@ private:
     if (RetrievedCanonicalType == StoredCanonicalType)
       return true;
 
-    ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+    ExplodedNode *ErrNode = C.generateErrorNode();
     if (!ErrNode)
       return false;
     llvm::SmallString<128> Str;

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -277,10 +277,10 @@ private:
     std::string StoredTypeName = StoredType->getAsString();
     std::string RetrievedTypeName = RetrievedType.getAsString();
     OS << "std::variant " << ArgMemRegion->getDescriptiveName() << " held "
-       << indefiniteArticleBasedOnVowel(StoredTypeName[0]) << " \'"
-       << StoredTypeName << "\', not "
-       << indefiniteArticleBasedOnVowel(RetrievedTypeName[0]) << " \'"
-       << RetrievedTypeName << "\'";
+       << indefiniteArticleBasedOnVowel(StoredTypeName[0]) << " '"
+       << StoredTypeName << "', not "
+       << indefiniteArticleBasedOnVowel(RetrievedTypeName[0]) << " '"
+       << RetrievedTypeName << "'";
     auto R = std::make_unique<PathSensitiveBugReport>(BadVariantType, OS.str(),
                                                       ErrNode);
     C.emitReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -240,7 +240,7 @@ private:
     if (FD->getTemplateSpecializationArgs()->size() < 1)
       return false;
 
-    const auto &TypeOut = FD->getTemplateSpecializationArgs()->asArray()[0];
+    const auto &TypeOut = FD->getTemplateSpecializationArgs()->get(0);
     // std::get's first template parameter can be the type we want to get
     // out of the std::variant or a natural number which is the position of
     // the requested type in the argument type list of the std::variant's

--- a/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
+++ b/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
@@ -23,8 +23,8 @@ bool isCopyAssignmentCall(const CallEvent &Call);
 bool isMoveAssignmentCall(const CallEvent &Call);
 bool isMoveConstructorCall(const CallEvent &Call);
 bool isStdType(const Type *Type, const std::string &TypeName);
-bool isStdVariant(const Type *Type);
 bool isStdAny(const Type *Type);
+bool isStdVariant(const Type *Type);
 bool isVowel(char a);
 llvm::StringRef indefiniteArticleBasedOnVowel(char a);
 

--- a/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
+++ b/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
@@ -9,15 +9,9 @@
 #ifndef LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_TAGGEDUNIONMODELING_H
 #define LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_TAGGEDUNIONMODELING_H
 
-#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
-#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
-#include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
-#include "clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
-#include "llvm/ADT/FoldingSet.h"
-#include <numeric>
 
 namespace clang::ento::tagged_union_modeling {
 
@@ -30,6 +24,9 @@ bool isMoveAssignmentCall(const CallEvent &Call);
 bool isMoveConstructorCall(const CallEvent &Call);
 bool isStdType(const Type *Type, const std::string &TypeName);
 bool isStdVariant(const Type *Type);
+bool isStdAny(const Type *Type);
+bool isVowel(char a);
+llvm::StringRef indefiniteArticleBasedOnVowel(char a);
 
 // When invalidating regions, we also have to follow that by invalidating the
 // corresponding custom data in the program state.

--- a/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
+++ b/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
@@ -1372,6 +1372,65 @@ template <typename Ret, typename... Args> class packaged_task<Ret(Args...)> {
             typename = std::enable_if_t<!is_same_v<std::variant<Types...>, decay_t<T>>>>
     variant& operator=(T&&);
   };
+
+  class bad_any_cast;
+ 
+  // class any
+  class any;
+ 
+  // non-member functions
+  void swap(any& x, any& y) noexcept;
+ 
+  template<class T, class... Args>
+    any make_any(Args&&... args);
+  template<class T, class U, class... Args>
+    any make_any(initializer_list<U> il, Args&&... args);
+ 
+  template<class T>
+    T any_cast(const any& operand);
+  template<class T>
+    T any_cast(any& operand);
+  template<class T>
+    T any_cast(any&& operand);
+ 
+  template<class T>
+    const T* any_cast(const any* operand) noexcept;
+  template<class T>
+    T* any_cast(any* operand) noexcept;
+
+  class any {
+  public:
+    // construction and destruction
+    constexpr any() noexcept;
+ 
+    any(const any& other);
+    any(any&& other) noexcept;
+ 
+    template<class T>
+    any(T&& value);
+ 
+    ~any();
+ 
+    // assignments
+    any& operator=(const any& rhs);    
+    any& operator=(any&& rhs) noexcept;
+ 
+    template<typename T,
+            typename = std::enable_if_t<!is_same_v<std::any, decay_t<T>>>>
+    any& operator=(T&& rhs);
+ 
+    // modifiers
+    template<class T, class... Args>
+      decay_t<T>& emplace(Args&&...);
+    template<class T, class U, class... Args>
+      decay_t<T>& emplace(initializer_list<U>, Args&&...);
+    void reset() noexcept;
+    void swap(any& rhs) noexcept;
+ 
+    // observers
+    bool has_value() const noexcept;
+  };
+
   #endif
 
 } // namespace std

--- a/clang/test/Analysis/std-any-checker.cpp
+++ b/clang/test/Analysis/std-any-checker.cpp
@@ -1,0 +1,170 @@
+// RUN: %clang %s -Xclang -verify --analyze \
+// RUN:   -Xclang -analyzer-checker=core \
+// RUN:   -Xclang -analyzer-checker=debug.ExprInspection \
+// RUN:   -Xclang -analyzer-checker=core,alpha.core.StdAny
+
+#include "Inputs/system-header-simulator-cxx.h"
+
+void clang_analyzer_warnIfReached();
+void clang_analyzer_eval(int);
+
+
+class DummyClass{
+  public:
+  void foo(){};
+};
+
+void nonInlined(std::any &a);
+void nonInlinedConst(const std::any & a);
+
+void inlined(std::any &a) {
+  a = 5;
+}
+
+using any_t = std::any;
+using any_tt = any_t;
+
+
+//----------------------------------------------------------------------------//
+// std::any_cast
+//----------------------------------------------------------------------------//
+void objectHeld() {
+  std::any a = DummyClass{};
+  DummyClass d = std::any_cast<DummyClass>(a);
+  d.foo();
+}
+
+void formVariable() {
+  std::any a = 5;
+  int b = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)b;
+  (void)c;
+}
+
+void pointerHeld() {
+  int i = 5;
+  std::any a = &i;
+  int* x = std::any_cast<int*>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int *', not a 'char'}}
+  (void)x;
+  (void)c;
+}
+
+//----------------------------------------------------------------------------//
+// Empty std::any
+//----------------------------------------------------------------------------//
+
+void noTypeHeld() {
+  std::any a;
+  int i = std::any_cast<int>(a); // expected-warning {{any 'a' is empty}}
+  (void)i;
+}
+
+void reset() {
+  std::any a = 15;
+  a.reset();
+  int i = std::any_cast<int>(a); // expected-warning {{any 'a' is empty}}
+  (void)i;
+}
+
+
+//----------------------------------------------------------------------------//
+// Typedefs
+//----------------------------------------------------------------------------//
+
+void typedefedAny () {
+  any_t a = 5;
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+void typedefedTypedefedAny () {
+  any_tt a = 5;
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+//----------------------------------------------------------------------------//
+// Constructors and assignments
+//----------------------------------------------------------------------------//
+
+void assignmentOp () {
+  std::any a;
+  a = 5;
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+void constructor() {
+  std::any a(5);
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+void copyCtor() {
+  std::any a(5);
+  std::any b(a);
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+void copyCtorNullType() {
+  std::any a;
+  std::any b(a);
+  char c = std::any_cast<char>(a); // expected-warning {{any 'a' is empty}}
+  (void)c;
+}
+
+void copyAssignment() {
+  std::any a = 5;
+  std::any b = 'c';
+  char c = std::any_cast<char>(b);
+  (void)c;
+  b = a;
+  int i = std::any_cast<int>(b);
+  c = std::any_cast<char>(b); // expected-warning {{std::any 'b' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+//----------------------------------------------------------------------------//
+// Function calls
+//----------------------------------------------------------------------------//
+
+void nonInlinedRefCall() {
+  std::any a = 5;
+  nonInlined(a);
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a);
+  (void)i;
+  (void)c;
+}
+
+void nonInlinedConstRefCall() {
+  std::any a = 5;
+  nonInlinedConst(a);
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}
+
+void inlinedCall() {
+  std::any a = 'c';
+  inlined(a);
+  int i = std::any_cast<int>(a);
+  char c = std::any_cast<char>(a); // expected-warning {{std::any 'a' held an 'int', not a 'char'}}
+  (void)i;
+  (void)c;
+}

--- a/clang/test/Analysis/std-any-checker.cpp
+++ b/clang/test/Analysis/std-any-checker.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang %s -Xclang -verify --analyze \
+// RUN: %clang %s -std=c++17 -Xclang -verify --analyze \
 // RUN:   -Xclang -analyzer-checker=core \
 // RUN:   -Xclang -analyzer-checker=debug.ExprInspection \
 // RUN:   -Xclang -analyzer-checker=core,alpha.core.StdAny

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -58,6 +58,14 @@ void wontConfuseStdGets() {
 //----------------------------------------------------------------------------//
 // std::get
 //----------------------------------------------------------------------------//
+void stdGetType2() {
+  std::variant<int, char> v = {25};
+  int a = std::get<int>(v);
+  char c = std::get<char>(v); // expected-warning {{std::variant 'v' held an 'int', not a 'char'}}
+  (void)a;
+  (void)c;
+}
+
 void stdGetType() {
   std::variant<int, char> v = 25;
   int a = std::get<int>(v);

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -58,14 +58,6 @@ void wontConfuseStdGets() {
 //----------------------------------------------------------------------------//
 // std::get
 //----------------------------------------------------------------------------//
-void stdGetType2() {
-  std::variant<int, char> v = {25};
-  int a = std::get<int>(v);
-  char c = std::get<char>(v); // expected-warning {{std::variant 'v' held an 'int', not a 'char'}}
-  (void)a;
-  (void)c;
-}
-
 void stdGetType() {
   std::variant<int, char> v = 25;
   int a = std::get<int>(v);


### PR DESCRIPTION
Add a checker to detect bad `std::any` type accesses.

It warns when the active type is different from the requested type when calling `std::any_cast`:

```cpp
void anyCast() {
  std::any a = 5;
  char c = std::any_cast<char>(a); // warn: "int" is the active alternative
 }
```

It also warns when the `std::any` instance is empty:

```cpp
 void noTypeHeld() {
  std::any a;
  int i = std::any_cast<int>(a); // warn: any 'a' is empty
 }
```

This checker works in a similar way to the `std::variant` checker: Recognizes when the active type of a `std::any` instance changes and stores this information. Later on, when the data held in this instance is accessed with `std::any_cast`, it is checked if the active type is retrieved or not. If not then a warning is emitted.

This checker does not produce false positives. It is conservative: if there is no information on the `std::any` instance or the already recorded information becomes invalid, no report will be emitted. 