### PR TITLE
[Flang][OpenMP][Sema] Module support for REQUIRES directive

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2055,6 +2055,22 @@ void OmpStructureChecker::Leave(const parser::OpenMPAtomicConstruct &) {
   dirContext_.pop_back();
 }
 
+void OmpStructureChecker::Enter(const parser::UseStmt &x) {
+  semantics::Symbol *symbol{x.moduleName.symbol};
+  if (!symbol) {
+    // Cannot check used module if it wasn't resolved.
+    return;
+  }
+
+  auto &details = std::get<ModuleDetails>(symbol->details());
+  if (details.has_ompRequires() && deviceConstructFound_) {
+    context_.Say(x.moduleName.source,
+        "'%s' module containing device-related REQUIRES directive imported "
+        "lexically after device construct"_err_en_US,
+        x.moduleName.ToString());
+  }
+}
+
 // Clauses
 // Mainly categorized as
 // 1. Checks on 'OmpClauseList' from 'parse-tree.h'.

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -127,6 +127,8 @@ public:
   void Enter(const parser::OmpAtomicCapture &);
   void Leave(const parser::OmpAtomic &);
 
+  void Enter(const parser::UseStmt &);
+
 #define GEN_FLANG_CLAUSE_CHECK_ENTER
 #include "llvm/Frontend/OpenMP/OMP.inc"
 

--- a/flang/test/Semantics/Inputs/requires_module.f90
+++ b/flang/test/Semantics/Inputs/requires_module.f90
@@ -1,0 +1,3 @@
+module requires_module
+  !$omp requires atomic_default_mem_order(seq_cst), unified_shared_memory
+end module

--- a/flang/test/Semantics/OpenMP/requires10.f90
+++ b/flang/test/Semantics/OpenMP/requires10.f90
@@ -1,0 +1,14 @@
+! RUN: rm -rf %t && mkdir %t
+! RUN: %flang_fc1 -fsyntax-only -fopenmp -module-dir %t '%S/../Inputs/requires_module.f90'
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -module-dir %t
+! OpenMP Version 5.0
+! 2.4 Requires directive
+! All atomic_default_mem_order clauses in REQUIRES directives found within a
+! compilation unit must specify the same ordering. Test that this is propagated
+! from imported modules
+
+!ERROR: Conflicting 'ATOMIC_DEFAULT_MEM_ORDER' REQUIRES clauses found in compilation unit
+use requires_module
+!$omp requires atomic_default_mem_order(relaxed)
+
+end program

--- a/flang/test/Semantics/OpenMP/requires11.f90
+++ b/flang/test/Semantics/OpenMP/requires11.f90
@@ -1,0 +1,17 @@
+! RUN: rm -rf %t && mkdir %t
+! RUN: %flang_fc1 -fsyntax-only -fopenmp -module-dir %t '%S/../Inputs/requires_module.f90'
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -module-dir %t
+! OpenMP Version 5.0
+! 2.4 Requires directive
+! Target-related clauses in REQUIRES directives must come strictly before any
+! device constructs, such as declare target with extended list. Test that this
+! is propagated from imported modules.
+
+subroutine f
+  !$omp declare target (f)
+end subroutine f
+
+program requires
+  !ERROR: 'requires_module' module containing device-related REQUIRES directive imported lexically after device construct
+  use requires_module
+end program requires

--- a/flang/test/Semantics/OpenMP/requires12.f90
+++ b/flang/test/Semantics/OpenMP/requires12.f90
@@ -1,0 +1,19 @@
+! RUN: rm -rf %t && mkdir %t
+! RUN: %flang_fc1 -fsyntax-only -fopenmp -module-dir %t '%S/../Inputs/requires_module.f90'
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -module-dir %t
+! OpenMP Version 5.0
+! 2.4 Requires directive
+! atomic_default_mem_order clauses in REQUIRES directives must come strictly
+! before any atomic constructs with no explicit memory order set. Test that this
+! is propagated from imported modules.
+
+subroutine f
+  integer :: a = 0
+  !$omp atomic
+  a = a + 1
+end subroutine f
+
+program requires
+  !ERROR: 'requires_module' module containing 'ATOMIC_DEFAULT_MEM_ORDER' REQUIRES clause imported lexically after atomic operation without a memory order clause
+  use requires_module
+end program requires


### PR DESCRIPTION
This patch adds support for passing REQUIRES clauses across Fortran modules via USE statements through changes to directive resolution, the directive rewrite pass and semantics checks. `.mod` files are also extended to include `!$omp requires` directives so this information can be parsed from external modules and added to the module's symbol.

This is patch 5/5 of a series splitting [D149337](https://reviews.llvm.org/D149337) to simplify review.

Re-created from Phabricator review: https://reviews.llvm.org/D158168