### PR TITLE
[MC][RISCV] Check hasEmitNops before call shouldInsertExtraNopBytesForCodeAlign

### DIFF
--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -708,7 +708,7 @@ static void AttemptToFoldSymbolOffsetDifference(
       if (DF) {
         Displacement += DF->getContents().size();
       } else if (auto *AF = dyn_cast<MCAlignFragment>(FI);
-                 AF && Layout &&
+                 AF && Layout && AF->hasEmitNops() &&
                  !Asm->getBackend().shouldInsertExtraNopBytesForCodeAlign(
                      *AF, Count)) {
         Displacement += Asm->computeFragmentSize(*Layout, *AF);

--- a/llvm/test/MC/RISCV/align-non-executable.s
+++ b/llvm/test/MC/RISCV/align-non-executable.s
@@ -1,6 +1,6 @@
-## Check the data diff (separated by aligment directives) directives which in
-## a section which has instructions but is not executable should generate relocs
-## because it can not be calculated out in AttemptToFoldSymbolOffsetDifference.
+## A label difference separated by an alignment directive, when the
+## referenced symbols are in a non-executable section with instructions,
+## should generate ADD/SUB relocations.
 ## https://github.com/llvm/llvm-project/pull/76552
 
 # RUN: llvm-mc --filetype=obj --triple=riscv64 --mattr=+relax %s \

--- a/llvm/test/MC/RISCV/align-non-executable.s
+++ b/llvm/test/MC/RISCV/align-non-executable.s
@@ -1,3 +1,8 @@
+## Check the data diff (separated by aligment directives) directives which in
+## a section which has instructions but is not executable should generate relocs
+## because it can not be calculated out in AttemptToFoldSymbolOffsetDifference.
+## https://github.com/llvm/llvm-project/pull/76552
+
 # RUN: llvm-mc --filetype=obj --triple=riscv64 --mattr=+relax %s \
 # RUN:     | llvm-readobj -r - | FileCheck --check-prefixes=CHECK,RELAX %s
 # RUN: llvm-mc --filetype=obj --triple=riscv64 --mattr=-relax %s \
@@ -9,9 +14,6 @@
 .p2align 3
 .L2:
 .dword .L2 - .L1
-.word .L2 - .L1
-.half .L2 - .L1
-.byte .L2 - .L1
 
 # CHECK:       Relocations [
 # CHECK-NEXT:    Section ({{.*}}) .rela.dummy {
@@ -19,11 +21,5 @@
 # RELAX-NEXT:      0x0 R_RISCV_RELAX - 0x0
 # CHECK-NEXT:      0x8 R_RISCV_ADD64 .L2 0x0
 # CHECK-NEXT:      0x8 R_RISCV_SUB64 .L1 0x0
-# CHECK-NEXT:      0x10 R_RISCV_ADD32 .L2 0x0
-# CHECK-NEXT:      0x10 R_RISCV_SUB32 .L1 0x0
-# CHECK-NEXT:      0x14 R_RISCV_ADD16 .L2 0x0
-# CHECK-NEXT:      0x14 R_RISCV_SUB16 .L1 0x0
-# CHECK-NEXT:      0x16 R_RISCV_ADD8 .L2 0x0
-# CHECK-NEXT:      0x16 R_RISCV_SUB8 .L1 0x0
 # CHECK-NEXT:    }
 # CHECK-NEXT:  ]

--- a/llvm/test/MC/RISCV/align-non-executable.s
+++ b/llvm/test/MC/RISCV/align-non-executable.s
@@ -1,0 +1,29 @@
+# RUN: llvm-mc --filetype=obj --triple=riscv64 --mattr=+relax %s \
+# RUN:     | llvm-readobj -r - | FileCheck --check-prefixes=CHECK,RELAX %s
+# RUN: llvm-mc --filetype=obj --triple=riscv64 --mattr=-relax %s \
+# RUN:     | llvm-readobj -r - | FileCheck %s
+
+.section ".dummy", "a"
+.L1:
+  call func
+.p2align 3
+.L2:
+.dword .L2 - .L1
+.word .L2 - .L1
+.half .L2 - .L1
+.byte .L2 - .L1
+
+# CHECK:       Relocations [
+# CHECK-NEXT:    Section ({{.*}}) .rela.dummy {
+# CHECK-NEXT:      0x0 R_RISCV_CALL_PLT func 0x0
+# RELAX-NEXT:      0x0 R_RISCV_RELAX - 0x0
+# CHECK-NEXT:      0x8 R_RISCV_ADD64 .L2 0x0
+# CHECK-NEXT:      0x8 R_RISCV_SUB64 .L1 0x0
+# CHECK-NEXT:      0x10 R_RISCV_ADD32 .L2 0x0
+# CHECK-NEXT:      0x10 R_RISCV_SUB32 .L1 0x0
+# CHECK-NEXT:      0x14 R_RISCV_ADD16 .L2 0x0
+# CHECK-NEXT:      0x14 R_RISCV_SUB16 .L1 0x0
+# CHECK-NEXT:      0x16 R_RISCV_ADD8 .L2 0x0
+# CHECK-NEXT:      0x16 R_RISCV_SUB8 .L1 0x0
+# CHECK-NEXT:    }
+# CHECK-NEXT:  ]


### PR DESCRIPTION
The shouldInsertExtraNopBytesForCodeAlign() need STI to check whether relax is enabled or not. It is initialized when call setEmitNops. The setEmitNops may not be called in a section which has instructions but is not executable. In this case uninitialized STI will cause problems. Thus, check hasEmitNops before call it.

Fixes: https://github.com/llvm/llvm-project/pull/76552#issuecomment-1878952480