### PR TITLE
[flang][driver] Add support for -isysroot in the frontend

### DIFF
--- a/clang/docs/InternalsManual.rst
+++ b/clang/docs/InternalsManual.rst
@@ -931,7 +931,7 @@ the option appears on the command line, the argument value is simply copied.
 .. code-block:: text
 
   def isysroot : JoinedOrSeparate<["-"], "isysroot">,
-    Visibility<[ClangOption, CC1Option]>,
+    Visibility<[ClangOption, CC1Option, FlangOption]>,
     MarshallingInfoString<HeaderSearchOpts<"Sysroot">, [{"/"}]>;
 
 **List of Strings**

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4265,7 +4265,7 @@ def iquote : JoinedOrSeparate<["-"], "iquote">, Group<clang_i_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Add directory to QUOTE include search path">, MetaVarName<"<directory>">;
 def isysroot : JoinedOrSeparate<["-"], "isysroot">, Group<clang_i_Group>,
-  Visibility<[ClangOption, CC1Option]>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
   HelpText<"Set the system root directory (usually /)">, MetaVarName<"<dir>">,
   MarshallingInfoString<HeaderSearchOpts<"Sysroot">, [{"/"}]>;
 def isystem : JoinedOrSeparate<["-"], "isystem">, Group<clang_i_Group>,

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -220,6 +220,13 @@ static or shared library, the generated library does not need a `main`
 function, as a final link stage will occur that will provide the `Fortran_main`
 library when creating the final executable.
 
+On Darwin, the logical root where the system libraries are located (sysroot)
+must be specified. This can be done with the cmake build flag `DEFAULT_SYSROOT`
+or by using the `-isysroot` flag when linking a binary. On other targets
+`-isysroot` doesn't change the linker command line. While with Clang
+`-isysroot` also changes the sysroot for includes, with Flang it only affects
+Darwin libraries' sysroot.
+
 ## Frontend Driver
 Flang's frontend driver is the main interface between compiler developers and
 the Flang frontend. The high-level design is similar to Clang's frontend

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -221,11 +221,12 @@ function, as a final link stage will occur that will provide the `Fortran_main`
 library when creating the final executable.
 
 On Darwin, the logical root where the system libraries are located (sysroot)
-must be specified. This can be done with the cmake build flag `DEFAULT_SYSROOT`
+must be specified. This can be done with the CMake build flag `DEFAULT_SYSROOT`
 or by using the `-isysroot` flag when linking a binary. On other targets
-`-isysroot` doesn't change the linker command line. While with Clang
-`-isysroot` also changes the sysroot for includes, with Flang it only affects
-Darwin libraries' sysroot.
+`-isysroot` doesn't change the linker command line (it only affects the header
+search path). While with Clang `-isysroot` also changes the sysroot for
+includes, with Flang (and Fortran in general) it only affects Darwin libraries'
+sysroot.
 
 ## Frontend Driver
 Flang's frontend driver is the main interface between compiler developers and

--- a/flang/test/Driver/compiler-options.f90
+++ b/flang/test/Driver/compiler-options.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -S -emit-llvm -flang-deprecated-no-hlfir -o - %s | FileCheck %s
 ! Test communication of COMPILER_OPTIONS from flang-new to flang-new -fc1.
-! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
+! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} {{.*}}-S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/ctofortran.f90
+++ b/flang/test/Driver/ctofortran.f90
@@ -1,8 +1,7 @@
-! MacOS needs -isysroot <osx_sysroot> with clang and flang to build binaries.
-! UNSUPPORTED: system-windows, system-darwin
+! UNSUPPORTED: system-windows
 ! RUN: split-file %s %t
 ! RUN: chmod +x %t/runtest.sh
-! RUN: %t/runtest.sh %t %flang $t/ffile.f90 $t/cfile.c
+! RUN: %t/runtest.sh %t %t/ffile.f90 %t/cfile.c %flang | FileCheck %s
 
 !--- ffile.f90
 program fmain
@@ -68,15 +67,21 @@ void csub() {
 }
 !--- runtest.sh
 #!/bin/bash
