### PR TITLE
[LLD] [MinGW] Sync --thinlto-cache-dir option details with ELF

### DIFF
--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -186,8 +186,8 @@ def appcontainer: F<"appcontainer">, HelpText<"Set the appcontainer flag in the 
 defm delayload: Eq<"delayload", "DLL to load only on demand">;
 defm mllvm: EqNoHelp<"mllvm">;
 defm pdb: Eq<"pdb", "Output PDB debug info file, chosen implicitly if the argument is empty">;
-defm thinlto_cache_dir: EqLong<"thinlto-cache-dir",
-  "Path to ThinLTO cached object file directory">;
+def thinlto_cache_dir: JJ<"thinlto-cache-dir=">,
+  HelpText<"Path to ThinLTO cached object file directory">;
 defm Xlink : Eq<"Xlink", "Pass <arg> to the COFF linker">, MetaVarName<"<arg>">;
 defm guard_cf : B<"guard-cf", "Enable Control Flow Guard" ,
   "Do not enable Control Flow Guard (default)">;


### PR DESCRIPTION
Disallow using the form with a separate argument,
"--thinlto-cache-dir dir", allow only the one with equals, "--thintlo-cache-dir=dir". This is the only form that actually was tested when this was added in
f794808bb9ec06966a67fe33d41a13b9601768f8, and matches the ELF side, where only the form with an equals is supported (and this was also the case at the time when this option was added to the MinGW linker).