### PR TITLE
[ORC] Add absoluteSymbolsLinkGraph to expose absolute symbols to platform

### DIFF
--- a/bolt/lib/Rewrite/JITLinkLinker.cpp
+++ b/bolt/lib/Rewrite/JITLinkLinker.cpp
@@ -173,7 +173,8 @@ struct JITLinkLinker::Context : jitlink::JITLinkContext {
 
   void notifyFinalized(
       jitlink::JITLinkMemoryManager::FinalizedAlloc Alloc) override {
-    Linker.Allocs.push_back(std::move(Alloc));
+    if (Alloc)
+      Linker.Allocs.push_back(std::move(Alloc));
     ++Linker.MM->ObjectsLoaded;
   }
 };

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
@@ -1922,6 +1923,10 @@ void visitExistingEdges(LinkGraph &G, VisitorTs &&...Vs) {
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromObject(MemoryBufferRef ObjectBuffer);
+
+/// Create a \c LinkGraph defining the given absolute symbols.
+std::unique_ptr<LinkGraph> absoluteSymbolsLinkGraph(const Triple &TT,
+                                                    orc::SymbolMap Symbols);
 
 /// Link the given graph.
 void link(std::unique_ptr<LinkGraph> G, std::unique_ptr<JITLinkContext> Ctx);

--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkGeneric.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkGeneric.cpp
@@ -48,6 +48,14 @@ void JITLinkerBase::linkPhase1(std::unique_ptr<JITLinkerBase> Self) {
   if (auto Err = runPasses(Passes.PostPrunePasses))
     return Ctx->notifyFailed(std::move(Err));
 
+  // Skip straight to phase 2 if the graph is empty with no associated actions.
+  if (G->allocActions().empty() && llvm::all_of(G->sections(), [](Section &S) {
+        return S.getMemLifetime() == orc::MemLifetime::NoAlloc;
+      })) {
+    linkPhase2(std::move(Self), nullptr);
+    return;
+  }
+
   Ctx->getMemoryManager().allocate(
       Ctx->getJITLinkDylib(), *G,
       [S = std::move(Self)](AllocResult AR) mutable {
@@ -162,6 +170,12 @@ void JITLinkerBase::linkPhase3(std::unique_ptr<JITLinkerBase> Self,
 
   if (auto Err = runPasses(Passes.PostFixupPasses))
     return abandonAllocAndBailOut(std::move(Self), std::move(Err));
+
+  // Skip straight to phase 4 if the graph has no allocation.
+  if (!Alloc) {
+    linkPhase4(std::move(Self), JITLinkMemoryManager::FinalizedAlloc{});
+    return;
+  }
 
   Alloc->finalize([S = std::move(Self)](FinalizeResult FR) mutable {
     // FIXME: Once MSVC implements c++17 order of evaluation rules for calls

--- a/llvm/lib/ExecutionEngine/Orc/ExecutionUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ExecutionUtils.cpp
@@ -218,19 +218,23 @@ void ItaniumCXAAtExitSupport::runAtExits(void *DSOHandle) {
 }
 
 DynamicLibrarySearchGenerator::DynamicLibrarySearchGenerator(
-    sys::DynamicLibrary Dylib, char GlobalPrefix, SymbolPredicate Allow)
+    sys::DynamicLibrary Dylib, char GlobalPrefix, SymbolPredicate Allow,
+    AddAbsoluteSymbolsFn AddAbsoluteSymbols)
     : Dylib(std::move(Dylib)), Allow(std::move(Allow)),
+      AddAbsoluteSymbols(std::move(AddAbsoluteSymbols)),
       GlobalPrefix(GlobalPrefix) {}
 
 Expected<std::unique_ptr<DynamicLibrarySearchGenerator>>
 DynamicLibrarySearchGenerator::Load(const char *FileName, char GlobalPrefix,
-                                    SymbolPredicate Allow) {
+                                    SymbolPredicate Allow,
+                                    AddAbsoluteSymbolsFn AddAbsoluteSymbols) {
   std::string ErrMsg;
   auto Lib = sys::DynamicLibrary::getPermanentLibrary(FileName, &ErrMsg);
   if (!Lib.isValid())
     return make_error<StringError>(std::move(ErrMsg), inconvertibleErrorCode());
   return std::make_unique<DynamicLibrarySearchGenerator>(
-      std::move(Lib), GlobalPrefix, std::move(Allow));
+      std::move(Lib), GlobalPrefix, std::move(Allow),
+      std::move(AddAbsoluteSymbols));
 }
 
 Error DynamicLibrarySearchGenerator::tryToGenerate(
@@ -261,6 +265,8 @@ Error DynamicLibrarySearchGenerator::tryToGenerate(
   if (NewSymbols.empty())
     return Error::success();
 
+  if (AddAbsoluteSymbols)
+    return AddAbsoluteSymbols(JD, std::move(NewSymbols));
   return JD.define(absoluteSymbols(std::move(NewSymbols)));
 }
 

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -1608,6 +1608,8 @@ Error MachOPlatform::MachOPlatformPlugin::prepareSymbolTableRegistration(
     SmallVector<jitlink::Symbol *> SymsToProcess;
     for (auto *Sym : G.defined_symbols())
       SymsToProcess.push_back(Sym);
+    for (auto *Sym : G.absolute_symbols())
+      SymsToProcess.push_back(Sym);
 
     for (auto *Sym : SymsToProcess) {
       if (!Sym->hasName())

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -10,6 +10,11 @@
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/JITLink/x86_64.h"
+#include "llvm/ExecutionEngine/JITSymbol.h"
+#include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -171,6 +176,98 @@ TEST_F(ObjectLinkingLayerTest, HandleErrorDuringPostAllocationPass) {
   EXPECT_THAT_ERROR(ObjLinkingLayer.add(JD, std::move(G)), Succeeded());
 
   EXPECT_THAT_EXPECTED(ES.lookup(&JD, "_anchor"), Failed());
+}
+
+TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
+  class TestEPC : public UnsupportedExecutorProcessControl {
+  public:
+    TestEPC()
+        : UnsupportedExecutorProcessControl(nullptr, nullptr,
+                                            "x86_64-apple-darwin") {}
+
+    Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override {
+      return ExecutorAddr::fromPtr((void *)nullptr);
+    }
+
+    Expected<std::vector<tpctypes::LookupResult>>
+    lookupSymbols(ArrayRef<LookupRequest> Request) override {
+      std::vector<ExecutorSymbolDef> Result;
+      EXPECT_EQ(Request.size(), 1u);
+      for (auto &LR : Request) {
+        EXPECT_EQ(LR.Symbols.size(), 1u);
+        for (auto &Sym : LR.Symbols) {
+          if (*Sym.first == "_testFunc") {
+            ExecutorSymbolDef Def{ExecutorAddr::fromPtr((void *)0x1000),
+                                  JITSymbolFlags::Exported};
+            Result.push_back(Def);
+          } else {
+            ADD_FAILURE() << "unexpected symbol request " << *Sym.first;
+          }
+        }
+      }
+      return std::vector<tpctypes::LookupResult>{1, Result};
+    }
+  };
+
+  ExecutionSession ES{std::make_unique<TestEPC>()};
+  JITDylib &JD = ES.createBareJITDylib("main");
+  ObjectLinkingLayer ObjLinkingLayer{
+      ES, std::make_unique<InProcessMemoryManager>(4096)};
+
+  auto G = EPCDynamicLibrarySearchGenerator::GetForTargetProcess(
+      ES, {}, [&](JITDylib &JD, SymbolMap Syms) {
+        auto G =
+            absoluteSymbolsLinkGraph(ES.getTargetTriple(), std::move(Syms));
+        return ObjLinkingLayer.add(JD, std::move(G));
+      });
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  JD.addGenerator(std::move(*G));
+
+  class CheckDefs : public ObjectLinkingLayer::Plugin {
+  public:
+    ~CheckDefs() { EXPECT_TRUE(SawSymbolDef); }
+
+    void modifyPassConfig(MaterializationResponsibility &MR,
+                          jitlink::LinkGraph &G,
+                          jitlink::PassConfiguration &Config) override {
+      Config.PostAllocationPasses.push_back([this](LinkGraph &G) {
+        unsigned SymCount = 0;
+        for (Symbol *Sym : G.absolute_symbols()) {
+          SymCount += 1;
+          if (!Sym->hasName()) {
+            ADD_FAILURE() << "unexpected unnamed symbol";
+            continue;
+          }
+          if (Sym->getName() == "_testFunc")
+            SawSymbolDef = true;
+          else
+            ADD_FAILURE() << "unexpected symbol " << Sym->getName();
+        }
+        EXPECT_EQ(SymCount, 1u);
+        return Error::success();
+      });
+    }
+
+    Error notifyFailed(MaterializationResponsibility &MR) override {
+      return Error::success();
+    }
+
+    Error notifyRemovingResources(JITDylib &JD, ResourceKey K) override {
+      return Error::success();
+    }
+    void notifyTransferringResources(JITDylib &JD, ResourceKey DstKey,
+                                     ResourceKey SrcKey) override {
+      llvm_unreachable("unexpected resource transfer");
+    }
+
+  private:
+    bool SawSymbolDef = false;
+  };
+
+  ObjLinkingLayer.addPlugin(std::make_unique<CheckDefs>());
+
+  EXPECT_THAT_EXPECTED(ES.lookup(&JD, "_testFunc"), Succeeded());
+  EXPECT_THAT_ERROR(ES.endSession(), Succeeded());
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
Adds a function to create a LinkGraph of absolute symbols, and a callback in dynamic library search generators to enable using it to expose its symbols to the platform/orc runtime. This allows e.g. using __orc_rt_run_program to run a precompiled function that was found via dlsym. Ideally we would use this in llvm-jitlink's own search generator, but it will require more work to align with the Process/Platform JITDylib split, so not handled here.

As part of this change we need to handle LinkGraphs that only have absolute symbols.