### PR TITLE
[Libomptarget] Remove extra cache for offloading entries

### DIFF
--- a/openmp/libomptarget/include/DeviceImage.h
+++ b/openmp/libomptarget/include/DeviceImage.h
@@ -26,7 +26,6 @@
 class DeviceImageTy {
 
   std::unique_ptr<llvm::object::OffloadBinary> Binary;
-  llvm::SmallVector<std::unique_ptr<OffloadEntryTy>> OffloadEntries;
 
   __tgt_bin_desc *BinaryDesc;
   __tgt_device_image Image;
@@ -37,7 +36,9 @@ public:
   __tgt_device_image &getExecutableImage() { return Image; }
   __tgt_bin_desc &getBinaryDesc() { return *BinaryDesc; }
 
-  auto entries() { return llvm::make_pointee_range(OffloadEntries); }
+  auto entries() {
+    return llvm::make_range(Image.EntriesBegin, Image.EntriesEnd);
+  }
 };
 
 #endif // OMPTARGET_DEVICE_IMAGE_H

--- a/openmp/libomptarget/include/OffloadEntry.h
+++ b/openmp/libomptarget/include/OffloadEntry.h
@@ -36,11 +36,11 @@ public:
   const char *getNameAsCStr() const { return OffloadEntry.name; }
   __tgt_bin_desc *getBinaryDescription() const;
 
-  bool isCTor() { return hasFlags(OMP_DECLARE_TARGET_CTOR); }
-  bool isDTor() { return hasFlags(OMP_DECLARE_TARGET_DTOR); }
-  bool isLink() { return hasFlags(OMP_DECLARE_TARGET_LINK); }
+  bool isCTor() const { return hasFlags(OMP_DECLARE_TARGET_CTOR); }
+  bool isDTor() const { return hasFlags(OMP_DECLARE_TARGET_DTOR); }
+  bool isLink() const { return hasFlags(OMP_DECLARE_TARGET_LINK); }
 
-  bool hasFlags(OpenMPOffloadingDeclareTargetFlags Flags) {
+  bool hasFlags(OpenMPOffloadingDeclareTargetFlags Flags) const {
     return Flags & OffloadEntry.flags;
   }
 };

--- a/openmp/libomptarget/include/device.h
+++ b/openmp/libomptarget/include/device.h
@@ -159,7 +159,7 @@ struct DeviceTy {
   /// }
 
   /// Register \p Entry as an offload entry that is avalable on this device.
-  void addOffloadEntry(OffloadEntryTy &Entry);
+  void addOffloadEntry(const OffloadEntryTy &Entry);
 
   /// Print all offload entries to stderr.
   void dumpOffloadEntries();
@@ -170,7 +170,7 @@ private:
 
   /// All offload entries available on this device.
   using DeviceOffloadEntriesMapTy =
-      llvm::DenseMap<llvm::StringRef, OffloadEntryTy *>;
+      llvm::DenseMap<llvm::StringRef, OffloadEntryTy>;
   ProtectedObj<DeviceOffloadEntriesMapTy> DeviceOffloadEntries;
 
   /// Handler to collect and organize host-2-device mapping information.

--- a/openmp/libomptarget/src/DeviceImage.cpp
+++ b/openmp/libomptarget/src/DeviceImage.cpp
@@ -27,10 +27,6 @@ DeviceImageTy::DeviceImageTy(__tgt_bin_desc &BinaryDesc,
                              __tgt_device_image &TgtDeviceImage)
     : BinaryDesc(&BinaryDesc), Image(TgtDeviceImage) {
 
-  for (__tgt_offload_entry &Entry :
-       llvm::make_range(Image.EntriesBegin, Image.EntriesEnd))
-    OffloadEntries.emplace_back(std::make_unique<OffloadEntryTy>(*this, Entry));
-
   llvm::StringRef ImageStr(
       static_cast<char *>(Image.ImageStart),
       llvm::omp::target::getPtrDiff(Image.ImageEnd, Image.ImageStart));

--- a/openmp/libomptarget/src/PluginManager.cpp
+++ b/openmp/libomptarget/src/PluginManager.cpp
@@ -97,8 +97,8 @@ void PluginAdaptorTy::addOffloadEntries(DeviceImageTy &DI) {
                     toString(DeviceOrErr.takeError()).c_str());
 
     DeviceTy &Device = *DeviceOrErr;
-    for (OffloadEntryTy &Entry : DI.entries())
-      Device.addOffloadEntry(Entry);
+    for (__tgt_offload_entry &Entry : DI.entries())
+      Device.addOffloadEntry(OffloadEntryTy(DI, Entry));
   }
 }
 

--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -291,10 +291,9 @@ int32_t DeviceTy::destroyEvent(void *Event) {
   return OFFLOAD_SUCCESS;
 }
 
-void DeviceTy::addOffloadEntry(OffloadEntryTy &Entry) {
+void DeviceTy::addOffloadEntry(const OffloadEntryTy &Entry) {
   std::lock_guard<decltype(PendingGlobalsMtx)> Lock(PendingGlobalsMtx);
-  DeviceOffloadEntries.getExclusiveAccessor()->insert(
-      {Entry.getName(), &Entry});
+  DeviceOffloadEntries.getExclusiveAccessor()->insert({Entry.getName(), Entry});
   if (Entry.isGlobal())
     return;
 
@@ -329,14 +328,14 @@ void DeviceTy::dumpOffloadEntries() {
   fprintf(stderr, "Device %i offload entries:\n", DeviceID);
   for (auto &It : *DeviceOffloadEntries.getExclusiveAccessor()) {
     const char *Kind = "kernel";
-    if (It.second->isCTor())
+    if (It.second.isCTor())
       Kind = "constructor";
-    else if (It.second->isDTor())
+    else if (It.second.isDTor())
       Kind = "destructor";
-    else if (It.second->isLink())
+    else if (It.second.isLink())
       Kind = "link";
-    else if (It.second->isGlobal())
+    else if (It.second.isGlobal())
       Kind = "global var.";
-    fprintf(stderr, "  %11s: %s\n", Kind, It.second->getNameAsCStr());
+    fprintf(stderr, "  %11s: %s\n", Kind, It.second.getNameAsCStr());
   }
 }


### PR DESCRIPTION
Summary:
The offloading entries right now are assumed to be baked into the binary
itself, and thus always valid whenever the library is executing. This
means that we don't need to copy them to additional storage and can
instead simply pass around references to it.

This is not likely to change in the expected operation of the OpenMP
library. Additionally, the indirection for the offload entry struct is
simply two pointers, so moving it by value is trivial.
