### PR TITLE
[llvm][lit] Handle case when there is no llvm default target triple

### DIFF
--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -632,15 +632,25 @@ class LLVMConfig(object):
             self.add_tool_substitutions(tool_substitutions)
             self.config.substitutions.append(("%resource_dir", builtin_include_dir))
 
-        self.config.substitutions.append(
-            (
-                "%itanium_abi_triple",
-                self.make_itanium_abi_triple(self.config.target_triple),
+        # There will be no default target triple if one was not specifically
+        # set, and the host's architecture is not an enabled target.
+        if self.config.target_triple:
+            self.config.substitutions.append(
+                (
+                    "%itanium_abi_triple",
+                    self.make_itanium_abi_triple(self.config.target_triple),
+                )
             )
-        )
-        self.config.substitutions.append(
-            ("%ms_abi_triple", self.make_msabi_triple(self.config.target_triple))
-        )
+            self.config.substitutions.append(
+                ("%ms_abi_triple", self.make_msabi_triple(self.config.target_triple))
+            )
+        else:
+            if not self.lit_config.quiet:
+                self.lit_config.note(
+                    "No default target triple was found, some tests may fail as a result."
+                )
+            self.config.substitutions.append(("%itanium_abi_triple", ""))
+            self.config.substitutions.append(("%ms_abi_triple", ""))
 
         # The host triple might not be set, at least if we're compiling clang
         # from an already installed llvm.


### PR DESCRIPTION
This can happen when you do not choose a specific target triple, and do not enable the host architecture when building (if you do enable it, it would become the default target). Such as only enabling RISC-V, when building on an AArch64 machine.

Originally reported https://discourse.llvm.org/t/llvm-test-error-could-not-turn-into-itanium-abi-triple/76013.

When attempting to run a single test via lit you get: `Could not turn '' into Itanium ABI triple`

Setting a default triple with `LLVM_DEFAULT_TARGET_TRIPLE` works around the issue.

This change copies the existing host triple checks to target triple, and adds a note to highlight the potential issue. As `check-clang` on my AArch64 machine failed 32% of tests in this configuration.

Which is to be expected and is ok if you only want to run specific tests, but for anyone unintentionally building this way the note is a clue to the cause.