### PR TITLE
LangRef: rint, nearbyint: mention that default rounding mode is assumed

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -15751,7 +15751,11 @@ Semantics:
 """"""""""
 
 This function returns the same values as the libm ``rint`` functions
-would, and handles error conditions in the same way.
+would, and handles error conditions in the same way. Since LLVM assumes the
+:ref:`default floating-point environment <floatenv>`, the rounding mode is
+assumed to be set to "nearest", so halfway cases are rounded to the even
+integer. Use :ref:`Constrained Floating-Point Intrinsics <constrainedfp>`
+to avoid that assumption.
 
 .. _int_nearbyint:
 
@@ -15789,7 +15793,11 @@ Semantics:
 """"""""""
 
 This function returns the same values as the libm ``nearbyint``
-functions would, and handles error conditions in the same way.
+functions would, and handles error conditions in the same way. Since LLVM
+assumes the :ref:`default floating-point environment <floatenv>`, the rounding
+mode is assumed to be set to "nearest", so halfway cases are rounded to the even
+integer. Use :ref:`Constrained Floating-Point Intrinsics <constrainedfp>` to
+avoid that assumption.
 
 .. _int_round:
 


### PR DESCRIPTION
According to [the docs](https://llvm.org/docs/LangRef.html#floating-point-environment), LLVM assumes round-to-nearest mode. The source code also contains some indications of LLVM constant-folding these intrinsics without regard for a possibly changed rounding mode:

https://github.com/llvm/llvm-project/blob/d08482924efe8b2c44913583af7b8f60a29975d1/llvm/lib/Analysis/ConstantFolding.cpp#L1615-L1624

https://github.com/llvm/llvm-project/blob/d08482924efe8b2c44913583af7b8f60a29975d1/llvm/lib/Analysis/ConstantFolding.cpp#L2097-L2100