### PR TITLE
[SCF] Set Insertion point after the root op when tiling using scf.for_all

### DIFF
--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -804,6 +804,7 @@ mlir::scf::tileUsingSCFForallOp(RewriterBase &rewriter, TilingInterface op,
                                 const scf::SCFTilingOptions &options) {
   Location loc = op->getLoc();
   OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfter(op);
 
   // 1. Get the range of loops that are represented by the operation.
   SmallVector<Range> loopRanges = op.getIterationDomain(rewriter);


### PR DESCRIPTION
This is consistent with that is done for tiling with scf.for utility

Co-authored-by: Abhishek Varma <abhvarma@amd.com>