### PR TITLE
[GitHub] Fix minor typos in .github/workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,1 +1,1 @@
-Github action workflows should be stored in this directrory.
+Github action workflows should be stored in this directory.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -167,4 +167,3 @@ jobs:
         run: |
           cmake -B flang-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;mlir;flang" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_WARNINGS_AS_ERRORS=OFF ./llvm
           TZ=UTC ninja -C flang-build docs-flang-html docs-flang-man
-

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -207,4 +207,3 @@ jobs:
             **/CMakeError.log
             **/CMakeOutput.log
             **/crash_diagnostics/*
-  


### PR DESCRIPTION
Fix one spelling typo and remove second newline from end of files.