### PR TITLE
[Clang] Use const pointer to eliminate warning with libxml 2.12.0

### DIFF
--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -695,7 +695,7 @@ static void ValidateCommentXML(const char *Str, const char *CommentSchemaFile) {
   Doc = xmlParseDoc((const xmlChar *) Str);
 
   if (!Doc) {
-    xmlErrorPtr Error = xmlGetLastError();
+    const xmlError *Error = xmlGetLastError();
     printf(" CommentXMLInvalid [not well-formed XML: %s]", Error->message);
     return;
   }
@@ -705,7 +705,7 @@ static void ValidateCommentXML(const char *Str, const char *CommentSchemaFile) {
   if (!status)
     printf(" CommentXMLValid");
   else if (status > 0) {
-    xmlErrorPtr Error = xmlGetLastError();
+    const xmlError *Error = xmlGetLastError();
     printf(" CommentXMLInvalid [not valid XML: %s]", Error->message);
   } else
     printf(" libXMLError");


### PR DESCRIPTION
Currently, if `CLANG_HAVE_LIBXML` is defined, and the version of libxml2 is above 2.12.0, there will be two warnings when building clang.

warning: initializing 'xmlErrorPtr' (aka 'struct _xmlError *') with an expression of type 'const xmlError *' (aka 'const struct _xmlError *') discards qualifiers

Since this commit
https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7, libxml2 makes cmlGetLastError return a const error. This patch follows libxml2. Making the result a const pointer should be compatible with versions before 2.12.0.

Tested on ArchLinux with libxml2 2.12.3 installed.