### PR TITLE
[libc++] tests: add long-double-is-double feature

### DIFF
--- a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+++ b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
@@ -8,20 +8,9 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// The following platforms have sizeof(long double) == sizeof(double), so this test doesn't apply to them.
-// This test does apply to aarch64 where Arm's AAPCS64 is followed. There they are different sizes.
-// UNSUPPORTED: target={{arm64|arm64e|armv(7|8)(l|m)?|powerpc|powerpc64}}-{{.+}}
-
-// MSVC configurations have long double equal to regular double on all
-// architectures.
-// UNSUPPORTED: target={{.+}}-pc-windows-msvc
-
-// ARM/AArch64 MinGW also has got long double equal to regular double, just
-// like MSVC (thus match both MinGW and MSVC here, for those architectures).
-// UNSUPPORTED: target={{aarch64|armv7}}-{{.*}}-windows-{{.+}}
-
-// Android's 32-bit x86 target has long double equal to regular double.
-// UNSUPPORTED: target=i686-{{.+}}-android{{.*}}
+// This test does not apply to platforms, which have
+// sizeof(long double) == sizeof(double).
+// XFAIL: long-double-is-double
 
 // <compare>
 

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -217,6 +217,17 @@ DEFAULT_FEATURES = [
           """,
         ),
     ),
+    Feature(
+        name="long-double-is-double",
+        when=lambda cfg: sourceBuilds(
+            cfg,
+            """
+            int main(int, char**) {
+              static_assert(sizeof(long double) == sizeof(double));
+            }
+            """,
+        ),
+    ),
     # TODO: Remove this feature once compiler-rt includes __atomic_is_lockfree()
     # on all supported platforms.
     Feature(


### PR DESCRIPTION
The current approach with matching the platforms by name is error prone. In my internal tests the platform is "arm-none-eabi" and was not matched even though the test is not valid there.