### PR TITLE
[RISCV] Refactor subreg indices.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -907,11 +907,11 @@ static bool lowerRISCVVMachineInstrToMCInst(const MachineInstr *MI,
         Reg = TRI->getSubReg(Reg, RISCV::sub_vrm1_0);
         assert(Reg && "Subregister does not exist");
       } else if (RISCV::FPR16RegClass.contains(Reg)) {
-        Reg =
-            TRI->getMatchingSuperReg(Reg, RISCV::sub_16, &RISCV::FPR32RegClass);
+        Reg = TRI->getMatchingSuperReg(Reg, RISCV::sub_fpr16,
+                                       &RISCV::FPR32RegClass);
         assert(Reg && "Subregister does not exist");
       } else if (RISCV::FPR64RegClass.contains(Reg)) {
-        Reg = TRI->getSubReg(Reg, RISCV::sub_32);
+        Reg = TRI->getSubReg(Reg, RISCV::sub_fpr32);
         assert(Reg && "Superregister does not exist");
       } else if (RISCV::VRN2M1RegClass.contains(Reg) ||
                  RISCV::VRN2M2RegClass.contains(Reg) ||

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -300,8 +300,10 @@ bool RISCVExpandPseudo::expandRV32ZdinxStore(MachineBasicBlock &MBB,
                                              MachineBasicBlock::iterator MBBI) {
   DebugLoc DL = MBBI->getDebugLoc();
   const TargetRegisterInfo *TRI = STI->getRegisterInfo();
-  Register Lo = TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_32);
-  Register Hi = TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_32_hi);
+  Register Lo =
+      TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_even);
+  Register Hi =
+      TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_odd);
   BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
       .addReg(Lo, getKillRegState(MBBI->getOperand(0).isKill()))
       .addReg(MBBI->getOperand(1).getReg())
@@ -334,8 +336,10 @@ bool RISCVExpandPseudo::expandRV32ZdinxLoad(MachineBasicBlock &MBB,
                                             MachineBasicBlock::iterator MBBI) {
   DebugLoc DL = MBBI->getDebugLoc();
   const TargetRegisterInfo *TRI = STI->getRegisterInfo();
-  Register Lo = TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_32);
-  Register Hi = TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_32_hi);
+  Register Lo =
+      TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_even);
+  Register Hi =
+      TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_odd);
 
   // If the register of operand 1 is equal to the Lo register, then swap the
   // order of loading the Lo and Hi statements.

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -417,12 +417,13 @@ void RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   if (RISCV::GPRPF64RegClass.contains(DstReg, SrcReg)) {
     // Emit an ADDI for both parts of GPRPF64.
     BuildMI(MBB, MBBI, DL, get(RISCV::ADDI),
-            TRI->getSubReg(DstReg, RISCV::sub_32))
-        .addReg(TRI->getSubReg(SrcReg, RISCV::sub_32), getKillRegState(KillSrc))
+            TRI->getSubReg(DstReg, RISCV::sub_gpr_even))
+        .addReg(TRI->getSubReg(SrcReg, RISCV::sub_gpr_even),
+                getKillRegState(KillSrc))
         .addImm(0);
     BuildMI(MBB, MBBI, DL, get(RISCV::ADDI),
-            TRI->getSubReg(DstReg, RISCV::sub_32_hi))
-        .addReg(TRI->getSubReg(SrcReg, RISCV::sub_32_hi),
+            TRI->getSubReg(DstReg, RISCV::sub_gpr_odd))
+        .addReg(TRI->getSubReg(SrcReg, RISCV::sub_gpr_odd),
                 getKillRegState(KillSrc))
         .addImm(0);
     return;
@@ -446,9 +447,9 @@ void RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
              (STI.hasStdExtZfhmin() || STI.hasStdExtZfbfmin()) &&
              "Unexpected extensions");
       // Zfhmin/Zfbfmin doesn't have FSGNJ_H, replace FSGNJ_H with FSGNJ_S.
