### PR TITLE
[SCEV][LV] Add Stride equal to one Predicate to enable strided access versioning

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -12778,9 +12778,22 @@ ScalarEvolution::howManyLessThans(const SCEV *LHS, const SCEV *RHS,
     // The positive stride case is the same as isKnownPositive(Stride) returning
     // true (original behavior of the function).
     //
-    if (PredicatedIV || !NoWrap || !loopIsFiniteByAssumption(L) ||
+    if (PredicatedIV || !loopIsFiniteByAssumption(L) ||
         !loopHasNoAbnormalExits(L))
       return getCouldNotCompute();
+
+    // Adding Stride equal to one Predicate when there is no wrap flags.
+    // It might enable strided access versioning in LAA and calculate BECount
+    // with Stride = 1.
+    if (!NoWrap) {
+      if (AllowPredicates) {
+        const auto *One =
+            static_cast<const SCEVConstant *>(getOne(Stride->getType()));
+        Predicates.insert(getEqualPredicate(Stride, One));
+        Stride = One;
+      } else
+        return getCouldNotCompute();
+    }
 
     if (!isKnownNonZero(Stride)) {
       // If we have a step of zero, and RHS isn't invariant in L, we don't know

--- a/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
+++ b/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
@@ -93,8 +93,12 @@ for.end:
   ret void
 }
 
+; We can vectorize the loop by using stride = 1 to calculate iteration count
+; and generate the runtime check to guard the vectorized loop.
+
 ; CHECK-LABEL: s172
-; CHECK-NOT: vector.body
+; CHECK-DAG: icmp ne i32 %xb, 1
+; CHECK: vector.body
 
 @b = global [32000 x float] zeroinitializer, align 64
 @a = global [32000 x float] zeroinitializer, align 64

--- a/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
+++ b/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
@@ -97,7 +97,9 @@ for.end:
 ; and generate the runtime check to guard the vectorized loop.
 
 ; CHECK-LABEL: s172
-; CHECK-DAG: icmp ne i32 %xb, 1
+; CHECK: vector.scevcheck:
+; CHECK:   [[CHECK:%.*]] = icmp ne i32 %xb, 1
+; CHECK:   br i1 [[CHECK]], label %scalar.ph, label %vector.ph
 ; CHECK: vector.body
 
 @b = global [32000 x float] zeroinitializer, align 64


### PR DESCRIPTION
This commit enables the vectorization for the case from https://github.com/llvm/llvm-project/issues/71517.
The loop can't be vectorized due to the BECount is unknown.

    float  s172(int xa, int xb)  {
      for (int i = xa - 1; i < 32000; i += xb)
         a[i] += b[i];
    }

By assuming the stride as one and generating the runtime checking to guard the vectorized loop, it seems the case can be vectorized.