### PR TITLE
[llvm-exegesis] Fix snippet value scaling

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -615,9 +616,9 @@ std::pair<Error, Benchmark> BenchmarkRunner::runConfiguration(
     // Scale the measurements by instruction.
     BM.PerInstructionValue /= BenchmarkResult.NumRepetitions;
     // Scale the measurements by snippet.
-    BM.PerSnippetValue *=
-        static_cast<double>(BenchmarkResult.Key.Instructions.size()) /
-        BenchmarkResult.NumRepetitions;
+    BM.PerSnippetValue /=
+        std::ceil(BenchmarkResult.NumRepetitions /
+                  static_cast<double>(BenchmarkResult.Key.Instructions.size()));
   }
   BenchmarkResult.Measurements = std::move(*NewMeasurements);
 


### PR DESCRIPTION
Currently, BenchmarkRunner scales the per snippet counters by multiplying the raw counter values by the number of instructions (casted to a double) divided by the minimum number of instructions. This is incorrect for the loop repetition mode for snippets that don't fit a whole number of times into the minimum instruction count. For example, with 3 instructions in the snippet and the minimum number of instructions set to 4, the loop repetitor will execute a total of six instructions, but BenchmarkRunner will scale the raw count by 3/4 instead of 3/6=1/2. This will also be incorrect for the duplicate snippet repetitor after #77224.

This patch fixes this behavior by dividing the raw count by the ceiling of the number of repetitions divided by the instruction count.