### PR TITLE
[LLD] [MinGW] Remove an unnecessary include of unistd.h. NFC.

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -46,10 +46,6 @@
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
-#include <unistd.h>
-#endif
-
 using namespace lld;
 using namespace llvm::opt;
 using namespace llvm;


### PR DESCRIPTION
This was present since when the MinGW LLD frontend first was merged in 894dbbe8eb0e3d8fc7d8746a76d2380f0c2b6c0f, where it most probably was a leftover from earlier evolution of the patch.