### PR TITLE
[Driver][Solaris] Remove reachable llvm_unreachable

### DIFF
--- a/clang/lib/Driver/ToolChains/Solaris.cpp
+++ b/clang/lib/Driver/ToolChains/Solaris.cpp
@@ -295,13 +295,12 @@ static StringRef getSolarisLibSuffix(const llvm::Triple &Triple) {
   switch (Triple.getArch()) {
   case llvm::Triple::x86:
   case llvm::Triple::sparc:
+  default:
     break;
   case llvm::Triple::x86_64:
     return "/amd64";
   case llvm::Triple::sparcv9:
     return "/sparcv9";
-  default:
-    llvm_unreachable("Unsupported architecture");
   }
   return "";
 }


### PR DESCRIPTION
Remove the llvm_unreachable from getSolarisLibSuffix(). The code path is
reachable. In the case of an unsupported architecture we're not worrying
about trying to actually find the library paths, and I don't think it
makes sense for the Driver to crash.

Fixes #58334