-export BINDIR=`dirname $2`
-export CCOMP=$BINDIR/clang
+TMPDIR=$1
+FFILE=$2
+CFILE=$3
+FLANG=$4
+shift 4
+FLAGS="$*"
+BINDIR=`dirname $FLANG`
+LIBDIR=$BINDIR/../lib
+CCOMP=$BINDIR/clang
 if [ -x $CCOMP ]
 then
-  export LIBDIR=$BINDIR/../lib
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBDIR
-  $CCOMP -c $1/$4 -o $1/cfile.o
-  $2 $1/$3 $1/cfile.o -o $1/ctofortran
-  $1/ctofortran # should print "PASS"
+  $CCOMP $FLAGS -c $CFILE -o $TMPDIR/cfile.o
+  $FLANG $FLAGS $FFILE $TMPDIR/cfile.o -o $TMPDIR/ctofortran
+  $TMPDIR/ctofortran # should print "PASS"
 else
   # No clang compiler, just pass by default
   echo "PASS"

--- a/flang/test/Driver/driver-help-hidden.f90
+++ b/flang/test/Driver/driver-help-hidden.f90
@@ -111,6 +111,7 @@
 ! CHECK-NEXT: -g                      Generate source-level debug information
 ! CHECK-NEXT: --help-hidden           Display help for hidden options
 ! CHECK-NEXT: -help                   Display available options
+! CHECK-NEXT: -isysroot <dir>         Set the system root directory (usually /)
 ! CHECK-NEXT: -I <dir>                Add directory to the end of the list of include search paths
 ! CHECK-NEXT: -L <dir>                Add directory to library search path
 ! CHECK-NEXT: -march=<value>          For a list of available architectures for the target use '-mcpu=help'

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -97,6 +97,7 @@
 ! HELP-NEXT: -g                      Generate source-level debug information
 ! HELP-NEXT: --help-hidden           Display help for hidden options
 ! HELP-NEXT: -help                   Display available options
+! HELP-NEXT: -isysroot <dir>         Set the system root directory (usually /)
 ! HELP-NEXT: -I <dir>                Add directory to the end of the list of include search paths
 ! HELP-NEXT: -L <dir>                Add directory to library search path
 ! HELP-NEXT: -march=<value>          For a list of available architectures for the target use '-mcpu=help'

--- a/flang/test/Driver/exec-darwin.f90
+++ b/flang/test/Driver/exec-darwin.f90
@@ -1,0 +1,11 @@
+! REQUIRES: system-darwin
+! Verify that flang can correctly build executables on Darwin.
+
+! RUN: %flang %s -o %t
+! RUN: %t | FileCheck %s
+! RUN: rm -f %t
+
+! CHECK: Hello, World!
+program hello
+  print *, "Hello, World!"
+end program

--- a/flang/test/Driver/exec.f90
+++ b/flang/test/Driver/exec.f90
@@ -1,5 +1,4 @@
-! REQUIRES: system-darwin
-! Verify that flang can correctly build executables on Darwin.
+! Verify that flang can correctly build executables.
 
 ! RUN: %flang %s -o %t
 ! RUN: %t | FileCheck %s

--- a/flang/test/Driver/falias-analysis.f90
+++ b/flang/test/Driver/falias-analysis.f90
@@ -9,12 +9,12 @@
 ! RUN: %flang -c -emit-llvm -O0 %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
 ! RUN: %flang -c -emit-llvm %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
 
-! RUN: %flang -fc1 -emit-llvm -O3 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
-! RUN: %flang -fc1 -emit-llvm -O2 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
-! RUN: %flang -fc1 -emit-llvm -O1 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
+! RUN: %flang_fc1 -emit-llvm -O3 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
+! RUN: %flang_fc1 -emit-llvm -O2 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
+! RUN: %flang_fc1 -emit-llvm -O1 %s -o - | FileCheck %s --check-prefix=CHECK-AA --check-prefix=CHECK-ALL
 
