### PR TITLE
Changed Checks from TriviallyCopyable to TriviallyCopyConstructible 

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -870,6 +870,9 @@ Bug Fixes to AST Handling
 - Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
+- Fixed a bug where range-loop-analysis checks for trivial copyability,
+  rather than trivial copy-constructibility
+  `Issue 47355 <https://github.com/llvm/llvm-project/issues/47355>`_
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -856,6 +856,9 @@ Bug Fixes to AST Handling
 - Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
+- Fixed a bug where range-loop-analysis checks for trivial copyability,
+  rather than trivial copy-constructibility
+  `Issue 47355 <https://github.com/llvm/llvm-project/issues/47355>`
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -870,9 +870,6 @@ Bug Fixes to AST Handling
 - Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
-- Fixed a bug where Template Instantiation failed to handle Lambda Expressions
-  with certain types of Attributes.
-  (`#76521 <https://github.com/llvm/llvm-project/issues/76521>`_)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -873,6 +873,9 @@ Bug Fixes to AST Handling
 - Fixed a bug where range-loop-analysis checks for trivial copyability,
   rather than trivial copy-constructibility
   `Issue 47355 <https://github.com/llvm/llvm-project/issues/47355>`_
+- Fixed a bug where Template Instantiation failed to handle Lambda Expressions
+  with certain types of Attributes.
+  (`#76521 <https://github.com/llvm/llvm-project/issues/76521>`_)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -1425,6 +1425,9 @@ public:
   /// (C++11 [class]p6).
   bool isTriviallyCopyable() const;
 
+  /// Determine whether this class is considered trivially copyable per
+  bool isTriviallyCopyConstructible() const;
+
   /// Determine whether this class is considered trivial.
   ///
   /// C++11 [class]p6:

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -917,6 +917,9 @@ public:
   /// Return true if this is a trivially copyable type (C++0x [basic.types]p9)
   bool isTriviallyCopyableType(const ASTContext &Context) const;
 
+  /// Return true if this is a trivially copyable type
+  bool isTriviallyCopyConstructibleType(const ASTContext &Context) const;
+
   /// Return true if this is a trivially relocatable type.
   bool isTriviallyRelocatableType(const ASTContext &Context) const;
 

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -911,7 +911,6 @@ public:
   /// CXXRecordDecl::isCXX11StandardLayout, this takes DRs into account.
   bool isCXX11PODType(const ASTContext &Context) const;
 
-
   /// Return true if this is a trivial type per (C++0x [basic.types]p9)
   bool isTrivialType(const ASTContext &Context) const;
 

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -766,7 +766,9 @@ public:
 
   bool UseExcessPrecision(const ASTContext &Ctx);
 
-  static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible);
+  static bool isTriviallyCopyableTypeImpl(const QualType &type,
+                                          const ASTContext &Context,
+                                          bool copy_constructible);
 
   /// Retrieves a pointer to the underlying (unqualified) type.
   ///
@@ -912,7 +914,6 @@ public:
   /// (C++0x [basic.types]p9). Note that, unlike
   /// CXXRecordDecl::isCXX11StandardLayout, this takes DRs into account.
   bool isCXX11PODType(const ASTContext &Context) const;
-
 
   /// Return true if this is a trivial type per (C++0x [basic.types]p9)
   bool isTrivialType(const ASTContext &Context) const;

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -766,8 +766,6 @@ public:
 
   bool UseExcessPrecision(const ASTContext &Ctx);
 
-  static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible);
-
   /// Retrieves a pointer to the underlying (unqualified) type.
   ///
   /// This function requires that the type not be NULL. If the type might be

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -766,9 +766,7 @@ public:
 
   bool UseExcessPrecision(const ASTContext &Ctx);
 
-  static bool isTriviallyCopyableTypeImpl(const QualType &type,
-                                          const ASTContext &Context,
-                                          bool copy_constructible);
+  static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible);
 
   /// Retrieves a pointer to the underlying (unqualified) type.
   ///

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -766,6 +766,8 @@ public:
 
   bool UseExcessPrecision(const ASTContext &Ctx);
 
+  static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible);
+
   /// Retrieves a pointer to the underlying (unqualified) type.
   ///
   /// This function requires that the type not be NULL. If the type might be
@@ -910,6 +912,7 @@ public:
   /// (C++0x [basic.types]p9). Note that, unlike
   /// CXXRecordDecl::isCXX11StandardLayout, this takes DRs into account.
   bool isCXX11PODType(const ASTContext &Context) const;
+
 
   /// Return true if this is a trivial type per (C++0x [basic.types]p9)
   bool isTrivialType(const ASTContext &Context) const;

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -913,6 +913,7 @@ public:
   /// CXXRecordDecl::isCXX11StandardLayout, this takes DRs into account.
   bool isCXX11PODType(const ASTContext &Context) const;
 
