### PR TITLE
[mlir][TD] update more tests to use the "main" interpreter pass

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformInterfaces.cpp
@@ -629,9 +629,6 @@ void transform::TransformState::recordOpHandleInvalidation(
   // the IR nested in each payload op associated with the given handle and look
   // for handles associated with each operation and value.
   for (const auto &[region, mapping] : llvm::reverse(mappings)) {
-    // Stop lookup when reaching a region that is isolated from above.
-    if (region->getParentOp()->hasTrait<OpTrait::IsIsolatedFromAbove>())
-      break;
     // Go over all op handle mappings and mark as invalidated any handle
     // pointing to any of the payload ops associated with the given handle or
     // any op nested in them.
@@ -652,6 +649,10 @@ void transform::TransformState::recordOpHandleInvalidation(
                                                    payloadValue, valueHandle,
                                                    newlyInvalidated);
     }
+
+    // Stop lookup when reaching a region that is isolated from above.
+    if (region->getParentOp()->hasTrait<OpTrait::IsIsolatedFromAbove>())
+      break;
   }
 }
 

--- a/mlir/test/Dialect/Transform/apply-foreach-nested.mlir
+++ b/mlir/test/Dialect/Transform/apply-foreach-nested.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s --split-input-file --verify-diagnostics \
-// RUN:          --pass-pipeline="builtin.module(test-transform-dialect-interpreter{enable-expensive-checks=1 bind-first-extra-to-ops=scf.for})"
+// RUN:             --transform-interpreter
 
 func.func private @bar()
 
@@ -17,12 +17,15 @@ func.func @foo() {
   return
 }
 
-transform.sequence failures(suppress) {
-^bb0(%arg0: !transform.any_op, %arg1: !transform.op<"scf.for">):
-  %1 = transform.test_reverse_payload_ops %arg1 : (!transform.op<"scf.for">) -> !transform.op<"scf.for">
-  // expected-error @below {{transform operation consumes a handle pointing to an ancestor payload operation before its descendant}}
-  // expected-note @below {{the ancestor is likely erased or rewritten before the descendant is accessed, leading to undefined behavior}}
-  transform.test_consume_operand_each %1 : !transform.op<"scf.for">
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["scf.for"]} in %arg0 : (!transform.any_op) -> !transform.op<"scf.for">
+    %1 = transform.test_reverse_payload_ops %0 : (!transform.op<"scf.for">) -> !transform.op<"scf.for">
+    // expected-error @below {{transform operation consumes a handle pointing to an ancestor payload operation before its descendant}}
+    // expected-note @below {{the ancestor is likely erased or rewritten before the descendant is accessed, leading to undefined behavior}}
+    transform.test_consume_operand_each %1 : !transform.op<"scf.for">
+    transform.yield
+  }
 }
 
 // -----
@@ -42,7 +45,10 @@ func.func @foo() {
 }
 
 // No error here, processing ancestors before descendants.
-transform.sequence failures(suppress) {
-^bb0(%arg0: !transform.any_op, %arg1: !transform.op<"scf.for">):
-  transform.test_consume_operand_each %arg1 : !transform.op<"scf.for">
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["scf.for"]} in %arg0 : (!transform.any_op) -> !transform.op<"scf.for">
+    transform.test_consume_operand_each %0 : !transform.op<"scf.for">
+    transform.yield
+  }
 }

--- a/mlir/test/Dialect/Transform/expensive-checks.mlir
+++ b/mlir/test/Dialect/Transform/expensive-checks.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --test-transform-dialect-interpreter='enable-expensive-checks=1' --split-input-file --verify-diagnostics %s
+// RUN: mlir-opt --transform-interpreter --split-input-file --verify-diagnostics %s
 
 // expected-note @below {{ancestor payload op}}
 func.func @func() {
@@ -6,24 +6,29 @@ func.func @func() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @return : benefit(1) {
-    %0 = operands
-    %1 = types
-    %2 = operation "func.return"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @return : benefit(1) {
+        %0 = operands
+        %1 = types
+        %2 = operation "func.return"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        rewrite %2 with "transform.dialect"
+      }
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    // expected-note @below {{handle to invalidated ops}}
-    %0 = pdl_match @return in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
-    test_consume_operand %1 : !transform.any_op
-    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-    test_print_remark_at_operand %0, "remark" : !transform.any_op
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        // expected-note @below {{handle to invalidated ops}}
+        %0 = pdl_match @return in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
+        test_consume_operand %1 : !transform.any_op
+        // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+        test_print_remark_at_operand %0, "remark" : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -35,29 +40,34 @@ func.func @func1() {
 }
 func.func private @func2()
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @func : benefit(1) {
-    %0 = operands
-    %1 = types
-    %2 = operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    rewrite %2 with "transform.dialect"
-  }
-  pdl.pattern @return : benefit(1) {
-    %0 = operands
-    %1 = types
-    %2 = operation "func.return"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @func : benefit(1) {
+        %0 = operands
+        %1 = types
+        %2 = operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        rewrite %2 with "transform.dialect"
+      }
+      pdl.pattern @return : benefit(1) {
+        %0 = operands
+        %1 = types
+        %2 = operation "func.return"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        rewrite %2 with "transform.dialect"
+      }
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @func in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = pdl_match @return in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
-    // expected-error @below {{a handle passed as operand #0 and consumed by this operation points to a payload entity more than once}}
-    test_consume_operand %2 : !transform.any_op
-    test_print_remark_at_operand %0, "remark" : !transform.any_op
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @func in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = pdl_match @return in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
+        // expected-error @below {{a handle passed as operand #0 and consumed by this operation points to a payload entity more than once}}
+        test_consume_operand %2 : !transform.any_op
+        test_print_remark_at_operand %0, "remark" : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -66,10 +76,9 @@ transform.with_pdl_patterns {
 
 // expected-note @below {{ancestor payload op}}
 // expected-note @below {{nested payload op}}
-module {
+module attributes {transform.with_named_sequence} {
 
-  transform.sequence failures(propagate) {
-  ^bb0(%0: !transform.any_op):
+  transform.named_sequence @__transform_main(%0: !transform.any_op) {
     %1 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
     // expected-note @below {{handle to invalidated ops}}
     %2 = transform.test_copy_payload %0 : (!transform.any_op) ->!transform.any_op
@@ -77,6 +86,7 @@ module {
     transform.test_consume_operand %1 : !transform.any_op
     // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
     transform.test_consume_operand %2 : !transform.any_op
+    transform.yield
   }
 }
 
@@ -84,10 +94,9 @@ module {
 
 // expected-note @below {{ancestor payload op}}
 // expected-note @below {{nested payload op}}
-module {
+module attributes {transform.with_named_sequence} {
 
-  transform.sequence failures(propagate) {
-  ^bb0(%0: !transform.any_op):
+  transform.named_sequence @__transform_main(%0: !transform.any_op) {
     %1 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
     // expected-note @below {{handle to invalidated ops}}
     %2 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
@@ -97,6 +106,7 @@ module {
     // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
     // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities}}
     transform.test_consume_operand %1, %2 : !transform.any_op, !transform.any_op
+    transform.yield
   }
 }
 
@@ -104,13 +114,13 @@ module {
 
 // Deduplication attribute allows "merge_handles" to take repeated operands.
 
-module {
+module attributes {transform.with_named_sequence} {
 
-  transform.sequence failures(propagate) {
-  ^bb0(%0: !transform.any_op):
+  transform.named_sequence @__transform_main(%0: !transform.any_op) {
     %1 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
     %2 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
     transform.merge_handles %1, %2 { deduplicate } : !transform.any_op
+    transform.yield
   }
 }
 // -----
@@ -118,16 +128,18 @@ module {
 // expected-note @below {{payload value}}
 %0 = "test.match_anchor"() : () -> (i32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated handle}}
-  %4 = test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates handles to the same values as associated with it}}
-  test_consume_operand %3 : !transform.any_value
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %4 : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated handle}}
+    %4 = transform.test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates handles to the same values as associated with it}}
+    transform.test_consume_operand %3 : !transform.any_value
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %4 : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -137,15 +149,17 @@ transform.sequence failures(propagate) {
 // expected-note @below {{op defining the value as result #0}}
 %0 = "test.match_anchor"() : () -> (i32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{invalidated handle}}
-  %3 = test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %2 : !transform.any_op
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %3 : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{invalidated handle}}
+    %3 = transform.test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %2 : !transform.any_op
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %3 : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -159,16 +173,18 @@ transform.sequence failures(propagate) {
   "test.region_terminator"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{invalidated handle}}
-  %3 = test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %1 : !transform.any_op
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %3 : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{invalidated handle}}
+    %3 = transform.test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %1 : !transform.any_op
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %3 : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -182,16 +198,18 @@ transform.sequence failures(propagate) {
   "test.region_terminator"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{invalidated handle}}
-  %3 = test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %1 : !transform.any_op
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %3 : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{invalidated handle}}
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %1 : !transform.any_op
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %3 : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -208,16 +226,18 @@ transform.sequence failures(propagate) {
   }): () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{invalidated handle}}
-  %3 = test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %1 : !transform.any_op
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %3 : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{invalidated handle}}
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %1 : !transform.any_op
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %3 : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -227,15 +247,17 @@ transform.sequence failures(propagate) {
 // expected-note @below {{consumed handle points to this payload value}}
 %0 = "test.match_anchor"() : () -> (i32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  // expected-note @below {{handle to invalidated ops}}
-  %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %3 : !transform.any_value
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %2 : !transform.any_op 
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-note @below {{handle to invalidated ops}}
+    %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_result %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %3 : !transform.any_value
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %2 : !transform.any_op 
+    transform.yield
+  }
 }
 
 // -----
@@ -249,16 +271,18 @@ transform.sequence failures(propagate) {
   "test.region_terminator"() : () -> ()
 }) : () -> (i32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{handle to invalidated ops}}
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %3 : !transform.any_value
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %2 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{handle to invalidated ops}}
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %3 : !transform.any_value
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %2 : !transform.any_op
+    transform.yield
+  }
 }
 
 
