### PR TITLE
[clang] Update cxx_dr_status.html

### DIFF
--- a/clang/test/CXX/drs/dr24xx.cpp
+++ b/clang/test/CXX/drs/dr24xx.cpp
@@ -45,7 +45,7 @@ void fallthrough(int n) {
 #endif
 }
 
-namespace dr2450 { // dr2450: 18 drafting
+namespace dr2450 { // dr2450: 18 review
 #if __cplusplus >= 202302L
 struct S {int a;};
 template <S s>

--- a/clang/test/CXX/drs/dr25xx.cpp
+++ b/clang/test/CXX/drs/dr25xx.cpp
@@ -83,7 +83,7 @@ using ::dr2521::operator""_div;
 
 
 #if __cplusplus >= 202302L
-namespace dr2553 { // dr2553: 18
+namespace dr2553 { // dr2553: 18 review
 struct B {
   virtual void f(this B&); 
   // since-cxx23-error@-1 {{an explicit object parameter cannot appear in a virtual function}}
@@ -143,7 +143,7 @@ void foo() {
 #endif
 
 
-namespace dr2565 { // dr2565: 16
+namespace dr2565 { // dr2565: 16 open
 #if __cplusplus >= 202002L
   template<typename T>
     concept C = requires (typename T::type x) {

--- a/clang/test/CXX/drs/dr26xx.cpp
+++ b/clang/test/CXX/drs/dr26xx.cpp
@@ -24,7 +24,7 @@ using enum E;
 #endif
 }
 
-namespace dr2628 { // dr2628: no open
+namespace dr2628 { // dr2628: no
                    // this was reverted for the 16.x release
                    // due to regressions, see the issue for more details:
                    // https://github.com/llvm/llvm-project/issues/60777
@@ -197,7 +197,7 @@ J j = { "ghi" };
 #endif
 }
 
-namespace dr2672 { // dr2672: 18 open
+namespace dr2672 { // dr2672: 18
 #if __cplusplus >= 202002L
 template <class T>
 void f(T) requires requires { []() { T::invalid; } (); };

--- a/clang/test/CXX/drs/dr27xx.cpp
+++ b/clang/test/CXX/drs/dr27xx.cpp
@@ -10,7 +10,7 @@
 // expected-no-diagnostics
 #endif
 
-namespace dr2789 { // dr2789: 18 open
+namespace dr2789 { // dr2789: 18
 #if __cplusplus >= 202302L
 template <typename T = int>
 struct Base {
@@ -42,7 +42,7 @@ void test() {
 #endif
 }
 
-namespace dr2798 { // dr2798: 17 drafting
+namespace dr2798 { // dr2798: 17
 #if __cpp_static_assert >= 202306
 struct string {
   constexpr string() {

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1055,7 +1055,7 @@
   </tr>
   <tr id="170">
     <td><a href="https://cplusplus.github.io/CWG/issues/170.html">170</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Pointer-to-member conversions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -1426,11 +1426,11 @@ accessible?</td>
     <td>Visibility of names after <I>using-directive</I>s</td>
     <td class="full" align="center">Yes</td>
   </tr>
-  <tr class="open" id="232">
+  <tr id="232">
     <td><a href="https://cplusplus.github.io/CWG/issues/232.html">232</a></td>
-    <td>drafting</td>
+    <td>NAD</td>
     <td>Is indirection through a null pointer undefined behavior?</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="233">
     <td><a href="https://cplusplus.github.io/CWG/issues/233.html">233</a></td>
@@ -2661,7 +2661,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/437.html">437</a></td>
     <td>CD1</td>
     <td>Is type of class allowed in member function exception specification?</td>
-    <td class="none" align="center">Superseded by <a href="#1308">1308</a></td>
+    <td class="full" align="center">Superseded by <a href="#1308">1308</a></td>
   </tr>
   <tr id="438">
     <td><a href="https://cplusplus.github.io/CWG/issues/438.html">438</a></td>
@@ -2753,11 +2753,11 @@ of class templates</td>
     <td>Wording nit on description of <TT>this</TT></td>
     <td class="full" align="center">Yes</td>
   </tr>
-  <tr class="open" id="453">
+  <tr id="453">
     <td><a href="https://cplusplus.github.io/CWG/issues/453.html">453</a></td>
-    <td>drafting</td>
+    <td>tentatively ready</td>
     <td>References may only bind to &#8220;valid&#8221; objects</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="454">
     <td><a href="https://cplusplus.github.io/CWG/issues/454.html">454</a></td>
@@ -2789,11 +2789,11 @@ of class templates</td>
     <td>Hiding of member template parameters by other members</td>
     <td class="full" align="center">Clang 11</td>
   </tr>
-  <tr class="open" id="459">
+  <tr id="459">
     <td><a href="https://cplusplus.github.io/CWG/issues/459.html">459</a></td>
-    <td>open</td>
+    <td>NAD</td>
     <td>Hiding of template parameters by base class members</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="460">
     <td><a href="https://cplusplus.github.io/CWG/issues/460.html">460</a></td>
@@ -5967,7 +5967,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1027">
     <td><a href="https://cplusplus.github.io/CWG/issues/1027.html">1027</a></td>
-    <td>drafting</td>
+    <td>review</td>
     <td>Type consistency and reallocation of scalar types</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -6033,7 +6033,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="1038">
     <td><a href="https://cplusplus.github.io/CWG/issues/1038.html">1038</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Overload resolution of <TT>&amp;x.static_func</TT></td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -6339,7 +6339,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1089">
     <td><a href="https://cplusplus.github.io/CWG/issues/1089.html">1089</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Template parameters in member selections</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -7923,7 +7923,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="1353">
     <td><a href="https://cplusplus.github.io/CWG/issues/1353.html">1353</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Array and variant members and deleted special member functions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -9657,7 +9657,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="1642">
     <td><a href="https://cplusplus.github.io/CWG/issues/1642.html">1642</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Missing requirements for prvalue operands</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -9993,7 +9993,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="1698">
     <td><a href="https://cplusplus.github.io/CWG/issues/1698.html">1698</a></td>
-    <td>ready</td>
+    <td>DR</td>
     <td>Files ending in <TT>\</TT></td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -11527,11 +11527,11 @@ and <I>POD class</I></td>
     <td>Data races and common initial sequence</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="1954">
+  <tr id="1954">
     <td><a href="https://cplusplus.github.io/CWG/issues/1954.html">1954</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td><TT>typeid</TT> null dereference check in subexpressions</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="1955">
     <td><a href="https://cplusplus.github.io/CWG/issues/1955.html">1955</a></td>
@@ -11643,7 +11643,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="1973">
     <td><a href="https://cplusplus.github.io/CWG/issues/1973.html">1973</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Which <I>parameter-declaration-clause</I> in a <I>lambda-expression</I>?</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -11911,11 +11911,11 @@ and <I>POD class</I></td>
     <td>Flowing off end is not equivalent to no-expression return</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2018">
+  <tr id="2018">
     <td><a href="https://cplusplus.github.io/CWG/issues/2018.html">2018</a></td>
-    <td>drafting</td>
+    <td>dup</td>
     <td>Qualification conversion vs reference binding</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2019">
     <td><a href="https://cplusplus.github.io/CWG/issues/2019.html">2019</a></td>
@@ -12127,11 +12127,11 @@ and <I>POD class</I></td>
     <td><TT>auto</TT> in non-generic lambdas</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2054">
+  <tr id="2054">
     <td><a href="https://cplusplus.github.io/CWG/issues/2054.html">2054</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Missing description of class SFINAE</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2055">
     <td><a href="https://cplusplus.github.io/CWG/issues/2055.html">2055</a></td>
@@ -12417,7 +12417,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2102">
     <td><a href="https://cplusplus.github.io/CWG/issues/2102.html">2102</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Constructor checking in <I>new-expression</I></td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -13315,11 +13315,11 @@ and <I>POD class</I></td>
     <td>Unreachable enumeration list-initialization</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2252">
+  <tr id="2252">
     <td><a href="https://cplusplus.github.io/CWG/issues/2252.html">2252</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Enumeration list-initialization from the same type</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2253">
     <td><a href="https://cplusplus.github.io/CWG/issues/2253.html">2253</a></td>
@@ -14505,7 +14505,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2450">
     <td><a href="https://cplusplus.github.io/CWG/issues/2450.html">2450</a></td>
-    <td>drafting</td>
+    <td>review</td>
     <td><I>braced-init-list</I> as a <I>template-argument</I></td>
     <td class="unreleased" align="center">Clang 18</td>
   </tr>
@@ -14715,7 +14715,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2485">
     <td><a href="https://cplusplus.github.io/CWG/issues/2485.html">2485</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Bit-fields in integral promotions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -14827,11 +14827,11 @@ and <I>POD class</I></td>
     <td>Unclear relationship among name, qualified name, and unqualified name</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2504">
+  <tr id="2504">
     <td><a href="https://cplusplus.github.io/CWG/issues/2504.html">2504</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Inheriting constructors from virtual base classes</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2505">
     <td><a href="https://cplusplus.github.io/CWG/issues/2505.html">2505</a></td>
@@ -14889,7 +14889,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2514">
     <td><a href="https://cplusplus.github.io/CWG/issues/2514.html">2514</a></td>
-    <td>review</td>
+    <td>open</td>
     <td>Modifying const subobjects</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -14919,7 +14919,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2519">
     <td><a href="https://cplusplus.github.io/CWG/issues/2519.html">2519</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Object representation of a bit-field</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -14989,11 +14989,11 @@ and <I>POD class</I></td>
     <td>Multiple definitions of enumerators</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2531">
+  <tr id="2531">
     <td><a href="https://cplusplus.github.io/CWG/issues/2531.html">2531</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Static data members redeclared as constexpr</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2532">
     <td><a href="https://cplusplus.github.io/CWG/issues/2532.html">2532</a></td>
@@ -15057,7 +15057,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2542">
     <td><a href="https://cplusplus.github.io/CWG/issues/2542.html">2542</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Is a closure type a structural type?</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15079,23 +15079,23 @@ and <I>POD class</I></td>
     <td>Transparently replacing objects in constant expressions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2546">
+  <tr id="2546">
     <td><a href="https://cplusplus.github.io/CWG/issues/2546.html">2546</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Defaulted secondary comparison operators defined as deleted</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2547">
+  <tr id="2547">
     <td><a href="https://cplusplus.github.io/CWG/issues/2547.html">2547</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Defaulted comparison operator function for non-classes</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2548">
+  <tr id="2548">
     <td><a href="https://cplusplus.github.io/CWG/issues/2548.html">2548</a></td>
-    <td>review</td>
+    <td>NAD</td>
     <td>Array prvalues and additive operators</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2549">
     <td><a href="https://cplusplus.github.io/CWG/issues/2549.html">2549</a></td>
@@ -15105,7 +15105,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2550">
     <td><a href="https://cplusplus.github.io/CWG/issues/2550.html">2550</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Type "reference to <I>cv</I> <TT>void</TT>" outside of a declarator</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15117,13 +15117,13 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2552">
     <td><a href="https://cplusplus.github.io/CWG/issues/2552.html">2552</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Constant evaluation of non-defining variable declarations</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr id="2553">
+  <tr class="open" id="2553">
     <td><a href="https://cplusplus.github.io/CWG/issues/2553.html">2553</a></td>
-    <td>ready</td>
+    <td>review</td>
     <td>Restrictions on explicit object member functions</td>
     <td class="unreleased" align="center">Clang 18</td>
   </tr>
@@ -15141,7 +15141,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2556">
     <td><a href="https://cplusplus.github.io/CWG/issues/2556.html">2556</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Unusable <TT>promise::return_void</TT></td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15163,11 +15163,11 @@ and <I>POD class</I></td>
     <td>Defaulted consteval functions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2560">
+  <tr id="2560">
     <td><a href="https://cplusplus.github.io/CWG/issues/2560.html">2560</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Parameter type determination in a <I>requirement-parameter-list</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2561">
     <td><a href="https://cplusplus.github.io/CWG/issues/2561.html">2561</a></td>
@@ -15193,9 +15193,9 @@ and <I>POD class</I></td>
     <td>Conversion to function pointer with an explicit object parameter</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr id="2565">
+  <tr class="open" id="2565">
     <td><a href="https://cplusplus.github.io/CWG/issues/2565.html">2565</a></td>
-    <td>tentatively ready</td>
+    <td>open</td>
     <td>Invalid types in the <I>parameter-declaration-clause</I> of a <I>requires-expression</I></td>
     <td class="full" align="center">Clang 16</td>
   </tr>
@@ -15211,11 +15211,11 @@ and <I>POD class</I></td>
     <td>Operator lookup ambiguity</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2568">
+  <tr id="2568">
     <td><a href="https://cplusplus.github.io/CWG/issues/2568.html">2568</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Access checking during synthesis of defaulted comparison operator</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2569">
     <td><a href="https://cplusplus.github.io/CWG/issues/2569.html">2569</a></td>
@@ -15225,7 +15225,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2570">
     <td><a href="https://cplusplus.github.io/CWG/issues/2570.html">2570</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Clarify constexpr for defaulted functions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15241,17 +15241,17 @@ and <I>POD class</I></td>
     <td>Address of overloaded function with no target</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2573">
+  <tr id="2573">
     <td><a href="https://cplusplus.github.io/CWG/issues/2573.html">2573</a></td>
-    <td>open</td>
+    <td>DRWP</td>
     <td>Undefined behavior when splicing results in a <I>universal-character-name</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2574">
+  <tr id="2574">
     <td><a href="https://cplusplus.github.io/CWG/issues/2574.html">2574</a></td>
-    <td>open</td>
+    <td>DRWP</td>
     <td>Undefined behavior when lexing unmatched quotes</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2575">
     <td><a href="https://cplusplus.github.io/CWG/issues/2575.html">2575</a></td>
@@ -15351,7 +15351,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2591">
     <td><a href="https://cplusplus.github.io/CWG/issues/2591.html">2591</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Implicit change of active union member for anonymous union in union</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15375,7 +15375,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2595">
     <td><a href="https://cplusplus.github.io/CWG/issues/2595.html">2595</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>"More constrained" for eligible special member functions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15405,7 +15405,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2600">
     <td><a href="https://cplusplus.github.io/CWG/issues/2600.html">2600</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Type dependency of placeholder types</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15571,9 +15571,9 @@ and <I>POD class</I></td>
     <td>Bit-fields and narrowing conversions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2628">
+  <tr id="2628">
     <td><a href="https://cplusplus.github.io/CWG/issues/2628.html">2628</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Implicit deduction guides should propagate constraints</td>
     <td class="none" align="center">No</td>
   </tr>
@@ -15597,7 +15597,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2632">
     <td><a href="https://cplusplus.github.io/CWG/issues/2632.html">2632</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>'user-declared' is not defined</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -15607,11 +15607,11 @@ and <I>POD class</I></td>
     <td>typeid of constexpr-unknown dynamic type</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2634">
+  <tr id="2634">
     <td><a href="https://cplusplus.github.io/CWG/issues/2634.html">2634</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Avoid circularity in specification of scope for friend class declarations</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2635">
     <td><a href="https://cplusplus.github.io/CWG/issues/2635.html">2635</a></td>
@@ -15625,17 +15625,17 @@ and <I>POD class</I></td>
     <td>Update Annex E based on Unicode 15.0 UAX #31</td>
     <td class="na" align="center">N/A</td>
   </tr>
-  <tr class="open" id="2637">
+  <tr id="2637">
     <td><a href="https://cplusplus.github.io/CWG/issues/2637.html">2637</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Injected-class-name as a <I>simple-template-id</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2638">
+  <tr id="2638">
     <td><a href="https://cplusplus.github.io/CWG/issues/2638.html">2638</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Improve the example for initializing by initializer list</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2639">
     <td><a href="https://cplusplus.github.io/CWG/issues/2639.html">2639</a></td>
@@ -15733,23 +15733,23 @@ and <I>POD class</I></td>
     <td>Un-deprecation of compound volatile assignments</td>
     <td class="full" align="center">Clang 16</td>
   </tr>
-  <tr class="open" id="2655">
+  <tr id="2655">
     <td><a href="https://cplusplus.github.io/CWG/issues/2655.html">2655</a></td>
-    <td>open</td>
+    <td>NAD</td>
     <td>Instantiation of default arguments in <I>lambda-expression</I>s</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2656">
     <td><a href="https://cplusplus.github.io/CWG/issues/2656.html">2656</a></td>
-    <td>open</td>
+    <td>drafting</td>
     <td>Converting consteval lambda to function pointer in non-immediate context</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2657">
+  <tr id="2657">
     <td><a href="https://cplusplus.github.io/CWG/issues/2657.html">2657</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Cv-qualification adjustment when binding reference to temporary</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2658">
     <td><a href="https://cplusplus.github.io/CWG/issues/2658.html">2658</a></td>
@@ -15783,7 +15783,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2663">
     <td><a href="https://cplusplus.github.io/CWG/issues/2663.html">2663</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Example for member redeclarations with <I>using-declaration</I>s</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15811,11 +15811,11 @@ and <I>POD class</I></td>
     <td>Named module imports do not import macros</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2668">
+  <tr id="2668">
     <td><a href="https://cplusplus.github.io/CWG/issues/2668.html">2668</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td><TT>co_await</TT> in a <I>lambda-expression</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2669">
     <td><a href="https://cplusplus.github.io/CWG/issues/2669.html">2669</a></td>
@@ -15835,9 +15835,9 @@ and <I>POD class</I></td>
     <td>friend named by a <I>template-id</I></td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2672">
+  <tr id="2672">
     <td><a href="https://cplusplus.github.io/CWG/issues/2672.html">2672</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Lambda body SFINAE is still required, contrary to intent and note</td>
     <td class="unreleased" align="center">Clang 18</td>
   </tr>
@@ -15903,7 +15903,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2683">
     <td><a href="https://cplusplus.github.io/CWG/issues/2683.html">2683</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Default arguments for member functions of templated nested classes</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -15937,11 +15937,11 @@ and <I>POD class</I></td>
     <td>Calling explicit object member functions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2689">
+  <tr id="2689">
     <td><a href="https://cplusplus.github.io/CWG/issues/2689.html">2689</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Are cv-qualified <TT>std::nullptr_t</TT> fundamental types?</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2690">
     <td><a href="https://cplusplus.github.io/CWG/issues/2690.html">2690</a></td>
@@ -15987,19 +15987,19 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2697">
     <td><a href="https://cplusplus.github.io/CWG/issues/2697.html">2697</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Deduction guides using abbreviated function syntax</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2698">
     <td><a href="https://cplusplus.github.io/CWG/issues/2698.html">2698</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Using extended integer types with <TT>z</TT> suffix</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2699">
     <td><a href="https://cplusplus.github.io/CWG/issues/2699.html">2699</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Inconsistency of <I>throw-expression</I> specification</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -16045,15 +16045,15 @@ and <I>POD class</I></td>
     <td>Repeated structured binding declarations</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2707">
+  <tr id="2707">
     <td><a href="https://cplusplus.github.io/CWG/issues/2707.html">2707</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Deduction guides cannot have a trailing <I>requires-clause</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2708">
     <td><a href="https://cplusplus.github.io/CWG/issues/2708.html">2708</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Parenthesized initialization of arrays</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -16065,25 +16065,25 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2710">
     <td><a href="https://cplusplus.github.io/CWG/issues/2710.html">2710</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Loops in constant expressions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2711">
     <td><a href="https://cplusplus.github.io/CWG/issues/2711.html">2711</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Source for copy-initializing the exception object</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2712">
     <td><a href="https://cplusplus.github.io/CWG/issues/2712.html">2712</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Simplify restrictions on built-in assignment operator candidates</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2713">
     <td><a href="https://cplusplus.github.io/CWG/issues/2713.html">2713</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Initialization of reference-to-aggregate from designated initializer list</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -16095,67 +16095,67 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2715">
     <td><a href="https://cplusplus.github.io/CWG/issues/2715.html">2715</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>"calling function" for parameter initialization may not exist</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2716">
     <td><a href="https://cplusplus.github.io/CWG/issues/2716.html">2716</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Rule about self-or-base conversion is normatively redundant</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2717">
     <td><a href="https://cplusplus.github.io/CWG/issues/2717.html">2717</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Pack expansion for <I>alignment-specifier</I></td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2718">
     <td><a href="https://cplusplus.github.io/CWG/issues/2718.html">2718</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Type completeness for derived-to-base conversions</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2719">
     <td><a href="https://cplusplus.github.io/CWG/issues/2719.html">2719</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Creating objects in misaligned storage</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2720">
     <td><a href="https://cplusplus.github.io/CWG/issues/2720.html">2720</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Template validity rules for templated entities and alias templates</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2721">
     <td><a href="https://cplusplus.github.io/CWG/issues/2721.html">2721</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>When exactly is storage reused?</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2722">
     <td><a href="https://cplusplus.github.io/CWG/issues/2722.html">2722</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Temporary materialization conversion for <TT>noexcept</TT> operator</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2723">
     <td><a href="https://cplusplus.github.io/CWG/issues/2723.html">2723</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Range of representable values for floating-point types</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2724">
     <td><a href="https://cplusplus.github.io/CWG/issues/2724.html">2724</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Clarify rounding for arithmetic right shift</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2725">
     <td><a href="https://cplusplus.github.io/CWG/issues/2725.html">2725</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Overload resolution for non-call of class member access</td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -16179,7 +16179,7 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2729">
     <td><a href="https://cplusplus.github.io/CWG/issues/2729.html">2729</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Meaning of <I>new-type-id</I></td>
     <td class="none" align="center">Unknown</td>
   </tr>
@@ -16197,15 +16197,15 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2732">
     <td><a href="https://cplusplus.github.io/CWG/issues/2732.html">2732</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>Can importable headers react to preprocessor state from point of import?</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2733">
+  <tr id="2733">
     <td><a href="https://cplusplus.github.io/CWG/issues/2733.html">2733</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Applying <TT>[[maybe_unused]]</TT> to a label</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2734">
     <td><a href="https://cplusplus.github.io/CWG/issues/2734.html">2734</a></td>
@@ -16287,33 +16287,33 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2747">
     <td><a href="https://cplusplus.github.io/CWG/issues/2747.html">2747</a></td>
-    <td>ready</td>
+    <td>DR</td>
     <td>Cannot depend on an already-deleted splice</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2748">
+  <tr id="2748">
     <td><a href="https://cplusplus.github.io/CWG/issues/2748.html">2748</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Accessing static data members via null pointer</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2749">
     <td><a href="https://cplusplus.github.io/CWG/issues/2749.html">2749</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Treatment of "pointer to void" for relational comparisons</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2750">
     <td><a href="https://cplusplus.github.io/CWG/issues/2750.html">2750</a></td>
-    <td>DR</td>
+    <td>DRWP</td>
     <td>construct_at without constructor call</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2751">
+  <tr id="2751">
     <td><a href="https://cplusplus.github.io/CWG/issues/2751.html">2751</a></td>
-    <td>open</td>
+    <td>NAD</td>
     <td>Order of destruction for parameters for operator functions</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2752">
     <td><a href="https://cplusplus.github.io/CWG/issues/2752.html">2752</a></td>
@@ -16323,75 +16323,75 @@ and <I>POD class</I></td>
   </tr>
   <tr id="2753">
     <td><a href="https://cplusplus.github.io/CWG/issues/2753.html">2753</a></td>
-    <td>tentatively ready</td>
+    <td>DR</td>
     <td>Storage reuse for string literal objects and backing arrays</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2754">
     <td><a href="https://cplusplus.github.io/CWG/issues/2754.html">2754</a></td>
-    <td>ready</td>
+    <td>DR</td>
     <td>Using *this in explicit object member functions that are coroutines</td>
     <td class="none" align="center">Unknown</td>
   </tr>
   <tr id="2755">
     <td><a href="https://cplusplus.github.io/CWG/issues/2755.html">2755</a></td>
-    <td>ready</td>
+    <td>DR</td>
     <td>Incorrect wording applied by P2738R1</td>
     <td class="none" align="center">Unknown</td>
   </tr>
-  <tr id="2756">
+  <tr class="open" id="2756">
     <td><a href="https://cplusplus.github.io/CWG/issues/2756.html">2756</a></td>
-    <td>tentatively ready</td>
+    <td>review</td>
     <td>Completion of initialization by delegating constructor</td>
-    <td class="none" align="center">Unknown</td>
+    <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2757">
     <td><a href="https://cplusplus.github.io/CWG/issues/2757.html">2757</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Deleting or deallocating storage of an object during its construction</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2758">
+  <tr id="2758">
     <td><a href="https://cplusplus.github.io/CWG/issues/2758.html">2758</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>What is "access and ambiguity control"?</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2759">
+  <tr id="2759">
     <td><a href="https://cplusplus.github.io/CWG/issues/2759.html">2759</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>[[no_unique_address] and common initial sequence</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2760">
+  <tr id="2760">
     <td><a href="https://cplusplus.github.io/CWG/issues/2760.html">2760</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Defaulted constructor that is an immediate function</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2761">
+  <tr id="2761">
     <td><a href="https://cplusplus.github.io/CWG/issues/2761.html">2761</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Implicitly invoking the deleted destructor of an anonymous union member</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2762">
+  <tr id="2762">
     <td><a href="https://cplusplus.github.io/CWG/issues/2762.html">2762</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Type of implicit object parameter</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2763">
+  <tr id="2763">
     <td><a href="https://cplusplus.github.io/CWG/issues/2763.html">2763</a></td>
-    <td>review</td>
+    <td>DR</td>
     <td>Ignorability of [[noreturn]] during constant evaluation</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
-  <tr class="open" id="2764">
+  <tr id="2764">
     <td><a href="https://cplusplus.github.io/CWG/issues/2764.html">2764</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Use of placeholders affecting name mangling</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2765">
     <td><a href="https://cplusplus.github.io/CWG/issues/2765.html">2765</a></td>
@@ -16411,11 +16411,11 @@ and <I>POD class</I></td>
     <td>Non-defining declarations of anonymous unions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2768">
+  <tr id="2768">
     <td><a href="https://cplusplus.github.io/CWG/issues/2768.html">2768</a></td>
-    <td>open</td>
-    <td>Assignment to scalar with a <I>braced-init-list</I></td>
-    <td align="center">Not resolved</td>
+    <td>DR</td>
+    <td>Assignment to enumeration variable with a <I>braced-init-list</I></td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2769">
     <td><a href="https://cplusplus.github.io/CWG/issues/2769.html">2769</a></td>
@@ -16435,11 +16435,11 @@ and <I>POD class</I></td>
     <td>Transformation for <I>unqualified-id</I>s in address operator</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2772">
+  <tr id="2772">
     <td><a href="https://cplusplus.github.io/CWG/issues/2772.html">2772</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td>Missing Annex C entry for linkage effects of <I>linkage-specification</I></td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2773">
     <td><a href="https://cplusplus.github.io/CWG/issues/2773.html">2773</a></td>
@@ -16453,11 +16453,11 @@ and <I>POD class</I></td>
     <td>Value-dependence of <I>requires-expression</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2775">
+  <tr id="2775">
     <td><a href="https://cplusplus.github.io/CWG/issues/2775.html">2775</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Unclear argument type for copy of exception object</td>
-    <td align="center">Not resolved</td>
+    <td class="none" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2776">
     <td><a href="https://cplusplus.github.io/CWG/issues/2776.html">2776</a></td>
@@ -16483,10 +16483,376 @@ and <I>POD class</I></td>
     <td>Restrictions on the ordinary literal encoding</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2780">
+  <tr id="2780">
     <td><a href="https://cplusplus.github.io/CWG/issues/2780.html">2780</a></td>
-    <td>open</td>
+    <td>DR</td>
     <td><TT>reinterpret_cast</TT> to reference to function types</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2781">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2781.html">2781</a></td>
+    <td>open</td>
+    <td>Unclear recursion in the one-definition rule</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2782">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2782.html">2782</a></td>
+    <td>open</td>
+    <td>Treatment of closure types in the one-definition rule</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2783">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2783.html">2783</a></td>
+    <td>DR</td>
+    <td>Handling of deduction guides in <I>global-module-fragment</I></td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2784">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2784.html">2784</a></td>
+    <td>open</td>
+    <td>Unclear definition of <I>member-designator</I> for <TT>offsetof</TT></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2785">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2785.html">2785</a></td>
+    <td>DR</td>
+    <td>Type-dependence of <I>requires-expression</I></td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2786">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2786.html">2786</a></td>
+    <td>open</td>
+    <td>Comparing pointers to complete objects</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2787">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2787.html">2787</a></td>
+    <td>open</td>
+    <td>Kind of explicit object copy/move assignment function</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2788">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2788.html">2788</a></td>
+    <td>open</td>
+    <td>Correspondence and redeclarations</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2789">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2789.html">2789</a></td>
+    <td>DR</td>
+    <td>Overload resolution with implicit and explicit object member functions</td>
+    <td class="unreleased" align="center">Clang 18</td>
+  </tr>
+  <tr class="open" id="2790">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2790.html">2790</a></td>
+    <td>open</td>
+    <td>Aggregate initialization and user-defined conversion sequence</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2791">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2791.html">2791</a></td>
+    <td>DR</td>
+    <td>Unclear phrasing about "returning to the caller"</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2792">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2792.html">2792</a></td>
+    <td>DR</td>
+    <td>Clean up specification of <TT>noexcept</TT> operator</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2793">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2793.html">2793</a></td>
+    <td>DR</td>
+    <td>Block-scope declaration conflicting with parameter name</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2794">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2794.html">2794</a></td>
+    <td>open</td>
+    <td>Uniqueness of lambdas in alias templates</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2795">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2795.html">2795</a></td>
+    <td>DR</td>
+    <td>Overlapping empty subobjects with different cv-qualification</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2796">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2796.html">2796</a></td>
+    <td>DR</td>
+    <td>Function pointer conversions for relational operators</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2797">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2797.html">2797</a></td>
+    <td>open</td>
+    <td>Meaning of "corresponds" for rewritten operator candidates</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2798">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2798.html">2798</a></td>
+    <td>DR</td>
+    <td>Manifestly constant evaluation of the <TT>static_assert</TT> message</td>
+    <td class="full" align="center">Clang 17</td>
+  </tr>
+  <tr class="open" id="2799">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2799.html">2799</a></td>
+    <td>drafting</td>
+    <td>Inheriting default constructors</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2800">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2800.html">2800</a></td>
+    <td>review</td>
+    <td>Instantiating constexpr variables for potential constant evaluation</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2801">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2801.html">2801</a></td>
+    <td>DR</td>
+    <td>Reference binding with reference-related types</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2802">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2802.html">2802</a></td>
+    <td>open</td>
+    <td>Constrained <TT>auto</TT> and redeclaration with non-abbreviated syntax</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2803">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2803.html">2803</a></td>
+    <td>tentatively ready</td>
+    <td>Overload resolution for reference binding of similar types</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2804">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2804.html">2804</a></td>
+    <td>open</td>
+    <td>Lookup for determining rewrite targets</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2805">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2805.html">2805</a></td>
+    <td>open</td>
+    <td>Underspecified selection of deallocation function</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2806">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2806.html">2806</a></td>
+    <td>DR</td>
+    <td>Make a <I>type-requirement</I> a type-only context</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2807">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2807.html">2807</a></td>
+    <td>DR</td>
+    <td>Destructors declared <TT>consteval</TT></td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2808">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2808.html">2808</a></td>
+    <td>review</td>
+    <td>Explicit specialization of defaulted special member function</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2809">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2809.html">2809</a></td>
+    <td>tentatively ready</td>
+    <td>An implicit definition does not redeclare a function</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2810">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2810.html">2810</a></td>
+    <td>tentatively ready</td>
+    <td>Requiring the absence of diagnostics for templates</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2811">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2811.html">2811</a></td>
+    <td>tentatively ready</td>
+    <td>Clarify "use" of main</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2812">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2812.html">2812</a></td>
+    <td>open</td>
+    <td>Allocation with explicit alignment</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2813">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2813.html">2813</a></td>
+    <td>review</td>
+    <td>Class member access with prvalues</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2814">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2814.html">2814</a></td>
+    <td>review</td>
+    <td>Alignment requirement of incomplete class type</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2815">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2815.html">2815</a></td>
+    <td>open</td>
+    <td>Overload resolution for references/pointers to <TT>noexcept</TT> functions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2816">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2816.html">2816</a></td>
+    <td>review</td>
+    <td>Unclear phrasing "may assume ... eventually"</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2817">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2817.html">2817</a></td>
+    <td>open</td>
+    <td>sizeof(abstract class) is underspecified</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2818">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2818.html">2818</a></td>
+    <td>review</td>
+    <td>Use of predefined reserved identifiers</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2819">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2819.html">2819</a></td>
+    <td>review</td>
+    <td>Cast from null pointer value in a constant expression</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2820">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2820.html">2820</a></td>
+    <td>open</td>
+    <td>Value-initialization and default constructors</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2821">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2821.html">2821</a></td>
+    <td>open</td>
+    <td>Lifetime, zero-initialization, and dynamic initialization</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="2822">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2822.html">2822</a></td>
+    <td>tentatively ready</td>
+    <td>Side-effect-free pointer zap</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2823">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2823.html">2823</a></td>
+    <td>DR</td>
+    <td>Implicit undefined behavior when dereferencing pointers</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2824">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2824.html">2824</a></td>
+    <td>tentatively ready</td>
+    <td>Copy-initialization of arrays</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2825">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2825.html">2825</a></td>
+    <td>tentatively ready</td>
+    <td>Range-based for statement using a <I>braced-init-list</I></td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr id="2826">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2826.html">2826</a></td>
+    <td>tentatively ready</td>
+    <td>Missing definition of "temporary expression"</td>
+    <td class="none" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="2827">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2827.html">2827</a></td>
+    <td>review</td>
+    <td>Representation of unsigned integral types</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2828">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2828.html">2828</a></td>
+    <td>review</td>
+    <td>Ambiguous interpretation of C-style cast</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2829">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2829.html">2829</a></td>
+    <td>open</td>
+    <td>Redundant case in restricting user-defined conversion sequences</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2830">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2830.html">2830</a></td>
+    <td>open</td>
+    <td>Top-level cv-qualification should be ignored for list-initialization</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2831">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2831.html">2831</a></td>
+    <td>open</td>
+    <td>Non-templated function definitions and <I>requires-clause</I>s</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2832">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2832.html">2832</a></td>
+    <td>open</td>
+    <td>Invented temporary variables and temporary objects</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2833">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2833.html">2833</a></td>
+    <td>review</td>
+    <td>Evaluation of odr-use</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2834">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2834.html">2834</a></td>
+    <td>open</td>
+    <td>Partial ordering and explicit object parameters</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2835">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2835.html">2835</a></td>
+    <td>open</td>
+    <td>Name-independent declarations</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2836">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2836.html">2836</a></td>
+    <td>open</td>
+    <td>Conversion rank of <TT>long double</TT> and extended floating-point types</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2837">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2837.html">2837</a></td>
+    <td>open</td>
+    <td>Instantiating and inheriting by-value copy constructors</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2838">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2838.html">2838</a></td>
+    <td>open</td>
+    <td>Declaration conflicts in <I>lambda-expression</I>s</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2839">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2839.html">2839</a></td>
+    <td>open</td>
+    <td>Explicit destruction of base classes</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2840">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2840.html">2840</a></td>
+    <td>open</td>
+    <td>Missing requirements for fundamental alignments</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2841">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2841.html">2841</a></td>
+    <td>open</td>
+    <td>When do const objects start being const?</td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
This patch updates cxx_dr_status.html with the latest changes from CWG, while also changing status of tests written for unresolved issues. The latter part requires review from their author.