### PR TITLE
[VFABI] Reject demangled variants with unexpected number of params.

### DIFF
--- a/llvm/lib/Analysis/VFABIDemangling.cpp
+++ b/llvm/lib/Analysis/VFABIDemangling.cpp
@@ -326,10 +326,6 @@ getScalableECFromSignature(const FunctionType *Signature, const VFISAKind ISA,
     // Only vector parameters are used when determining the VF; uniform or
     // linear are left as scalars, so do not affect VF.
     if (Param.ParamKind == VFParamKind::Vector) {
-      // If the scalar function doesn't actually have a corresponding argument,
-      // reject the mapping.
-      if (Param.ParamPos >= Signature->getNumParams())
-        return std::nullopt;
       Type *PTy = Signature->getParamType(Param.ParamPos);
 
       std::optional<ElementCount> EC = getElementCountForTy(ISA, PTy);
@@ -425,6 +421,11 @@ std::optional<VFInfo> VFABI::tryDemangleForVFABI(StringRef MangledName,
   // A valid MangledName must have at least one valid entry in the
   // <parameters>.
   if (Parameters.empty())
+    return std::nullopt;
+
+  // If the number of arguments of the scalar function does not match the
+  // vector variant we have just demangled then reject the mapping.
+  if (Parameters.size() != FTy->getNumParams())
     return std::nullopt;
 
   // Figure out the number of lanes in vectors for this function variant. This


### PR DESCRIPTION
When demangling a vector variant we are not checking that the number of parameters is the same as that of the scalar function. This check is hoisted out of getScalableECFromSignature() making the equvalent check in the unittests obsolete.