### PR TITLE
[System][z/OS] Fix per-thread timing error on z/OS

### DIFF
--- a/third-party/benchmark/src/timers.cc
+++ b/third-party/benchmark/src/timers.cc
@@ -168,6 +168,9 @@ double ThreadCPUUsage() {
   // RTEMS doesn't support CLOCK_THREAD_CPUTIME_ID. See
   // https://github.com/RTEMS/rtems/blob/master/cpukit/posix/src/clockgettime.c
   return ProcessCPUUsage();
+#elif defined(BENCHMARK_OS_ZOS)
+  // z/OS doesn't support CLOCK_THREAD_CPUTIME_ID.
+  return ProcessCPUUsage();
 #elif defined(BENCHMARK_OS_SOLARIS)
   struct rusage ru;
   if (getrusage(RUSAGE_LWP, &ru) == 0) return MakeTime(ru);


### PR DESCRIPTION
This patch calls ProcessCPUUsage() for z/OS because we do not support CLOCK_THREAD_CPUTIME_ID.  This copies the change made to google benchmark here https://github.com/google/benchmark/commit/e3824e7503187993b287ac8c8144a35bf5ccfd44