### PR TITLE
[ELF] Correctly set the `nvptx` triple from `makeTriple()`

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -1349,6 +1349,13 @@ template <class ELFT> Triple::ArchType ELFObjectFile<ELFT>::getArch() const {
     return Triple::UnknownArch;
   }
 
+  case ELF::EM_CUDA: {
+    if (EF.getHeader().e_ident[ELF::EI_CLASS] == ELF::ELFCLASS32)
+      return Triple::nvptx;
+    else
+      return Triple::nvptx64;
+  }
+
   case ELF::EM_BPF:
     return IsLittleEndian ? Triple::bpfel : Triple::bpfeb;
 


### PR DESCRIPTION
Summary:
The ELFObject file should be able to handle `nvptx` objects but we
currently list them as unknown. This patch should now make it return
`nvptx64--` correctly.
