### PR TITLE
[coroutines] Do not check coroutine wrappers for skipped function bodies

### DIFF
--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -465,13 +465,15 @@ template <typename T> struct [[clang::coro_return_type]] Gen {
 Gen<int> foo_coro(int b) { co_return b; }
   )cpp";
   Annotations Main(R"cpp(
-    #include "header.hpp"
+// error-ok
+#include "header.hpp"
+Gen<int> $[[bar_coro]](int b) { return foo_coro(b); }
   )cpp");
   TestTU TU = TestTU::withCode(Main.code());
   TU.AdditionalFiles["coroutine.h"] = std::string(CoroutineH);
   TU.AdditionalFiles["header.hpp"] = std::string(Header);
   TU.ExtraArgs.push_back("--std=c++20");
-  EXPECT_THAT(TU.build().getDiagnostics(), IsEmpty());
+  EXPECT_THAT(TU.build().getDiagnostics(), ElementsAre(hasRange(Main.range())));
 }
 
 TEST(DiagnosticTest, MakeShared) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15845,7 +15845,7 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
 }
 
 void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
-  if (!FD)
+  if (!FD || FD->hasSkippedBody())
     return;
   RecordDecl *RD = FD->getReturnType()->getAsRecordDecl();
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15845,8 +15845,6 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
 }
 
 void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
-  if (!FD || FD->hasSkippedBody())
-    return;
   RecordDecl *RD = FD->getReturnType()->getAsRecordDecl();
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
     return;
@@ -15869,7 +15867,8 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   sema::AnalysisBasedWarnings::Policy WP = AnalysisWarnings.getDefaultPolicy();
   sema::AnalysisBasedWarnings::Policy *ActivePolicy = nullptr;
 
-  if (getLangOpts().Coroutines) {
+  // If we skip function body, we can't tell if a function is a coroutine.
+  if (getLangOpts().Coroutines && FD && !FD->hasSkippedBody()) {
     if (FSI->isCoroutine())
       CheckCompletedCoroutineBody(FD, Body);
     else


### PR DESCRIPTION
Without function bodies, we cannot tell whether a function is a coroutine or not.
The analysis of coroutine wrappers is not useful when this information is not available.

We therefore now skip this analysis for skipped function bodies.