### PR TITLE
[Clang][OpenMP] Fix stdio.h wrapper when glibc includes again

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/stdio.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/stdio.h
@@ -6,14 +6,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__
-#define __CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__
-
 #if !defined(_OPENMP) && !defined(__HIP__) && !defined(__CUDA__)
 #error "This file is for GPU offloading compilation only"
 #endif
 
 #include_next <stdio.h>
+
+// In some old versions of glibc, other standard headers sometimes define
+// special macros (e.g., __need_FILE) before including stdio.h to cause stdio.h
+// to produce special definitions.  Future includes of stdio.h when those
+// special macros are undefined are expected to produce the normal definitions
+// from stdio.h.
+//
+// We do not apply our include guard (__CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__)
+// unconditionally to the above include_next.  Otherwise, after an occurrence of
+// the first glibc stdio.h use case described above, the include_next would be
+// skipped for remaining includes of stdio.h, leaving required symbols
+// undefined.
+//
+// We make the following assumptions to handle all use cases:
+//
+// 1. If the above include_next produces special glibc definitions, then (a) it
+//    does not produce the normal definitions that we must intercept below, (b)
+//    the current file was included from a glibc header that already defined
+//    __GLIBC__ (usually by including glibc's <features.h>), and (c) the above
+//    include_next does not define _STDIO_H.  In that case, we skip the rest of
+//    the current file and don't guard against future includes.
+// 2. If the above include_next produces the normal stdio.h definitions, then
+//    either (a) __GLIBC__ is not defined because C headers are from some other
+//    libc implementation or (b) the above include_next defines _STDIO_H to
+//    prevent the above include_next from having any effect in the future.
+#if !defined(__GLIBC__) || defined(_STDIO_H)
+
+#ifndef __CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__
+#define __CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__
 
 #if __has_include(<llvm-libc-decls/stdio.h>)
 
@@ -50,3 +76,5 @@
 #endif
 
 #endif // __CLANG_LLVM_LIBC_WRAPPERS_STDIO_H__
+
+#endif


### PR DESCRIPTION
Since D154036 landed (2a65d0388ca0 on July 7, 2023), I've been seeing many (40-50) libomptarget test failures with errors like the following on some of our test systems:

```
/auto/software/gcc/x86_64/gcc-11.1.0/lib/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/cstdio:99:11: error: no member named 'fpos_t' in the global namespace
   99 |   using ::fpos_t;
      |         ~~^
```

This patch fixes that and doesn't break our other test sytems.  I've looked through the glibc history and at LLVM's libc stdio.h to give me confidence that this solution should work on other systems.  Of course, there might be use cases I've overlooked, so feedback is appreciated.