### PR TITLE
[coroutines][coro_lifetimebound] Detect lifetime issues with lambda captures

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11219,6 +11219,12 @@ public:
   bool buildCoroutineParameterMoves(SourceLocation Loc);
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
+  // Heuristaclly tells if the function is promise::get_return_object().
+  static bool isGetReturnObject(const FunctionDecl *FD) {
+    return isa_and_nonnull<CXXMethodDecl>(FD) &&
+           FD->getDeclName().isIdentifier() &&
+           FD->getName().equals("get_return_object") && FD->param_empty();
+  }
 
   // As a clang extension, enforces that a non-coroutine function must be marked
   // with [[clang::coro_wrapper]] if it returns a type marked with

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11219,12 +11219,6 @@ public:
   bool buildCoroutineParameterMoves(SourceLocation Loc);
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
-  // Heuristaclly tells if the function is promise::get_return_object().
-  static bool isGetReturnObject(const FunctionDecl *FD) {
-    return isa_and_nonnull<CXXMethodDecl>(FD) &&
-           FD->getDeclName().isIdentifier() &&
-           FD->getName().equals("get_return_object") && FD->param_empty();
-  }
 
   // As a clang extension, enforces that a non-coroutine function must be marked
   // with [[clang::coro_wrapper]] if it returns a type marked with

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11220,6 +11220,11 @@ public:
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
 
+  // Heuristically tells if the function is get_return_object by matching
+  // function name.
+  static bool IsGetReturnObject(const FunctionDecl *FD);
+  static bool IsGetReturnTypeOnAllocFailure(const FunctionDecl *FD);
+
   // As a clang extension, enforces that a non-coroutine function must be marked
   // with [[clang::coro_wrapper]] if it returns a type marked with
   // [[clang::coro_return_type]].

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11220,10 +11220,10 @@ public:
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
 
