### PR TITLE
[MLIR][Presburger] Fix ParamPoint to be column-wise instead of row-wise

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
@@ -22,7 +22,7 @@ namespace presburger {
 namespace detail {
 
 // A parametric point is a vector, each of whose elements
-// is an affine function of n parameters. Each row
+// is an affine function of n parameters. Each column
 // in the matrix represents the affine function and
 // has n+1 elements.
 using ParamPoint = FracMatrix;

--- a/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
@@ -56,7 +56,7 @@ public:
       : numParam(numParam), signs(signs), numerators(nums), denominators(dens) {
 #ifndef NDEBUG
     for (const ParamPoint &term : numerators)
-      assert(term.getNumColumns() == numParam + 1 &&
+      assert(term.getNumRows() == numParam + 1 &&
              "dimensionality of numerator exponents does not match number of "
              "parameters!");
 #endif // NDEBUG

--- a/mlir/unittests/Analysis/Presburger/GeneratingFunctionTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/GeneratingFunctionTest.cpp
@@ -17,21 +17,21 @@ using namespace mlir::presburger::detail;
 
 TEST(GeneratingFunctionTest, sum) {
   GeneratingFunction gf1(2, {1, -1},
-                         {makeFracMatrix(2, 3, {{1, 2, 5}, {7, 2, 6}}),
-                          makeFracMatrix(2, 3, {{5, 2, 5}, {3, 7, 2}})},
+                         {makeFracMatrix(3, 2, {{1, 2}, {5, 7}, {2, 6}}),
+                          makeFracMatrix(3, 2, {{5, 2}, {5, 3}, {7, 2}})},
                          {{{3, 6}, {7, 2}}, {{2, 8}, {6, 3}}});
   GeneratingFunction gf2(2, {1, 1},
-                         {makeFracMatrix(2, 3, {{6, 2, 1}, {4, 2, 6}}),
-                          makeFracMatrix(2, 3, {{3, 2, 6}, {9, 2, 5}})},
+                         {makeFracMatrix(3, 2, {{6, 2}, {1, 4}, {2, 6}}),
+                          makeFracMatrix(3, 2, {{3, 2}, {6, 9}, {2, 5}})},
                          {{{3, 7}, {5, 1}}, {{5, 2}, {6, 2}}});
 
   GeneratingFunction sum = gf1 + gf2;
   EXPECT_EQ_REPR_GENERATINGFUNCTION(
       sum, GeneratingFunction(2, {1, -1, 1, 1},
-                              {makeFracMatrix(2, 3, {{1, 2, 5}, {7, 2, 6}}),
-                               makeFracMatrix(2, 3, {{5, 2, 5}, {3, 7, 2}}),
-                               makeFracMatrix(2, 3, {{6, 2, 1}, {4, 2, 6}}),
-                               makeFracMatrix(2, 3, {{3, 2, 6}, {9, 2, 5}})},
+                              {makeFracMatrix(3, 2, {{1, 2}, {5, 7}, {2, 6}}),
+                               makeFracMatrix(3, 2, {{5, 2}, {5, 3}, {7, 2}}),
+                               makeFracMatrix(3, 2, {{6, 2}, {1, 4}, {2, 6}}),
+                               makeFracMatrix(3, 2, {{3, 2}, {6, 9}, {2, 5}})},
                               {{{3, 6}, {7, 2}},
                                {{2, 8}, {6, 3}},
                                {{3, 7}, {5, 1}},


### PR DESCRIPTION
The ParamPoint datatype has each column representing an affine function. The code for generating functions is modified to reflect this.