### PR TITLE
[libc++] Improves _LIBCPP_HAS_NO_THREADS guards.

### DIFF
--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -45,11 +45,16 @@ namespace std
 
 */
 
+#include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<barrier> is not supported since libc++ has been configured without support for threads."
+#endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__atomic/atomic_base.h>
 #include <__atomic/memory_order.h>
 #include <__availability>
-#include <__config>
 #include <__memory/unique_ptr.h>
 #include <__thread/poll_with_backoff.h>
 #include <__thread/timed_backoff_policy.h>
@@ -61,10 +66,6 @@ namespace std
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<barrier> is not supported since libc++ has been configured without support for threads."
 #endif
 
 _LIBCPP_PUSH_MACROS

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -362,11 +362,16 @@ template <class R, class Alloc> struct uses_allocator<packaged_task<R>, Alloc>;
 
 */
 
+#include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<future> is not supported since libc++ has been configured without support for threads."
+#endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__availability>
 #include <__chrono/duration.h>
 #include <__chrono/time_point.h>
-#include <__config>
 #include <__exception/exception_ptr.h>
 #include <__memory/addressof.h>
 #include <__memory/allocator.h>
@@ -394,10 +399,6 @@ template <class R, class Alloc> struct uses_allocator<packaged_task<R>, Alloc>;
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<future> is not supported since libc++ has been configured without support for threads."
 #endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD

--- a/libcxx/include/latch
+++ b/libcxx/include/latch
@@ -40,22 +40,23 @@ namespace std
 
 */
 
+#include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<latch> is not supported since libc++ has been configured without support for threads."
+#endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__atomic/atomic_base.h>
 #include <__atomic/atomic_sync.h>
 #include <__atomic/memory_order.h>
 #include <__availability>
-#include <__config>
 #include <cstddef>
 #include <limits>
 #include <version>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<latch> is not supported since libc++ has been configured without support for threads."
 #endif
 
 _LIBCPP_PUSH_MACROS

--- a/libcxx/include/semaphore
+++ b/libcxx/include/semaphore
@@ -45,13 +45,18 @@ using binary_semaphore = counting_semaphore<1>;
 
 */
 
+#include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<semaphore> is not supported since libc++ has been configured without support for threads."
+#endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__atomic/atomic_base.h>
 #include <__atomic/atomic_sync.h>
 #include <__atomic/memory_order.h>
 #include <__availability>
 #include <__chrono/time_point.h>
-#include <__config>
 #include <__thread/poll_with_backoff.h>
 #include <__thread/timed_backoff_policy.h>
 #include <__threading_support>
@@ -61,10 +66,6 @@ using binary_semaphore = counting_semaphore<1>;
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<semaphore> is not supported since libc++ has been configured without support for threads."
 #endif
 
 _LIBCPP_PUSH_MACROS

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -122,13 +122,18 @@ template <class Mutex>
 
 */
 
+#include <__config>
+
+#  ifdef _LIBCPP_HAS_NO_THREADS
+#    error "<shared_mutex> is not supported since libc++ has been configured without support for threads."
+#  endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__availability>
 #include <__chrono/duration.h>
 #include <__chrono/steady_clock.h>
 #include <__chrono/time_point.h>
 #include <__condition_variable/condition_variable.h>
-#include <__config>
 #include <__memory/addressof.h>
 #include <__mutex/mutex.h>
 #include <__mutex/tag_types.h>
@@ -145,10 +150,6 @@ _LIBCPP_PUSH_MACROS
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header
-#  endif
-
-#  ifdef _LIBCPP_HAS_NO_THREADS
-#    error "<shared_mutex> is not supported since libc++ has been configured without support for threads."
 #  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD

--- a/libcxx/include/stop_token
+++ b/libcxx/include/stop_token
@@ -31,8 +31,13 @@ namespace std {
 
 */
 
-#include <__assert> // all public C++ headers provide the assertion handler
 #include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<stop_token> is not supported since libc++ has been configured without support for threads."
+#endif
+
+#include <__assert> // all public C++ headers provide the assertion handler
 #include <__stop_token/stop_callback.h>
 #include <__stop_token/stop_source.h>
 #include <__stop_token/stop_token.h>
@@ -40,10 +45,6 @@ namespace std {
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<stop_token> is not supported since libc++ has been configured without support for threads."
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20

--- a/libcxx/include/thread
+++ b/libcxx/include/thread
@@ -86,9 +86,14 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 
 */
 
+#include <__config>
+
+#ifdef _LIBCPP_HAS_NO_THREADS
+#  error "<thread> is not supported since libc++ has been configured without support for threads."
+#endif
+
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__availability>
-#include <__config>
 #include <__thread/formatter.h>
 #include <__thread/jthread.h>
 #include <__thread/this_thread.h>
@@ -103,10 +108,6 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
-#endif
-
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<thread> is not supported since libc++ has been configured without support for threads."
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)


### PR DESCRIPTION
Previously the header included several headers, possibly granularized threading headers. This could lead to build errors when these headers were incompatible with threading disabled.

Now test the guard before inclusion. This matches the pattern used for no localization and no wide characters.

Fixes: https://github.com/llvm/llvm-project/issues/76620