### PR TITLE
[libc++][doc] Marks LWG3257 as complete

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -176,7 +176,7 @@
 "`3245 <https://wg21.link/LWG3245>`__","Unnecessary restriction on ``'%p'``\  parse specifier","Belfast","","","|chrono|"
 "`3244 <https://wg21.link/LWG3244>`__","Constraints for ``Source``\  in |sect|\ [fs.path.req] insufficiently constrainty","Belfast","",""
 "`3241 <https://wg21.link/LWG3241>`__","``chrono-spec``\  grammar ambiguity in |sect|\ [time.format]","Belfast","|Complete|","16.0","|chrono| |format|"
-"`3257 <https://wg21.link/LWG3257>`__","Missing feature testing macro update from P0858","Belfast","",""
+"`3257 <https://wg21.link/LWG3257>`__","Missing feature testing macro update from P0858","Belfast","|Complete|","12.0"
 "`3256 <https://wg21.link/LWG3256>`__","Feature testing macro for ``constexpr``\  algorithms","Belfast","|Complete|","13.0"
 "`3273 <https://wg21.link/LWG3273>`__","Specify ``weekday_indexed``\  to range of ``[0, 7]``\ ","Belfast","|Complete|","16.0","|chrono|"
 "`3070 <https://wg21.link/LWG3070>`__","``path::lexically_relative``\  causes surprising results if a filename can also be a  *root-name*","Belfast","",""


### PR DESCRIPTION
The macros were already updated
- __cpp_lib_string_view in 466df1718e41fe2fca6ce6bd98c01b18f42c05e4
- __cpp_lib_array_constexpr in 77b9abfc8e89ca627e4f9a1cc206bea131db6db1

Based on the dates of the commit and that
 P0858 "Constexpr iterator requirements"
was completed in LLVM 12, set this issue as completed in the same version.

Completes
- LWG3257 Missing feature testing macro update from P0858