### PR TITLE
[DebugInfo] Correctly track metadata slots for DPValues

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -859,6 +859,9 @@ private:
 
   /// Add all of the metadata from an instruction.
   void processInstructionMetadata(const Instruction &I);
+
+  /// Add all of the metadata from an instruction.
+  void processDPValueMetadata(const DPValue &DPV);
 };
 
 } // end namespace llvm
@@ -1126,9 +1129,17 @@ void SlotTracker::processGlobalObjectMetadata(const GlobalObject &GO) {
 void SlotTracker::processFunctionMetadata(const Function &F) {
   processGlobalObjectMetadata(F);
   for (auto &BB : F) {
-    for (auto &I : BB)
+    for (auto &I : BB) {
+      for (const DPValue &DPV : I.getDbgValueRange())
+        processDPValueMetadata(DPV);
       processInstructionMetadata(I);
+    }
   }
+}
+
+void SlotTracker::processDPValueMetadata(const DPValue &DPV) {
+  CreateMetadataSlot(DPV.getVariable());
+  CreateMetadataSlot(DPV.getDebugLoc());
 }
 
 void SlotTracker::processInstructionMetadata(const Instruction &I) {


### PR DESCRIPTION
Currently, the AsmWriter can print DPValues, but does not consider them when creating slots for metadata, which can result in erroneous output where metadata is numbered incorrectly. This patch modifies the ModuleSlotTracker to correctly track slots for metadata that appears in DPValues.