@@ -273,15 +297,17 @@ transform.sequence failures(propagate) {
   "test.region_terminator"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  // expected-note @below {{handle to invalidated ops}}
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %3 : !transform.any_value
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %2 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-note @below {{handle to invalidated ops}}
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %2, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %3 : !transform.any_value
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %2 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -299,16 +325,18 @@ transform.sequence failures(propagate) {
   "test.match_anchor_1"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // expected-note @below {{handle to invalidated ops}}
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_argument_of_parent_block %1, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
-  test_consume_operand %3 : !transform.any_value
-  // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-  test_consume_operand %2 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-note @below {{handle to invalidated ops}}
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %1, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0 and invalidates all handles to payload IR entities associated with this operand and entities nested in them}}
+    transform.test_consume_operand %3 : !transform.any_value
+    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+    transform.test_consume_operand %2 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -323,24 +351,28 @@ transform.sequence failures(propagate) {
   "test.match_anchor_2"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_argument_of_parent_block %1, 0 : (!transform.any_op) -> !transform.any_value
-  test_consume_operand %3 : !transform.any_value
-  test_consume_operand %2 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.match_anchor_1"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.match ops{["test.match_anchor_2"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %1, 0 : (!transform.any_op) -> !transform.any_value
+    transform.test_consume_operand %3 : !transform.any_value
+    transform.test_consume_operand %2 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_empty_payload : !transform.any_op
-  // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
-  transform.test_consume_operand %0 : !transform.any_op
-  // expected-error @below {{uses a handle associated with empty payload and invalidated by a previously executed transform op}}
-  transform.test_print_remark_at_operand %0, "remark" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_empty_payload : !transform.any_op
+    // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
+    transform.test_consume_operand %0 : !transform.any_op
+    // expected-error @below {{uses a handle associated with empty payload and invalidated by a previously executed transform op}}
+    transform.test_print_remark_at_operand %0, "remark" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -352,9 +384,8 @@ transform.sequence failures(propagate) {
 // invalidate the handle to the root module thus invalidating all other handles.
 
 // expected-note @below {{ancestor payload op}}
-module {
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence}  {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     // expected-note @below {{handle to invalidated ops}}
     // expected-note @below {{nested payload op}}
     %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
@@ -362,19 +393,6 @@ module {
     transform.test_consume_operand %arg0 : !transform.any_op
     // expected-error @below {{uses a handle invalidated by a previously executed transform op}}
     transform.test_consume_operand %0 { allow_repeated_handles } : !transform.any_op
-  }
-}
-
-// -----
-
-// Re-entering the region should not trigger the consumption error from previous
-// execution of the region.
-
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  transform.test_re_enter_region {
-    %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-    transform.test_consume_operand %0 : !transform.any_op
     transform.yield
   }
 }
@@ -384,12 +402,30 @@ transform.sequence failures(propagate) {
 // Re-entering the region should not trigger the consumption error from previous
 // execution of the region.
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-  transform.test_re_enter_region %0 : !transform.any_op {
-  ^bb0(%arg1: !transform.any_op):
-    transform.test_consume_operand %arg1 : !transform.any_op
+module attributes {transform.with_named_sequence}  {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.test_re_enter_region {
+      %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+      transform.test_consume_operand %0 : !transform.any_op
+      transform.yield
+    }
+    transform.yield
+  }
+}
+
+// -----
+
+// Re-entering the region should not trigger the consumption error from previous
+// execution of the region.
+
+module attributes {transform.with_named_sequence}  {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+    transform.test_re_enter_region %0 : !transform.any_op {
+    ^bb0(%arg1: !transform.any_op):
+      transform.test_consume_operand %arg1 : !transform.any_op
+      transform.yield
+    }
     transform.yield
   }
 }
@@ -397,16 +433,17 @@ transform.sequence failures(propagate) {
 // -----
 
 // Consuming the same handle repeatedly in the region should trigger an error.
-
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-note @below {{payload op}}
-  // expected-note @below {{handle to invalidated ops}}
-  %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-  transform.test_re_enter_region {
-    // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-    // expected-note @below {{invalidated by this transform op}}
-    transform.test_consume_operand %0 : !transform.any_op
+module attributes {transform.with_named_sequence}  {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-note @below {{payload op}}
+    // expected-note @below {{handle to invalidated ops}}
+    %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+    transform.test_re_enter_region {
+      // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
+      // expected-note @below {{invalidated by this transform op}}
+      transform.test_consume_operand %0 : !transform.any_op
+      transform.yield
+    }
     transform.yield
   }
 }
@@ -424,8 +461,8 @@ module @named_inclusion_and_consumption attributes { transform.with_named_sequen
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
-    include @foo failures(propagate) (%arg0) : (!transform.any_op) -> ()
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.include @foo failures(propagate) (%arg0) : (!transform.any_op) -> ()
+    transform.yield
   }
 }

--- a/mlir/test/Dialect/Transform/selective-targeting.mlir
+++ b/mlir/test/Dialect/Transform/selective-targeting.mlir
@@ -1,4 +1,4 @@
-// RUN:  mlir-opt %s -test-transform-dialect-interpreter --split-input-file | FileCheck %s
+// RUN:  mlir-opt %s --transform-interpreter --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors_1(
 func.func @matmul_tensors_1(
@@ -52,35 +52,40 @@ func.func @matmul_tensors_3(
   func.return %0 : tensor<128x128xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  // Match matmul operations inside @matmul_tensors with test.attrA set.
-  pdl.pattern @pdl_target_attrA : benefit(1) {
-    %args = operands
-    %results = types
-    %attr = attribute
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrA" = %attr}-> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root : !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      // Match matmul operations inside @matmul_tensors with test.attrA set.
+      pdl.pattern @pdl_target_attrA : benefit(1) {
+        %args = operands
+        %results = types
+        %attr = attribute
+        %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrA" = %attr}-> (%results : !pdl.range<type>)
+        // TODO: we don't want this, but it is the required terminator for pdl.pattern
+        rewrite %0 with "transform.dialect"
+      }
 
-  // Match matmul operations inside @matmul_tensors with test.attrC set.
-  pdl.pattern @pdl_target_attrC : benefit(1) {
-    %args = operands
-    %results = types
-    %attr = attribute
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrC" = %attr}-> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
+      // Match matmul operations inside @matmul_tensors with test.attrC set.
+      pdl.pattern @pdl_target_attrC : benefit(1) {
+        %args = operands
+        %results = types
+        %attr = attribute
+        %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrC" = %attr}-> (%results : !pdl.range<type>)
+        // TODO: we don't want this, but it is the required terminator for pdl.pattern
+        rewrite %0 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @pdl_target_attrA in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.tile_using_for %0 [4, 4, 4] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
-    %1 = pdl_match @pdl_target_attrC in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = get_parent_op %1 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize_children_and_apply_patterns %2 : (!transform.any_op) -> !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @pdl_target_attrA in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.structured.tile_using_for %0 [4, 4, 4] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+        %1 = pdl_match @pdl_target_attrC in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = get_parent_op %1 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        transform.structured.vectorize_children_and_apply_patterns %2 : (!transform.any_op) -> !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -110,22 +115,27 @@ func.func @vectorize_none(
   func.return %0 : tensor<128x128xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @pdl_target : benefit(1) {
-    %args = operands
-    %results = types
-    %attr = attribute
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrA" = %attr}-> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root : !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @pdl_target : benefit(1) {
+        %args = operands
+        %results = types
+        %attr = attribute
+        %0 = operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrA" = %attr}-> (%results : !pdl.range<type>)
+        // TODO: we don't want this, but it is the required terminator for pdl.pattern
+        rewrite %0 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @pdl_target in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @pdl_target in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -148,7 +158,9 @@ func.func @vectorize_all(
   return %1 : tensor<128x128xf32>
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  transform.structured.vectorize_children_and_apply_patterns %arg0 : (!transform.any_op) -> !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.structured.vectorize_children_and_apply_patterns %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
 }

--- a/mlir/test/Dialect/Transform/test-interpreter.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter.mlir
@@ -1,29 +1,35 @@
-// RUN: mlir-opt %s --test-transform-dialect-interpreter -allow-unregistered-dialect --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter -allow-unregistered-dialect --split-input-file --verify-diagnostics | FileCheck %s
 
 // UNSUPPORTED: target=aarch64-pc-windows-msvc
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-remark @below {{applying transformation}}
-  transform.test_transform_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-remark @below {{applying transformation}}
+    transform.test_transform_op
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
-  // expected-remark @below {{succeeded}}
-  transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
+    // expected-remark @below {{succeeded}}
+    transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
-  // expected-error @below {{expected the operand to be associated a payload op of kind transform.sequence got transform.test_produce_self_handle_or_forward_operand}}
-  transform.test_consume_operand_of_op_kind_or_fail %0, "transform.sequence" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
+    // expected-error @below {{expected the operand to be associated a payload op of kind transform.sequence got transform.test_produce_self_handle_or_forward_operand}}
+    transform.test_consume_operand_of_op_kind_or_fail %0, "transform.sequence" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -31,56 +37,64 @@ transform.sequence failures(propagate) {
 // It is okay to have multiple handles to the same payload op as long
 // as only one of them is consumed. The expensive checks mode is necessary
 // to detect double-consumption.
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
-  %1 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
-  // expected-remark @below {{succeeded}}
-  transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
-}
-
-// -----
-
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    // expected-remark @below {{applying transformation "a"}}
-    test_transform_op "a"
-    // expected-remark @below {{applying transformation "b"}}
-    test_transform_op "b"
-    // expected-remark @below {{applying transformation "c"}}
-    test_transform_op "c"
-  }
-  // expected-remark @below {{applying transformation "d"}}
-  test_transform_op "d"
-  // expected-remark @below {{applying transformation "e"}}
-  test_transform_op "e"
-}
-
-// -----
-
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-  sequence %0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_self_handle_or_forward_operand { foo = "bar" } : () -> !transform.any_op
+    %1 = transform.test_copy_payload %0 : (!transform.any_op) -> !transform.any_op
     // expected-remark @below {{succeeded}}
-    test_consume_operand_of_op_kind_or_fail %arg1, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    transform.yield
   }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = sequence %arg0 : !transform.any_op -> !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %1 = test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-    yield %1 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.sequence %arg0 : !transform.any_op failures(propagate) {
+    ^bb0(%arg1: !transform.any_op):
+      // expected-remark @below {{applying transformation "a"}}
+      test_transform_op "a"
+      // expected-remark @below {{applying transformation "b"}}
+      test_transform_op "b"
+      // expected-remark @below {{applying transformation "c"}}
+      test_transform_op "c"
+    }
+    // expected-remark @below {{applying transformation "d"}}
+    transform.test_transform_op "d"
+    // expected-remark @below {{applying transformation "e"}}
+    transform.test_transform_op "e"
+    transform.yield
   }
-  // expected-remark @below {{succeeded}}
-  test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+}
+
+// -----
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+    transform.sequence %0 : !transform.any_op failures(propagate) {
+    ^bb0(%arg1: !transform.any_op):
+      // expected-remark @below {{succeeded}}
+      test_consume_operand_of_op_kind_or_fail %arg1, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    }
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.sequence %arg0 : !transform.any_op -> !transform.any_op failures(propagate) {
+    ^bb0(%arg1: !transform.any_op):
+      %1 = test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+      yield %1 : !transform.any_op
+    }
+    // expected-remark @below {{succeeded}}
+    transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -98,19 +112,24 @@ func.func @bar() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @const : benefit(1) {
-    %r = pdl.types
-    %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @const : benefit(1) {
+        %r = pdl.types
+        %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %f = pdl_match @const in %arg1 : (!transform.any_op) -> !transform.any_op
-    %m = get_parent_op %f {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    test_print_remark_at_operand %m, "parent function" : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %f = pdl_match @const in %arg1 : (!transform.any_op) -> !transform.any_op
+        %m = get_parent_op %f {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        test_print_remark_at_operand %m, "parent function" : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -130,14 +149,15 @@ func.func @test_get_nth_parent() {
   }) : () -> ()
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %f = transform.structured.match ops{["test.bar"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %parent = get_parent_op %f {nth_parent = 1, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %parent, "1st parent" : !transform.any_op
-  %parent2 = get_parent_op %f {nth_parent = 2, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %parent2, "2nd parent" : !transform.any_op
-  transform.yield
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %f = transform.structured.match ops{["test.bar"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %parent = transform.get_parent_op %f {nth_parent = 1, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %parent, "1st parent" : !transform.any_op
+    %parent2 = transform.get_parent_op %f {nth_parent = 2, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %parent2, "2nd parent" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -147,32 +167,37 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_func : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_func : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    // This is necessary to run the transformation on something other than the
-    // top-level module, "alternatives" cannot be run on that.
-    %0 = pdl_match @match_func in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.alternatives %0 : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %1 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-      // This operation fails, which triggers the next alternative without
-      // reporting the error.
-      transform.test_consume_operand_of_op_kind_or_fail %1, "transform.sequence" : !transform.any_op
-    }, {
-    ^bb2(%arg2: !transform.any_op):
-      %1 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-      // expected-remark @below {{succeeded}}
-      transform.test_consume_operand_of_op_kind_or_fail %1, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        // This is necessary to run the transformation on something other than the
+        // top-level module, "alternatives" cannot be run on that.
+        %0 = pdl_match @match_func in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.alternatives %0 : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %1 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+          // This operation fails, which triggers the next alternative without
+          // reporting the error.
+          transform.test_consume_operand_of_op_kind_or_fail %1, "transform.sequence" : !transform.any_op
+        }, {
+        ^bb2(%arg2: !transform.any_op):
+          %1 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+          // expected-remark @below {{succeeded}}
+          transform.test_consume_operand_of_op_kind_or_fail %1, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+        }
+      }
     }
+    transform.yield
   }
 }
 
@@ -185,26 +210,31 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_call : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_call : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{all alternatives failed}}
-    transform.alternatives %1 : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      // expected-remark @below {{applying}}
-      transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{all alternatives failed}}
+        transform.alternatives %1 : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          // expected-remark @below {{applying}}
+          transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
+        }
+      }
     }
+    transform.yield
   }
 }
 
@@ -218,35 +248,40 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_call : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_call : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    transform.alternatives %1 : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      // expected-remark @below {{applying}}
-      transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
-    }, {
-    ^bb2(%arg2: !transform.any_op):
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      transform.test_print_remark_at_operand %2, "still here" : !transform.any_op
-      // This alternative succeeds.
-    }, {
-    ^bb2(%arg2: !transform.any_op):
-      // This alternative is never run, so we must not have a remark here.
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      transform.test_emit_remark_and_erase_operand %2, "should not happen" {fail_after_erase} : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        transform.alternatives %1 : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          // expected-remark @below {{applying}}
+          transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
+        }, {
+        ^bb2(%arg2: !transform.any_op):
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          transform.test_print_remark_at_operand %2, "still here" : !transform.any_op
+          // This alternative succeeds.
+        }, {
+        ^bb2(%arg2: !transform.any_op):
+          // This alternative is never run, so we must not have a remark here.
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          transform.test_emit_remark_and_erase_operand %2, "should not happen" {fail_after_erase} : !transform.any_op
+        }
+      }
     }
