### PR TITLE
[mlir][sparse][CRunnerUtils] Add shuffle in CRunnerUtils

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
@@ -482,13 +482,16 @@ extern "C" MLIR_CRUNNERUTILS_EXPORT double rtclock();
 //===----------------------------------------------------------------------===//
 // Uses a seed to initialize a random generator and returns the generator.
 extern "C" MLIR_CRUNNERUTILS_EXPORT void *rtsrand(uint64_t s);
-// Uses a random number generator g and returns a random number in the range of [0, m).
+// Uses a random number generator g and returns a random number
+// in the range of [0, m).
 extern "C" MLIR_CRUNNERUTILS_EXPORT uint64_t rtrand(void *g, uint64_t m);
 // Deletes the random number generator.
 extern "C" MLIR_CRUNNERUTILS_EXPORT void rtdrand(void *g);
-// Uses a random number generator g and std::shuffle to modify memref m in place.
-// m will be populated with unique and random numbers in the range of [0, size of m).
-extern "C" MLIR_CRUNNERUTILS_EXPORT void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g);
+// Uses a random number generator g and std::shuffle to modify memref m
+// in place. m will be populated with unique and random numbers
+// in the range of [0, size of m).
+extern "C" MLIR_CRUNNERUTILS_EXPORT void
+_mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g);
 
 //===----------------------------------------------------------------------===//
 // Runtime support library to allow the use of std::sort in MLIR program.

--- a/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
@@ -487,11 +487,11 @@ extern "C" MLIR_CRUNNERUTILS_EXPORT void *rtsrand(uint64_t s);
 extern "C" MLIR_CRUNNERUTILS_EXPORT uint64_t rtrand(void *g, uint64_t m);
 // Deletes the random number generator.
 extern "C" MLIR_CRUNNERUTILS_EXPORT void rtdrand(void *g);
-// Uses a random number generator g and std::shuffle to modify memref m
-// in place. m will be populated with unique and random numbers
-// in the range of [0, size of m).
+// Uses a random number generator g and std::shuffle to modify mref
+// in place. Memref mref will be a permutation of all numbers
+// in the range of [0, size of mref).
 extern "C" MLIR_CRUNNERUTILS_EXPORT void
-_mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g);
+_mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *mref, void *g);
 
 //===----------------------------------------------------------------------===//
 // Runtime support library to allow the use of std::sort in MLIR program.

--- a/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
@@ -486,6 +486,10 @@ extern "C" MLIR_CRUNNERUTILS_EXPORT void *rtsrand(uint64_t s);
 extern "C" MLIR_CRUNNERUTILS_EXPORT uint64_t rtrand(void *, uint64_t m);
 // Deletes the random number generator.
 extern "C" MLIR_CRUNNERUTILS_EXPORT void rtdrand(void *);
+// Returns a pointer to an array of random numbers in the range of [0, s).
+extern "C" MLIR_CRUNNERUTILS_EXPORT void *shuffle(uint64_t s, void *g);
+// Deletes the array of random numbers.
+extern "C" MLIR_CRUNNERUTILS_EXPORT void shuffleFree(void *a);
 
 //===----------------------------------------------------------------------===//
 // Runtime support library to allow the use of std::sort in MLIR program.

--- a/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
@@ -482,14 +482,13 @@ extern "C" MLIR_CRUNNERUTILS_EXPORT double rtclock();
 //===----------------------------------------------------------------------===//
 // Uses a seed to initialize a random generator and returns the generator.
 extern "C" MLIR_CRUNNERUTILS_EXPORT void *rtsrand(uint64_t s);
-// Returns a random number in the range of [0, m).
-extern "C" MLIR_CRUNNERUTILS_EXPORT uint64_t rtrand(void *, uint64_t m);
+// Uses a random number generator g and returns a random number in the range of [0, m).
+extern "C" MLIR_CRUNNERUTILS_EXPORT uint64_t rtrand(void *g, uint64_t m);
 // Deletes the random number generator.
-extern "C" MLIR_CRUNNERUTILS_EXPORT void rtdrand(void *);
-// Returns a pointer to an array of random numbers in the range of [0, s).
-extern "C" MLIR_CRUNNERUTILS_EXPORT void *shuffle(uint64_t s, void *g);
-// Deletes the array of random numbers.
-extern "C" MLIR_CRUNNERUTILS_EXPORT void shuffleFree(void *a);
+extern "C" MLIR_CRUNNERUTILS_EXPORT void rtdrand(void *g);
+// Uses a random number generator g and std::shuffle to modify memref m in place.
+// m will be populated with unique and random numbers in the range of [0, size of m).
+extern "C" MLIR_CRUNNERUTILS_EXPORT void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g);
 
 //===----------------------------------------------------------------------===//
 // Runtime support library to allow the use of std::sort in MLIR program.

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -160,6 +160,22 @@ extern "C" void mlirAlignedFree(void *ptr) {
 #endif
 }
 
