### PR TITLE
[libc] fix -Wmissing-braces

### DIFF
--- a/libc/src/__support/HashTable/generic/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/generic/bitmask_impl.inc
@@ -113,7 +113,8 @@ struct Group {
   }
 
   LIBC_INLINE IteratableBitMask occupied() const {
-    return {{static_cast<bitmask_t>(mask_available().word ^ repeat_byte(0x80))}};
+    return {
+        {static_cast<bitmask_t>(mask_available().word ^ repeat_byte(0x80))}};
   }
 };
 } // namespace internal

--- a/libc/src/__support/HashTable/generic/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/generic/bitmask_impl.inc
@@ -113,7 +113,7 @@ struct Group {
   }
 
   LIBC_INLINE IteratableBitMask occupied() const {
-    return {static_cast<bitmask_t>(mask_available().word ^ repeat_byte(0x80))};
+    return {{static_cast<bitmask_t>(mask_available().word ^ repeat_byte(0x80))}};
   }
 };
 } // namespace internal

--- a/libc/src/__support/HashTable/table.h
+++ b/libc/src/__support/HashTable/table.h
@@ -333,7 +333,7 @@ public:
     return {0, full_capacity() - available_slots,
             Group::load_aligned(&control(0)).occupied(), *this};
   }
-  iterator end() const { return {0, 0, {{0}}, *this}; }
+  iterator end() const { return {0, 0, {BitMask{0}}, *this}; }
 
   LIBC_INLINE ENTRY *find(const char *key) {
     uint64_t primary = oneshot_hash(key);

--- a/libc/src/__support/HashTable/table.h
+++ b/libc/src/__support/HashTable/table.h
@@ -333,7 +333,7 @@ public:
     return {0, full_capacity() - available_slots,
             Group::load_aligned(&control(0)).occupied(), *this};
   }
-  iterator end() const { return {0, 0, {0}, *this}; }
+  iterator end() const { return {0, 0, {{0}}, *this}; }
 
   LIBC_INLINE ENTRY *find(const char *key) {
     uint64_t primary = oneshot_hash(key);


### PR DESCRIPTION
Fixes the following errors observed on the aarch64 fullbuild:

    /home/libc-buildbot/libc-aarch64-ubuntu/libc-aarch64-ubuntu-fullbuild-dbg/llvm-project/libc/src/__support/HashTable/generic/bitmask_impl.inc:116:13:
    error: suggest braces around initialization of subobject
    [-Werror,-Wmissing-braces]
        return {static_cast<bitmask_t>(mask_available().word ^ repeat_byte(0x80))};
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                {                                                                }
    In file included from
    /home/libc-buildbot/libc-aarch64-ubuntu/libc-aarch64-ubuntu-fullbuild-dbg/llvm-project/libc/src/search/hdestroy.cpp:10:
    /home/libc-buildbot/libc-aarch64-ubuntu/libc-aarch64-ubuntu-fullbuild-dbg/llvm-project/libc/src/__support/HashTable/table.h:336:41:
    error: suggest braces around initialization of subobject
    [-Werror,-Wmissing-braces]
      iterator end() const { return {0, 0, {0}, *this}; }
                                            ^
                                            {}

Link: https://lab.llvm.org/buildbot/#/builders/223/builds/33868/steps/6/logs/stdio
Link: https://github.com/llvm/llvm-project/pull/74506
