### PR TITLE
Move the PowerPC/PPCMergeStringPool work to initializer

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCMergeStringPool.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMergeStringPool.cpp
@@ -86,7 +86,8 @@ public:
   static char ID;
   PPCMergeStringPool() : ModulePass(ID) {}
 
-  bool runOnModule(Module &M) override { return mergeModuleStringPool(M); }
+  bool doInitialization(Module &M) override { return mergeModuleStringPool(M); }
+  bool runOnModule(Module &M) override { return false; }
 
   StringRef getPassName() const override { return "PPC Merge String Pool"; }
 

--- a/llvm/test/CodeGen/PowerPC/mergeable-string-pool-large.ll
+++ b/llvm/test/CodeGen/PowerPC/mergeable-string-pool-large.ll
@@ -319,16 +319,16 @@ define dso_local signext i32 @array0() local_unnamed_addr #0 {
 ; AIX32-NEXT:    mflr r0
 ; AIX32-NEXT:    stwu r1, -96(r1)
 ; AIX32-NEXT:    lis r6, 0
-; AIX32-NEXT:    lwz r4, L..C0(r2) # @__ModuleStringPool
-; AIX32-NEXT:    li r5, 12
+; AIX32-NEXT:    lwz r5, L..C0(r2) # @__ModuleStringPool
+; AIX32-NEXT:    li r4, 12
 ; AIX32-NEXT:    addi r3, r1, 64
 ; AIX32-NEXT:    stw r0, 104(r1)
 ; AIX32-NEXT:    ori r7, r6, 35596
-; AIX32-NEXT:    rlwimi r5, r3, 0, 30, 27
-; AIX32-NEXT:    lxvw4x vs0, r4, r7
-; AIX32-NEXT:    stxvw4x vs0, 0, r5
-; AIX32-NEXT:    ori r5, r6, 35584
-; AIX32-NEXT:    lxvw4x vs0, r4, r5
+; AIX32-NEXT:    rlwimi r4, r3, 0, 30, 27
+; AIX32-NEXT:    lxvw4x vs0, r5, r7
+; AIX32-NEXT:    stxvw4x vs0, 0, r4
+; AIX32-NEXT:    ori r4, r6, 35584
+; AIX32-NEXT:    lxvw4x vs0, r5, r4
 ; AIX32-NEXT:    stxvw4x vs0, 0, r3
 ; AIX32-NEXT:    bl .calleeInt[PR]
 ; AIX32-NEXT:    nop

--- a/llvm/test/CodeGen/PowerPC/mergeable-string-pool.ll
+++ b/llvm/test/CodeGen/PowerPC/mergeable-string-pool.ll
@@ -398,16 +398,16 @@ define dso_local signext i32 @array1() local_unnamed_addr #0 {
 ; AIX32:       # %bb.0: # %entry
 ; AIX32-NEXT:    mflr r0
 ; AIX32-NEXT:    stwu r1, -96(r1)
-; AIX32-NEXT:    lwz r4, L..C0(r2) # @__ModuleStringPool
+; AIX32-NEXT:    lwz r5, L..C0(r2) # @__ModuleStringPool
 ; AIX32-NEXT:    li r6, 372
-; AIX32-NEXT:    li r5, 12
+; AIX32-NEXT:    li r4, 12
 ; AIX32-NEXT:    addi r3, r1, 64
 ; AIX32-NEXT:    stw r0, 104(r1)
-; AIX32-NEXT:    rlwimi r5, r3, 0, 30, 27
-; AIX32-NEXT:    lxvw4x vs0, r4, r6
-; AIX32-NEXT:    stxvw4x vs0, 0, r5
-; AIX32-NEXT:    li r5, 360
-; AIX32-NEXT:    lxvw4x vs0, r4, r5
+; AIX32-NEXT:    rlwimi r4, r3, 0, 30, 27
+; AIX32-NEXT:    lxvw4x vs0, r5, r6
+; AIX32-NEXT:    stxvw4x vs0, 0, r4
+; AIX32-NEXT:    li r4, 360
+; AIX32-NEXT:    lxvw4x vs0, r5, r4
 ; AIX32-NEXT:    stxvw4x vs0, 0, r3
 ; AIX32-NEXT:    bl .calleeInt[PR]
 ; AIX32-NEXT:    nop
@@ -1148,7 +1148,7 @@ entry:
 
 attributes #0 = { nounwind }
 
-; AIXDATA: .csect L..__ModuleStringPool[RO],2
+; AIXDATA: .csect L..__ModuleStringPool[RO],3
 ; AIXDATA:       .align  3                               # @__ModuleStringPool
 ; AIXDATA:       .vbyte  4, 5                            # 0x5
 ; AIXDATA:       .vbyte  4, 7                            # 0x7


### PR DESCRIPTION
Currently, the `PPCMergeStringPool` merges the global variable after the `AsmPrinter` initializer adds the global variables to its symbol list. This is to move the merging work of `PPCMergeStringPool` to its initializer, just like what GlobalMerge does, to avoid adding merged global variables to the `AsmPrinter` symbol lis.  