+/// Generates an array with unique and random numbers from 0 to s-1.
+extern "C" void *shuffle(uint64_t s, void *g) {
+  std::mt19937 *generator = static_cast<std::mt19937 *>(g);
+  uint64_t *output = new uint64_t[s];
+  std::vector<uint64_t> arr(s);
+  std::iota(arr.begin(), arr.end(), 0);
+  std::shuffle(arr.begin(), arr.end(), *generator);
+  std::copy(arr.begin(), arr.end(), output);
+  return output;
+}
+
+extern "C" void shuffleFree(void *a) {
+  uint64_t *arr = static_cast<uint64_t *>(a);
+  delete[] arr;
+}
+
 extern "C" void *rtsrand(uint64_t s) {
   // Standard mersenne_twister_engine seeded with s.
   return new std::mt19937(s);

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -176,7 +176,8 @@ extern "C" void rtdrand(void *g) {
   delete generator;
 }
 
-extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g) {
+extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m,
+                                     void *g) {
   std::mt19937 *generator = static_cast<std::mt19937 *>(g);
   uint64_t s = m->sizes[0];
   std::vector<uint64_t> arr(s);

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <random>
 #include <string.h>
+#include <numeric>
 
 #ifdef MLIR_CRUNNERUTILS_DEFINE_FUNCTIONS
 

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -160,22 +160,6 @@ extern "C" void mlirAlignedFree(void *ptr) {
 #endif
 }
 
-/// Generates an array with unique and random numbers from 0 to s-1.
-extern "C" void *shuffle(uint64_t s, void *g) {
-  std::mt19937 *generator = static_cast<std::mt19937 *>(g);
-  uint64_t *output = new uint64_t[s];
-  std::vector<uint64_t> arr(s);
-  std::iota(arr.begin(), arr.end(), 0);
-  std::shuffle(arr.begin(), arr.end(), *generator);
-  std::copy(arr.begin(), arr.end(), output);
-  return output;
-}
-
-extern "C" void shuffleFree(void *a) {
-  uint64_t *arr = static_cast<uint64_t *>(a);
-  delete[] arr;
-}
-
 extern "C" void *rtsrand(uint64_t s) {
   // Standard mersenne_twister_engine seeded with s.
   return new std::mt19937(s);
@@ -190,6 +174,15 @@ extern "C" uint64_t rtrand(void *g, uint64_t m) {
 extern "C" void rtdrand(void *g) {
   std::mt19937 *generator = static_cast<std::mt19937 *>(g);
   delete generator;
+}
+
+extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m, void *g) {
+  std::mt19937 *generator = static_cast<std::mt19937 *>(g);
+  uint64_t s = m->sizes[0];
+  std::vector<uint64_t> arr(s);
+  std::iota(arr.begin(), arr.end(), 0);
+  std::shuffle(arr.begin(), arr.end(), *generator);
+  std::copy(arr.begin(), arr.end(), m->data);
 }
 
 #define IMPL_STDSORT(VNAME, V)                                                 \

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -179,10 +179,13 @@ extern "C" void rtdrand(void *g) {
 
 extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *mref,
                                      void *g) {
+  assert(mref);
+  assert(mref->strides[0] == 1); // consecutive
   std::mt19937 *generator = static_cast<std::mt19937 *>(g);
   uint64_t s = mref->sizes[0];
-  std::iota(mref->data, mref->data + s, 0);
-  std::shuffle(mref->data, mref->data + s, *generator);
+  uint64_t *data = mref->data + mref->offset;
+  std::iota(data, data + s, 0);
+  std::shuffle(data, data + s, *generator);
 }
 
 #define IMPL_STDSORT(VNAME, V)                                                 \

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -177,14 +177,12 @@ extern "C" void rtdrand(void *g) {
   delete generator;
 }
 
-extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *m,
+extern "C" void _mlir_ciface_shuffle(StridedMemRefType<uint64_t, 1> *mref,
                                      void *g) {
   std::mt19937 *generator = static_cast<std::mt19937 *>(g);
-  uint64_t s = m->sizes[0];
-  std::vector<uint64_t> arr(s);
-  std::iota(arr.begin(), arr.end(), 0);
-  std::shuffle(arr.begin(), arr.end(), *generator);
-  std::copy(arr.begin(), arr.end(), m->data);
+  uint64_t s = mref->sizes[0];
+  std::iota(mref->data, mref->data + s, 0);
+  std::shuffle(mref->data, mref->data + s, *generator);
 }
 
 #define IMPL_STDSORT(VNAME, V)                                                 \

--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -31,9 +31,9 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include <numeric>
 #include <random>
 #include <string.h>
-#include <numeric>
 
 #ifdef MLIR_CRUNNERUTILS_DEFINE_FUNCTIONS
 

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_generate.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_generate.mlir
@@ -1,0 +1,108 @@
+//--------------------------------------------------------------------------------------------------
+// WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.
+//
+// Set-up that's shared across all tests in this directory. In principle, this
+// config could be moved to lit.local.cfg. However, there are downstream users that
+//  do not use these LIT config files. Hence why this is kept inline.
+//
+// DEFINE: %{sparsifier_opts} = enable-runtime-library=true
+// DEFINE: %{sparsifier_opts_sve} = enable-arm-sve=true %{sparsifier_opts}
+// DEFINE: %{compile} = mlir-opt %s --sparsifier="%{sparsifier_opts}"
+// DEFINE: %{compile_sve} = mlir-opt %s --sparsifier="%{sparsifier_opts_sve}"
+// DEFINE: %{run_libs} = -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils
+// DEFINE: %{run_opts} = -e entry -entry-point-result=void
+// DEFINE: %{run} = mlir-cpu-runner %{run_opts} %{run_libs}
+// DEFINE: %{run_sve} = %mcr_aarch64_cmd --march=aarch64 --mattr="+sve" %{run_opts} %{run_libs}
+//
+// DEFINE: %{env} =
+//--------------------------------------------------------------------------------------------------
+
+// RUN: %{compile} | %{run} | FileCheck %s
+//
+// Do the same run, but now with direct IR generation.
+// REDEFINE: %{sparsifier_opts} = enable-runtime-library=false
+// RUN: %{compile} | %{run} | FileCheck %s
+//
+// Do the same run, but now with direct IR generation and vectorization.
+// REDEFINE: %{sparsifier_opts} = enable-runtime-library=false vl=2 reassociate-fp-reductions=true enable-index-optimizations=true
+// RUN: %{compile} | %{run} | FileCheck %s
+//
+// Do the same run, but now with direct IR generation and VLA vectorization.
+// RUN: %if mlir_arm_sve_tests %{ %{compile_sve} | %{run_sve} | FileCheck %s %}
+
+//
+// Integration test that generates a tensor with specified sparsity level.
+//
+
+!Generator = !llvm.ptr
+!Array = !llvm.ptr
+
+#SparseVector = #sparse_tensor.encoding<{
+  map = (d0) -> (d0 : compressed)
+}>
+
+module {
+  func.func private @rtsrand(index) -> (!Generator)
+  func.func private @rtrand(!Generator, index) -> (index)
+  func.func private @rtdrand(!Generator) -> ()
+  func.func private @shuffle(index, !Generator) -> (!Array)
+  func.func private @shuffleFree(!Array) -> ()
+
+  //
+  // Main driver.
+  //
+  func.func @entry() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %f0 = arith.constant 0.0 : f64
+    %c99 = arith.constant 99 : index
+    %c100 = arith.constant 100 : index
+
+    // Set up input size and sparsity level.
+    %size = arith.constant 50 : index
+    %sparsity = arith.constant 90 : index
+    %zeros = arith.muli %size, %sparsity : index
+    %nz = arith.floordivsi %zeros, %c100 : index
+    %nse = arith.subi %size, %nz : index
+
+    // Set up an empty vector.
+    %empty = tensor.empty(%size) : tensor<?xf64>
+    %zero_vec = linalg.fill ins(%f0 : f64) outs(%empty : tensor<?xf64>) -> tensor<?xf64>
+
+    // Generate shuffled indices in the range of [0, %size).
+    %g = func.call @rtsrand(%c0) : (index) ->(!Generator)
+    %res = func.call @shuffle(%size, %g) : (index, !Generator) -> !Array
+
+    // Iterate through the number of nse indices to insert values.
+    %output = scf.for %iv = %c0 to %nse step %c1 iter_args(%iter = %zero_vec) -> tensor<?xf64> {
+      // Fetch the index to insert value from shuffled index array.
+      %r = arith.index_cast %iv : index to i64
+      %arr = llvm.getelementptr %res[%r] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+      %val = llvm.load %arr : !Array -> i64
+      %idx = arith.index_cast %val : i64 to index
+      // Generate a random number from 1 to 100.
+      %ri0 = func.call @rtrand(%g, %c99) : (!Generator, index) -> (index)
+      %ri1 = arith.addi %ri0, %c1 : index
+      %r0 = arith.index_cast %ri1 : index to i64
+      %fr = arith.uitofp %r0 : i64 to f64
+      // Insert the random number to current index.
+      %out = tensor.insert %fr into %iter[%idx] : tensor<?xf64>
+      scf.yield %out : tensor<?xf64>
+    }
+
+    %sv = sparse_tensor.convert %output : tensor<?xf64> to tensor<?xf64, #SparseVector>
+    %n0 = sparse_tensor.number_of_entries %sv : tensor<?xf64, #SparseVector>
+
+    // Print the number of non-zeros for verification.
+    //
+    // CHECK: 5
+    vector.print %n0 : index
+
+    // Release the resources.
+    bufferization.dealloc_tensor %sv : tensor<?xf64, #SparseVector>
+    func.call @shuffleFree(%res) : (!Array) -> ()
+    func.call @rtdrand(%g) : (!Generator) -> ()
+
+    return
+  }
+}


### PR DESCRIPTION
Shuffle can generate an array of unique and random numbers from 0 to size-1. It can be used to generate tensors with specified sparsity level.