### PR TITLE
[mlir][bufferization][NFC] Remove `BufferPlacementTransformationBase`

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/BufferUtils.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/BufferUtils.h
@@ -98,26 +98,6 @@ Block *findCommonDominator(Value value,
   return doms.findNearestCommonDominator(blocks);
 }
 
-/// The base class for all BufferPlacement transformations.
-class BufferPlacementTransformationBase {
-public:
-  using ValueSetT = BufferViewFlowAnalysis::ValueSetT;
-
-  /// Constructs a new operation base using the given root operation.
-  BufferPlacementTransformationBase(Operation *op);
-
-protected:
-  /// Alias information that can be updated during the insertion of copies.
-  BufferViewFlowAnalysis aliases;
-
-  /// Stores all internally managed allocations.
-  BufferPlacementAllocs allocs;
-
-  /// The underlying liveness analysis to compute fine grained information
-  /// about alloc and dealloc positions.
-  Liveness liveness;
-};
-
 // Create a global op for the given tensor-valued constant in the program.
 // Globals are created lazily at the top of the enclosing ModuleOp with pretty
 // names. Duplicates are avoided.

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferDeallocation.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferDeallocation.cpp
@@ -201,14 +201,14 @@ private:
 /// The buffer deallocation transformation which ensures that all allocs in the
 /// program have a corresponding de-allocation. As a side-effect, it might also
 /// introduce clones that in turn leads to additional deallocations.
-class BufferDeallocation : public BufferPlacementTransformationBase {
+class BufferDeallocation {
 public:
   using AliasAllocationMapT =
       llvm::DenseMap<Value, bufferization::AllocationOpInterface>;
 
   BufferDeallocation(Operation *op)
-      : BufferPlacementTransformationBase(op), dominators(op),
-        postDominators(op) {}
+      : dominators(op), postDominators(op), aliases(op), allocs(op),
+        liveness(op) {}
 
   /// Checks if all allocation operations either provide an already existing
   /// deallocation operation or implement the AllocationOpInterface. In
@@ -615,10 +615,20 @@ private:
   PostDominanceInfo postDominators;
 
   /// Stores already cloned buffers to avoid additional clones of clones.
-  ValueSetT clonedValues;
+  BufferViewFlowAnalysis::ValueSetT clonedValues;
 
   /// Maps aliases to their source allocation interfaces (inverse mapping).
   AliasAllocationMapT aliasToAllocations;
+
+  /// Alias information that can be updated during the insertion of copies.
+  BufferViewFlowAnalysis aliases;
+
+  /// Stores all internally managed allocations.
+  BufferPlacementAllocs allocs;
+
+  /// The underlying liveness analysis to compute fine grained information
+  /// about alloc and dealloc positions.
+  Liveness liveness;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferUtils.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferUtils.cpp
@@ -91,15 +91,6 @@ void BufferPlacementAllocs::build(Operation *op) {
 // BufferPlacementTransformationBase
 //===----------------------------------------------------------------------===//
 
-/// Constructs a new transformation base using the given root operation.
-BufferPlacementTransformationBase::BufferPlacementTransformationBase(
-    Operation *op)
-    : aliases(op), allocs(op), liveness(op) {}
-
-//===----------------------------------------------------------------------===//
-// BufferPlacementTransformationBase
-//===----------------------------------------------------------------------===//
-
 FailureOr<memref::GlobalOp>
 bufferization::getGlobalFor(arith::ConstantOp constantOp, uint64_t alignment,
                             Attribute memorySpace) {


### PR DESCRIPTION
`BufferPlacementTransformationBase` makes it difficult to add error handling to `BufferViewFlowAnalysis`. Error handling is added to `BufferViewFlowAnalysis` in a subsequent commit.