### PR TITLE
[flang] Allow use of COMMON in PURE

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -317,15 +317,13 @@ void CheckHelper::Check(const Symbol &symbol) {
       // are not pertinent to the characteristics of the procedure.
       // Restrictions on entities in pure procedure interfaces don't need
       // enforcement.
-    } else {
-      if (IsSaved(symbol)) {
-        if (IsInitialized(symbol)) {
-          messages_.Say(
-              "A pure subprogram may not initialize a variable"_err_en_US);
-        } else {
-          messages_.Say(
-              "A pure subprogram may not have a variable with the SAVE attribute"_err_en_US);
-        }
+    } else if (!FindCommonBlockContaining(symbol) && IsSaved(symbol)) {
+      if (IsInitialized(symbol)) {
+        messages_.Say(
+            "A pure subprogram may not initialize a variable"_err_en_US);
+      } else {
+        messages_.Say(
+            "A pure subprogram may not have a variable with the SAVE attribute"_err_en_US);
       }
     }
     if (symbol.attrs().test(Attr::VOLATILE) &&

--- a/flang/test/Semantics/call10.f90
+++ b/flang/test/Semantics/call10.f90
@@ -109,10 +109,8 @@ module m
     !ERROR: A pure subprogram may not initialize a variable
     real :: v3
     data v3/0./
-    !ERROR: A pure subprogram may not have a variable with the SAVE attribute
     real :: v4
     common /blk/ v4
-    save /blk/
     block
     !ERROR: A pure subprogram may not have a variable with the SAVE attribute
       real, save :: v5


### PR DESCRIPTION
Although COMMON variables implicitly have the SAVE attribute, and variables with the SAVE attribute are generally disallowed in PURE subprograms, we must allow the use of COMMON in PURE as an exception.  F'2023 constraint C1598 applies only to local variables.