### PR TITLE
[OpenMP][libomptarget] Enable lazy device initialization

### DIFF
--- a/openmp/libomptarget/include/PluginManager.h
+++ b/openmp/libomptarget/include/PluginManager.h
@@ -54,10 +54,6 @@ struct PluginAdaptorTy {
   /// Return the number of devices visible to the underlying plugin.
   int32_t getNumberOfPluginDevices() const { return NumberOfPluginDevices; }
 
-  /// Return the number of devices successfully initialized and visible to the
-  /// user.
-  int32_t getNumberOfUserDevices() const { return NumberOfUserDevices; }
-
   /// Add all offload entries described by \p DI to the devices managed by this
   /// plugin.
   void addOffloadEntries(DeviceImageTy &DI);
@@ -81,6 +77,8 @@ struct PluginAdaptorTy {
 #undef PLUGIN_API_HANDLE
 
   llvm::DenseSet<const __tgt_device_image *> UsedImages;
+
+  bool LazyDeviceInitialization;
 
 private:
   /// Number of devices the underling plugins sees.
@@ -108,6 +106,9 @@ struct PluginManager {
   /// Exclusive accessor type for the device container.
   using ExclusiveDevicesAccessorTy = Accessor<DeviceContainerTy>;
 
+  /// Keep track of the number of initialized devices:
+  int32_t NumberOfInitializedDevices = 0;
+
   PluginManager() {}
 
   void init();
@@ -124,7 +125,8 @@ struct PluginManager {
 
   /// Return the device presented to the user as device \p DeviceNo if it is
   /// initialized and ready. Otherwise return an error explaining the problem.
-  llvm::Expected<DeviceTy &> getDevice(uint32_t DeviceNo);
+  llvm::Expected<DeviceTy &> getDevice(uint32_t DeviceNo,
+                                       bool WithoutInit = false);
 
   /// Iterate over all initialized and ready devices registered with this
   /// plugin.

--- a/openmp/libomptarget/include/device.h
+++ b/openmp/libomptarget/include/device.h
@@ -51,6 +51,8 @@ struct DeviceTy {
   PluginAdaptorTy *RTL;
   int32_t RTLDeviceID;
 
+  bool IsInit;
+
   bool HasMappedGlobalData = false;
 
   PendingCtorsDtorsPerLibrary PendingCtorsDtors;

--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -65,7 +65,7 @@ int HostDataToTargetTy::addEventIfNecessary(DeviceTy &Device,
 }
 
 DeviceTy::DeviceTy(PluginAdaptorTy *RTL, int32_t DeviceID, int32_t RTLDeviceID)
-    : DeviceID(DeviceID), RTL(RTL), RTLDeviceID(RTLDeviceID),
+    : DeviceID(DeviceID), RTL(RTL), RTLDeviceID(RTLDeviceID), IsInit(false),
       PendingCtorsDtors(), PendingGlobalsMtx(), MappingInfo(*this) {}
 
 DeviceTy::~DeviceTy() {
@@ -77,6 +77,10 @@ DeviceTy::~DeviceTy() {
 }
 
 llvm::Error DeviceTy::init() {
+  // If device is already initialized then return success:
+  if (IsInit)
+    return llvm::Error::success();
+
   // Make call to init_requires if it exists for this plugin.
   int32_t Ret = 0;
   if (RTL->init_requires)
@@ -103,6 +107,7 @@ llvm::Error DeviceTy::init() {
                                   OMPX_ReplaySaveOutput, ReqPtrArgOffset);
   }
 
+  IsInit = true;
   return llvm::Error::success();
 }
 

--- a/openmp/libomptarget/test/offloading/lazy_device_init.cpp
+++ b/openmp/libomptarget/test/offloading/lazy_device_init.cpp
@@ -1,0 +1,34 @@
+// clang-format off
+// RUN: %libomptarget-compilexx-generic && env LIBOMPTARGET_LAZY_DEVICE_INIT=1 LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
+// clang-format on
+
+// REQUIRES: libomptarget-debug
+
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  int *a = (int *)malloc(sizeof(int) * 10);
+
+  // clang-format off
+// CHECK: omptarget --> Using lazy device initialization!
+// CHECK: omptarget --> Plugin adaptor {{.*}} has index 0, exposes 0 out of {{.*}} devices!
+// CHECK: omptarget --> Done registering entries!
+// CHECK: omptarget --> Use default device id [[DEVICE_ID:.*]]
+// CHECK: omptarget --> Device [[DEVICE_ID]] (local ID 0) has been lazily initialized! (IsInit = 1)
+  // clang-format on
+
+#pragma omp target map(from : a[ : 10])
+  { a[5] = 4; }
+
+  // CHECK: a[5] = 4
+
+  printf("a[5] = %d\n", a[5]);
+
+  free(a);
+
+  return 0;
+}


### PR DESCRIPTION
Enable lazy device initialization. This addresses this issue: https://github.com/llvm/llvm-project/issues/75677

This is a runtime feature which can be enabled using the following environment variable when running an OpenMP program:

```
LIBOMPTARGET_LAZY_DEVICE_INIT=1
```