### PR TITLE
[libc++][test] Replace uses of `_LIBCPP_ABI_MICROSOFT` in tests

### DIFF
--- a/libcxx/test/libcxx/memory/trivial_abi/unique_ptr_destruction_order.pass.cpp
+++ b/libcxx/test/libcxx/memory/trivial_abi/unique_ptr_destruction_order.pass.cpp
@@ -55,7 +55,7 @@ int main(int, char**) {
   func(A(shared_buf, &cur_idx), std::unique_ptr<B>(new B(shared_buf, &cur_idx)),
        C(shared_buf, &cur_idx));
 
-#if defined(_LIBCPP_ABI_MICROSOFT)
+#if defined(TEST_ABI_MICROSOFT)
   // On Microsoft ABI, the dtor order is always A,B,C (because callee-destroyed)
   assert(shared_buf[0] == 'A' && shared_buf[1] == 'B' && shared_buf[2] == 'C');
 #else

--- a/libcxx/test/libcxx/memory/trivial_abi/unique_ptr_destruction_order.pass.cpp
+++ b/libcxx/test/libcxx/memory/trivial_abi/unique_ptr_destruction_order.pass.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <cassert>
 
+#include "test_macros.h"
+
 __attribute__((noinline)) void call_something() { asm volatile(""); }
 
 struct Base {

--- a/libcxx/test/std/language.support/support.exception/propagation/make_exception_ptr.pass.cpp
+++ b/libcxx/test/std/language.support/support.exception/propagation/make_exception_ptr.pass.cpp
@@ -39,7 +39,7 @@ int main(int, char**)
         }
         catch (const A& a)
         {
-#ifndef _LIBCPP_ABI_MICROSOFT
+#ifndef TEST_ABI_MICROSOFT
             assert(A::constructed == 1);
 #else
             // On Windows exception_ptr copies the exception

--- a/libcxx/test/std/language.support/support.exception/propagation/rethrow_exception.pass.cpp
+++ b/libcxx/test/std/language.support/support.exception/propagation/rethrow_exception.pass.cpp
@@ -47,7 +47,7 @@ int main(int, char**)
         }
         catch (const A& a)
         {
-#ifndef _LIBCPP_ABI_MICROSOFT
+#ifndef TEST_ABI_MICROSOFT
             assert(A::constructed == 1);
 #else
             // On Windows the exception_ptr copies the exception

--- a/libcxx/test/support/msvc_stdlib_force_include.h
+++ b/libcxx/test/support/msvc_stdlib_force_include.h
@@ -101,6 +101,7 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
 #endif
 
 #define TEST_SHORT_WCHAR
+#define TEST_ABI_MICROSOFT
 
 #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
 

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -443,6 +443,10 @@ inline void DoNotOptimize(Tp const& value) {
 #  define TEST_SHORT_WCHAR
 #endif
 
+#ifdef _LIBCPP_ABI_MICROSOFT
+#  define TEST_ABI_MICROSOFT
+#endif
+
 // This is a temporary workaround for user-defined `operator new` definitions
 // not being picked up on Apple platforms in some circumstances. This is under
 // investigation and should be short-lived.


### PR DESCRIPTION
No functional change for libc++. But this allows MSVC STL to pass the tests.