### PR TITLE
[X86] Check if machine loop is passed while getting loop alignment

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -57672,7 +57672,7 @@ X86TargetLowering::getStackProbeSize(const MachineFunction &MF) const {
 }
 
 Align X86TargetLowering::getPrefLoopAlignment(MachineLoop *ML) const {
-  if (ML->isInnermost() &&
+  if (ML && ML->isInnermost() &&
       ExperimentalPrefInnermostLoopAlignment.getNumOccurrences())
     return Align(1ULL << ExperimentalPrefInnermostLoopAlignment);
   return TargetLowering::getPrefLoopAlignment();


### PR DESCRIPTION
After d6bb96e677759375b2bea00115918b2cb6552f5b, calling getPrefLoopAlignment without passing in a pointer to a MachineLoop causes a segmentation fault. This conflicts with the API in TargetLoweringBase where the default MachineLoop pointer passed is nullptr. This patch fixes this by checking if the pointer points to something before enabling the optional functionality.