### PR TITLE
[Flang] Remove unused triple variable. NFC

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -743,9 +743,6 @@ void CodeGenAction::generateLLVMIR() {
 
   MLIRToLLVMPassPipelineConfig config(level, opts);
 
-  const auto targetOpts = ci.getInvocation().getTargetOpts();
-  const llvm::Triple triple(targetOpts.triple);
-
   if (auto vsr = getVScaleRange(ci)) {
     config.VScaleMin = vsr->first;
     config.VScaleMax = vsr->second;


### PR DESCRIPTION
I'm not sure why we don't get an unused variable warning, but triple doesn't
seem to be used after 898db1136e679.
