### PR TITLE
[XCOFF][obj2yaml] Support SymbolAlignmentAndType as 2 separate fields in YAML.

### DIFF
--- a/llvm/include/llvm/ObjectYAML/XCOFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/XCOFFYAML.h
@@ -121,6 +121,9 @@ struct CsectAuxEnt : AuxSymbolEnt {
   // Common fields for both XCOFF32 and XCOFF64.
   std::optional<uint32_t> ParameterHashIndex;
   std::optional<uint16_t> TypeChkSectNum;
+  std::optional<XCOFF::SymbolType> SymbolType;
+  std::optional<uint8_t> SymbolAlignment;
+  // The two previous values can be encoded as a single value.
   std::optional<uint8_t> SymbolAlignmentAndType;
   std::optional<XCOFF::StorageMappingClass> StorageMappingClass;
 
@@ -235,6 +238,10 @@ template <> struct ScalarEnumerationTraits<XCOFF::StorageClass> {
 
 template <> struct ScalarEnumerationTraits<XCOFF::StorageMappingClass> {
   static void enumeration(IO &IO, XCOFF::StorageMappingClass &Value);
+};
+
+template <> struct ScalarEnumerationTraits<XCOFF::SymbolType> {
+  static void enumeration(IO &IO, XCOFF::SymbolType &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::CFileStringType> {

--- a/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
@@ -57,14 +57,14 @@ private:
   bool writeSymbols();
   void writeStringTable();
 
-  void writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::FileAuxEnt &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::FunctionAuxEnt &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::ExcpetionAuxEnt &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::BlockAuxEnt &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::SectAuxEntForDWARF &AuxSym);
-  void writeAuxSymbol(const XCOFFYAML::SectAuxEntForStat &AuxSym);
-  void writeAuxSymbol(const std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::FileAuxEnt &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::FunctionAuxEnt &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::ExcpetionAuxEnt &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::BlockAuxEnt &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::SectAuxEntForDWARF &AuxSym);
+  bool writeAuxSymbol(const XCOFFYAML::SectAuxEntForStat &AuxSym);
+  bool writeAuxSymbol(const std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym);
 
   XCOFFYAML::Object &Obj;
   bool Is64Bit = false;
@@ -525,15 +525,25 @@ bool XCOFFWriter::writeRelocations() {
   return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym) {
   uint8_t SymAlignAndType = AuxSym.SymbolAlignmentAndType.value_or(0);
   if (AuxSym.SymbolType)
     SymAlignAndType = (SymAlignAndType & ~XCOFFCsectAuxRef::SymbolTypeMask) |
                       *AuxSym.SymbolType;
-  if (AuxSym.SymbolAlignment)
+  if (AuxSym.SymbolAlignment) {
+    const uint8_t ShiftedSymbolAlignmentMask =
+        XCOFFCsectAuxRef::SymbolAlignmentMask >>
+        XCOFFCsectAuxRef::SymbolAlignmentBitOffset;
+
+    if (*AuxSym.SymbolAlignment & ~ShiftedSymbolAlignmentMask) {
+      ErrHandler("Symbol alignment must be less than " +
+                 Twine(1 + ShiftedSymbolAlignmentMask));
+      return false;
+    }
     SymAlignAndType =
         (SymAlignAndType & ~XCOFFCsectAuxRef::SymbolAlignmentMask) |
         (*AuxSym.SymbolAlignment << XCOFFCsectAuxRef::SymbolAlignmentBitOffset);
+  }
   if (Is64Bit) {
     W.write<uint32_t>(AuxSym.SectionOrLengthLo.value_or(0));
     W.write<uint32_t>(AuxSym.ParameterHashIndex.value_or(0));
@@ -552,18 +562,20 @@ void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym) {
     W.write<uint32_t>(AuxSym.StabInfoIndex.value_or(0));
     W.write<uint16_t>(AuxSym.StabSectNum.value_or(0));
   }
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::ExcpetionAuxEnt &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::ExcpetionAuxEnt &AuxSym) {
   assert(Is64Bit && "can't write the exception auxiliary symbol for XCOFF32");
   W.write<uint64_t>(AuxSym.OffsetToExceptionTbl.value_or(0));
   W.write<uint32_t>(AuxSym.SizeOfFunction.value_or(0));
   W.write<uint32_t>(AuxSym.SymIdxOfNextBeyond.value_or(0));
   W.write<uint8_t>(0);
   W.write<uint8_t>(XCOFF::AUX_EXCEPT);
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FunctionAuxEnt &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FunctionAuxEnt &AuxSym) {
   if (Is64Bit) {
     W.write<uint64_t>(AuxSym.PtrToLineNum.value_or(0));
     W.write<uint32_t>(AuxSym.SizeOfFunction.value_or(0));
@@ -577,9 +589,10 @@ void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FunctionAuxEnt &AuxSym) {
     W.write<uint32_t>(AuxSym.SymIdxOfNextBeyond.value_or(0));
     W.OS.write_zeros(2);
   }
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FileAuxEnt &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FileAuxEnt &AuxSym) {
   StringRef FileName = AuxSym.FileNameOrString.value_or("");
   if (nameShouldBeInStringTable(FileName)) {
     W.write<int32_t>(0);
@@ -595,9 +608,10 @@ void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::FileAuxEnt &AuxSym) {
   } else {
     W.OS.write_zeros(3);
   }
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::BlockAuxEnt &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::BlockAuxEnt &AuxSym) {
   if (Is64Bit) {
     W.write<uint32_t>(AuxSym.LineNum.value_or(0));
     W.OS.write_zeros(13);
@@ -608,9 +622,10 @@ void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::BlockAuxEnt &AuxSym) {
     W.write<uint16_t>(AuxSym.LineNumLo.value_or(0));
     W.OS.write_zeros(12);
   }
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::SectAuxEntForDWARF &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::SectAuxEntForDWARF &AuxSym) {
   if (Is64Bit) {
     W.write<uint64_t>(AuxSym.LengthOfSectionPortion.value_or(0));
     W.write<uint64_t>(AuxSym.NumberOfRelocEnt.value_or(0));
@@ -622,34 +637,36 @@ void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::SectAuxEntForDWARF &AuxSym) {
     W.write<uint32_t>(AuxSym.NumberOfRelocEnt.value_or(0));
     W.OS.write_zeros(6);
   }
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(const XCOFFYAML::SectAuxEntForStat &AuxSym) {
+bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::SectAuxEntForStat &AuxSym) {
   assert(!Is64Bit && "can't write the stat auxiliary symbol for XCOFF64");
   W.write<uint32_t>(AuxSym.SectionLength.value_or(0));
   W.write<uint16_t>(AuxSym.NumberOfRelocEnt.value_or(0));
   W.write<uint16_t>(AuxSym.NumberOfLineNum.value_or(0));
   W.OS.write_zeros(10);
+  return true;
 }
 
-void XCOFFWriter::writeAuxSymbol(
+bool XCOFFWriter::writeAuxSymbol(
     const std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym) {
   if (auto AS = dyn_cast<XCOFFYAML::CsectAuxEnt>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::FunctionAuxEnt>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::ExcpetionAuxEnt>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::FileAuxEnt>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::BlockAuxEnt>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::SectAuxEntForDWARF>(AuxSym.get()))
-    writeAuxSymbol(*AS);
+    return writeAuxSymbol(*AS);
   else if (auto AS = dyn_cast<XCOFFYAML::SectAuxEntForStat>(AuxSym.get()))
-    writeAuxSymbol(*AS);
-  else
-    llvm_unreachable("unknown auxiliary symbol type");
+    return writeAuxSymbol(*AS);
+  llvm_unreachable("unknown auxiliary symbol type");
+  return false;
 }
 
 bool XCOFFWriter::writeSymbols() {
@@ -707,7 +724,8 @@ bool XCOFFWriter::writeSymbols() {
     } else {
       for (const std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym :
            YamlSym.AuxEntries) {
-        writeAuxSymbol(AuxSym);
+        if (!writeAuxSymbol(AuxSym))
+          return false;
       }
       // Pad with zeros.
       if (NumOfAuxSym > YamlSym.AuxEntries.size())

--- a/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
@@ -554,9 +554,9 @@ bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym) {
                    Twine(1 + ShiftedSymbolAlignmentMask));
         return false;
       }
+      SymAlignAndType |= (*AuxSym.SymbolAlignment
+                          << XCOFFCsectAuxRef::SymbolAlignmentBitOffset);
     }
-    SymAlignAndType |=
-        (*AuxSym.SymbolAlignment << XCOFFCsectAuxRef::SymbolAlignmentBitOffset);
   }
   if (Is64Bit) {
     W.write<uint32_t>(AuxSym.SectionOrLengthLo.value_or(0));

--- a/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
@@ -182,7 +182,7 @@ bool XCOFFWriter::initStringTable() {
   StrTblBuilder.clear();
 
   if (Obj.StrTbl.Strings) {
-    // All specified strings should be added to the string table.
+    // Add all specified strings to the string table.
     for (StringRef StringEnt : *Obj.StrTbl.Strings)
       StrTblBuilder.add(StringEnt);
 

--- a/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFEmitter.cpp
@@ -535,8 +535,15 @@ bool XCOFFWriter::writeAuxSymbol(const XCOFFYAML::CsectAuxEnt &AuxSym) {
     }
     SymAlignAndType = *AuxSym.SymbolAlignmentAndType;
   } else {
-    if (AuxSym.SymbolType)
-      SymAlignAndType = *AuxSym.SymbolType;
+    if (AuxSym.SymbolType) {
+      uint8_t SymbolType = *AuxSym.SymbolType;
+      if (SymbolType & ~XCOFFCsectAuxRef::SymbolTypeMask) {
+        ErrHandler("symbol type must be less than " +
+                   Twine(1 + XCOFFCsectAuxRef::SymbolTypeMask));
+        return false;
+      }
+      SymAlignAndType = SymbolType;
+    }
     if (AuxSym.SymbolAlignment) {
       const uint8_t ShiftedSymbolAlignmentMask =
           XCOFFCsectAuxRef::SymbolAlignmentMask >>

--- a/llvm/lib/ObjectYAML/XCOFFYAML.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFYAML.cpp
@@ -127,6 +127,16 @@ void ScalarEnumerationTraits<XCOFF::StorageMappingClass>::enumeration(
 #undef ECase
 }
 
+void ScalarEnumerationTraits<XCOFF::SymbolType>::enumeration(
+    IO &IO, XCOFF::SymbolType &Value) {
+#define ECase(X) IO.enumCase(Value, #X, XCOFF::X)
+  ECase(XTY_ER);
+  ECase(XTY_SD);
+  ECase(XTY_LD);
+  ECase(XTY_CM);
+#undef ECase
+}
+
 void ScalarEnumerationTraits<XCOFFYAML::AuxSymbolType>::enumeration(
     IO &IO, XCOFFYAML::AuxSymbolType &Type) {
 #define ECase(X) IO.enumCase(Type, #X, XCOFFYAML::X)
@@ -229,6 +239,8 @@ static void auxSymMapping(IO &IO, XCOFFYAML::CsectAuxEnt &AuxSym, bool Is64) {
   IO.mapOptional("ParameterHashIndex", AuxSym.ParameterHashIndex);
   IO.mapOptional("TypeChkSectNum", AuxSym.TypeChkSectNum);
   IO.mapOptional("SymbolAlignmentAndType", AuxSym.SymbolAlignmentAndType);
+  IO.mapOptional("SymbolType", AuxSym.SymbolType);
+  IO.mapOptional("SymbolAlignment", AuxSym.SymbolAlignment);
   IO.mapOptional("StorageMappingClass", AuxSym.StorageMappingClass);
   if (Is64) {
     IO.mapOptional("SectionOrLengthLo", AuxSym.SectionOrLengthLo);
@@ -350,7 +362,8 @@ void MappingTraits<XCOFFYAML::Symbol>::mapping(IO &IO, XCOFFYAML::Symbol &S) {
   IO.mapOptional("AuxEntries", S.AuxEntries);
 }
 
-void MappingTraits<XCOFFYAML::StringTable>::mapping(IO &IO, XCOFFYAML::StringTable &Str) {
+void MappingTraits<XCOFFYAML::StringTable>::mapping(
+    IO &IO, XCOFFYAML::StringTable &Str) {
   IO.mapOptional("ContentSize", Str.ContentSize);
   IO.mapOptional("Length", Str.Length);
   IO.mapOptional("Strings", Str.Strings);

--- a/llvm/lib/ObjectYAML/XCOFFYAML.cpp
+++ b/llvm/lib/ObjectYAML/XCOFFYAML.cpp
@@ -135,6 +135,7 @@ void ScalarEnumerationTraits<XCOFF::SymbolType>::enumeration(
   ECase(XTY_LD);
   ECase(XTY_CM);
 #undef ECase
+  IO.enumFallback<Hex8>(Value);
 }
 
 void ScalarEnumerationTraits<XCOFFYAML::AuxSymbolType>::enumeration(

--- a/llvm/test/tools/obj2yaml/XCOFF/aix.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aix.yaml
@@ -56,7 +56,8 @@
 # CHECK32-NEXT:       - Type:            AUX_CSECT
 # CHECK32-NEXT:         ParameterHashIndex: 0
 # CHECK32-NEXT:         TypeChkSectNum:  0
-# CHECK32-NEXT:         SymbolAlignmentAndType: 0
+# CHECK32-NEXT:         SymbolType:      XTY_ER
+# CHECK32-NEXT:         SymbolAlignment: 0
 # CHECK32-NEXT:         StorageMappingClass: XMC_PR
 # CHECK32-NEXT:         SectionOrLength: 0
 # CHECK32-NEXT:         StabInfoIndex:   0
@@ -71,7 +72,8 @@
 # CHECK32-NEXT:       - Type:            AUX_CSECT
 # CHECK32-NEXT:         ParameterHashIndex: 0
 # CHECK32-NEXT:         TypeChkSectNum:  0
-# CHECK32-NEXT:         SymbolAlignmentAndType: 0
+# CHECK32-NEXT:         SymbolType:      XTY_ER
+# CHECK32-NEXT:         SymbolAlignment: 0
 # CHECK32-NEXT:         StorageMappingClass: XMC_PR
 # CHECK32-NEXT:         SectionOrLength: 0
 # CHECK32-NEXT:         StabInfoIndex:   0
@@ -128,7 +130,8 @@
 # CHECK64-NEXT:       - Type:            AUX_CSECT
 # CHECK64-NEXT:         ParameterHashIndex: 0
 # CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolAlignmentAndType: 0
+# CHECK64-NEXT:         SymbolType:      XTY_ER
+# CHECK64-NEXT:         SymbolAlignment: 0
 # CHECK64-NEXT:         StorageMappingClass: XMC_PR
 # CHECK64-NEXT:         SectionOrLengthLo: 0
 # CHECK64-NEXT:         SectionOrLengthHi: 0
@@ -142,7 +145,8 @@
 # CHECK64-NEXT:       - Type:            AUX_CSECT
 # CHECK64-NEXT:         ParameterHashIndex: 0
 # CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolAlignmentAndType: 0
+# CHECK64-NEXT:         SymbolType:      XTY_ER
+# CHECK64-NEXT:         SymbolAlignment: 0
 # CHECK64-NEXT:         StorageMappingClass: XMC_PR
 # CHECK64-NEXT:         SectionOrLengthLo: 0
 # CHECK64-NEXT:         SectionOrLengthHi: 0

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
@@ -1,0 +1,209 @@
+## Check that obj2yaml can parse SymbolAlignmentAndType, SymbolAlignment, and SymbolType.
+
+# RUN: yaml2obj %s --docnum=1 -o %t32
+# RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK32
+
+# CHECK32:      --- !XCOFF
+# CHECK32-NEXT: FileHeader:
+# CHECK32-NEXT:   MagicNumber:     0x1DF
+# CHECK32-NEXT:   NumberOfSections: 0
+# CHECK32-NEXT:   CreationTime:    0
+# CHECK32-NEXT:   OffsetToSymbolTable: 0x14
+# CHECK32-NEXT:   EntriesInSymbolTable: 10
+# CHECK32-NEXT:   AuxiliaryHeaderSize: 0
+# CHECK32-NEXT:   Flags:           0x0
+# CHECK32-NEXT: Symbols:
+# CHECK32:       - Name:            .fcn1
+# CHECK32-NEXT:    Value:           0x0
+# CHECK32-NEXT:    Section:         N_UNDEF
+# CHECK32-NEXT:    Type:            0x0
+# CHECK32-NEXT:    StorageClass:    C_EXT
+# CHECK32-NEXT:    NumberOfAuxEntries: 1
+# CHECK32-NEXT:    AuxEntries:
+# CHECK32-NEXT:      - Type:            AUX_CSECT
+# CHECK32-NEXT:        ParameterHashIndex: 0
+# CHECK32-NEXT:        TypeChkSectNum:  0
+# CHECK32-NEXT:        SymbolType:      XTY_SD
+# CHECK32-NEXT:        SymbolAlignment: 4
+# CHECK32-NEXT:        StorageMappingClass: XMC_PR
+# CHECK32:       - Name:            .fcn2
+# CHECK32-NEXT:    Value:           0x0
+# CHECK32-NEXT:    Section:         N_UNDEF
+# CHECK32-NEXT:    Type:            0x0
+# CHECK32-NEXT:    StorageClass:    C_EXT
+# CHECK32-NEXT:    NumberOfAuxEntries: 1
+# CHECK32-NEXT:    AuxEntries:
+# CHECK32-NEXT:      - Type:            AUX_CSECT
+# CHECK32-NEXT:        ParameterHashIndex: 0
+# CHECK32-NEXT:        TypeChkSectNum:  0
+# CHECK32-NEXT:        SymbolType:      XTY_SD
+# CHECK32-NEXT:        SymbolAlignment: 2
+# CHECK32-NEXT:        StorageMappingClass: XMC_PR
+# CHECK32:       - Name:            .fcn3
+# CHECK32-NEXT:    Value:           0x0
+# CHECK32-NEXT:    Section:         N_UNDEF
+# CHECK32-NEXT:    Type:            0x0
+# CHECK32-NEXT:    StorageClass:    C_EXT
+# CHECK32-NEXT:    NumberOfAuxEntries: 1
+# CHECK32-NEXT:    AuxEntries:
+# CHECK32-NEXT:      - Type:            AUX_CSECT
+# CHECK32-NEXT:        ParameterHashIndex: 0
+# CHECK32-NEXT:        TypeChkSectNum:  0
+# CHECK32-NEXT:        SymbolType:      XTY_SD
+# CHECK32-NEXT:        SymbolAlignment: 0
+# CHECK32-NEXT:        StorageMappingClass: XMC_PR
+# CHECK32:       - Name:            .fcn4
+# CHECK32-NEXT:    Value:           0x0
+# CHECK32-NEXT:    Section:         N_UNDEF
+# CHECK32-NEXT:    Type:            0x0
+# CHECK32-NEXT:    StorageClass:    C_EXT
+# CHECK32-NEXT:    NumberOfAuxEntries: 1
+# CHECK32-NEXT:    AuxEntries:
+# CHECK32-NEXT:      - Type:            AUX_CSECT
+# CHECK32-NEXT:        ParameterHashIndex: 0
+# CHECK32-NEXT:        TypeChkSectNum:  0
+# CHECK32-NEXT:        SymbolType:      XTY_ER
+# CHECK32-NEXT:        SymbolAlignment: 5
+# CHECK32-NEXT:        StorageMappingClass: XMC_PR
+
+--- !XCOFF
+FileHeader:
+  MagicNumber: 0x1DF
+Symbols:
+  - StorageClass:    C_FILE
+    AuxEntries:
+      - Type:             AUX_FILE
+        FileNameOrString: FileName
+        FileStringType:   XFT_CD
+  - StorageClass:    C_EXT
+    Name:               .fcn1
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignmentAndType: 17
+        SymbolAlignment: 4
+        SectionOrLength:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn2
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignmentAndType: 18
+        SymbolType: XTY_SD
+        SectionOrLength:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn3
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolType: XTY_SD
+        SectionOrLength:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn4
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignment: 5
+        SectionOrLength:    4
+
+# RUN: yaml2obj %s --docnum=2 -o %t64
+# RUN: obj2yaml %t64 | FileCheck %s --check-prefix=CHECK64
+#
+# CHECK64:      --- !XCOFF
+# CHECK64-NEXT: FileHeader:
+# CHECK64-NEXT:   MagicNumber:     0x1F7
+# CHECK64-NEXT:   NumberOfSections: 0
+# CHECK64-NEXT:   CreationTime:    0
+# CHECK64-NEXT:   OffsetToSymbolTable: 0x18
+# CHECK64-NEXT:   EntriesInSymbolTable: 10
+# CHECK64-NEXT:   AuxiliaryHeaderSize: 0
+# CHECK64-NEXT:   Flags:           0x0
+# CHECK64-NEXT: Symbols:
+# CHECK64:        - Name:            .fcn1
+# CHECK64-NEXT:     Value:           0x0
+# CHECK64-NEXT:     Section:         N_UNDEF
+# CHECK64-NEXT:     Type:            0x0
+# CHECK64-NEXT:     StorageClass:    C_EXT
+# CHECK64-NEXT:     NumberOfAuxEntries: 1
+# CHECK64-NEXT:     AuxEntries:
+# CHECK64-NEXT:       - Type:            AUX_CSECT
+# CHECK64-NEXT:         ParameterHashIndex: 0
+# CHECK64-NEXT:         TypeChkSectNum:  0
+# CHECK64-NEXT:         SymbolType:      XTY_SD
+# CHECK64-NEXT:         SymbolAlignment: 4
+# CHECK64-NEXT:         StorageMappingClass: XMC_PR
+# CHECK64-NEXT:         SectionOrLengthLo: 4
+# CHECK64:        - Name:            .fcn2
+# CHECK64-NEXT:     Value:           0x0
+# CHECK64-NEXT:     Section:         N_UNDEF
+# CHECK64-NEXT:     Type:            0x0
+# CHECK64-NEXT:     StorageClass:    C_EXT
+# CHECK64-NEXT:     NumberOfAuxEntries: 1
+# CHECK64-NEXT:     AuxEntries:
+# CHECK64-NEXT:       - Type:            AUX_CSECT
+# CHECK64-NEXT:         ParameterHashIndex: 0
+# CHECK64-NEXT:         TypeChkSectNum:  0
+# CHECK64-NEXT:         SymbolType:      XTY_SD
+# CHECK64-NEXT:         SymbolAlignment: 2
+# CHECK64-NEXT:         StorageMappingClass: XMC_PR
+# CHECK64-NEXT:         SectionOrLengthLo: 4
+# CHECK64:        - Name:            .fcn3
+# CHECK64-NEXT:     Value:           0x0
+# CHECK64-NEXT:     Section:         N_UNDEF
+# CHECK64-NEXT:     Type:            0x0
+# CHECK64-NEXT:     StorageClass:    C_EXT
+# CHECK64-NEXT:     NumberOfAuxEntries: 1
+# CHECK64-NEXT:     AuxEntries:
+# CHECK64-NEXT:       - Type:            AUX_CSECT
+# CHECK64-NEXT:         ParameterHashIndex: 0
+# CHECK64-NEXT:         TypeChkSectNum:  0
+# CHECK64-NEXT:         SymbolType:      XTY_SD
+# CHECK64-NEXT:         SymbolAlignment: 0
+# CHECK64-NEXT:         StorageMappingClass: XMC_PR
+# CHECK64-NEXT:         SectionOrLengthLo: 4
+# CHECK64:        - Name:            .fcn4
+# CHECK64-NEXT:     Value:           0x0
+# CHECK64-NEXT:     Section:         N_UNDEF
+# CHECK64-NEXT:     Type:            0x0
+# CHECK64-NEXT:     StorageClass:    C_EXT
+# CHECK64-NEXT:     NumberOfAuxEntries: 1
+# CHECK64-NEXT:     AuxEntries:
+# CHECK64-NEXT:       - Type:            AUX_CSECT
+# CHECK64-NEXT:         ParameterHashIndex: 0
+# CHECK64-NEXT:         TypeChkSectNum:  0
+# CHECK64-NEXT:         SymbolType:      XTY_ER
+# CHECK64-NEXT:         SymbolAlignment: 5
+# CHECK64-NEXT:         StorageMappingClass: XMC_PR
+# CHECK64-NEXT:         SectionOrLengthLo: 4
+
+--- !XCOFF
+FileHeader:
+  MagicNumber:     0x1F7
+Symbols:
+  - StorageClass:    C_FILE
+    AuxEntries:
+      - Type:             AUX_FILE
+        FileNameOrString: FileName
+        FileStringType:   XFT_CD
+  - StorageClass:    C_EXT
+    Name:               .fcn1
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignmentAndType: 17
+        SymbolAlignment: 4
+        SectionOrLengthLo:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn2
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignmentAndType: 18
+        SymbolType: XTY_SD
+        SectionOrLengthLo:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn3
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolType: XTY_SD
+        SectionOrLengthLo:    4
+  - StorageClass:    C_EXT
+    Name:               .fcn4
+    AuxEntries:
+      - Type:               AUX_CSECT
+        SymbolAlignment: 5
+        SectionOrLengthLo:    4

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
@@ -1,177 +1,82 @@
 ## Check that obj2yaml can parse SymbolAlignmentAndType, SymbolAlignment, and SymbolType.
+## If either SymbolAlignment or SymbolType are specified along with SymbolAligmentAndType,
+## their values override the corresponding portions of SymbolAligmentAndType.
 
-# RUN: yaml2obj %s --docnum=1 -o %t32
-# RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK32
+# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01DF -DSectionOrLength=SectionOrLength -o %t32
+# RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK
+# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01F7 -DSectionOrLength=SectionOrLengthLo -o %t64
+# RUN: obj2yaml %t64 | FileCheck %s --check-prefix=CHECK
 
-# CHECK32:      --- !XCOFF
-# CHECK32-NEXT: FileHeader:
-# CHECK32-NEXT:   MagicNumber:     0x1DF
-# CHECK32-NEXT:   NumberOfSections: 0
-# CHECK32-NEXT:   CreationTime:    0
-# CHECK32-NEXT:   OffsetToSymbolTable: 0x14
-# CHECK32-NEXT:   EntriesInSymbolTable: 10
-# CHECK32-NEXT:   AuxiliaryHeaderSize: 0
-# CHECK32-NEXT:   Flags:           0x0
-# CHECK32-NEXT: Symbols:
-# CHECK32:       - Name:            .fcn1
-# CHECK32-NEXT:    Value:           0x0
-# CHECK32-NEXT:    Section:         N_UNDEF
-# CHECK32-NEXT:    Type:            0x0
-# CHECK32-NEXT:    StorageClass:    C_EXT
-# CHECK32-NEXT:    NumberOfAuxEntries: 1
-# CHECK32-NEXT:    AuxEntries:
-# CHECK32-NEXT:      - Type:            AUX_CSECT
-# CHECK32-NEXT:        ParameterHashIndex: 0
-# CHECK32-NEXT:        TypeChkSectNum:  0
-# CHECK32-NEXT:        SymbolType:      XTY_SD
-# CHECK32-NEXT:        SymbolAlignment: 4
-# CHECK32-NEXT:        StorageMappingClass: XMC_PR
-# CHECK32:       - Name:            .fcn2
-# CHECK32-NEXT:    Value:           0x0
-# CHECK32-NEXT:    Section:         N_UNDEF
-# CHECK32-NEXT:    Type:            0x0
-# CHECK32-NEXT:    StorageClass:    C_EXT
-# CHECK32-NEXT:    NumberOfAuxEntries: 1
-# CHECK32-NEXT:    AuxEntries:
-# CHECK32-NEXT:      - Type:            AUX_CSECT
-# CHECK32-NEXT:        ParameterHashIndex: 0
-# CHECK32-NEXT:        TypeChkSectNum:  0
-# CHECK32-NEXT:        SymbolType:      XTY_SD
-# CHECK32-NEXT:        SymbolAlignment: 2
-# CHECK32-NEXT:        StorageMappingClass: XMC_PR
-# CHECK32:       - Name:            .fcn3
-# CHECK32-NEXT:    Value:           0x0
-# CHECK32-NEXT:    Section:         N_UNDEF
-# CHECK32-NEXT:    Type:            0x0
-# CHECK32-NEXT:    StorageClass:    C_EXT
-# CHECK32-NEXT:    NumberOfAuxEntries: 1
-# CHECK32-NEXT:    AuxEntries:
-# CHECK32-NEXT:      - Type:            AUX_CSECT
-# CHECK32-NEXT:        ParameterHashIndex: 0
-# CHECK32-NEXT:        TypeChkSectNum:  0
-# CHECK32-NEXT:        SymbolType:      XTY_SD
-# CHECK32-NEXT:        SymbolAlignment: 0
-# CHECK32-NEXT:        StorageMappingClass: XMC_PR
-# CHECK32:       - Name:            .fcn4
-# CHECK32-NEXT:    Value:           0x0
-# CHECK32-NEXT:    Section:         N_UNDEF
-# CHECK32-NEXT:    Type:            0x0
-# CHECK32-NEXT:    StorageClass:    C_EXT
-# CHECK32-NEXT:    NumberOfAuxEntries: 1
-# CHECK32-NEXT:    AuxEntries:
-# CHECK32-NEXT:      - Type:            AUX_CSECT
-# CHECK32-NEXT:        ParameterHashIndex: 0
-# CHECK32-NEXT:        TypeChkSectNum:  0
-# CHECK32-NEXT:        SymbolType:      XTY_ER
-# CHECK32-NEXT:        SymbolAlignment: 5
-# CHECK32-NEXT:        StorageMappingClass: XMC_PR
+# CHECK:        --- !XCOFF
+# CHECK-NEXT: FileHeader:
+# CHECK-NEXT:   MagicNumber:
+# CHECK:      Symbols:
+# CHECK:       - Name:            .fcn1
+# CHECK:         NumberOfAuxEntries: 1
+# CHECK-NEXT:    AuxEntries:
+# CHECK-NEXT:      - Type:            AUX_CSECT
+# CHECK:             SymbolType:      XTY_SD
+# CHECK-NEXT:        SymbolAlignment: 4
+# CHECK:       - Name:            .fcn2
+# CHECK:         NumberOfAuxEntries: 1
+# CHECK-NEXT:    AuxEntries:
+# CHECK-NEXT:      - Type:            AUX_CSECT
+# CHECK:             SymbolType:      XTY_SD
+# CHECK-NEXT:        SymbolAlignment: 2
+# CHECK:       - Name:            .fcn3
+# CHECK:         NumberOfAuxEntries: 1
+# CHECK-NEXT:    AuxEntries:
+# CHECK-NEXT:      - Type:            AUX_CSECT
+# CHECK:             SymbolType:      XTY_SD
+# CHECK-NEXT:        SymbolAlignment: 0
+# CHECK:       - Name:            .fcn4
+# CHECK:         NumberOfAuxEntries: 1
+# CHECK-NEXT:    AuxEntries:
+# CHECK-NEXT:      - Type:            AUX_CSECT
+# CHECK:             SymbolType:      XTY_SD
+# CHECK-NEXT:        SymbolAlignment: 31
 
 --- !XCOFF
 FileHeader:
-  MagicNumber: 0x1DF
+  MagicNumber: [[MAGIC]]
 Symbols:
-  - StorageClass:    C_FILE
+  - StorageClass: C_FILE
     AuxEntries:
-      - Type:             AUX_FILE
+      - Type: AUX_FILE
         FileNameOrString: FileName
         FileStringType:   XFT_CD
-  - StorageClass:    C_EXT
-    Name:               .fcn1
+  - StorageClass: C_EXT
+    Name: .fcn1
     AuxEntries:
-      - Type:               AUX_CSECT
+      - Type: AUX_CSECT
         SymbolAlignmentAndType: 17
         SymbolAlignment: 4
-        SectionOrLength:    4
-  - StorageClass:    C_EXT
-    Name:               .fcn2
+        [[SectionOrLength]]: 4
+  - StorageClass: C_EXT
+    Name: .fcn2
     AuxEntries:
-      - Type:               AUX_CSECT
+      - Type: AUX_CSECT
         SymbolAlignmentAndType: 18
         SymbolType: XTY_SD
-        SectionOrLength:    4
+        [[SectionOrLength]]: 4
   - StorageClass:    C_EXT
-    Name:               .fcn3
+    Name: .fcn3
     AuxEntries:
-      - Type:               AUX_CSECT
+      - Type: AUX_CSECT
         SymbolType: XTY_SD
-        SectionOrLength:    4
+        [[SectionOrLength]]: 4
   - StorageClass:    C_EXT
-    Name:               .fcn4
+    Name: .fcn4
     AuxEntries:
-      - Type:               AUX_CSECT
-        SymbolAlignment: 5
-        SectionOrLength:    4
+      - Type: AUX_CSECT
+        SymbolType: XTY_SD
+        SymbolAlignment: 31
+        [[SectionOrLength]]: 4
 
-# RUN: yaml2obj %s --docnum=2 -o %t64
-# RUN: obj2yaml %t64 | FileCheck %s --check-prefix=CHECK64
-#
-# CHECK64:      --- !XCOFF
-# CHECK64-NEXT: FileHeader:
-# CHECK64-NEXT:   MagicNumber:     0x1F7
-# CHECK64-NEXT:   NumberOfSections: 0
-# CHECK64-NEXT:   CreationTime:    0
-# CHECK64-NEXT:   OffsetToSymbolTable: 0x18
-# CHECK64-NEXT:   EntriesInSymbolTable: 10
-# CHECK64-NEXT:   AuxiliaryHeaderSize: 0
-# CHECK64-NEXT:   Flags:           0x0
-# CHECK64-NEXT: Symbols:
-# CHECK64:        - Name:            .fcn1
-# CHECK64-NEXT:     Value:           0x0
-# CHECK64-NEXT:     Section:         N_UNDEF
-# CHECK64-NEXT:     Type:            0x0
-# CHECK64-NEXT:     StorageClass:    C_EXT
-# CHECK64-NEXT:     NumberOfAuxEntries: 1
-# CHECK64-NEXT:     AuxEntries:
-# CHECK64-NEXT:       - Type:            AUX_CSECT
-# CHECK64-NEXT:         ParameterHashIndex: 0
-# CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolType:      XTY_SD
-# CHECK64-NEXT:         SymbolAlignment: 4
-# CHECK64-NEXT:         StorageMappingClass: XMC_PR
-# CHECK64-NEXT:         SectionOrLengthLo: 4
-# CHECK64:        - Name:            .fcn2
-# CHECK64-NEXT:     Value:           0x0
-# CHECK64-NEXT:     Section:         N_UNDEF
-# CHECK64-NEXT:     Type:            0x0
-# CHECK64-NEXT:     StorageClass:    C_EXT
-# CHECK64-NEXT:     NumberOfAuxEntries: 1
-# CHECK64-NEXT:     AuxEntries:
-# CHECK64-NEXT:       - Type:            AUX_CSECT
-# CHECK64-NEXT:         ParameterHashIndex: 0
-# CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolType:      XTY_SD
-# CHECK64-NEXT:         SymbolAlignment: 2
-# CHECK64-NEXT:         StorageMappingClass: XMC_PR
-# CHECK64-NEXT:         SectionOrLengthLo: 4
-# CHECK64:        - Name:            .fcn3
-# CHECK64-NEXT:     Value:           0x0
-# CHECK64-NEXT:     Section:         N_UNDEF
-# CHECK64-NEXT:     Type:            0x0
-# CHECK64-NEXT:     StorageClass:    C_EXT
-# CHECK64-NEXT:     NumberOfAuxEntries: 1
-# CHECK64-NEXT:     AuxEntries:
-# CHECK64-NEXT:       - Type:            AUX_CSECT
-# CHECK64-NEXT:         ParameterHashIndex: 0
-# CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolType:      XTY_SD
-# CHECK64-NEXT:         SymbolAlignment: 0
-# CHECK64-NEXT:         StorageMappingClass: XMC_PR
-# CHECK64-NEXT:         SectionOrLengthLo: 4
-# CHECK64:        - Name:            .fcn4
-# CHECK64-NEXT:     Value:           0x0
-# CHECK64-NEXT:     Section:         N_UNDEF
-# CHECK64-NEXT:     Type:            0x0
-# CHECK64-NEXT:     StorageClass:    C_EXT
-# CHECK64-NEXT:     NumberOfAuxEntries: 1
-# CHECK64-NEXT:     AuxEntries:
-# CHECK64-NEXT:       - Type:            AUX_CSECT
-# CHECK64-NEXT:         ParameterHashIndex: 0
-# CHECK64-NEXT:         TypeChkSectNum:  0
-# CHECK64-NEXT:         SymbolType:      XTY_ER
-# CHECK64-NEXT:         SymbolAlignment: 5
-# CHECK64-NEXT:         StorageMappingClass: XMC_PR
-# CHECK64-NEXT:         SectionOrLengthLo: 4
 
+## Ensure that SymbolAlignment is in range.
+# RUN: not yaml2obj %s --docnum=2 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR1
+# ERROR1: Symbol alignment must be less than 32
 --- !XCOFF
 FileHeader:
   MagicNumber:     0x1F7
@@ -185,25 +90,6 @@ Symbols:
     Name:               .fcn1
     AuxEntries:
       - Type:               AUX_CSECT
-        SymbolAlignmentAndType: 17
-        SymbolAlignment: 4
-        SectionOrLengthLo:    4
-  - StorageClass:    C_EXT
-    Name:               .fcn2
-    AuxEntries:
-      - Type:               AUX_CSECT
-        SymbolAlignmentAndType: 18
         SymbolType: XTY_SD
-        SectionOrLengthLo:    4
-  - StorageClass:    C_EXT
-    Name:               .fcn3
-    AuxEntries:
-      - Type:               AUX_CSECT
-        SymbolType: XTY_SD
-        SectionOrLengthLo:    4
-  - StorageClass:    C_EXT
-    Name:               .fcn4
-    AuxEntries:
-      - Type:               AUX_CSECT
-        SymbolAlignment: 5
+        SymbolAlignment: 32
         SectionOrLengthLo:    4

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
@@ -1,6 +1,6 @@
-## Check that obj2yaml can parse SymbolAlignmentAndType, SymbolAlignment, and SymbolType.
-## If either SymbolAlignment or SymbolType are specified along with SymbolAligmentAndType,
-## their values override the corresponding portions of SymbolAligmentAndType.
+## Check that obj2yaml can parse SymbolAlignmentAndType, SymbolAlignment,
+## and SymbolType.  If either SymbolAlignment or SymbolType are specified
+## along with SymbolAligmentAndType, report an error.
 
 # RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01DF -DSectionOrLength=SectionOrLength -o %t32
 # RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK
@@ -15,7 +15,7 @@
 # CHECK:         NumberOfAuxEntries: 1
 # CHECK-NEXT:    AuxEntries:
 # CHECK-NEXT:      - Type:            AUX_CSECT
-# CHECK:             SymbolType:      XTY_SD
+# CHECK:             SymbolType:      XTY_ER
 # CHECK-NEXT:        SymbolAlignment: 4
 # CHECK:       - Name:            .fcn2
 # CHECK:         NumberOfAuxEntries: 1
@@ -29,12 +29,6 @@
 # CHECK-NEXT:      - Type:            AUX_CSECT
 # CHECK:             SymbolType:      XTY_SD
 # CHECK-NEXT:        SymbolAlignment: 0
-# CHECK:       - Name:            .fcn4
-# CHECK:         NumberOfAuxEntries: 1
-# CHECK-NEXT:    AuxEntries:
-# CHECK-NEXT:      - Type:            AUX_CSECT
-# CHECK:             SymbolType:      XTY_SD
-# CHECK-NEXT:        SymbolAlignment: 31
 
 --- !XCOFF
 FileHeader:
@@ -49,14 +43,13 @@ Symbols:
     Name: .fcn1
     AuxEntries:
       - Type: AUX_CSECT
-        SymbolAlignmentAndType: 17
         SymbolAlignment: 4
         [[SectionOrLength]]: 4
   - StorageClass: C_EXT
     Name: .fcn2
     AuxEntries:
       - Type: AUX_CSECT
-        SymbolAlignmentAndType: 18
+        SymbolAlignment: 2
         SymbolType: XTY_SD
         [[SectionOrLength]]: 4
   - StorageClass:    C_EXT
@@ -65,14 +58,6 @@ Symbols:
       - Type: AUX_CSECT
         SymbolType: XTY_SD
         [[SectionOrLength]]: 4
-  - StorageClass:    C_EXT
-    Name: .fcn4
-    AuxEntries:
-      - Type: AUX_CSECT
-        SymbolType: XTY_SD
-        SymbolAlignment: 31
-        [[SectionOrLength]]: 4
-
 
 ## Ensure that SymbolAlignment is in range.
 # RUN: not yaml2obj %s --docnum=2 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR1
@@ -93,3 +78,63 @@ Symbols:
         SymbolType: XTY_SD
         SymbolAlignment: 32
         SectionOrLengthLo:    4
+
+## Ensure that neither SymbolAlignment nor SymbolType can be specified if
+## SymbolAlignmentAndType is specified.
+# RUN: not yaml2obj %s --docnum=3 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
+# ERROR2: cannot specify SymbolType or SymbolAlignment if SymbolAlignmentAndType is specified
+--- !XCOFF
+FileHeader:
+  MagicNumber: 0x1DF
+Symbols:
+  - StorageClass: C_FILE
+    AuxEntries:
+      - Type: AUX_FILE
+        FileNameOrString: FileName
+        FileStringType:   XFT_CD
+  - StorageClass: C_EXT
+    Name: .fcn1
+    AuxEntries:
+      - Type: AUX_CSECT
+        SymbolAlignmentAndType: 17
+        SymbolAlignment: 4
+        SectionOrLength: 4
+
+# RUN: not yaml2obj %s --docnum=4 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
+--- !XCOFF
+FileHeader:
+  MagicNumber: 0x1DF
+Symbols:
+  - StorageClass: C_FILE
+    AuxEntries:
+      - Type: AUX_FILE
+        FileNameOrString: FileName
+        FileStringType:   XFT_CD
+  - StorageClass: C_EXT
+    Name: .fcn1
+    AuxEntries:
+      - Type: AUX_CSECT
+        SymbolAlignmentAndType: 17
+        SymbolAlignment: 4
+        SymbolType: XTY_CM
+        SectionOrLength: 4
+
+# RUN: not yaml2obj %s --docnum=5 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
+--- !XCOFF
+FileHeader:
+  MagicNumber: 0x1F7
+Symbols:
+  - StorageClass: C_FILE
+    AuxEntries:
+      - Type: AUX_FILE
+        FileNameOrString: FileName
+        FileStringType:   XFT_CD
+  - StorageClass: C_EXT
+  - StorageClass: C_EXT
+    Name: .fcn2
+    AuxEntries:
+      - Type: AUX_CSECT
+        SymbolAlignmentAndType: 18
+        SymbolType: XTY_SD
+        SectionOrLengthLo: 4
+

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
@@ -54,6 +54,7 @@ Symbols:
 ## Ensure that SymbolAlignment is in range.
 # RUN: not yaml2obj %s --docnum=2 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR1
 # ERROR1: symbol alignment must be less than 32
+
 --- !XCOFF
 FileHeader:
   MagicNumber:     0x1F7
@@ -70,6 +71,7 @@ Symbols:
 ## SymbolAlignmentAndType is specified.
 # RUN: not yaml2obj %s --docnum=3 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
 # ERROR2: cannot specify SymbolType or SymbolAlignment if SymbolAlignmentAndType is specified
+
 --- !XCOFF
 FileHeader:
   MagicNumber: 0x1DF
@@ -83,6 +85,7 @@ Symbols:
         SectionOrLength: 4
 
 # RUN: not yaml2obj %s --docnum=4 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
+
 --- !XCOFF
 FileHeader:
   MagicNumber: 0x1DF
@@ -97,6 +100,7 @@ Symbols:
         SectionOrLength: 4
 
 # RUN: not yaml2obj %s --docnum=5 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR2
+
 --- !XCOFF
 FileHeader:
   MagicNumber: 0x1F7

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-aligntype.yaml
@@ -2,9 +2,9 @@
 ## and SymbolType.  If either SymbolAlignment or SymbolType are specified
 ## along with SymbolAligmentAndType, report an error.
 
-# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01DF -DSectionOrLength=SectionOrLength -o %t32
+# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01DF -o %t32
 # RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK
-# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01F7 -DSectionOrLength=SectionOrLengthLo -o %t64
+# RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01F7 -o %t64
 # RUN: obj2yaml %t64 | FileCheck %s --check-prefix=CHECK
 
 # CHECK:        --- !XCOFF
@@ -34,43 +34,30 @@
 FileHeader:
   MagicNumber: [[MAGIC]]
 Symbols:
-  - StorageClass: C_FILE
-    AuxEntries:
-      - Type: AUX_FILE
-        FileNameOrString: FileName
-        FileStringType:   XFT_CD
   - StorageClass: C_EXT
     Name: .fcn1
     AuxEntries:
       - Type: AUX_CSECT
         SymbolAlignment: 4
-        [[SectionOrLength]]: 4
   - StorageClass: C_EXT
     Name: .fcn2
     AuxEntries:
       - Type: AUX_CSECT
         SymbolAlignment: 2
         SymbolType: XTY_SD
-        [[SectionOrLength]]: 4
   - StorageClass:    C_EXT
     Name: .fcn3
     AuxEntries:
       - Type: AUX_CSECT
         SymbolType: XTY_SD
-        [[SectionOrLength]]: 4
 
 ## Ensure that SymbolAlignment is in range.
 # RUN: not yaml2obj %s --docnum=2 -o %t 2>&1 | FileCheck %s --check-prefix=ERROR1
-# ERROR1: Symbol alignment must be less than 32
+# ERROR1: symbol alignment must be less than 32
 --- !XCOFF
 FileHeader:
   MagicNumber:     0x1F7
 Symbols:
-  - StorageClass:    C_FILE
-    AuxEntries:
-      - Type:             AUX_FILE
-        FileNameOrString: FileName
-        FileStringType:   XFT_CD
   - StorageClass:    C_EXT
     Name:               .fcn1
     AuxEntries:
@@ -87,11 +74,6 @@ Symbols:
 FileHeader:
   MagicNumber: 0x1DF
 Symbols:
-  - StorageClass: C_FILE
-    AuxEntries:
-      - Type: AUX_FILE
-        FileNameOrString: FileName
-        FileStringType:   XFT_CD
   - StorageClass: C_EXT
     Name: .fcn1
     AuxEntries:
@@ -105,11 +87,6 @@ Symbols:
 FileHeader:
   MagicNumber: 0x1DF
 Symbols:
-  - StorageClass: C_FILE
-    AuxEntries:
-      - Type: AUX_FILE
-        FileNameOrString: FileName
-        FileStringType:   XFT_CD
   - StorageClass: C_EXT
     Name: .fcn1
     AuxEntries:
@@ -124,11 +101,6 @@ Symbols:
 FileHeader:
   MagicNumber: 0x1F7
 Symbols:
-  - StorageClass: C_FILE
-    AuxEntries:
-      - Type: AUX_FILE
-        FileNameOrString: FileName
-        FileStringType:   XFT_CD
   - StorageClass: C_EXT
   - StorageClass: C_EXT
     Name: .fcn2

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-symbols.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-symbols.yaml
@@ -107,8 +107,7 @@ Symbols:
       - Type:               AUX_CSECT
         ParameterHashIndex: 1
         TypeChkSectNum:     2
-        SymbolAlignment: 5
-        SymbolType: XTY_SD
+        SymbolAlignmentAndType: 41
         SectionOrLength:    3
         StabInfoIndex:      4
         StabSectNum:        5

--- a/llvm/test/tools/obj2yaml/XCOFF/aux-symbols.yaml
+++ b/llvm/test/tools/obj2yaml/XCOFF/aux-symbols.yaml
@@ -34,7 +34,8 @@
 # CHECK32-NEXT:       - Type:            AUX_CSECT
 # CHECK32-NEXT:         ParameterHashIndex: 1
 # CHECK32-NEXT:         TypeChkSectNum:  2
-# CHECK32-NEXT:         SymbolAlignmentAndType: 41
+# CHECK32-NEXT:         SymbolType: XTY_SD
+# CHECK32-NEXT:         SymbolAlignment: 5
 # CHECK32-NEXT:         StorageMappingClass: XMC_PR
 # CHECK32-NEXT:         SectionOrLength: 3
 # CHECK32-NEXT:         StabInfoIndex:   4
@@ -54,7 +55,8 @@
 # CHECK32-NEXT:       - Type:            AUX_CSECT
 # CHECK32-NEXT:         ParameterHashIndex: 1
 # CHECK32-NEXT:         TypeChkSectNum:  2
-# CHECK32-NEXT:         SymbolAlignmentAndType: 17
+# CHECK32-NEXT:         SymbolType: XTY_SD
+# CHECK32-NEXT:         SymbolAlignment: 2
 # CHECK32-NEXT:         StorageMappingClass: XMC_PR
 # CHECK32-NEXT:         SectionOrLength: 4
 # CHECK32-NEXT:         StabInfoIndex:   5
@@ -105,7 +107,8 @@ Symbols:
       - Type:               AUX_CSECT
         ParameterHashIndex: 1
         TypeChkSectNum:     2
-        SymbolAlignmentAndType: 41
+        SymbolAlignment: 5
+        SymbolType: XTY_SD
         SectionOrLength:    3
         StabInfoIndex:      4
         StabSectNum:        5
@@ -174,7 +177,8 @@ Symbols:
 # CHECK64-NEXT:       - Type:            AUX_CSECT
 # CHECK64-NEXT:         ParameterHashIndex: 1
 # CHECK64-NEXT:         TypeChkSectNum:  2
-# CHECK64-NEXT:         SymbolAlignmentAndType: 41
+# CHECK64-NEXT:         SymbolType: XTY_SD
+# CHECK64-NEXT:         SymbolAlignment: 5
 # CHECK64-NEXT:         StorageMappingClass: XMC_PR
 # CHECK64-NEXT:         SectionOrLengthLo: 3
 # CHECK64-NEXT:         SectionOrLengthHi: 4
@@ -196,7 +200,8 @@ Symbols:
 # CHECK64-NEXT:       - Type:            AUX_CSECT
 # CHECK64-NEXT:         ParameterHashIndex: 1
 # CHECK64-NEXT:         TypeChkSectNum:  2
-# CHECK64-NEXT:         SymbolAlignmentAndType: 17
+# CHECK64-NEXT:         SymbolType: XTY_SD
+# CHECK64-NEXT:         SymbolAlignment: 2
 # CHECK64-NEXT:         StorageMappingClass: XMC_PR
 # CHECK64-NEXT:         SectionOrLengthLo: 3
 # CHECK64-NEXT:         SectionOrLengthHi: 4

--- a/llvm/test/tools/yaml2obj/XCOFF/aux-aligntype.yaml
+++ b/llvm/test/tools/yaml2obj/XCOFF/aux-aligntype.yaml
@@ -1,6 +1,5 @@
-## Check that obj2yaml can parse SymbolAlignmentAndType, SymbolAlignment,
-## and SymbolType.  If either SymbolAlignment or SymbolType are specified
-## along with SymbolAligmentAndType, report an error.
+## Check that yaml2obj can parse SymbolAlignmentAndType, SymbolAlignment,
+## and SymbolType.
 
 # RUN: yaml2obj %s --docnum=1 -DMAGIC=0x01DF -o %t32
 # RUN: obj2yaml %t32 | FileCheck %s --check-prefix=CHECK
@@ -113,4 +112,3 @@ Symbols:
         SymbolAlignmentAndType: 18
         SymbolType: XTY_SD
         SectionOrLengthLo: 4
-

--- a/llvm/test/tools/yaml2obj/XCOFF/aux-symbols.yaml
+++ b/llvm/test/tools/yaml2obj/XCOFF/aux-symbols.yaml
@@ -580,13 +580,13 @@ Symbols:
       - Type: AUX_FILE
         FileNameOrString: foo
 
-## Case10: Specify a SymbolType outside the range of field definition
+## Case10: Specify a SymbolType outside the range of field definition.
 # RUN: not yaml2obj %s -DSYMTYPE=8 --docnum=8 -o %t10 2>&1 | \ 
 # RUN:   FileCheck %s --check-prefix BADSYMTYPE
 
 # BADSYMTYPE: error: symbol type must be less than 8
 
-## Case11: Specify a SymbolType outside the range of its enumeration
+## Case11: Specify a SymbolType outside the range of its enumeration.
 # RUN: yaml2obj %s -DSYMTYPE=7 --docnum=8 -o %t11
 # RUN: llvm-readobj --syms %t11 | FileCheck %s --check-prefix=STYPE
 

--- a/llvm/test/tools/yaml2obj/XCOFF/aux-symbols.yaml
+++ b/llvm/test/tools/yaml2obj/XCOFF/aux-symbols.yaml
@@ -579,3 +579,28 @@ Symbols:
     AuxEntries:
       - Type: AUX_FILE
         FileNameOrString: foo
+
+## Case10: Specify a SymbolType outside the range of field definition
+# RUN: not yaml2obj %s -DSYMTYPE=8 --docnum=8 -o %t10 2>&1 | \ 
+# RUN:   FileCheck %s --check-prefix BADSYMTYPE
+
+# BADSYMTYPE: error: symbol type must be less than 8
+
+## Case11: Specify a SymbolType outside the range of its enumeration
+# RUN: yaml2obj %s -DSYMTYPE=7 --docnum=8 -o %t11
+# RUN: llvm-readobj --syms %t11 | FileCheck %s --check-prefix=STYPE
+
+--- !XCOFF
+FileHeader:
+  MagicNumber: 0x1DF
+Symbols:
+  - Name:               aux_fcn_csect
+    StorageClass:       C_EXT
+    Type:               0x20
+    AuxEntries:
+      - Type:                   AUX_CSECT
+        SymbolAlignment: 4
+        SymbolType: [[SYMTYPE=<none>]]
+
+# STYPE:      SymbolAlignmentLog2: 4
+# STYPE-NEXT:   SymbolType: 0x7

--- a/llvm/tools/obj2yaml/xcoff2yaml.cpp
+++ b/llvm/tools/obj2yaml/xcoff2yaml.cpp
@@ -37,7 +37,7 @@ class XCOFFDumper {
   Error dumpAuxSyms(XCOFFYAML::Symbol &Sym, const XCOFFSymbolRef &SymbolEntRef);
   void dumpFuncAuxSym(XCOFFYAML::Symbol &Sym, const uintptr_t AuxAddress);
   void dumpExpAuxSym(XCOFFYAML::Symbol &Sym, const uintptr_t AuxAddress);
-  void dumpCscetAuxSym(XCOFFYAML::Symbol &Sym,
+  void dumpCsectAuxSym(XCOFFYAML::Symbol &Sym,
                        const object::XCOFFCsectAuxRef &AuxEntPtr);
 
 public:
@@ -204,12 +204,14 @@ void XCOFFDumper::dumpExpAuxSym(XCOFFYAML::Symbol &Sym,
       std::make_unique<XCOFFYAML::ExcpetionAuxEnt>(ExceptAuxSym));
 }
 
-void XCOFFDumper::dumpCscetAuxSym(XCOFFYAML::Symbol &Sym,
+void XCOFFDumper::dumpCsectAuxSym(XCOFFYAML::Symbol &Sym,
                                   const object::XCOFFCsectAuxRef &AuxEntPtr) {
   XCOFFYAML::CsectAuxEnt CsectAuxSym;
   CsectAuxSym.ParameterHashIndex = AuxEntPtr.getParameterHashIndex();
   CsectAuxSym.TypeChkSectNum = AuxEntPtr.getTypeChkSectNum();
-  CsectAuxSym.SymbolAlignmentAndType = AuxEntPtr.getSymbolAlignmentAndType();
+  CsectAuxSym.SymbolAlignment = AuxEntPtr.getAlignmentLog2();
+  CsectAuxSym.SymbolType =
+      static_cast<XCOFF::SymbolType>(AuxEntPtr.getSymbolType());
   CsectAuxSym.StorageMappingClass = AuxEntPtr.getStorageMappingClass();
 
   if (Obj.is64Bit()) {
@@ -237,7 +239,7 @@ Error XCOFFDumper::dumpAuxSyms(XCOFFYAML::Symbol &Sym,
   for (uint8_t I = 1; I <= Sym.NumberOfAuxEntries; ++I) {
 
     if (I == Sym.NumberOfAuxEntries && !Obj.is64Bit()) {
-      dumpCscetAuxSym(Sym, CsectAuxRef);
+      dumpCsectAuxSym(Sym, CsectAuxRef);
       return Error::success();
     }
 
@@ -247,7 +249,7 @@ Error XCOFFDumper::dumpAuxSyms(XCOFFYAML::Symbol &Sym,
     if (Obj.is64Bit()) {
       XCOFF::SymbolAuxType Type = *Obj.getSymbolAuxType(AuxAddress);
       if (Type == XCOFF::SymbolAuxType::AUX_CSECT)
-        dumpCscetAuxSym(Sym, CsectAuxRef);
+        dumpCsectAuxSym(Sym, CsectAuxRef);
       else if (Type == XCOFF::SymbolAuxType::AUX_FCN)
         dumpFuncAuxSym(Sym, AuxAddress);
       else if (Type == XCOFF::SymbolAuxType::AUX_EXCEPT)

--- a/llvm/tools/obj2yaml/xcoff2yaml.cpp
+++ b/llvm/tools/obj2yaml/xcoff2yaml.cpp
@@ -37,7 +37,7 @@ class XCOFFDumper {
   Error dumpAuxSyms(XCOFFYAML::Symbol &Sym, const XCOFFSymbolRef &SymbolEntRef);
   void dumpFuncAuxSym(XCOFFYAML::Symbol &Sym, const uintptr_t AuxAddress);
   void dumpExpAuxSym(XCOFFYAML::Symbol &Sym, const uintptr_t AuxAddress);
-  void dumpCsectAuxSym(XCOFFYAML::Symbol &Sym,
+  void dumpCscetAuxSym(XCOFFYAML::Symbol &Sym,
                        const object::XCOFFCsectAuxRef &AuxEntPtr);
 
 public:
@@ -204,7 +204,7 @@ void XCOFFDumper::dumpExpAuxSym(XCOFFYAML::Symbol &Sym,
       std::make_unique<XCOFFYAML::ExcpetionAuxEnt>(ExceptAuxSym));
 }
 
-void XCOFFDumper::dumpCsectAuxSym(XCOFFYAML::Symbol &Sym,
+void XCOFFDumper::dumpCscetAuxSym(XCOFFYAML::Symbol &Sym,
                                   const object::XCOFFCsectAuxRef &AuxEntPtr) {
   XCOFFYAML::CsectAuxEnt CsectAuxSym;
   CsectAuxSym.ParameterHashIndex = AuxEntPtr.getParameterHashIndex();
@@ -239,7 +239,7 @@ Error XCOFFDumper::dumpAuxSyms(XCOFFYAML::Symbol &Sym,
   for (uint8_t I = 1; I <= Sym.NumberOfAuxEntries; ++I) {
 
     if (I == Sym.NumberOfAuxEntries && !Obj.is64Bit()) {
-      dumpCsectAuxSym(Sym, CsectAuxRef);
+      dumpCscetAuxSym(Sym, CsectAuxRef);
       return Error::success();
     }
 
@@ -249,7 +249,7 @@ Error XCOFFDumper::dumpAuxSyms(XCOFFYAML::Symbol &Sym,
     if (Obj.is64Bit()) {
       XCOFF::SymbolAuxType Type = *Obj.getSymbolAuxType(AuxAddress);
       if (Type == XCOFF::SymbolAuxType::AUX_CSECT)
-        dumpCsectAuxSym(Sym, CsectAuxRef);
+        dumpCscetAuxSym(Sym, CsectAuxRef);
       else if (Type == XCOFF::SymbolAuxType::AUX_FCN)
         dumpFuncAuxSym(Sym, AuxAddress);
       else if (Type == XCOFF::SymbolAuxType::AUX_EXCEPT)


### PR DESCRIPTION
XCOFF encodes a symbol type and alignment in a single 8-bit field. It is easier to read and write YAML files if the fields can be specified separately.  This PR causes obj2yaml to write the fields separately and allows yaml2obj to read either the single combined field or the separate fields.