### PR TITLE
[GlobalIsel] zero out State.DL to fix use-after-free

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
@@ -26,6 +26,8 @@ void MachineIRBuilder::setMF(MachineFunction &MF) {
   State.MBB = nullptr;
   State.MRI = &MF.getRegInfo();
   State.TII = MF.getSubtarget().getInstrInfo();
+  // Ensure State.DL is zeroed to avoid potential UAF
+  memset(&(State.DL), 0, sizeof(DebugLoc));
   State.DL = DebugLoc();
   State.PCSections = nullptr;
   State.II = MachineBasicBlock::iterator();

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -74,6 +74,7 @@ LLVMContextImpl::~LLVMContextImpl() {
   for (auto *I : CLASS##s)                                                     \
     I->dropAllReferences();
 #include "llvm/IR/Metadata.def"
+  DistinctMDNodes.clear();
 
   // Also drop references that come from the Value bridges.
   for (auto &Pair : ValuesAsMetadata)


### PR DESCRIPTION
llvm-isel-fuzzer--aarch64-gisel is running into a UAF and this fixes it. I'm not familiar in detail with this part of the codebase, however, it seems that `State.DL` may carry data that causes a UAF.

The UAF details:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64761

The problem occurs over two iterations of the
[llvm-isel-fuzzer](https://github.com/llvm/llvm-project/blob/main/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp#L81) and it's due to the DILocation embedded in the `State.DL`. The problem is that the `DILocation` pointer is freed when the fuzzer destructs the `LLVMContext Context`, however, it seems some memory is reused in the next iteration of the fuzzer, which causes the UAF. Ensuring the memory is zerod and emptying the `DistinctMDNodes` fixes the UAF.