+    transform.yield
   }
 }
 
@@ -259,30 +294,35 @@ func.func @erase_call() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_call : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_call : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    transform.alternatives %1 : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      // expected-remark @below {{applying}}
-      transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
-    }, {
-    ^bb2(%arg2: !transform.any_op):
-      %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      // expected-remark @below {{applying second time}}
-      transform.test_emit_remark_and_erase_operand %2, "applying second time" : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        transform.alternatives %1 : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          // expected-remark @below {{applying}}
+          transform.test_emit_remark_and_erase_operand %2, "applying" {fail_after_erase} : !transform.any_op
+        }, {
+        ^bb2(%arg2: !transform.any_op):
+          %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          // expected-remark @below {{applying second time}}
+          transform.test_emit_remark_and_erase_operand %2, "applying second time" : !transform.any_op
+        }
+      }
     }
+    transform.yield
   }
 }
 
@@ -295,43 +335,48 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_call : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_call : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.call"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    %2 = transform.alternatives %1 : !transform.any_op -> !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %3 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-      // expected-remark @below {{applying}}
-      transform.test_emit_remark_and_erase_operand %3, "applying" {fail_after_erase} : !transform.any_op
-      %4 = transform.test_produce_self_handle_or_forward_operand %3 : (!transform.any_op) -> !transform.any_op
-      transform.yield %4 : !transform.any_op
-    }, {
-    ^bb2(%arg2: !transform.any_op):
-      %4 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
-      transform.yield %4 : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @match_call in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+        %2 = transform.alternatives %1 : !transform.any_op -> !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %3 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
+          // expected-remark @below {{applying}}
+          transform.test_emit_remark_and_erase_operand %3, "applying" {fail_after_erase} : !transform.any_op
+          %4 = transform.test_produce_self_handle_or_forward_operand %3 : (!transform.any_op) -> !transform.any_op
+          transform.yield %4 : !transform.any_op
+        }, {
+        ^bb2(%arg2: !transform.any_op):
+          %4 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
+          transform.yield %4 : !transform.any_op
+        }
+        // The first alternative failed, so the returned value is taken from the
+        // second alternative, associated test_produce_self_handle_or_forward_operand rather
+        // than pdl_match.
+        // expected-remark @below {{succeeded}}
+        transform.test_consume_operand_of_op_kind_or_fail %2, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+      }
     }
-    // The first alternative failed, so the returned value is taken from the
-    // second alternative, associated test_produce_self_handle_or_forward_operand rather
-    // than pdl_match.
-    // expected-remark @below {{succeeded}}
-    transform.test_consume_operand_of_op_kind_or_fail %2, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
+    transform.yield
   }
 }
 
 // -----
 
 // expected-note @below {{scope}}
-module {
+module attributes {transform.with_named_sequence} {
   func.func @foo() {
     %0 = arith.constant 0 : i32
     return
@@ -343,8 +388,7 @@ module {
     return
   }
 
-  transform.sequence failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     // expected-error @below {{scope must not contain the transforms being applied}}
     transform.alternatives %arg1 : !transform.any_op {
     ^bb2(%arg2: !transform.any_op):
@@ -355,6 +399,7 @@ module {
       %0 = transform.test_produce_self_handle_or_forward_operand : () -> !transform.any_op
       transform.test_consume_operand_of_op_kind_or_fail %0, "transform.test_produce_self_handle_or_forward_operand" : !transform.any_op
     }
+    transform.yield
   }
 }
 
@@ -368,24 +413,29 @@ func.func @foo(%arg0: index, %arg1: index, %arg2: index) {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @match_const : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "arith.constant"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @match_const : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "arith.constant"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = transform.pdl_match @match_const in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = transform.get_parent_op %0 {op_name = "scf.for"} : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{only isolated-from-above ops can be alternative scopes}}
-    alternatives %1 : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = transform.pdl_match @match_const in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = transform.get_parent_op %0 {op_name = "scf.for"} : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{only isolated-from-above ops can be alternative scopes}}
+        alternatives %1 : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+        }
+      }
     }
+    transform.yield
   }
 }
 // -----
@@ -396,21 +446,26 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{application of transform.test_wrong_number_of_results expected to produce 3 results (actually produced 1).}}
-    // expected-note @below {{if you need variadic results, consider a generic `apply` instead of the specialized `applyToOne`.}}
-    transform.test_wrong_number_of_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{application of transform.test_wrong_number_of_results expected to produce 3 results (actually produced 1).}}
+        // expected-note @below {{if you need variadic results, consider a generic `apply` instead of the specialized `applyToOne`.}}
+        transform.test_wrong_number_of_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+      }
+    }
+    transform.yield
   }
 }
 
@@ -423,21 +478,26 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{application of transform.test_wrong_number_of_multi_results expected to produce 1 results (actually produced 0)}}
-    // expected-note @below {{if you need variadic results, consider a generic `apply` instead of the specialized `applyToOne`.}}
-    transform.test_wrong_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op)
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{application of transform.test_wrong_number_of_multi_results expected to produce 1 results (actually produced 0)}}
+        // expected-note @below {{if you need variadic results, consider a generic `apply` instead of the specialized `applyToOne`.}}
+        transform.test_wrong_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op)
+      }
+    }
+    transform.yield
   }
 }
 
@@ -450,20 +510,25 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // Transform matches 3 ops and produces 2 results.
-    %1:2 = transform.test_correct_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // Transform matches 3 ops and produces 2 results.
+        %1:2 = transform.test_correct_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      }
+    }
+    transform.yield
   }
 }
 
@@ -474,20 +539,25 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // Transform fails to match any but still produces 2 results.
-    %1:2 = transform.test_correct_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // Transform fails to match any but still produces 2 results.
+        %1:2 = transform.test_correct_number_of_multi_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      }
+    }
+    transform.yield
   }
 }
 
@@ -500,19 +570,24 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_mixed_null_and_non_null_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.test_mixed_null_and_non_null_results %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      }
+    }
+    transform.yield
   }
 }
 
@@ -530,27 +605,32 @@ func.func @foo(%arg0: index) {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @addi : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "arith.addi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
-  pdl.pattern @subi : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "arith.subi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @addi : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "arith.addi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
+      pdl.pattern @subi : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "arith.subi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = pdl_match @subi in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = merge_handles %0, %1 : !transform.any_op
-    test_print_remark_at_operand %2, "matched" : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = pdl_match @subi in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = merge_handles %0, %1 : !transform.any_op
+        test_print_remark_at_operand %2, "matched" : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -561,23 +641,28 @@ func.func @foo(%arg0: index) {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @addi : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "arith.addi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @addi : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "arith.addi"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = merge_handles deduplicate %0, %1 : !transform.any_op
-    %3 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
-    // expected-remark @below {{1}}
-    test_print_param %3 : !transform.param<i64>
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = merge_handles deduplicate %0, %1 : !transform.any_op
+        %3 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
+        // expected-remark @below {{1}}
+        test_print_param %3 : !transform.param<i64>
+      }
+    }
+    transform.yield
   }
 }
 