-  // Heuristically tells if the function is get_return_object by matching
-  // function name.
-  static bool IsGetReturnObject(const FunctionDecl *FD);
-  static bool IsGetReturnTypeOnAllocFailure(const FunctionDecl *FD);
+  // Heuristically tells if the function is `get_return_object` member of a
+  // coroutine promise_type by matching the function name.
+  static bool CanBeGetReturnObject(const FunctionDecl *FD);
+  static bool CanBeGetReturnTypeOnAllocFailure(const FunctionDecl *FD);
 
   // As a clang extension, enforces that a non-coroutine function must be marked
   // with [[clang::coro_wrapper]] if it returns a type marked with

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -303,7 +303,7 @@ static void handleGetReturnObject(Sema &S, MemberExpr *ME) {
   if (!ME || !ME->getMemberDecl() || !ME->getMemberDecl()->getAsFunction())
     return;
   auto *MD = ME->getMemberDecl()->getAsFunction();
-  auto* RetType = MD->getReturnType()->getAsRecordDecl();
+  auto *RetType = MD->getReturnType()->getAsRecordDecl();
   if (!RetType || !RetType->hasAttr<CoroReturnTypeAttr>())
     return;
   // `get_return_object` should be allowed to return coro_return_type.

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1800,9 +1800,9 @@ bool CoroutineStmtBuilder::makeOnException() {
 // Adds [[clang::coro_wrapper]] and [[clang::coro_disable_lifetimebound]]
 // attributes to the function `get_return_object`.
 static void handleGetReturnObject(Sema &S, Expr *E) {
-  if(auto* TE = dyn_cast<CXXBindTemporaryExpr>(E))
+  if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
     E = TE->getSubExpr();
-  auto* CE = dyn_cast<CallExpr>(E);
+  auto *CE = dyn_cast<CallExpr>(E);
   assert(CE);
   auto *MD = CE->getDirectCallee();
   if (!MD)

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1798,7 +1798,7 @@ bool CoroutineStmtBuilder::makeOnException() {
 }
 
 // Adds [[clang::coro_wrapper]] and [[clang::coro_disable_lifetimebound]]
-// attributes to the function `get_return_object`.
+// attributes to the function `get_return_object` if its return type is marked with `[[clang::coro_return_type]]` to avoid false-positive diagnostic for `get_return_object`.
 static void handleGetReturnObject(Sema &S, Expr *E) {
   if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
     E = TE->getSubExpr();

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1802,8 +1802,7 @@ bool CoroutineStmtBuilder::makeOnException() {
 static void handleGetReturnObject(Sema &S, Expr *E) {
   if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
     E = TE->getSubExpr();
-  auto *CE = dyn_cast<CallExpr>(E);
-  assert(CE);
+  auto *CE = cast<CallExpr>(E);
   auto *MD = CE->getDirectCallee();
   if (!MD)
     return;

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1798,7 +1798,9 @@ bool CoroutineStmtBuilder::makeOnException() {
 }
 
 // Adds [[clang::coro_wrapper]] and [[clang::coro_disable_lifetimebound]]
-// attributes to the function `get_return_object` if its return type is marked with `[[clang::coro_return_type]]` to avoid false-positive diagnostic for `get_return_object`.
+// attributes to the function `get_return_object` if its return type is marked
+// with `[[clang::coro_return_type]]` to avoid false-positive diagnostic for
+// `get_return_object`.
 static void handleGetReturnObject(Sema &S, Expr *E) {
   if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
     E = TE->getSubExpr();

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1321,6 +1321,33 @@ static bool diagReturnOnAllocFailure(Sema &S, Expr *E,
   return false;
 }
 
+// Adds [[clang::coro_wrapper]] and [[clang::coro_disable_lifetimebound]]
+// attributes to the function `get_return_object` if its return type is marked
+// with `[[clang::coro_return_type]]` to avoid false-positive diagnostic for
+// `get_return_object`.
+static void handleGetReturnObject(Sema &S, Expr *E) {
+  if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
+    E = TE->getSubExpr();
+  auto *CE = cast<CallExpr>(E);
+  auto *MD = CE->getDirectCallee();
+  if (!MD)
+    return;
+  // This analysis is done only for types marked with
+  // [[clang::coro_return_type]].
+  auto *RetType = MD->getReturnType()->getAsRecordDecl();
+  if (!RetType || !RetType->hasAttr<CoroReturnTypeAttr>())
+    return;
+  // `get_return_object` should be allowed to return coro_return_type.
+  if (!MD->hasAttr<CoroWrapperAttr>())
+    MD->addAttr(
+        CoroWrapperAttr::CreateImplicit(S.getASTContext(), MD->getLocation()));
+  // Object arg of `__promise.get_return_object()` is not lifetimebound.
+  if (RetType->hasAttr<CoroLifetimeBoundAttr>() &&
+      !MD->hasAttr<CoroDisableLifetimeBoundAttr>())
+    MD->addAttr(CoroDisableLifetimeBoundAttr::CreateImplicit(
+        S.getASTContext(), MD->getLocation()));
+}
+
 bool CoroutineStmtBuilder::makeReturnOnAllocFailure() {
   assert(!IsPromiseDependentType &&
          "cannot make statement while the promise type is dependent");
@@ -1354,6 +1381,7 @@ bool CoroutineStmtBuilder::makeReturnOnAllocFailure() {
   if (ReturnObjectOnAllocationFailure.isInvalid())
     return false;
 
+  handleGetReturnObject(S, ReturnObjectOnAllocationFailure.get());
   StmtResult ReturnStmt =
       S.BuildReturnStmt(Loc, ReturnObjectOnAllocationFailure.get());
   if (ReturnStmt.isInvalid()) {
@@ -1795,33 +1823,6 @@ bool CoroutineStmtBuilder::makeOnException() {
 
   this->OnException = UnhandledException.get();
   return true;
-}
-
-// Adds [[clang::coro_wrapper]] and [[clang::coro_disable_lifetimebound]]
-// attributes to the function `get_return_object` if its return type is marked
-// with `[[clang::coro_return_type]]` to avoid false-positive diagnostic for
-// `get_return_object`.
-static void handleGetReturnObject(Sema &S, Expr *E) {
-  if (auto *TE = dyn_cast<CXXBindTemporaryExpr>(E))
-    E = TE->getSubExpr();
-  auto *CE = cast<CallExpr>(E);
-  auto *MD = CE->getDirectCallee();
-  if (!MD)
-    return;
-  // This analysis is done only for types marked with
-  // [[clang::coro_return_type]].
-  auto *RetType = MD->getReturnType()->getAsRecordDecl();
-  if (!RetType || !RetType->hasAttr<CoroReturnTypeAttr>())
-    return;
-  // `get_return_object` should be allowed to return coro_return_type.
-  if (!MD->hasAttr<CoroWrapperAttr>())
-    MD->addAttr(
-        CoroWrapperAttr::CreateImplicit(S.getASTContext(), MD->getLocation()));
-  // Object arg of `__promise.get_return_object()` is not lifetimebound.
-  if (RetType->hasAttr<CoroLifetimeBoundAttr>() &&
-      !MD->hasAttr<CoroDisableLifetimeBoundAttr>())
-    MD->addAttr(CoroDisableLifetimeBoundAttr::CreateImplicit(
-        S.getASTContext(), MD->getLocation()));
 }
 
 bool CoroutineStmtBuilder::makeReturnObject() {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15846,8 +15846,7 @@ void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
     return;
   // Allow `get_return_object()`.
-  if (FD->getDeclName().isIdentifier() &&
-      FD->getName().equals("get_return_object") && FD->param_empty())
+  if (isGetReturnObject(FD))
     return;
   if (!FD->hasAttr<CoroWrapperAttr>())
     Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15845,8 +15845,11 @@ void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   RecordDecl *RD = FD->getReturnType()->getAsRecordDecl();
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
     return;
-  // Allow `get_return_object()`.
-  if (isGetReturnObject(FD))
+  // Allow some_promise_type::get_return_object().
+  // Since we are still in the promise definition, we can only do this
+  // heuristically as the promise may not be yet associated to a coroutine.
+  if (isa<CXXMethodDecl>(FD) && FD->getDeclName().isIdentifier() &&
+      FD->getName().equals("get_return_object") && FD->param_empty())
     return;
   if (!FD->hasAttr<CoroWrapperAttr>())
     Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15841,10 +15841,9 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
           << FixItHint::CreateInsertion(P.first, "self->");
 }
 
-static bool methodHasName(const FunctionDecl* FD, StringRef Name) {
+static bool methodHasName(const FunctionDecl *FD, StringRef Name) {
   return isa<CXXMethodDecl>(FD) && FD->param_empty() &&
-         FD->getDeclName().isIdentifier() &&
-         FD->getName().equals(Name);
+         FD->getDeclName().isIdentifier() && FD->getName().equals(Name);
 }
 
 bool Sema::CanBeGetReturnObject(const FunctionDecl *FD) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15841,13 +15841,13 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
           << FixItHint::CreateInsertion(P.first, "self->");
 }
 
-static bool IsGetReturnType(FunctionDecl *FD) {
+bool Sema::IsGetReturnObject(const FunctionDecl *FD) {
   return isa<CXXMethodDecl>(FD) && FD->param_empty() &&
          FD->getDeclName().isIdentifier() &&
          FD->getName().equals("get_return_object");
 }
 
-static bool IsGetReturnTypeOnAllocFailure(FunctionDecl *FD) {
+bool Sema::IsGetReturnTypeOnAllocFailure(const FunctionDecl *FD) {
   return FD->isStatic() && FD->param_empty() &&
          FD->getDeclName().isIdentifier() &&
          FD->getName().equals("get_return_object_on_allocation_failure");
@@ -15858,9 +15858,7 @@ void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
     return;
   // Allow some_promise_type::get_return_object().
-  // Since we are still in the promise definition, we can only do this
-  // heuristically as the promise may not be yet associated to a coroutine.
-  if (IsGetReturnType(FD) || IsGetReturnTypeOnAllocFailure(FD))
+  if (IsGetReturnObject(FD) || IsGetReturnTypeOnAllocFailure(FD))
     return;
   if (!FD->hasAttr<CoroWrapperAttr>())
     Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15841,13 +15841,13 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
           << FixItHint::CreateInsertion(P.first, "self->");
 }
 
-static bool IsGetReturnType(FunctionDecl* FD) {
+static bool IsGetReturnType(FunctionDecl *FD) {
   return isa<CXXMethodDecl>(FD) && FD->param_empty() &&
          FD->getDeclName().isIdentifier() &&
          FD->getName().equals("get_return_object");
 }
 
-static bool IsGetReturnTypeOnAllocFailure(FunctionDecl* FD) {
+static bool IsGetReturnTypeOnAllocFailure(FunctionDecl *FD) {
   return FD->isStatic() && FD->param_empty() &&
          FD->getDeclName().isIdentifier() &&
          FD->getName().equals("get_return_object_on_allocation_failure");

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7586,8 +7586,8 @@ static void visitLifetimeBoundArguments(IndirectLocalPath &Path, Expr *Call,
 
   if (ObjectArg) {
     bool CheckCoroObjArg = CheckCoroCall;
-    // Ignore `__promise.get_return_object()` as it not lifetimebound.
-    if (Callee->getDeclName().isIdentifier() &&
+    // Ignore `__promise.get_return_object()` as it is not lifetimebound.
+    if (CheckCoroObjArg && Callee->getDeclName().isIdentifier() &&
         Callee->getName() == "get_return_object")
       CheckCoroObjArg = false;
     // Coroutine lambda objects with empty capture list are not lifetimebound.

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7587,8 +7587,7 @@ static void visitLifetimeBoundArguments(IndirectLocalPath &Path, Expr *Call,
   if (ObjectArg) {
     bool CheckCoroObjArg = CheckCoroCall;
     // Ignore `__promise.get_return_object()` as it is not lifetimebound.
-    if (CheckCoroObjArg && Callee->getDeclName().isIdentifier() &&
-        Callee->getName() == "get_return_object")
+    if (CheckCoroObjArg && Sema::isGetReturnObject(Callee))
       CheckCoroObjArg = false;
     // Coroutine lambda objects with empty capture list are not lifetimebound.
     if (auto *LE = dyn_cast<LambdaExpr>(ObjectArg->IgnoreImplicit());

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7586,9 +7586,6 @@ static void visitLifetimeBoundArguments(IndirectLocalPath &Path, Expr *Call,
 
   if (ObjectArg) {
     bool CheckCoroObjArg = CheckCoroCall;
-    // Ignore `__promise.get_return_object()` as it is not lifetimebound.
-    if (CheckCoroObjArg && Sema::isGetReturnObject(Callee))
-      CheckCoroObjArg = false;
     // Coroutine lambda objects with empty capture list are not lifetimebound.
     if (auto *LE = dyn_cast<LambdaExpr>(ObjectArg->IgnoreImplicit());
         LE && LE->captures().empty())

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7591,7 +7591,7 @@ static void visitLifetimeBoundArguments(IndirectLocalPath &Path, Expr *Call,
       CheckCoroObjArg = false;
     // Allow `get_return_object()` as the object param (__promise) is not
     // lifetimebound.
-    if (Sema::IsGetReturnObject(Callee))
+    if (Sema::CanBeGetReturnObject(Callee))
       CheckCoroObjArg = false;
     if (implicitObjectParamIsLifetimeBound(Callee) || CheckCoroObjArg)
       VisitLifetimeBoundArg(Callee, ObjectArg);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -34,7 +34,6 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7589,6 +7589,10 @@ static void visitLifetimeBoundArguments(IndirectLocalPath &Path, Expr *Call,
     if (auto *LE = dyn_cast<LambdaExpr>(ObjectArg->IgnoreImplicit());
         LE && LE->captures().empty())
       CheckCoroObjArg = false;
+    // Allow `get_return_object()` as the object param (__promise) is not
+    // lifetimebound.
+    if (Sema::IsGetReturnObject(Callee))
+      CheckCoroObjArg = false;
     if (implicitObjectParamIsLifetimeBound(Callee) || CheckCoroObjArg)
       VisitLifetimeBoundArg(Callee, ObjectArg);
   }

--- a/clang/test/SemaCXX/coro-lifetimebound.cpp
+++ b/clang/test/SemaCXX/coro-lifetimebound.cpp
@@ -64,6 +64,10 @@ Co<int> bar_coro(const int &b, int c) {
       : bar_coro(0, 1); // expected-warning {{returning address of local temporary object}}
 }
 
+// =============================================================================
+// Lambdas
+// =============================================================================
+namespace lambdas {
 void lambdas() {
   auto unsafe_lambda = [] [[clang::coro_wrapper]] (int b) {
     return foo_coro(b); // expected-warning {{address of stack memory associated with parameter}}
@@ -84,14 +88,46 @@ void lambdas() {
     co_return x + co_await foo_coro(b);
   };
 }
-// =============================================================================
-// Safe usage when parameters are value
-// =============================================================================
-namespace by_value {
-Co<int> value_coro(int b) { co_return co_await foo_coro(b); }
-[[clang::coro_wrapper]] Co<int> wrapper1(int b) { return value_coro(b); }
-[[clang::coro_wrapper]] Co<int> wrapper2(const int& b) { return value_coro(b); }
+
+Co<int> lambda_captures() {
+  int a = 1;
+  // Temporary lambda object dies.
+  auto lamb = [a](int x, const int& y) -> Co<int> { // expected-warning {{temporary whose address is used as value of local variable 'lamb'}}
+    co_return x + y + a;
+  }(1, a);
+  // Object dies but it has no capture.
+  auto no_capture = []() -> Co<int> { co_return 1; }();
+  auto bad_no_capture = [](const int& a) -> Co<int> { co_return a; }(1); // expected-warning {{temporary}}
+  // Temporary lambda object with lifetime extension under co_await.
+  int res = co_await [a](int x, const int& y) -> Co<int> {
+    co_return x + y + a;
+  }(1, a);
+  co_return 1;
 }
+} // namespace lambdas
+
+// =============================================================================
+// Member coroutines
+// =============================================================================
+namespace member_coroutines{
+struct S {
+  Co<int> member(const int& a) { co_return a; }  
+};
+
+Co<int> use() {
+  S s;
+  int a = 1;
+  auto test1 = s.member(1);  // expected-warning {{temporary whose address is used as value of local variable}}
+  auto test2 = s.member(a);
+  auto test3 = S{}.member(a);  // expected-warning {{temporary whose address is used as value of local variable}}
+  co_return 1;
+}
+
+[[clang::coro_wrapper]] Co<int> wrapper(const int& a) {
+  S s;
+  return s.member(a); // expected-warning {{address of stack memory}}
+}
+} // member_coroutines
 
 // =============================================================================
 // Lifetime bound but not a Coroutine Return Type: No analysis.
@@ -128,5 +164,23 @@ Co<int> foo_wrapper(const int& x) { return foo(x); }
 [[clang::coro_wrapper]] Co<int> caller() {
   // The call to foo_wrapper is wrapper is safe.
   return foo_wrapper(1);
+}
+
+struct S{
+[[clang::coro_wrapper, clang::coro_disable_lifetimebound]] 
+Co<int> member(const int& x) { return foo(x); }
+};
+
+Co<int> use() {
+  S s;
+  int a = 1;
+  auto test1 = s.member(1); // param is not flagged.
+  auto test2 = S{}.member(a); // 'this' is not flagged.
+  co_return 1;
+}
+
+[[clang::coro_wrapper]] Co<int> return_stack_addr(const int& a) {
+  S s;
+  return s.member(a); // return of stack addr is not flagged.
 }
 } // namespace disable_lifetimebound

--- a/clang/test/SemaCXX/coro-lifetimebound.cpp
+++ b/clang/test/SemaCXX/coro-lifetimebound.cpp
@@ -180,7 +180,7 @@ Co<int> foo_wrapper(const int& x) { return foo(x); }
 }
 
 struct S{
-[[clang::coro_wrapper, clang::coro_disable_lifetimebound]] 
+[[clang::coro_wrapper, clang::coro_disable_lifetimebound]]
 Co<int> member(const int& x) { return foo(x); }
 };
 

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -5,9 +5,21 @@ using std::suspend_always;
 using std::suspend_never;
 
 
+namespace std {
+  struct nothrow_t {};
+  constexpr nothrow_t nothrow = {};
+}
+
+using SizeT = decltype(sizeof(int));
+
+void* operator new(SizeT __sz, const std::nothrow_t&) noexcept;
+
 template <typename T> struct [[clang::coro_return_type]] Gen {
   struct promise_type {
     Gen<T> get_return_object() {
+      return {};
+    }
+    static Gen<T> get_return_object_on_allocation_failure() {
       return {};
     }
     suspend_always initial_suspend();


### PR DESCRIPTION
### Problem

```cpp
co_task<int> coro() {
    int a = 1;
    auto lamb = [a]() -> co_task<int> {
        co_return a; // 'a' in the lambda object dies after the iniital_suspend in the lambda coroutine.
    }();
    co_return co_await lamb;
}
```
[use-after-free](https://godbolt.org/z/GWPEovWWc)

Lambda captures (even by value) are prone to use-after-free once the lambda object dies. In the above example, the lambda object appears only as a temporary in the call expression. It dies after the first suspension (`initial_suspend`) in the lambda.
On resumption in `co_await lamb`, the lambda accesses `a` which is part of the already-dead lambda object.

---

### Solution

This problem can be formulated by saying that the `this` parameter of the lambda call operator is a lifetimebound parameter. The lambda object argument should therefore live atleast as long as the return object.
That said, this requirement does not hold if the lambda does not have a capture list. In principle, the coroutine frame still has a reference to a dead lambda object, but it is easy to see that the object would not be used in the lambda-coroutine body due to no capture list.

It is safe to use this pattern inside a`co_await` expression due to the lifetime extension of temporaries. Example:

```cpp
co_task<int> coro() {
    int a = 1;
    int res = co_await [a]() -> co_task<int> { co_return a; }();
    co_return res;
}
```
---
### Background

This came up in the discussion with seastar folks on [RFC](https://discourse.llvm.org/t/rfc-lifetime-bound-check-for-parameters-of-coroutines/74253/19?u=usx95). This is a fairly common pattern in continuation-style-passing (CSP) async programming involving futures and continuations. Document ["Lambda coroutine fiasco"](https://github.com/scylladb/seastar/blob/master/doc/lambda-coroutine-fiasco.md) by Seastar captures the problem.
This pattern makes the migration from CSP-style async programming to coroutines very bugprone.


Fixes https://github.com/llvm/llvm-project/issues/76995 