### PR TITLE
[Support] Fix buffer overflow in regcomp

### DIFF
--- a/llvm/lib/Support/regcomp.c
+++ b/llvm/lib/Support/regcomp.c
@@ -1601,6 +1601,7 @@ findmust(struct parse *p, struct re_guts *g)
 	sop s;
 	char *cp;
 	sopno i;
+	unsigned int skipsize;
 
 	/* avoid making error situations worse */
 	if (p->error != 0)
@@ -1625,7 +1626,16 @@ findmust(struct parse *p, struct re_guts *g)
 		case OCH_:
 			scan--;
 			do {
-				scan += OPND(s);
+				/* Ensure end is not skipped */
+				skipsize = OPND(s);
+				while (skipsize > 0) {
+					if (OP(*scan) == OEND) {
+						g->iflags |= REGEX_BAD;
+						return;
+					}
+					scan++;
+					skipsize--;
+				}
 				s = *scan;
 				/* assert() interferes w debug printouts */
 				if (OP(s) != O_QUEST && OP(s) != O_CH &&

--- a/llvm/unittests/Support/SpecialCaseListTest.cpp
+++ b/llvm/unittests/Support/SpecialCaseListTest.cpp
@@ -306,4 +306,19 @@ TEST_F(SpecialCaseListTest, Version2) {
   EXPECT_TRUE(SCL->inSection("sect2", "fun", "bar"));
   EXPECT_FALSE(SCL->inSection("sect3", "fun", "bar"));
 }
+
+TEST_F(SpecialCaseListTest, OSSFuzz65423) {
+  // Regression test for:
+  // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65423
+  const uint8_t Data[38] = {0x23, 0x21, 0x73, 0x70, 0x65, 0x63, 0x69, 0x61,
+                            0x6c, 0x2d, 0x63, 0x61, 0x73, 0x65, 0x2d, 0x6c,
+                            0x69, 0x73, 0x74, 0x2d, 0x76, 0x31, 0x0a, 0x3a,
+                            0x29, 0x7b, 0x30, 0x7d, 0x28, 0x20, 0x20, 0x20,
+                            0x7c, 0x20, 0x29, 0x28, 0x5c, 0x31};
+  std::string Payload(reinterpret_cast<const char *>(Data), 38);
+  std::unique_ptr<llvm::MemoryBuffer> Buf =
+      llvm::MemoryBuffer::getMemBuffer(Payload);
+  std::string Error;
+  SpecialCaseList::create(Buf.get(), Error);
+}
 }


### PR DESCRIPTION
`OQUEST_` and `OCH_` causes the scan pointer to skip elements in `g`'s `strip` buffer. However, the terminating character of `g->strip` may be within the skipped elements, and there is currently no checking of that. This adds a check on the skipped elements to ensure no overflow happens.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65423