### PR TITLE
[llvm-exegesis] Add additional validation counters

### DIFF
--- a/llvm/include/llvm/Target/TargetPfmCounters.td
+++ b/llvm/include/llvm/Target/TargetPfmCounters.td
@@ -36,6 +36,13 @@ class ValidationEvent <int event_number> {
 }
 
 def InstructionRetired  : ValidationEvent<0>;
+def L1DCacheLoadMiss : ValidationEvent<1>;
+def L1DCacheStoreMiss : ValidationEvent<2>;
+def L1ICacheLoadMiss : ValidationEvent<3>;
+def DataTLBLoadMiss : ValidationEvent<4>;
+def DataTLBStoreMiss : ValidationEvent<5>;
+def InstructionTLBLoadMiss : ValidationEvent<6>;
+
 
 // PfmValidationCounter provides a mapping between the events that are
 // are interesting in regards to the snippet execution environment and

--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -19,7 +19,12 @@ def : PfmCountersDefaultBinding<DefaultPfmCounters>;
 
 // Intel X86 Counters.
 defvar DefaultIntelPfmValidationCounters = [
-  PfmValidationCounter<InstructionRetired, "INSTRUCTIONS_RETIRED">
+  PfmValidationCounter<InstructionRetired, "INSTRUCTIONS_RETIRED">,
+  PfmValidationCounter<L1DCacheLoadMiss, "MEM_LOAD_UOPS_RETIRED:L1_MISS">,
+  PfmValidationCounter<L1ICacheLoadMiss, "L1-ICACHE-LOAD-MISSES">,
+  PfmValidationCounter<DataTLBLoadMiss, "DTLB_LOAD_MISSES:MISS_CAUSES_A_WALK">,
+  PfmValidationCounter<DataTLBStoreMiss, "DTLB_STORE_MISSES:MISS_CAUSES_A_WALK">,
+  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB_MISSES:MISS_CAUSES_A_WALK">
 ];
 
 def PentiumPfmCounters : ProcPfmCounters {
@@ -200,7 +205,12 @@ def : PfmCountersBinding<"tigerlake", IceLakePfmCounters>;
 
 // AMD X86 Counters.
 defvar DefaultAMDPfmValidationCounters = [
-  PfmValidationCounter<InstructionRetired, "RETIRED_INSTRUCTIONS">
+  PfmValidationCounter<InstructionRetired, "RETIRED_INSTRUCTIONS">,
+  PfmValidationCounter<L1DCacheLoadMiss, "L1-DCACHE-LOAD-MISSES">,
+  PfmValidationCounter<L1DCacheStoreMiss, "L1-DCACHE-STORE-MISSES">,
+  PfmValidationCounter<L1ICacheLoadMiss, "L1-ICACHE-LOAD-MISSES">,
+  PfmValidationCounter<DataTLBLoadMiss, "DTLB-LOAD-MISSES">,
+  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB-LOAD-MISSES">
 ];
 
 // Set basic counters for AMD cpus that we know libpfm4 supports.

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -197,6 +197,18 @@ const char *validationEventToString(exegesis::ValidationEvent VE) {
   switch (VE) {
   case exegesis::ValidationEvent::InstructionRetired:
     return "instructions-retired";
+  case exegesis::ValidationEvent::L1DCacheLoadMiss:
+    return "l1d-cache-load-misses";
+  case exegesis::ValidationEvent::L1DCacheStoreMiss:
+    return "l1d-cache-store-misses";
+  case exegesis::ValidationEvent::L1ICacheLoadMiss:
+    return "l1i-cache-load-misses";
+  case exegesis::ValidationEvent::DataTLBLoadMiss:
+    return "data-tlb-load-misses";
+  case exegesis::ValidationEvent::DataTLBStoreMiss:
+    return "data-tlb-store-misses";
+  case exegesis::ValidationEvent::InstructionTLBLoadMiss:
+    return "instruction-tlb-load-misses";
   }
   llvm_unreachable("Unhandled exegesis::ValidationEvent enum");
 }
@@ -204,6 +216,18 @@ const char *validationEventToString(exegesis::ValidationEvent VE) {
 Expected<exegesis::ValidationEvent> stringToValidationEvent(StringRef Input) {
   if (Input == "instructions-retired")
     return exegesis::ValidationEvent::InstructionRetired;
+  else if (Input == "l1d-cache-load-misses")
+    return exegesis::ValidationEvent::L1DCacheLoadMiss;
+  else if (Input == "l1d-cache-store-misses")
+    return exegesis::ValidationEvent::L1DCacheStoreMiss;
+  else if (Input == "l1i-cache-load-misses")
+    return exegesis::ValidationEvent::L1ICacheLoadMiss;
+  else if (Input == "data-tlb-load-misses")
+    return exegesis::ValidationEvent::DataTLBLoadMiss;
+  else if (Input == "data-tlb-store-misses")
+    return exegesis::ValidationEvent::DataTLBStoreMiss;
+  else if (Input == "instruction-tlb-load-misses")
+    return exegesis::ValidationEvent::InstructionTLBLoadMiss;
   else
     return make_error<StringError>("Invalid validation event string",
                                    errc::invalid_argument);

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
@@ -32,7 +32,15 @@ class Error;
 
 namespace exegesis {
 
-enum ValidationEvent { InstructionRetired };
+enum ValidationEvent {
+  InstructionRetired,
+  L1DCacheLoadMiss,
+  L1DCacheStoreMiss,
+  L1ICacheLoadMiss,
+  DataTLBLoadMiss,
+  DataTLBStoreMiss,
+  InstructionTLBLoadMiss
+};
 
 enum class BenchmarkPhaseSelectorE {
   PrepareSnippet,

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -274,9 +274,21 @@ static cl::list<ValidationEvent> ValidationCounters(
         "The name of a validation counter to run concurrently with the main "
         "counter to validate benchmarking assumptions"),
     cl::CommaSeparated, cl::cat(BenchmarkOptions),
-    cl::values(clEnumValN(ValidationEvent::InstructionRetired,
-                          "instructions-retired",
-                          "Count retired instructions")));
+    cl::values(
+        clEnumValN(ValidationEvent::InstructionRetired, "instructions-retired",
+                   "Count retired instructions"),
+        clEnumValN(ValidationEvent::L1DCacheLoadMiss, "l1d-cache-load-misses",
+                   "Count L1D load cache misses"),
+        clEnumValN(ValidationEvent::L1DCacheStoreMiss, "l1d-cache-store-misses",
+                   "Count L1D store cache misses"),
+        clEnumValN(ValidationEvent::L1ICacheLoadMiss, "l1i-cache-load-misses",
+                   "Count L1I load cache misses"),
+        clEnumValN(ValidationEvent::DataTLBLoadMiss, "data-tlb-load-misses",
+                   "Count DTLB load misses"),
+        clEnumValN(ValidationEvent::DataTLBStoreMiss, "data-tlb-store-misses",
+                   "Count DTLB store misses"),
+        clEnumValN(ValidationEvent::InstructionTLBLoadMiss,
+                   "instruction-tlb-load-misses", "Count ITLB load misses")));
 
 static ExitOnError ExitOnErr("llvm-exegesis error: ");
 


### PR DESCRIPTION
This patch adds support for additional types of validation counters and also adds mappings between these new validation counter types and physical counters on the hardware for microarchitectures that I have the ability to test on.