### PR TITLE
[RISCV] Deduplicate RISCVISAInfo::toFeatures/toFeatureVector. NFC

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -296,7 +296,7 @@ bool RISCVTargetInfo::initFeatureMap(
   }
 
   // RISCVISAInfo makes implications for ISA features
-  std::vector<std::string> ImpliedFeatures = (*ParseResult)->toFeatureVector();
+  std::vector<std::string> ImpliedFeatures = (*ParseResult)->toFeatures();
 
   // parseFeatures normalizes the feature set by dropping any explicit
   // negatives, and non-extension features.  We need to preserve the later
@@ -413,7 +413,7 @@ static void handleFullArchString(StringRef FullArchStr,
     // Forward the invalid FullArchStr.
     Features.push_back("+" + FullArchStr.str());
   } else {
-    std::vector<std::string> FeatStrings = (*RII)->toFeatureVector();
+    std::vector<std::string> FeatStrings = (*RII)->toFeatures();
     Features.insert(Features.end(), FeatStrings.begin(), FeatStrings.end());
   }
 }

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -42,10 +42,9 @@ static bool getArchFeatures(const Driver &D, StringRef Arch,
     return false;
   }
 
-  const auto ISAInfoFeatures = (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
-                                                      /*IgnoreUnknown=*/false);
-  Features.insert(Features.end(), ISAInfoFeatures.begin(),
-                  ISAInfoFeatures.end());
+  for (const std::string &Str : (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
+                                                       /*IgnoreUnknown=*/false))
+    Features.push_back(Args.MakeArgString(Str));
 
   if (EnableExperimentalExtensions)
     Features.push_back(Args.MakeArgString("+experimental"));

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -42,9 +42,9 @@ static bool getArchFeatures(const Driver &D, StringRef Arch,
     return false;
   }
 
-  (*ISAInfo)->toFeatures(
-      Features, [&Args](const Twine &Str) { return Args.MakeArgString(Str); },
-      /*AddAllExtensions=*/true);
+  for (std::string &Str : (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
+                                                 /*IgnoreUnknown=*/false))
+    Features.push_back(Args.MakeArgString(Str));
 
   if (EnableExperimentalExtensions)
     Features.push_back(Args.MakeArgString("+experimental"));

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -42,9 +42,10 @@ static bool getArchFeatures(const Driver &D, StringRef Arch,
     return false;
   }
 
-  for (const std::string &Str : (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
-                                                       /*IgnoreUnknown=*/false))
-    Features.push_back(Args.MakeArgString(Str));
+  const auto ISAInfoFeatures = (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
+                                                      /*IgnoreUnknown=*/false);
+  Features.insert(Features.end(), ISAInfoFeatures.begin(),
+                  ISAInfoFeatures.end());
 
   if (EnableExperimentalExtensions)
     Features.push_back(Args.MakeArgString("+experimental"));

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -42,8 +42,8 @@ static bool getArchFeatures(const Driver &D, StringRef Arch,
     return false;
   }
 
-  for (std::string &Str : (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
-                                                 /*IgnoreUnknown=*/false))
+  for (const std::string &Str : (*ISAInfo)->toFeatures(/*AddAllExtension=*/true,
+                                                       /*IgnoreUnknown=*/false))
     Features.push_back(Args.MakeArgString(Str));
 
   if (EnableExperimentalExtensions)

--- a/llvm/include/llvm/Support/RISCVISAInfo.h
+++ b/llvm/include/llvm/Support/RISCVISAInfo.h
@@ -68,9 +68,8 @@ public:
   parseFeatures(unsigned XLen, const std::vector<std::string> &Features);
 
   /// Convert RISC-V ISA info to a feature vector.
-  void toFeatures(std::vector<StringRef> &Features,
-                  llvm::function_ref<StringRef(const Twine &)> StrAlloc,
-                  bool AddAllExtensions) const;
+  std::vector<std::string> toFeatures(bool AddAllExtensions = false,
+                                      bool IgnoreUnknown = true) const;
 
   const OrderedExtensionMap &getExtensions() const { return Exts; };
 
@@ -83,7 +82,6 @@ public:
 
   bool hasExtension(StringRef Ext) const;
   std::string toString() const;
