### PR TITLE
[flang][runtime] Don't prematurely end formatted integer input

### DIFF
--- a/flang/runtime/edit-input.cpp
+++ b/flang/runtime/edit-input.cpp
@@ -243,7 +243,7 @@ bool EditIntegerInput(
   if (sign == '-') {
     value = -value;
   }
-  if (any || !io.GetConnectionState().IsAtEOF()) {
+  if (any || !io.GetIoErrorHandler().InError()) {
     // The value is stored in the lower order bits on big endian platform.
     // When memcpy, shift the value to the higher order bit.
     auto shft{static_cast<int>(sizeof(value.low())) - kind};
@@ -254,8 +254,10 @@ bool EditIntegerInput(
     } else {
       std::memcpy(n, &value, kind); // a blank field means zero
     }
+    return true;
+  } else {
+    return false;
   }
-  return any;
 }
 
 // Parses a REAL input number from the input source as a normalized


### PR DESCRIPTION
When an input data-list has more items than can be read by a format from the input record (e.g., "(4I5)" reading "1 2"), don't return false from EditIntegerInput() just because nothing was read -- that will prevent later items from being set to zero, as they should be.  Return true unless nothing was read and there is some kind of error pending.

Fixes llvm-error-tests/Fortran/gfortran/regression/pr478478.f90.