### PR TITLE
[Clang][RISCV] Move getVScaleRange logic into libLLVMFrontendDriver. NFC

### DIFF
--- a/clang/lib/Basic/CMakeLists.txt
+++ b/clang/lib/Basic/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   TargetParser
   FrontendOpenMP
+  FrontendDriver
   )
 
 find_first_existing_vc_file("${LLVM_MAIN_SRC_DIR}" llvm_vc)

--- a/llvm/include/llvm/Frontend/Driver/RISCV.h
+++ b/llvm/include/llvm/Frontend/Driver/RISCV.h
@@ -1,0 +1,27 @@
+//===--- RISCV.h ------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines RISC-V frontend logic common to clang and flang
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_FRONTEND_DRIVER_RISCV_H
+#define LLVM_FRONTEND_DRIVER_RISCV_H
+
+#include "llvm/Support/RISCVISAInfo.h"
+#include <optional>
+
+namespace llvm::driver::riscv {
+
+std::optional<std::pair<unsigned, unsigned>>
+getVScaleRange(const RISCVISAInfo &ISAInfo, unsigned ExplicitMin,
+               unsigned ExplicitMax);
+
+} // namespace llvm::driver::riscv
+
+#endif

--- a/llvm/lib/Frontend/Driver/CMakeLists.txt
+++ b/llvm/lib/Frontend/Driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_llvm_component_library(LLVMFrontendDriver
   CodeGenOptions.cpp
+  RISCV.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend/Driver

--- a/llvm/lib/Frontend/Driver/RISCV.cpp
+++ b/llvm/lib/Frontend/Driver/RISCV.cpp
@@ -1,0 +1,37 @@
+//===--- RISCV.cpp - Shared RISC-V frontend logic -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Frontend/Driver/RISCV.h"
+#include "llvm/TargetParser/RISCVTargetParser.h"
+
+namespace llvm::driver::riscv {
+
+std::optional<std::pair<unsigned, unsigned>>
+getVScaleRange(const RISCVISAInfo &ISAInfo, unsigned ExplicitMin,
+               unsigned ExplicitMax) {
+  // RISCV::RVVBitsPerBlock is 64.
+  unsigned VScaleMin = ISAInfo.getMinVLen() / RISCV::RVVBitsPerBlock;
+
+  if (ExplicitMin || ExplicitMax) {
+    // Treat Zvl*b as a lower bound on vscale.
+    VScaleMin = std::max(VScaleMin, ExplicitMin);
+    unsigned VScaleMax = ExplicitMax;
+    if (VScaleMax != 0 && VScaleMax < VScaleMin)
+      VScaleMax = VScaleMin;
+    return std::pair<unsigned, unsigned>(VScaleMin ? VScaleMin : 1, VScaleMax);
+  }
+
+  if (VScaleMin > 0) {
+    unsigned VScaleMax = ISAInfo.getMaxVLen() / RISCV::RVVBitsPerBlock;
+    return std::make_pair(VScaleMin, VScaleMax);
+  }
+
+  return std::nullopt;
+}
+
+} // namespace llvm::driver::riscv


### PR DESCRIPTION
In #77277, we would like to be able to reuse the logic for calculating the
vscale_range in Flang. This is currently in clang::TargetInfo which is quite C
specific, and given that only two targets implement getVScaleRange, it doesn't
seem worthwhile trying to shoehorn clang::TargetInfo into Flang.

This instead moves the logic into llvm/Frontend/Driver where it can be shared
by both (provided that a RISCVISAInfo is passed in: we don't want to have to
recompute it every time).
