### PR TITLE
[GitHub] Fix slow sccache install on macOS by upgrading macOS version

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -89,10 +89,6 @@ jobs:
           variant: sccache
       - name: Build and Test
         uses: llvm/actions/build-test-llvm-project@main
-        env:
-          # Workaround for https://github.com/actions/virtual-environments/issues/5900.
-          # This should be a no-op for non-mac OSes
-          PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
           cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ inputs.extra_cmake_args }}'
           build_target: '${{ inputs.build_target }}'

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
+        default: '["ubuntu-latest", "windows-2019", "macOS-12"]'
   workflow_call:
     inputs:
       build_target:
@@ -34,9 +34,7 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        # We're using a specific version of macOS due to:
-        # https://github.com/actions/virtual-environments/issues/5900
-        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
+        default: '["ubuntu-latest", "windows-2019", "macOS-12"]'
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
The "Setup ccache" step on macOS-11 builds takes between 15 to 20 mins, whereas this step takes a less than 10 seconds on other runners. The bulk of this time is spent at the "Install sccache" step, where brew emits warnings like "Warning: You are using macOS 11." and "We (and Apple) do not provide support for this old version...".

Bumping the version of macOS greatly decreases this cache setup time to about 20 seconds. Furthermore, it seems like it is speeding up general build times, too.

It appears that https://github.com/actions/virtual-environments/issues/5900 has been resolved or obsoleted, so I do not believe
we need to lock macOS to 11 anymore.