### PR TITLE
[flang][runtime] Fix total MAXLOC/MINLOC over CHARACTER data

### DIFF
--- a/flang/runtime/extrema.cpp
+++ b/flang/runtime/extrema.cpp
@@ -135,7 +135,7 @@ template <bool IS_MAX> struct CharacterMaxOrMinLocHelper {
     RT_API_ATTRS void operator()(const char *intrinsic, Descriptor &result,
         const Descriptor &x, int kind, const char *source, int line,
         const Descriptor *mask, bool back) const {
-      DoMaxOrMinLoc<TypeCategory::Character, KIND, IS_MAX, NumericCompare>(
+      DoMaxOrMinLoc<TypeCategory::Character, KIND, IS_MAX, CharacterCompare>(
           intrinsic, result, x, kind, source, line, mask, back);
     }
   };


### PR DESCRIPTION
The implementation of MAXLOC/MINLOC without DIM=1 is wrong for CHARACTER data -- change it to use the character comparator rather than the numeric comparator.

Fixes llvm-test-suite/Fortran/gfortran/regression/maxloc_string_1.f90.