### PR TITLE
[libcxx] Re-include <osreldate.h> in __config for FreeBSD

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -484,6 +484,10 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    include <features.h> // for __NATIVE_ASCII_F
 #  endif
 
+#  ifdef __FreeBSD__
+#    include <osreldate.h> // for __FreeBSD_version
+#  endif
+
 #  ifndef __BYTE_ORDER__
 #    error                                                                                                             \
         "Your compiler doesn't seem to define __BYTE_ORDER__, which is required by libc++ to know the endianness of your target platform"


### PR DESCRIPTION
In 0a97720d0197 some changes were made to `__config` for assuming that `__BYTE_ORDER__` is always present.

However, this deleted a `<osreldate.h>` include for FreeBSD, which is required to get the value of `__FreeBSD_version`, and that is used later in the file to determine whether `_LIBCPP_C_HAS_NO_GETS` needs to be enabled.

Include `<osreldate.h>` just after the other includes used for feature detection, to fix this.

Note that when FreeBSD 13 is EOLed, this can be removed, as then all supported FreeBSD versions will no longer have `gets()`.