@@ -590,45 +675,25 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{failed to apply}}
-    transform.test_mixed_success_and_silenceable %0 : !transform.any_op
-  }
-}
-
-// -----
-
-func.func @foo() {
-  "op" () : () -> ()
-  return
-}
-
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
-
-  transform.sequence %arg0 : !transform.any_op failures(suppress) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // Not expecting error here because we are suppressing it.
-    // expected-remark @below {{foo}}
-    test_emit_remark_and_erase_operand %0, "foo" {fail_after_erase} : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{failed to apply}}
+        transform.test_mixed_success_and_silenceable %0 : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -639,52 +704,91 @@ func.func @foo() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operands
-    %1 = pdl.types
-    %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-    pdl.rewrite %2 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{silenceable error}}
-    // expected-remark @below {{foo}}
-    test_emit_remark_and_erase_operand %0, "foo" {fail_after_erase} : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(suppress) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // Not expecting error here because we are suppressing it.
+        // expected-remark @below {{foo}}
+        test_emit_remark_and_erase_operand %0, "foo" {fail_after_erase} : !transform.any_op
+      }
+    }
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @foo() {
+  "op" () : () -> ()
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "op"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
+
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{silenceable error}}
+        // expected-remark @below {{foo}}
+        test_emit_remark_and_erase_operand %0, "foo" {fail_after_erase} : !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
 
 // -----
 
-module {
+module attributes {transform.with_named_sequence} {
   func.func private @foo()
   func.func private @bar()
 
-  transform.with_pdl_patterns {
-  ^bb0(%arg0: !transform.any_op):
-    pdl.pattern @func : benefit(1) {
-      %0 = pdl.operands
-      %1 = pdl.types
-      %2 = pdl.operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
-      pdl.rewrite %2 with "transform.dialect"
-    }
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
 
-    transform.sequence %arg0 : !transform.any_op failures(propagate) {
-    ^bb0(%arg1: !transform.any_op):
-      %0 = pdl_match @func in %arg1 : (!transform.any_op) -> !transform.any_op
-      %1 = replicate num(%0) %arg1 : !transform.any_op, !transform.any_op
-      %p = num_associations %1 : (!transform.any_op) -> !transform.param<i64>
-      // expected-remark @below {{2}}
-      test_print_param %p : !transform.param<i64>
-      %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
-      %p2 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
-      // expected-remark @below {{4}}
-      test_print_param %p2 : !transform.param<i64>
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @func : benefit(1) {
+        %0 = pdl.operands
+        %1 = pdl.types
+        %2 = pdl.operation "func.func"(%0 : !pdl.range<value>) -> (%1 : !pdl.range<type>)
+        pdl.rewrite %2 with "transform.dialect"
+      }
+
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @func in %arg1 : (!transform.any_op) -> !transform.any_op
+        %1 = replicate num(%0) %arg1 : !transform.any_op, !transform.any_op
+        %p = num_associations %1 : (!transform.any_op) -> !transform.param<i64>
+        // expected-remark @below {{2}}
+        test_print_param %p : !transform.param<i64>
+        %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
+        %p2 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
+        // expected-remark @below {{4}}
+        test_print_param %p2 : !transform.param<i64>
+      }
     }
+    transform.yield
   }
 }
 
@@ -698,24 +802,29 @@ func.func @bar() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @const : benefit(1) {
-    %r = pdl.types
-    %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @const : benefit(1) {
+        %r = pdl.types
+        %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %f = pdl_match @const in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.foreach %f : !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %p = transform.num_associations %arg2 : (!transform.any_op) -> !transform.param<i64>
-      // expected-remark @below {{1}}
-      transform.test_print_param %p : !transform.param<i64>
-      transform.test_print_remark_at_operand %arg2, "transform applied" : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %f = pdl_match @const in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.foreach %f : !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %p = transform.num_associations %arg2 : (!transform.any_op) -> !transform.param<i64>
+          // expected-remark @below {{1}}
+          transform.test_print_param %p : !transform.param<i64>
+          transform.test_print_remark_at_operand %arg2, "transform applied" : !transform.any_op
+        }
+      }
     }
+    transform.yield
   }
 }
 
@@ -731,13 +840,15 @@ func.func @consume_in_foreach() {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %f = transform.structured.match ops{["arith.constant"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  transform.foreach %f : !transform.any_op {
-  ^bb2(%arg2: !transform.any_op):
-    // expected-remark @below {{erasing}}
-    transform.test_emit_remark_and_erase_operand %arg2, "erasing" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %f = transform.structured.match ops{["arith.constant"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.foreach %f : !transform.any_op {
+    ^bb2(%arg2: !transform.any_op):
+      // expected-remark @below {{erasing}}
+      transform.test_emit_remark_and_erase_operand %arg2, "erasing" : !transform.any_op
+    }
+    transform.yield
   }
 }
 
@@ -761,33 +872,38 @@ func.func @bar() {
   return
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @const : benefit(1) {
-    %r = pdl.types
-    %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @const : benefit(1) {
+        %r = pdl.types
+        %0 = pdl.operation "arith.constant" -> (%r : !pdl.range<type>)
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  pdl.pattern @execute_region : benefit(1) {
-    %r = pdl.types
-    %0 = pdl.operation "scf.execute_region" -> (%r : !pdl.range<type>)
-    pdl.rewrite %0 with "transform.dialect"
-  }
+      pdl.pattern @execute_region : benefit(1) {
+        %r = pdl.types
+        %0 = pdl.operation "scf.execute_region" -> (%r : !pdl.range<type>)
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %f = pdl_match @execute_region in %arg1 : (!transform.any_op) -> !transform.any_op
-    %results = transform.foreach %f : !transform.any_op -> !transform.any_op {
-    ^bb2(%arg2: !transform.any_op):
-      %g = transform.pdl_match @const in %arg2 : (!transform.any_op) -> !transform.any_op
-      transform.yield %g : !transform.any_op
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %f = pdl_match @execute_region in %arg1 : (!transform.any_op) -> !transform.any_op
+        %results = transform.foreach %f : !transform.any_op -> !transform.any_op {
+        ^bb2(%arg2: !transform.any_op):
+          %g = transform.pdl_match @const in %arg2 : (!transform.any_op) -> !transform.any_op
+          transform.yield %g : !transform.any_op
+        }
+
+        %p = transform.num_associations %results : (!transform.any_op) -> !transform.param<i64>
+        // expected-remark @below {{3}}
+        transform.test_print_param %p : !transform.param<i64>
+        transform.test_print_remark_at_operand %results, "transform applied" : !transform.any_op
+      }
     }
-
-    %p = transform.num_associations %results : (!transform.any_op) -> !transform.param<i64>
-    // expected-remark @below {{3}}
-    transform.test_print_param %p : !transform.param<i64>
-    transform.test_print_remark_at_operand %results, "transform applied" : !transform.any_op
+    transform.yield
   }
 }
 
@@ -800,11 +916,13 @@ func.func @get_parent_for_op_no_loop(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %muli = get_producer_of_operand %addi[0] : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %muli, "found muli" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %muli = transform.get_producer_of_operand %addi[0] : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %muli, "found muli" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -815,12 +933,13 @@ func.func @get_parent_for_op_no_loop(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{could not find a producer for operand number: 0 of}}
-  %bbarg = get_producer_of_operand %muli[0] : (!transform.any_op) -> !transform.any_op
-
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{could not find a producer for operand number: 0 of}}
+    %bbarg = transform.get_producer_of_operand %muli[0] : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -832,11 +951,13 @@ func.func @get_consumer(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %addi = get_consumers_of_result %muli[0] : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %addi, "found addi" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %addi = transform.get_consumers_of_result %muli[0] : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %addi, "found addi" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -847,12 +968,13 @@ func.func @get_consumer_fail_1(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{handle must be mapped to exactly one payload op}}
-  %bbarg = get_consumers_of_result %muli[0] : (!transform.any_op) -> !transform.any_op
-
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{handle must be mapped to exactly one payload op}}
+    %bbarg = transform.get_consumers_of_result %muli[0] : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -862,12 +984,13 @@ func.func @get_consumer_fail_2(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{result number overflow}}
-  %bbarg = get_consumers_of_result %muli[1] : (!transform.any_op) -> !transform.any_op
-
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{result number overflow}}
+    %bbarg = transform.get_consumers_of_result %muli[1] : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -878,16 +1001,18 @@ func.func @split_handle(%a: index, %b: index, %c: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%fun: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  %h:2 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-  %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  transform.test_print_param %p : !transform.param<i64>
-  %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{expected to contain 3 payload ops but it contains 2 payload ops}}
-  %h_2:3 = split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%fun: !transform.any_op) {
+    %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+    %h:2 = transform.split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p : !transform.param<i64>
+    %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{expected to contain 3 payload ops but it contains 2 payload ops}}
+    %h_2:3 = transform.split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
 }
 
 // -----
@@ -898,19 +1023,24 @@ func.func @split_handle(%a: index, %b: index, %c: index) {
   return
 }
 
-transform.sequence failures(suppress) {
-^bb1(%fun: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  %h:2 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-  %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  transform.test_print_param %p : !transform.param<i64>
-  %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  // Silenceable failure and all handles are now empty.
-  %h_2:3 = split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-  %p2 = transform.num_associations %h_2#0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{0}}
-  transform.test_print_param %p2 : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.sequence %root : !transform.any_op failures(suppress) {
+    ^bb1(%fun: !transform.any_op):
+      %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+      %h:2 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
+      // expected-remark @below {{1}}
+      transform.test_print_param %p : !transform.param<i64>
+      %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+      // Silenceable failure and all handles are now empty.
+      %h_2:3 = split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+      %p2 = transform.num_associations %h_2#0 : (!transform.any_op) -> !transform.param<i64>
+      // expected-remark @below {{0}}
+      transform.test_print_param %p2 : !transform.param<i64>
+    }
+    transform.yield
+  }
 }
 
 // -----
@@ -921,20 +1051,22 @@ func.func @split_handle(%a: index, %b: index, %c: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%fun: !transform.any_op):
-  %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  // No error, last result handle is empty.
-  %h:3 = split_handle %muli_2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-  %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  transform.test_print_param %p : !transform.param<i64>
-  %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  transform.test_print_param %p2 : !transform.param<i64>
-  %p3 = transform.num_associations %h#2 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{0}}
-  transform.test_print_param %p3 : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%fun: !transform.any_op) {
+    %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+    // No error, last result handle is empty.
+    %h:3 = transform.split_handle %muli_2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p : !transform.param<i64>
+    %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p2 : !transform.param<i64>
+    %p3 = transform.num_associations %h#2 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{0}}
+    transform.test_print_param %p3 : !transform.param<i64>
+    transform.yield
+  }
 }
 
 // -----
@@ -947,35 +1079,17 @@ func.func @split_handle(%a: index, %b: index, %c: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%fun: !transform.any_op):
-  %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  %h:2 = split_handle %muli_2 {overflow_result = 0} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-  %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{3}}
-  transform.test_print_param %p : !transform.param<i64>
-  %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  transform.test_print_param %p2 : !transform.param<i64>
-}
-
-// -----
-
-"test.some_op"() : () -> ()
-"other_dialect.other_op"() : () -> ()
-
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operation "test.some_op"
-    pdl.rewrite %0 with "transform.dialect"
-  }
-
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = transform.cast %0 : !transform.any_op to !transform.test_dialect_op
-    transform.cast %2 : !transform.test_dialect_op to !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%fun: !transform.any_op) {
+    %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+    %h:2 = transform.split_handle %muli_2 {overflow_result = 0} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{3}}
+    transform.test_print_param %p : !transform.param<i64>
+    %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p2 : !transform.param<i64>
+    transform.yield
   }
 }
 
