### PR TITLE
[llvm-exegesis] Align loop MBB in loop repetitor

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -10,6 +10,7 @@
 #include "Target.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 
 namespace llvm {
@@ -74,9 +75,10 @@ public:
       auto Loop = Filler.addBasicBlock();
       auto Exit = Filler.addBasicBlock();
 
-      // Align the loop machine basic block to a sixteen byte boundary
-      // so that instruction fetch on modern x86 platforms works optimally.
-      Loop.MBB->setAlignment(Align(16));
+      // Align the loop machine basic block to a target-specific boundary
+      // to promote optimal instruction fetch/predecoding conditions.
+      Loop.MBB->setAlignment(
+          Filler.MF.getSubtarget().getTargetLowering()->getPrefLoopAlignment());
 
       const unsigned LoopUnrollFactor =
           LoopBodySize <= Instructions.size()

--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -74,6 +74,10 @@ public:
       auto Loop = Filler.addBasicBlock();
       auto Exit = Filler.addBasicBlock();
 
+      // Align the loop machine basic block to a sixteen byte boundary
+      // so that instruction fetch on modern x86 platforms works optimally.
+      Loop.MBB->setAlignment(Align(16));
+
       const unsigned LoopUnrollFactor =
           LoopBodySize <= Instructions.size()
               ? 1


### PR DESCRIPTION
This patch sets the alignment of the loob MBB in the loop repetitor to 16 to avoid instruction fetch/predecoding bottlenecks that can come up with unaligned code. The value of 16 was chosen based on numbers for recent Intel microarchitectures and reccomendations from Agner Fog.

Fixes #77259.