### PR TITLE
[Flang] remove setting lowerbound for non existing dimension in shift runtime test case (NFC)

### DIFF
--- a/flang/unittests/Runtime/Transformational.cpp
+++ b/flang/unittests/Runtime/Transformational.cpp
@@ -250,7 +250,6 @@ TEST(Transformational, Shifts) {
   auto shift2{MakeArray<TypeCategory::Integer, 1>(
       std::vector<int>{2}, std::vector<std::int8_t>{1, -1})};
   shift2->GetDimension(0).SetLowerBound(-1); // shouldn't matter
-  shift2->GetDimension(1).SetLowerBound(2);
   RTNAME(Cshift)(result, *array, *shift2, 2, __FILE__, __LINE__);
   EXPECT_EQ(result.type(), array->type());
   EXPECT_EQ(result.rank(), 2);


### PR DESCRIPTION
The shift2 array only has 1 dimension but the lower bound for a second dimension is being set causing a seg fault on AIX. 