### PR TITLE
[GitHub] Remove redundant cache key prefix

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -87,7 +87,7 @@ jobs:
           # enough cache space for all the tests to run at once and still
           # fit under the 10 GB limit.
           max-size: 500M
-          key: sccache-${{ matrix.os }}
+          key: ${{ matrix.os }}
           variant: sccache
       - name: Build and Test
         uses: llvm/actions/build-test-llvm-project@main


### PR DESCRIPTION
Remove the redundant sccache cache key prefix.
This prefix is already added by the ccache action, which results in cache keys like "sccache-sccache-ubuntu-...".

See the following source lines as proof:
https://github.com/hendrikmuhs/ccache-action/blob/2a51777f6f64b7b7bea213601acba8f5f4fdbe03/src/restore.ts#L22-L23