### PR TITLE
Improve modeling of 'getcwd' in the StdLibraryFunctionsChecker

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1138,9 +1138,10 @@ Improvements
 ^^^^^^^^^^^^
 
 - Improved the ``unix.StdCLibraryFunctions`` checker by modeling more
-  functions like ``send``, ``recv``, ``readlink``, ``fflush``, ``mkdtemp`` and
-  ``errno`` behavior.
+  functions like ``send``, ``recv``, ``readlink``, ``fflush``, ``mkdtemp``,
+  ``getcwd`` and ``errno`` behavior.
   (`52ac71f92d38 <https://github.com/llvm/llvm-project/commit/52ac71f92d38f75df5cb88e9c090ac5fd5a71548>`_,
+  `#77040 <https://github.com/llvm/llvm-project/pull/77040>`_,
   `#76671 <https://github.com/llvm/llvm-project/pull/76671>`_,
   `#71373 <https://github.com/llvm/llvm-project/pull/71373>`_,
   `#76557 <https://github.com/llvm/llvm-project/pull/76557>`_,

--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -2522,9 +2522,12 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
             .Case({ArgumentCondition(1, WithinRange, Range(1, SizeMax)),
                    ReturnValueCondition(BO_EQ, ArgNo(0))},
                   ErrnoMustNotBeChecked, GenericSuccessMsg)
-            .Case({ArgumentCondition(1, WithinRange, SingleValue(0))},
+            .Case({ArgumentCondition(1, WithinRange, SingleValue(0)),
+                   IsNull(Ret)},
+                  ErrnoNEZeroIrrelevant, "Assuming that argument 'size' is 0")
+            .Case({ArgumentCondition(1, WithinRange, Range(1, SizeMax)),
+                   IsNull(Ret)},
                   ErrnoNEZeroIrrelevant, GenericFailureMsg)
-            .Case({IsNull(Ret)}, ErrnoNEZeroIrrelevant, GenericFailureMsg)
             .ArgConstraint(NotNull(ArgNo(0)))
             .ArgConstraint(
                 BufferSize(/*Buffer*/ ArgNo(0), /*BufSize*/ ArgNo(1)))

--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -2519,12 +2519,17 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
     addToFunctionSummaryMap(
         "getcwd", Signature(ArgTypes{CharPtrTy, SizeTy}, RetType{CharPtrTy}),
         Summary(NoEvalCall)
-            .Case({ReturnValueCondition(BO_EQ, ArgNo(0))},
+            .Case({ArgumentCondition(1, WithinRange, Range(1, SizeMax)),
+                   ReturnValueCondition(BO_EQ, ArgNo(0))},
                   ErrnoMustNotBeChecked, GenericSuccessMsg)
+            .Case({ArgumentCondition(1, WithinRange, SingleValue(0))},
+                  ErrnoNEZeroIrrelevant, GenericFailureMsg)
             .Case({IsNull(Ret)}, ErrnoNEZeroIrrelevant, GenericFailureMsg)
             .ArgConstraint(NotNull(ArgNo(0)))
             .ArgConstraint(
-                ArgumentCondition(1, WithinRange, Range(1, SizeMax))));
+                BufferSize(/*Buffer*/ ArgNo(0), /*BufSize*/ ArgNo(1)))
+            .ArgConstraint(
+                ArgumentCondition(1, WithinRange, Range(0, SizeMax))));
 
     // int mkdir(const char *pathname, mode_t mode);
     addToFunctionSummaryMap(

--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -2516,12 +2516,15 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
             .ArgConstraint(NotNull(ArgNo(0))));
 
     // char *getcwd(char *buf, size_t size);
-    // FIXME: Improve for errno modeling.
     addToFunctionSummaryMap(
         "getcwd", Signature(ArgTypes{CharPtrTy, SizeTy}, RetType{CharPtrTy}),
         Summary(NoEvalCall)
+            .Case({ReturnValueCondition(BO_EQ, ArgNo(0))},
+                  ErrnoMustNotBeChecked, GenericSuccessMsg)
+            .Case({IsNull(Ret)}, ErrnoNEZeroIrrelevant, GenericFailureMsg)
+            .ArgConstraint(NotNull(ArgNo(0)))
             .ArgConstraint(
-                ArgumentCondition(1, WithinRange, Range(0, SizeMax))));
+                ArgumentCondition(1, WithinRange, Range(1, SizeMax))));
 
     // int mkdir(const char *pathname, mode_t mode);
     addToFunctionSummaryMap(

--- a/clang/test/Analysis/errno-stdlibraryfunctions.c
+++ b/clang/test/Analysis/errno-stdlibraryfunctions.c
@@ -75,16 +75,17 @@ void errno_mkdtemp(char *template) {
   }
 }
 
