### PR TITLE
[compiler-rt][Fuzzer] implements SetThreadName for darwin.

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -229,6 +229,7 @@ static void PulseThread() {
 
 static void WorkerThread(const Command &BaseCmd, std::atomic<unsigned> *Counter,
                          unsigned NumJobs, std::atomic<bool> *HasErrors) {
+  SetThreadName("FuzzerWorker");
   while (true) {
     unsigned C = (*Counter)++;
     if (C >= NumJobs) break;
@@ -297,7 +298,6 @@ static int RunInMultipleProcesses(const std::vector<std::string> &Args,
   for (unsigned i = 0; i < NumWorkers; i++) {
     V[i] = std::thread(WorkerThread, std::ref(Cmd), &Counter, NumJobs,
                             &HasErrors);
-    SetThreadName(V[i], "FuzzerWorker");
   }
   for (auto &T : V)
     T.join();

--- a/compiler-rt/lib/fuzzer/FuzzerUtil.h
+++ b/compiler-rt/lib/fuzzer/FuzzerUtil.h
@@ -59,7 +59,7 @@ size_t GetPeakRSSMb();
 int ExecuteCommand(const Command &Cmd);
 bool ExecuteCommand(const Command &Cmd, std::string *CmdOutput);
 
-void SetThreadName(std::thread &thread, const std::string &name);
+void SetThreadName(const std::string &name);
 
 // Fuchsia does not have popen/pclose.
 FILE *OpenProcessPipe(const char *Command, const char *Mode);

--- a/compiler-rt/lib/fuzzer/FuzzerUtilDarwin.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilDarwin.cpp
@@ -12,6 +12,7 @@
 #include "FuzzerCommand.h"
 #include "FuzzerIO.h"
 #include <mutex>
+#include <pthread.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdlib.h>
@@ -165,9 +166,8 @@ void DiscardOutput(int Fd) {
   fclose(Temp);
 }
 
-void SetThreadName(std::thread &thread, const std::string &name) {
-  // TODO ?
-  // Darwin allows to set the name only on the current thread it seems
+void SetThreadName(const std::string &name) {
+  pthread_setname_np(name.c_str());
 }
 
 } // namespace fuzzer

--- a/compiler-rt/lib/fuzzer/FuzzerUtilFuchsia.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilFuchsia.cpp
@@ -605,7 +605,7 @@ size_t PageSize() {
   return PageSizeCached;
 }
 
-void SetThreadName(std::thread &thread, const std::string &name) {
+void SetThreadName(const std::string &name) {
   // TODO ?
 }
 

--- a/compiler-rt/lib/fuzzer/FuzzerUtilLinux.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilLinux.cpp
@@ -40,11 +40,11 @@ void DiscardOutput(int Fd) {
   fclose(Temp);
 }
 
-void SetThreadName(std::thread &thread, const std::string &name) {
+void SetThreadName(const std::string &name) {
 #if LIBFUZZER_LINUX || LIBFUZZER_FREEBSD
-  (void)pthread_setname_np(thread.native_handle(), name.c_str());
+  (void)pthread_setname_np(pthread_self(), name.c_str());
 #elif LIBFUZZER_NETBSD
-  (void)pthread_set_name_np(thread.native_handle(), "%s", name.c_str());
+  (void)pthread_set_name_np(pthread_self(), "%s", name.c_str());
 #endif
 }
 


### PR DESCRIPTION
Unfortunately, the api makes it impossible to set a id for a thread but only for the current one.
Thus refactoring to set it from the worker callback's standpoint.