### PR TITLE
[SHT_LLVM_BB_ADDR_MAP] Add assertion and clarify docstring

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -110,11 +110,12 @@ public:
   Expected<std::vector<VersionEntry>> readDynsymVersions() const;
 
   /// Returns a vector of all BB address maps in the object file. When
-  // `TextSectionIndex` is specified, only returns the BB address maps
-  // corresponding to the section with that index. When `PGOAnalyses`is
-  // specified, the vector is cleared then filled with extra PGO data.
-  // `PGOAnalyses` will always be the same length as the return value on
-  // success, otherwise it is empty.
+  /// `TextSectionIndex` is specified, only returns the BB address maps
+  /// corresponding to the section with that index. When `PGOAnalyses`is
+  /// specified, the vector is cleared then filled with extra PGO data.
+  /// When PGO information is requested (`PGOAnalyses` is not nullptr),
+  /// `PGOAnalyses` will always be the same length as the return value,
+  /// assuming no error occurs. Upon failure, `PGOAnalyses` will be empty.
   Expected<std::vector<BBAddrMap>>
   readBBAddrMap(std::optional<unsigned> TextSectionIndex = std::nullopt,
                 std::vector<PGOAnalysisMap> *PGOAnalyses = nullptr) const;

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -115,7 +115,7 @@ public:
   /// specified, the vector is cleared then filled with extra PGO data.
   /// When PGO information is requested (`PGOAnalyses` is not nullptr),
   /// `PGOAnalyses` will always be the same length as the return value,
-  /// assuming no error occurs. Upon failure, `PGOAnalyses` will be empty.
+  /// assuming no error occurs. Upon failure, `PGOAnalyses` will be emptied.
   Expected<std::vector<BBAddrMap>>
   readBBAddrMap(std::optional<unsigned> TextSectionIndex = std::nullopt,
                 std::vector<PGOAnalysisMap> *PGOAnalyses = nullptr) const;

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -112,10 +112,10 @@ public:
   /// Returns a vector of all BB address maps in the object file. When
   /// `TextSectionIndex` is specified, only returns the BB address maps
   /// corresponding to the section with that index. When `PGOAnalyses`is
-  /// specified, the vector is cleared then filled with extra PGO data.
-  /// When PGO information is requested (`PGOAnalyses` is not nullptr),
-  /// `PGOAnalyses` will always be the same length as the return value,
-  /// assuming no error occurs. Upon failure, `PGOAnalyses` will be emptied.
+  /// specified (PGOAnalyses is not nullptr), the vector is cleared then filled
+  /// with extra PGO data. `PGOAnalyses` will always be the same length as the
+  /// return value when it is requested assuming no error occurs. Upon failure,
+  /// `PGOAnalyses` will be emptied.
   Expected<std::vector<BBAddrMap>>
   readBBAddrMap(std::optional<unsigned> TextSectionIndex = std::nullopt,
                 std::vector<PGOAnalysisMap> *PGOAnalyses = nullptr) const;

--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -830,6 +830,10 @@ Expected<std::vector<BBAddrMap>> static readBBAddrMapImpl(
     std::move(BBAddrMapOrErr->begin(), BBAddrMapOrErr->end(),
               std::back_inserter(BBAddrMaps));
   }
+  if (PGOAnalyses)
+    assert(PGOAnalyses->size() == BBAddrMaps.size() &&
+           "The same number of BBAddrMaps and PGOAnalysisMaps should be "
+           "returned when PGO information is requested");
   return BBAddrMaps;
 }
 


### PR DESCRIPTION
This patch adds an assertion to readBBAddrMapImpl to confirm that PGOAnalyses and BBAddrMaps are of the same size when PGO information is requested (part of the API contract). This patch also updates the docstring for readBBAddrMap to better clarify what is guaranteed.