### PR TITLE
[BasicAA] Enable separate storage hints by default

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -69,7 +69,7 @@ static cl::opt<bool> EnableRecPhiAnalysis("basic-aa-recphi", cl::Hidden,
                                           cl::init(true));
 
 static cl::opt<bool> EnableSeparateStorageAnalysis("basic-aa-separate-storage",
-                                                   cl::Hidden, cl::init(false));
+                                                   cl::Hidden, cl::init(true));
 
 /// SearchLimitReached / SearchTimes shows how often the limit of
 /// to decompose GEPs is reached. It will affect the precision


### PR DESCRIPTION
As requested in https://github.com/llvm/llvm-project/pull/76770#pullrequestreview-1801649466

A few months of experimentation in a large codebase did not reveal any significant build speed regressions, and b07bf16 speeds up hint lookup even further.