### PR TITLE
[clang][ExtractAPI] Record availability information only for the target platform

### DIFF
--- a/clang/include/clang/ExtractAPI/API.h
+++ b/clang/include/clang/ExtractAPI/API.h
@@ -260,10 +260,10 @@ public:
             LinkageInfo Linkage, const DocComment &Comment,
             DeclarationFragments Declaration, DeclarationFragments SubHeading,
             bool IsFromSystemHeader)
-      : USR(USR), Name(Name), Location(Location), Availability(std::move(Availability)),
-        Linkage(Linkage), Comment(Comment), Declaration(Declaration),
-        SubHeading(SubHeading), IsFromSystemHeader(IsFromSystemHeader),
-        Kind(Kind) {}
+      : USR(USR), Name(Name), Location(Location),
+        Availability(std::move(Availability)), Linkage(Linkage),
+        Comment(Comment), Declaration(Declaration), SubHeading(SubHeading),
+        IsFromSystemHeader(IsFromSystemHeader), Kind(Kind) {}
 
   APIRecord(RecordKind Kind, StringRef USR, StringRef Name)
       : USR(USR), Name(Name), Kind(Kind) {}
@@ -277,8 +277,9 @@ struct NamespaceRecord : APIRecord {
                   AvailabilityInfo Availability, LinkageInfo Linkage,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_Namespace, USR, Name, Loc, std::move(Availability), Linkage, Comment,
-                  Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(RK_Namespace, USR, Name, Loc, std::move(Availability),
+                  Linkage, Comment, Declaration, SubHeading,
+                  IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_Namespace;
@@ -290,13 +291,14 @@ struct GlobalFunctionRecord : APIRecord {
   FunctionSignature Signature;
 
   GlobalFunctionRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       AvailabilityInfo Availability,
-                       LinkageInfo Linkage, const DocComment &Comment,
+                       AvailabilityInfo Availability, LinkageInfo Linkage,
+                       const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, bool IsFromSystemHeader)
-      : APIRecord(RK_GlobalFunction, USR, Name, Loc, std::move(Availability), Linkage,
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(RK_GlobalFunction, USR, Name, Loc, std::move(Availability),
+                  Linkage, Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Signature(Signature) {}
 
   GlobalFunctionRecord(RecordKind Kind, StringRef USR, StringRef Name,
@@ -305,8 +307,8 @@ struct GlobalFunctionRecord : APIRecord {
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
-                  Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage,
+                  Comment, Declaration, SubHeading, IsFromSystemHeader),
         Signature(Signature) {}
 
   static bool classof(const APIRecord *Record) {
@@ -328,8 +330,9 @@ struct GlobalFunctionTemplateRecord : GlobalFunctionRecord {
                                FunctionSignature Signature, Template Template,
                                bool IsFromSystemHeader)
       : GlobalFunctionRecord(RK_GlobalFunctionTemplate, USR, Name, Loc,
-                             std::move(Availability), Linkage, Comment, Declaration,
-                             SubHeading, Signature, IsFromSystemHeader),
+                             std::move(Availability), Linkage, Comment,
+                             Declaration, SubHeading, Signature,
+                             IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -345,8 +348,9 @@ struct GlobalFunctionTemplateSpecializationRecord : GlobalFunctionRecord {
       DeclarationFragments SubHeading, FunctionSignature Signature,
       bool IsFromSystemHeader)
       : GlobalFunctionRecord(RK_GlobalFunctionTemplateSpecialization, USR, Name,
-                             Loc, std::move(Availability), Linkage, Comment, Declaration,
-                             SubHeading, Signature, IsFromSystemHeader) {}
+                             Loc, std::move(Availability), Linkage, Comment,
+                             Declaration, SubHeading, Signature,
+                             IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_GlobalFunctionTemplateSpecialization;
@@ -356,20 +360,21 @@ struct GlobalFunctionTemplateSpecializationRecord : GlobalFunctionRecord {
 /// This holds information associated with global functions.
 struct GlobalVariableRecord : APIRecord {
   GlobalVariableRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       AvailabilityInfo Availability,
-                       LinkageInfo Linkage, const DocComment &Comment,
+                       AvailabilityInfo Availability, LinkageInfo Linkage,
+                       const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_GlobalVariable, USR, Name, Loc, std::move(Availability), Linkage,
-                  Comment, Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(RK_GlobalVariable, USR, Name, Loc, std::move(Availability),
+                  Linkage, Comment, Declaration, SubHeading,
+                  IsFromSystemHeader) {}
 
   GlobalVariableRecord(RecordKind Kind, StringRef USR, StringRef Name,
                        PresumedLoc Loc, AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
-                  Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage,
+                  Comment, Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_GlobalVariable;
@@ -389,8 +394,8 @@ struct GlobalVariableTemplateRecord : GlobalVariableRecord {
                                DeclarationFragments SubHeading,
                                class Template Template, bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplate, USR, Name, Loc,
-                             std::move(Availability), Linkage, Comment, Declaration,
-                             SubHeading, IsFromSystemHeader),
+                             std::move(Availability), Linkage, Comment,
+                             Declaration, SubHeading, IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -405,8 +410,8 @@ struct GlobalVariableTemplateSpecializationRecord : GlobalVariableRecord {
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplateSpecialization, USR, Name,
-                             Loc, std::move(Availability), Linkage, Comment, Declaration,
-                             SubHeading, IsFromSystemHeader) {}
+                             Loc, std::move(Availability), Linkage, Comment,
+                             Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_GlobalVariableTemplateSpecialization;
@@ -424,8 +429,9 @@ struct GlobalVariableTemplatePartialSpecializationRecord
       DeclarationFragments SubHeading, class Template Template,
       bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplatePartialSpecialization,
-                             USR, Name, Loc, std::move(Availability), Linkage, Comment,
-                             Declaration, SubHeading, IsFromSystemHeader),
+                             USR, Name, Loc, std::move(Availability), Linkage,
+                             Comment, Declaration, SubHeading,
+                             IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -436,8 +442,7 @@ struct GlobalVariableTemplatePartialSpecializationRecord
 /// This holds information associated with enum constants.
 struct EnumConstantRecord : APIRecord {
   EnumConstantRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     AvailabilityInfo Availability,
-                     const DocComment &Comment,
+                     AvailabilityInfo Availability, const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader)
       : APIRecord(RK_EnumConstant, USR, Name, Loc, std::move(Availability),
@@ -460,8 +465,9 @@ struct EnumRecord : APIRecord {
              AvailabilityInfo Availability, const DocComment &Comment,
              DeclarationFragments Declaration, DeclarationFragments SubHeading,
              bool IsFromSystemHeader)
-      : APIRecord(RK_Enum, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(RK_Enum, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_Enum;
@@ -474,8 +480,8 @@ private:
 /// This holds information associated with struct fields.
 struct StructFieldRecord : APIRecord {
   StructFieldRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                    AvailabilityInfo Availability,
-                    const DocComment &Comment, DeclarationFragments Declaration,
+                    AvailabilityInfo Availability, const DocComment &Comment,
+                    DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, bool IsFromSystemHeader)
       : APIRecord(RK_StructField, USR, Name, Loc, std::move(Availability),
                   LinkageInfo::none(), Comment, Declaration, SubHeading,
@@ -497,8 +503,9 @@ struct StructRecord : APIRecord {
                AvailabilityInfo Availability, const DocComment &Comment,
                DeclarationFragments Declaration,
                DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_Struct, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(RK_Struct, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_Struct;
@@ -512,8 +519,8 @@ struct CXXFieldRecord : APIRecord {
   AccessControl Access;
 
   CXXFieldRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                 AvailabilityInfo Availability,
-                 const DocComment &Comment, DeclarationFragments Declaration,
+                 AvailabilityInfo Availability, const DocComment &Comment,
+                 DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, AccessControl Access,
                  bool IsFromSystemHeader)
       : APIRecord(RK_CXXField, USR, Name, Loc, std::move(Availability),
@@ -526,8 +533,9 @@ struct CXXFieldRecord : APIRecord {
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, AccessControl Access,
                  bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Access(Access) {}
 
   static bool classof(const APIRecord *Record) {
@@ -547,9 +555,9 @@ struct CXXFieldTemplateRecord : CXXFieldRecord {
                          DeclarationFragments Declaration,
                          DeclarationFragments SubHeading, AccessControl Access,
                          Template Template, bool IsFromSystemHeader)
-      : CXXFieldRecord(RK_CXXFieldTemplate, USR, Name, Loc, std::move(Availability),
-                       Comment, Declaration, SubHeading, Access,
-                       IsFromSystemHeader),
+      : CXXFieldRecord(RK_CXXFieldTemplate, USR, Name, Loc,
+                       std::move(Availability), Comment, Declaration,
+                       SubHeading, Access, IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -568,8 +576,9 @@ struct CXXMethodRecord : APIRecord {
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, FunctionSignature Signature,
                   AccessControl Access, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Signature(Signature), Access(Access) {}
 
   virtual ~CXXMethodRecord() = 0;
@@ -577,15 +586,14 @@ struct CXXMethodRecord : APIRecord {
 
 struct CXXConstructorRecord : CXXMethodRecord {
   CXXConstructorRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       AvailabilityInfo Availability,
-                       const DocComment &Comment,
+                       AvailabilityInfo Availability, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, AccessControl Access,
                        bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXConstructorMethod, USR, Name, Loc, std::move(Availability),
-                        Comment, Declaration, SubHeading, Signature, Access,
-                        IsFromSystemHeader) {}
+      : CXXMethodRecord(RK_CXXConstructorMethod, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_CXXConstructorMethod;
   }
@@ -596,15 +604,14 @@ private:
 
 struct CXXDestructorRecord : CXXMethodRecord {
   CXXDestructorRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                      AvailabilityInfo Availability,
-                      const DocComment &Comment,
+                      AvailabilityInfo Availability, const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading,
                       FunctionSignature Signature, AccessControl Access,
                       bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXDestructorMethod, USR, Name, Loc, std::move(Availability),
-                        Comment, Declaration, SubHeading, Signature, Access,
-                        IsFromSystemHeader) {}
+      : CXXMethodRecord(RK_CXXDestructorMethod, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_CXXDestructorMethod;
   }
@@ -621,9 +628,9 @@ struct CXXStaticMethodRecord : CXXMethodRecord {
                         DeclarationFragments SubHeading,
                         FunctionSignature Signature, AccessControl Access,
                         bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXStaticMethod, USR, Name, Loc, std::move(Availability),
-                        Comment, Declaration, SubHeading, Signature, Access,
-                        IsFromSystemHeader) {}
+      : CXXMethodRecord(RK_CXXStaticMethod, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_CXXStaticMethod;
   }
@@ -640,9 +647,9 @@ struct CXXInstanceMethodRecord : CXXMethodRecord {
                           DeclarationFragments SubHeading,
                           FunctionSignature Signature, AccessControl Access,
                           bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXInstanceMethod, USR, Name, Loc, std::move(Availability),
-                        Comment, Declaration, SubHeading, Signature, Access,
-                        IsFromSystemHeader) {}
+      : CXXMethodRecord(RK_CXXInstanceMethod, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_CXXInstanceMethod;
@@ -662,9 +669,9 @@ struct CXXMethodTemplateRecord : CXXMethodRecord {
                           DeclarationFragments SubHeading,
                           FunctionSignature Signature, AccessControl Access,
                           Template Template, bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXMethodTemplate, USR, Name, Loc, std::move(Availability),
-                        Comment, Declaration, SubHeading, Signature, Access,
-                        IsFromSystemHeader),
+      : CXXMethodRecord(RK_CXXMethodTemplate, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -680,8 +687,8 @@ struct CXXMethodTemplateSpecializationRecord : CXXMethodRecord {
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader)
       : CXXMethodRecord(RK_CXXMethodTemplateSpecialization, USR, Name, Loc,
-                        std::move(Availability), Comment, Declaration, SubHeading,
-                        Signature, Access, IsFromSystemHeader) {}
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Signature, Access, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_CXXMethodTemplateSpecialization;
@@ -709,8 +716,9 @@ struct ObjCPropertyRecord : APIRecord {
                      DeclarationFragments SubHeading, AttributeKind Attributes,
                      StringRef GetterName, StringRef SetterName,
                      bool IsOptional, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Attributes(Attributes), GetterName(GetterName), SetterName(SetterName),
         IsOptional(IsOptional) {}
 
@@ -730,9 +738,9 @@ struct ObjCInstancePropertyRecord : ObjCPropertyRecord {
                              StringRef SetterName, bool IsOptional,
                              bool IsFromSystemHeader)
       : ObjCPropertyRecord(RK_ObjCInstanceProperty, USR, Name, Loc,
-                           std::move(Availability), Comment, Declaration, SubHeading,
-                           Attributes, GetterName, SetterName, IsOptional,
-                           IsFromSystemHeader) {}
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, Attributes, GetterName, SetterName,
+                           IsOptional, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ObjCInstanceProperty;
@@ -751,10 +759,10 @@ struct ObjCClassPropertyRecord : ObjCPropertyRecord {
                           AttributeKind Attributes, StringRef GetterName,
                           StringRef SetterName, bool IsOptional,
                           bool IsFromSystemHeader)
-      : ObjCPropertyRecord(RK_ObjCClassProperty, USR, Name, Loc, std::move(Availability),
-                           Comment, Declaration, SubHeading, Attributes,
-                           GetterName, SetterName, IsOptional,
-                           IsFromSystemHeader) {}
+      : ObjCPropertyRecord(RK_ObjCClassProperty, USR, Name, Loc,
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, Attributes, GetterName, SetterName,
+                           IsOptional, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ObjCClassProperty;
@@ -799,8 +807,9 @@ struct ObjCMethodRecord : APIRecord {
                    const DocComment &Comment, DeclarationFragments Declaration,
                    DeclarationFragments SubHeading, FunctionSignature Signature,
                    bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Signature(Signature) {}
 
   virtual ~ObjCMethodRecord() = 0;
@@ -813,9 +822,9 @@ struct ObjCInstanceMethodRecord : ObjCMethodRecord {
                            DeclarationFragments Declaration,
                            DeclarationFragments SubHeading,
                            FunctionSignature Signature, bool IsFromSystemHeader)
-      : ObjCMethodRecord(RK_ObjCInstanceMethod, USR, Name, Loc, std::move(Availability),
-                         Comment, Declaration, SubHeading, Signature,
-                         IsFromSystemHeader) {}
+      : ObjCMethodRecord(RK_ObjCInstanceMethod, USR, Name, Loc,
+                         std::move(Availability), Comment, Declaration,
+                         SubHeading, Signature, IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ObjCInstanceMethod;
   }
@@ -831,9 +840,9 @@ struct ObjCClassMethodRecord : ObjCMethodRecord {
                         DeclarationFragments Declaration,
                         DeclarationFragments SubHeading,
                         FunctionSignature Signature, bool IsFromSystemHeader)
-      : ObjCMethodRecord(RK_ObjCClassMethod, USR, Name, Loc, std::move(Availability),
-                         Comment, Declaration, SubHeading, Signature,
-                         IsFromSystemHeader) {}
+      : ObjCMethodRecord(RK_ObjCClassMethod, USR, Name, Loc,
+                         std::move(Availability), Comment, Declaration,
+                         SubHeading, Signature, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ObjCClassMethod;
@@ -874,8 +883,9 @@ struct StaticFieldRecord : CXXFieldRecord {
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, SymbolReference Context,
                     AccessControl Access, bool IsFromSystemHeader)
-      : CXXFieldRecord(RK_StaticField, USR, Name, Loc, std::move(Availability), Comment,
-                       Declaration, SubHeading, Access, IsFromSystemHeader),
+      : CXXFieldRecord(RK_StaticField, USR, Name, Loc, std::move(Availability),
+                       Comment, Declaration, SubHeading, Access,
+                       IsFromSystemHeader),
         Context(Context) {}
 
   static bool classof(const APIRecord *Record) {
@@ -898,8 +908,8 @@ struct ObjCContainerRecord : APIRecord {
                       LinkageInfo Linkage, const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
-                  Declaration, SubHeading, IsFromSystemHeader) {}
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage,
+                  Comment, Declaration, SubHeading, IsFromSystemHeader) {}
 
   virtual ~ObjCContainerRecord() = 0;
 };
@@ -911,12 +921,13 @@ struct CXXClassRecord : APIRecord {
   AccessControl Access;
 
   CXXClassRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                 AvailabilityInfo Availability,
-                 const DocComment &Comment, DeclarationFragments Declaration,
+                 AvailabilityInfo Availability, const DocComment &Comment,
+                 DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, RecordKind Kind,
                  AccessControl Access, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Access(Access) {}
 
   static bool classof(const APIRecord *Record) {
@@ -931,13 +942,12 @@ struct ClassTemplateRecord : CXXClassRecord {
   Template Templ;
 
   ClassTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                      AvailabilityInfo Availability,
-                      const DocComment &Comment,
+                      AvailabilityInfo Availability, const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, Template Template,
                       AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
-                       SubHeading, RK_ClassTemplate, Access,
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment,
+                       Declaration, SubHeading, RK_ClassTemplate, Access,
                        IsFromSystemHeader),
         Templ(Template) {}
 
@@ -952,9 +962,9 @@ struct ClassTemplateSpecializationRecord : CXXClassRecord {
       AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
-                       SubHeading, RK_ClassTemplateSpecialization, Access,
-                       IsFromSystemHeader) {}
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment,
+                       Declaration, SubHeading, RK_ClassTemplateSpecialization,
+                       Access, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ClassTemplateSpecialization;
@@ -968,9 +978,9 @@ struct ClassTemplatePartialSpecializationRecord : CXXClassRecord {
       AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       Template Template, AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
-                       SubHeading, RK_ClassTemplateSpecialization, Access,
-                       IsFromSystemHeader),
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment,
+                       Declaration, SubHeading, RK_ClassTemplateSpecialization,
+                       Access, IsFromSystemHeader),
         Templ(Template) {}
 
   static bool classof(const APIRecord *Record) {
@@ -986,8 +996,9 @@ struct ConceptRecord : APIRecord {
                 DeclarationFragments Declaration,
                 DeclarationFragments SubHeading, Template Template,
                 bool IsFromSystemHeader)
-      : APIRecord(RK_Concept, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(RK_Concept, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo::none(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         Templ(Template) {}
 };
 
@@ -998,14 +1009,14 @@ struct ObjCCategoryRecord : ObjCContainerRecord {
   bool IsFromExternalModule = false;
 
   ObjCCategoryRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     AvailabilityInfo Availability,
-                     const DocComment &Comment,
+                     AvailabilityInfo Availability, const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, SymbolReference Interface,
                      bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCCategory, USR, Name, Loc, std::move(Availability),
-                            LinkageInfo::none(), Comment, Declaration,
-                            SubHeading, IsFromSystemHeader),
+      : ObjCContainerRecord(RK_ObjCCategory, USR, Name, Loc,
+                            std::move(Availability), LinkageInfo::none(),
+                            Comment, Declaration, SubHeading,
+                            IsFromSystemHeader),
         Interface(Interface) {}
 
   static bool classof(const APIRecord *Record) {
@@ -1028,9 +1039,9 @@ struct ObjCInterfaceRecord : ObjCContainerRecord {
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading,
                       SymbolReference SuperClass, bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCInterface, USR, Name, Loc, std::move(Availability),
-                            Linkage, Comment, Declaration, SubHeading,
-                            IsFromSystemHeader),
+      : ObjCContainerRecord(RK_ObjCInterface, USR, Name, Loc,
+                            std::move(Availability), Linkage, Comment,
+                            Declaration, SubHeading, IsFromSystemHeader),
         SuperClass(SuperClass) {}
 
   static bool classof(const APIRecord *Record) {
@@ -1044,13 +1055,13 @@ private:
 /// This holds information associated with Objective-C protocols.
 struct ObjCProtocolRecord : ObjCContainerRecord {
   ObjCProtocolRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     AvailabilityInfo Availability,
-                     const DocComment &Comment,
+                     AvailabilityInfo Availability, const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCProtocol, USR, Name, Loc, std::move(Availability),
-                            LinkageInfo::none(), Comment, Declaration,
-                            SubHeading, IsFromSystemHeader) {}
+      : ObjCContainerRecord(RK_ObjCProtocol, USR, Name, Loc,
+                            std::move(Availability), LinkageInfo::none(),
+                            Comment, Declaration, SubHeading,
+                            IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
     return Record->getKind() == RK_ObjCProtocol;
@@ -1091,8 +1102,9 @@ struct TypedefRecord : APIRecord {
                 DeclarationFragments Declaration,
                 DeclarationFragments SubHeading, SymbolReference UnderlyingType,
                 bool IsFromSystemHeader)
-      : APIRecord(RK_Typedef, USR, Name, Loc, std::move(Availability), LinkageInfo(),
-                  Comment, Declaration, SubHeading, IsFromSystemHeader),
+      : APIRecord(RK_Typedef, USR, Name, Loc, std::move(Availability),
+                  LinkageInfo(), Comment, Declaration, SubHeading,
+                  IsFromSystemHeader),
         UnderlyingType(UnderlyingType) {}
 
   static bool classof(const APIRecord *Record) {
@@ -1197,8 +1209,8 @@ public:
 
   GlobalVariableTemplateRecord *
   addGlobalVariableTemplate(StringRef Name, StringRef USR, PresumedLoc Loc,
-                            AvailabilityInfo Availability,
-                            LinkageInfo Linkage, const DocComment &Comment,
+                            AvailabilityInfo Availability, LinkageInfo Linkage,
+                            const DocComment &Comment,
                             DeclarationFragments Declaration,
                             DeclarationFragments SubHeading, Template Template,
                             bool IsFromSystemHeader);
@@ -1250,8 +1262,7 @@ public:
   /// APISet itself, and APISet::recordUSR(const Decl *D) is a helper method
   /// to generate the USR for \c D and keep it alive in APISet.
   EnumRecord *addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
-                      AvailabilityInfo Availability,
-                      const DocComment &Comment,
+                      AvailabilityInfo Availability, const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
@@ -1301,12 +1312,13 @@ public:
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       AccessControl Access, Template Template, bool IsFromSystemHeader);
 
-  CXXClassRecord *
-  addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-              AvailabilityInfo Availability, const DocComment &Comment,
-              DeclarationFragments Declaration, DeclarationFragments SubHeading,
-              APIRecord::RecordKind Kind, AccessControl Access,
-              bool IsFromSystemHeader);
+  CXXClassRecord *addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
+                              PresumedLoc Loc, AvailabilityInfo Availability,
+                              const DocComment &Comment,
+                              DeclarationFragments Declaration,
+                              DeclarationFragments SubHeading,
+                              APIRecord::RecordKind Kind, AccessControl Access,
+                              bool IsFromSystemHeader);
 
   ClassTemplateRecord *
   addClassTemplate(APIRecord *Parent, StringRef Name, StringRef USR,
@@ -1393,8 +1405,8 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCCategoryRecord *
   addObjCCategory(StringRef Name, StringRef USR, PresumedLoc Loc,
-                  AvailabilityInfo Availability,
-                  const DocComment &Comment, DeclarationFragments Declaration,
+                  AvailabilityInfo Availability, const DocComment &Comment,
+                  DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, SymbolReference Interface,
                   bool IsFromSystemHeader, bool IsFromExternalModule);
 
@@ -1447,9 +1459,8 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCInstanceVariableRecord *addObjCInstanceVariable(
       ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-      PresumedLoc Loc, AvailabilityInfo Availability,
-      const DocComment &Comment, DeclarationFragments Declaration,
-      DeclarationFragments SubHeading,
+      PresumedLoc Loc, AvailabilityInfo Availability, const DocComment &Comment,
+      DeclarationFragments Declaration, DeclarationFragments SubHeading,
       ObjCInstanceVariableRecord::AccessControl Access,
       bool IsFromSystemHeader);
 
@@ -1461,8 +1472,8 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCProtocolRecord *
   addObjCProtocol(StringRef Name, StringRef USR, PresumedLoc Loc,
-                  AvailabilityInfo Availability,
-                  const DocComment &Comment, DeclarationFragments Declaration,
+                  AvailabilityInfo Availability, const DocComment &Comment,
+                  DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
   /// Create a macro definition record into the API set.

--- a/clang/include/clang/ExtractAPI/API.h
+++ b/clang/include/clang/ExtractAPI/API.h
@@ -256,11 +256,11 @@ public:
   APIRecord() = delete;
 
   APIRecord(RecordKind Kind, StringRef USR, StringRef Name,
-            PresumedLoc Location, const AvailabilityInfo &Availability,
+            PresumedLoc Location, AvailabilityInfo Availability,
             LinkageInfo Linkage, const DocComment &Comment,
             DeclarationFragments Declaration, DeclarationFragments SubHeading,
             bool IsFromSystemHeader)
-      : USR(USR), Name(Name), Location(Location), Availability(Availability),
+      : USR(USR), Name(Name), Location(Location), Availability(std::move(Availability)),
         Linkage(Linkage), Comment(Comment), Declaration(Declaration),
         SubHeading(SubHeading), IsFromSystemHeader(IsFromSystemHeader),
         Kind(Kind) {}
@@ -274,10 +274,10 @@ public:
 
 struct NamespaceRecord : APIRecord {
   NamespaceRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                  const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                  AvailabilityInfo Availability, LinkageInfo Linkage,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_Namespace, USR, Name, Loc, Availability, Linkage, Comment,
+      : APIRecord(RK_Namespace, USR, Name, Loc, std::move(Availability), Linkage, Comment,
                   Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -290,22 +290,22 @@ struct GlobalFunctionRecord : APIRecord {
   FunctionSignature Signature;
 
   GlobalFunctionRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       const AvailabilityInfo &Availability,
+                       AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, bool IsFromSystemHeader)
-      : APIRecord(RK_GlobalFunction, USR, Name, Loc, Availability, Linkage,
+      : APIRecord(RK_GlobalFunction, USR, Name, Loc, std::move(Availability), Linkage,
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Signature(Signature) {}
 
   GlobalFunctionRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                       PresumedLoc Loc, const AvailabilityInfo &Availability,
+                       PresumedLoc Loc, AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, Linkage, Comment,
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
                   Declaration, SubHeading, IsFromSystemHeader),
         Signature(Signature) {}
 
@@ -321,14 +321,14 @@ struct GlobalFunctionTemplateRecord : GlobalFunctionRecord {
   Template Templ;
 
   GlobalFunctionTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                               const AvailabilityInfo &Availability,
+                               AvailabilityInfo Availability,
                                LinkageInfo Linkage, const DocComment &Comment,
                                DeclarationFragments Declaration,
                                DeclarationFragments SubHeading,
                                FunctionSignature Signature, Template Template,
                                bool IsFromSystemHeader)
       : GlobalFunctionRecord(RK_GlobalFunctionTemplate, USR, Name, Loc,
-                             Availability, Linkage, Comment, Declaration,
+                             std::move(Availability), Linkage, Comment, Declaration,
                              SubHeading, Signature, IsFromSystemHeader),
         Templ(Template) {}
 
@@ -340,12 +340,12 @@ struct GlobalFunctionTemplateRecord : GlobalFunctionRecord {
 struct GlobalFunctionTemplateSpecializationRecord : GlobalFunctionRecord {
   GlobalFunctionTemplateSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, FunctionSignature Signature,
       bool IsFromSystemHeader)
       : GlobalFunctionRecord(RK_GlobalFunctionTemplateSpecialization, USR, Name,
-                             Loc, Availability, Linkage, Comment, Declaration,
+                             Loc, std::move(Availability), Linkage, Comment, Declaration,
                              SubHeading, Signature, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -356,19 +356,19 @@ struct GlobalFunctionTemplateSpecializationRecord : GlobalFunctionRecord {
 /// This holds information associated with global functions.
 struct GlobalVariableRecord : APIRecord {
   GlobalVariableRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       const AvailabilityInfo &Availability,
+                       AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_GlobalVariable, USR, Name, Loc, Availability, Linkage,
+      : APIRecord(RK_GlobalVariable, USR, Name, Loc, std::move(Availability), Linkage,
                   Comment, Declaration, SubHeading, IsFromSystemHeader) {}
 
   GlobalVariableRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                       PresumedLoc Loc, const AvailabilityInfo &Availability,
+                       PresumedLoc Loc, AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, Linkage, Comment,
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
                   Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -383,13 +383,13 @@ struct GlobalVariableTemplateRecord : GlobalVariableRecord {
   Template Templ;
 
   GlobalVariableTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                               const AvailabilityInfo &Availability,
+                               AvailabilityInfo Availability,
                                LinkageInfo Linkage, const DocComment &Comment,
                                DeclarationFragments Declaration,
                                DeclarationFragments SubHeading,
                                class Template Template, bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplate, USR, Name, Loc,
-                             Availability, Linkage, Comment, Declaration,
+                             std::move(Availability), Linkage, Comment, Declaration,
                              SubHeading, IsFromSystemHeader),
         Templ(Template) {}
 
@@ -401,11 +401,11 @@ struct GlobalVariableTemplateRecord : GlobalVariableRecord {
 struct GlobalVariableTemplateSpecializationRecord : GlobalVariableRecord {
   GlobalVariableTemplateSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplateSpecialization, USR, Name,
-                             Loc, Availability, Linkage, Comment, Declaration,
+                             Loc, std::move(Availability), Linkage, Comment, Declaration,
                              SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -419,12 +419,12 @@ struct GlobalVariableTemplatePartialSpecializationRecord
 
   GlobalVariableTemplatePartialSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, class Template Template,
       bool IsFromSystemHeader)
       : GlobalVariableRecord(RK_GlobalVariableTemplatePartialSpecialization,
-                             USR, Name, Loc, Availability, Linkage, Comment,
+                             USR, Name, Loc, std::move(Availability), Linkage, Comment,
                              Declaration, SubHeading, IsFromSystemHeader),
         Templ(Template) {}
 
@@ -436,11 +436,11 @@ struct GlobalVariableTemplatePartialSpecializationRecord
 /// This holds information associated with enum constants.
 struct EnumConstantRecord : APIRecord {
   EnumConstantRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     const AvailabilityInfo &Availability,
+                     AvailabilityInfo Availability,
                      const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_EnumConstant, USR, Name, Loc, Availability,
+      : APIRecord(RK_EnumConstant, USR, Name, Loc, std::move(Availability),
                   LinkageInfo::none(), Comment, Declaration, SubHeading,
                   IsFromSystemHeader) {}
 
@@ -457,10 +457,10 @@ struct EnumRecord : APIRecord {
   SmallVector<std::unique_ptr<EnumConstantRecord>> Constants;
 
   EnumRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-             const AvailabilityInfo &Availability, const DocComment &Comment,
+             AvailabilityInfo Availability, const DocComment &Comment,
              DeclarationFragments Declaration, DeclarationFragments SubHeading,
              bool IsFromSystemHeader)
-      : APIRecord(RK_Enum, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(RK_Enum, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -474,10 +474,10 @@ private:
 /// This holds information associated with struct fields.
 struct StructFieldRecord : APIRecord {
   StructFieldRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                    const AvailabilityInfo &Availability,
+                    AvailabilityInfo Availability,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_StructField, USR, Name, Loc, Availability,
+      : APIRecord(RK_StructField, USR, Name, Loc, std::move(Availability),
                   LinkageInfo::none(), Comment, Declaration, SubHeading,
                   IsFromSystemHeader) {}
 
@@ -494,10 +494,10 @@ struct StructRecord : APIRecord {
   SmallVector<std::unique_ptr<StructFieldRecord>> Fields;
 
   StructRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-               const AvailabilityInfo &Availability, const DocComment &Comment,
+               AvailabilityInfo Availability, const DocComment &Comment,
                DeclarationFragments Declaration,
                DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(RK_Struct, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(RK_Struct, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -512,21 +512,21 @@ struct CXXFieldRecord : APIRecord {
   AccessControl Access;
 
   CXXFieldRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                 const AvailabilityInfo &Availability,
+                 AvailabilityInfo Availability,
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, AccessControl Access,
                  bool IsFromSystemHeader)
-      : APIRecord(RK_CXXField, USR, Name, Loc, Availability,
+      : APIRecord(RK_CXXField, USR, Name, Loc, std::move(Availability),
                   LinkageInfo::none(), Comment, Declaration, SubHeading,
                   IsFromSystemHeader),
         Access(Access) {}
 
   CXXFieldRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                 PresumedLoc Loc, const AvailabilityInfo &Availability,
+                 PresumedLoc Loc, AvailabilityInfo Availability,
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, AccessControl Access,
                  bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Access(Access) {}
 
@@ -542,12 +542,12 @@ struct CXXFieldTemplateRecord : CXXFieldRecord {
   Template Templ;
 
   CXXFieldTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                         const AvailabilityInfo &Availability,
+                         AvailabilityInfo Availability,
                          const DocComment &Comment,
                          DeclarationFragments Declaration,
                          DeclarationFragments SubHeading, AccessControl Access,
                          Template Template, bool IsFromSystemHeader)
-      : CXXFieldRecord(RK_CXXFieldTemplate, USR, Name, Loc, Availability,
+      : CXXFieldRecord(RK_CXXFieldTemplate, USR, Name, Loc, std::move(Availability),
                        Comment, Declaration, SubHeading, Access,
                        IsFromSystemHeader),
         Templ(Template) {}
@@ -564,11 +564,11 @@ struct CXXMethodRecord : APIRecord {
   CXXMethodRecord() = delete;
 
   CXXMethodRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                  PresumedLoc Loc, const AvailabilityInfo &Availability,
+                  PresumedLoc Loc, AvailabilityInfo Availability,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, FunctionSignature Signature,
                   AccessControl Access, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Signature(Signature), Access(Access) {}
 
@@ -577,13 +577,13 @@ struct CXXMethodRecord : APIRecord {
 
 struct CXXConstructorRecord : CXXMethodRecord {
   CXXConstructorRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                       const AvailabilityInfo &Availability,
+                       AvailabilityInfo Availability,
                        const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading,
                        FunctionSignature Signature, AccessControl Access,
                        bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXConstructorMethod, USR, Name, Loc, Availability,
+      : CXXMethodRecord(RK_CXXConstructorMethod, USR, Name, Loc, std::move(Availability),
                         Comment, Declaration, SubHeading, Signature, Access,
                         IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
@@ -596,13 +596,13 @@ private:
 
 struct CXXDestructorRecord : CXXMethodRecord {
   CXXDestructorRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                      const AvailabilityInfo &Availability,
+                      AvailabilityInfo Availability,
                       const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading,
                       FunctionSignature Signature, AccessControl Access,
                       bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXDestructorMethod, USR, Name, Loc, Availability,
+      : CXXMethodRecord(RK_CXXDestructorMethod, USR, Name, Loc, std::move(Availability),
                         Comment, Declaration, SubHeading, Signature, Access,
                         IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
@@ -615,13 +615,13 @@ private:
 
 struct CXXStaticMethodRecord : CXXMethodRecord {
   CXXStaticMethodRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                        const AvailabilityInfo &Availability,
+                        AvailabilityInfo Availability,
                         const DocComment &Comment,
                         DeclarationFragments Declaration,
                         DeclarationFragments SubHeading,
                         FunctionSignature Signature, AccessControl Access,
                         bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXStaticMethod, USR, Name, Loc, Availability,
+      : CXXMethodRecord(RK_CXXStaticMethod, USR, Name, Loc, std::move(Availability),
                         Comment, Declaration, SubHeading, Signature, Access,
                         IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
@@ -634,13 +634,13 @@ private:
 
 struct CXXInstanceMethodRecord : CXXMethodRecord {
   CXXInstanceMethodRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                          const AvailabilityInfo &Availability,
+                          AvailabilityInfo Availability,
                           const DocComment &Comment,
                           DeclarationFragments Declaration,
                           DeclarationFragments SubHeading,
                           FunctionSignature Signature, AccessControl Access,
                           bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXInstanceMethod, USR, Name, Loc, Availability,
+      : CXXMethodRecord(RK_CXXInstanceMethod, USR, Name, Loc, std::move(Availability),
                         Comment, Declaration, SubHeading, Signature, Access,
                         IsFromSystemHeader) {}
 
@@ -656,13 +656,13 @@ struct CXXMethodTemplateRecord : CXXMethodRecord {
   Template Templ;
 
   CXXMethodTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                          const AvailabilityInfo &Availability,
+                          AvailabilityInfo Availability,
                           const DocComment &Comment,
                           DeclarationFragments Declaration,
                           DeclarationFragments SubHeading,
                           FunctionSignature Signature, AccessControl Access,
                           Template Template, bool IsFromSystemHeader)
-      : CXXMethodRecord(RK_CXXMethodTemplate, USR, Name, Loc, Availability,
+      : CXXMethodRecord(RK_CXXMethodTemplate, USR, Name, Loc, std::move(Availability),
                         Comment, Declaration, SubHeading, Signature, Access,
                         IsFromSystemHeader),
         Templ(Template) {}
@@ -675,12 +675,12 @@ struct CXXMethodTemplateRecord : CXXMethodRecord {
 struct CXXMethodTemplateSpecializationRecord : CXXMethodRecord {
   CXXMethodTemplateSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader)
       : CXXMethodRecord(RK_CXXMethodTemplateSpecialization, USR, Name, Loc,
-                        Availability, Comment, Declaration, SubHeading,
+                        std::move(Availability), Comment, Declaration, SubHeading,
                         Signature, Access, IsFromSystemHeader) {}
 
   static bool classof(const APIRecord *Record) {
@@ -703,13 +703,13 @@ struct ObjCPropertyRecord : APIRecord {
   bool IsOptional;
 
   ObjCPropertyRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                     PresumedLoc Loc, const AvailabilityInfo &Availability,
+                     PresumedLoc Loc, AvailabilityInfo Availability,
                      const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, AttributeKind Attributes,
                      StringRef GetterName, StringRef SetterName,
                      bool IsOptional, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Attributes(Attributes), GetterName(GetterName), SetterName(SetterName),
         IsOptional(IsOptional) {}
@@ -722,7 +722,7 @@ struct ObjCPropertyRecord : APIRecord {
 
 struct ObjCInstancePropertyRecord : ObjCPropertyRecord {
   ObjCInstancePropertyRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                             const AvailabilityInfo &Availability,
+                             AvailabilityInfo Availability,
                              const DocComment &Comment,
                              DeclarationFragments Declaration,
                              DeclarationFragments SubHeading,
@@ -730,7 +730,7 @@ struct ObjCInstancePropertyRecord : ObjCPropertyRecord {
                              StringRef SetterName, bool IsOptional,
                              bool IsFromSystemHeader)
       : ObjCPropertyRecord(RK_ObjCInstanceProperty, USR, Name, Loc,
-                           Availability, Comment, Declaration, SubHeading,
+                           std::move(Availability), Comment, Declaration, SubHeading,
                            Attributes, GetterName, SetterName, IsOptional,
                            IsFromSystemHeader) {}
 
@@ -744,14 +744,14 @@ private:
 
 struct ObjCClassPropertyRecord : ObjCPropertyRecord {
   ObjCClassPropertyRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                          const AvailabilityInfo &Availability,
+                          AvailabilityInfo Availability,
                           const DocComment &Comment,
                           DeclarationFragments Declaration,
                           DeclarationFragments SubHeading,
                           AttributeKind Attributes, StringRef GetterName,
                           StringRef SetterName, bool IsOptional,
                           bool IsFromSystemHeader)
-      : ObjCPropertyRecord(RK_ObjCClassProperty, USR, Name, Loc, Availability,
+      : ObjCPropertyRecord(RK_ObjCClassProperty, USR, Name, Loc, std::move(Availability),
                            Comment, Declaration, SubHeading, Attributes,
                            GetterName, SetterName, IsOptional,
                            IsFromSystemHeader) {}
@@ -770,12 +770,12 @@ struct ObjCInstanceVariableRecord : APIRecord {
   AccessControl Access;
 
   ObjCInstanceVariableRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                             const AvailabilityInfo &Availability,
+                             AvailabilityInfo Availability,
                              const DocComment &Comment,
                              DeclarationFragments Declaration,
                              DeclarationFragments SubHeading,
                              AccessControl Access, bool IsFromSystemHeader)
-      : APIRecord(RK_ObjCIvar, USR, Name, Loc, Availability,
+      : APIRecord(RK_ObjCIvar, USR, Name, Loc, std::move(Availability),
                   LinkageInfo::none(), Comment, Declaration, SubHeading,
                   IsFromSystemHeader),
         Access(Access) {}
@@ -795,11 +795,11 @@ struct ObjCMethodRecord : APIRecord {
   ObjCMethodRecord() = delete;
 
   ObjCMethodRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                   PresumedLoc Loc, const AvailabilityInfo &Availability,
+                   PresumedLoc Loc, AvailabilityInfo Availability,
                    const DocComment &Comment, DeclarationFragments Declaration,
                    DeclarationFragments SubHeading, FunctionSignature Signature,
                    bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Signature(Signature) {}
 
@@ -808,12 +808,12 @@ struct ObjCMethodRecord : APIRecord {
 
 struct ObjCInstanceMethodRecord : ObjCMethodRecord {
   ObjCInstanceMethodRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                           const AvailabilityInfo &Availability,
+                           AvailabilityInfo Availability,
                            const DocComment &Comment,
                            DeclarationFragments Declaration,
                            DeclarationFragments SubHeading,
                            FunctionSignature Signature, bool IsFromSystemHeader)
-      : ObjCMethodRecord(RK_ObjCInstanceMethod, USR, Name, Loc, Availability,
+      : ObjCMethodRecord(RK_ObjCInstanceMethod, USR, Name, Loc, std::move(Availability),
                          Comment, Declaration, SubHeading, Signature,
                          IsFromSystemHeader) {}
   static bool classof(const APIRecord *Record) {
@@ -826,12 +826,12 @@ private:
 
 struct ObjCClassMethodRecord : ObjCMethodRecord {
   ObjCClassMethodRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                        const AvailabilityInfo &Availability,
+                        AvailabilityInfo Availability,
                         const DocComment &Comment,
                         DeclarationFragments Declaration,
                         DeclarationFragments SubHeading,
                         FunctionSignature Signature, bool IsFromSystemHeader)
-      : ObjCMethodRecord(RK_ObjCClassMethod, USR, Name, Loc, Availability,
+      : ObjCMethodRecord(RK_ObjCClassMethod, USR, Name, Loc, std::move(Availability),
                          Comment, Declaration, SubHeading, Signature,
                          IsFromSystemHeader) {}
 
@@ -870,11 +870,11 @@ struct StaticFieldRecord : CXXFieldRecord {
   SymbolReference Context;
 
   StaticFieldRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                    AvailabilityInfo Availability, LinkageInfo Linkage,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, SymbolReference Context,
                     AccessControl Access, bool IsFromSystemHeader)
-      : CXXFieldRecord(RK_StaticField, USR, Name, Loc, Availability, Comment,
+      : CXXFieldRecord(RK_StaticField, USR, Name, Loc, std::move(Availability), Comment,
                        Declaration, SubHeading, Access, IsFromSystemHeader),
         Context(Context) {}
 
@@ -894,11 +894,11 @@ struct ObjCContainerRecord : APIRecord {
   ObjCContainerRecord() = delete;
 
   ObjCContainerRecord(RecordKind Kind, StringRef USR, StringRef Name,
-                      PresumedLoc Loc, const AvailabilityInfo &Availability,
+                      PresumedLoc Loc, AvailabilityInfo Availability,
                       LinkageInfo Linkage, const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, Linkage, Comment,
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), Linkage, Comment,
                   Declaration, SubHeading, IsFromSystemHeader) {}
 
   virtual ~ObjCContainerRecord() = 0;
@@ -911,11 +911,11 @@ struct CXXClassRecord : APIRecord {
   AccessControl Access;
 
   CXXClassRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                 const AvailabilityInfo &Availability,
+                 AvailabilityInfo Availability,
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, RecordKind Kind,
                  AccessControl Access, bool IsFromSystemHeader)
-      : APIRecord(Kind, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(Kind, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Access(Access) {}
 
@@ -931,12 +931,12 @@ struct ClassTemplateRecord : CXXClassRecord {
   Template Templ;
 
   ClassTemplateRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                      const AvailabilityInfo &Availability,
+                      AvailabilityInfo Availability,
                       const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, Template Template,
                       AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, Availability, Comment, Declaration,
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
                        SubHeading, RK_ClassTemplate, Access,
                        IsFromSystemHeader),
         Templ(Template) {}
@@ -949,10 +949,10 @@ struct ClassTemplateRecord : CXXClassRecord {
 struct ClassTemplateSpecializationRecord : CXXClassRecord {
   ClassTemplateSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, Availability, Comment, Declaration,
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
                        SubHeading, RK_ClassTemplateSpecialization, Access,
                        IsFromSystemHeader) {}
 
@@ -965,10 +965,10 @@ struct ClassTemplatePartialSpecializationRecord : CXXClassRecord {
   Template Templ;
   ClassTemplatePartialSpecializationRecord(
       StringRef USR, StringRef Name, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       Template Template, AccessControl Access, bool IsFromSystemHeader)
-      : CXXClassRecord(USR, Name, Loc, Availability, Comment, Declaration,
+      : CXXClassRecord(USR, Name, Loc, std::move(Availability), Comment, Declaration,
                        SubHeading, RK_ClassTemplateSpecialization, Access,
                        IsFromSystemHeader),
         Templ(Template) {}
@@ -982,11 +982,11 @@ struct ConceptRecord : APIRecord {
   Template Templ;
 
   ConceptRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                const AvailabilityInfo &Availability, const DocComment &Comment,
+                AvailabilityInfo Availability, const DocComment &Comment,
                 DeclarationFragments Declaration,
                 DeclarationFragments SubHeading, Template Template,
                 bool IsFromSystemHeader)
-      : APIRecord(RK_Concept, USR, Name, Loc, Availability, LinkageInfo::none(),
+      : APIRecord(RK_Concept, USR, Name, Loc, std::move(Availability), LinkageInfo::none(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         Templ(Template) {}
 };
@@ -998,12 +998,12 @@ struct ObjCCategoryRecord : ObjCContainerRecord {
   bool IsFromExternalModule = false;
 
   ObjCCategoryRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     const AvailabilityInfo &Availability,
+                     AvailabilityInfo Availability,
                      const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, SymbolReference Interface,
                      bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCCategory, USR, Name, Loc, Availability,
+      : ObjCContainerRecord(RK_ObjCCategory, USR, Name, Loc, std::move(Availability),
                             LinkageInfo::none(), Comment, Declaration,
                             SubHeading, IsFromSystemHeader),
         Interface(Interface) {}
@@ -1023,12 +1023,12 @@ struct ObjCInterfaceRecord : ObjCContainerRecord {
   SmallVector<ObjCCategoryRecord *> Categories;
 
   ObjCInterfaceRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                      AvailabilityInfo Availability, LinkageInfo Linkage,
                       const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading,
                       SymbolReference SuperClass, bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCInterface, USR, Name, Loc, Availability,
+      : ObjCContainerRecord(RK_ObjCInterface, USR, Name, Loc, std::move(Availability),
                             Linkage, Comment, Declaration, SubHeading,
                             IsFromSystemHeader),
         SuperClass(SuperClass) {}
@@ -1044,11 +1044,11 @@ private:
 /// This holds information associated with Objective-C protocols.
 struct ObjCProtocolRecord : ObjCContainerRecord {
   ObjCProtocolRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                     const AvailabilityInfo &Availability,
+                     AvailabilityInfo Availability,
                      const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader)
-      : ObjCContainerRecord(RK_ObjCProtocol, USR, Name, Loc, Availability,
+      : ObjCContainerRecord(RK_ObjCProtocol, USR, Name, Loc, std::move(Availability),
                             LinkageInfo::none(), Comment, Declaration,
                             SubHeading, IsFromSystemHeader) {}
 
@@ -1087,11 +1087,11 @@ struct TypedefRecord : APIRecord {
   SymbolReference UnderlyingType;
 
   TypedefRecord(StringRef USR, StringRef Name, PresumedLoc Loc,
-                const AvailabilityInfo &Availability, const DocComment &Comment,
+                AvailabilityInfo Availability, const DocComment &Comment,
                 DeclarationFragments Declaration,
                 DeclarationFragments SubHeading, SymbolReference UnderlyingType,
                 bool IsFromSystemHeader)
-      : APIRecord(RK_Typedef, USR, Name, Loc, Availability, LinkageInfo(),
+      : APIRecord(RK_Typedef, USR, Name, Loc, std::move(Availability), LinkageInfo(),
                   Comment, Declaration, SubHeading, IsFromSystemHeader),
         UnderlyingType(UnderlyingType) {}
 
@@ -1178,7 +1178,7 @@ class APISet {
 public:
   NamespaceRecord *addNamespace(APIRecord *Parent, StringRef Name,
                                 StringRef USR, PresumedLoc Loc,
-                                const AvailabilityInfo &Availability,
+                                AvailabilityInfo Availability,
                                 LinkageInfo Linkage, const DocComment &Comment,
                                 DeclarationFragments Declaration,
                                 DeclarationFragments SubHeading,
@@ -1191,13 +1191,13 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   GlobalVariableRecord *
   addGlobalVar(StringRef Name, StringRef USR, PresumedLoc Loc,
-               const AvailabilityInfo &Availability, LinkageInfo Linkage,
+               AvailabilityInfo Availability, LinkageInfo Linkage,
                const DocComment &Comment, DeclarationFragments Declaration,
                DeclarationFragments SubHeadin, bool IsFromSystemHeaderg);
 
   GlobalVariableTemplateRecord *
   addGlobalVariableTemplate(StringRef Name, StringRef USR, PresumedLoc Loc,
-                            const AvailabilityInfo &Availability,
+                            AvailabilityInfo Availability,
                             LinkageInfo Linkage, const DocComment &Comment,
                             DeclarationFragments Declaration,
                             DeclarationFragments SubHeading, Template Template,
@@ -1211,14 +1211,14 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   GlobalFunctionRecord *
   addGlobalFunction(StringRef Name, StringRef USR, PresumedLoc Loc,
-                    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                    AvailabilityInfo Availability, LinkageInfo Linkage,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading,
                     FunctionSignature Signature, bool IsFromSystemHeader);
 
   GlobalFunctionTemplateRecord *addGlobalFunctionTemplate(
       StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, FunctionSignature Signature,
       Template Template, bool IsFromSystemHeader);
@@ -1226,7 +1226,7 @@ public:
   GlobalFunctionTemplateSpecializationRecord *
   addGlobalFunctionTemplateSpecialization(
       StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, FunctionSignature Signature,
       bool IsFromSystemHeader);
@@ -1239,7 +1239,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   EnumConstantRecord *
   addEnumConstant(EnumRecord *Enum, StringRef Name, StringRef USR,
-                  PresumedLoc Loc, const AvailabilityInfo &Availability,
+                  PresumedLoc Loc, AvailabilityInfo Availability,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
@@ -1250,7 +1250,7 @@ public:
   /// APISet itself, and APISet::recordUSR(const Decl *D) is a helper method
   /// to generate the USR for \c D and keep it alive in APISet.
   EnumRecord *addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
-                      const AvailabilityInfo &Availability,
+                      AvailabilityInfo Availability,
                       const DocComment &Comment,
                       DeclarationFragments Declaration,
                       DeclarationFragments SubHeading, bool IsFromSystemHeader);
@@ -1263,7 +1263,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   StructFieldRecord *
   addStructField(StructRecord *Struct, StringRef Name, StringRef USR,
-                 PresumedLoc Loc, const AvailabilityInfo &Availability,
+                 PresumedLoc Loc, AvailabilityInfo Availability,
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
@@ -1274,7 +1274,7 @@ public:
   /// APISet itself, and APISet::recordUSR(const Decl *D) is a helper method
   /// to generate the USR for \c D and keep it alive in APISet.
   StructRecord *addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
-                          const AvailabilityInfo &Availability,
+                          AvailabilityInfo Availability,
                           const DocComment &Comment,
                           DeclarationFragments Declaration,
                           DeclarationFragments SubHeading,
@@ -1282,14 +1282,14 @@ public:
 
   StaticFieldRecord *
   addStaticField(StringRef Name, StringRef USR, PresumedLoc Loc,
-                 const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                 AvailabilityInfo Availability, LinkageInfo Linkage,
                  const DocComment &Comment, DeclarationFragments Declaration,
                  DeclarationFragments SubHeading, SymbolReference Context,
                  AccessControl Access, bool IsFromSystemHeaderg);
 
   CXXFieldRecord *addCXXField(APIRecord *CXXClass, StringRef Name,
                               StringRef USR, PresumedLoc Loc,
-                              const AvailabilityInfo &Availability,
+                              AvailabilityInfo Availability,
                               const DocComment &Comment,
                               DeclarationFragments Declaration,
                               DeclarationFragments SubHeading,
@@ -1297,89 +1297,89 @@ public:
 
   CXXFieldTemplateRecord *addCXXFieldTemplate(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       AccessControl Access, Template Template, bool IsFromSystemHeader);
 
   CXXClassRecord *
   addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-              const AvailabilityInfo &Availability, const DocComment &Comment,
+              AvailabilityInfo Availability, const DocComment &Comment,
               DeclarationFragments Declaration, DeclarationFragments SubHeading,
               APIRecord::RecordKind Kind, AccessControl Access,
               bool IsFromSystemHeader);
 
   ClassTemplateRecord *
   addClassTemplate(APIRecord *Parent, StringRef Name, StringRef USR,
-                   PresumedLoc Loc, const AvailabilityInfo &Availability,
+                   PresumedLoc Loc, AvailabilityInfo Availability,
                    const DocComment &Comment, DeclarationFragments Declaration,
                    DeclarationFragments SubHeading, Template Template,
                    AccessControl Access, bool IsFromSystemHeader);
 
   ClassTemplateSpecializationRecord *addClassTemplateSpecialization(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       AccessControl Access, bool IsFromSystemHeader);
 
   ClassTemplatePartialSpecializationRecord *
   addClassTemplatePartialSpecialization(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       Template Template, AccessControl Access, bool IsFromSystemHeader);
 
   GlobalVariableTemplateSpecializationRecord *
   addGlobalVariableTemplateSpecialization(
       StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
   GlobalVariableTemplatePartialSpecializationRecord *
   addGlobalVariableTemplatePartialSpecialization(
       StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, LinkageInfo Linkage,
+      AvailabilityInfo Availability, LinkageInfo Linkage,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading, Template Template,
       bool IsFromSystemHeader);
 
   CXXMethodRecord *addCXXInstanceMethod(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader);
 
   CXXMethodRecord *addCXXStaticMethod(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader);
 
   CXXMethodRecord *addCXXSpecialMethod(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader);
 
   CXXMethodTemplateRecord *addCXXMethodTemplate(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access, Template Template,
       bool IsFromSystemHeader);
 
   CXXMethodTemplateSpecializationRecord *addCXXMethodTemplateSpec(
       APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-      const AvailabilityInfo &Availability, const DocComment &Comment,
+      AvailabilityInfo Availability, const DocComment &Comment,
       DeclarationFragments Declaration, DeclarationFragments SubHeading,
       FunctionSignature Signature, AccessControl Access,
       bool IsFromSystemHeader);
 
   ConceptRecord *addConcept(StringRef Name, StringRef USR, PresumedLoc Loc,
-                            const AvailabilityInfo &Availability,
+                            AvailabilityInfo Availability,
                             const DocComment &Comment,
                             DeclarationFragments Declaration,
                             DeclarationFragments SubHeading, Template Template,
@@ -1393,7 +1393,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCCategoryRecord *
   addObjCCategory(StringRef Name, StringRef USR, PresumedLoc Loc,
-                  const AvailabilityInfo &Availability,
+                  AvailabilityInfo Availability,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, SymbolReference Interface,
                   bool IsFromSystemHeader, bool IsFromExternalModule);
@@ -1406,7 +1406,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCInterfaceRecord *
   addObjCInterface(StringRef Name, StringRef USR, PresumedLoc Loc,
-                   const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                   AvailabilityInfo Availability, LinkageInfo Linkage,
                    const DocComment &Comment, DeclarationFragments Declaration,
                    DeclarationFragments SubHeading, SymbolReference SuperClass,
                    bool IsFromSystemHeader);
@@ -1419,7 +1419,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCMethodRecord *
   addObjCMethod(ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-                PresumedLoc Loc, const AvailabilityInfo &Availability,
+                PresumedLoc Loc, AvailabilityInfo Availability,
                 const DocComment &Comment, DeclarationFragments Declaration,
                 DeclarationFragments SubHeading, FunctionSignature Signature,
                 bool IsInstanceMethod, bool IsFromSystemHeader);
@@ -1432,7 +1432,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCPropertyRecord *
   addObjCProperty(ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-                  PresumedLoc Loc, const AvailabilityInfo &Availability,
+                  PresumedLoc Loc, AvailabilityInfo Availability,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading,
                   ObjCPropertyRecord::AttributeKind Attributes,
@@ -1447,7 +1447,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCInstanceVariableRecord *addObjCInstanceVariable(
       ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-      PresumedLoc Loc, const AvailabilityInfo &Availability,
+      PresumedLoc Loc, AvailabilityInfo Availability,
       const DocComment &Comment, DeclarationFragments Declaration,
       DeclarationFragments SubHeading,
       ObjCInstanceVariableRecord::AccessControl Access,
@@ -1461,7 +1461,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   ObjCProtocolRecord *
   addObjCProtocol(StringRef Name, StringRef USR, PresumedLoc Loc,
-                  const AvailabilityInfo &Availability,
+                  AvailabilityInfo Availability,
                   const DocComment &Comment, DeclarationFragments Declaration,
                   DeclarationFragments SubHeading, bool IsFromSystemHeader);
 
@@ -1486,7 +1486,7 @@ public:
   /// to generate the USR for \c D and keep it alive in APISet.
   TypedefRecord *
   addTypedef(StringRef Name, StringRef USR, PresumedLoc Loc,
-             const AvailabilityInfo &Availability, const DocComment &Comment,
+             AvailabilityInfo Availability, const DocComment &Comment,
              DeclarationFragments Declaration, DeclarationFragments SubHeading,
              SymbolReference UnderlyingType, bool IsFromSystemHeader);
 

--- a/clang/include/clang/ExtractAPI/AvailabilityInfo.h
+++ b/clang/include/clang/ExtractAPI/AvailabilityInfo.h
@@ -19,8 +19,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/raw_ostream.h"
-
-using llvm::VersionTuple;
+#include <vector>
 
 namespace clang {
 namespace extractapi {
@@ -58,7 +57,8 @@ struct AvailabilityInfo {
   friend bool operator==(const AvailabilityInfo &Lhs,
                          const AvailabilityInfo &Rhs);
 
-  AvailabilityInfo(const Decl *Decl);
+public:
+  static AvailabilityInfo createFromDecl(const Decl *Decl);
 };
 
 inline bool operator==(const AvailabilityInfo &Lhs,

--- a/clang/include/clang/ExtractAPI/AvailabilityInfo.h
+++ b/clang/include/clang/ExtractAPI/AvailabilityInfo.h
@@ -16,7 +16,6 @@
 #define LLVM_CLANG_EXTRACTAPI_AVAILABILITY_INFO_H
 
 #include "clang/AST/Decl.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/raw_ostream.h"
@@ -26,46 +25,24 @@ using llvm::VersionTuple;
 namespace clang {
 namespace extractapi {
 
-/// Stores availability attributes of a symbol in a given domain.
+/// Stores availability attributes of a symbol.
 struct AvailabilityInfo {
   /// The domain for which this availability info item applies
   std::string Domain;
   VersionTuple Introduced;
   VersionTuple Deprecated;
   VersionTuple Obsoleted;
-  bool Unavailable;
-
-  AvailabilityInfo() = default;
-
-  AvailabilityInfo(StringRef Domain, VersionTuple I, VersionTuple D,
-                   VersionTuple O, bool U)
-      : Domain(Domain), Introduced(I), Deprecated(D), Obsoleted(O),
-        Unavailable(U) {}
-};
-
-class AvailabilitySet {
-private:
-  using AvailabilityList = llvm::SmallVector<AvailabilityInfo, 4>;
-  AvailabilityList Availabilities;
-
   bool UnconditionallyDeprecated = false;
   bool UnconditionallyUnavailable = false;
 
-public:
-  AvailabilitySet(const Decl *Decl);
-  AvailabilitySet() = default;
+  AvailabilityInfo() = default;
 
-  AvailabilityList::const_iterator begin() const {
-    return Availabilities.begin();
-  }
-
-  AvailabilityList::const_iterator end() const { return Availabilities.end(); }
-
+  /// Determine if this AvailabilityInfo represents the default availability.
+  bool isDefault() const { return *this == AvailabilityInfo(); }
   /// Check if the symbol is unconditionally deprecated.
   ///
   /// i.e. \code __attribute__((deprecated)) \endcode
   bool isUnconditionallyDeprecated() const { return UnconditionallyDeprecated; }
-
   /// Check if the symbol is unconditionally unavailable.
   ///
   /// i.e. \code __attribute__((unavailable)) \endcode
@@ -73,9 +50,26 @@ public:
     return UnconditionallyUnavailable;
   }
 
-  /// Determine if this AvailabilitySet represents default availability.
-  bool isDefault() const { return Availabilities.empty(); }
+  AvailabilityInfo(StringRef Domain, VersionTuple I, VersionTuple D,
+                   VersionTuple O, bool UD, bool UU)
+      : Domain(Domain), Introduced(I), Deprecated(D), Obsoleted(O),
+        UnconditionallyDeprecated(UD), UnconditionallyUnavailable(UU) {}
+
+  friend bool operator==(const AvailabilityInfo &Lhs,
+                         const AvailabilityInfo &Rhs);
+
+  AvailabilityInfo(const Decl *Decl);
 };
+
+inline bool operator==(const AvailabilityInfo &Lhs,
+                       const AvailabilityInfo &Rhs) {
+  return std::tie(Lhs.Introduced, Lhs.Deprecated, Lhs.Obsoleted,
+                  Lhs.UnconditionallyDeprecated,
+                  Lhs.UnconditionallyUnavailable) ==
+         std::tie(Rhs.Introduced, Rhs.Deprecated, Rhs.Obsoleted,
+                  Rhs.UnconditionallyDeprecated,
+                  Rhs.UnconditionallyUnavailable);
+}
 
 } // namespace extractapi
 } // namespace clang

--- a/clang/include/clang/ExtractAPI/AvailabilityInfo.h
+++ b/clang/include/clang/ExtractAPI/AvailabilityInfo.h
@@ -19,7 +19,6 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/raw_ostream.h"
-#include <vector>
 
 namespace clang {
 namespace extractapi {

--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -18,6 +18,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/Specifiers.h"
+#include "clang/ExtractAPI/AvailabilityInfo.h"
 #include "clang/ExtractAPI/DeclarationFragments.h"
 #include "llvm/ADT/FunctionExtras.h"
 
@@ -263,7 +264,6 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarDecl(const VarDecl *Decl) {
       DeclarationFragmentsBuilder::getFragmentsForVar(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
   if (Decl->isStaticDataMember()) {
     SymbolReference Context;
     // getDeclContext() should return a RecordDecl since we
@@ -272,13 +272,14 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarDecl(const VarDecl *Decl) {
     Context.Name = Record->getName();
     Context.USR = API.recordUSR(Record);
     auto Access = DeclarationFragmentsBuilder::getAccessControl(Decl);
-    API.addStaticField(Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment,
-                       Declaration, SubHeading, Context, Access,
-                       isInSystemHeader(Decl));
+    API.addStaticField(Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+                       Linkage, Comment, Declaration, SubHeading, Context,
+                       Access, isInSystemHeader(Decl));
   } else
     // Add the global variable record to the API set.
-    API.addGlobalVar(Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment,
-                     Declaration, SubHeading, isInSystemHeader(Decl));
+    API.addGlobalVar(Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+                     Linkage, Comment, Declaration, SubHeading,
+                     isInSystemHeader(Decl));
   return true;
 }
 
@@ -333,19 +334,19 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionDecl(
       DeclarationFragmentsBuilder::getSubHeading(Decl);
   FunctionSignature Signature =
       DeclarationFragmentsBuilder::getFunctionSignature(Decl);
-
   if (Decl->getTemplateSpecializationInfo())
     API.addGlobalFunctionTemplateSpecialization(
-        Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment,
+        Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage,
+        Comment,
         DeclarationFragmentsBuilder::
             getFragmentsForFunctionTemplateSpecialization(Decl),
         SubHeading, Signature, isInSystemHeader(Decl));
   else
     // Add the function record to the API set.
     API.addGlobalFunction(
-        Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment,
-        DeclarationFragmentsBuilder::getFragmentsForFunction(Decl), SubHeading,
-        Signature, isInSystemHeader(Decl));
+        Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage,
+        Comment, DeclarationFragmentsBuilder::getFragmentsForFunction(Decl),
+        SubHeading, Signature, isInSystemHeader(Decl));
   return true;
 }
 
@@ -379,10 +380,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitEnumDecl(const EnumDecl *Decl) {
       DeclarationFragmentsBuilder::getFragmentsForEnum(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
-  EnumRecord *EnumRecord =
-      API.addEnum(API.copyString(Name), USR, Loc, AvailabilityInfo(Decl),
-                  Comment, Declaration, SubHeading, isInSystemHeader(Decl));
+  EnumRecord *EnumRecord = API.addEnum(
+      API.copyString(Name), USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+      Comment, Declaration, SubHeading, isInSystemHeader(Decl));
 
   // Now collect information about the enumerators in this enum.
   getDerivedExtractAPIVisitor().recordEnumConstants(EnumRecord,
@@ -496,8 +496,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitNamespaceDecl(
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
   APIRecord *Parent = determineParentRecord(Decl->getDeclContext());
-  API.addNamespace(Parent, Name, USR, Loc, AvailabilityInfo(Decl), Linkage,
-                   Comment, Declaration, SubHeading, isInSystemHeader(Decl));
+  API.addNamespace(Parent, Name, USR, Loc,
+                   AvailabilityInfo::createFromDecl(Decl), Linkage, Comment,
+                   Declaration, SubHeading, isInSystemHeader(Decl));
 
   return true;
 }
@@ -527,10 +528,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitRecordDecl(const RecordDecl *Decl) {
       DeclarationFragmentsBuilder::getFragmentsForStruct(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
   StructRecord *StructRecord =
-      API.addStruct(Name, USR, Loc, AvailabilityInfo(Decl), Comment,
-                    Declaration, SubHeading, isInSystemHeader(Decl));
+      API.addStruct(Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+                    Comment, Declaration, SubHeading, isInSystemHeader(Decl));
 
   // Now collect information about the fields in this struct.
   getDerivedExtractAPIVisitor().recordStructFields(StructRecord,
@@ -578,13 +578,13 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXRecordDecl(
         DeclarationFragmentsBuilder::getFragmentsForRedeclarableTemplate(
             Decl->getDescribedClassTemplate()));
     CXXClassRecord = API.addClassTemplate(
-        Parent, Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration,
-        SubHeading, Template(Decl->getDescribedClassTemplate()), Access,
-        isInSystemHeader(Decl));
+        Parent, Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
+        Declaration, SubHeading, Template(Decl->getDescribedClassTemplate()),
+        Access, isInSystemHeader(Decl));
   } else
     CXXClassRecord = API.addCXXClass(
-        Parent, Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration,
-        SubHeading, Kind, Access, isInSystemHeader(Decl));
+        Parent, Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
+        Declaration, SubHeading, Kind, Access, isInSystemHeader(Decl));
 
   CXXClassRecord->Bases = getBases(Decl);
 
@@ -624,7 +624,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
     FunctionTemplateDecl *TemplateDecl = Decl->getDescribedFunctionTemplate();
     API.addCXXMethodTemplate(
         API.findRecordForUSR(ParentUSR), Decl->getName(), USR, Loc,
-        AvailabilityInfo(Decl), Comment,
+        AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForFunctionTemplate(
             TemplateDecl),
         SubHeading, DeclarationFragmentsBuilder::getFunctionSignature(Decl),
@@ -632,24 +632,27 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
         Template(TemplateDecl), isInSystemHeader(Decl));
   } else if (Decl->getTemplateSpecializationInfo())
     API.addCXXMethodTemplateSpec(
-        Parent, Decl->getName(), USR, Loc, AvailabilityInfo(Decl), Comment,
+        Parent, Decl->getName(), USR, Loc,
+        AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::
             getFragmentsForFunctionTemplateSpecialization(Decl),
         SubHeading, Signature, Access, isInSystemHeader(Decl));
   else if (Decl->isOverloadedOperator())
     API.addCXXInstanceMethod(
         Parent, API.copyString(Decl->getNameAsString()), USR, Loc,
-        AvailabilityInfo(Decl), Comment,
+        AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForOverloadedOperator(Decl),
         SubHeading, Signature, Access, isInSystemHeader(Decl));
   else if (Decl->isStatic())
     API.addCXXStaticMethod(
-        Parent, Decl->getName(), USR, Loc, AvailabilityInfo(Decl), Comment,
+        Parent, Decl->getName(), USR, Loc,
+        AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForCXXMethod(Decl), SubHeading,
         Signature, Access, isInSystemHeader(Decl));
   else
     API.addCXXInstanceMethod(
-        Parent, Decl->getName(), USR, Loc, AvailabilityInfo(Decl), Comment,
+        Parent, Decl->getName(), USR, Loc,
+        AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForCXXMethod(Decl), SubHeading,
         Signature, Access, isInSystemHeader(Decl));
 
@@ -678,13 +681,12 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXConstructorDecl(
   FunctionSignature Signature =
       DeclarationFragmentsBuilder::getFunctionSignature(Decl);
   AccessControl Access = DeclarationFragmentsBuilder::getAccessControl(Decl);
-
   SmallString<128> ParentUSR;
   index::generateUSRForDecl(dyn_cast<CXXRecordDecl>(Decl->getDeclContext()),
                             ParentUSR);
   API.addCXXInstanceMethod(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                           AvailabilityInfo(Decl), Comment, Declaration,
-                           SubHeading, Signature, Access,
+                           AvailabilityInfo::createFromDecl(Decl), Comment,
+                           Declaration, SubHeading, Signature, Access,
                            isInSystemHeader(Decl));
   return true;
 }
@@ -711,13 +713,12 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXDestructorDecl(
   FunctionSignature Signature =
       DeclarationFragmentsBuilder::getFunctionSignature(Decl);
   AccessControl Access = DeclarationFragmentsBuilder::getAccessControl(Decl);
-
   SmallString<128> ParentUSR;
   index::generateUSRForDecl(dyn_cast<CXXRecordDecl>(Decl->getDeclContext()),
                             ParentUSR);
   API.addCXXInstanceMethod(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                           AvailabilityInfo(Decl), Comment, Declaration,
-                           SubHeading, Signature, Access,
+                           AvailabilityInfo::createFromDecl(Decl), Comment,
+                           Declaration, SubHeading, Signature, Access,
                            isInSystemHeader(Decl));
   return true;
 }
@@ -740,8 +741,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitConceptDecl(const ConceptDecl *Decl) {
       DeclarationFragmentsBuilder::getFragmentsForConcept(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-  API.addConcept(Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration,
-                 SubHeading, Template(Decl), isInSystemHeader(Decl));
+  API.addConcept(Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+                 Comment, Declaration, SubHeading, Template(Decl),
+                 isInSystemHeader(Decl));
   return true;
 }
 
@@ -768,8 +770,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitClassTemplateSpecializationDecl(
 
   APIRecord *Parent = determineParentRecord(Decl->getDeclContext());
   auto *ClassTemplateSpecializationRecord = API.addClassTemplateSpecialization(
-      Parent, Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration,
-      SubHeading, DeclarationFragmentsBuilder::getAccessControl(Decl),
+      Parent, Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
+      Declaration, SubHeading,
+      DeclarationFragmentsBuilder::getAccessControl(Decl),
       isInSystemHeader(Decl));
 
   ClassTemplateSpecializationRecord->Bases = getBases(Decl);
@@ -797,12 +800,11 @@ bool ExtractAPIVisitorBase<Derived>::
       getFragmentsForClassTemplatePartialSpecialization(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
   APIRecord *Parent = determineParentRecord(Decl->getDeclContext());
   auto *ClassTemplatePartialSpecRecord =
       API.addClassTemplatePartialSpecialization(
-          Parent, Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration,
-          SubHeading, Template(Decl),
+          Parent, Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+          Comment, Declaration, SubHeading, Template(Decl),
           DeclarationFragmentsBuilder::getAccessControl(Decl),
           isInSystemHeader(Decl));
 
@@ -845,12 +847,13 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplateDecl(
                             ParentUSR);
   if (Decl->getDeclContext()->getDeclKind() == Decl::CXXRecord)
     API.addCXXFieldTemplate(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                            AvailabilityInfo(Decl), Comment, Declaration,
-                            SubHeading,
+                            AvailabilityInfo::createFromDecl(Decl), Comment,
+                            Declaration, SubHeading,
                             DeclarationFragmentsBuilder::getAccessControl(Decl),
                             Template(Decl), isInSystemHeader(Decl));
   else
-    API.addGlobalVariableTemplate(Name, USR, Loc, AvailabilityInfo(Decl),
+    API.addGlobalVariableTemplate(Name, USR, Loc,
+                                  AvailabilityInfo::createFromDecl(Decl),
                                   Linkage, Comment, Declaration, SubHeading,
                                   Template(Decl), isInSystemHeader(Decl));
   return true;
@@ -880,10 +883,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplateSpecializationDecl(
           Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
   API.addGlobalVariableTemplateSpecialization(
-      Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment, Declaration,
-      SubHeading, isInSystemHeader(Decl));
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage, Comment,
+      Declaration, SubHeading, isInSystemHeader(Decl));
   return true;
 }
 
@@ -910,10 +912,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplatePartialSpecializationDecl(
       getFragmentsForVarTemplatePartialSpecialization(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
-
   API.addGlobalVariableTemplatePartialSpecialization(
-      Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment, Declaration,
-      SubHeading, Template(Decl), isInSystemHeader(Decl));
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage, Comment,
+      Declaration, SubHeading, Template(Decl), isInSystemHeader(Decl));
   return true;
 }
 
@@ -942,9 +943,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionTemplateDecl(
   FunctionSignature Signature =
       DeclarationFragmentsBuilder::getFunctionSignature(
           Decl->getTemplatedDecl());
-
   API.addGlobalFunctionTemplate(
-      Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment,
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage, Comment,
       DeclarationFragmentsBuilder::getFragmentsForFunctionTemplate(Decl),
       SubHeading, Signature, Template(Decl), isInSystemHeader(Decl));
 
@@ -983,8 +983,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCInterfaceDecl(
   }
 
   ObjCInterfaceRecord *ObjCInterfaceRecord = API.addObjCInterface(
-      Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment, Declaration,
-      SubHeading, SuperClass, isInSystemHeader(Decl));
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage, Comment,
+      Declaration, SubHeading, SuperClass, isInSystemHeader(Decl));
 
   // Record all methods (selectors). This doesn't include automatically
   // synthesized property methods.
@@ -1023,9 +1023,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCProtocolDecl(
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
 
-  ObjCProtocolRecord *ObjCProtocolRecord =
-      API.addObjCProtocol(Name, USR, Loc, AvailabilityInfo(Decl), Comment,
-                          Declaration, SubHeading, isInSystemHeader(Decl));
+  ObjCProtocolRecord *ObjCProtocolRecord = API.addObjCProtocol(
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
+      Declaration, SubHeading, isInSystemHeader(Decl));
 
   getDerivedExtractAPIVisitor().recordObjCMethods(ObjCProtocolRecord,
                                                   Decl->methods());
@@ -1080,7 +1080,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitTypedefNameDecl(
       TypedefUnderlyingTypeResolver(Context).getSymbolReferenceForType(Type,
                                                                        API);
 
-  API.addTypedef(Name, USR, Loc, AvailabilityInfo(Decl), Comment,
+  API.addTypedef(Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl),
+                 Comment,
                  DeclarationFragmentsBuilder::getFragmentsForTypedef(Decl),
                  DeclarationFragmentsBuilder::getSubHeading(Decl), SymRef,
                  isInSystemHeader(Decl));
@@ -1122,8 +1123,9 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCCategoryDecl(
   }
 
   ObjCCategoryRecord *ObjCCategoryRecord = API.addObjCCategory(
-      Name, USR, Loc, AvailabilityInfo(Decl), Comment, Declaration, SubHeading,
-      Interface, isInSystemHeader(Decl), IsFromExternalModule);
+      Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
+      Declaration, SubHeading, Interface, isInSystemHeader(Decl),
+      IsFromExternalModule);
 
   getDerivedExtractAPIVisitor().recordObjCMethods(ObjCCategoryRecord,
                                                   Decl->methods());
@@ -1160,9 +1162,9 @@ void ExtractAPIVisitorBase<Derived>::recordEnumConstants(
     DeclarationFragments SubHeading =
         DeclarationFragmentsBuilder::getSubHeading(Constant);
 
-    API.addEnumConstant(EnumRecord, Name, USR, Loc, AvailabilityInfo(Constant),
-                        Comment, Declaration, SubHeading,
-                        isInSystemHeader(Constant));
+    API.addEnumConstant(EnumRecord, Name, USR, Loc,
+                        AvailabilityInfo::createFromDecl(Constant), Comment,
+                        Declaration, SubHeading, isInSystemHeader(Constant));
   }
 }
 
@@ -1189,9 +1191,9 @@ void ExtractAPIVisitorBase<Derived>::recordStructFields(
     DeclarationFragments SubHeading =
         DeclarationFragmentsBuilder::getSubHeading(Field);
 
-    API.addStructField(StructRecord, Name, USR, Loc, AvailabilityInfo(Field),
-                       Comment, Declaration, SubHeading,
-                       isInSystemHeader(Field));
+    API.addStructField(StructRecord, Name, USR, Loc,
+                       AvailabilityInfo::createFromDecl(Field), Comment,
+                       Declaration, SubHeading, isInSystemHeader(Field));
   }
 }
 
@@ -1223,8 +1225,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitFieldDecl(const FieldDecl *Decl) {
   index::generateUSRForDecl(dyn_cast<CXXRecordDecl>(Decl->getDeclContext()),
                             ParentUSR);
   API.addCXXField(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                  AvailabilityInfo(Decl), Comment, Declaration, SubHeading,
-                  Access, isInSystemHeader(Decl));
+                  AvailabilityInfo::createFromDecl(Decl), Comment, Declaration,
+                  SubHeading, Access, isInSystemHeader(Decl));
   return true;
 }
 
@@ -1255,13 +1257,13 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXConversionDecl(
                             ParentUSR);
   if (Decl->isStatic())
     API.addCXXStaticMethod(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                           AvailabilityInfo(Decl), Comment, Declaration,
-                           SubHeading, Signature, Access,
+                           AvailabilityInfo::createFromDecl(Decl), Comment,
+                           Declaration, SubHeading, Signature, Access,
                            isInSystemHeader(Decl));
   else
     API.addCXXInstanceMethod(API.findRecordForUSR(ParentUSR), Name, USR, Loc,
-                             AvailabilityInfo(Decl), Comment, Declaration,
-                             SubHeading, Signature, Access,
+                             AvailabilityInfo::createFromDecl(Decl), Comment,
+                             Declaration, SubHeading, Signature, Access,
                              isInSystemHeader(Decl));
   return true;
 }
@@ -1295,8 +1297,9 @@ void ExtractAPIVisitorBase<Derived>::recordObjCMethods(
     FunctionSignature Signature =
         DeclarationFragmentsBuilder::getFunctionSignature(Method);
 
-    API.addObjCMethod(Container, Name, USR, Loc, AvailabilityInfo(Method),
-                      Comment, Declaration, SubHeading, Signature,
+    API.addObjCMethod(Container, Name, USR, Loc,
+                      AvailabilityInfo::createFromDecl(Method), Comment,
+                      Declaration, SubHeading, Signature,
                       Method->isInstanceMethod(), isInSystemHeader(Method));
   }
 }
@@ -1334,8 +1337,8 @@ void ExtractAPIVisitorBase<Derived>::recordObjCProperties(
       Attributes |= ObjCPropertyRecord::ReadOnly;
 
     API.addObjCProperty(
-        Container, Name, USR, Loc, AvailabilityInfo(Property), Comment,
-        Declaration, SubHeading,
+        Container, Name, USR, Loc, AvailabilityInfo::createFromDecl(Property),
+        Comment, Declaration, SubHeading,
         static_cast<ObjCPropertyRecord::AttributeKind>(Attributes), GetterName,
         SetterName, Property->isOptional(),
         !(Property->getPropertyAttributes() &
@@ -1370,9 +1373,9 @@ void ExtractAPIVisitorBase<Derived>::recordObjCInstanceVariables(
     ObjCInstanceVariableRecord::AccessControl Access =
         Ivar->getCanonicalAccessControl();
 
-    API.addObjCInstanceVariable(Container, Name, USR, Loc,
-                                AvailabilityInfo(Ivar), Comment, Declaration,
-                                SubHeading, Access, isInSystemHeader(Ivar));
+    API.addObjCInstanceVariable(
+        Container, Name, USR, Loc, AvailabilityInfo::createFromDecl(Ivar),
+        Comment, Declaration, SubHeading, Access, isInSystemHeader(Ivar));
   }
 }
 

--- a/clang/lib/ExtractAPI/API.cpp
+++ b/clang/lib/ExtractAPI/API.cpp
@@ -45,7 +45,7 @@ RecordTy *addTopLevelRecord(DenseMap<StringRef, APIRecord *> &USRLookupTable,
 
 NamespaceRecord *
 APISet::addNamespace(APIRecord *Parent, StringRef Name, StringRef USR,
-                     PresumedLoc Loc, const AvailabilityInfo &Availability,
+                     PresumedLoc Loc, AvailabilityInfo Availability,
                      LinkageInfo Linkage, const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader) {
@@ -61,17 +61,17 @@ APISet::addNamespace(APIRecord *Parent, StringRef Name, StringRef USR,
 
 GlobalVariableRecord *
 APISet::addGlobalVar(StringRef Name, StringRef USR, PresumedLoc Loc,
-                     const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                     AvailabilityInfo Availability, LinkageInfo Linkage,
                      const DocComment &Comment, DeclarationFragments Fragments,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, GlobalVariables, USR, Name, Loc,
-                           Availability, Linkage, Comment, Fragments,
+                           std::move(Availability), Linkage, Comment, Fragments,
                            SubHeading, IsFromSystemHeader);
 }
 
 GlobalVariableTemplateRecord *APISet::addGlobalVariableTemplate(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, Template Template,
     bool IsFromSystemHeader) {
@@ -83,18 +83,18 @@ GlobalVariableTemplateRecord *APISet::addGlobalVariableTemplate(
 
 GlobalFunctionRecord *APISet::addGlobalFunction(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Fragments,
     DeclarationFragments SubHeading, FunctionSignature Signature,
     bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, GlobalFunctions, USR, Name, Loc,
-                           Availability, Linkage, Comment, Fragments,
+                           std::move(Availability), Linkage, Comment, Fragments,
                            SubHeading, Signature, IsFromSystemHeader);
 }
 
 GlobalFunctionTemplateRecord *APISet::addGlobalFunctionTemplate(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, FunctionSignature Signature,
     Template Template, bool IsFromSystemHeader) {
@@ -107,7 +107,7 @@ GlobalFunctionTemplateRecord *APISet::addGlobalFunctionTemplate(
 GlobalFunctionTemplateSpecializationRecord *
 APISet::addGlobalFunctionTemplateSpecialization(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, FunctionSignature Signature,
     bool IsFromSystemHeader) {
@@ -119,11 +119,11 @@ APISet::addGlobalFunctionTemplateSpecialization(
 
 EnumConstantRecord *APISet::addEnumConstant(
     EnumRecord *Enum, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     bool IsFromSystemHeader) {
   auto Record = std::make_unique<EnumConstantRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+      USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
       IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Enum->USR, Enum->Name, Enum->getKind(), Enum);
@@ -132,25 +132,25 @@ EnumConstantRecord *APISet::addEnumConstant(
 }
 
 EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
-                            const AvailabilityInfo &Availability,
+                            AvailabilityInfo Availability,
                             const DocComment &Comment,
                             DeclarationFragments Declaration,
                             DeclarationFragments SubHeading,
                             bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Enums, USR, Name, Loc,
-                           Availability, Comment, Declaration, SubHeading,
+                           std::move(Availability), Comment, Declaration, SubHeading,
                            IsFromSystemHeader);
 }
 
 StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
                                           StringRef USR, PresumedLoc Loc,
-                                          const AvailabilityInfo &Availability,
+                                          AvailabilityInfo Availability,
                                           const DocComment &Comment,
                                           DeclarationFragments Declaration,
                                           DeclarationFragments SubHeading,
                                           bool IsFromSystemHeader) {
   auto Record = std::make_unique<StructFieldRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+      USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
       IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Struct->USR, Struct->Name, Struct->getKind(), Struct);
@@ -159,36 +159,36 @@ StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
 }
 
 StructRecord *APISet::addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
-                                const AvailabilityInfo &Availability,
+                                AvailabilityInfo Availability,
                                 const DocComment &Comment,
                                 DeclarationFragments Declaration,
                                 DeclarationFragments SubHeading,
                                 bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Structs, USR, Name, Loc,
-                           Availability, Comment, Declaration, SubHeading,
+                           std::move(Availability), Comment, Declaration, SubHeading,
                            IsFromSystemHeader);
 }
 
 StaticFieldRecord *
 APISet::addStaticField(StringRef Name, StringRef USR, PresumedLoc Loc,
-                       const AvailabilityInfo &Availability,
+                       AvailabilityInfo Availability,
                        LinkageInfo Linkage, const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, SymbolReference Context,
                        AccessControl Access, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, StaticFields, USR, Name, Loc,
-                           Availability, Linkage, Comment, Declaration,
+                           std::move(Availability), Linkage, Comment, Declaration,
                            SubHeading, Context, Access, IsFromSystemHeader);
 }
 
 CXXFieldRecord *
 APISet::addCXXField(APIRecord *CXXClass, StringRef Name, StringRef USR,
-                    PresumedLoc Loc, const AvailabilityInfo &Availability,
+                    PresumedLoc Loc, AvailabilityInfo Availability,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, AccessControl Access,
                     bool IsFromSystemHeader) {
   auto *Record = addTopLevelRecord(USRBasedLookupTable, CXXFields, USR, Name,
-                                   Loc, Availability, Comment, Declaration,
+                                   Loc, std::move(Availability), Comment, Declaration,
                                    SubHeading, Access, IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       CXXClass->USR, CXXClass->Name, CXXClass->getKind(), CXXClass);
@@ -197,7 +197,7 @@ APISet::addCXXField(APIRecord *CXXClass, StringRef Name, StringRef USR,
 
 CXXFieldTemplateRecord *APISet::addCXXFieldTemplate(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     AccessControl Access, Template Template, bool IsFromSystemHeader) {
   auto *Record =
@@ -212,12 +212,12 @@ CXXFieldTemplateRecord *APISet::addCXXFieldTemplate(
 
 CXXClassRecord *
 APISet::addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
-                    PresumedLoc Loc, const AvailabilityInfo &Availability,
+                    PresumedLoc Loc, AvailabilityInfo Availability,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, APIRecord::RecordKind Kind,
                     AccessControl Access, bool IsFromSystemHeader) {
   auto *Record = addTopLevelRecord(
-      USRBasedLookupTable, CXXClasses, USR, Name, Loc, Availability, Comment,
+      USRBasedLookupTable, CXXClasses, USR, Name, Loc, std::move(Availability), Comment,
       Declaration, SubHeading, Kind, Access, IsFromSystemHeader);
   if (Parent)
     Record->ParentInformation = APIRecord::HierarchyInformation(
@@ -227,7 +227,7 @@ APISet::addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
 
 ClassTemplateRecord *APISet::addClassTemplate(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     Template Template, AccessControl Access, bool IsFromSystemHeader) {
   auto *Record =
@@ -242,7 +242,7 @@ ClassTemplateRecord *APISet::addClassTemplate(
 
 ClassTemplateSpecializationRecord *APISet::addClassTemplateSpecialization(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     AccessControl Access, bool IsFromSystemHeader) {
   auto *Record =
@@ -258,7 +258,7 @@ ClassTemplateSpecializationRecord *APISet::addClassTemplateSpecialization(
 ClassTemplatePartialSpecializationRecord *
 APISet::addClassTemplatePartialSpecialization(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     Template Template, AccessControl Access, bool IsFromSystemHeader) {
   auto *Record = addTopLevelRecord(
@@ -274,7 +274,7 @@ APISet::addClassTemplatePartialSpecialization(
 GlobalVariableTemplateSpecializationRecord *
 APISet::addGlobalVariableTemplateSpecialization(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable,
@@ -286,7 +286,7 @@ APISet::addGlobalVariableTemplateSpecialization(
 GlobalVariableTemplatePartialSpecializationRecord *
 APISet::addGlobalVariableTemplatePartialSpecialization(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilityInfo Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, Template Template,
     bool IsFromSystemHeader) {
@@ -298,7 +298,7 @@ APISet::addGlobalVariableTemplatePartialSpecialization(
 
 ConceptRecord *APISet::addConcept(StringRef Name, StringRef USR,
                                   PresumedLoc Loc,
-                                  const AvailabilityInfo &Availability,
+                                  AvailabilityInfo Availability,
                                   const DocComment &Comment,
                                   DeclarationFragments Declaration,
                                   DeclarationFragments SubHeading,
@@ -310,7 +310,7 @@ ConceptRecord *APISet::addConcept(StringRef Name, StringRef USR,
 
 CXXMethodRecord *APISet::addCXXInstanceMethod(
     APIRecord *CXXClassRecord, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
     bool IsFromSystemHeader) {
@@ -327,7 +327,7 @@ CXXMethodRecord *APISet::addCXXInstanceMethod(
 
 CXXMethodRecord *APISet::addCXXStaticMethod(
     APIRecord *CXXClassRecord, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
     bool IsFromSystemHeader) {
@@ -344,7 +344,7 @@ CXXMethodRecord *APISet::addCXXStaticMethod(
 
 CXXMethodTemplateRecord *APISet::addCXXMethodTemplate(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access, Template Template,
     bool IsFromSystemHeader) {
@@ -360,7 +360,7 @@ CXXMethodTemplateRecord *APISet::addCXXMethodTemplate(
 
 CXXMethodTemplateSpecializationRecord *APISet::addCXXMethodTemplateSpec(
     APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
     bool IsFromSystemHeader) {
@@ -377,13 +377,13 @@ CXXMethodTemplateSpecializationRecord *APISet::addCXXMethodTemplateSpec(
 
 ObjCCategoryRecord *APISet::addObjCCategory(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     SymbolReference Interface, bool IsFromSystemHeader,
     bool IsFromExternalModule) {
   // Create the category record.
   auto *Record = addTopLevelRecord(
-      USRBasedLookupTable, ObjCCategories, USR, Name, Loc, Availability,
+      USRBasedLookupTable, ObjCCategories, USR, Name, Loc, std::move(Availability),
       Comment, Declaration, SubHeading, Interface, IsFromSystemHeader);
 
   Record->IsFromExternalModule = IsFromExternalModule;
@@ -397,30 +397,30 @@ ObjCCategoryRecord *APISet::addObjCCategory(
 
 ObjCInterfaceRecord *
 APISet::addObjCInterface(StringRef Name, StringRef USR, PresumedLoc Loc,
-                         const AvailabilityInfo &Availability,
+                         AvailabilityInfo Availability,
                          LinkageInfo Linkage, const DocComment &Comment,
                          DeclarationFragments Declaration,
                          DeclarationFragments SubHeading,
                          SymbolReference SuperClass, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, ObjCInterfaces, USR, Name, Loc,
-                           Availability, Linkage, Comment, Declaration,
+                           std::move(Availability), Linkage, Comment, Declaration,
                            SubHeading, SuperClass, IsFromSystemHeader);
 }
 
 ObjCMethodRecord *APISet::addObjCMethod(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
+    PresumedLoc Loc, AvailabilityInfo Availability,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, FunctionSignature Signature,
     bool IsInstanceMethod, bool IsFromSystemHeader) {
   std::unique_ptr<ObjCMethodRecord> Record;
   if (IsInstanceMethod)
     Record = std::make_unique<ObjCInstanceMethodRecord>(
-        USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
         Signature, IsFromSystemHeader);
   else
     Record = std::make_unique<ObjCClassMethodRecord>(
-        USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
         Signature, IsFromSystemHeader);
 
   Record->ParentInformation = APIRecord::HierarchyInformation(
@@ -431,7 +431,7 @@ ObjCMethodRecord *APISet::addObjCMethod(
 
 ObjCPropertyRecord *APISet::addObjCProperty(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
+    PresumedLoc Loc, AvailabilityInfo Availability,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading,
     ObjCPropertyRecord::AttributeKind Attributes, StringRef GetterName,
@@ -440,11 +440,11 @@ ObjCPropertyRecord *APISet::addObjCProperty(
   std::unique_ptr<ObjCPropertyRecord> Record;
   if (IsInstanceProperty)
     Record = std::make_unique<ObjCInstancePropertyRecord>(
-        USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
         Attributes, GetterName, SetterName, IsOptional, IsFromSystemHeader);
   else
     Record = std::make_unique<ObjCClassPropertyRecord>(
-        USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
+        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
         Attributes, GetterName, SetterName, IsOptional, IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Container->USR, Container->Name, Container->getKind(), Container);
@@ -454,12 +454,12 @@ ObjCPropertyRecord *APISet::addObjCProperty(
 
 ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
+    PresumedLoc Loc, AvailabilityInfo Availability,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading,
     ObjCInstanceVariableRecord::AccessControl Access, bool IsFromSystemHeader) {
   auto Record = std::make_unique<ObjCInstanceVariableRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading, Access,
+      USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading, Access,
       IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Container->USR, Container->Name, Container->getKind(), Container);
@@ -469,11 +469,11 @@ ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
 
 ObjCProtocolRecord *APISet::addObjCProtocol(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
+    AvailabilityInfo Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, ObjCProtocols, USR, Name, Loc,
-                           Availability, Comment, Declaration, SubHeading,
+                           std::move(Availability), Comment, Declaration, SubHeading,
                            IsFromSystemHeader);
 }
 
@@ -488,12 +488,12 @@ APISet::addMacroDefinition(StringRef Name, StringRef USR, PresumedLoc Loc,
 
 TypedefRecord *
 APISet::addTypedef(StringRef Name, StringRef USR, PresumedLoc Loc,
-                   const AvailabilityInfo &Availability,
+                   AvailabilityInfo Availability,
                    const DocComment &Comment, DeclarationFragments Declaration,
                    DeclarationFragments SubHeading,
                    SymbolReference UnderlyingType, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Typedefs, USR, Name, Loc,
-                           Availability, Comment, Declaration, SubHeading,
+                           std::move(Availability), Comment, Declaration, SubHeading,
                            UnderlyingType, IsFromSystemHeader);
 }
 

--- a/clang/lib/ExtractAPI/API.cpp
+++ b/clang/lib/ExtractAPI/API.cpp
@@ -117,11 +117,13 @@ APISet::addGlobalFunctionTemplateSpecialization(
       Signature, IsFromSystemHeader);
 }
 
-EnumConstantRecord *APISet::addEnumConstant(
-    EnumRecord *Enum, StringRef Name, StringRef USR, PresumedLoc Loc,
-    AvailabilityInfo Availability, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
-    bool IsFromSystemHeader) {
+EnumConstantRecord *APISet::addEnumConstant(EnumRecord *Enum, StringRef Name,
+                                            StringRef USR, PresumedLoc Loc,
+                                            AvailabilityInfo Availability,
+                                            const DocComment &Comment,
+                                            DeclarationFragments Declaration,
+                                            DeclarationFragments SubHeading,
+                                            bool IsFromSystemHeader) {
   auto Record = std::make_unique<EnumConstantRecord>(
       USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
       IsFromSystemHeader);
@@ -138,8 +140,8 @@ EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
                             DeclarationFragments SubHeading,
                             bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Enums, USR, Name, Loc,
-                           std::move(Availability), Comment, Declaration, SubHeading,
-                           IsFromSystemHeader);
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, IsFromSystemHeader);
 }
 
 StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
@@ -165,20 +167,21 @@ StructRecord *APISet::addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
                                 DeclarationFragments SubHeading,
                                 bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Structs, USR, Name, Loc,
-                           std::move(Availability), Comment, Declaration, SubHeading,
-                           IsFromSystemHeader);
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, IsFromSystemHeader);
 }
 
 StaticFieldRecord *
 APISet::addStaticField(StringRef Name, StringRef USR, PresumedLoc Loc,
-                       AvailabilityInfo Availability,
-                       LinkageInfo Linkage, const DocComment &Comment,
+                       AvailabilityInfo Availability, LinkageInfo Linkage,
+                       const DocComment &Comment,
                        DeclarationFragments Declaration,
                        DeclarationFragments SubHeading, SymbolReference Context,
                        AccessControl Access, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, StaticFields, USR, Name, Loc,
-                           std::move(Availability), Linkage, Comment, Declaration,
-                           SubHeading, Context, Access, IsFromSystemHeader);
+                           std::move(Availability), Linkage, Comment,
+                           Declaration, SubHeading, Context, Access,
+                           IsFromSystemHeader);
 }
 
 CXXFieldRecord *
@@ -187,9 +190,9 @@ APISet::addCXXField(APIRecord *CXXClass, StringRef Name, StringRef USR,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, AccessControl Access,
                     bool IsFromSystemHeader) {
-  auto *Record = addTopLevelRecord(USRBasedLookupTable, CXXFields, USR, Name,
-                                   Loc, std::move(Availability), Comment, Declaration,
-                                   SubHeading, Access, IsFromSystemHeader);
+  auto *Record = addTopLevelRecord(
+      USRBasedLookupTable, CXXFields, USR, Name, Loc, std::move(Availability),
+      Comment, Declaration, SubHeading, Access, IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       CXXClass->USR, CXXClass->Name, CXXClass->getKind(), CXXClass);
   return Record;
@@ -217,8 +220,8 @@ APISet::addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
                     DeclarationFragments SubHeading, APIRecord::RecordKind Kind,
                     AccessControl Access, bool IsFromSystemHeader) {
   auto *Record = addTopLevelRecord(
-      USRBasedLookupTable, CXXClasses, USR, Name, Loc, std::move(Availability), Comment,
-      Declaration, SubHeading, Kind, Access, IsFromSystemHeader);
+      USRBasedLookupTable, CXXClasses, USR, Name, Loc, std::move(Availability),
+      Comment, Declaration, SubHeading, Kind, Access, IsFromSystemHeader);
   if (Parent)
     Record->ParentInformation = APIRecord::HierarchyInformation(
         Parent->USR, Parent->Name, Parent->getKind(), Parent);
@@ -382,9 +385,10 @@ ObjCCategoryRecord *APISet::addObjCCategory(
     SymbolReference Interface, bool IsFromSystemHeader,
     bool IsFromExternalModule) {
   // Create the category record.
-  auto *Record = addTopLevelRecord(
-      USRBasedLookupTable, ObjCCategories, USR, Name, Loc, std::move(Availability),
-      Comment, Declaration, SubHeading, Interface, IsFromSystemHeader);
+  auto *Record =
+      addTopLevelRecord(USRBasedLookupTable, ObjCCategories, USR, Name, Loc,
+                        std::move(Availability), Comment, Declaration,
+                        SubHeading, Interface, IsFromSystemHeader);
 
   Record->IsFromExternalModule = IsFromExternalModule;
 
@@ -397,31 +401,32 @@ ObjCCategoryRecord *APISet::addObjCCategory(
 
 ObjCInterfaceRecord *
 APISet::addObjCInterface(StringRef Name, StringRef USR, PresumedLoc Loc,
-                         AvailabilityInfo Availability,
-                         LinkageInfo Linkage, const DocComment &Comment,
+                         AvailabilityInfo Availability, LinkageInfo Linkage,
+                         const DocComment &Comment,
                          DeclarationFragments Declaration,
                          DeclarationFragments SubHeading,
                          SymbolReference SuperClass, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, ObjCInterfaces, USR, Name, Loc,
-                           std::move(Availability), Linkage, Comment, Declaration,
-                           SubHeading, SuperClass, IsFromSystemHeader);
+                           std::move(Availability), Linkage, Comment,
+                           Declaration, SubHeading, SuperClass,
+                           IsFromSystemHeader);
 }
 
 ObjCMethodRecord *APISet::addObjCMethod(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilityInfo Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading, FunctionSignature Signature,
-    bool IsInstanceMethod, bool IsFromSystemHeader) {
+    PresumedLoc Loc, AvailabilityInfo Availability, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
+    FunctionSignature Signature, bool IsInstanceMethod,
+    bool IsFromSystemHeader) {
   std::unique_ptr<ObjCMethodRecord> Record;
   if (IsInstanceMethod)
     Record = std::make_unique<ObjCInstanceMethodRecord>(
-        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
-        Signature, IsFromSystemHeader);
+        USR, Name, Loc, std::move(Availability), Comment, Declaration,
+        SubHeading, Signature, IsFromSystemHeader);
   else
     Record = std::make_unique<ObjCClassMethodRecord>(
-        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
-        Signature, IsFromSystemHeader);
+        USR, Name, Loc, std::move(Availability), Comment, Declaration,
+        SubHeading, Signature, IsFromSystemHeader);
 
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Container->USR, Container->Name, Container->getKind(), Container);
@@ -431,21 +436,22 @@ ObjCMethodRecord *APISet::addObjCMethod(
 
 ObjCPropertyRecord *APISet::addObjCProperty(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilityInfo Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading,
+    PresumedLoc Loc, AvailabilityInfo Availability, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
     ObjCPropertyRecord::AttributeKind Attributes, StringRef GetterName,
     StringRef SetterName, bool IsOptional, bool IsInstanceProperty,
     bool IsFromSystemHeader) {
   std::unique_ptr<ObjCPropertyRecord> Record;
   if (IsInstanceProperty)
     Record = std::make_unique<ObjCInstancePropertyRecord>(
-        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
-        Attributes, GetterName, SetterName, IsOptional, IsFromSystemHeader);
+        USR, Name, Loc, std::move(Availability), Comment, Declaration,
+        SubHeading, Attributes, GetterName, SetterName, IsOptional,
+        IsFromSystemHeader);
   else
     Record = std::make_unique<ObjCClassPropertyRecord>(
-        USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
-        Attributes, GetterName, SetterName, IsOptional, IsFromSystemHeader);
+        USR, Name, Loc, std::move(Availability), Comment, Declaration,
+        SubHeading, Attributes, GetterName, SetterName, IsOptional,
+        IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Container->USR, Container->Name, Container->getKind(), Container);
   USRBasedLookupTable.insert({USR, Record.get()});
@@ -454,27 +460,28 @@ ObjCPropertyRecord *APISet::addObjCProperty(
 
 ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilityInfo Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading,
+    PresumedLoc Loc, AvailabilityInfo Availability, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
     ObjCInstanceVariableRecord::AccessControl Access, bool IsFromSystemHeader) {
   auto Record = std::make_unique<ObjCInstanceVariableRecord>(
-      USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading, Access,
-      IsFromSystemHeader);
+      USR, Name, Loc, std::move(Availability), Comment, Declaration, SubHeading,
+      Access, IsFromSystemHeader);
   Record->ParentInformation = APIRecord::HierarchyInformation(
       Container->USR, Container->Name, Container->getKind(), Container);
   USRBasedLookupTable.insert({USR, Record.get()});
   return Container->Ivars.emplace_back(std::move(Record)).get();
 }
 
-ObjCProtocolRecord *APISet::addObjCProtocol(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
-    AvailabilityInfo Availability, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
-    bool IsFromSystemHeader) {
+ObjCProtocolRecord *APISet::addObjCProtocol(StringRef Name, StringRef USR,
+                                            PresumedLoc Loc,
+                                            AvailabilityInfo Availability,
+                                            const DocComment &Comment,
+                                            DeclarationFragments Declaration,
+                                            DeclarationFragments SubHeading,
+                                            bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, ObjCProtocols, USR, Name, Loc,
-                           std::move(Availability), Comment, Declaration, SubHeading,
-                           IsFromSystemHeader);
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, IsFromSystemHeader);
 }
 
 MacroDefinitionRecord *
@@ -488,13 +495,13 @@ APISet::addMacroDefinition(StringRef Name, StringRef USR, PresumedLoc Loc,
 
 TypedefRecord *
 APISet::addTypedef(StringRef Name, StringRef USR, PresumedLoc Loc,
-                   AvailabilityInfo Availability,
-                   const DocComment &Comment, DeclarationFragments Declaration,
+                   AvailabilityInfo Availability, const DocComment &Comment,
+                   DeclarationFragments Declaration,
                    DeclarationFragments SubHeading,
                    SymbolReference UnderlyingType, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Typedefs, USR, Name, Loc,
-                           std::move(Availability), Comment, Declaration, SubHeading,
-                           UnderlyingType, IsFromSystemHeader);
+                           std::move(Availability), Comment, Declaration,
+                           SubHeading, UnderlyingType, IsFromSystemHeader);
 }
 
 APIRecord *APISet::findRecordForUSR(StringRef USR) const {

--- a/clang/lib/ExtractAPI/AvailabilityInfo.cpp
+++ b/clang/lib/ExtractAPI/AvailabilityInfo.cpp
@@ -1,17 +1,15 @@
 #include "clang/ExtractAPI/AvailabilityInfo.h"
-#include "clang/AST/Attr.h"
-#include "llvm/ADT/STLExtras.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
 #include "clang/Basic/TargetInfo.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace clang;
 using namespace extractapi;
 
 AvailabilitySet::AvailabilitySet(const Decl *Decl) {
-    
   ASTContext &Context = Decl->getASTContext();
   StringRef PlatformName = Context.getTargetInfo().getPlatformName();
-    
   // Collect availability attributes from all redeclrations.
   for (const auto *RD : Decl->redecls()) {
     if (const auto *A = RD->getAttr<UnavailableAttr>()) {

--- a/clang/lib/ExtractAPI/AvailabilityInfo.cpp
+++ b/clang/lib/ExtractAPI/AvailabilityInfo.cpp
@@ -4,19 +4,20 @@
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
 
-using namespace clang;
-using namespace extractapi;
+using namespace clang::extractapi;
+using namespace llvm;
 
-AvailabilityInfo::AvailabilityInfo(const Decl *Decl) {
+AvailabilityInfo AvailabilityInfo::createFromDecl(const Decl *Decl) {
   ASTContext &Context = Decl->getASTContext();
   StringRef PlatformName = Context.getTargetInfo().getPlatformName();
+  AvailabilityInfo Availability;
 
   // Collect availability attributes from all redeclarations.
   for (const auto *RD : Decl->redecls()) {
     for (const auto *A : RD->specific_attrs<AvailabilityAttr>()) {
       if (A->getPlatform()->getName() != PlatformName)
         continue;
-      *this =
+      Availability =
           AvailabilityInfo(A->getPlatform()->getName(), A->getIntroduced(),
                            A->getDeprecated(), A->getObsoleted(), false, false);
       break;
@@ -24,10 +25,11 @@ AvailabilityInfo::AvailabilityInfo(const Decl *Decl) {
 
     if (const auto *A = RD->getAttr<UnavailableAttr>())
       if (!A->isImplicit())
-        UnconditionallyUnavailable = true;
+        Availability.UnconditionallyUnavailable = true;
 
     if (const auto *A = RD->getAttr<DeprecatedAttr>())
       if (!A->isImplicit())
-        UnconditionallyDeprecated = true;
+        Availability.UnconditionallyDeprecated = true;
   }
+  return Availability;
 }

--- a/clang/lib/ExtractAPI/AvailabilityInfo.cpp
+++ b/clang/lib/ExtractAPI/AvailabilityInfo.cpp
@@ -7,50 +7,27 @@
 using namespace clang;
 using namespace extractapi;
 
-AvailabilitySet::AvailabilitySet(const Decl *Decl) {
+AvailabilityInfo::AvailabilityInfo(const Decl *Decl) {
   ASTContext &Context = Decl->getASTContext();
   StringRef PlatformName = Context.getTargetInfo().getPlatformName();
-  // Collect availability attributes from all redeclrations.
+
+  // Collect availability attributes from all redeclarations.
   for (const auto *RD : Decl->redecls()) {
-    if (const auto *A = RD->getAttr<UnavailableAttr>()) {
-      if (!A->isImplicit()) {
-        this->Availabilities.clear();
-        UnconditionallyUnavailable = true;
-      }
-    }
-
-    if (const auto *A = RD->getAttr<DeprecatedAttr>()) {
-      if (!A->isImplicit()) {
-        this->Availabilities.clear();
-        UnconditionallyDeprecated = true;
-      }
-    }
-
-    for (const auto *Attr : RD->specific_attrs<AvailabilityAttr>()) {
-      StringRef Domain = Attr->getPlatform()->getName();
-      if (Domain != PlatformName)
+    for (const auto *A : RD->specific_attrs<AvailabilityAttr>()) {
+      if (A->getPlatform()->getName() != PlatformName)
         continue;
-      auto *Availability =
-          llvm::find_if(Availabilities, [Domain](const AvailabilityInfo &Info) {
-            return Domain.equals(Info.Domain);
-          });
-      if (Availability != Availabilities.end()) {
-        // Get the highest introduced version for all redeclarations.
-        if (Availability->Introduced < Attr->getIntroduced())
-          Availability->Introduced = Attr->getIntroduced();
-
-        // Get the lowest deprecated version for all redeclarations.
-        if (Availability->Deprecated > Attr->getDeprecated())
-          Availability->Deprecated = Attr->getDeprecated();
-
-        // Get the lowest obsoleted version for all redeclarations.
-        if (Availability->Obsoleted > Attr->getObsoleted())
-          Availability->Obsoleted = Attr->getObsoleted();
-      } else {
-        Availabilities.emplace_back(Domain, Attr->getIntroduced(),
-                                    Attr->getDeprecated(), Attr->getObsoleted(),
-                                    Attr->getUnavailable());
-      }
+      *this =
+          AvailabilityInfo(A->getPlatform()->getName(), A->getIntroduced(),
+                           A->getDeprecated(), A->getObsoleted(), false, false);
+      break;
     }
+
+    if (const auto *A = RD->getAttr<UnavailableAttr>())
+      if (!A->isImplicit())
+        UnconditionallyUnavailable = true;
+
+    if (const auto *A = RD->getAttr<DeprecatedAttr>())
+      if (!A->isImplicit())
+        UnconditionallyDeprecated = true;
   }
 }

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -147,46 +147,34 @@ Object serializeSourceRange(const PresumedLoc &BeginLoc,
 /// Serialize the availability attributes of a symbol.
 ///
 /// Availability information contains the introduced, deprecated, and obsoleted
-/// versions of the symbol for a given domain (roughly corresponds to a
-/// platform) as semantic versions, if not default.  Availability information
-/// also contains flags to indicate if the symbol is unconditionally unavailable
-/// or deprecated, i.e. \c __attribute__((unavailable)) and \c
-/// __attribute__((deprecated)).
+/// versions of the symbol as semantic versions, if not default.
+/// Availability information also contains flags to indicate if the symbol is
+/// unconditionally unavailable or deprecated,
+/// i.e. \c __attribute__((unavailable)) and \c __attribute__((deprecated)).
 ///
 /// \returns \c std::nullopt if the symbol has default availability attributes,
-/// or an \c Array containing the formatted availability information.
-std::optional<Array>
-serializeAvailability(const AvailabilitySet &Availabilities) {
-  if (Availabilities.isDefault())
+/// or an \c Array containing an object with the formatted availability
+/// information.
+std::optional<Array> serializeAvailability(const AvailabilityInfo &Avail) {
+  if (Avail.isDefault())
     return std::nullopt;
 
+  Object Availability;
   Array AvailabilityArray;
-
-  if (Availabilities.isUnconditionallyDeprecated()) {
+  Availability["domain"] = Avail.Domain;
+  serializeObject(Availability, "introduced",
+                  serializeSemanticVersion(Avail.Introduced));
+  serializeObject(Availability, "deprecated",
+                  serializeSemanticVersion(Avail.Deprecated));
+  serializeObject(Availability, "obsoleted",
+                  serializeSemanticVersion(Avail.Obsoleted));
+  if (Avail.isUnconditionallyDeprecated()) {
     Object UnconditionallyDeprecated;
     UnconditionallyDeprecated["domain"] = "*";
     UnconditionallyDeprecated["isUnconditionallyDeprecated"] = true;
     AvailabilityArray.emplace_back(std::move(UnconditionallyDeprecated));
   }
-
-  // Note unconditionally unavailable records are skipped.
-
-  for (const auto &AvailInfo : Availabilities) {
-    Object Availability;
-    Availability["domain"] = AvailInfo.Domain;
-    if (AvailInfo.Unavailable)
-      Availability["isUnconditionallyUnavailable"] = true;
-    else {
-      serializeObject(Availability, "introduced",
-                      serializeSemanticVersion(AvailInfo.Introduced));
-      serializeObject(Availability, "deprecated",
-                      serializeSemanticVersion(AvailInfo.Deprecated));
-      serializeObject(Availability, "obsoleted",
-                      serializeSemanticVersion(AvailInfo.Obsoleted));
-    }
-    AvailabilityArray.emplace_back(std::move(Availability));
-  }
-
+  AvailabilityArray.emplace_back(std::move(Availability));
   return AvailabilityArray;
 }
 
@@ -738,7 +726,7 @@ bool SymbolGraphSerializer::shouldSkip(const APIRecord &Record) const {
     return true;
 
   // Skip unconditionally unavailable symbols
-  if (Record.Availabilities.isUnconditionallyUnavailable())
+  if (Record.Availability.isUnconditionallyUnavailable())
     return true;
 
   // Filter out symbols prefixed with an underscored as they are understood to
@@ -764,7 +752,7 @@ SymbolGraphSerializer::serializeAPIRecord(const RecordTy &Record) const {
       Obj, "location",
       serializeSourceLocation(Record.Location, /*IncludeFileURI=*/true));
   serializeArray(Obj, "availability",
-                 serializeAvailability(Record.Availabilities));
+                 serializeAvailability(Record.Availability));
   serializeObject(Obj, "docComment", serializeDocComment(Record.Comment));
   serializeArray(Obj, "declarationFragments",
                  serializeDeclarationFragments(Record.Declaration));

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -174,6 +174,12 @@ std::optional<Array> serializeAvailability(const AvailabilityInfo &Avail) {
     UnconditionallyDeprecated["isUnconditionallyDeprecated"] = true;
     AvailabilityArray.emplace_back(std::move(UnconditionallyDeprecated));
   }
+  if (Avail.isUnconditionallyUnavailable()) {
+    Object UnconditionallyUnavailable;
+    UnconditionallyUnavailable["domain"] = "*";
+    UnconditionallyUnavailable["isUnconditionallyUnavailable"] = true;
+    AvailabilityArray.emplace_back(std::move(UnconditionallyUnavailable));
+  }
   AvailabilityArray.emplace_back(std::move(Availability));
   return AvailabilityArray;
 }

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -300,22 +300,6 @@ void e(void) __attribute__((availability(tvos, unavailable)));
             "minor": 0,
             "patch": 0
           }
-        },
-        {
-          "domain": "ios",
-          "introduced": {
-            "major": 13,
-            "minor": 0,
-            "patch": 0
-          }
-        },
-        {
-          "domain": "tvos",
-          "introduced": {
-            "major": 15,
-            "minor": 0,
-            "patch": 0
-          }
         }
       ],
       "declarationFragments": [
@@ -394,10 +378,6 @@ void e(void) __attribute__((availability(tvos, unavailable)));
             "minor": 0,
             "patch": 0
           }
-        },
-        {
-          "domain": "tvos",
-          "isUnconditionallyUnavailable": true
         }
       ],
       "declarationFragments": [

--- a/clang/tools/libclang/CXExtractAPI.cpp
+++ b/clang/tools/libclang/CXExtractAPI.cpp
@@ -80,8 +80,8 @@ struct LibClangExtractAPIVisitor
     }
 
     ObjCInterfaceRecord *ObjCInterfaceRecord = API.addObjCInterface(
-        Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment, Declaration,
-        SubHeading, SuperClass, isInSystemHeader(Decl));
+        Name, USR, Loc, AvailabilityInfo::createFromDecl(Decl), Linkage,
+        Comment, Declaration, SubHeading, SuperClass, isInSystemHeader(Decl));
 
     // Record all methods (selectors). This doesn't include automatically
     // synthesized property methods.

--- a/clang/tools/libclang/CXExtractAPI.cpp
+++ b/clang/tools/libclang/CXExtractAPI.cpp
@@ -80,7 +80,7 @@ struct LibClangExtractAPIVisitor
     }
 
     ObjCInterfaceRecord *ObjCInterfaceRecord = API.addObjCInterface(
-        Name, USR, Loc, AvailabilitySet(Decl), Linkage, Comment, Declaration,
+        Name, USR, Loc, AvailabilityInfo(Decl), Linkage, Comment, Declaration,
         SubHeading, SuperClass, isInSystemHeader(Decl));
 
     // Record all methods (selectors). This doesn't include automatically


### PR DESCRIPTION
Currently, ExtractAPI provides availability information for all platforms within a given domain. With this change, we narrow down the output to include availability details only for the specified target platform, so users can generate the symbol graph with only the availability information they need, omitting information of the other platforms.

This change reverts the functionality introduced in [`57c9780`](https://github.com/llvm/llvm-project/commit/57c9780).

rdar://120419037
