### PR TITLE
[OpenMP][Offloading][AMDGPU] Exclude `nogpulib` in `lit.cfg`

### DIFF
--- a/openmp/libomptarget/test/lit.cfg
+++ b/openmp/libomptarget/test/lit.cfg
@@ -132,7 +132,7 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
-    if config.libomptarget_current_target != "nvptx64-nvidia-cuda":
+    if config.libomptarget_current_target != "nvptx64-nvidia-cuda" and config.libomptarget_current_target != "amdgcn-amd-amdhsa":
         config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory


### PR DESCRIPTION
In order to run offloading tests for AMDGPUs, we should not use the
`nogpulib` flag added by `lit.cfg`. This is already done for Nvidia GPUs
and seems to have been overlooked for AMD.

This is a follow-up to #76355, please review only the last commit.