### PR TITLE
[libc] make off_t 32b for 32b arm

### DIFF
--- a/libc/include/llvm-libc-types/off_t.h
+++ b/libc/include/llvm-libc-types/off_t.h
@@ -9,7 +9,7 @@
 #ifndef __LLVM_LIBC_TYPES_OFF_T_H__
 #define __LLVM_LIBC_TYPES_OFF_T_H__
 
-#if defined(__LP64__) || defined (__riscv)
+#if defined(__LP64__) || defined(__riscv)
 typedef __INT64_TYPE__ off_t;
 #else
 typedef __INT32_TYPE__ off_t;

--- a/libc/include/llvm-libc-types/off_t.h
+++ b/libc/include/llvm-libc-types/off_t.h
@@ -9,6 +9,10 @@
 #ifndef __LLVM_LIBC_TYPES_OFF_T_H__
 #define __LLVM_LIBC_TYPES_OFF_T_H__
 
+#if defined(__LP64__) || defined (__riscv)
 typedef __INT64_TYPE__ off_t;
+#else
+typedef __INT32_TYPE__ off_t;
+#endif // __LP64__ || __riscv
 
 #endif // __LLVM_LIBC_TYPES_OFF_T_H__


### PR DESCRIPTION
Fixes the following diagnostic:

    llvm-project/libc/src/sys/mman/linux/mmap.cpp:44:59: error: implicit
    conversion loses integer precision: 'off_t' (aka 'long long') to 'long'
    [-Werror,-Wshorten-64-to-32]
     size, prot, flags, fd, offset);
                            ^~~~~~

It looks like off_t is a curious types on different platforms.  FWICT, it's 32b
on arm (at least for arm-linux-gnueabi) but 64b elsewhere (including 32b
riscv32-linux-gnu).
