### PR TITLE
[C++20] [Modules] Implementing Eliding Unreachable Decls of GMF in ASTWriter

### DIFF
--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -233,9 +233,12 @@ public:
 
     /// This declaration has an owning module, but is only visible to
     /// lookups that occur within that module.
-    /// The discarded declarations in global module fragment belongs
-    /// to this group too.
-    ModulePrivate
+    ModulePrivate,
+
+    /// This declaration is part of a Global Module Fragment, it is permitted
+    /// to discard it and therefore it is not reachable or visible to importers
+    /// of the named module of which the GMF is part.
+    ModuleDiscardable
   };
 
 protected:
@@ -658,9 +661,10 @@ public:
   /// Whether this declaration comes from another module unit.
   bool isInAnotherModuleUnit() const;
 
-  /// FIXME: Implement discarding declarations actually in global module
-  /// fragment. See [module.global.frag]p3,4 for details.
-  bool isDiscardedInGlobalModuleFragment() const { return false; }
+  /// See [module.global.frag]p3,4 for details.
+  bool isDiscardedInGlobalModuleFragment() const {
+    return getModuleOwnershipKind() == ModuleOwnershipKind::ModuleDiscardable;
+  }
 
   /// Return true if this declaration has an attribute which acts as
   /// definition of the entity, such as 'alias' or 'ifunc'.

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -178,6 +178,7 @@ LANGOPT(BuiltinHeadersInSystemModules, 1, 0, "builtin headers belong to system m
 BENIGN_ENUM_LANGOPT(CompilingModule, CompilingModuleKind, 3, CMK_None,
                     "compiling a module interface")
 BENIGN_LANGOPT(CompilingPCH, 1, 0, "building a pch")
+LANGOPT(DiscardGMFDecls   , 1, 1, "Discard unreachable decls in GMF")
 BENIGN_LANGOPT(BuildingPCHWithObjectFile, 1, 0, "building a pch which has a corresponding object file")
 BENIGN_LANGOPT(CacheGeneratedPCH, 1, 0, "cache generated PCH files in memory")
 BENIGN_LANGOPT(PCHInstantiateTemplates, 1, 0, "instantiate templates while building a PCH")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2970,6 +2970,13 @@ defm prebuilt_implicit_modules : BoolFOption<"prebuilt-implicit-modules",
   PosFlag<SetTrue, [], [ClangOption], "Look up implicit modules in the prebuilt module path">,
   NegFlag<SetFalse>, BothFlags<[], [ClangOption, CC1Option]>>;
 
+defm discarding_gmf_decls : BoolFOption<"discarding-gmf-decls",
+  LangOpts<"DiscardGMFDecls">, DefaultTrue,
+  PosFlag<SetTrue>,
+  NegFlag<SetFalse, [], [ClangOption],
+          "Disable to discard unreachable decls in global module fragment">,
+  BothFlags<[], [ClangOption, CC1Option]>>;
+
 def fmodule_output_EQ : Joined<["-"], "fmodule-output=">,
   Flags<[NoXarchOption]>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Save intermediate module file results when compiling a standard C++ module unit.">;

--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -88,7 +88,11 @@ Sema::ActOnGlobalModuleFragmentDecl(SourceLocation ModuleLoc) {
   // within the module unit.
   //
   // So the declations in the global module shouldn't be visible by default.
-  TU->setModuleOwnershipKind(Decl::ModuleOwnershipKind::ReachableWhenImported);
+  if (getLangOpts().DiscardGMFDecls)
+    TU->setModuleOwnershipKind(Decl::ModuleOwnershipKind::ModuleDiscardable);
+  else
+    TU->setModuleOwnershipKind(
+        Decl::ModuleOwnershipKind::ReachableWhenImported);
   TU->setLocalOwningModule(GlobalModule);
 
   // FIXME: Consider creating an explicit representation of this declaration.

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -656,6 +656,9 @@ void ASTDeclReader::VisitDecl(Decl *D) {
     case Decl::ModuleOwnershipKind::ReachableWhenImported:
     case Decl::ModuleOwnershipKind::ModulePrivate:
       break;
+
+    case Decl::ModuleOwnershipKind::ModuleDiscardable:
+      llvm_unreachable("We should never read module discardable decls");
     }
 
     D->setModuleOwnershipKind(ModuleOwnership);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1987,6 +1987,8 @@ void ASTDeclWriter::VisitRedeclarable(Redeclarable<T> *D) {
     //
     // FIXME: This is not correct; when we reach an imported declaration we
     // won't emit its previous declaration.
+    Writer.MarkDeclReachable(D->getPreviousDecl());
+    Writer.MarkDeclReachable(MostRecent);
     (void)Writer.GetDeclRef(D->getPreviousDecl());
     (void)Writer.GetDeclRef(MostRecent);
   } else {

--- a/clang/test/CXX/basic/basic.scope/basic.scope.namespace/p2.cpp
+++ b/clang/test/CXX/basic/basic.scope/basic.scope.namespace/p2.cpp
@@ -30,7 +30,6 @@ module;
 
 void test_early() {
   in_header = 1; // expected-error {{use of undeclared identifier 'in_header'}}
-  // expected-note@* {{not visible}}
 
   global_module_fragment = 1; // expected-error {{use of undeclared identifier 'global_module_fragment'}}
 
@@ -53,10 +52,9 @@ import A;
 #endif
 
 void test_late() {
-  in_header = 1; // expected-error {{missing '#include "foo.h"'; 'in_header' must be declared before it is used}}
-  // expected-note@* {{not visible}}
+  in_header = 1; // expected-error {{use of undeclared identifier 'in_header'}}
 
-  global_module_fragment = 1; // expected-error {{missing '#include'; 'global_module_fragment' must be declared before it is used}}
+  global_module_fragment = 1; // expected-error {{use of undeclared identifier 'global_module_fragment'}}
 
   exported = 1;
 

--- a/clang/test/CXX/module/module.glob.frag/cxx20-10-4-ex2.cppm
+++ b/clang/test/CXX/module/module.glob.frag/cxx20-10-4-ex2.cppm
@@ -1,0 +1,72 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 %t/std-10-4-ex2-interface.cppm -emit-module-interface \
+// RUN:     -o %t/M.pcm -Wno-unused-value
+// RUN: %clang_cc1 -std=c++20 %t/std-10-4-ex2-implementation.cpp -fmodule-file=M=%t/M.pcm \
+// RUN:     -fsyntax-only -verify
+//
+// RUN: %clang_cc1 -std=c++20 %t/std-10-4-ex2-interface.cppm -emit-module-interface \
+// RUN:     -o %t/M.pcm -Wno-unused-value -fno-discarding-gmf-decls
+// RUN: %clang_cc1 -std=c++20 %t/std-10-4-ex2-implementation.cpp -fmodule-file=M=%t/M.pcm \
+// RUN:     -fsyntax-only -verify -fno-discarding-gmf-decls -DNO_DISCARD
+
+//--- std-10-4-ex2.h
+
+namespace N {
+struct X {};
+int d();
+int e();
+inline int f(X, int = d()) { return e(); }
+int g(X);
+int h(X);
+} // namespace N
+
+//--- std-10-4-ex2-interface.cppm
+
+module;
+
+#include "std-10-4-ex2.h"
+
+export module M;
+
+template <typename T> int use_f() {
+  N::X x;           // N::X, N, and  ::  are decl-reachable from use_f
+  return f(x, 123); // N::f is decl-reachable from use_f,
+                    // N::e is indirectly decl-reachable from use_f
+                    //   because it is decl-reachable from N::f, and
+                    // N::d is decl-reachable from use_f
+                    //   because it is decl-reachable from N::f
+                    //   even though it is not used in this call
+}
+
+template <typename T> int use_g() {
+  N::X x;             // N::X, N, and :: are decl-reachable from use_g
+  return g((T(), x)); // N::g is not decl-reachable from use_g
+}
+
+template <typename T> int use_h() {
+  N::X x;             // N::X, N, and :: are decl-reachable from use_h
+  return h((T(), x)); // N::h is not decl-reachable from use_h, but
+                      // N::h is decl-reachable from use_h<int>
+}
+
+int k = use_h<int>();
+// use_h<int> is decl-reachable from k, so
+// N::h is decl-reachable from k
+
+//--- std-10-4-ex2-implementation.cpp
+#ifdef NO_DISCARD
+// expected-no-diagnostics
+#endif
+
+module M;
+
+int a = use_f<int>();
+int b = use_g<int>();
+#ifndef NO_DISCARD
+// expected-error@std-10-4-ex2-interface.cppm:20 {{use of undeclared identifier 'g'}}
+// expected-note@-3 {{in instantiation of function template specialization 'use_g<int>' requested here}}
+#endif
+int c = use_h<int>();

--- a/clang/test/CXX/module/module.import/p2.cpp
+++ b/clang/test/CXX/module/module.import/p2.cpp
@@ -67,13 +67,14 @@ void test() {
 module;
 class A{};
 export module C;
-void test() {
+export void C() {
   A a;
 }
 
 //--- UseGlobal.cpp
 import C;
 void test() {
-  A a; // expected-error {{'A' must be declared before it is used}}
-       // expected-note@Global.cppm:2 {{declaration here is not visible}}
+  A a; // expected-error {{missing '#include'; 'A' must be declared before it is used}}
+       // expected-note@* {{declaration here is not visible}}
+  C();
 }

--- a/clang/test/CodeGenCXX/module-intializer-pmf.cpp
+++ b/clang/test/CodeGenCXX/module-intializer-pmf.cpp
@@ -20,6 +20,8 @@ export struct InMod {
 
 export InMod IM;
 
+export using ::G;
+
 module :private;
 
 struct InPMF {
@@ -29,11 +31,11 @@ struct InPMF {
 InPMF P;
 
 // CHECK: define internal void @__cxx_global_var_init
-// CHECK: call {{.*}} @_ZN4GlobC1Ev
-// CHECK: define internal void @__cxx_global_var_init
 // CHECK: call {{.*}} @_ZNW6HasPMF5InPMFC1Ev
 // CHECK: define internal void @__cxx_global_var_init
 // CHECK: call {{.*}} @_ZNW6HasPMF5InModC1Ev
+// CHECK: define internal void @__cxx_global_var_init
+// CHECK: call {{.*}} @_ZN4GlobC1Ev
 // CHECK: define void @_ZGIW6HasPMF
 // CHECK: store i8 1, ptr @_ZGIW6HasPMF__in_chrg
 // CHECK: call void @__cxx_global_var_init

--- a/clang/test/CodeGenCXX/module-intializer.cpp
+++ b/clang/test/CodeGenCXX/module-intializer.cpp
@@ -31,19 +31,6 @@
 // RUN: -fmodule-file=M=M.pcm -S -emit-llvm  -o - \
 // RUN: | FileCheck %s --check-prefix=CHECK-IMPL
 
-// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 N.cpp -S -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefix=CHECK-N
-
-// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 O.cpp -S -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefix=CHECK-O
-
-// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 M-part.cpp -S -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefix=CHECK-P
-
-// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 M.cpp \
-// RUN:   -fmodule-file=N.pcm -fmodule-file=O=O.pcm -fmodule-file=M:Part=M-part.pcm \
-// RUN:   -S -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-M
-
 //--- N-h.h
 
 struct Oink {
@@ -59,6 +46,8 @@ module;
 
 export module N;
 
+export using ::Hog;
+
 export struct Quack {
   Quack(){};
 };
@@ -66,9 +55,9 @@ export struct Quack {
 export Quack Duck;
 
 // CHECK-N: define internal void @__cxx_global_var_init
-// CHECK-N: call {{.*}} @_ZN4OinkC1Ev
-// CHECK-N: define internal void @__cxx_global_var_init
 // CHECK-N: call {{.*}} @_ZNW1N5QuackC1Ev
+// CHECK-N: define internal void @__cxx_global_var_init
+// CHECK-N: call {{.*}} @_ZN4OinkC1Ev
 // CHECK-N: define void @_ZGIW1N
 // CHECK-N: store i8 1, ptr @_ZGIW1N__in_chrg
 // CHECK-N: call void @__cxx_global_var_init
@@ -89,16 +78,19 @@ module;
 
 export module O;
 
+export using ::Cat;
+
 export struct Bark {
   Bark(){};
 };
 
 export Bark Dog;
 
-// CHECK-O: define internal void @__cxx_global_var_init
-// CHECK-O: call {{.*}} @_ZN4MeowC2Ev
+
 // CHECK-O: define internal void @__cxx_global_var_init
 // CHECK-O: call {{.*}} @_ZNW1O4BarkC1Ev
+// CHECK-O: define internal void @__cxx_global_var_init
+// CHECK-O: call {{.*}} @_ZN4MeowC2Ev
 // CHECK-O: define void @_ZGIW1O
 // CHECK-O: store i8 1, ptr @_ZGIW1O__in_chrg
 // CHECK-O: call void @__cxx_global_var_init
@@ -119,6 +111,8 @@ module;
 
 module M:Part;
 
+using ::Frog;
+
 struct Squawk {
   Squawk(){};
 };
@@ -126,9 +120,9 @@ struct Squawk {
 Squawk parrot;
 
 // CHECK-P: define internal void @__cxx_global_var_init
-// CHECK-P: call {{.*}} @_ZN5CroakC1Ev
-// CHECK-P: define internal void @__cxx_global_var_init
 // CHECK-P: call {{.*}} @_ZNW1M6SquawkC1Ev
+// CHECK-P: define internal void @__cxx_global_var_init
+// CHECK-P: call {{.*}} @_ZN5CroakC1Ev
 // CHECK-P: define void @_ZGIW1MWP4Part
 // CHECK-P: store i8 1, ptr @_ZGIW1MWP4Part__in_chrg
 // CHECK-P: call void @__cxx_global_var_init
@@ -152,6 +146,8 @@ import N;
 export import O;
 import :Part;
 
+using ::Cow;
+
 export struct Baa {
   int x;
   Baa(){};
@@ -161,10 +157,11 @@ export struct Baa {
 
 export Baa Sheep(10);
 
-// CHECK-M: define internal void @__cxx_global_var_init
-// CHECK-M: call {{.*}} @_ZN3MooC1Ev
+
 // CHECK-M: define internal void @__cxx_global_var_init
 // CHECK-M: call {{.*}} @_ZNW1M3BaaC1Ei
+// CHECK-M: define internal void @__cxx_global_var_init
+// CHECK-M: call {{.*}} @_ZN3MooC1Ev
 // CHECK-M: declare void @_ZGIW1O()
 // CHECK-M: declare void @_ZGIW1N()
 // CHECK-M: declare void @_ZGIW1MWP4Part()

--- a/clang/test/Modules/abi-tag.cppm
+++ b/clang/test/Modules/abi-tag.cppm
@@ -1,0 +1,69 @@
+// Tests that the namespace with abi tag attribute won't get discarded.
+// The pattern is widely used in libstdc++.
+//
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/m.cppm -emit-module-interface -o %t/m.pcm
+// RUNX: %clang_cc1 -std=c++20 %t/m.pcm -S -emit-llvm -o - | FileCheck %t/m.cppm
+
+//--- foo.h
+#pragma GCC system_header
+
+namespace std {
+    inline namespace __cxx11 __attribute__((__abi_tag__ ("tag_name"))) { }
+}
+
+namespace __gnu_cxx {
+    inline namespace __cxx11 __attribute__((__abi_tag__ ("tag_name"))) { }
+}
+
+namespace std {
+    namespace __cxx11 {
+        struct C { int x; };
+    }
+}
+
+std::C foo() { return {3}; }
+
+//--- m.cppm
+module;
+#include "foo.h"
+export module m;
+export using ::foo;
+
+// CHECK: define{{.*}}@_Z3fooB8tag_namev
+
+//--- bar.h
+#pragma GCC system_header
+
+namespace std {
+    inline namespace __cxx11 __attribute__((__abi_tag__ ("tag_name"))) { }
+}
+
+namespace __gnu_cxx {
+    inline namespace __cxx11 __attribute__((__abi_tag__ ("tag_name"))) { }
+}
+
+namespace __gnu_cxx {
+    namespace __cxx11 {
+        template <class C>
+        struct traits {
+            typedef C type;
+        };
+    }
+}
+
+namespace std {
+    template <class C>
+    struct vec {
+        typedef traits<C>::type type;
+    };
+}
+
+//--- n.cppm
+module;
+#include "bar.h"
+export module n;
+export using ::foo;

--- a/clang/test/Modules/concept.cppm
+++ b/clang/test/Modules/concept.cppm
@@ -63,12 +63,14 @@ struct __fn {
 module;
 #include "foo.h"
 export module A;
+export using ::__fn;
 
 //--- B.cppm
 module;
 #include "foo.h"
 export module B;
 import A;
+export using ::__fn;
 
 #ifdef DIFFERENT
 // expected-error@foo.h:41 {{'__fn::operator()' from module 'A.<global>' is not present in definition of '__fn' provided earlier}}

--- a/clang/test/Modules/explicitly-specialized-template.cpp
+++ b/clang/test/Modules/explicitly-specialized-template.cpp
@@ -39,7 +39,7 @@ public:
 
 //--- Use.cpp
 import X;
-foo<int> f; // expected-error {{'foo' must be declared before it is used}}
+foo<int> f; // expected-error {{missing '#include "foo.h"'; 'foo' must be declared before it is used}}
             // expected-note@* {{declaration here is not visible}}
 int bar() {
   X<int> x;

--- a/clang/test/Modules/inconsistent-deduction-guide-linkage.cppm
+++ b/clang/test/Modules/inconsistent-deduction-guide-linkage.cppm
@@ -19,6 +19,9 @@ module;
 
 #include "C.h"
 export module B;
+export namespace foo {
+  using foo::bar;
+}
 
 //--- C.h
 namespace foo {
@@ -33,6 +36,9 @@ namespace foo {
 module;
 #include "E.h"
 export module D;
+export namespace foo {
+  using foo::bar;
+}
 
 //--- D-part.cppm
 export module D:part;

--- a/clang/test/Modules/named-modules-adl-2.cppm
+++ b/clang/test/Modules/named-modules-adl-2.cppm
@@ -31,6 +31,8 @@ void b() {
 	a(s());
 }
 
+export using ::operator+;
+
 //--- c.cppm
 // expected-no-diagnostics
 export module c;

--- a/clang/test/Modules/named-modules-adl.cppm
+++ b/clang/test/Modules/named-modules-adl.cppm
@@ -25,6 +25,8 @@ void a(T x) {
 	n::s() + x;
 }
 
+export using n::operator+;
+
 //--- b.cppm
 // expected-no-diagnostics
 export module b;

--- a/clang/test/Modules/polluted-operator.cppm
+++ b/clang/test/Modules/polluted-operator.cppm
@@ -44,6 +44,10 @@ module;
 #include "foo.h"
 #include "bar.h"
 export module a;
+export namespace std {
+  using std::variant;
+  using std::_Traits;
+}
 
 //--- b.cppm
 module;
@@ -51,7 +55,10 @@ module;
 export module b;
 import a;
 
+export namespace std {
+  using std::variant;
+  using std::_Traits;
+}
+
 // expected-error@* {{has different definitions in different modules; first difference is defined here found data member '_S_copy_ctor' with an initializer}}
 // expected-note@* {{but in 'a.<global>' found data member '_S_copy_ctor' with a different initializer}}
-// expected-error@* {{from module 'a.<global>' is not present in definition of 'variant<_Types...>' provided earlier}}
-// expected-note@* {{declaration of 'swap' does not match}}

--- a/clang/test/Modules/pr58716.cppm
+++ b/clang/test/Modules/pr58716.cppm
@@ -14,6 +14,8 @@ module;
 #include "fail.h"
 export module mymodule;
 
+export using ::this_fails;
+
 // CHECK: @.str = {{.*}}"{}\00"
 // CHECK: store{{.*}}ptr @.str
 

--- a/clang/test/Modules/pr60775.cppm
+++ b/clang/test/Modules/pr60775.cppm
@@ -32,6 +32,10 @@ void a() {
 	}
 }
 
+export namespace std {
+    using std::initializer_list;
+}
+
 //--- b.cpp
 // expected-no-diagnostics
 import a;

--- a/clang/test/Modules/pr62589.cppm
+++ b/clang/test/Modules/pr62589.cppm
@@ -70,6 +70,9 @@ export module a;
 export using ::a;
 export using ::a_view;
 
+// Otherwise the operator== would be discarded.
+using ::operator==;
+
 //--- b.cpp
 // expected-no-diagnostics
 import a;

--- a/clang/test/Modules/preferred_name.cppm
+++ b/clang/test/Modules/preferred_name.cppm
@@ -32,6 +32,8 @@ inline foo_templ<char> bar()
 module;
 #include "foo.h"
 export module A;
+export using ::foo_templ;
+export using ::bar;
 
 //--- Use.cppm
 // expected-no-diagnostics

--- a/clang/test/Modules/redundant-template-default-arg3.cpp
+++ b/clang/test/Modules/redundant-template-default-arg3.cpp
@@ -88,6 +88,15 @@ int v9;
 module;
 #include "foo.h"
 export module foo;
+export using ::v;
+export using ::v2;
+export using ::v3;
+export using ::v4;
+export using ::v5;
+export using ::v6;
+export using ::v7;
+export using ::v8;
+export using ::v9;
 
 //--- use.cpp
 import foo;

--- a/clang/test/Modules/template-function-specialization.cpp
+++ b/clang/test/Modules/template-function-specialization.cpp
@@ -48,10 +48,8 @@ import foo;
 void use() {
   foo<short>();
   foo<int>();
-  foo2<short>(); // expected-error {{missing '#include'; 'foo2' must be declared before it is used}}
-                 // expected-note@* {{declaration here is not visible}}
-  foo2<int>();   // expected-error {{missing '#include'; 'foo2' must be declared before it is used}}
-                 // expected-note@* {{declaration here is not visible}}
+  foo2<short>(); // expected-error {{use of undeclared identifier 'foo2'}}
+  foo2<int>();   // expected-error {{use of undeclared identifier 'foo2'}}
   foo3<short>();
   foo3<int>();
 


### PR DESCRIPTION
This was a patch to try to implement eliding unreachable decls in GMF in ASTWriter. It was developed a half year ago and I just rebased it but I did't fix the failing test. It ran well. 

The core idea of the patch is that we can implement the idea **reachable** in ASTWriter naturally. 

The secret is that we skip writing GMF initially (generally we will write decls from the top to the bottom) and we start to write the declarations from module purview. Then we will only write the declarations in GMF if it is mentioned during the writing process. So the unreachable decls won't be written natually.

The experience in implementing this patch is pretty smooth and the tests from the spec can be passed. I felt this should be the natural way to implement this feature.

The only one and big problem is that we didn't implement the formal semantics in the spec in this way : |