### PR TITLE
[mlir] Make fold result type check more verbose

### DIFF
--- a/mlir/lib/IR/Operation.cpp
+++ b/mlir/lib/IR/Operation.cpp
@@ -618,9 +618,9 @@ static void checkFoldResultTypes(Operation *op,
   for (auto [ofr, opResult] : llvm::zip_equal(results, op->getResults())) {
     if (auto value = dyn_cast<Value>(ofr)) {
       if (value.getType() != opResult.getType()) {
-        llvm::errs() << "Folder produced a value of incorrect type for: " << *op
-                     << "\nOriginal type: '" << value.getType()
-                     << "'\nNew type: '" << opResult.getType() << "'\n";
+        op->emitOpError() << "folder produced a value of incorrect type: "
+                          << opResult.getType()
+                          << ", expected: " << value.getType();
         assert(false && "incorrect fold result type");
       }
     }

--- a/mlir/lib/IR/Operation.cpp
+++ b/mlir/lib/IR/Operation.cpp
@@ -618,8 +618,8 @@ static void checkFoldResultTypes(Operation *op,
   for (auto [ofr, opResult] : llvm::zip_equal(results, op->getResults())) {
     if (auto value = dyn_cast<Value>(ofr)) {
       if (value.getType() != opResult.getType()) {
-        llvm::errs() << "Folder produced a value of incorrect type for: "
-                     << *op << "\nOriginal type: '" << value.getType()
+        llvm::errs() << "Folder produced a value of incorrect type for: " << *op
+                     << "\nOriginal type: '" << value.getType()
                      << "'\nNew type: '" << opResult.getType() << "'\n";
         assert(false && "incorrect fold result type");
       }


### PR DESCRIPTION
Print the op and its types when the fold type check fails. This is to speed up debuging as it should be trivial to map the offending op to its folder based on the op name.