+
   /// Return true if this is a trivial type per (C++0x [basic.types]p9)
   bool isTrivialType(const ASTContext &Context) const;
 

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -587,6 +587,19 @@ bool CXXRecordDecl::isTriviallyCopyable() const {
   return true;
 }
 
+bool CXXRecordDecl::isTriviallyCopyConstructible() const {
+
+  //   A trivially copy constructible class is a class that:
+  //   -- has no non-trivial copy constructors,
+  if (hasNonTrivialCopyConstructor())
+    return false;
+  //   -- has a trivial destructor.
+  if (!hasTrivialDestructor())
+    return false;
+
+  return true;
+}
+
 void CXXRecordDecl::markedVirtualFunctionPure() {
   // C++ [class.abstract]p2:
   //   A class is abstract if it has at least one pure virtual function.

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2605,16 +2605,20 @@ bool QualType::isTrivialType(const ASTContext &Context) const {
 }
 
 bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
-  return isTriviallyCopyableTypeImpl(*this,Context,false);
+  return isTriviallyCopyableTypeImpl(*this, Context, false);
 }
 
-bool QualType::isTriviallyCopyConstructibleType(const ASTContext &Context) const {
-  return isTriviallyCopyableTypeImpl(*this,Context,true);
+bool QualType::isTriviallyCopyConstructibleType(
+    const ASTContext &Context) const {
+  return isTriviallyCopyableTypeImpl(*this, Context, true);
 }
 
-bool QualType::isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible){
+bool QualType::isTriviallyCopyableTypeImpl(const QualType &type,
+                                           const ASTContext &Context,
+                                           bool copy_constructible) {
   if (type->isArrayType())
-    return Context.getBaseElementType(type).isTriviallyCopyableTypeImpl(type,Context,copy_constructible);
+    return Context.getBaseElementType(type).isTriviallyCopyableTypeImpl(
+        type, Context, copy_constructible);
 
   if (type.hasNonTrivialObjCLifetime())
     return false;

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2604,9 +2604,12 @@ bool QualType::isTrivialType(const ASTContext &Context) const {
   return false;
 }
 
-static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &Context,bool copy_constructible){
+static bool isTriviallyCopyableTypeImpl(const QualType &type,
+                                        const ASTContext &Context,
+                                        bool copy_constructible) {
   if (type->isArrayType())
-    return isTriviallyCopyableTypeImpl(Context.getBaseElementType(type),Context,copy_constructible);
+    return isTriviallyCopyableTypeImpl(Context.getBaseElementType(type),
+                                       Context, copy_constructible);
 
   if (type.hasNonTrivialObjCLifetime())
     return false;
@@ -2634,30 +2637,28 @@ static bool isTriviallyCopyableTypeImpl(const QualType &type, const ASTContext &
 
   if (const auto *RT = CanonicalType->getAs<RecordType>()) {
     if (const auto *ClassDecl = dyn_cast<CXXRecordDecl>(RT->getDecl())) {
-      if(copy_constructible){
+      if (copy_constructible) {
         return ClassDecl->isTriviallyCopyConstructible();
+      } else {
+        return ClassDecl->isTriviallyCopyable();
       }
-    else{
-      return ClassDecl->isTriviallyCopyable();
-
     }
-    }
-  return true;
- 
+    return true;
   }
-// No other types can match.
- return false;
+  // No other types can match.
+  return false;
 }
 
 bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
-  return isTriviallyCopyableTypeImpl(*this,Context,/*IsCopyConstructible=*/false);
+  return isTriviallyCopyableTypeImpl(*this, Context,
+                                     /*IsCopyConstructible=*/false);
 }
 
-bool QualType::isTriviallyCopyConstructibleType(const ASTContext &Context) const {
-  return isTriviallyCopyableTypeImpl(*this,Context,/*IsCopyConstructible=*/true);
+bool QualType::isTriviallyCopyConstructibleType(
+    const ASTContext &Context) const {
+  return isTriviallyCopyableTypeImpl(*this, Context,
+                                     /*IsCopyConstructible=*/true);
 }
-
-
 
 bool QualType::isTriviallyRelocatableType(const ASTContext &Context) const {
   QualType BaseElementType = Context.getBaseElementType(*this);

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2651,7 +2651,7 @@ static bool isTriviallyCopyableTypeImpl(const QualType &type,
 
 bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
   return isTriviallyCopyableTypeImpl(*this, Context,
-                                     /*IsCopyConstructible*/ false);
+                                     /*IsCopyConstructible=*/false);
 }
 
 bool QualType::isTriviallyCopyConstructibleType(

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2606,10 +2606,10 @@ bool QualType::isTrivialType(const ASTContext &Context) const {
 
 static bool isTriviallyCopyableTypeImpl(const QualType &type,
                                         const ASTContext &Context,
-                                        bool copy_constructible) {
+                                        bool IsCopyConstructible) {
   if (type->isArrayType())
     return isTriviallyCopyableTypeImpl(Context.getBaseElementType(type),
-                                       Context, copy_constructible);
+                                       Context, IsCopyConstructible);
 
   if (type.hasNonTrivialObjCLifetime())
     return false;
@@ -2637,7 +2637,7 @@ static bool isTriviallyCopyableTypeImpl(const QualType &type,
 
   if (const auto *RT = CanonicalType->getAs<RecordType>()) {
     if (const auto *ClassDecl = dyn_cast<CXXRecordDecl>(RT->getDecl())) {
-      if (copy_constructible) {
+      if (IsCopyConstructible) {
         return ClassDecl->isTriviallyCopyConstructible();
       } else {
         return ClassDecl->isTriviallyCopyable();
@@ -2651,7 +2651,7 @@ static bool isTriviallyCopyableTypeImpl(const QualType &type,
 
 bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
   return isTriviallyCopyableTypeImpl(*this, Context,
-                                     /*IsCopyConstructible=*/false);
+                                     /*IsCopyConstructible*/false);
 }
 
 bool QualType::isTriviallyCopyConstructibleType(

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2651,7 +2651,7 @@ static bool isTriviallyCopyableTypeImpl(const QualType &type,
 
 bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
   return isTriviallyCopyableTypeImpl(*this, Context,
-                                     /*IsCopyConstructible*/false);
+                                     /*IsCopyConstructible*/ false);
 }
 
 bool QualType::isTriviallyCopyConstructibleType(

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3200,7 +3200,7 @@ static void DiagnoseForRangeConstVariableCopies(Sema &SemaRef,
   // (The function `getTypeSize` returns the size in bits.)
   ASTContext &Ctx = SemaRef.Context;
   if (Ctx.getTypeSize(VariableType) <= 64 * 8 &&
-      (VariableType.isTriviallyCopyableType(Ctx) ||
+      (VariableType.isTriviallyCopyConstructibleType(Ctx) ||
        hasTrivialABIAttr(VariableType)))
     return;
 

--- a/clang/test/SemaCXX/warn-range-loop-analysis-trivially-copyable.cpp
+++ b/clang/test/SemaCXX/warn-range-loop-analysis-trivially-copyable.cpp
@@ -33,6 +33,17 @@ void test_TriviallyCopyable_64_bytes() {
   for (const auto r : records)
     (void)r;
 }
+void test_TriviallyCopyConstructible_64_bytes() {
+  struct Record {
+    char a[64];
+    Record& operator=(Record const& other){return *this;};
+
+  };
+
+  Record records[8];
+  for (const auto r : records)
+    (void)r;
+}
 
 void test_TriviallyCopyable_65_bytes() {
   struct Record {
@@ -40,6 +51,19 @@ void test_TriviallyCopyable_65_bytes() {
     char a[65];
   };
 
+  // expected-warning@+3 {{loop variable 'r' creates a copy from type 'const Record'}}
+  // expected-note@+2 {{use reference type 'const Record &' to prevent copying}}
+  Record records[8];
+  for (const auto r : records)
+    (void)r;
+}
+
+void test_TriviallyCopyConstructible_65_bytes() {
+  struct Record {
+    char a[65];
+    Record& operator=(Record const& other){return *this;};
+
+  };
   // expected-warning@+3 {{loop variable 'r' creates a copy from type 'const Record'}}
   // expected-note@+2 {{use reference type 'const Record &' to prevent copying}}
   Record records[8];
@@ -87,3 +111,4 @@ void test_TrivialABI_65_bytes() {
   for (const auto r : records)
     (void)r;
 }
+


### PR DESCRIPTION
**Overview:**
This pull request fixes #47355 where in the Clang compiler's range-loop-analysis incorrectly checks for trivial copyability instead of trivial copy constructibility, leading to erroneous warnings.

**Testing:**
- Tested the updated code.
- Verified that other functionalities remain unaffected.
![Screenshot from 2024-01-01 19-50-20](https://github.com/llvm/llvm-project/assets/76656712/c664f01a-522e-45e4-8363-39f13d8cc241)


**Dependencies:**
- No dependencies on other pull requests.

**References:**
- https://cplusplus.com/reference/type_traits/is_trivially_copy_constructible/
- https://en.cppreference.com/w/cpp/named_req/CopyConstructible
- https://cplusplus.com/reference/type_traits/is_trivially_copyable/

**CC:**
- @Endilll , @cor3ntin  , @AaronBallman 
