### PR TITLE
Revert "[GitHub] Fix slow sccache install on macOS by upgrading macOS version (#77165)"

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-latest", "windows-2019", "macOS-12"]'
+        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
   workflow_call:
     inputs:
       build_target:
@@ -34,7 +34,9 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        default: '["ubuntu-latest", "windows-2019", "macOS-12"]'
+        # We're using a specific version of macOS due to:
+        # https://github.com/actions/virtual-environments/issues/5900
+        default: '["ubuntu-latest", "windows-2019", "macOS-11"]'
 
 concurrency:
   # Skip intermediate builds: always.
@@ -89,6 +91,10 @@ jobs:
           variant: sccache
       - name: Build and Test
         uses: llvm/actions/build-test-llvm-project@main
+        env:
+          # Workaround for https://github.com/actions/virtual-environments/issues/5900.
+          # This should be a no-op for non-mac OSes
+          PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
           cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ inputs.extra_cmake_args }}'
           build_target: '${{ inputs.build_target }}'


### PR DESCRIPTION
This reverts commit 602c8fa2d8da6562e4f36df3bd63c26a4c7461e7, due to an sccache issue seen on larger builds using macOS-12 runners.

The issue is documented in in the following issue:
https://github.com/hendrikmuhs/ccache-action/issues/174

The original PR is the following:
https://github.com/llvm/llvm-project/pull/77165