### PR TITLE
[GitHub] Add python 3.7 to libclang python test

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -30,6 +30,10 @@ jobs:
   check-clang-python:
     # Build libclang and then run the libclang Python binding's unit tests.
     name: Build and run Python unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.11"]
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-clang-python
@@ -37,3 +41,4 @@ jobs:
       # There is an issue running on "windows-2019".
       # See https://github.com/llvm/llvm-project/issues/76601#issuecomment-1873049082.
       os_list: '["ubuntu-latest"]'
+      python_version: ${{ matrix.python-version }}

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -15,6 +15,10 @@ on:
       os_list:
         required: false
         default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
+      python_version:
+        required: false
+        type: string
+        default: '3.11'
   workflow_call:
     inputs:
       build_target:
@@ -37,6 +41,11 @@ on:
         # We're using a specific version of macOS due to:
         # https://github.com/actions/virtual-environments/issues/5900
         default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
+
+      python_version:
+        required: false
+        type: string
+        default: '3.11'
 
 concurrency:
   # Skip intermediate builds: always.
@@ -67,7 +76,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.python_version }}
       - name: Install Ninja
         uses: llvm/actions/install-ninja@main
       # actions/checkout deletes any existing files in the new git directory,


### PR DESCRIPTION
This enables the libclang python binding test to check
the oldest version of Python supported in addition
to the normal python version.

It is important to check this for issue #76664, since
many new mainstream python type annotation features
and best practices are not compatible with older
versions of python.

Additionally, frustration around ever increasing
platform dependencies and versions has been raised.
This will help ensure that python maintains reasonable
backwards compatibility.

Adding this additional build step will increase the
run time, but this should always be minimal, since
the additional libclang compilation should see 100%
cache hit rate.

Issue #76664.
Fixes #76601.