### PR TITLE
[libc++] Implements P2517R1.

### DIFF
--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -59,6 +59,7 @@ Implemented Papers
 - P2821R5 - span.at()
 - P0521R0 - Proposed Resolution for CA 14 (shared_ptr use_count/unique)
 - P1759R6 - Native handles and file streams
+- P2517R1 - Add a conditional ``noexcept`` specification to ``std::apply``
 
 
 Improvements and New Features

--- a/libcxx/docs/Status/Cxx23Papers.csv
+++ b/libcxx/docs/Status/Cxx23Papers.csv
@@ -83,7 +83,7 @@
 "`P2502R2 <https://wg21.link/P2502R2>`__","LWG","``std::generator``: Synchronous Coroutine Generator for Ranges","July 2022","","","|ranges|"
 "`P2508R1 <https://wg21.link/P2508R1>`__","LWG","Exposing ``std::basic-format-string``","July 2022","|Complete|","15.0"
 "`P2513R4 <https://wg21.link/P2513R4>`__","LWG","``char8_t`` Compatibility and Portability Fixes","July 2022","",""
-"`P2517R1 <https://wg21.link/P2517R1>`__","LWG","Add a conditional ``noexcept`` specification to ``std::apply``","July 2022","",""
+"`P2517R1 <https://wg21.link/P2517R1>`__","LWG","Add a conditional ``noexcept`` specification to ``std::apply``","July 2022","|Complete|","3.9"
 "`P2520R0 <https://wg21.link/P2520R0>`__","LWG","``move_iterator`` should be a random access iterator","July 2022","|Complete| [#note-P2520R0]_","17.0","|ranges|"
 "`P2540R1 <https://wg21.link/P2540R1>`__","LWG","Empty Product for certain Views","July 2022","","","|ranges|"
 "`P2549R1 <https://wg21.link/P2549R1>`__","LWG","``std::unexpected`` should have ``error()`` as member accessor","July 2022","|Complete|","16.0"

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -141,7 +141,7 @@ template <class... Tuples> tuple<CTypes...> tuple_cat(Tuples&&... tpls); // cons
 
 // [tuple.apply], calling a function with a tuple of arguments:
 template <class F, class Tuple>
-  constexpr decltype(auto) apply(F&& f, Tuple&& t); // C++17
+  constexpr decltype(auto) apply(F&& f, Tuple&& t) noexcept(see below);  // C++17 noexcept since C++23
 template <class T, class Tuple>
   constexpr T make_from_tuple(Tuple&& t); // C++17
 

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
@@ -10,7 +10,7 @@
 
 // <tuple>
 
-// template <class F, class T> constexpr decltype(auto) apply(F &&, T &&)
+// template <class F, class T> constexpr decltype(auto) apply(F &&, T &&) noexcept(see below) // noexcept since C++23
 
 // Test with different ref/ptr/cv qualified argument types.
 
@@ -192,7 +192,11 @@ void test_noexcept()
         // test that the functions noexcept-ness is propagated
         using Tup = std::tuple<int, const char*, long>;
         Tup t;
+#if TEST_STD_VER >= 23
+        ASSERT_NOEXCEPT(std::apply(nec, t));
+#else
         LIBCPP_ASSERT_NOEXCEPT(std::apply(nec, t));
+#endif
         ASSERT_NOT_NOEXCEPT(std::apply(tc, t));
     }
     {
@@ -200,7 +204,11 @@ void test_noexcept()
         using Tup = std::tuple<NothrowMoveable, int>;
         Tup t;
         ASSERT_NOT_NOEXCEPT(std::apply(nec, t));
+#if TEST_STD_VER >= 23
+        ASSERT_NOEXCEPT(std::apply(nec, std::move(t)));
+#else
         LIBCPP_ASSERT_NOEXCEPT(std::apply(nec, std::move(t)));
+#endif
     }
 }
 


### PR DESCRIPTION
As pointed out by @Zingam the paper was implemented in libc++ as an extension. This patch does the bookkeeping. The inital release version is based on historical release dates.

Completes:
- Add a conditional noexcept specification to std::apply