-! RUN: %flang -fc1 -emit-llvm -O0 %s -o - | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
-! RUN: %flang -fc1 -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
+! RUN: %flang_fc1 -emit-llvm -O0 %s -o - | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
+! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-NOAA --check-prefix=CHECK-ALL
 
 subroutine simple(a)
   integer, intent(inout) :: a(:)

--- a/flang/test/Driver/input-from-stdin/input-from-stdin.f90
+++ b/flang/test/Driver/input-from-stdin/input-from-stdin.f90
@@ -17,13 +17,13 @@
 ! FLANG FRONTEND DRIVER (flang -fc1)
 !---------------------------------------
 ! Test `-E`: for the corresponding frontend actions the driver relies on the prescanner API to handle file I/O
-! RUN: cat %s | %flang -fc1 -E -cpp | FileCheck %s --check-prefix=PP-NOT-DEFINED
-! RUN: cat %s | %flang -fc1 -DNEW -E -cpp | FileCheck %s --check-prefix=PP-DEFINED
+! RUN: cat %s | %flang_fc1 -E -cpp | FileCheck %s --check-prefix=PP-NOT-DEFINED
+! RUN: cat %s | %flang_fc1 -DNEW -E -cpp | FileCheck %s --check-prefix=PP-DEFINED
 
 ! Test `-test-io`: for the corresponding frontend action (`InputOutputTestAction`) the driver handles the file I/O on its own
 ! the corresponding action (`PrintPreprocessedAction`)
-! RUN: cat %s | %flang -fc1 -test-io -cpp | FileCheck %s --check-prefix=IO --match-full-lines
-! RUN: cat %s | %flang -fc1 -DNEW -cpp -test-io | FileCheck %s --check-prefix=IO --match-full-lines
+! RUN: cat %s | %flang_fc1 -test-io -cpp | FileCheck %s --check-prefix=IO --match-full-lines
+! RUN: cat %s | %flang_fc1 -DNEW -cpp -test-io | FileCheck %s --check-prefix=IO --match-full-lines
 
 ! PP-NOT-DEFINED: Program B
 ! PP-DEFINED: Program A

--- a/flang/test/Driver/isysroot.f90
+++ b/flang/test/Driver/isysroot.f90
@@ -6,7 +6,7 @@
 ! RUN: %flang -### --target=aarch64-linux-gnu -isysroot /path/to/sysroot \
 ! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-LINUX
 
-! CHECK-DARWIN: "{{.*}}/ld" {{.*}}"-syslibroot" "/path/to/sysroot"
+! CHECK-DARWIN: "{{.*[\/]}}ld" {{.*}}"-syslibroot" "/path/to/sysroot"
 ! Unused on Linux.
 ! CHECK-LINUX: warning: argument unused during compilation: '-isysroot /path/to/sysroot'
 ! CHECK-LINUX-NOT: /path/to/sysroot

--- a/flang/test/Driver/isysroot.f90
+++ b/flang/test/Driver/isysroot.f90
@@ -1,0 +1,12 @@
+! Verify that the -isysroot flag is known to the frontend and, on Darwin,
+! is passed on to the linker.
+
+! RUN: %flang -### --target=aarch64-apple-darwin -isysroot /path/to/sysroot \
+! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-DARWIN
+! RUN: %flang -### --target=aarch64-linux-gnu -isysroot /path/to/sysroot \
+! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-LINUX
+
+! CHECK-DARWIN: "{{.*}}/ld" {{.*}}"-syslibroot" "/path/to/sysroot"
+! Unused on Linux.
+! CHECK-LINUX: warning: argument unused during compilation: '-isysroot /path/to/sysroot'
+! CHECK-LINUX-NOT: /path/to/sysroot

--- a/flang/test/Preprocessing/preprocessed-dirs.F90
+++ b/flang/test/Preprocessing/preprocessed-dirs.F90
@@ -1,4 +1,4 @@
-! RUN: %flang -fc1 -E -fopenacc %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -E -fopenacc %s 2>&1 | FileCheck %s
 !CHECK: subroutine r4(x) Z real :: x Z !$acc routine Z print *, x Z end
 #define SUB(s, t) subroutine s(x) Z\
   t :: x Z\

