### PR TITLE
[CMake][runtimes] Check LLVM_ENABLE_PROJECTS for libc

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -414,7 +414,7 @@ if(runtimes)
       endif()
     endforeach()
   endif()
-  if("libc" IN_LIST LLVM_ENABLE_RUNTIMES AND 
+  if("libc" IN_LIST LLVM_ENABLE_PROJECTS AND
       (LLVM_LIBC_FULL_BUILD OR LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES))
     if(TARGET libc-hdrgen)
       set(libc_tools libc-hdrgen)


### PR DESCRIPTION
Only some targets may be building llvm-libc in which case the top-level LLVM_ENABLE_RUNTIMES variable won't contain libc. Rather, we can check LLVM_ENABLE_PROJECTS since libc is required to be included there for libc-hdrgen to be built (and when LLVM_ENABLE_RUNTIMES contains libc, we automatically include libc in LLVM_ENABLE_PROJECTS as well).