### PR TITLE
[clangd] Fix is spelled in source bug

### DIFF
--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -232,7 +232,12 @@ bool isSpelledInSource(SourceLocation Loc, const SourceManager &SM) {
   if (Loc.isFileID())
     return true;
   auto Spelling = SM.getDecomposedSpellingLoc(Loc);
-  StringRef SpellingFile = SM.getSLocEntry(Spelling.first).getFile().getName();
+  bool InvalidSLocEntry = false;
+  const auto SLocEntry = SM.getSLocEntry(Spelling.first, &InvalidSLocEntry);
+  if (InvalidSLocEntry) {
+    return false;
+  }
+  const StringRef SpellingFile = SLocEntry.getFile().getName();
   if (SpellingFile == "<scratch space>")
     return false;
   if (SpellingFile == "<built-in>")

--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -236,7 +236,7 @@ bool isSpelledInSource(SourceLocation Loc, const SourceManager &SM) {
   const auto SLocEntry = SM.getSLocEntry(Spelling.first, &InvalidSLocEntry);
   if (InvalidSLocEntry)
     return false;
-  const StringRef SpellingFile = SLocEntry.getFile().getName();
+  StringRef SpellingFile = SLocEntry.getFile().getName();
   if (SpellingFile == "<scratch space>")
     return false;
   if (SpellingFile == "<built-in>")

--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -234,9 +234,8 @@ bool isSpelledInSource(SourceLocation Loc, const SourceManager &SM) {
   auto Spelling = SM.getDecomposedSpellingLoc(Loc);
   bool InvalidSLocEntry = false;
   const auto SLocEntry = SM.getSLocEntry(Spelling.first, &InvalidSLocEntry);
-  if (InvalidSLocEntry) {
+  if (InvalidSLocEntry)
     return false;
-  }
   const StringRef SpellingFile = SLocEntry.getFile().getName();
   if (SpellingFile == "<scratch space>")
     return false;

--- a/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
@@ -813,6 +813,21 @@ TEST(SourceCodeTests, isKeywords) {
   EXPECT_FALSE(isKeyword("override", LangOpts));
 }
 
+TEST(SourceCodeTests, isSpelledInSource) {
+  Annotations Test(R"cpp(
+        int abc = 1;
+    )cpp");
+
+  ParsedAST AST = TestTU::withCode(Test.code()).build();
+  llvm::errs() << Test.code();
+  const SourceManager &SM = AST.getSourceManager();
+
+  EXPECT_TRUE(
+      isSpelledInSource(SM.getLocForStartOfFile(SM.getMainFileID()), SM));
+  EXPECT_TRUE(isSpelledInSource(SourceLocation(), SM));
+  EXPECT_FALSE(isSpelledInSource(SourceLocation::getFromRawEncoding(-1), SM));
+}
+
 struct IncrementalTestStep {
   llvm::StringRef Src;
   llvm::StringRef Contents;

--- a/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
@@ -814,18 +814,15 @@ TEST(SourceCodeTests, isKeywords) {
 }
 
 TEST(SourceCodeTests, isSpelledInSource) {
-  Annotations Test(R"cpp(
-        int abc = 1;
-    )cpp");
-
+  Annotations Test("");
   ParsedAST AST = TestTU::withCode(Test.code()).build();
-  llvm::errs() << Test.code();
   const SourceManager &SM = AST.getSourceManager();
 
   EXPECT_TRUE(
       isSpelledInSource(SM.getLocForStartOfFile(SM.getMainFileID()), SM));
   EXPECT_TRUE(isSpelledInSource(SourceLocation(), SM));
-  EXPECT_FALSE(isSpelledInSource(SourceLocation::getFromRawEncoding(-1), SM));
+  EXPECT_FALSE(isSpelledInSource(
+      SourceLocation::getFromRawEncoding(SourceLocation::UIntTy(1 << 31)), SM));
 }
 
 struct IncrementalTestStep {

--- a/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
@@ -820,6 +820,13 @@ TEST(SourceCodeTests, isSpelledInSource) {
 
   EXPECT_TRUE(
       isSpelledInSource(SM.getLocForStartOfFile(SM.getMainFileID()), SM));
+
+  // Check that isSpelledInSource() handles various invalid source locations
+  // gracefully.
+  //
+  // Returning true for SourceLocation() is a behavior that falls out of the
+  // current implementation, which has an early exit for isFileID().
+  // FIXME: Should it return false on SourceLocation()? Does it matter?
   EXPECT_TRUE(isSpelledInSource(SourceLocation(), SM));
   EXPECT_FALSE(isSpelledInSource(
       SourceLocation::getFromRawEncoding(SourceLocation::UIntTy(1 << 31)), SM));


### PR DESCRIPTION
This fixes the issue reported in #76667 and adds an initial unit test for isSpelledInSource().

Note that in that issue there was still some underlying corrupted AST, but this at least makes isSpelledInSource() robust to it.