### PR TITLE
[libc] Fix GPU tests not running after recent patches

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -498,10 +498,14 @@ function(add_integration_test test_name)
       libc.src.string.memcpy
       libc.src.string.memmove
       libc.src.string.memset
-      # __stack_chk_fail should always be included to allow building libc with
-      # stack protector.
-      libc.src.compiler.__stack_chk_fail
   )
+
+  if(libc.src.compiler.__stack_chk_fail IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
+    # __stack_chk_fail should always be included if supported to allow building
+    # libc with the stack protector enabled.
+    list(APPEND fq_deps_list libc.src.compiler.__stack_chk_fail)
+  endif()
+
   list(REMOVE_DUPLICATES fq_deps_list)
 
   # TODO: Instead of gathering internal object files from entrypoints,
@@ -668,12 +672,15 @@ function(add_libc_hermetic_test test_name)
       libc.src.string.memmove
       libc.src.string.memset
       libc.src.__support.StringUtil.error_to_string
-      # __stack_chk_fail should always be included to allow building libc with
-      # stack protector.
-      libc.src.compiler.__stack_chk_fail
   )
 
-  if(TARGET libc.src.time.clock)
+  if(libc.src.compiler.__stack_chk_fail IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
+    # __stack_chk_fail should always be included if supported to allow building
+    # libc with the stack protector enabled.
+    list(APPEND fq_deps_list libc.src.compiler.__stack_chk_fail)
+  endif()
+
+  if(libc.src.time.clock IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
     # We will link in the 'clock' implementation if it exists for test timing.
     list(APPEND fq_deps_list libc.src.time.clock)
   endif()

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -184,24 +184,28 @@ add_gen_header(
     .llvm-libc-macros.generic_error_number_macros
 )
 
-add_gen_header(
-  signal
-  DEF_FILE signal.h.def
-  PARAMS
-    platform_signal=../config/${LIBC_TARGET_OS}/signal.h.in
-  GEN_HDR signal.h
-  DATA_FILES
-    ../config/${LIBC_TARGET_OS}/signal.h.in
-  DEPENDS
-    .llvm-libc-macros.signal_macros
-    .llvm-libc-types.sig_atomic_t
-    .llvm-libc-types.sigset_t
-    .llvm-libc-types.struct_sigaction
-    .llvm-libc-types.union_sigval
-    .llvm-libc-types.siginfo_t
-    .llvm-libc-types.stack_t
-    .llvm-libc-types.pid_t
-)
+if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/signal.h.in")
+  add_gen_header(
+    signal
+    DEF_FILE signal.h.def
+    PARAMS
+    platform_signal=${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/signal.h.in
+    GEN_HDR signal.h
+    DATA_FILES
+      ${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/signal.h.in
+    DEPENDS
+      .llvm-libc-macros.signal_macros
+      .llvm-libc-types.sig_atomic_t
+      .llvm-libc-types.sigset_t
+      .llvm-libc-types.struct_sigaction
+      .llvm-libc-types.union_sigval
+      .llvm-libc-types.siginfo_t
+      .llvm-libc-types.stack_t
+      .llvm-libc-types.pid_t
+  )
+else()
+  message(STATUS "Skipping header signal.h as the target config is missing")
+endif()
 
 add_gen_header(
   stdio

--- a/libc/src/__support/StringUtil/CMakeLists.txt
+++ b/libc/src/__support/StringUtil/CMakeLists.txt
@@ -51,19 +51,21 @@ add_object_library(
     libc.src.__support.integer_to_string
 )
 
-add_object_library(
-  signal_to_string
-  HDRS
-    signal_to_string.h
-  SRCS
-    signal_to_string.cpp
-  DEPENDS
-    .message_mapper
-    .platform_signals
-    libc.include.signal
-    libc.src.__support.common
-    libc.src.__support.CPP.span
-    libc.src.__support.CPP.string_view
-    libc.src.__support.CPP.stringstream
-    libc.src.__support.integer_to_string
-)
+if(TARGET libc.include.signal)
+  add_object_library(
+    signal_to_string
+    HDRS
+      signal_to_string.h
+    SRCS
+      signal_to_string.cpp
+    DEPENDS
+      .message_mapper
+      .platform_signals
+      libc.include.signal
+      libc.src.__support.common
+      libc.src.__support.CPP.span
+      libc.src.__support.CPP.string_view
+      libc.src.__support.CPP.stringstream
+      libc.src.__support.integer_to_string
+  )
+endif()


### PR DESCRIPTION
Summary:
A previous patch added a dependency on the stack protectors, this was
not built on the GPU targets so every test was disabled. It turns out
that disabled tests still get targets so we need to specifically check
if the it is in the target's set of entrypoints before we can use it.

Another patch, because the build-bot was down, snuck in that prevented
the new math tests from being run. The problem is that the `signal.h`
header requires target specific definitions but was being used
unconditionally. I have made changes that disable building this header
if the file is not defined in the config. This required disbaling the
signal_to_string utility, so that will simply be missing from targets
that don't define it.
