### PR TITLE
Fixed shared_ptr comparisons with nullptr_t when spaceship is unavailable.

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -1166,12 +1166,12 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(nullptr_t, const shared_ptr<_Tp>& _
 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI bool operator<(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT {
-  return less<_Tp*>()(__x.get(), nullptr);
+  return less<typename shared_ptr<_Tp>::element_type*>()(__x.get(), nullptr);
 }
 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI bool operator<(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT {
-  return less<_Tp*>()(nullptr, __x.get());
+  return less<typename shared_ptr<_Tp>::element_type*>()(nullptr, __x.get());
 }
 
 template <class _Tp>

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
@@ -87,5 +87,36 @@ int main(int, char**)
   assert((nullptr <=> p2) == std::strong_ordering::equivalent);
 #endif
 
+  const std::shared_ptr<int[]> p3(new int[1]);
+  assert(!(p3 == nullptr));
+  assert(!(nullptr == p3));
+  assert(!(p3 < nullptr));
+  assert((nullptr < p3));
+  assert(!(p3 <= nullptr));
+  assert((nullptr <= p3));
+  assert((p3 > nullptr));
+  assert(!(nullptr > p3));
+  assert((p3 >= nullptr));
+  assert(!(nullptr >= p3));
+#if TEST_STD_VER > 17
+  assert((nullptr <=> p3) == std::strong_ordering::less);
+  assert((p3 <=> nullptr) == std::strong_ordering::greater);
+#endif
+
+  const std::shared_ptr<int[]> p4;
+  assert((p4 == nullptr));
+  assert((nullptr == p4));
+  assert(!(p4 < nullptr));
+  assert(!(nullptr < p4));
+  assert((p4 <= nullptr));
+  assert((nullptr <= p4));
+  assert(!(p4 > nullptr));
+  assert(!(nullptr > p4));
+  assert((p4 >= nullptr));
+  assert((nullptr >= p4));
+#if TEST_STD_VER > 17
+  assert((nullptr <=> p4) == std::strong_ordering::equivalent);
+#endif
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
@@ -87,6 +87,7 @@ int main(int, char**)
   assert((nullptr <=> p2) == std::strong_ordering::equivalent);
 #endif
 
+#if TEST_STD_VER > 14
   const std::shared_ptr<int[]> p3(new int[1]);
   assert(!(p3 == nullptr));
   assert(!(nullptr == p3));
@@ -98,10 +99,10 @@ int main(int, char**)
   assert(!(nullptr > p3));
   assert((p3 >= nullptr));
   assert(!(nullptr >= p3));
-#if TEST_STD_VER > 17
+#  if TEST_STD_VER > 17
   assert((nullptr <=> p3) == std::strong_ordering::less);
   assert((p3 <=> nullptr) == std::strong_ordering::greater);
-#endif
+#  endif
 
   const std::shared_ptr<int[]> p4;
   assert((p4 == nullptr));
@@ -114,8 +115,9 @@ int main(int, char**)
   assert(!(nullptr > p4));
   assert((p4 >= nullptr));
   assert((nullptr >= p4));
-#if TEST_STD_VER > 17
+#  if TEST_STD_VER > 17
   assert((nullptr <=> p4) == std::strong_ordering::equivalent);
+#  endif
 #endif
 
   return 0;

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
@@ -51,7 +51,7 @@ int main(int, char**)
   AssertComparisonsAreNoexcept<nullptr_t, std::shared_ptr<int> >();
   AssertComparisonsReturnBool<std::shared_ptr<int>, nullptr_t>();
   AssertComparisonsReturnBool<nullptr_t, std::shared_ptr<int> >();
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
   AssertOrderAreNoexcept<std::shared_ptr<int>>();
   AssertOrderReturn<std::strong_ordering, std::shared_ptr<int>>();
 #endif
@@ -67,7 +67,7 @@ int main(int, char**)
   assert(!(nullptr > p1));
   assert((p1 >= nullptr));
   assert(!(nullptr >= p1));
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
   assert((nullptr <=> p1) == std::strong_ordering::less);
   assert((p1 <=> nullptr) == std::strong_ordering::greater);
 #endif
@@ -83,11 +83,12 @@ int main(int, char**)
   assert(!(nullptr > p2));
   assert((p2 >= nullptr));
   assert((nullptr >= p2));
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
+  assert((p2 <=> nullptr) == std::strong_ordering::equivalent);
   assert((nullptr <=> p2) == std::strong_ordering::equivalent);
 #endif
 
-#if TEST_STD_VER > 14
+#if TEST_STD_VER >= 17
   const std::shared_ptr<int[]> p3(new int[1]);
   assert(!(p3 == nullptr));
   assert(!(nullptr == p3));
@@ -99,9 +100,9 @@ int main(int, char**)
   assert(!(nullptr > p3));
   assert((p3 >= nullptr));
   assert(!(nullptr >= p3));
-#  if TEST_STD_VER > 17
-  assert((nullptr <=> p3) == std::strong_ordering::less);
+#  if TEST_STD_VER >= 20
   assert((p3 <=> nullptr) == std::strong_ordering::greater);
+  assert((nullptr <=> p3) == std::strong_ordering::less);
 #  endif
 
   const std::shared_ptr<int[]> p4;
@@ -115,7 +116,8 @@ int main(int, char**)
   assert(!(nullptr > p4));
   assert((p4 >= nullptr));
   assert((nullptr >= p4));
-#  if TEST_STD_VER > 17
+#  if TEST_STD_VER >= 20
+  assert((p4 <=> nullptr) == std::strong_ordering::equivalent);
   assert((nullptr <=> p4) == std::strong_ordering::equivalent);
 #  endif
 #endif

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
@@ -92,6 +92,40 @@ TEST_CONSTEXPR_CXX23 bool test() {
   assert((nullptr <=> p2) == std::strong_ordering::equivalent);
 #endif
 
+  const std::unique_ptr<int[]> p3(new int[1]);
+  assert(!(p3 == nullptr));
+  assert(!(nullptr == p3));
+  // A pointer to allocated storage and a nullptr can't be compared at compile-time
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    assert(!(p3 < nullptr));
+    assert((nullptr < p3));
+    assert(!(p3 <= nullptr));
+    assert((nullptr <= p3));
+    assert((p3 > nullptr));
+    assert(!(nullptr > p3));
+    assert((p3 >= nullptr));
+    assert(!(nullptr >= p3));
+#if TEST_STD_VER > 17
+    assert((nullptr <=> p3) == std::strong_ordering::less);
+    assert((p3 <=> nullptr) == std::strong_ordering::greater);
+#endif
+  }
+
+  const std::unique_ptr<int[]> p4;
+  assert((p4 == nullptr));
+  assert((nullptr == p4));
+  assert(!(p4 < nullptr));
+  assert(!(nullptr < p4));
+  assert((p4 <= nullptr));
+  assert((nullptr <= p4));
+  assert(!(p4 > nullptr));
+  assert(!(nullptr > p4));
+  assert((p4 >= nullptr));
+  assert((nullptr >= p4));
+#if TEST_STD_VER > 17
+  assert((nullptr <=> p4) == std::strong_ordering::equivalent);
+#endif
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
@@ -52,7 +52,7 @@ TEST_CONSTEXPR_CXX23 bool test() {
     AssertEqualityAreNoexcept<nullptr_t, std::unique_ptr<int> >();
     AssertComparisonsReturnBool<std::unique_ptr<int>, nullptr_t>();
     AssertComparisonsReturnBool<nullptr_t, std::unique_ptr<int> >();
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
     AssertOrderReturn<std::strong_ordering, std::unique_ptr<int>, nullptr_t>();
     AssertOrderReturn<std::strong_ordering, nullptr_t, std::unique_ptr<int>>();
 #endif
@@ -71,9 +71,9 @@ TEST_CONSTEXPR_CXX23 bool test() {
     assert(!(nullptr > p1));
     assert((p1 >= nullptr));
     assert(!(nullptr >= p1));
-#if TEST_STD_VER > 17
-    assert((nullptr <=> p1) == std::strong_ordering::less);
+#if TEST_STD_VER >= 20
     assert((p1 <=> nullptr) == std::strong_ordering::greater);
+    assert((nullptr <=> p1) == std::strong_ordering::less);
 #endif
   }
 
@@ -88,7 +88,8 @@ TEST_CONSTEXPR_CXX23 bool test() {
   assert(!(nullptr > p2));
   assert((p2 >= nullptr));
   assert((nullptr >= p2));
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
+  assert((p2 <=> nullptr) == std::strong_ordering::equivalent);
   assert((nullptr <=> p2) == std::strong_ordering::equivalent);
 #endif
 
@@ -105,7 +106,7 @@ TEST_CONSTEXPR_CXX23 bool test() {
     assert(!(nullptr > p3));
     assert((p3 >= nullptr));
     assert(!(nullptr >= p3));
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
     assert((nullptr <=> p3) == std::strong_ordering::less);
     assert((p3 <=> nullptr) == std::strong_ordering::greater);
 #endif
@@ -122,7 +123,8 @@ TEST_CONSTEXPR_CXX23 bool test() {
   assert(!(nullptr > p4));
   assert((p4 >= nullptr));
   assert((nullptr >= p4));
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
+  assert((p4 <=> nullptr) == std::strong_ordering::equivalent);
   assert((nullptr <=> p4) == std::strong_ordering::equivalent);
 #endif
 


### PR DESCRIPTION
@ldionne

This was causing compilation errors when attempting to compare a `shared_ptr<T[]>` with `nullptr`, as `get()` returns `T*` rather than `T (*)[]`.  `unique_ptr` did not have this issue, but I've added tests to make sure.