### PR TITLE
[Support] Trim trailing null character in PrettyStackTraceFormat.

### DIFF
--- a/llvm/lib/Support/PrettyStackTrace.cpp
+++ b/llvm/lib/Support/PrettyStackTrace.cpp
@@ -249,6 +249,8 @@ PrettyStackTraceFormat::PrettyStackTraceFormat(const char *Format, ...) {
   va_start(AP, Format);
   vsnprintf(Str.data(), Size, Format, AP);
   va_end(AP);
+  // Remove the '\0' for printing.
+  Str.pop_back();
 }
 
 void PrettyStackTraceFormat::print(raw_ostream &OS) const { OS << Str << "\n"; }


### PR DESCRIPTION
Space for the `\0` is added on line 247, but the value is not trimmed. `SmallVector` prints the entire contents, including the `\0`. To fix, pop the back value to remove the `\0`.

Sample program, and `cat -v` can be used to show the null (as `^@`):

```
#include "llvm/Support/PrettyStackTrace.h"

auto main() -> int {
  auto msg = llvm::PrettyStackTraceFormat("x");
  llvm::EnablePrettyStackTrace();
  assert(false);
}
```

Before:

```
$ ./crash_test |& cat -v
crash_test: toolchain/driver/crash_test.cpp:6: int main(): Assertion `false' failed.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.	x^@
```

After:

```
$ ./crash_test |& cat -v
crash_test: toolchain/driver/crash_test.cpp:6: int main(): Assertion `false' failed.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.	x
```

Fixes #81273