### PR TITLE
[clang-format][Docs] Remove duplicated words in AlignCaseColons description

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -868,7 +868,7 @@ the configuration (without a prefix: ``Auto``).
       }
 
   * ``bool AlignCaseColons`` Whether aligned case labels are aligned on the colon, or on the
-    , or on the tokens after the colon.
+    tokens after the colon.
 
     .. code-block:: c++
 


### PR DESCRIPTION
A few words got duplicated in the documentation of AlignCaseColons option for AlignConsecutiveShortCaseStatements

Remove them to improve readability