### PR TITLE
[libc++] Fix `regex_search` to match `$` alone with `match_default` flag

### DIFF
--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -1889,6 +1889,9 @@ void __r_anchor_multiline<_CharT>::__exec(__state& __s) const {
   if (__s.__current_ == __s.__last_ && !(__s.__flags_ & regex_constants::match_not_eol)) {
     __s.__do_   = __state::__accept_but_not_consume;
     __s.__node_ = this->first();
+  } else if (__s.__current_ == __s.__first_ && !(__s.__flags_ & regex_constants::match_not_eol)) {
+    __s.__do_   = __state::__accept_but_not_consume;
+    __s.__node_ = this->first();
   } else if (__multiline_ && std::__is_eol(*__s.__current_)) {
     __s.__do_   = __state::__accept_but_not_consume;
     __s.__node_ = this->first();

--- a/libcxx/test/std/re/re.const/re.matchflag/match_not_eol.pass.cpp
+++ b/libcxx/test/std/re/re.const/re.matchflag/match_not_eol.pass.cpp
@@ -47,5 +47,19 @@ int main(int, char**)
     assert( std::regex_search(target, re, std::regex_constants::match_not_eol));
     }
 
+    {
+      std::string target = "foo";
+      std::regex re("$");
+      assert(std::regex_search(target, re));
+      assert(!std::regex_search(target, re, std::regex_constants::match_not_eol));
+    }
+
+    {
+      std::string target = "foo";
+      std::regex re("$");
+      assert(!std::regex_match(target, re));
+      assert(!std::regex_match(target, re, std::regex_constants::match_not_eol));
+    }
+
   return 0;
 }


### PR DESCRIPTION
Using `regex_search` with the regex_constant `match_default` and a simple regex pattern `$` is expected to match general strings such as _"a", "ab", "abc"..._ at `[last, last)` positions.  But, the current implementation fails to do so.

Fixes #75042
