### PR TITLE
[MLIR][Presburger] Fix a bug with determinant of IntMatrix

### DIFF
--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -452,6 +452,9 @@ MPInt IntMatrix::determinant(IntMatrix *inverse) const {
   if (detM == 0)
     return MPInt(0);
 
+  if (!inverse)
+    return detM;
+
   *inverse = IntMatrix(nRows, nColumns);
   for (unsigned i = 0; i < nRows; i++)
     for (unsigned j = 0; j < nColumns; j++)

--- a/mlir/unittests/Analysis/Presburger/MatrixTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/MatrixTest.cpp
@@ -251,6 +251,9 @@ TEST(MatrixTest, computeHermiteNormalForm) {
 }
 
 TEST(MatrixTest, inverse) {
+  IntMatrix mat1 = makeIntMatrix(2, 2, {{2, 1}, {7, 0}});
+  EXPECT_EQ(mat1.determinant(), -7);
+
   FracMatrix mat = makeFracMatrix(
       2, 2, {{Fraction(2), Fraction(1)}, {Fraction(7), Fraction(0)}});
   FracMatrix inverse = makeFracMatrix(


### PR DESCRIPTION
IntMatrix determinant() had a bug where it would try to assign to a null pointer.
A check to avoid this case has been added.