### PR TITLE
[clang-doc] Fix failing test

### DIFF
--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -7,7 +7,7 @@
 // RUN: rm -rf %t
 
 template<typename T, int U = 1>
-void function<bool, 0>(T x) {}
+void function(T x) {}
 
 template<>
 void function<bool, 0>(bool x) {}


### PR DESCRIPTION
This fixes a failing test case in clang-doc introduced by 7fbc1de9896029636dd572a692ee90ba88285943 (PR https://github.com/llvm/llvm-project/pull/76677). I presume the test is intended to be well-formed, so I have changed it accordingly. 