--- a/flang/test/Semantics/OpenMP/use_device_addr.f90
+++ b/flang/test/Semantics/OpenMP/use_device_addr.f90
@@ -1,4 +1,4 @@
-! RUN: %flang -fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
 ! OpenMP Version 5.1
 ! 2.14.2 use_device_addr clause
 ! List item that appears in a use_device_addr clause has corresponding storage

--- a/flang/test/Semantics/OpenMP/use_device_ptr.f90
+++ b/flang/test/Semantics/OpenMP/use_device_ptr.f90
@@ -1,4 +1,4 @@
-! RUN: %flang -fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
 ! OpenMP Version 5.0
 ! 2.10.1 use_device_ptr clause
 ! List items that appear in a use_device_ptr clause are converted into device

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -130,7 +130,7 @@ tools = [
         "%flang",
         command=FindTool("flang-new"),
         extra_args=isysroot_flag,
-        unresolved="fatal"
+        unresolved="fatal",
     ),
     ToolSubst(
         "%flang_fc1",

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -118,10 +118,17 @@ if config.flang_standalone_build:
                 "PATH", config.flang_llvm_tools_dir, append_path=True
             )
 
+# On MacOS, -isysroot is needed to build binaries.
+isysroot_flag = []
+if config.osx_sysroot:
+    isysroot_flag = ["-isysroot", config.osx_sysroot]
+
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.
 tools = [
-    ToolSubst("%flang", command=FindTool("flang-new"), unresolved="fatal"),
+    ToolSubst("%flang", command=FindTool("flang-new"),
+              extra_args=isysroot_flag,
+              unresolved="fatal"),
     ToolSubst(
         "%flang_fc1",
         command=FindTool("flang-new"),
@@ -163,10 +170,9 @@ if config.cc:
         and os.path.isdir(include)
     ):
         config.available_features.add("c-compiler")
-        cc_cmd = config.cc
-        if config.osx_sysroot:
-            cc_cmd += " -isysroot " + config.osx_sysroot
-        tools.append(ToolSubst("%cc", command=cc_cmd, unresolved="fatal"))
+        tools.append(ToolSubst("%cc", command=config.cc,
+                               extra_args=isysroot_flag,
+                               unresolved="fatal"))
         tools.append(ToolSubst("%libruntime", command=libruntime, unresolved="fatal"))
         tools.append(ToolSubst("%libdecimal", command=libdecimal, unresolved="fatal"))
         tools.append(ToolSubst("%include", command=include, unresolved="fatal"))

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -126,9 +126,12 @@ if config.osx_sysroot:
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.
 tools = [
-    ToolSubst("%flang", command=FindTool("flang-new"),
-              extra_args=isysroot_flag,
-              unresolved="fatal"),
+    ToolSubst(
+        "%flang",
+        command=FindTool("flang-new"),
+        extra_args=isysroot_flag,
+        unresolved="fatal"
+    ),
     ToolSubst(
         "%flang_fc1",
         command=FindTool("flang-new"),
@@ -170,9 +173,11 @@ if config.cc:
         and os.path.isdir(include)
     ):
         config.available_features.add("c-compiler")
-        tools.append(ToolSubst("%cc", command=config.cc,
-                               extra_args=isysroot_flag,
-                               unresolved="fatal"))
+        tools.append(
+            ToolSubst(
+                "%cc", command=config.cc, extra_args=isysroot_flag, unresolved="fatal"
+            )
+        )
         tools.append(ToolSubst("%libruntime", command=libruntime, unresolved="fatal"))
         tools.append(ToolSubst("%libdecimal", command=libdecimal, unresolved="fatal"))
         tools.append(ToolSubst("%include", command=include, unresolved="fatal"))


### PR DESCRIPTION
If DEFAULT_SYSROOT is not specfied when building flang, then the
-isysroot flag is needed to link binaries against system libraries
on Darwin. It's also needed when linking against a non-default
sysroot.