-void errno_getcwd_general(char *Buf, size_t Sz) {
+void errno_getcwd(char *Buf, size_t Sz) {
   char *Path = getcwd(Buf, Sz);
   if (Sz == 0) {
-    clang_analyzer_eval(errno != 0);  // expected-warning{{TRUE}}
-    if (errno) {}                     // no warning
+    clang_analyzer_eval(errno != 0);   // expected-warning{{TRUE}}
+    clang_analyzer_eval(Path == NULL); // expected-warning{{TRUE}}
+    if (errno) {}                      // no warning
   } else if (Path == NULL) {
-    clang_analyzer_eval(errno != 0);  // expected-warning{{TRUE}}
-    if (errno) {}                     // no warning
+    clang_analyzer_eval(errno != 0);   // expected-warning{{TRUE}}
+    if (errno) {}                      // no warning
   } else {
-    clang_analyzer_eval(Path == Buf); // expected-warning{{TRUE}}
-    if (errno) {}                     // expected-warning{{An undefined value may be read from 'errno'}}
+    clang_analyzer_eval(Path == Buf);  // expected-warning{{TRUE}}
+    if (errno) {}                      // expected-warning{{An undefined value may be read from 'errno'}}
   }
 }

--- a/clang/test/Analysis/errno-stdlibraryfunctions.c
+++ b/clang/test/Analysis/errno-stdlibraryfunctions.c
@@ -75,13 +75,16 @@ void errno_mkdtemp(char *template) {
   }
 }
 
-void errno_getcwd(char *Buf, size_t sz) {
-  char *Path = getcwd(Buf, sz);
-  if (Path == NULL) {
-    clang_analyzer_eval(errno != 0);      // expected-warning{{TRUE}}
-    if (errno) {}                         // no warning
+void errno_getcwd_general(char *Buf, size_t Sz) {
+  char *Path = getcwd(Buf, Sz);
+  if (Sz == 0) {
+    clang_analyzer_eval(errno != 0);  // expected-warning{{TRUE}}
+    if (errno) {}                     // no warning
+  } else if (Path == NULL) {
+    clang_analyzer_eval(errno != 0);  // expected-warning{{TRUE}}
+    if (errno) {}                     // no warning
   } else {
-    clang_analyzer_eval(Path == Buf);     // expected-warning{{TRUE}}
-    if (errno) {}                         // expected-warning{{An undefined value may be read from 'errno'}}
+    clang_analyzer_eval(Path == Buf); // expected-warning{{TRUE}}
+    if (errno) {}                     // expected-warning{{An undefined value may be read from 'errno'}}
   }
 }

--- a/clang/test/Analysis/errno-stdlibraryfunctions.c
+++ b/clang/test/Analysis/errno-stdlibraryfunctions.c
@@ -74,3 +74,14 @@ void errno_mkdtemp(char *template) {
     if (errno) {}                         // expected-warning{{An undefined value may be read from 'errno'}}
   }
 }
+
+void errno_getcwd(char *Buf, size_t sz) {
+  char *Path = getcwd(Buf, sz);
+  if (Path == NULL) {
+    clang_analyzer_eval(errno != 0);      // expected-warning{{TRUE}}
+    if (errno) {}                         // no warning
+  } else {
+    clang_analyzer_eval(Path == Buf);     // expected-warning{{TRUE}}
+    if (errno) {}                         // expected-warning{{An undefined value may be read from 'errno'}}
+  }
+}

--- a/clang/test/Analysis/std-c-library-functions-path-notes.c
+++ b/clang/test/Analysis/std-c-library-functions-path-notes.c
@@ -89,9 +89,3 @@ int test_readlink_bufsize_zero(char *Buf, size_t Bufsize) {
   // expected-warning{{Division by zero}} \
   // expected-note{{Division by zero}}
 }
-
-char *test_getcwd_bufsize_zero(char *Buf) {
-  return getcwd(Buf, 0); // \
-  // expected-warning {{The 2nd argument to 'getcwd' is 0 but should be > 0}} \
-  // expected-note    {{The 2nd argument to 'getcwd' is 0 but should be > 0}}
-}

--- a/clang/test/Analysis/std-c-library-functions-path-notes.c
+++ b/clang/test/Analysis/std-c-library-functions-path-notes.c
@@ -89,3 +89,9 @@ int test_readlink_bufsize_zero(char *Buf, size_t Bufsize) {
   // expected-warning{{Division by zero}} \
   // expected-note{{Division by zero}}
 }
+
+char *test_getcwd_bufsize_zero(char *Buf) {
+  return getcwd(Buf, 0); // \
+  // expected-warning {{The 2nd argument to 'getcwd' is 0 but should be > 0}} \
+  // expected-note    {{The 2nd argument to 'getcwd' is 0 but should be > 0}}
+}


### PR DESCRIPTION
1. Improve the 'errno' modeling.
2. Improve the buffer size argument's constraint.