### PR TITLE
[Flang] Xfail hlfir test case on AIX

### DIFF
--- a/flang/test/HLFIR/simplify-hlfir-intrinsics.fir
+++ b/flang/test/HLFIR/simplify-hlfir-intrinsics.fir
@@ -1,3 +1,5 @@
+// XFail the following test case on AIX due to potential miscompilation
+// XFAIL: system-aix
 // RUN: fir-opt --simplify-hlfir-intrinsics %s | FileCheck %s
 
 // box with known extents

--- a/flang/test/HLFIR/simplify-hlfir-intrinsics.fir
+++ b/flang/test/HLFIR/simplify-hlfir-intrinsics.fir
@@ -1,4 +1,5 @@
 // XFail the following test case on AIX due to potential miscompilation
+// TODO: Crash fir-opt on AIX
 // XFAIL: system-aix
 // RUN: fir-opt --simplify-hlfir-intrinsics %s | FileCheck %s
 


### PR DESCRIPTION
This test case seems to fail at the `Merge disjoint stack slots` pass on AIX, it passes if compilled with `-mllvm --no-stack-coloring`. This PR xfails the teest case on AIX temporarily until the issue is addressed.