### PR TITLE
[Clang] Fix the instantiation of return type requirements in lambda bodies

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -843,6 +843,9 @@ Bug Fixes to C++ Support
 - Fix crash when parsing nested requirement. Fixes:
   (`#73112 <https://github.com/llvm/llvm-project/issues/73112>`_)
 
+- Fixed a crash caused by using return type requirement in a lambda. Fixes:
+  (`#64607 <https://github.com/llvm/llvm-project/issues/64607>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -844,7 +844,9 @@ Bug Fixes to C++ Support
   (`#73112 <https://github.com/llvm/llvm-project/issues/73112>`_)
 
 - Fixed a crash caused by using return type requirement in a lambda. Fixes:
+  (`#63808 <https://github.com/llvm/llvm-project/issues/63808>`_)
   (`#64607 <https://github.com/llvm/llvm-project/issues/64607>`_)
+  (`#64086 <https://github.com/llvm/llvm-project/issues/64086>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1479,6 +1479,14 @@ namespace {
       return Result;
     }
 
+    StmtResult TransformLambdaBody(LambdaExpr *E, Stmt *Body) {
+      bool Prev = EvaluateConstraints;
+      EvaluateConstraints = true;
+      StmtResult Stmt = inherited::TransformLambdaBody(E, Body);
+      EvaluateConstraints = Prev;
+      return Stmt;
+    }
+
     ExprResult TransformRequiresExpr(RequiresExpr *E) {
       LocalInstantiationScope Scope(SemaRef, /*CombineWithOuterScope=*/true);
       ExprResult TransReq = inherited::TransformRequiresExpr(E);

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1480,6 +1480,15 @@ namespace {
     }
 
     StmtResult TransformLambdaBody(LambdaExpr *E, Stmt *Body) {
+      // Currently, we instantiate the body when instantiating the lambda
+      // expression. However, `EvaluateConstraints` is disabled during the
+      // instantiation of the lambda expression, causing the instantiation
+      // failure of the return type requirement in the body. If p0588r1 is fully
+      // implemented, the body will be lazily instantiated, and this problem
+      // will not occur. Here, `EvaluateConstraints` is temporarily set to
+      // `true` to temporarily fix this issue.
+      // FIXME: This temporary fix can be removed after fully implementing
+      // p0588r1.
       bool Prev = EvaluateConstraints;
       EvaluateConstraints = true;
       StmtResult Stmt = inherited::TransformLambdaBody(E, Body);

--- a/clang/test/SemaTemplate/concepts-lambda.cpp
+++ b/clang/test/SemaTemplate/concepts-lambda.cpp
@@ -116,3 +116,36 @@ static_assert(E<int>);
 // expected-note@-11{{because 'Q.template operator()<float>()' would be invalid: no matching member function for call to 'operator()'}}
 }
 }
+
+namespace ReturnTypeConstraintInLambda {
+template <typename T>
+concept C1 = true;
+
+template <class T>
+concept test = [] {
+  return requires(T t) {
+    { t } -> C1;
+  };
+}();
+
+static_assert(test<int>);
+
+template <typename T>
+concept C2 = true;
+struct S1 {
+  int f1() { return 1; }
+};
+
+void foo() {
+  auto make_caller = []<auto member> {
+    return [](S1 *ps) {
+      if constexpr (requires {
+                      { (ps->*member)() } -> C2;
+                    })
+        ;
+    };
+  };
+
+  auto caller = make_caller.operator()<&S1::f1>();
+}
+} // namespace ReturnTypeConstraintInLambda

--- a/clang/test/SemaTemplate/concepts-lambda.cpp
+++ b/clang/test/SemaTemplate/concepts-lambda.cpp
@@ -117,7 +117,7 @@ static_assert(E<int>);
 }
 }
 
-namespace ReturnTypeConstraintInLambda {
+namespace ReturnTypeRequirementInLambda {
 template <typename T>
 concept C1 = true;
 
@@ -148,4 +148,4 @@ void foo() {
 
   auto caller = make_caller.operator()<&S1::f1>();
 }
-} // namespace ReturnTypeConstraintInLambda
+} // namespace ReturnTypeRequirementInLambda


### PR DESCRIPTION
Currently, due to the incomplete implementation of p0588r1, the instantiation of lambda expressions leads to the instantiation of the body. And `EvaluateConstraints` is false during the instantiation of the body, which causes crashes during the instantiation of the return type requirement:

```cpp
template<typename T> concept doesnt_matter = true;

template<class T>
concept test = 
    []{
        return requires(T t) {
            { t } -> doesnt_matter; // crash
        };
    }();

static_assert(test<int>);
```

 Although a complete implementation of p0588r1 can solve these crashes, it will take some time. Therefore, this pull request aims to fix these crashes first.

Fixes https://github.com/llvm/llvm-project/issues/63808
Fixes https://github.com/llvm/llvm-project/issues/64607
Fixes https://github.com/llvm/llvm-project/issues/64086
