### PR TITLE
[clang] Fix incorrect line numbers with -E and raw string (#47577)

### DIFF
--- a/clang/lib/Frontend/PrintPreprocessedOutput.cpp
+++ b/clang/lib/Frontend/PrintPreprocessedOutput.cpp
@@ -886,6 +886,10 @@ static void PrintPreprocessedTokens(Preprocessor &PP, Token &Tok,
       *Callbacks->OS << II->getName();
     } else if (Tok.isLiteral() && !Tok.needsCleaning() &&
                Tok.getLiteralData()) {
+      if (tok::isStringLiteral(Tok.getKind())) {
+        // Raw string literal may contain newlines
+        Callbacks->HandleNewlinesInToken(Tok.getLiteralData(), Tok.getLength());
+      }
       Callbacks->OS->write(Tok.getLiteralData(), Tok.getLength());
     } else if (Tok.getLength() < std::size(Buffer)) {
       const char *TokPtr = Buffer;

--- a/clang/test/Frontend/raw_string_line_number.cpp
+++ b/clang/test/Frontend/raw_string_line_number.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -E %s | FileCheck %s
+// CHECK: AAA
+// CHECK-NEXT: BBB
+R"(
+AAA)"
+BBB


### PR DESCRIPTION
When printing preprocessed tokens, handle newlines in string literals because raw string literals may contain newlines.