### PR TITLE
[libc++] Remove _LIBCPP_C_HAS_NO_GETS

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1133,11 +1133,6 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 #    define _LIBCPP_HAS_TRIVIAL_CONDVAR_DESTRUCTION
 #  endif
 
-// Some systems do not provide gets() in their C library, for security reasons.
-#  if defined(_LIBCPP_MSVCRT) || (defined(__FreeBSD_version) && __FreeBSD_version >= 1300043) || defined(__OpenBSD__)
-#    define _LIBCPP_C_HAS_NO_GETS
-#  endif
-
 #  if defined(__BIONIC__) || defined(__NuttX__) || defined(__Fuchsia__) || defined(__wasi__) ||                        \
       defined(_LIBCPP_HAS_MUSL_LIBC) || defined(__OpenBSD__)
 #    define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE

--- a/libcxx/include/cstdio
+++ b/libcxx/include/cstdio
@@ -159,7 +159,7 @@ using ::tmpfile _LIBCPP_USING_IF_EXISTS;
 using ::tmpnam _LIBCPP_USING_IF_EXISTS;
 
 using ::getchar _LIBCPP_USING_IF_EXISTS;
-#if _LIBCPP_STD_VER <= 11 && !defined(_LIBCPP_C_HAS_NO_GETS)
+#if _LIBCPP_STD_VER <= 11
 using ::gets _LIBCPP_USING_IF_EXISTS;
 #endif
 using ::scanf _LIBCPP_USING_IF_EXISTS;


### PR DESCRIPTION
Since we use _LIBCPP_USING_IF_EXISTS to handle missing C library functions now, _LIBCPP_C_HAS_NO_GETS shouldn't be necessary anymore. See discussion thread in #77242 for more details.