### PR TITLE
[llvm-exegesis] Make duplicate snippet repetitor produce whole snippets

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -31,7 +31,11 @@ public:
       if (!Instructions.empty()) {
         // Add the whole snippet at least once.
         Entry.addInstructions(Instructions);
-        for (unsigned I = Instructions.size(); I < MinInstructions; ++I) {
+        unsigned FullInstructionCount = MinInstructions;
+        if (FullInstructionCount % Instructions.size() != 0)
+          FullInstructionCount +=
+              Instructions.size() - (MinInstructions % Instructions.size());
+        for (unsigned I = Instructions.size(); I < FullInstructionCount; ++I) {
           Entry.addInstruction(Instructions[I % Instructions.size()]);
         }
       }

--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -29,14 +29,10 @@ public:
             CleanupMemory](FunctionFiller &Filler) {
       auto Entry = Filler.getEntry();
       if (!Instructions.empty()) {
-        // Add the whole snippet at least once.
-        Entry.addInstructions(Instructions);
-        unsigned FullInstructionCount = MinInstructions;
-        if (FullInstructionCount % Instructions.size() != 0)
-          FullInstructionCount +=
-              Instructions.size() - (MinInstructions % Instructions.size());
-        for (unsigned I = Instructions.size(); I < FullInstructionCount; ++I) {
-          Entry.addInstruction(Instructions[I % Instructions.size()]);
+        const unsigned NumRepetitions =
+            divideCeil(MinInstructions, Instructions.size());
+        for (unsigned I = 0; I < NumRepetitions; ++I) {
+          Entry.addInstructions(Instructions);
         }
       }
       Entry.addReturn(State.getExegesisTarget(), CleanupMemory);

--- a/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
@@ -38,9 +38,11 @@ protected:
     MF = &createVoidVoidPtrMachineFunction("TestFn", Mod.get(), MMI.get());
   }
 
-  void TestCommon(Benchmark::RepetitionModeE RepetitionMode) {
+  void TestCommon(Benchmark::RepetitionModeE RepetitionMode,
+                  unsigned SnippetInstructions = 1) {
     const auto Repetitor = SnippetRepetitor::Create(RepetitionMode, State);
-    const std::vector<MCInst> Instructions = {MCInstBuilder(X86::NOOP)};
+    const std::vector<MCInst> Instructions(SnippetInstructions,
+                                           MCInstBuilder(X86::NOOP));
     FunctionFiller Sink(*MF, {X86::EAX});
     const auto Fill =
         Repetitor->Repeat(Instructions, kMinInstructions, kLoopBodySize, false);
@@ -72,6 +74,18 @@ TEST_F(X86SnippetRepetitorTest, Duplicate) {
   EXPECT_THAT(MF->getBlockNumbered(0)->instrs(),
               ElementsAre(HasOpcode(X86::NOOP), HasOpcode(X86::NOOP),
                           HasOpcode(X86::NOOP), HasOpcode(X86::RET64)));
+}
+
+TEST_F(X86SnippetRepetitorTest, DuplicateSnippetInstructionCount) {
+  TestCommon(Benchmark::Duplicate, 2);
+  // Duplicating a snippet of two instructions with the minimum number of
+  // instructions set to three duplicates the snippet twice for a total of
+  // four instructions.
+  ASSERT_EQ(MF->getNumBlockIDs(), 1u);
+  EXPECT_THAT(MF->getBlockNumbered(0)->instrs(),
+              ElementsAre(HasOpcode(X86::NOOP), HasOpcode(X86::NOOP),
+                          HasOpcode(X86::NOOP), HasOpcode(X86::NOOP),
+                          HasOpcode(X86::RET64)));
 }
 
 TEST_F(X86SnippetRepetitorTest, Loop) {


### PR DESCRIPTION
Currently, the duplicate snippet repetitor will truncate snippets that do not exactly divide the minimum number of instructions. This patch corrects that behavior by making the duplicate snippet repetitor duplicate the snippet in its entirety until the minimum number of instructions has been reached.

This makes the behavior consistent with the loop snippet repetitor, which will execute at least `--num-repetitions` (soon to be renamed `--min-instructions`) instructions.