### PR TITLE
[Orc] Let LLJIT default to JITLink for ELF-based ARM targets 

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -734,6 +734,12 @@ Error LLJITBuilderState::prepareForConstruction() {
     case Triple::aarch64:
       UseJITLink = !TT.isOSBinFormatCOFF();
       break;
+    case Triple::arm:
+    case Triple::armeb:
+    case Triple::thumb:
+    case Triple::thumbeb:
+      UseJITLink = TT.isOSBinFormatELF();
+      break;
     case Triple::x86_64:
       UseJITLink = !TT.isOSBinFormatCOFF();
       break;


### PR DESCRIPTION
Over the last weeks, I have landed a number of patches to JITLink's AArch32 backend to reach feature-parity with RuntimeDyld for ELF:
```
9577806b1e6c [JITLink][AArch32] Implement R_ARM_PREL31 and process .ARM.exidx sections (#79044)
e5ca202ef887 [JITLink][AArch32] Multi-stub support for armv7/thumbv7 (#78371)
2bb6d7b8a4d1 [clang-repl] Limit use of PLT offset flag to linkers that support it
565470ed2713 [JITLink][AArch32] Implement ELF relocation R_ARM_NONE
bfb09326be22 [JITLink][AArch32] Implement ELF relocation R_ARM_TARGET1
4821c90c24d5 [clang-repl] Fix PLT offset too large linker error on ARM (#78959)
c4fc563b8d41 [JITLink][AArch32] Add GOT builder and implement R_ARM_GOT_PREL relocations for ELF (#78753)
6a433d77b1f4 [llvm-jitlink] Allow optional stub-kind filter in stub_addr() expressions (#78369)
01ba627f431c [llvm-jitlink] Refactor GOT and stubs registration (NFC) (#78365)
9c607e77eae7 [JITLink][AArch32] Refactor StubsManager (NFC)
```

This allows us to run clang-repl on armv7 and use all the features we had with RuntimeDyld before. All existing tests for clang-repl are passing.