-  std::vector<std::string> toFeatureVector() const;
   StringRef computeDefaultABI() const;
 
   static bool isSupportedExtensionFeature(StringRef Ext);

--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -315,7 +315,7 @@ Expected<SubtargetFeatures> ELFObjectFileBase::getRISCVFeatures() const {
     else
       llvm_unreachable("XLEN should be 32 or 64.");
 
-    Features.addFeaturesVector(ISAInfo->toFeatureVector());
+    Features.addFeaturesVector(ISAInfo->toFeatures());
   }
 
   return Features;

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -470,7 +470,7 @@ std::vector<std::string> RISCVISAInfo::toFeatures(bool AddAllExtensions,
                                                   bool IgnoreUnknown) const {
   std::vector<std::string> Features;
   for (auto const &Ext : Exts) {
-    std::string ExtName = Ext.first;
+    StringRef ExtName = Ext.first;
 
     if (ExtName == "i") // i is not recognized in clang -cc1
       continue;
@@ -478,9 +478,9 @@ std::vector<std::string> RISCVISAInfo::toFeatures(bool AddAllExtensions,
       continue;
 
     if (isExperimentalExtension(ExtName)) {
-      Features.push_back("+experimental-" + ExtName);
+      Features.push_back("+experimental-" + std::string(ExtName));
     } else {
-      Features.push_back("+" + ExtName);
+      Features.push_back("+" + std::string(ExtName));
     }
   }
   if (AddAllExtensions) {

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -470,7 +470,10 @@ std::vector<std::string> RISCVISAInfo::toFeatures(bool AddAllExtensions,
                                                   bool IgnoreUnknown) const {
   std::vector<std::string> Features;
   for (const auto &[ExtName, _] : Exts) {
-    if (ExtName == "i") // i is not recognized in clang -cc1
+    // i is a base instruction set, not an extension (see
+    // https://github.com/riscv/riscv-isa-manual/blob/main/src/naming.adoc#base-integer-isa)
+    // and is not recognized in clang -cc1
+    if (ExtName == "i")
       continue;
     if (IgnoreUnknown && !isSupportedExtension(ExtName))
       continue;

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -469,31 +469,29 @@ bool RISCVISAInfo::compareExtension(const std::string &LHS,
 std::vector<std::string> RISCVISAInfo::toFeatures(bool AddAllExtensions,
                                                   bool IgnoreUnknown) const {
   std::vector<std::string> Features;
-  for (auto const &Ext : Exts) {
-    StringRef ExtName = Ext.first;
-
+  for (const auto &[ExtName, _] : Exts) {
     if (ExtName == "i") // i is not recognized in clang -cc1
       continue;
     if (IgnoreUnknown && !isSupportedExtension(ExtName))
       continue;
 
     if (isExperimentalExtension(ExtName)) {
-      Features.push_back("+experimental-" + std::string(ExtName));
+      Features.push_back((llvm::Twine("+experimental-") + ExtName).str());
     } else {
-      Features.push_back("+" + std::string(ExtName));
+      Features.push_back((llvm::Twine("+") + ExtName).str());
     }
   }
   if (AddAllExtensions) {
     for (const RISCVSupportedExtension &Ext : SupportedExtensions) {
       if (Exts.count(Ext.Name))
         continue;
-      Features.push_back("-" + std::string(Ext.Name));
+      Features.push_back((llvm::Twine("-") + Ext.Name).str());
     }
 
     for (const RISCVSupportedExtension &Ext : SupportedExperimentalExtensions) {
       if (Exts.count(Ext.Name))
         continue;
-      Features.push_back("-experimental-" + std::string(Ext.Name));
+      Features.push_back((llvm::Twine("-experimental-") + Ext.Name).str());
     }
   }
   return Features;


### PR DESCRIPTION
toFeatures and toFeatureVector both output a list of target feature flags, just with a slightly different interface. toFeatures keeps any unsupported extensions, and also provides a way to append negative extensions (AddAllExtensions=true).

This patch combines them into one function, so that a later patch will be be able to get a std::vector of features that includes all the negative extensions, which was previously only possible through the StrAlloc interface.