### PR TITLE
[libc][Obvious] Correctly initialize the default clock frequency

### DIFF
--- a/libc/src/time/gpu/time_utils.h
+++ b/libc/src/time/gpu/time_utils.h
@@ -36,10 +36,11 @@ constexpr uint64_t clock_freq = 25000000;
 constexpr uint64_t clock_freq = 0;
 #endif
 
-// We provide an externally visible symbol such that the runtime can set this to
-// the correct value. If it is not set we try to default to the known values.
+// We provide an externally visible symbol such that the runtime can set
+// this to the correct value. If it is not set we try to default to the
+// known values.
 extern "C" [[gnu::visibility("protected")]] uint64_t
-    [[clang::address_space(4)]] __llvm_libc_clock_freq;
+    [[clang::address_space(4)]] __llvm_libc_clock_freq = clock_freq;
 #define GPU_CLOCKS_PER_SEC static_cast<clock_t>(__llvm_libc_clock_freq)
 
 #elif defined(LIBC_TARGET_ARCH_IS_NVPTX)


### PR DESCRIPTION
Summary:
The AMDGPU architecture does not use a fixed frequency for all of its
architectures. However, the newer GPUs tend to have one that's
consistent between them (Except for Vega10). This was set up but not
actually used, so the implementation was just defaulting to whatever
value the global was being set to. Fix.
