### PR TITLE
[clang][Sema] Warn on self move for inlined static cast

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -18845,7 +18845,7 @@ void Sema::DiagnoseSelfMove(const Expr *LHSExpr, const Expr *RHSExpr,
 
   // Check for a call expression or static_cast expression
   const CallExpr *CE = dyn_cast<CallExpr>(RHSExpr);
-  const CXXStaticCastExpr *CXXSCE = dyn_cast<CXXStaticCastExpr>(RHSExpr);
+  const auto *CXXSCE = dyn_cast<CXXStaticCastExpr>(RHSExpr);
   if (!CE && !CXXSCE)
     return;
 

--- a/clang/test/SemaCXX/warn-self-move.cpp
+++ b/clang/test/SemaCXX/warn-self-move.cpp
@@ -16,6 +16,9 @@ void int_test() {
   x = std::move(x);  // expected-warning{{explicitly moving}}
   (x) = std::move(x);  // expected-warning{{explicitly moving}}
 
+  x = static_cast<int&&>(x);  // expected-warning{{explicitly moving}}
+  (x) = static_cast<int&&>(x);  // expected-warning{{explicitly moving}}
+
   using std::move;
   x = move(x); // expected-warning{{explicitly moving}} \
                    expected-warning {{unqualified call to 'std::move}}
@@ -26,6 +29,9 @@ void global_int_test() {
   global = std::move(global);  // expected-warning{{explicitly moving}}
   (global) = std::move(global);  // expected-warning{{explicitly moving}}
 
+  global = static_cast<int&&>(global);  // expected-warning{{explicitly moving}}
+  (global) = static_cast<int&&>(global);  // expected-warning{{explicitly moving}}
+
   using std::move;
   global = move(global); // expected-warning{{explicitly moving}} \
                              expected-warning {{unqualified call to 'std::move}}
@@ -35,11 +41,14 @@ class field_test {
   int x;
   field_test(field_test&& other) {
     x = std::move(x);  // expected-warning{{explicitly moving}}
+    x = static_cast<int&&>(x);  // expected-warning{{explicitly moving}}
     x = std::move(other.x);
     other.x = std::move(x);
     other.x = std::move(other.x);  // expected-warning{{explicitly moving}}
+    other.x = static_cast<int&&>(other.x);  // expected-warning{{explicitly moving}}
   }
   void withSuggest(int x) {
+    x = static_cast<int&&>(x); // expected-warning{{explicitly moving variable of type 'int' to itself; did you mean to move to member 'x'?}}
     x = std::move(x); // expected-warning{{explicitly moving variable of type 'int' to itself; did you mean to move to member 'x'?}}
   }
 };
@@ -50,11 +59,15 @@ struct C { C() {}; ~C() {} };
 void struct_test() {
   A a;
   a = std::move(a);  // expected-warning{{explicitly moving}}
+  a = static_cast<A&&>(a);  // expected-warning{{explicitly moving}}
 
   B b;
   b = std::move(b);  // expected-warning{{explicitly moving}}
+  b = static_cast<B&&>(b);  // expected-warning{{explicitly moving}}
   b.a = std::move(b.a);  // expected-warning{{explicitly moving}}
+  b.a = static_cast<A&&>(b.a);  // expected-warning{{explicitly moving}}
 
   C c;
   c = std::move(c);  // expected-warning{{explicitly moving}}
+  c = static_cast<C&&>(c);  // expected-warning{{explicitly moving}}
 }

--- a/clang/test/SemaCXX/warn-self-move.cpp
+++ b/clang/test/SemaCXX/warn-self-move.cpp
@@ -43,7 +43,9 @@ class field_test {
     x = std::move(x);  // expected-warning{{explicitly moving}}
     x = static_cast<int&&>(x);  // expected-warning{{explicitly moving}}
     x = std::move(other.x);
+    x = static_cast<int&&>(other.x);
     other.x = std::move(x);
+    other.x = static_cast<int&&>(x);
     other.x = std::move(other.x);  // expected-warning{{explicitly moving}}
     other.x = static_cast<int&&>(other.x);  // expected-warning{{explicitly moving}}
   }


### PR DESCRIPTION
There are code bases that inline `std::move` manually via `static_cast`.
Treat a static cast to an xvalue as an inlined `std::move` call and warn on a self move.