### PR TITLE
[clang] Fix assertion failure when initializing union with FAM

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -696,6 +696,9 @@ Bug Fixes in This Version
 - Clang now accepts recursive non-dependent calls to functions with deduced
   return type.
   Fixes (`#71015 <https://github.com/llvm/llvm-project/issues/71015>`_)
+- Fix assertion failure when initializing union containing struct with
+  flexible array member using empty initializer list.
+  Fixes (`#77085 <https://github.com/llvm/llvm-project/issues/77085>`)
 
 
 Bug Fixes to Compiler Builtins

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -698,7 +698,7 @@ Bug Fixes in This Version
   Fixes (`#71015 <https://github.com/llvm/llvm-project/issues/71015>`_)
 - Fix assertion failure when initializing union containing struct with
   flexible array member using empty initializer list.
-  Fixes (`#77085 <https://github.com/llvm/llvm-project/issues/77085>`)
+  Fixes (`#77085 <https://github.com/llvm/llvm-project/issues/77085>`_)
 
 
 Bug Fixes to Compiler Builtins

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2835,7 +2835,7 @@ CharUnits VarDecl::getFlexibleArrayInitChars(const ASTContext &Ctx) const {
   if (!Ty || !Ty->getDecl()->hasFlexibleArrayMember())
     return CharUnits::Zero();
   auto *List = dyn_cast<InitListExpr>(getInit()->IgnoreParens());
-  if (!List)
+  if (!List || List->getNumInits() == 0)
     return CharUnits::Zero();
   const Expr *FlexibleInit = List->getInit(List->getNumInits() - 1);
   auto InitTy = Ctx.getAsConstantArrayType(FlexibleInit->getType());

--- a/clang/test/CodeGen/flexible-array-init.c
+++ b/clang/test/CodeGen/flexible-array-init.c
@@ -20,3 +20,11 @@ struct __attribute((packed, aligned(4))) { char a; int x; char z[]; } e = { 1, 2
 
 struct { int x; char y[]; } f = { 1, { 13, 15 } };
 // CHECK: @f ={{.*}} global <{ i32, [2 x i8] }> <{ i32 1, [2 x i8] c"\0D\0F" }>
+
+union {
+  struct {
+    int a;
+    char b[];
+  } x;
+} in_union = {};
+// CHECK: @in_union ={{.*}} global %union.anon zeroinitializer


### PR DESCRIPTION
When initializing a union that constrain a struct with a flexible array member, and the initializer list is empty, we currently trigger an assertion failure. This happens because getFlexibleArrayInitChars() assumes that the initializer list is non-empty.

The relevant code is only executed in assertion-enabled builds: https://github.com/llvm/llvm-project/blob/main/clang/lib/CodeGen/CodeGenModule.cpp#L5318-L5324

Fixes https://github.com/llvm/llvm-project/issues/77085.