### PR TITLE
[libomptarget][flang] Explicitly pass the OpenMP device libraries to tests

### DIFF
--- a/openmp/libomptarget/test/lit.cfg
+++ b/openmp/libomptarget/test/lit.cfg
@@ -247,7 +247,7 @@ for libomptarget_target in config.libomptarget_all_targets:
             "%clang-" + libomptarget_target + add_libraries(" %s -o %t")))
         config.substitutions.append(("%libomptarget-compile-fortran-" + \
             libomptarget_target, \
-            "%flang-" + libomptarget_target + " %s -o %t"))
+            "%flang-" + libomptarget_target + add_libraries(" %s -o %t")))
         config.substitutions.append(("%libomptarget-compileoptxx-run-and-check-" + \
             libomptarget_target, \
             "%libomptarget-compileoptxx-and-run-" + libomptarget_target + \


### PR DESCRIPTION
This pull request is a follow-up of patch:
https://github.com/llvm/llvm-project/pull/68225 and it explicitly specifies OpenMP device libraries for Fortran OpenMP tests.