### PR TITLE
[lld][ELF][X86] Add missing X86_64_TPOFF64 case in switches

### DIFF
--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -358,6 +358,7 @@ RelExpr X86_64::getRelExpr(RelType type, const Symbol &s,
   case R_X86_64_DTPOFF64:
     return R_DTPREL;
   case R_X86_64_TPOFF32:
+  case R_X86_64_TPOFF64:
     return R_TPREL;
   case R_X86_64_TLSDESC_CALL:
     return R_TLSDESC_CALL;
@@ -791,6 +792,7 @@ void X86_64::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     write32le(loc, val);
     break;
   case R_X86_64_64:
+  case R_X86_64_TPOFF64:
   case R_X86_64_DTPOFF64:
   case R_X86_64_PC64:
   case R_X86_64_SIZE64:

--- a/lld/test/ELF/x86-64-tls-pie.s
+++ b/lld/test/ELF/x86-64-tls-pie.s
@@ -1,14 +1,23 @@
 # REQUIRES: x86
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-cloudabi %s -o %t1.o
 # RUN: ld.lld -pie %t1.o -o %t
-# RUN: llvm-readobj -r %t | FileCheck %s
+# RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOCS %s
+# RUN: llvm-objdump -d --no-show-raw-insn --no-print-imm-hex --no-leading-addr %t1.o | FileCheck --check-prefix=DIS %s
 
 # Bug 27174: R_X86_64_TPOFF32 and R_X86_64_GOTTPOFF relocations should
 # be eliminated when building a PIE executable, as the static TLS layout
 # is fixed.
 #
-# CHECK:      Relocations [
-# CHECK-NEXT: ]
+# RELOCS:      Relocations [
+# RELOCS-NEXT: ]
+#
+# DIS: <_start>:
+# DIS-NEXT:                movq    %fs:0, %rax
+# DIS-NEXT:                movl    $3, (%rax)
+# DIS-NEXT:                movq    %fs:0, %rdx
+# DIS-NEXT:                movq    (%rip), %rcx
+# DIS-NEXT:                movl    $3, (%rdx,%rcx)
+# DIS-NEXT:                movabsq 0, %rax
 
 	.globl	_start
 _start:
@@ -18,6 +27,9 @@ _start:
 	movq	%fs:0, %rdx
 	movq	i@GOTTPOFF(%rip), %rcx
 	movl	$3, (%rdx,%rcx)
+
+	# This additionally tests support for R_X86_64_TPOFF64 relocations.
+	movabs  i@TPOFF, %rax
 
 	.section	.tbss.i,"awT",@nobits
 	.globl	i


### PR DESCRIPTION
Close #77201. When linking code with a R_X86_64_TPOFF64 relocation, LLD exits with an 'unknown reloaction' error message due to two missing cases in relocation switch statements. This patch adds in those cases so that LLD successfully links code R_X86_64_TPOFF64 relocations.