### PR TITLE
Ensure that python directory exists before starting build

### DIFF
--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -110,6 +110,25 @@ set python32_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python310-32
 set python64_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python310
 set pythonarm64_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python311-arm64
 
+if "%x86%" == "true" (
+  if not exist %python32_dir% (
+    echo Can't find python directory %python32_dir%
+    exit /b 1
+  )
+)
+if "%x64%" == "true" (
+  if not exist %python64_dir% (
+    echo Can't find python directory %python64_dir%
+    exit /b 1
+  )
+)
+if "%arm64%" == "true" (
+  if not exist %pythonarm64_dir% (
+    echo Can't find python directory %pythonarm64_dir%
+    exit /b 1
+  )
+)
+
 set revision=llvmorg-%version%
 set package_version=%version%
 set build_dir=%cd%\llvm_package_%package_version%


### PR DESCRIPTION
Later steps will fail if the python directory does not exist. Performing this check first avoids wasting time downloading and extracting sources only for the build to later fail because python cannot be found.