### PR TITLE
[clang] Fix test for case-insensitive absolute includes

### DIFF
--- a/clang/test/Lexer/case-insensitive-include-absolute.c
+++ b/clang/test/Lexer/case-insensitive-include-absolute.c
@@ -1,8 +1,8 @@
 // REQUIRES: case-insensitive-filesystem
 
 // RUN: rm -rf %t && split-file %s %t
-// RUN: sed "s|DIR|%/t|g" %t/tu.c.in > %t/tu.c
-// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s --DDIR=%/t
+// RUN: sed "s|DIR|%{/t:real}|g" %t/tu.c.in > %t/tu.c
+// RUN: %clang_cc1 -fsyntax-only %t/tu.c 2>&1 | FileCheck %s -DDIR=%{/t:real}
 
 //--- header.h
 //--- tu.c.in


### PR DESCRIPTION
When CMake on Windows is told to generate the build into a directory whose real path has a different drive letter (e.g. due to a symlink), the "clang/test/Lexer/case-insensitive-include-absolute.c" test fails. That happens because because `trySimplifyPath()` in `PPDirectives.cpp` finds out there's more than a case difference between the `#include` path (containing `%/t`) and the real path, which prevents the diagnostic to fire.

I thought this is only an issue on Windows due to the fact that LIT does not drag the path to the build directory through `os.path.realpath()` like it does on other systems (see `abs_path_preserve_drive()` in "llvm/utils/lit/lit/util.py"). However, even after only using `os.path.abspath()` on a Unix system, build generated into a symlinked directory tests correctly. I assume there must be something else at play, but I don't have the time to dig deeper.

The fix is is fairly straightforward: use the real path in the `#include` (with `%{/t:real}`), which removes the non-case difference and unblocks the diagnostic.