### PR TITLE
add prop-dict support for custom directive for mlir-tblgen

### DIFF
--- a/mlir/test/mlir-tblgen/op-format-spec.td
+++ b/mlir/test/mlir-tblgen/op-format-spec.td
@@ -44,6 +44,9 @@ def DirectiveCustomValidC : TestFormat_Op<[{
 def DirectiveCustomValidD : TestFormat_Op<[{
   (`(` custom<MyDirective>($operand)^ `)`)? attr-dict
 }]>, Arguments<(ins Optional<I64>:$operand)>;
+def DirectiveCustomValidE : TestFormat_Op<[{
+  custom<MyDirective>(prop-dict) attr-dict
+}]>, Arguments<(ins UnitAttr:$flag)>;
 
 //===----------------------------------------------------------------------===//
 // functional-type

--- a/mlir/test/mlir-tblgen/op-format.td
+++ b/mlir/test/mlir-tblgen/op-format.td
@@ -42,6 +42,14 @@ def CustomStringLiteralC : TestFormat_Op<[{
   custom<Foo>("$_builder.getStringAttr(\"foo\")") attr-dict
 }]>;
 
+// CHECK-LABEL: CustomStringLiteralD::parse
+// CHECK: parseFoo({{.*}}, result)
+// CHECK-LABEL: CustomStringLiteralD::print
+// CHECK: printFoo({{.*}}, getProperties())
+def CustomStringLiteralD : TestFormat_Op<[{
+  custom<Foo>(prop-dict) attr-dict
+}]>;
+
 //===----------------------------------------------------------------------===//
 // Optional Groups
 //===----------------------------------------------------------------------===//

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -895,6 +895,8 @@ static void genCustomParameterParser(FormatElement *param, MethodBody &body) {
     body << attr->getVar()->name << "Attr";
   } else if (isa<AttrDictDirective>(param)) {
     body << "result.attributes";
+  } else if (isa<PropDictDirective>(param)) {
+    body << "result";
   } else if (auto *operand = dyn_cast<OperandVariable>(param)) {
     StringRef name = operand->getVar()->name;
     ArgumentLengthKind lengthKind = getArgumentLengthKind(operand->getVar());
@@ -1853,6 +1855,9 @@ static void genCustomDirectiveParameterPrinter(FormatElement *element,
 
   } else if (isa<AttrDictDirective>(element)) {
     body << "getOperation()->getAttrDictionary()";
+
+  } else if (isa<PropDictDirective>(element)) {
+    body << "getProperties()";
 
   } else if (auto *operand = dyn_cast<OperandVariable>(element)) {
     body << op.getGetterName(operand->getVar()->name) << "()";
@@ -3138,9 +3143,9 @@ OpFormatParser::parsePropDictDirective(SMLoc loc, Context context) {
 LogicalResult OpFormatParser::verifyCustomDirectiveArguments(
     SMLoc loc, ArrayRef<FormatElement *> arguments) {
   for (FormatElement *argument : arguments) {
-    if (!isa<AttrDictDirective, AttributeVariable, OperandVariable,
-             PropertyVariable, RefDirective, RegionVariable, SuccessorVariable,
-             StringElement, TypeDirective>(argument)) {
+    if (!isa<AttrDictDirective, PropDictDirective, AttributeVariable,
+             OperandVariable, PropertyVariable, RefDirective, RegionVariable,
+             SuccessorVariable, StringElement, TypeDirective>(argument)) {
       // TODO: FormatElement should have location info attached.
       return emitError(loc, "only variables and types may be used as "
                             "parameters to a custom directive");


### PR DESCRIPTION
According to https://mlir.llvm.org/docs/DefiningDialects/Operations/#custom-directives, custom directive supports attr-dict

> attr-dict Directive: NamedAttrList &

But it doesn't support prop-dict which is introduced into MLIR recently. It's useful to have tblgen support prop-dict like attr-dict. This PR enable tblgen to support prop-dict

```bash
error: only variables and types may be used as parameters to a custom directive
   ... custom<Print>(prop-dict)
```