### PR TITLE
[Coverage] Mark coverage sections as metadata sections on COFF.

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1669,9 +1669,18 @@ static int getSelectionForCOFF(const GlobalValue *GV) {
 
 MCSection *TargetLoweringObjectFileCOFF::getExplicitSectionGlobal(
     const GlobalObject *GO, SectionKind Kind, const TargetMachine &TM) const {
+  StringRef Name = GO->getSection();
+  if (Name == getInstrProfSectionName(IPSK_covmap, Triple::COFF,
+                                      /*AddSegmentInfo=*/false) ||
+      Name == getInstrProfSectionName(IPSK_covfun, Triple::COFF,
+                                      /*AddSegmentInfo=*/false) ||
+      Name == getInstrProfSectionName(IPSK_covdata, Triple::COFF,
+                                      /*AddSegmentInfo=*/false) ||
+      Name == getInstrProfSectionName(IPSK_covname, Triple::COFF,
+                                      /*AddSegmentInfo=*/false))
+    Kind = SectionKind::getMetadata();
   int Selection = 0;
   unsigned Characteristics = getCOFFSectionFlags(Kind, TM);
-  StringRef Name = GO->getSection();
   StringRef COMDATSymName = "";
   if (GO->hasComdat()) {
     Selection = getSelectionForCOFF(GO);

--- a/llvm/test/CodeGen/X86/cov-sections.ll
+++ b/llvm/test/CodeGen/X86/cov-sections.ll
@@ -1,0 +1,15 @@
+; RUN: llc < %s -mtriple=x86_64-pc-windows-msvc -filetype=obj -o - | llvm-readobj -S - | FileCheck %s
+
+@covmap = private global i32 0, section ".lcovmap$M"
+@covfun = private global i32 0, section ".lcovfun$M"
+@covname = private global i32 0, section ".lcovd"
+@covdata= private global i32 0, section ".lcovn"
+
+; CHECK: Name: .lcovmap$M
+; CHECK: IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+; CHECK: Name: .lcovfun$M
+; CHECK: IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+; CHECK: Name: .lcovd
+; CHECK: IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+; CHECK: Name: .lcovn
+; CHECK: IMAGE_SCN_MEM_DISCARDABLE (0x2000000)


### PR DESCRIPTION
Mark `.lcovmap$M`, `.lcovfun$M`, `.lcovd` and `.lcovn` as metadata sections on COFF so they are not loaded into memory.