### PR TITLE
[libc++][CI] Moves CI badge to main README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The LLVM Compiler Infrastructure
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/llvm/llvm-project/badge)](https://securityscorecards.dev/viewer/?uri=github.com/llvm/llvm-project)
+[![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule)
 
 Welcome to the LLVM project!
 

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -202,10 +202,6 @@ Design Documents
 Build Bots and Test Coverage
 ============================
 
-.. image:: https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule
-   :target: https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule
-   :alt: Build and Test libc++
-
 * `Github Actions CI pipeline <https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml>`_
 * `Buildkite CI pipeline <https://buildkite.com/llvm-project/libcxx-ci>`_
 * `LLVM Buildbot Builders <https://lab.llvm.org/buildbot>`_


### PR DESCRIPTION
The current CI badge is currently in libc++ documentation. This does not seem the right place:
- The typical location on GitHub is on the main README.
- The documentation is shipped as part of the release:
  - This link does not work in off-line mode. Currently our documentation works in off-line mode.
  - The status in the release documentation does not reflect the status of the shipped library. So users looking at it may see a red status and get confused.

This moves the badge to the README.