### PR TITLE
[Clang] Fix failing CI with different test case attribute & host triple

### DIFF
--- a/clang/test/SemaCXX/template-instantiation.cpp
+++ b/clang/test/SemaCXX/template-instantiation.cpp
@@ -1,11 +1,11 @@
-// RUN: %clang_cc1 -verify -fsyntax-only -Wno-ignored-attributes %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 namespace GH76521 {
 
 template <typename T>
 void foo() {
-  auto l = []() __attribute__((pcs("aapcs-vfp"))) {};
+  auto l = []() __attribute__((preserve_most)) {};
 }
 
 void bar() {


### PR DESCRIPTION
As in title, https://github.com/llvm/llvm-project/commit/a8f43974260ec244d78336d2530f8fc097753580 broke CI due to the calling convention not available on certain targets. This patch uses a simpler calling convention and enables the test only when the attribute exists. It's verified that this test crashes the compiler before a8f43974260ec244d78336d2530f8fc097753580 so it's the same effect as the previous test. Disabling the test on platforms that don't have the calling convention is fine because it's guarding against a frontend bug. 