### PR TITLE
[FuncAttrs] Don't infer `noundef` for functions with `sanitize_memory` attribute

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1296,6 +1296,12 @@ static void addNoUndefAttrs(const SCCNodeSet &SCCNodes,
     if (!F->hasExactDefinition())
       return;
 
+    // MemorySanitizer assumes that the definition and declaration of a
+    // function will be consistent. A function with sanitize_memory attribute
+    // should be skipped from inference.
+    if (F->hasFnAttribute(Attribute::SanitizeMemory))
+      continue;
+
     if (F->getReturnType()->isVoidTy())
       continue;
 

--- a/llvm/test/Transforms/FunctionAttrs/noundef.ll
+++ b/llvm/test/Transforms/FunctionAttrs/noundef.ll
@@ -143,3 +143,12 @@ define i32 @test_noundef_prop() {
   %ret = call i32 @test_ret_constant()
   ret i32 %ret
 }
+
+; FIXME: Don't deduce noundef for functions with sanitize_memory.
+define i32 @test_ret_constant_msan() sanitize_memory {
+; CHECK-LABEL: define noundef i32 @test_ret_constant_msan(
+; CHECK-SAME: ) #[[ATTR1:[0-9]+]] {
+; CHECK-NEXT:    ret i32 0
+;
+  ret i32 0
+}

--- a/llvm/test/Transforms/FunctionAttrs/noundef.ll
+++ b/llvm/test/Transforms/FunctionAttrs/noundef.ll
@@ -144,9 +144,9 @@ define i32 @test_noundef_prop() {
   ret i32 %ret
 }
 
-; FIXME: Don't deduce noundef for functions with sanitize_memory.
+; Don't deduce noundef for functions with sanitize_memory.
 define i32 @test_ret_constant_msan() sanitize_memory {
-; CHECK-LABEL: define noundef i32 @test_ret_constant_msan(
+; CHECK-LABEL: define i32 @test_ret_constant_msan(
 ; CHECK-SAME: ) #[[ATTR1:[0-9]+]] {
 ; CHECK-NEXT:    ret i32 0
 ;


### PR DESCRIPTION
MemorySanitizer assumes that the definition and declaration of a function will be consistent. If we add `noundef` for some definitions, it will break msan.

Fix buildbot failure caused by #76553.
