### PR TITLE
[GitHub] Add basic CI for libclang Python binding unit tests

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -1,0 +1,40 @@
+name: Libclang Python Binding Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'clang/bindings/python/**'
+      - 'clang/tools/libclang/**'
+      - 'clang/CMakeList.txt'
+      - '.github/workflows/libclang-python-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+  pull_request:
+    paths:
+      - 'clang/bindings/python/**'
+      - 'clang/tools/libclang/**'
+      - 'clang/CMakeList.txt'
+      - '.github/workflows/libclang-python-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check-clang-python:
+    if: github.repository_owner == 'llvm'
+    # Build libclang and then run the libclang Python binding's unit tests.
+    name: Build and run Python unit tests
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-clang-python
+      projects: clang
+      # There is an issue running on "windows-2019".
+      # See https://github.com/llvm/llvm-project/issues/76601#issuecomment-1873049082.
+      os_list: '["ubuntu-latest"]'

--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -28,7 +28,6 @@ concurrency:
 
 jobs:
   check-clang-python:
-    if: github.repository_owner == 'llvm'
     # Build libclang and then run the libclang Python binding's unit tests.
     name: Build and run Python unit tests
     uses: ./.github/workflows/llvm-project-tests.yml


### PR DESCRIPTION
This is important to aid development of Python type annotations in the libclang binding.
See https://github.com/llvm/llvm-project/issues/76664 for more details.

* Run on all pull requests and direct pushes.
* This makes use of the existing llvm-project-tests.yml recipe, which will preload ccache from previous runs.
* Building libclang currently takes about 9mins when ccache is warm and about an 1hr 20mins if it is cold using the standard GitHub ubuntu runner.
* In the future, this could be broken into the following discrete steps for clarity:
   1. Build libclang dependency.
       ninja -C build libclang
   2. Run Python unit tests.
       ninja -C build check-clang-python
* Followup changes will bring testing on older python versions and static type checking.

Issue https://github.com/llvm/llvm-project/issues/76601.