### PR TITLE
[NewPM] Add `disable-passes` command line option

### DIFF
--- a/llvm/test/tools/opt/disable-passes.ll
+++ b/llvm/test/tools/opt/disable-passes.ll
@@ -1,0 +1,8 @@
+; RUN: opt --disable-output --debug-pass-manager \
+; RUN:   --passes='default<O2>' --disable-passes=early-cse,inline < %s 2>&1 | FileCheck %s
+define void @test() {
+  ret void
+}
+
+; CHECK: Skipping pass: InlinerPass on (test)
+; CHECK: Skipping pass: EarlyCSEPass on test


### PR DESCRIPTION
Noticed there are some command line options to disable passes in `TargetPassConfig.cpp`, this patch adds a unified option to disable them. This option may be rarely used in tools like `opt`, but `llc` could benefit from it.