### PR TITLE
[docs] Make rebase advice more explicit for cases where pre-commit CI is failing

### DIFF
--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -107,7 +107,7 @@ make the context of the old changes and comments harder to find and read.
 Sometimes, a rebase might be needed to update your branch with a fix for a test
 or in some dependent code. This is especially encouraged if it turns out that
 the upstream base commit used for your branch had test failures, meaning the
-pre-commit CI results are not useful.
+pre-commit CI results can't be shown as cleanly passing.
 
 After your PR is reviewed and accepted, you want to rebase your branch to ensure
 you won't encounter merge conflicts when landing the PR.

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -105,7 +105,9 @@ branch that's the root of the Pull Request during the review. This action will
 make the context of the old changes and comments harder to find and read.
 
 Sometimes, a rebase might be needed to update your branch with a fix for a test
-or in some dependent code.
+or in some dependent code. This is especially encouraged if it turns out that
+the upstream base commit used for your branch had test failures, meaning the
+pre-commit CI results are not useful.
 
 After your PR is reviewed and accepted, you want to rebase your branch to ensure
 you won't encounter merge conflicts when landing the PR.


### PR DESCRIPTION
You could argue that rebasing if pre-commit CI is failing due to issues unrelated to your patchset is already suggested, but I think it would be beneficial to make this advice more explicit. If pre-commit CI is failing because the base commit you used was bad, you're doing your reviewers a service by rebasing in order to fix that issue.