### PR TITLE
[clang][Driver] Don't warn when -nostdinc and -nostdinc++ are both specified

### DIFF
--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
+++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
@@ -293,9 +293,8 @@ void BareMetal::addClangTargetOptions(const ArgList &DriverArgs,
 
 void BareMetal::AddClangCXXStdlibIncludeArgs(const ArgList &DriverArgs,
                                              ArgStringList &CC1Args) const {
-  if (DriverArgs.hasArg(options::OPT_nostdinc) ||
-      DriverArgs.hasArg(options::OPT_nostdlibinc) ||
-      DriverArgs.hasArg(options::OPT_nostdincxx))
+  if (DriverArgs.hasArg(options::OPT_nostdinc, options::OPT_nostdlibinc,
+                        options::OPT_nostdincxx))
     return;
 
   const Driver &D = getDriver();

--- a/clang/test/Driver/nostdincxx.cpp
+++ b/clang/test/Driver/nostdincxx.cpp
@@ -2,6 +2,7 @@
 // RUN: not %clangxx -nostdinc++ %s 2>&1 | FileCheck %s
 // RUN: not %clangxx -nostdlibinc %s 2>&1 | FileCheck %s
 // RUN: not %clangxx --target=x86_64-unknown-unknown-gnu -fsyntax-only -nostdinc -nostdinc++ %s 2>&1 | FileCheck /dev/null --implicit-check-not=-Wunused-command-line-argument
+// RUN: not %clangxx --target=riscv64-unknown-elf -fsyntax-only -nostdinc -nostdinc++ %s 2>&1 | FileCheck /dev/null --implicit-check-not=-Wunused-command-line-argument
 // CHECK: 'vector' file not found
 #include <vector>
 


### PR DESCRIPTION
When -nostdinc and -nostdinc++ are both specified and the Baremetal toolchain is used, an unused command line argument warning for -nostdinc++ is produced. This doesn't seem particularly meaningful as -nostdinc++ would have been claimed/used had the check in AddClangCXXStdlibIncludeArgs not short-circuited. So, just claim all arguments in this check.

I believe this is consistent with what was done for the GNU toolchain (see 6fe7de90b9e4e466a5c2baadafd5f72d3203651d), so hopefully this is appropriate here as well.