### PR TITLE
[libc] set -Wno-frame-address for thread.cpp

### DIFF
--- a/libc/src/__support/threads/linux/CMakeLists.txt
+++ b/libc/src/__support/threads/linux/CMakeLists.txt
@@ -39,6 +39,8 @@ add_object_library(
     -O3
     -fno-omit-frame-pointer # This allows us to sniff out the thread args from
                             # the new thread's stack reliably.
+    -Wno-frame-address      # Yes, calling __builtin_return_address with a
+                            # value other than 0 is dangerous. We know.
 )
 
 add_object_library(


### PR DESCRIPTION
The aarch64 code is using __builtin_return_address with a non-zero parameter,
which generates the following warning:

        llvm-project/libc/src/__support/threads/linux/thread.cpp:171:38: error:
        calling '__builtin_frame_address' with a nonzero argument is unsafe
        [-Werror,-Wframe-address]
          171 |   return reinterpret_cast<uintptr_t>(__builtin_frame_address(1));
              |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
    
Disable this diagnostic just for this file so that we can enable -Werror.
    
Fixes: #77007