@@ -984,19 +1098,23 @@ transform.with_pdl_patterns {
 "test.some_op"() : () -> ()
 "other_dialect.other_op"() : () -> ()
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @other : benefit(1) {
-    %0 = pdl.operation "other_dialect.other_op"
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operation "test.some_op"
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @other in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{expected the payload operation to belong to the 'test' dialect}}
-    %2 = transform.cast %0 : !transform.any_op to !transform.test_dialect_op
-    transform.cast %2 : !transform.test_dialect_op to !transform.any_op
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = transform.cast %0 : !transform.any_op to !transform.test_dialect_op
+        transform.cast %2 : !transform.test_dialect_op to !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -1005,18 +1123,49 @@ transform.with_pdl_patterns {
 "test.some_op"() : () -> ()
 "other_dialect.other_op"() : () -> ()
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operation "test.some_op"
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @other : benefit(1) {
+        %0 = pdl.operation "other_dialect.other_op"
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    %2 = transform.cast %0 : !transform.any_op to !transform.op<"test.some_op">
-    transform.cast %2 : !transform.op<"test.some_op"> to !transform.any_op
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @other in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{expected the payload operation to belong to the 'test' dialect}}
+        %2 = transform.cast %0 : !transform.any_op to !transform.test_dialect_op
+        transform.cast %2 : !transform.test_dialect_op to !transform.any_op
+      }
+    }
+    transform.yield
+  }
+}
+
+// -----
+
+"test.some_op"() : () -> ()
+"other_dialect.other_op"() : () -> ()
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operation "test.some_op"
+        pdl.rewrite %0 with "transform.dialect"
+      }
+
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        %2 = transform.cast %0 : !transform.any_op to !transform.op<"test.some_op">
+        transform.cast %2 : !transform.op<"test.some_op"> to !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
@@ -1026,42 +1175,52 @@ transform.with_pdl_patterns {
 // expected-note @below {{payload operation}}
 "other_dialect.other_op"() : () -> ()
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  pdl.pattern @other : benefit(1) {
-    %0 = pdl.operation "other_dialect.other_op"
-    pdl.rewrite %0 with "transform.dialect"
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      pdl.pattern @other : benefit(1) {
+        %0 = pdl.operation "other_dialect.other_op"
+        pdl.rewrite %0 with "transform.dialect"
+      }
 
-  sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
-    %0 = pdl_match @other in %arg1 : (!transform.any_op) -> !transform.any_op
-    // expected-error @below {{incompatible payload operation name}}
-    %2 = transform.cast %0 : !transform.any_op to !transform.op<"test.some_op">
-    transform.cast %2 : !transform.op<"test.some_op"> to !transform.any_op
+      sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb1(%arg1: !transform.any_op):
+        %0 = pdl_match @other in %arg1 : (!transform.any_op) -> !transform.any_op
+        // expected-error @below {{incompatible payload operation name}}
+        %2 = transform.cast %0 : !transform.any_op to !transform.op<"test.some_op">
+        transform.cast %2 : !transform.op<"test.some_op"> to !transform.any_op
+      }
+    }
+    transform.yield
   }
 }
 
 // -----
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !transform.any_op):
-  transform.sequence %arg0 : !transform.any_op failures(propagate) {
-  ^bb0(%arg1: !transform.any_op):
-    %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    // here, the handles nested under are {%arg0, %arg1, %0}
-    // expected-remark @below {{3 handles nested under}}
-    transform.test_report_number_of_tracked_handles_nested_under %arg1 : !transform.any_op
-    // expected-remark @below {{erased}}
-    transform.test_emit_remark_and_erase_operand %0, "erased" : !transform.any_op
-    // here, the handles nested under are only {%arg0, %arg1}
-    // expected-remark @below {{2 handles nested under}}
-    transform.test_report_number_of_tracked_handles_nested_under %arg1 : !transform.any_op
-  }
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.with_pdl_patterns %root : !transform.any_op {
+    ^bb0(%arg0: !transform.any_op):
+      transform.sequence %arg0 : !transform.any_op failures(propagate) {
+      ^bb0(%arg1: !transform.any_op):
+        %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
+        // here, the handles nested under are {%root, %arg0, %arg1, %0}
+        // expected-remark @below {{4 handles nested under}}
+        transform.test_report_number_of_tracked_handles_nested_under %arg1 : !transform.any_op
+        // expected-remark @below {{erased}}
+        transform.test_emit_remark_and_erase_operand %0, "erased" : !transform.any_op
+        // here, the handles nested under are only {%root, %arg0, %arg1}
+        // expected-remark @below {{3 handles nested under}}
+        transform.test_report_number_of_tracked_handles_nested_under %arg1 : !transform.any_op
+      }
 
-  pdl.pattern @some : benefit(1) {
-    %0 = pdl.operation "test.some_op"
-    pdl.rewrite %0 with "transform.dialect"
+      pdl.pattern @some : benefit(1) {
+        %0 = pdl.operation "test.some_op"
+        pdl.rewrite %0 with "transform.dialect"
+      }
+    }
+    transform.yield
   }
 }
 
@@ -1075,66 +1234,84 @@ func.func @split_handle(%a: index, %b: index, %c: index) {
   return
 }
 
-transform.sequence -> !transform.any_op failures(propagate) {
-^bb1(%fun: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{expected to contain 3 payload ops but it contains 2 payload ops}}
-  %h_2:3 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-  /// Test that yield does not crash in the presence of silenceable error in
-  /// propagate mode.
-  yield %fun : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.sequence %root : !transform.any_op -> !transform.any_op failures(propagate) {
+    ^bb1(%fun: !transform.any_op):
+      %muli = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
+      // expected-error @below {{expected to contain 3 payload ops but it contains 2 payload ops}}
+      %h_2:3 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+      /// Test that yield does not crash in the presence of silenceable error in
+      /// propagate mode.
+      yield %fun : !transform.any_op
+    }
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence -> !transform.any_op failures(suppress) {
-^bb0(%arg0: !transform.any_op):
-  %muli = transform.structured.match ops{["arith.muli"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  // Edge case propagating empty handles in splitting.
-  %0:3 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-  // Test does not crash when accessing the empty handle.
-  yield %0#0 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.sequence %root : !transform.any_op -> !transform.any_op failures(suppress) {
+    ^bb0(%arg0: !transform.any_op):
+      %muli = transform.structured.match ops{["arith.muli"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+      // Edge case propagating empty handles in splitting.
+      %0:3 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+      // Test does not crash when accessing the empty handle.
+      yield %0#0 : !transform.any_op
+    }
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_produce_param (0 : i32) : !transform.test_dialect_param
-  // expected-remark @below {{0 : i32}}
-  transform.test_print_param %0 : !transform.test_dialect_param
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_param (0 : i32) : !transform.test_dialect_param
+    // expected-remark @below {{0 : i32}}
+    transform.test_print_param %0 : !transform.test_dialect_param
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{expected the type of the parameter attribute ('i32') to match the parameter type ('i64')}}
-  transform.test_produce_param (0 : i32) : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{expected the type of the parameter attribute ('i32') to match the parameter type ('i64')}}
+    transform.test_produce_param (0 : i32) : !transform.param<i64>
+    transform.yield
+  }
 }
 
 // -----
 
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.test_add_to_param 40
-  %1 = transform.test_add_to_param %0, 2
-  // expected-remark @below {{42 : i32}}
-  transform.test_print_param %1 : !transform.test_dialect_param
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_add_to_param 40
+    %1 = transform.test_add_to_param %0, 2
+    // expected-remark @below {{42 : i32}}
+    transform.test_print_param %1 : !transform.test_dialect_param
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %1 = transform.test_produce_param_with_number_of_test_ops %0 : !transform.any_op
-  // expected-remark @below {{1 : i32, 3 : i32}}
-  transform.test_print_param %1 : !transform.test_dialect_param
-  %2 = transform.test_add_to_param %1, 100
-  // expected-remark @below {{101 : i32, 103 : i32}}
-  transform.test_print_param %2 : !transform.test_dialect_param
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.test_produce_param_with_number_of_test_ops %0 : !transform.any_op
+    // expected-remark @below {{1 : i32, 3 : i32}}
+    transform.test_print_param %1 : !transform.test_dialect_param
+    %2 = transform.test_add_to_param %1, 100
+    // expected-remark @below {{101 : i32, 103 : i32}}
+    transform.test_print_param %2 : !transform.test_dialect_param
+    transform.yield
+  }
 }
 
 func.func private @one_test_op(%arg0: i32) {
@@ -1152,13 +1329,13 @@ func.func private @three_test_ops(%arg0: i32) {
 // -----
 
 // expected-note @below {{when applied to this op}}
-module {
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     // expected-error @below {{expected to produce an Operation * for result #0}}
     transform.test_produce_transform_param_or_forward_operand %arg0
       { first_result_is_param }
       : (!transform.any_op) -> (!transform.any_op, !transform.param<i64>)
+    transform.yield
   }
 }
 
@@ -1166,92 +1343,88 @@ module {
 
 // Should not fail.
 
-module {
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     transform.test_produce_transform_param_or_forward_operand %arg0
       { first_result_is_null }
       : (!transform.any_op) -> (!transform.any_op, !transform.param<i64>)
+    transform.yield
   }
 }
 
 // -----
 
 // expected-note @below {{when applied to this op}}
-module {
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     // expected-error @below {{expected to produce an Attribute for result #1}}
     transform.test_produce_transform_param_or_forward_operand %arg0
       { second_result_is_handle }
       : (!transform.any_op) -> (!transform.any_op, !transform.param<i64>)
+    transform.yield
   }
 }
 
 // -----
 
 // expected-note @below {{when applied to this op}}
-module {
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     // expected-error @below {{expected to produce a Value for result #0}}
     transform.test_produce_transform_param_or_forward_operand %arg0
       { second_result_is_handle }
       : (!transform.any_op) -> (!transform.any_value, !transform.param<i64>)
+    transform.yield
   }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{attempting to assign a null payload op to this transform value}}
-  %0 = transform.test_produce_null_payload : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{attempting to assign a null payload op to this transform value}}
+    %0 = transform.test_produce_null_payload : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{attempting to assign a null parameter to this transform value}}
-  %0 = transform.test_produce_null_param : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{attempting to assign a null parameter to this transform value}}
+    %0 = transform.test_produce_null_param : !transform.param<i64>
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{attempting to assign a null payload value to this transform handle}}
-  %0 = transform.test_produce_null_value : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{attempting to assign a null payload value to this transform handle}}
+    %0 = transform.test_produce_null_value : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
 
