### PR TITLE
[lldb][NFCI] Change return type of BreakpointIDList::GetBreakpointIDAtIndex

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -33,7 +33,7 @@ public:
 
   size_t GetSize() const;
 
-  const BreakpointID &GetBreakpointIDAtIndex(size_t index) const;
+  BreakpointID GetBreakpointIDAtIndex(size_t index) const;
 
   bool RemoveBreakpointIDAtIndex(size_t index);
 
@@ -66,7 +66,6 @@ public:
 
 private:
   BreakpointIDArray m_breakpoint_ids;
-  BreakpointID m_invalid_id;
 
   BreakpointIDList(const BreakpointIDList &) = delete;
   const BreakpointIDList &operator=(const BreakpointIDList &) = delete;

--- a/lldb/source/Breakpoint/BreakpointIDList.cpp
+++ b/lldb/source/Breakpoint/BreakpointIDList.cpp
@@ -20,17 +20,15 @@ using namespace lldb_private;
 
 // class BreakpointIDList
 
-BreakpointIDList::BreakpointIDList()
-    : m_invalid_id(LLDB_INVALID_BREAK_ID, LLDB_INVALID_BREAK_ID) {}
+BreakpointIDList::BreakpointIDList() : m_breakpoint_ids() {}
 
 BreakpointIDList::~BreakpointIDList() = default;
 
 size_t BreakpointIDList::GetSize() const { return m_breakpoint_ids.size(); }
 
-const BreakpointID &
-BreakpointIDList::GetBreakpointIDAtIndex(size_t index) const {
+BreakpointID BreakpointIDList::GetBreakpointIDAtIndex(size_t index) const {
   return ((index < m_breakpoint_ids.size()) ? m_breakpoint_ids[index]
-                                            : m_invalid_id);
+                                            : BreakpointID());
 }
 
 bool BreakpointIDList::RemoveBreakpointIDAtIndex(size_t index) {


### PR DESCRIPTION
There are 2 motivations here:
1.) There is no need to hand out constant references to BreakpointIDs,
  they are only 8 bytes big. In addition, every use of this method already
  makes a copy anyway.
2.) Each BreakpointIDList held onto an invalid BreakpointID specifically to
  prevent lifetime issues. Returning a value means you can return an
  invalid BreakpointID instead of needing to allocate storage for an
  invalid BreakpointID.