### PR TITLE
[Flang][OpenMP] Disable declarate target tests on Windows

### DIFF
--- a/flang/test/Lower/OpenMP/FIR/declare-target-implicit-func-and-subr-cap-enter.f90
+++ b/flang/test/Lower/OpenMP/FIR/declare-target-implicit-func-and-subr-cap-enter.f90
@@ -3,6 +3,8 @@
 !RUN: bbc -emit-fir -fopenmp %s -o - | FileCheck %s
 !RUN: bbc -emit-fir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
 
+!XFAIL: system-windows
+
 ! CHECK-LABEL: func.func @_QPimplicitly_captured_twice
 ! CHECK-SAME: {{.*}}attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>{{.*}}}
 function implicitly_captured_twice() result(k)

--- a/flang/test/Lower/OpenMP/FIR/declare-target-implicit-func-and-subr-cap.f90
+++ b/flang/test/Lower/OpenMP/FIR/declare-target-implicit-func-and-subr-cap.f90
@@ -3,6 +3,8 @@
 !RUN: bbc -emit-fir -fopenmp %s -o - | FileCheck %s
 !RUN: bbc -emit-fir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
 
+!XFAIL: system-windows
+
 ! CHECK-LABEL: func.func @_QPimplicitly_captured
 ! CHECK-SAME: {{.*}}attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>{{.*}}}
 function implicitly_captured(toggle) result(k)

--- a/flang/test/Lower/OpenMP/declare-target-implicit-func-and-subr-cap-enter.f90
+++ b/flang/test/Lower/OpenMP/declare-target-implicit-func-and-subr-cap-enter.f90
@@ -3,6 +3,8 @@
 !RUN: bbc -emit-hlfir -fopenmp %s -o - | FileCheck %s
 !RUN: bbc -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
 
+!XFAIL: system-windows
+
 ! CHECK-LABEL: func.func @_QPimplicitly_captured_twice
 ! CHECK-SAME: {{.*}}attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>{{.*}}}
 function implicitly_captured_twice() result(k)

--- a/flang/test/Lower/OpenMP/declare-target-implicit-func-and-subr-cap.f90
+++ b/flang/test/Lower/OpenMP/declare-target-implicit-func-and-subr-cap.f90
@@ -3,6 +3,8 @@
 !RUN: bbc -emit-hlfir -fopenmp %s -o - | FileCheck %s
 !RUN: bbc -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
 
+!XFAIL: system-windows
+
 ! CHECK-LABEL: func.func @_QPimplicitly_captured
 ! CHECK-SAME: {{.*}}attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>{{.*}}}
 function implicitly_captured(toggle) result(k)


### PR DESCRIPTION
These tests seem to be failing in Windows bots.
See https://github.com/llvm/llvm-project/issues/77086