### PR TITLE
[Cygwin] Cygwin X86ISelDAGToDAG.cpp 2

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -1833,6 +1833,7 @@ bool X86DAGToDAGISel::matchWrapper(SDValue N, X86ISelAddressMode &AM) {
                                 M == CodeModel::Medium && !IsRIPRel)))
     return true;
 
+
   // Base and index reg must be 0 in order to use %rip as base.
   if (IsRIPRel && AM.hasBaseOrIndexReg())
     return true;

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -1828,7 +1828,9 @@ bool X86DAGToDAGISel::matchWrapper(SDValue N, X86ISelAddressMode &AM) {
   // That signifies access to globals that are known to be "near",
   // such as the GOT itself.
   CodeModel::Model M = TM.getCodeModel();
-  if (Subtarget->is64Bit() && M == CodeModel::Large && !IsRIPRelTLS)
+  if (Subtarget->is64Bit() && ((M == CodeModel::Large && !IsRIPRelTLS) ||
+                               (Subtarget->isTargetWindowsCygwin() &&
+                                M == CodeModel::Medium && !IsRIPRel)))
     return true;
 
   // Base and index reg must be 0 in order to use %rip as base.

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -1833,7 +1833,6 @@ bool X86DAGToDAGISel::matchWrapper(SDValue N, X86ISelAddressMode &AM) {
                                 M == CodeModel::Medium && !IsRIPRel)))
     return true;
 
-
   // Base and index reg must be 0 in order to use %rip as base.
   if (IsRIPRel && AM.hasBaseOrIndexReg())
     return true;


### PR DESCRIPTION
Fix the regression caused by commit 2366d53d8d8726b73408597b534d2f910c3d3e6d 2023-12-22, that, in Cygwin, Clang can't bootstrap.
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0xb9b): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0xba2): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x126c): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x1273): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x1377): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x137e): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x1f32): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x1f39): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x2b76): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x2b7d): relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against `.rdata'
CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o:ItaniumDemangle.cpp:(.text+0x399e): additional relocation overflows omitted from the output
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/Demangle/CMakeFiles/LLVMDemangle.dir/build.make:177: bin/cygLLVMDemangle-18git.dll] Error 1
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make[1]: *** [CMakeFiles/Makefile2:10800: lib/Demangle/CMakeFiles/LLVMDemangle.dir/all] Error 2
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
[  3%] Built target obj.LLVMTableGenCommon
make[2]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
[  3%] Built target obj.LLVMCFIVerify
make[1]: Leaving directory '/cygdrive/e/Note/Tool/llvm-release-build'
make: *** [Makefile:156: all] Error 2


I have build scripts and patches at https://github.com/xu-chiheng/Note .
I can use the build scripts and patches to build and bootstrap GCC(start from 13.0.0) and Clang/LLVM(start from 16.0.0), using GCC or Clang, on Cygwin and MinGW.
If you have interests, you can look at my other PRs at https://github.com/llvm/llvm-project/pulls/xu-chiheng .

Most patches come from upstream at 

https://cygwin.com/git-cygwin-packages/
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/clang.git;a=summary
git://cygwin.com/git/cygwin-packages/clang.git
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/llvm.git;a=summary
git://cygwin.com/git/cygwin-packages/llvm.git

https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-clang
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/PKGBUILD

https://src.fedoraproject.org/rpms/llvm.git

