### PR TITLE
[clang] Fix a crash when referencing the result if the overload fails

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13994,21 +13994,22 @@ ExprResult Sema::BuildOverloadedCallExpr(Scope *S, Expr *Fn,
   OverloadCandidateSet::iterator Best;
   OverloadingResult OverloadResult =
       CandidateSet.BestViableFunction(*this, Fn->getBeginLoc(), Best);
-  FunctionDecl *FDecl = Best->Function;
 
   // Model the case with a call to a templated function whose definition
   // encloses the call and whose return type contains a placeholder type as if
   // the UnresolvedLookupExpr was type-dependent.
-  if (OverloadResult == OR_Success && FDecl &&
-      FDecl->isTemplateInstantiation() &&
-      FDecl->getReturnType()->isUndeducedType()) {
-    if (auto TP = FDecl->getTemplateInstantiationPattern(false)) {
-      if (TP->willHaveBody()) {
-        CallExpr *CE =
-            CallExpr::Create(Context, Fn, Args, Context.DependentTy, VK_PRValue,
-                             RParenLoc, CurFPFeatureOverrides());
-        result = CE;
-        return result;
+  if (OverloadResult == OR_Success) {
+    FunctionDecl *FDecl = Best->Function;
+    if (FDecl && FDecl->isTemplateInstantiation() &&
+        FDecl->getReturnType()->isUndeducedType()) {
+      if (auto TP = FDecl->getTemplateInstantiationPattern(false)) {
+        if (TP->willHaveBody()) {
+          CallExpr *CE =
+              CallExpr::Create(Context, Fn, Args, Context.DependentTy,
+                               VK_PRValue, RParenLoc, CurFPFeatureOverrides());
+          result = CE;
+          return result;
+        }
       }
     }
   }


### PR DESCRIPTION
after 20a05677f9394d4bc9467fe7bc93a4ebd3aeda61

If the overload fails, the `Best` might point to the `end()`, referencing it leads to asan crashes.