### PR TITLE
[RISCV][ISel] Combine vector fadd/fsub/fmul with fp extend.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13167,17 +13167,11 @@ struct NodeExtensionHelper {
       break;
     }
     case RISCVISD::VZEXT_VL:
-      SupportsZExt = true;
-      Mask = OrigOperand.getOperand(1);
-      VL = OrigOperand.getOperand(2);
-      break;
     case RISCVISD::VSEXT_VL:
-      SupportsSExt = true;
-      Mask = OrigOperand.getOperand(1);
-      VL = OrigOperand.getOperand(2);
-      break;
     case RISCVISD::FP_EXTEND_VL:
-      SupportsFPExt = true;
+      SupportsZExt = Opc == RISCVISD::VZEXT_VL;
+      SupportsSExt = Opc == RISCVISD::VSEXT_VL;
+      SupportsFPExt = Opc == RISCVISD::FP_EXTEND_VL;
       Mask = OrigOperand.getOperand(1);
       VL = OrigOperand.getOperand(2);
       break;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -12985,7 +12985,7 @@ struct NodeExtensionHelper {
     // Determine the narrow size.
     unsigned NarrowSize = VT.getScalarSizeInBits() / 2;
     // Determine the minimum narrow size.
-    unsigned MinSize = VT.isInteger() ? 8 : 32;
+    unsigned MinSize = VT.isInteger() ? 8 : 16;
 
     assert(NarrowSize >= MinSize &&
            "Trying to extend something we can't represent");

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwadd.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwadd.ll
@@ -396,12 +396,10 @@ define <32 x double> @vfwadd_vf_v32f32(ptr %x, float %y) {
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v24, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; CHECK-NEXT:    vslidedown.vi v0, v24, 16
+; CHECK-NEXT:    vslidedown.vi v8, v24, 16
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vfmv.v.f v16, fa0
-; CHECK-NEXT:    vfwcvt.f.f.v v8, v16
-; CHECK-NEXT:    vfwadd.wv v16, v8, v0
-; CHECK-NEXT:    vfwadd.wv v8, v8, v24
+; CHECK-NEXT:    vfwadd.vf v16, v8, fa0
+; CHECK-NEXT:    vfwadd.vf v8, v24, fa0
 ; CHECK-NEXT:    ret
   %a = load <32 x float>, ptr %x
   %b = insertelement <32 x float> poison, float %y, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
@@ -394,18 +394,12 @@ define <32 x double> @vfwmul_vf_v32f32(ptr %x, float %y) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a1, 32
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vle32.v v16, (a0)
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vfwcvt.f.f.v v8, v16
+; CHECK-NEXT:    vle32.v v24, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; CHECK-NEXT:    vslidedown.vi v16, v16, 16
+; CHECK-NEXT:    vslidedown.vi v8, v24, 16
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vfwcvt.f.f.v v24, v16
-; CHECK-NEXT:    vfmv.v.f v16, fa0
-; CHECK-NEXT:    vfwcvt.f.f.v v0, v16
-; CHECK-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
-; CHECK-NEXT:    vfmul.vv v16, v24, v0
-; CHECK-NEXT:    vfmul.vv v8, v8, v0
+; CHECK-NEXT:    vfwmul.vf v16, v8, fa0
+; CHECK-NEXT:    vfwmul.vf v8, v24, fa0
 ; CHECK-NEXT:    ret
   %a = load <32 x float>, ptr %x
   %b = insertelement <32 x float> poison, float %y, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwsub.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwsub.ll
@@ -394,18 +394,12 @@ define <32 x double> @vfwsub_vf_v32f32(ptr %x, float %y) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a1, 32
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vle32.v v16, (a0)
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vfwcvt.f.f.v v8, v16
+; CHECK-NEXT:    vle32.v v24, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; CHECK-NEXT:    vslidedown.vi v16, v16, 16
+; CHECK-NEXT:    vslidedown.vi v8, v24, 16
 ; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vfwcvt.f.f.v v24, v16
-; CHECK-NEXT:    vfmv.v.f v16, fa0
-; CHECK-NEXT:    vfwcvt.f.f.v v0, v16
-; CHECK-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
-; CHECK-NEXT:    vfsub.vv v16, v24, v0
-; CHECK-NEXT:    vfsub.vv v8, v8, v0
+; CHECK-NEXT:    vfwsub.vf v16, v8, fa0
+; CHECK-NEXT:    vfwsub.vf v8, v24, fa0
 ; CHECK-NEXT:    ret
   %a = load <32 x float>, ptr %x
   %b = insertelement <32 x float> poison, float %y, i32 0


### PR DESCRIPTION
This patch is an extension of #72340 and [D133739](https://reviews.llvm.org/D133739), supporting floating-point extension.

Specifically, this patch works for the below optimization case:  
[Compiler Explorer](https://godbolt.org/z/aaEMs5s9h)

### Source code 
```
define void @vfwadd(ptr %dst1, ptr %dst2,  ptr %dst3, ptr %x, ptr %y, ptr %z) {
  %a = load <2 x float>, ptr %x, align 4
  %b = load <2 x float>, ptr %y, align 4
  %c = load <2 x float>, ptr %z, align 4
  %a2 = fpext <2 x float> %a to <2 x double>
  %b2 = fpext <2 x float> %b to <2 x double>
  %c2 = fpext <2 x float> %c to <2 x double>
  %add1 = fadd <2 x double> %a2, %b2
  %add2 = fadd <2 x double> %c2, %b2
  %add3 = fadd <2 x double> %c2, %a2
  store <2 x double> %add1, ptr %dst1
  store <2 x double> %add2, ptr %dst2   
  store <2 x double> %add3, ptr %dst3
  ret void
}
```

### Before this patch
```
vfwadd:
        vsetivli        zero, 2, e32, mf2, ta, ma
        vle32.v v8, (a3)
        vle32.v v9, (a4)
        vle32.v v10, (a5)
        vfwcvt.f.f.v    v11, v8
        vfwcvt.f.f.v    v8, v9
        vfwcvt.f.f.v    v9, v10
        vsetvli zero, zero, e64, m1, ta, ma
        vfadd.vv        v10, v11, v8
        vfadd.vv        v8, v9, v8
        vfadd.vv        v9, v9, v11
        vse64.v v10, (a0)
        vse64.v v8, (a1)
        vse64.v v9, (a2)
        ret
```
### After this patch
```
vfwadd:
	vsetivli	zero, 2, e32, mf2, ta, ma
	vle32.v	v8, (a3)
	vle32.v	v9, (a4)
	vle32.v	v10, (a5)
	vfwadd.vv	v11, v8, v9
	vfwadd.vv	v12, v10, v9
	vfwadd.vv	v9, v10, v8
	vse64.v	v11, (a0)
	vse64.v	v12, (a1)
	vse64.v	v9, (a2)
	ret
```