### PR TITLE
Add support to meger strings used by metadata

### DIFF
--- a/llvm/test/CodeGen/PowerPC/merge-string-used-by-metadata.mir
+++ b/llvm/test/CodeGen/PowerPC/merge-string-used-by-metadata.mir
@@ -1,0 +1,54 @@
+# RUN: llc -run-pass=ppc-merge-strings -mcpu=pwr8 -mtriple powerpc64le-unknown-linux-gnu \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+# RUN: llc -run-pass=ppc-merge-strings -mcpu=pwr8 -mtriple powerpc64-ibm-aix-xcoff \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+--- |
+  ; Constants list.
+  @const.1 = internal constant [7 x i8] c"const1\00", align 1
+  @const.2 = internal constant [7 x i8] c"const2\00", align 1
+
+  ;;
+  ;; Start of test code.
+  ;;
+
+  define noundef ptr @func1(ptr noundef nonnull align 8 dereferenceable(8) %this) #0 !dbg !6 {
+  ; CHECK-LABEL: func1
+  ; CHECK:       %0 = getelementptr { [7 x i8], [7 x i8] }, ptr @__ModuleStringPool, i32 0, i32 1
+  ; CHECK-NEXT:  ret ptr %0, !dbg !14
+  entry:
+    ret ptr @const.2, !dbg !14
+  }
+
+  define noundef ptr @func2(ptr noundef nonnull align 8 dereferenceable(8) %this) #0 {
+  ; CHECK-LABEL: func2
+  ; CHECK:       %0 = getelementptr { [7 x i8], [7 x i8] }, ptr @__ModuleStringPool, i32 0, i32 0
+  ; CHECK-NEXT:  ret ptr %0
+  entry:
+    ret ptr @const.1
+  }
+
+  attributes #0 = { noinline nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="pwr8" "target-features"="+altivec,+bpermd,+crbits,+crypto,+direct-move,+extdiv,+htm,+isa-v206-instructions,+isa-v207-instructions,+power8-vector,+quadword-atomics,+vsx,-aix-small-local-exec-tls,-isa-v30-instructions,-power9-vector,-privileged,-rop-protect,-spe" }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3, !4}
+  !llvm.ident = !{!5}
+
+  ; CHECK:       !10 = !DITemplateValueParameter(name: "ID", type: !11, value: ptr getelementptr inbounds ({ [7 x i8], [7 x i8] }, ptr @__ModuleStringPool, i32 0, i32 1))
+  !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
+  !1 = !DIFile(filename: "constant-pointers.cpp", directory: "/tmp/dbginfo")
+  !2 = !{}
+  !3 = !{i32 7, !"Dwarf Version", i32 3}
+  !4 = !{i32 2, !"Debug Info Version", i32 3}
+  !5 = !{!"clang version 17.0.0"}
+  !6 = distinct !DISubprogram(name: "getId", linkageName: "func1", scope: !1, file: !1, line: 2, type: !7, scopeLine: 2, virtualIndex: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !9, retainedNodes: !2)
+  !7 = !DISubroutineType(types: !8)
+  !8 = !{null}
+  !9 = !{!10}
+  !10 = !DITemplateValueParameter(name: "ID", type: !11, value: ptr @const.2)
+  !11 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !12, size: 64)
+  !12 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !13)
+  !13 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+  !14 = !DILocation(line: 3, scope: !6)
+
+...


### PR DESCRIPTION
Currently if the merged string is used by metadata, its metadata uses are not replaced if the string is merged. This is to add code support for the metadata use replacement.