-      DstReg = TRI->getMatchingSuperReg(DstReg, RISCV::sub_16,
+      DstReg = TRI->getMatchingSuperReg(DstReg, RISCV::sub_fpr16,
                                         &RISCV::FPR32RegClass);
-      SrcReg = TRI->getMatchingSuperReg(SrcReg, RISCV::sub_16,
+      SrcReg = TRI->getMatchingSuperReg(SrcReg, RISCV::sub_fpr16,
                                         &RISCV::FPR32RegClass);
       Opc = RISCV::FSGNJ_S;
     }

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -28,21 +28,21 @@ class RISCVReg16<bits<5> Enc, string n, list<string> alt = []> : Register<n> {
   let AltNames = alt;
 }
 
-def sub_16 : SubRegIndex<16>;
+def sub_fpr16 : SubRegIndex<16>;
 class RISCVReg32<RISCVReg16 subreg>
   : RISCVRegWithSubRegs<subreg.HWEncoding{4-0}, subreg.AsmName, [subreg],
                         subreg.AltNames> {
-  let SubRegIndices = [sub_16];
+  let SubRegIndices = [sub_fpr16];
 }
 
 // Because RISCVReg64 register have AsmName and AltNames that alias with their
 // 16/32-bit sub-register, RISCVAsmParser will need to coerce a register number
 // from a RISCVReg16/RISCVReg32 to the equivalent RISCVReg64 when appropriate.
-def sub_32 : SubRegIndex<32>;
+def sub_fpr32 : SubRegIndex<32>;
 class RISCVReg64<RISCVReg32 subreg>
   : RISCVRegWithSubRegs<subreg.HWEncoding{4-0}, subreg.AsmName, [subreg],
                         subreg.AltNames> {
-  let SubRegIndices = [sub_32];
+  let SubRegIndices = [sub_fpr32];
 }
 
 let FallbackRegAltNameIndex = NoRegAltName in
@@ -63,7 +63,8 @@ def sub_vrm1_5 : ComposedSubRegIndex<sub_vrm2_2, sub_vrm1_1>;
 def sub_vrm1_6 : ComposedSubRegIndex<sub_vrm2_3, sub_vrm1_0>;
 def sub_vrm1_7 : ComposedSubRegIndex<sub_vrm2_3, sub_vrm1_1>;
 
-def sub_32_hi  : SubRegIndex<32, 32>;
+def sub_gpr_even : SubRegIndex<32>;
+def sub_gpr_odd  : SubRegIndex<32>;
 } // Namespace = "RISCV"
 
 // Integer registers
@@ -549,7 +550,7 @@ let RegAltNameIndices = [ABIRegAltName] in {
   def X0_PD : RISCVRegWithSubRegs<0, X0.AsmName,
                                      [X0, DUMMY_REG_PAIR_WITH_X0],
                                      X0.AltNames> {
-    let SubRegIndices = [sub_32, sub_32_hi];
+    let SubRegIndices = [sub_gpr_even, sub_gpr_odd];
     let CoveredBySubRegs = 1;
   }
   foreach I = 1-15 in {
@@ -559,7 +560,7 @@ let RegAltNameIndices = [ABIRegAltName] in {
     def X#Index#_PD : RISCVRegWithSubRegs<Index, Reg.AsmName,
                                           [Reg, RegP1],
                                           Reg.AltNames> {
-      let SubRegIndices = [sub_32, sub_32_hi];
+      let SubRegIndices = [sub_gpr_even, sub_gpr_odd];
       let CoveredBySubRegs = 1;
     }
   }


### PR DESCRIPTION
-Rename sub_32_hi to sub_gpr_odd
-Add dedicated sub_gpr_even.
-Rename sub_32 and sub_16 to sub_fpr32 and sub_fpr16. -Remove start offset from sub_gpr_odd. AArch64 doesn't use non-zero offset for GPR tuples.

This is preparation for a RV64 GPRPair for Zacas.