### PR TITLE
[Clang][Parser] pop explicitly to keep context stack balance

### DIFF
--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2669,6 +2669,7 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
             /*Braced=*/false);
         CalledSignatureHelp = true;
       }
+      InitScope.pop();
       Actions.ActOnInitializerError(ThisDecl);
       SkipUntil(tok::r_paren, StopAtSemi);
     } else {

--- a/clang/test/Parser/cxx-static-member-init-no-crash.cpp
+++ b/clang/test/Parser/cxx-static-member-init-no-crash.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+
+template <typename T, typename Base> class EngineClassTypeInfo; // expected-note {{template is declared here}}
+template <typename T> struct _ConcreteClassBase {};
+
+struct _GLOBALSCOPE {};
+template <typename T = _GLOBALSCOPE> struct _SCOPE {};
+
+class Zone {
+private:
+  typedef _ConcreteClassBase<Zone> _ClassBase;
+  static EngineClassTypeInfo<Zone, _ClassBase> _smTypeInfo;
+  static EngineExportScope &__engineExportScope(); // expected-error {{unknown type name 'EngineExportScope'}}
+};
+
+EngineClassTypeInfo<Zone, Zone::_ClassBase>
+    Zone::_smTypeInfo("Zone", &_SCOPE<__DeclScope>()(), 0); /* expected-error {{use of undeclared identifier '__DeclScope'}} \
+                                                              expected-error {{implicit instantiation of undefined template 'EngineClassTypeInfo<Zone, _ConcreteClassBase<Zone>>'}} */
+EngineExportScope &Zone::__engineExportScope() { return Zone::_smTypeInfo; } // expected-error {{unknown type name 'EngineExportScope'}}


### PR DESCRIPTION
During parsing a `VarDecl`, `InitializerScopeRAII` calls constructor and `ActOnCXXEnterDeclInitializer` is called. Context of current `VarDecl` will be pushed into stack when the `VarDecl` is **valid**. While calls destructor of `InitializerScopeRAII`, `ActOnCXXExitDeclInitializer` return directly if current `VarDecl` becomes invalid and make the stack no balance. This patch fix this problem by call `pop` of `InitializerScopeRAII` explicitly before `ActOnInitializerError` makes current `VarDecl` invalid.