-// expected-error @below {{could not find a nested top-level transform op}}
-// expected-note @below {{use the 'transform-file-name' option to provide transform as external file}}
+// expected-error @below {{could not find a nested named sequence with name: __transform_main}}
+// expected-error @below {{could not find transform entry point: __transform_main in either payload or transform module}}
 module {
 }
 
 // -----
 
-// expected-note @below {{previous top-level transform op}}
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-}
-
-// expected-error @below {{more than one top-level transform op}}
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-}
-
-// -----
-
-transform.sequence failures(propagate) {
-// expected-remark @below {{value handle}}
-// expected-note @below {{value handle points to a block argument #0 in block #0 in region #0}}
-^bb1(%arg0: !transform.any_op):
-  %0 = test_produce_value_handle_to_self_operand %arg0 : (!transform.any_op) -> !transform.any_value
-  test_print_remark_at_operand_value %0, "value handle" : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  // expected-remark @below {{value handle}}
+  // expected-note @below {{value handle points to a block argument #0 in block #0 in region #0}}
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.test_produce_value_handle_to_self_operand %arg0 : (!transform.any_op) -> !transform.any_value
+    transform.test_print_remark_at_operand_value %0, "value handle" : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -1263,11 +1436,13 @@ transform.sequence failures(propagate) {
 // expected-note @below {{value handle points to an op result #1}}
 %1:3 = "test.get_three_results"() : () -> (i32, i32, f32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %2 = transform.structured.match ops{["test.get_two_results", "test.get_three_results"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_result %2, 1 : (!transform.any_op) -> !transform.any_value
-  test_print_remark_at_operand_value %3, "result handle" : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %2 = transform.structured.match ops{["test.get_two_results", "test.get_three_results"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_result %2, 1 : (!transform.any_op) -> !transform.any_value
+    transform.test_print_remark_at_operand_value %3, "result handle" : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -1285,21 +1460,25 @@ transform.sequence failures(propagate) {
   "test.regon_terminator"() : () -> ()
 }) : () -> ()
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %3 = test_produce_value_handle_to_argument_of_parent_block %2, 2 : (!transform.any_op) -> !transform.any_value
-  test_print_remark_at_operand_value %3, "block argument handle" : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %3 = transform.test_produce_value_handle_to_argument_of_parent_block %2, 2 : (!transform.any_op) -> !transform.any_value
+    transform.test_print_remark_at_operand_value %3, "block argument handle" : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-note @below {{value defined here with type '!transform.test_dialect_param'}}
-  %0 = test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
-  // expected-error @below {{unexpectedly consumed a value that is not a handle as operand #0}}
-  test_consume_operand %0 : !transform.test_dialect_param
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-note @below {{value defined here with type '!transform.test_dialect_param'}}
+    %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
+    // expected-error @below {{unexpectedly consumed a value that is not a handle as operand #0}}
+    transform.test_consume_operand %0 : !transform.test_dialect_param
+    transform.yield
+  }
 }
 
 // -----
@@ -1311,11 +1490,13 @@ func.func @get_result_of_op(%arg0: index, %arg1: index) -> index {
   return %r : index
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
-  transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
+    transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -1326,12 +1507,14 @@ func.func @get_out_of_bounds_result_of_op(%arg0: index, %arg1: index) -> index {
   return %r : index
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{targeted op does not have enough results}}
-  %result = transform.get_result %addi[1] : (!transform.any_op) -> !transform.any_value
-  transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{targeted op does not have enough results}}
+    %result = transform.get_result %addi[1] : (!transform.any_op) -> !transform.any_value
+    transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+    transform.yield
+  }
 }
 
 // -----
@@ -1342,12 +1525,14 @@ func.func @get_result_of_op(%arg0: index, %arg1: index) -> index {
   return %r : index
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
-  %op = transform.get_defining_op %result : (!transform.any_value) -> !transform.any_op
-  transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
+    %op = transform.get_defining_op %result : (!transform.any_value) -> !transform.any_op
+    transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -1358,13 +1543,15 @@ func.func @get_result_of_op_bbarg(%arg0: index, %arg1: index) -> index {
   return %r : index
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %bbarg = test_produce_value_handle_to_argument_of_parent_block %addi, 0 : (!transform.any_op) -> !transform.any_value
-  // expected-error @below {{cannot get defining op of block argument}}
-  %op = transform.get_defining_op %bbarg : (!transform.any_value) -> !transform.any_op
-  transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %bbarg = transform.test_produce_value_handle_to_argument_of_parent_block %addi, 0 : (!transform.any_op) -> !transform.any_value
+    // expected-error @below {{cannot get defining op of block argument}}
+    %op = transform.get_defining_op %bbarg : (!transform.any_value) -> !transform.any_op
+    transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -1377,9 +1564,9 @@ module @named_inclusion attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
-    include @foo failures(propagate) (%arg0) : (!transform.any_op) -> ()
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.include @foo failures(propagate) (%arg0) : (!transform.any_op) -> ()
+    transform.yield
   }
 }
 
@@ -1400,9 +1587,9 @@ module @named_inclusion_in_named attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     transform.include @bar failures(suppress) (%arg0) : (!transform.any_op) -> ()
+    transform.yield
   }
 }
 
@@ -1418,12 +1605,12 @@ module @named_operands attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
   // expected-remark @below {{value}}
   // expected-note @below {{value handle points to a block argument #0 in block #0 in region #0}}
-  ^bb0(%arg0: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %0 = transform.test_produce_value_handle_to_self_operand %arg0 : (!transform.any_op) -> !transform.any_value
-    include @foo failures(propagate) (%arg0, %0) : (!transform.any_op, !transform.any_value) -> ()
+    transform.include @foo failures(propagate) (%arg0, %0) : (!transform.any_op, !transform.any_value) -> ()
+    transform.yield
   }
 }
 
@@ -1439,11 +1626,11 @@ module @named_return attributes { transform.with_named_sequence } {
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_value
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
-    %0:2 = include @foo failures(propagate) (%arg0) : (!transform.any_op) -> (!transform.any_op, !transform.any_value)
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0:2 = transform.include @foo failures(propagate) (%arg0) : (!transform.any_op) -> (!transform.any_op, !transform.any_value)
     transform.test_print_remark_at_operand %0#0, "operation" : !transform.any_op
     transform.test_print_remark_at_operand_value %0#1, "value" : !transform.any_value
+    transform.yield
   }
 }
 
@@ -1469,8 +1656,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%root: !transform.any_op):
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
     transform.foreach_match in %root
         @match1 -> @action1,
         @match2 -> @action2
@@ -1493,11 +1679,11 @@ module attributes { transform.with_named_sequence } {
   transform.named_sequence @match(!transform.any_op {transform.readonly})
   transform.named_sequence @action()
 
-  transform.sequence failures(propagate) {
-  ^bb0(%root: !transform.any_op):
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
     // expected-error @below {{unresolved external symbol @match}}
     transform.foreach_match in %root
       @match -> @action : (!transform.any_op) -> !transform.any_op
+    transform.yield
   }
 }
 
@@ -1509,11 +1695,11 @@ module attributes { transform.with_named_sequence } {
   }
   transform.named_sequence @action()
 
-  transform.sequence failures(propagate) {
-  ^bb0(%root: !transform.any_op):
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
     // expected-error @below {{unresolved external symbol @action}}
     transform.foreach_match in %root
       @match -> @action : (!transform.any_op) -> !transform.any_op
+    transform.yield
   }
 }
 
@@ -1529,17 +1715,17 @@ module attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb0(%root: !transform.any_op):
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
     transform.foreach_match in %root
       @match -> @action : (!transform.any_op) -> !transform.any_op
