### PR TITLE
[RISCV] Don't call use_nodbg_operands for physical registers in RISCVOptWInstrs hasAllNBitUsers.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -126,10 +126,11 @@ static bool hasAllNBitUsers(const MachineInstr &OrigMI,
     if (MI->getNumExplicitDefs() != 1)
       return false;
 
-    if (!MI->getOperand(0).getReg().isVirtual())
+    Register DestReg = MI->getOperand(0).getReg();
+    if (!DestReg.isVirtual())
       return false;
 
-    for (auto &UserOp : MRI.use_nodbg_operands(MI->getOperand(0).getReg())) {
+    for (auto &UserOp : MRI.use_nodbg_operands(DestReg)) {
       const MachineInstr *UserMI = UserOp.getParent();
       unsigned OpIdx = UserOp.getOperandNo();
 

--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -126,6 +126,9 @@ static bool hasAllNBitUsers(const MachineInstr &OrigMI,
     if (MI->getNumExplicitDefs() != 1)
       return false;
 
+    if (!MI->getOperand(0).getReg().isVirtual())
+      return false;
+
     for (auto &UserOp : MRI.use_nodbg_operands(MI->getOperand(0).getReg())) {
       const MachineInstr *UserMI = UserOp.getParent();
       unsigned OpIdx = UserOp.getOperandNo();

--- a/llvm/test/CodeGen/RISCV/opt-w-instrs.mir
+++ b/llvm/test/CodeGen/RISCV/opt-w-instrs.mir
@@ -28,3 +28,23 @@ body:             |
     $x11 = COPY %4
     PseudoRET
 ...
+
+---
+name:            physreg
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+
+    ; CHECK-ZFA-LABEL: name: physreg
+    ; CHECK-ZFA: liveins: $x10, $x11
+    ; CHECK-ZFA-NEXT: {{  $}}
+    ; CHECK-ZFA-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
+    ; CHECK-ZFA-NEXT: [[ADDIW:%[0-9]+]]:gpr = ADDIW [[COPY]], 0
+    ; CHECK-ZFA-NEXT: $x10 = COPY [[ADDIW]]
+    ; CHECK-ZFA-NEXT: PseudoRET
+    %0:gpr = COPY $x10
+    %1:gpr = ADDIW %0, 0
+    $x10 = COPY %1
+    PseudoRET
+...


### PR DESCRIPTION
The ADDIW in the new test case was incorrectly removed due to incorrectly following the x10 register from the return value back to the argument. This is due to use_nodbg_operands returning every instruction that uses a physical register regardless of the data flow.