### PR TITLE
[lldb][[DWARFDeclContext] Add function to extract qualified names as vector

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
@@ -55,6 +55,12 @@ const char *DWARFDeclContext::GetQualifiedName() const {
   return m_qualified_name.c_str();
 }
 
+llvm::SmallVector<llvm::StringRef>
+DWARFDeclContext::GetQualifiedNameAsVector() const {
+  return llvm::to_vector_of<llvm::StringRef>(
+      llvm::map_range(m_entries, GetName));
+}
+
 bool DWARFDeclContext::operator==(const DWARFDeclContext &rhs) const {
   if (m_entries.size() != rhs.m_entries.size())
     return false;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
@@ -68,6 +68,11 @@ public:
 
   const char *GetQualifiedName() const;
 
+  /// Returns a vector of string, one string per entry in the fully qualified
+  /// name. For example, for the name `A::B::C`, this methods returns `{"A",
+  /// "B", "C"}`
+  llvm::SmallVector<llvm::StringRef> GetQualifiedNameAsVector() const;
+
   // Same as GetQualifiedName, but the life time of the returned string will
   // be that of the LLDB session.
   ConstString GetQualifiedNameAsConstString() const {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
@@ -69,8 +69,8 @@ public:
   const char *GetQualifiedName() const;
 
   /// Returns a vector of string, one string per entry in the fully qualified
-  /// name. For example, for the name `A::B::C`, this methods returns `{"A",
-  /// "B", "C"}`
+  /// name. For example, for the DeclContext `A::B::C`, this methods returns
+  /// `{"C", "B", "A"}`
   llvm::SmallVector<llvm::StringRef> GetQualifiedNameAsVector() const;
 
   // Same as GetQualifiedName, but the life time of the returned string will


### PR DESCRIPTION
This functionality will support the efforts to implement the IDX_Parent attribute of accelerator table entries, and it will allow us to more easily compare each of the names in a DIE parent chain hierarchy.

https://discourse.llvm.org/t/rfc-improve-dwarf-5-debug-names-type-lookup-parsing-speed/74151/45