### PR TITLE
[llvm-exegesis] Add matcher for register initial values

### DIFF
--- a/llvm/unittests/tools/llvm-exegesis/X86/BenchmarkResultTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/BenchmarkResultTest.cpp
@@ -46,6 +46,15 @@ MATCHER(EqMCInst, "") {
   return true;
 }
 
+MATCHER(EqRegValue, "") {
+  const RegisterValue Lhs = get<0>(arg);
+  const RegisterValue Rhs = get<1>(arg);
+  if (Lhs.Register != Rhs.Register || Lhs.Value != Rhs.Value)
+    return false;
+
+  return true;
+}
+
 namespace {
 
 TEST(BenchmarkResultTest, WriteToAndReadFromDisk) {
@@ -120,6 +129,8 @@ TEST(BenchmarkResultTest, WriteToAndReadFromDisk) {
     EXPECT_THAT(FromDisk.Key.Instructions,
                 Pointwise(EqMCInst(), ToDisk.Key.Instructions));
     EXPECT_EQ(FromDisk.Key.Config, ToDisk.Key.Config);
+    EXPECT_THAT(FromDisk.Key.RegisterInitialValues,
+                Pointwise(EqRegValue(), ToDisk.Key.RegisterInitialValues));
     EXPECT_EQ(FromDisk.Mode, ToDisk.Mode);
     EXPECT_EQ(FromDisk.CpuName, ToDisk.CpuName);
     EXPECT_EQ(FromDisk.LLVMTriple, ToDisk.LLVMTriple);
@@ -137,6 +148,8 @@ TEST(BenchmarkResultTest, WriteToAndReadFromDisk) {
     EXPECT_THAT(FromDisk.Key.Instructions,
                 Pointwise(EqMCInst(), ToDisk.Key.Instructions));
     EXPECT_EQ(FromDisk.Key.Config, ToDisk.Key.Config);
+    EXPECT_THAT(FromDisk.Key.RegisterInitialValues,
+                Pointwise(EqRegValue(), ToDisk.Key.RegisterInitialValues));
     EXPECT_EQ(FromDisk.Mode, ToDisk.Mode);
     EXPECT_EQ(FromDisk.CpuName, ToDisk.CpuName);
     EXPECT_EQ(FromDisk.LLVMTriple, ToDisk.LLVMTriple);


### PR DESCRIPTION
Currently, the unit tests for the BenchmarkResult struct do not check if the register initial values can be parsed back in. This patch adds a matcher and tests that the register initial values can be parsed correctly. This exercises code already contained within the benchmark to yaml infrastructure.