### PR TITLE
[lldb] Fix breakpoint resolver serialization bug

### DIFF
--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -65,13 +65,11 @@ BreakpointResolverAddress::SerializeToStructuredData() {
       new StructuredData::Dictionary());
   SectionSP section_sp = m_addr.GetSection();
   if (section_sp) {
-    ModuleSP module_sp = section_sp->GetModule();
-    ConstString module_name;
-    if (module_sp)
-      module_name.SetCString(module_name.GetCString());
-
-    options_dict_sp->AddStringItem(GetKey(OptionNames::ModuleName),
-                                   module_name.GetCString());
+    if (ModuleSP module_sp = section_sp->GetModule()) {
+      const FileSpec &module_fspec = module_sp->GetFileSpec();
+      options_dict_sp->AddStringItem(GetKey(OptionNames::ModuleName),
+                                     module_fspec.GetPath().c_str());
+    }
     options_dict_sp->AddIntegerItem(GetKey(OptionNames::AddressOffset),
                                     m_addr.GetOffset());
   } else {

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -54,21 +54,24 @@ class BreakpointSerialization(TestBase):
         self.build()
         self.setup_targets_and_cleanup()
 
-        sym_ctx_list = self.orig_target.FindFunctions("main")
-        self.assertTrue(sym_ctx_list.GetSize() == 1, "Unable to find function `main'")
+        exe_path = self.getBuildArtifact("a.out")
+        exe_module = self.orig_target.module[exe_path]
+        self.assertTrue(exe_module.IsValid(), "Failed to find the executable module in target")
+        sym_ctx_list = exe_module.FindFunctions("main")
+        self.assertTrue(sym_ctx_list.GetSize() == 1, "Unable to find function 'main'")
         sym_ctx = sym_ctx_list.GetContextAtIndex(0)
         self.assertTrue(
-            sym_ctx.IsValid(), "SBSymbolContext representing function `main' is invalid"
+            sym_ctx.IsValid(), "SBSymbolContext representing function 'main' is invalid"
         )
         main_func = sym_ctx.GetFunction()
         self.assertTrue(
-            main_func.IsValid(), "SBFunction representing `main' is invalid"
+            main_func.IsValid(), "SBFunction representing 'main' is invalid"
         )
         main_addr = main_func.GetStartAddress()
 
         bkpt = self.orig_target.BreakpointCreateBySBAddress(main_addr)
         self.assertTrue(
-            bkpt.IsValid(), "Could not place breakpoint on `main' by address"
+            bkpt.IsValid(), "Could not place breakpoint on 'main' by address"
         )
         stream = lldb.SBStream()
         sd = bkpt.SerializeToStructuredData()
@@ -76,7 +79,7 @@ class BreakpointSerialization(TestBase):
         serialized_data = json.loads(stream.GetData())
 
         self.assertIn(
-            "a.out",
+            exe_path,
             serialized_data["Breakpoint"]["BKPTResolver"]["Options"]["ModuleName"],
         )
 

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -56,7 +56,9 @@ class BreakpointSerialization(TestBase):
 
         exe_path = self.getBuildArtifact("a.out")
         exe_module = self.orig_target.module[exe_path]
-        self.assertTrue(exe_module.IsValid(), "Failed to find the executable module in target")
+        self.assertTrue(
+            exe_module.IsValid(), "Failed to find the executable module in target"
+        )
         sym_ctx_list = exe_module.FindFunctions("main")
         self.assertTrue(sym_ctx_list.GetSize() == 1, "Unable to find function 'main'")
         sym_ctx = sym_ctx_list.GetContextAtIndex(0)

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -49,6 +49,37 @@ class BreakpointSerialization(TestBase):
         self.setup_targets_and_cleanup()
         self.do_check_extra_args()
 
+    def test_resolver_serialization(self):
+        """Test that breakpoint resolvers contain the expected information"""
+        self.build()
+        self.setup_targets_and_cleanup()
+
+        sym_ctx_list = self.orig_target.FindFunctions("main")
+        self.assertTrue(sym_ctx_list.GetSize() == 1, "Unable to find function `main'")
+        sym_ctx = sym_ctx_list.GetContextAtIndex(0)
+        self.assertTrue(
+            sym_ctx.IsValid(), "SBSymbolContext representing function `main' is invalid"
+        )
+        main_func = sym_ctx.GetFunction()
+        self.assertTrue(
+            main_func.IsValid(), "SBFunction representing `main' is invalid"
+        )
+        main_addr = main_func.GetStartAddress()
+
+        bkpt = self.orig_target.BreakpointCreateBySBAddress(main_addr)
+        self.assertTrue(
+            bkpt.IsValid(), "Could not place breakpoint on `main' by address"
+        )
+        stream = lldb.SBStream()
+        sd = bkpt.SerializeToStructuredData()
+        sd.GetAsJSON(stream)
+        serialized_data = json.loads(stream.GetData())
+
+        self.assertIn(
+            "a.out",
+            serialized_data["Breakpoint"]["BKPTResolver"]["Options"]["ModuleName"],
+        )
+
     def test_structured_data_serialization(self):
         target = self.dbg.GetDummyTarget()
         self.assertTrue(target.IsValid(), VALID_TARGET)


### PR DESCRIPTION
BreakpointResolverAddress optionally can include the module name related to the address that gets resolved. Currently this will never work because it sets the name to itself (which is empty).