### PR TITLE
[Clang][NFC] Fix out-of-bounds access

### DIFF
--- a/clang/include/clang/Analysis/CFG.h
+++ b/clang/include/clang/Analysis/CFG.h
@@ -1215,7 +1215,9 @@ public:
   //===--------------------------------------------------------------------===//
 
   class BuildOptions {
-    std::bitset<Stmt::lastStmtConstant> alwaysAddMask;
+    // Stmt::lastStmtConstant has the same value as the last Stmt kind,
+    // so make sure we add one to account for this!
+    std::bitset<Stmt::lastStmtConstant + 1> alwaysAddMask;
 
   public:
     using ForcedBlkExprs = llvm::DenseMap<const Stmt *, const CFGBlock *>;


### PR DESCRIPTION
The changes to tablegen made by https://github.com/llvm/llvm-project/pull/76825 result in `StmtClass::lastStmtConstant` changing from `StmtClass::WhileStmtClass` to `StmtClass::GCCAsmStmtClass`. Since `CFG::BuildOptions::alwaysAdd` is never called with a `WhileStmt`, this has flown under the radar until now. 

Once such test in which an out-of-bounds access occurs is `test/Sema/inline-asm-validate.c`, among many others.