+    transform.yield
   }
 }
 
 // -----
 
 module attributes { transform.with_named_sequence } {
-  transform.named_sequence @match_func(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @match_func(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     transform.yield %arg0 : !transform.any_op
@@ -1550,8 +1736,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb(%arg0: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     transform.foreach_match in %arg0 @match_func -> @print_func : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
@@ -1570,7 +1755,7 @@ module attributes { transform.with_named_sequence } {
 // -----
 
 module attributes { transform.with_named_sequence } {
-  transform.named_sequence @eq_1(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @eq_1(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1580,7 +1765,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @ne_0(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @ne_0(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1590,7 +1775,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @gt_m1(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @gt_m1(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1600,7 +1785,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @ge_1(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @ge_1(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1610,7 +1795,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @lt_1(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @lt_1(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1620,7 +1805,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @le_1(%arg0: !transform.any_op {transform.readonly}) 
+  transform.named_sequence @le_1(%arg0: !transform.any_op {transform.readonly})
     -> !transform.any_op {
     transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
@@ -1634,8 +1819,7 @@ module attributes { transform.with_named_sequence } {
     transform.yield
   }
 
-  transform.sequence failures(propagate) {
-  ^bb(%arg0: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %0 = transform.foreach_match in %arg0 @eq_1 -> @do_nothing : (!transform.any_op) -> !transform.any_op
     %1 = transform.foreach_match in %0 @ne_0 -> @do_nothing : (!transform.any_op) -> !transform.any_op
     %2 = transform.foreach_match in %1 @gt_m1 -> @do_nothing : (!transform.any_op) -> !transform.any_op
@@ -1675,47 +1859,49 @@ func.func @test_tracked_rewrite() {
   func.return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %0 = transform.structured.match ops{["transform.test_dummy_payload_op"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-remark @below {{2 iterations}}
-  transform.test_tracked_rewrite %0 : (!transform.any_op) -> ()
-  // One replacement op (test.drop_mapping) is dropped from the mapping.
-  %p = num_associations %0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below {{2}}
-  test_print_param %p : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match ops{["transform.test_dummy_payload_op"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    // expected-remark @below {{2 iterations}}
+    transform.test_tracked_rewrite %0 : (!transform.any_op) -> ()
+    // One replacement op (test.drop_mapping) is dropped from the mapping.
+    %p = transform.num_associations %0 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below {{2}}
+    transform.test_print_param %p : !transform.param<i64>
+    transform.yield
+  }
 }
 
 // -----
 
 // Parameter deduplication happens by value
 
-module {
+module attributes {transform.with_named_sequence} {
 
-  transform.sequence failures(propagate) {
-  ^bb0(%0: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %1 = transform.param.constant 1 -> !transform.param<i64>
     %2 = transform.param.constant 1 -> !transform.param<i64>
     %3 = transform.param.constant 2 -> !transform.param<i64>
     %4 = transform.merge_handles %1, %2 { deduplicate } : !transform.param<i64>
-    %p = num_associations %4 : (!transform.param<i64>) -> !transform.param<i64>
+    %p = transform.num_associations %4 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    test_print_param %p : !transform.param<i64>
+    transform.test_print_param %p : !transform.param<i64>
 
     %5 = transform.merge_handles %1, %1 { deduplicate } : !transform.param<i64>
-    %p2 = num_associations %5 : (!transform.param<i64>) -> !transform.param<i64>
+    %p2 = transform.num_associations %5 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    test_print_param %p2 : !transform.param<i64>
+    transform.test_print_param %p2 : !transform.param<i64>
 
     %6 = transform.merge_handles %1, %3 { deduplicate } : !transform.param<i64>
-    %p3 = num_associations %6 : (!transform.param<i64>) -> !transform.param<i64>
+    %p3 = transform.num_associations %6 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{2}}
-    test_print_param %p3 : !transform.param<i64>
+    transform.test_print_param %p3 : !transform.param<i64>
 
     %7 = transform.merge_handles %1, %1, %2, %3 : !transform.param<i64>
-    %p4 = num_associations %7 : (!transform.param<i64>) -> !transform.param<i64>
+    %p4 = transform.num_associations %7 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{4}}
-    test_print_param %p4 : !transform.param<i64>
+    transform.test_print_param %p4 : !transform.param<i64>
+    transform.yield
   }
 }
 
@@ -1723,32 +1909,34 @@ module {
 
 %0:3 = "test.get_two_results"() : () -> (i32, i32, f32)
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %1 = transform.structured.match ops{["test.get_two_results"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %2 = test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
-  %3 = test_produce_value_handle_to_result %1, 1 : (!transform.any_op) -> !transform.any_value
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %1 = transform.structured.match ops{["test.get_two_results"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %2 = transform.test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
+    %3 = transform.test_produce_value_handle_to_result %1, 1 : (!transform.any_op) -> !transform.any_value
 
-  %4 = transform.merge_handles %2, %2 { deduplicate } : !transform.any_value
-  %p = num_associations %4 : (!transform.any_value) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  test_print_param %p : !transform.param<i64>
+    %4 = transform.merge_handles %2, %2 { deduplicate } : !transform.any_value
+    %p = transform.num_associations %4 : (!transform.any_value) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p : !transform.param<i64>
 
-  %5 = transform.merge_handles %2, %3 { deduplicate } : !transform.any_value
-  %p2 = num_associations %5 : (!transform.any_value) -> !transform.param<i64>
-  // expected-remark @below {{2}}
-  test_print_param %p2 : !transform.param<i64>
+    %5 = transform.merge_handles %2, %3 { deduplicate } : !transform.any_value
+    %p2 = transform.num_associations %5 : (!transform.any_value) -> !transform.param<i64>
+    // expected-remark @below {{2}}
+    transform.test_print_param %p2 : !transform.param<i64>
 
-  %6 = test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
-  %7 = transform.merge_handles %2, %6 { deduplicate } : !transform.any_value
-  %p3 = num_associations %6 : (!transform.any_value) -> !transform.param<i64>
-  // expected-remark @below {{1}}
-  test_print_param %p3 : !transform.param<i64>
+    %6 = transform.test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
+    %7 = transform.merge_handles %2, %6 { deduplicate } : !transform.any_value
+    %p3 = transform.num_associations %6 : (!transform.any_value) -> !transform.param<i64>
+    // expected-remark @below {{1}}
+    transform.test_print_param %p3 : !transform.param<i64>
 
-  %8 = transform.merge_handles %2, %2, %3, %4 : !transform.any_value
-  %p4 = num_associations %8 : (!transform.any_value) -> !transform.param<i64>
-  // expected-remark @below {{4}}
-  test_print_param %p4 : !transform.param<i64>
+    %8 = transform.merge_handles %2, %2, %3, %4 : !transform.any_value
+    %p4 = transform.num_associations %8 : (!transform.any_value) -> !transform.param<i64>
+    // expected-remark @below {{4}}
+    transform.test_print_param %p4 : !transform.param<i64>
+    transform.yield
+  }
 }
 // -----
 
@@ -1775,18 +1963,20 @@ func.func @test_annotation() {
   %2 = "test.annotate_me"() {new_attr = 0} : () -> (i1)
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg0: !transform.any_op):
-  %0 = transform.structured.match ops{["test.annotate_me"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %1 = transform.test_produce_param_with_number_of_test_ops %0 : !transform.any_op
-  transform.annotate %0 "new_attr" = %1 : !transform.any_op, !transform.test_dialect_param
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["test.annotate_me"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.test_produce_param_with_number_of_test_ops %0 : !transform.any_op
+    transform.annotate %0 "new_attr" = %1 : !transform.any_op, !transform.test_dialect_param
 
-  %2 = transform.param.constant 2 -> !transform.param<i64>
-  transform.annotate %0 "broadcast_attr" = %2 : !transform.any_op, !transform.param<i64>
-  transform.annotate %0 "unit_attr" : !transform.any_op
+    %2 = transform.param.constant 2 -> !transform.param<i64>
+    transform.annotate %0 "broadcast_attr" = %2 : !transform.any_op, !transform.param<i64>
+    transform.annotate %0 "unit_attr" : !transform.any_op
 
-  %3 = transform.param.constant "example" -> !transform.any_param
-  transform.annotate %0 "any_attr" = %3 : !transform.any_op, !transform.any_param
+    %3 = transform.param.constant "example" -> !transform.any_param
+    transform.annotate %0 "any_attr" = %3 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
 }
 
 // -----
@@ -1798,12 +1988,14 @@ func.func @notify_payload_op_replaced(%arg0: index, %arg1: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %0 = transform.structured.match attributes{original} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %1 = transform.structured.match attributes{replacement} in %arg1 : (!transform.any_op) -> !transform.any_op
-  test_notify_payload_op_replaced %0, %1 : (!transform.any_op, !transform.any_op) -> ()
-  test_print_remark_at_operand %0, "updated handle" : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match attributes{original} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.structured.match attributes{replacement} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.test_notify_payload_op_replaced %0, %1 : (!transform.any_op, !transform.any_op) -> ()
+    transform.test_print_remark_at_operand %0, "updated handle" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -1832,47 +2024,49 @@ func.func @test_apply_cse() -> (index, index, index) {
   return %0, %1, %3 : index, index, index
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %first = transform.structured.match attributes{first} in %0 : (!transform.any_op) -> !transform.any_op
-  %elim_first = transform.structured.match ops{["arith.constant"]} in %first : (!transform.any_op) -> !transform.any_op
-  %second = transform.structured.match attributes{first} in %0 : (!transform.any_op) -> !transform.any_op
-  %elim_second = transform.structured.match ops{["arith.constant"]} in %first : (!transform.any_op) -> !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %first = transform.structured.match attributes{first} in %0 : (!transform.any_op) -> !transform.any_op
+    %elim_first = transform.structured.match ops{["arith.constant"]} in %first : (!transform.any_op) -> !transform.any_op
+    %second = transform.structured.match attributes{first} in %0 : (!transform.any_op) -> !transform.any_op
+    %elim_second = transform.structured.match ops{["arith.constant"]} in %first : (!transform.any_op) -> !transform.any_op
 
-  // There are 3 arith.constant ops.
-  %all = transform.structured.match ops{["arith.constant"]} in %0 : (!transform.any_op) -> !transform.any_op
-  %p = num_associations %all : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{3}}
-  test_print_param %p : !transform.param<i64>
-  // "deduplicate" has no effect because these are 3 different ops.
-  %merged_before = transform.merge_handles deduplicate %all : !transform.any_op
-  %p2 = num_associations %merged_before : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{3}}
-  test_print_param %p2 : !transform.param<i64>
+    // There are 3 arith.constant ops.
+    %all = transform.structured.match ops{["arith.constant"]} in %0 : (!transform.any_op) -> !transform.any_op
+    %p = transform.num_associations %all : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{3}}
+    transform.test_print_param %p : !transform.param<i64>
+    // "deduplicate" has no effect because these are 3 different ops.
+    %merged_before = transform.merge_handles deduplicate %all : !transform.any_op
+    %p2 = transform.num_associations %merged_before : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{3}}
+    transform.test_print_param %p2 : !transform.param<i64>
 
-  // Apply CSE.
-  transform.apply_cse to %0 : !transform.any_op
+    // Apply CSE.
+    transform.apply_cse to %0 : !transform.any_op
 
-  // The handle is still mapped to 3 arith.constant ops.
-  %p3 = num_associations %all : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{3}}
-  test_print_param %p3 : !transform.param<i64>
-  // But they are all the same op.
-  %merged_after = transform.merge_handles deduplicate %all : !transform.any_op
-  %p4 = num_associations %merged_after : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{1}}
-  test_print_param %p4 : !transform.param<i64>
+    // The handle is still mapped to 3 arith.constant ops.
+    %p3 = transform.num_associations %all : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{3}}
+    transform.test_print_param %p3 : !transform.param<i64>
+    // But they are all the same op.
+    %merged_after = transform.merge_handles deduplicate %all : !transform.any_op
+    %p4 = transform.num_associations %merged_after : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{1}}
+    transform.test_print_param %p4 : !transform.param<i64>
 
-  // The other handles were also updated.
-  test_print_remark_at_operand %elim_first, "eliminated 1" : !transform.any_op
-  %p5 = num_associations %elim_first : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{1}}
-  test_print_param %p5 : !transform.param<i64>
-  test_print_remark_at_operand %elim_second, "eliminated 2" : !transform.any_op
-  %p6 = num_associations %elim_second : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{1}}
-  test_print_param %p6 : !transform.param<i64>
+    // The other handles were also updated.
+    transform.test_print_remark_at_operand %elim_first, "eliminated 1" : !transform.any_op
+    %p5 = transform.num_associations %elim_first : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{1}}
+    transform.test_print_param %p5 : !transform.param<i64>
+    transform.test_print_remark_at_operand %elim_second, "eliminated 2" : !transform.any_op
+    %p6 = transform.num_associations %elim_second : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{1}}
+    transform.test_print_param %p6 : !transform.param<i64>
+    transform.yield
+  }
 }
 
 // -----
@@ -1890,24 +2084,26 @@ func.func @test_licm(%arg0: index, %arg1: index, %arg2: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %0 = transform.structured.match ops{["scf.for"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  transform.apply_licm to %0 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match ops{["scf.for"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_licm to %0 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
 
 // expected-note @below{{when applied to this op}}
-module {
+module attributes {transform.with_named_sequence} {
   func.func @test_licm_invalid() {
     return
   }
 
-  transform.sequence failures(propagate) {
-  ^bb1(%arg1: !transform.any_op):
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     // expected-error @below{{transform applied to the wrong op kind}}
     transform.apply_licm to %arg1 : !transform.any_op
+    transform.yield
   }
 }
 
@@ -1924,38 +2120,40 @@ func.func @get_parent_op() {
   }) : () -> ()
 }
 
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %0 = transform.structured.match ops{["test.qux"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match ops{["test.qux"]} in %arg1 : (!transform.any_op) -> !transform.any_op
 
-  // Get parent by name.
-  %1 = transform.get_parent_op %0 {op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %1, "found test.foo parent" : !transform.any_op
+    // Get parent by name.
+    %1 = transform.get_parent_op %0 {op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %1, "found test.foo parent" : !transform.any_op
 
-  // Get immediate parent.
-  %2 = transform.get_parent_op %0 : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %2, "direct parent" : !transform.any_op
-  %p = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{2}}
-  test_print_param %p : !transform.param<i64>
+    // Get immediate parent.
+    %2 = transform.get_parent_op %0 : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %2, "direct parent" : !transform.any_op
+    %p = transform.num_associations %2 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{2}}
+    transform.test_print_param %p : !transform.param<i64>
 
-  // Deduplicate results.
-  %3 = transform.structured.match ops{["test.qux"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  %4 = transform.get_parent_op %3 {deduplicate} : (!transform.any_op) -> !transform.any_op
-  %p2 = num_associations %4 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{1}}
-  test_print_param %p2 : !transform.param<i64>
+    // Deduplicate results.
+    %3 = transform.structured.match ops{["test.qux"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %4 = transform.get_parent_op %3 {deduplicate} : (!transform.any_op) -> !transform.any_op
+    %p2 = transform.num_associations %4 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{1}}
+    transform.test_print_param %p2 : !transform.param<i64>
+    transform.yield
+  }
 }
 
 
 // -----
 
 // expected-note @below {{target op}}
-module {
-  transform.sequence  failures(propagate) {
-  ^bb0(%arg0: !transform.any_op):
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     // expected-error @below{{could not find a parent op that matches all requirements}}
-    %3 = get_parent_op %arg0 {op_name = "builtin.module"} : (!transform.any_op) -> !transform.any_op
+    %3 = transform.get_parent_op %arg0 {op_name = "builtin.module"} : (!transform.any_op) -> !transform.any_op
+    transform.yield
   }
 }
 
@@ -1967,29 +2165,34 @@ func.func @cast(%arg0: f32) -> f64 {
   return %0 : f64
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.structured.match ops{["arith.extf"]} in %arg0 : (!transform.any_op) -> !transform.op<"arith.extf">
-  %1 = transform.get_result %0[0] : (!transform.op<"arith.extf">) -> !transform.any_value
-  %2 = transform.get_type %1 : (!transform.any_value) -> !transform.type
-  transform.test_print_param %2 at %0 : !transform.type, !transform.op<"arith.extf">
-  transform.yield
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["arith.extf"]} in %arg0 : (!transform.any_op) -> !transform.op<"arith.extf">
+    %1 = transform.get_result %0[0] : (!transform.op<"arith.extf">) -> !transform.any_value
+    %2 = transform.get_type %1 : (!transform.any_value) -> !transform.type
+    transform.test_print_param %2 at %0 : !transform.type, !transform.op<"arith.extf">
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{expected type attribute, got 0 : i32}}
-  transform.test_produce_param (0 : i32) : !transform.type
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{expected type attribute, got 0 : i32}}
+    transform.test_produce_param (0 : i32) : !transform.type
+    transform.yield
+  }
 }
 
 // -----
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // expected-error @below {{expected affine map attribute, got 0 : i32}}
-  transform.test_produce_param (0 : i32) : !transform.affine_map
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // expected-error @below {{expected affine map attribute, got 0 : i32}}
+    transform.test_produce_param (0 : i32) : !transform.affine_map
+    transform.yield
+  }
 }
 
 // -----
@@ -1997,10 +2200,12 @@ transform.sequence failures(propagate) {
 // CHECK-LABEL: @type_param_anchor
 func.func private @type_param_anchor()
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // CHECK: test_produce_param(f32) : !transform.type
-  transform.test_produce_param(f32) : !transform.type
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // CHECK: test_produce_param(f32) : !transform.type
+    transform.test_produce_param(f32) : !transform.type
+    transform.yield
+  }
 }
 
 // -----
@@ -2008,10 +2213,12 @@ transform.sequence failures(propagate) {
 // CHECK-LABEL: @affine_map_param_anchor
 func.func private @affine_map_param_anchor()
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // CHECK: test_produce_param(#{{.*}}) : !transform.affine_map
-  transform.test_produce_param(affine_map<(d0) -> ()>) : !transform.affine_map
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // CHECK: test_produce_param(#{{.*}}) : !transform.affine_map
+    transform.test_produce_param(affine_map<(d0) -> ()>) : !transform.affine_map
+    transform.yield
+  }
 }
 
 // -----
@@ -2020,10 +2227,12 @@ func.func @verify_success(%arg0: f64) -> f64 {
   return %arg0 : f64
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  transform.verify %0 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.verify %0 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -2034,12 +2243,14 @@ func.func @verify_failure(%arg0: f64) -> f64 {
   return %arg0 : f64
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  transform.test_produce_invalid_ir %0 : !transform.any_op
-  // expected-error @below{{failed to verify payload op}}
-  transform.verify %0 : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.test_produce_invalid_ir %0 : !transform.any_op
+    // expected-error @below{{failed to verify payload op}}
+    transform.verify %0 : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -2054,22 +2265,24 @@ func.func @select() {
   func.return
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  // Match all ops inside the function (including the function itself).
-  %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %0 = transform.structured.match in %func_op : (!transform.any_op) -> !transform.any_op
-  %p = num_associations %0 : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{5}}
-  test_print_param %p : !transform.param<i64>
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    // Match all ops inside the function (including the function itself).
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %0 = transform.structured.match in %func_op : (!transform.any_op) -> !transform.any_op
+    %p = transform.num_associations %0 : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{5}}
+    transform.test_print_param %p : !transform.param<i64>
 
-  // Select "test.foo".
-  %foo = transform.select "test.foo" in %0 : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %foo, "found foo" : !transform.any_op
+    // Select "test.foo".
+    %foo = transform.select "test.foo" in %0 : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %foo, "found foo" : !transform.any_op
 
-  // Select "test.bar".
-  %bar = transform.select "test.bar" in %0 : (!transform.any_op) -> !transform.any_op
-  test_print_remark_at_operand %bar, "found bar" : !transform.any_op
+    // Select "test.bar".
+    %bar = transform.select "test.bar" in %0 : (!transform.any_op) -> !transform.any_op
+    transform.test_print_remark_at_operand %bar, "found bar" : !transform.any_op
+    transform.yield
+  }
 }
 
 // -----
@@ -2085,15 +2298,17 @@ func.func @apply_dce(%f: f32, %m: memref<5xf32>, %idx: index) {
   return
 }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  %empty_op = transform.structured.match ops{["tensor.empty"]} in %func_op : (!transform.any_op) -> !transform.any_op
-  transform.apply_dce to %func_op : !transform.any_op
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %empty_op = transform.structured.match ops{["tensor.empty"]} in %func_op : (!transform.any_op) -> !transform.any_op
+    transform.apply_dce to %func_op : !transform.any_op
 
-  %p = num_associations %empty_op : (!transform.any_op) -> !transform.param<i64>
-  // expected-remark @below{{0}}
-  test_print_param %p : !transform.param<i64>
+    %p = transform.num_associations %empty_op : (!transform.any_op) -> !transform.param<i64>
+    // expected-remark @below{{0}}
+    transform.test_print_param %p : !transform.param<i64>
+    transform.yield
+  }
 }
 
 
@@ -2110,27 +2325,26 @@ module @named_inclusion attributes { transform.with_named_sequence } {
 // Match `arith.constant`s that are not nested under a `scf.for` and ensure
 // there are none in the program
 
-transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
-  transform.test_print_remark_at_operand %root, "matched func" : !transform.any_op
-  transform.yield 
-}
+  transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
+    transform.test_print_remark_at_operand %root, "matched func" : !transform.any_op
+    transform.yield
+  }
 
-transform.named_sequence @match_constant_not_under_scf_for(%root: !transform.any_op {transform.readonly}) 
-  -> !transform.any_op {
-  transform.match.operation_name %root ["arith.constant"] : !transform.any_op
-  %for = transform.get_parent_op %root { op_name = "scf.for", allow_empty_results }
-    : (!transform.any_op) -> (!transform.any_op)
-  transform.match.operation_empty %for : !transform.any_op
-  transform.yield %root : !transform.any_op
-}
+  transform.named_sequence @match_constant_not_under_scf_for(%root: !transform.any_op {transform.readonly})
+    -> !transform.any_op {
+    transform.match.operation_name %root ["arith.constant"] : !transform.any_op
+    %for = transform.get_parent_op %root { op_name = "scf.for", allow_empty_results }
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.match.operation_empty %for : !transform.any_op
+    transform.yield %root : !transform.any_op
+  }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  transform.foreach_match in %arg0
-      @match_constant_not_under_scf_for -> @print
-    : (!transform.any_op) -> (!transform.any_op)
-  transform.yield 
-}
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.foreach_match in %arg0
+        @match_constant_not_under_scf_for -> @print
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
 }
 
 // -----
@@ -2142,28 +2356,27 @@ func.func @no_constant_under_loop(%lb: index, %ub: index, %step: index) {
 }
 
 module @named_inclusion attributes { transform.with_named_sequence } {
-// Match `arith.constant`s that are not nested under a `scf.for` and ensure
-// there are none in the program
+  // Match `arith.constant`s that are not nested under a `scf.for` and ensure
+  // there are none in the program
 
-transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
-  transform.test_print_remark_at_operand %root, "no parent scf.for" : !transform.any_op
-  transform.yield 
-}
+  transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
+    transform.test_print_remark_at_operand %root, "no parent scf.for" : !transform.any_op
+    transform.yield
+  }
 
-transform.named_sequence @match_constant_not_under_scf_for(%root: !transform.any_op {transform.readonly}) 
-  -> !transform.any_op {
-  transform.match.operation_name %root ["arith.constant"] : !transform.any_op
-  %for = transform.get_parent_op %root { op_name = "scf.for", allow_empty_results }
-    : (!transform.any_op) -> (!transform.any_op)
-  transform.match.operation_empty %for : !transform.any_op
-  transform.yield %root : !transform.any_op
-}
+  transform.named_sequence @match_constant_not_under_scf_for(%root: !transform.any_op {transform.readonly})
+    -> !transform.any_op {
+    transform.match.operation_name %root ["arith.constant"] : !transform.any_op
+    %for = transform.get_parent_op %root { op_name = "scf.for", allow_empty_results }
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.match.operation_empty %for : !transform.any_op
+    transform.yield %root : !transform.any_op
+  }
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  transform.foreach_match in %arg0
-      @match_constant_not_under_scf_for -> @print
-    : (!transform.any_op) -> (!transform.any_op)
-  transform.yield 
-}
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.foreach_match in %arg0
+        @match_constant_not_under_scf_for -> @print
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
 }


### PR DESCRIPTION
Update several tests under mlir/test/Dialect/Transform to use the "main" transform interpreter pass with named entry points rather than the test interpreter pass.

This helped discover a logic error in the expensive checks mechanism that was exiting too early.