### PR TITLE
[GlobalISel][NFC]Delete the comments of XXLegalizerInfo

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
@@ -23,7 +23,8 @@ namespace llvm {
 
 class AArch64Subtarget;
 
-/// This class provides the information for the target register banks.
+/// This class provides the information for the AArch64 target legalizer for
+/// GlobalISel.
 class AArch64LegalizerInfo : public LegalizerInfo {
 public:
   AArch64LegalizerInfo(const AArch64Subtarget &ST);

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
@@ -23,8 +23,6 @@ namespace llvm {
 
 class AArch64Subtarget;
 
-/// This class provides the information for the AArch64 target legalizer for
-/// GlobalISel.
 class AArch64LegalizerInfo : public LegalizerInfo {
 public:
   AArch64LegalizerInfo(const AArch64Subtarget &ST);

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.h
@@ -27,7 +27,8 @@ class MachineIRBuilder;
 namespace AMDGPU {
 struct ImageDimIntrinsicInfo;
 }
-/// This class provides the information for the target register banks.
+/// This class provides the information for the AMDGPU target legalizer for
+/// GlobalISel.
 class AMDGPULegalizerInfo final : public LegalizerInfo {
   const GCNSubtarget &ST;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.h
@@ -27,8 +27,6 @@ class MachineIRBuilder;
 namespace AMDGPU {
 struct ImageDimIntrinsicInfo;
 }
-/// This class provides the information for the AMDGPU target legalizer for
-/// GlobalISel.
 class AMDGPULegalizerInfo final : public LegalizerInfo {
   const GCNSubtarget &ST;
 

--- a/llvm/lib/Target/ARM/ARMLegalizerInfo.h
+++ b/llvm/lib/Target/ARM/ARMLegalizerInfo.h
@@ -23,7 +23,8 @@ namespace llvm {
 
 class ARMSubtarget;
 
-/// This class provides the information for the target register banks.
+/// This class provides the information for the ARM target legalizer for
+/// GlobalISel.
 class ARMLegalizerInfo : public LegalizerInfo {
 public:
   ARMLegalizerInfo(const ARMSubtarget &ST);

--- a/llvm/lib/Target/ARM/ARMLegalizerInfo.h
+++ b/llvm/lib/Target/ARM/ARMLegalizerInfo.h
@@ -23,8 +23,6 @@ namespace llvm {
 
 class ARMSubtarget;
 
-/// This class provides the information for the ARM target legalizer for
-/// GlobalISel.
 class ARMLegalizerInfo : public LegalizerInfo {
 public:
   ARMLegalizerInfo(const ARMSubtarget &ST);

--- a/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.h
+++ b/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.h
@@ -20,7 +20,8 @@ namespace llvm {
 
 class M68kSubtarget;
 
-/// This struct provides the information for the target register banks.
+/// This class provides the information for the M68k target legalizer for
+/// GlobalISel.
 struct M68kLegalizerInfo : public LegalizerInfo {
 public:
   M68kLegalizerInfo(const M68kSubtarget &ST);

--- a/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.h
+++ b/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.h
@@ -20,8 +20,6 @@ namespace llvm {
 
 class M68kSubtarget;
 
-/// This class provides the information for the M68k target legalizer for
-/// GlobalISel.
 struct M68kLegalizerInfo : public LegalizerInfo {
 public:
   M68kLegalizerInfo(const M68kSubtarget &ST);

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
@@ -21,7 +21,8 @@ class GISelChangeObserver;
 class MachineIRBuilder;
 class RISCVSubtarget;
 
-/// This class provides the information for the target register banks.
+/// This class provides the information for the RISCV target legalizer for
+/// GlobalISel.
 class RISCVLegalizerInfo : public LegalizerInfo {
   const RISCVSubtarget &STI;
   const unsigned XLen;

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
@@ -21,8 +21,6 @@ class GISelChangeObserver;
 class MachineIRBuilder;
 class RISCVSubtarget;
 
-/// This class provides the information for the RISCV target legalizer for
-/// GlobalISel.
 class RISCVLegalizerInfo : public LegalizerInfo {
   const RISCVSubtarget &STI;
   const unsigned XLen;

--- a/llvm/lib/Target/X86/GISel/X86LegalizerInfo.h
+++ b/llvm/lib/Target/X86/GISel/X86LegalizerInfo.h
@@ -21,7 +21,8 @@ namespace llvm {
 class X86Subtarget;
 class X86TargetMachine;
 
-/// This class provides the information for the target register banks.
+/// This class provides the information for the X86 target legalizer for
+/// GlobalISel.
 class X86LegalizerInfo : public LegalizerInfo {
 private:
   /// Keep a reference to the X86Subtarget around so that we can

--- a/llvm/lib/Target/X86/GISel/X86LegalizerInfo.h
+++ b/llvm/lib/Target/X86/GISel/X86LegalizerInfo.h
@@ -21,8 +21,6 @@ namespace llvm {
 class X86Subtarget;
 class X86TargetMachine;
 
-/// This class provides the information for the X86 target legalizer for
-/// GlobalISel.
 class X86LegalizerInfo : public LegalizerInfo {
 private:
   /// Keep a reference to the X86Subtarget around so that we can


### PR DESCRIPTION
Delete the LegalizerInfo comments of AArch64/AMD64/ARM/M68k/RISCV/x86, they are copied from register bank.