### PR TITLE
[mlir][spirv] Enable using 64 bit index when lowering cf to spirv

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -340,7 +340,10 @@ def ConvertControlFlowToSPIRV : Pass<"convert-cf-to-spirv"> {
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
            "bool", /*default=*/"true",
            "Emulate narrower scalar types with 32-bit ones if not supported by"
-           " the target">
+           " the target">,
+    Option<"use64bitIndex", "use-64bit-index",
+           "bool", /*default=*/"false",
+           "Use 64-bit integers to convert index types">
   ];
 }
 

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
@@ -42,6 +42,7 @@ void ConvertControlFlowToSPIRVPass::runOnOperation() {
 
   SPIRVConversionOptions options;
   options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
+  options.use64bitIndex = this->use64bitIndex;
   SPIRVTypeConverter typeConverter(targetAttr, options);
 
   // TODO: We should also take care of block argument type conversion.

--- a/mlir/test/Conversion/ControlFlowToSPIRV/cf-ops-to-spirv.mlir
+++ b/mlir/test/Conversion/ControlFlowToSPIRV/cf-ops-to-spirv.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt --split-input-file --convert-cf-to-spirv --verify-diagnostics %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --convert-cf-to-spirv='use-64bit-index=true' --verify-diagnostics %s | FileCheck %s -check-prefix=INDEX64
 
 //===----------------------------------------------------------------------===//
 // cf.br, cf.cond_br
@@ -41,19 +42,28 @@ func.func @simple_loop(%begin: i32, %end: i32, %step: i32) {
 
 // Handle blocks whose arguments require type conversion.
 
+module attributes {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64], []>, #spirv.resource_limits<>>
+} {
+  
 // CHECK-LABEL: func.func @main_graph
 func.func @main_graph(%arg0: index) {
   %c3 = arith.constant 1 : index
 // CHECK:  spirv.Branch ^bb1({{.*}} : i32)
+// INDEX64:  spirv.Branch ^bb1({{.*}} : i64)
   cf.br ^bb1(%arg0 : index)
 // CHECK:      ^bb1({{.*}}: i32):       // 2 preds: ^bb0, ^bb2
+// INDEX64:      ^bb1({{.*}}: i64):       // 2 preds: ^bb0, ^bb2
 ^bb1(%0: index):  // 2 preds: ^bb0, ^bb2
   %1 = arith.cmpi slt, %0, %c3 : index
 // CHECK:        spirv.BranchConditional {{.*}}, ^bb2, ^bb3
   cf.cond_br %1, ^bb2, ^bb3
 ^bb2:  // pred: ^bb1
 // CHECK:  spirv.Branch ^bb1({{.*}} : i32)
+// INDEX64:  spirv.Branch ^bb1({{.*}} : i64)
   cf.br ^bb1(%c3 : index)
 ^bb3:  // pred: ^bb1
   return
+}
+
 }

--- a/mlir/test/Conversion/FuncToSPIRV/func-ops-to-spirv.mlir
+++ b/mlir/test/Conversion/FuncToSPIRV/func-ops-to-spirv.mlir
@@ -46,6 +46,21 @@ func.func @call_functions(%arg0: index) -> index {
   return %0: index
 }
 
+// CHECK-LABEL: spirv.func @resolve_unrealized_conversion_cast
+func.func @resolve_unrealized_conversion_cast(%arg0: index, %arg1: index) {
+  %0 = builtin.unrealized_conversion_cast %arg1 : index to i32
+  %1 = builtin.unrealized_conversion_cast %arg0 : index to i32
+// CHECK-NOT: builtin.unrealized_conversion_cast
+  spirv.Branch ^bb1(%1 : i32)
+^bb1(%2: i32):  // 2 preds: ^bb0, ^bb2
+  %3 = spirv.SLessThan %2, %0 : i32
+  spirv.BranchConditional %3, ^bb2, ^bb3
+^bb2:  // pred: ^bb1
+  spirv.Branch ^bb1(%0 : i32)
+^bb3:  // pred: ^bb1
+  return
+}
+
 }
 
 // -----


### PR DESCRIPTION
- Add 'use-64bit-index' option to the 'convert-cf-to-spirv' pass, so user can specify the index bitwidth when control flow ops have a `index` type operand.
- Resolve unrealizedconversioncast op if possible in the func-to-spirv pass