### PR TITLE
Move verify-no-file.yaml to AArch64 folder

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/AArch64/verify-no-file.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/verify-no-file.yaml
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: llvm-dwarfdump --debug-line --verify %t.o 2>&1 | FileCheck %s
+# RUN: llvm-dwarfdump -arch arm64 --debug-line --verify %t.o 2>&1 | FileCheck %s
 
 # CHECK-NOT: error: .debug_line[0x{{[0-9a-f]+}}][0] has invalid file index 1 (valid values are [1,0]):
 --- !mach-o


### PR DESCRIPTION
This test fails on power pc and solaris, moving it to AArch64 folder because the yaml is generated for an AArch64 MachO object file.