### PR TITLE
[flang][Driver] Support -pthread in the frontend

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5307,7 +5307,8 @@ def pthreads : Flag<["-"], "pthreads">;
 defm pthread : BoolOption<"", "pthread",
   LangOpts<"POSIXThreads">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption], "Support POSIX threads in generated code">,
-  NegFlag<SetFalse>, BothFlags<[], [ClangOption, CC1Option]>>;
+  NegFlag<SetFalse>,
+  BothFlags<[], [ClangOption, CC1Option, FlangOption, FC1Option]>>;
 def pie : Flag<["-"], "pie">, Group<Link_Group>;
 def static_pie : Flag<["-"], "static-pie">, Group<Link_Group>;
 def read__only__relocs : Separate<["-"], "read_only_relocs">;

--- a/flang/test/Driver/driver-help-hidden.f90
+++ b/flang/test/Driver/driver-help-hidden.f90
@@ -139,6 +139,7 @@
 ! CHECK-NEXT: -pedantic               Warn on language extensions
 ! CHECK-NEXT: -print-effective-triple Print the effective target triple
 ! CHECK-NEXT: -print-target-triple    Print the normalized target triple
+! CHECK-NEXT: -pthread                Support POSIX threads in generated code
 ! CHECK-NEXT: -P                      Disable linemarker output in -E mode
 ! CHECK-NEXT: -Rpass-analysis=<value> Report transformation analysis from optimization passes whose name matches the given POSIX regular expression
 ! CHECK-NEXT: -Rpass-missed=<value>   Report missed transformations by optimization passes whose name matches the given POSIX regular expression

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -125,6 +125,7 @@
 ! HELP-NEXT: -pedantic               Warn on language extensions
 ! HELP-NEXT: -print-effective-triple Print the effective target triple
 ! HELP-NEXT: -print-target-triple    Print the normalized target triple
+! HELP-NEXT: -pthread                Support POSIX threads in generated code
 ! HELP-NEXT: -P                      Disable linemarker output in -E mode
 ! HELP-NEXT: -Rpass-analysis=<value> Report transformation analysis from optimization passes whose name matches the given POSIX regular expression
 ! HELP-NEXT: -Rpass-missed=<value>   Report missed transformations by optimization passes whose name matches the given POSIX regular expression
@@ -265,6 +266,7 @@
 ! HELP-FC1-NEXT: -pic-is-pie             File is for a position independent executable
 ! HELP-FC1-NEXT: -pic-level <value>      Value for __PIC__
 ! HELP-FC1-NEXT: -plugin <name>          Use the named plugin action instead of the default action (use "help" to list available options)
+! HELP-FC1-NEXT: -pthread                Support POSIX threads in generated code
 ! HELP-FC1-NEXT: -P                      Disable linemarker output in -E mode
 ! HELP-FC1-NEXT: -Rpass-analysis=<value> Report transformation analysis from optimization passes whose name matches the given POSIX regular expression
 ! HELP-FC1-NEXT: -Rpass-missed=<value>   Report missed transformations by optimization passes whose name matches the given POSIX regular expression

--- a/flang/test/Driver/pthread.f90
+++ b/flang/test/Driver/pthread.f90
@@ -1,0 +1,22 @@
+! In release 2.34, glibc removed libpthread as a separate library. All the
+! pthread_* functions were subsumed into libc, so linking that is sufficient.
+! However, when linking against older glibc builds, the explicit link of
+! -pthread will be required. More details are here:
+!
+! https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread#the_developer_view
+!
+! This makes it difficult to write a test that requires the -pthread flag in
+! order to pass. Checking for the presence of -lpthread in the linker flags is
+! not reliable since the linker could just skip the flag altogether if it is
+! linking against a new libc implementation.
+
+! RUN: %flang -### -pthread /dev/null -o /dev/null 2>&1 | FileCheck %s
+! RUN: %flang -### -Xflang -pthread /dev/null -o /dev/null 2>&1 | FileCheck %s
+
+! How the -pthread flag is handled is very platform-specific. A lot of that
+! functionality is tested by clang, and the flag itself is handled by clang's
+! driver that flang also uses. Instead of duplicating all that testing here,
+! just check that the presence of the flag does not raise an error. If we need
+! more customized handling of -pthread, the tests for that can be added here.
+!
+! CHECK-NOT: error:


### PR DESCRIPTION
The -pthread option is supported by both clang and gfortran.

The -pthread option seems to be extensively tested for various platforms by clang. We should be able to piggy-back on those tests since we use the relevant parts of the clang driver. Therefore, the only test added is to ensure that the option is recognized by the frontend.

This has only be tested on x86 Linux.