### PR TITLE
[llvm-exegesis] Add support for warmup iterations

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/Assembler.h
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.h
@@ -44,7 +44,7 @@ BitVector getFunctionReservedRegs(const TargetMachine &TM);
 // Helper to fill in a basic block.
 class BasicBlockFiller {
 public:
-  BasicBlockFiller(MachineFunction &MF, MachineBasicBlock *MBB,
+  BasicBlockFiller(MachineFunction *MF, MachineBasicBlock *MBB,
                    const MCInstrInfo *MCII);
 
   void addInstruction(const MCInst &Inst, const DebugLoc &DL = DebugLoc());
@@ -53,9 +53,9 @@ public:
   void addReturn(const ExegesisTarget &ET, bool SubprocessCleanup,
                  const DebugLoc &DL = DebugLoc());
 
-  MachineFunction &MF;
-  MachineBasicBlock *const MBB;
-  const MCInstrInfo *const MCII;
+  MachineFunction *MF;
+  MachineBasicBlock *MBB;
+  const MCInstrInfo *MCII;
 };
 
 // Helper to fill in a function.
@@ -82,7 +82,8 @@ private:
 };
 
 // A callback that fills a function.
-using FillFunction = std::function<void(FunctionFiller &)>;
+using FillFunction =
+    std::function<BasicBlockFiller(FunctionFiller &, bool, BasicBlockFiller &)>;
 
 // Creates a temporary `void foo(char*)` function containing the provided
 // Instructions. Runs a set of llvm Passes to provide correct prologue and
@@ -92,7 +93,8 @@ Error assembleToStream(const ExegesisTarget &ET,
                        std::unique_ptr<LLVMTargetMachine> TM,
                        ArrayRef<unsigned> LiveIns, const FillFunction &Fill,
                        raw_pwrite_stream &AsmStreamm, const BenchmarkKey &Key,
-                       bool GenerateMemoryInstructions);
+                       bool GenerateMemoryInstructions,
+                       std::optional<FillFunction> WarmupFill);
 
 // Creates an ObjectFile in the format understood by the host.
 // Note: the resulting object keeps a copy of Buffer so it can be discarded once

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
@@ -63,7 +63,8 @@ public:
   Expected<RunnableConfiguration>
   getRunnableConfiguration(const BenchmarkCode &Configuration,
                            unsigned NumRepetitions, unsigned LoopUnrollFactor,
-                           const SnippetRepetitor &Repetitor) const;
+                           const SnippetRepetitor &Repetitor,
+                           unsigned WarmupMinInstructions) const;
 
   std::pair<Error, Benchmark>
   runConfiguration(RunnableConfiguration &&RC,
@@ -116,7 +117,8 @@ private:
   Expected<SmallString<0>>
   assembleSnippet(const BenchmarkCode &BC, const SnippetRepetitor &Repetitor,
                   unsigned MinInstructions, unsigned LoopBodySize,
-                  bool GenerateMemoryInstructions) const;
+                  bool GenerateMemoryInstructions,
+                  unsigned MinWarmupInstructions) const;
 
   Expected<std::string> writeObjectFile(StringRef Buffer,
                                         StringRef FileName) const;

--- a/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
+++ b/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
@@ -81,7 +81,7 @@ private:
     BenchmarkKey Key;
     Key.RegisterInitialValues = RegisterInitialValues;
     EXPECT_FALSE(assembleToStream(*ET, createTargetMachine(), /*LiveIns=*/{},
-                                  Fill, AsmStream, Key, false));
+                                  Fill, AsmStream, Key, false, {}));
     Expected<ExecutableFunction> ExecFunc = ExecutableFunction::create(
         createTargetMachine(), getObjectFromBuffer(AsmStream.str()));
 

--- a/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
@@ -44,7 +44,8 @@ protected:
     FunctionFiller Sink(*MF, {X86::EAX});
     const auto Fill =
         Repetitor->Repeat(Instructions, kMinInstructions, kLoopBodySize, false);
-    Fill(Sink);
+    BasicBlockFiller Entry = Sink.getEntry();
+    Fill(Sink, true, Entry);
   }
 
   static constexpr const unsigned kMinInstructions = 3;


### PR DESCRIPTION
This patch adds in support for warmup iterations in the subprocess execution mode. These are essentially iterations of the snippet run after setup has complete, but before the performance counters are turned on to warmup the cache/TLB.