### PR TITLE
[lldb] All ValueObjectSP instances are now valid (non-null) but have an error state (In-progress | Take 2)

### DIFF
--- a/lldb/include/lldb/Breakpoint/Watchpoint.h
+++ b/lldb/include/lldb/Breakpoint/Watchpoint.h
@@ -219,8 +219,8 @@ private:
   uint32_t m_ignore_count;      // Number of times to ignore this watchpoint
   std::string m_decl_str;       // Declaration information, if any.
   std::string m_watch_spec_str; // Spec for the watchpoint.
-  lldb::ValueObjectSP m_old_value_sp;
-  lldb::ValueObjectSP m_new_value_sp;
+  std::optional<lldb::ValueObjectSP> m_old_value_sp;
+  std::optional<lldb::ValueObjectSP> m_new_value_sp;
   CompilerType m_type;
   Status m_error; // An error object describing errors associated with this
                   // watchpoint.

--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -409,7 +409,7 @@ public:
       Stream &s,
       GetExpressionPathFormat = eGetExpressionPathFormatDereferencePointers);
 
-  lldb::ValueObjectSP GetValueForExpressionPath(
+  std::optional<lldb::ValueObjectSP> GetValueForExpressionPath(
       llvm::StringRef expression,
       ExpressionPathScanEndReason *reason_to_stop = nullptr,
       ExpressionPathEndResultType *final_value_type = nullptr,
@@ -465,14 +465,18 @@ public:
   /// Returns a unique id for this ValueObject.
   lldb::user_id_t GetID() const { return m_id.GetID(); }
 
-  virtual lldb::ValueObjectSP GetChildAtIndex(size_t idx,
-                                              bool can_create = true);
+  virtual std::optional<lldb::ValueObjectSP>
+  GetChildAtIndex(size_t idx, bool can_create = true);
 
-  // The method always creates missing children in the path, if necessary.
-  lldb::ValueObjectSP GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names);
 
   virtual lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
                                                      bool can_create = true);
+  /// The method always creates missing children in the path, if necessary.
+  std::optional<lldb::ValueObjectSP>
+  GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names);
+
+  virtual std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true);
 
   virtual size_t GetIndexOfChildWithName(llvm::StringRef name);
 
@@ -536,7 +540,11 @@ public:
 
   bool UpdateFormatsIfNeeded();
 
-  lldb::ValueObjectSP GetSP() { return m_manager->GetSharedPointer(this); }
+  lldb::ValueObjectSP GetSP() {
+    auto shared_pointer = m_manager->GetSharedPointer(this);
+    lldb::ValueObjectSP value_object_sp(std::move(shared_pointer));
+    return value_object_sp;
+  }
 
   /// Change the name of the current ValueObject. Should *not* be used from a
   /// synthetic child provider as it would change the name of the non synthetic
@@ -548,26 +556,28 @@ public:
 
   lldb::addr_t GetPointerValue(AddressType *address_type = nullptr);
 
-  lldb::ValueObjectSP GetSyntheticChild(ConstString key) const;
+  std::optional<lldb::ValueObjectSP> GetSyntheticChild(ConstString key) const;
 
-  lldb::ValueObjectSP GetSyntheticArrayMember(size_t index, bool can_create);
+  std::optional<lldb::ValueObjectSP> GetSyntheticArrayMember(size_t index,
+                                                             bool can_create);
 
-  lldb::ValueObjectSP GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
-                                                bool can_create);
+  std::optional<lldb::ValueObjectSP>
+  GetSyntheticBitFieldChild(uint32_t from, uint32_t to, bool can_create);
 
-  lldb::ValueObjectSP GetSyntheticExpressionPathChild(const char *expression,
-                                                      bool can_create);
+  std::optional<lldb::ValueObjectSP>
+  GetSyntheticExpressionPathChild(const char *expression, bool can_create);
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticChildAtOffset(uint32_t offset, const CompilerType &type,
                             bool can_create,
                             ConstString name_const_str = ConstString());
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticBase(uint32_t offset, const CompilerType &type, bool can_create,
                    ConstString name_const_str = ConstString());
 
-  virtual lldb::ValueObjectSP GetDynamicValue(lldb::DynamicValueType valueType);
+  virtual std::optional<lldb::ValueObjectSP>
+  GetDynamicValue(lldb::DynamicValueType valueType);
 
   lldb::DynamicValueType GetDynamicValueType();
 
@@ -575,7 +585,7 @@ public:
 
   virtual lldb::ValueObjectSP GetNonSyntheticValue() { return GetSP(); }
 
-  lldb::ValueObjectSP GetSyntheticValue();
+  std::optional<lldb::ValueObjectSP> GetSyntheticValue();
 
   virtual bool HasSyntheticValue();
 
@@ -587,7 +597,7 @@ public:
 
   virtual lldb::ValueObjectSP CreateConstantValue(ConstString name);
 
-  virtual lldb::ValueObjectSP Dereference(Status &error);
+  virtual lldb::ValueObjectSP Dereference();
 
   /// Creates a copy of the ValueObject with a new name and setting the current
   /// ValueObject as its parent. It should be used when we want to change the
@@ -595,7 +605,7 @@ public:
   /// (e.g. sythetic child provider).
   virtual lldb::ValueObjectSP Clone(ConstString new_name);
 
-  virtual lldb::ValueObjectSP AddressOf(Status &error);
+  virtual lldb::ValueObjectSP AddressOf();
 
   virtual lldb::addr_t GetLiveAddress() { return LLDB_INVALID_ADDRESS; }
 
@@ -606,11 +616,11 @@ public:
 
   virtual lldb::ValueObjectSP DoCast(const CompilerType &compiler_type);
 
-  virtual lldb::ValueObjectSP CastPointerType(const char *name,
-                                              CompilerType &ast_type);
+  virtual std::optional<lldb::ValueObjectSP>
+  CastPointerType(const char *name, CompilerType &ast_type);
 
-  virtual lldb::ValueObjectSP CastPointerType(const char *name,
-                                              lldb::TypeSP &type_sp);
+  virtual std::optional<lldb::ValueObjectSP>
+  CastPointerType(const char *name, lldb::TypeSP &type_sp);
 
   /// If this object represents a C++ class with a vtable, return an object
   /// that represents the virtual function table. If the object isn't a class
@@ -642,18 +652,18 @@ public:
 
   void Dump(Stream &s, const DumpValueObjectOptions &options);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx,
                                   const EvaluateExpressionOptions &options);
 
-  static lldb::ValueObjectSP
+  static std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromAddress(llvm::StringRef name, uint64_t address,
                                const ExecutionContext &exe_ctx,
                                CompilerType type);
@@ -662,7 +672,7 @@ public:
   CreateValueObjectFromData(llvm::StringRef name, const DataExtractor &data,
                             const ExecutionContext &exe_ctx, CompilerType type);
 
-  lldb::ValueObjectSP Persist();
+  std::optional<lldb::ValueObjectSP> Persist();
 
   /// Returns true if this is a char* or a char[] if it is a char* and
   /// check_pointer is true, it also checks that the pointer is valid.
@@ -874,7 +884,7 @@ protected:
 
   /// We have to hold onto a shared  pointer to this one because it is created
   /// as an independent ValueObjectConstResult, which isn't managed by us.
-  lldb::ValueObjectSP m_addr_of_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_addr_of_valobj_sp;
 
   lldb::Format m_format = lldb::eFormatDefault;
   lldb::Format m_last_format = lldb::eFormatDefault;
@@ -998,7 +1008,7 @@ private:
     GetRoot()->DoUpdateChildrenAddressType(*this);
   }
 
-  lldb::ValueObjectSP GetValueForExpressionPath_Impl(
+  std::optional<lldb::ValueObjectSP> GetValueForExpressionPath_Impl(
       llvm::StringRef expression_cstr,
       ExpressionPathScanEndReason *reason_to_stop,
       ExpressionPathEndResultType *final_value_type,

--- a/lldb/include/lldb/Core/ValueObjectConstResult.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResult.h
@@ -77,16 +77,16 @@ public:
 
   void SetByteSize(size_t size);
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   lldb::addr_t GetAddressOf(bool scalar_is_load_address = true,
                             AddressType *address_type = nullptr) override;
@@ -101,7 +101,7 @@ public:
     m_impl.SetLiveAddress(addr, address_type);
   }
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetDynamicValue(lldb::DynamicValueType valueType) override;
 
   lldb::LanguageType GetPreferredDisplayLanguage() override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultCast.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultCast.h
@@ -33,7 +33,7 @@ public:
 
   ~ValueObjectConstResultCast() override;
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
@@ -42,11 +42,11 @@ public:
     return ValueObjectCast::GetCompilerType();
   }
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   size_t GetPointeeData(DataExtractor &data, uint32_t item_idx = 0,
                         uint32_t item_count = 1) override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultChild.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultChild.h
@@ -39,7 +39,7 @@ public:
 
   ~ValueObjectConstResultChild() override;
 
-  lldb::ValueObjectSP Dereference(Status &error) override;
+  lldb::ValueObjectSP Dereference() override;
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
@@ -48,11 +48,11 @@ public:
     return ValueObjectChild::GetCompilerType();
   }
 
-  lldb::ValueObjectSP GetSyntheticChildAtOffset(
+  std::optional<lldb::ValueObjectSP> GetSyntheticChildAtOffset(
       uint32_t offset, const CompilerType &type, bool can_create,
       ConstString name_const_str = ConstString()) override;
 
-  lldb::ValueObjectSP AddressOf(Status &error) override;
+  lldb::ValueObjectSP AddressOf() override;
 
   lldb::addr_t GetAddressOf(bool scalar_is_load_address = true,
                             AddressType *address_type = nullptr) override;

--- a/lldb/include/lldb/Core/ValueObjectConstResultImpl.h
+++ b/lldb/include/lldb/Core/ValueObjectConstResultImpl.h
@@ -36,17 +36,17 @@ public:
 
   virtual ~ValueObjectConstResultImpl() = default;
 
-  lldb::ValueObjectSP Dereference(Status &error);
+  lldb::ValueObjectSP Dereference();
 
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index);
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetSyntheticChildAtOffset(uint32_t offset, const CompilerType &type,
                             bool can_create,
                             ConstString name_const_str = ConstString());
 
-  lldb::ValueObjectSP AddressOf(Status &error);
+  lldb::ValueObjectSP AddressOf();
 
   lldb::addr_t GetLiveAddress() { return m_live_address; }
 
@@ -68,7 +68,7 @@ private:
   ValueObject *m_impl_backend;
   lldb::addr_t m_live_address;
   AddressType m_live_address_type;
-  lldb::ValueObjectSP m_address_of_backend;
+  std::optional<lldb::ValueObjectSP> m_address_of_backend;
 
   ValueObjectConstResultImpl(const ValueObjectConstResultImpl &) = delete;
   const ValueObjectConstResultImpl &

--- a/lldb/include/lldb/Core/ValueObjectList.h
+++ b/lldb/include/lldb/Core/ValueObjectList.h
@@ -28,31 +28,34 @@ public:
 
   void Append(const ValueObjectList &valobj_list);
 
-  lldb::ValueObjectSP FindValueObjectByPointer(ValueObject *valobj);
+  std::optional<lldb::ValueObjectSP>
+  FindValueObjectByPointer(ValueObject *valobj);
 
   size_t GetSize() const;
 
   void Resize(size_t size);
 
-  lldb::ValueObjectSP GetValueObjectAtIndex(size_t idx);
+  std::optional<lldb::ValueObjectSP> GetValueObjectAtIndex(size_t idx);
 
-  lldb::ValueObjectSP RemoveValueObjectAtIndex(size_t idx);
+  std::optional<lldb::ValueObjectSP> RemoveValueObjectAtIndex(size_t idx);
 
   void SetValueObjectAtIndex(size_t idx, const lldb::ValueObjectSP &valobj_sp);
 
-  lldb::ValueObjectSP FindValueObjectByValueName(const char *name);
+  std::optional<lldb::ValueObjectSP>
+  FindValueObjectByValueName(const char *name);
 
-  lldb::ValueObjectSP FindValueObjectByUID(lldb::user_id_t uid);
+  std::optional<lldb::ValueObjectSP> FindValueObjectByUID(lldb::user_id_t uid);
 
   void Swap(ValueObjectList &value_object_list);
 
   void Clear() { m_value_objects.clear(); }
 
-  const std::vector<lldb::ValueObjectSP> &GetObjects() const {
+  const std::vector<std::optional<lldb::ValueObjectSP>> &GetObjects() const {
     return m_value_objects;
   }
+
 protected:
-  typedef std::vector<lldb::ValueObjectSP> collection;
+  typedef std::vector<std::optional<lldb::ValueObjectSP>> collection;
   // Classes that inherit from ValueObjectList can see and modify these
   collection m_value_objects;
 };

--- a/lldb/include/lldb/Core/ValueObjectRegister.h
+++ b/lldb/include/lldb/Core/ValueObjectRegister.h
@@ -52,8 +52,8 @@ public:
   ValueObject *CreateChildAtIndex(size_t idx, bool synthetic_array_member,
                                   int32_t synthetic_index) override;
 
-  lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
-                                             bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true) override;
 
   size_t GetIndexOfChildWithName(llvm::StringRef name) override;
 

--- a/lldb/include/lldb/Core/ValueObjectSyntheticFilter.h
+++ b/lldb/include/lldb/Core/ValueObjectSyntheticFilter.h
@@ -51,15 +51,15 @@ public:
 
   lldb::ValueType GetValueType() const override;
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx,
-                                      bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildAtIndex(size_t idx, bool can_create = true) override;
 
-  lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
-                                             bool can_create = true) override;
+  std::optional<lldb::ValueObjectSP>
+  GetChildMemberWithName(llvm::StringRef name, bool can_create = true) override;
 
   size_t GetIndexOfChildWithName(llvm::StringRef name) override;
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetDynamicValue(lldb::DynamicValueType valueType) override;
 
   bool IsInScope() override;

--- a/lldb/include/lldb/Core/ValueObjectUpdater.h
+++ b/lldb/include/lldb/Core/ValueObjectUpdater.h
@@ -20,9 +20,9 @@ namespace lldb_private {
 /// process' stop ID and will update the user type when needed.
 class ValueObjectUpdater {
   /// The root value object is the static typed variable object.
-  lldb::ValueObjectSP m_root_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_root_valobj_sp;
   /// The user value object is the value object the user wants to see.
-  lldb::ValueObjectSP m_user_valobj_sp;
+  std::optional<lldb::ValueObjectSP> m_user_valobj_sp;
   /// The stop ID that m_user_valobj_sp is valid for.
   uint32_t m_stop_id = UINT32_MAX;
 
@@ -33,7 +33,7 @@ public:
   /// stop ID. If dynamic values are enabled, or if synthetic children are
   /// enabled, the value object that the user wants to see might change while
   /// debugging.
-  lldb::ValueObjectSP GetSP();
+  std::optional<lldb::ValueObjectSP> GetSP();
 
   lldb::ProcessSP GetProcessSP() const;
 };

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -45,7 +45,7 @@ public:
     return count <= max ? count : max;
   }
 
-  virtual lldb::ValueObjectSP GetChildAtIndex(size_t idx) = 0;
+  virtual std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) = 0;
 
   virtual size_t GetIndexOfChildWithName(ConstString name) = 0;
 
@@ -68,7 +68,7 @@ public:
   // if this function returns a non-null ValueObject, then the returned
   // ValueObject will stand for this ValueObject whenever a "value" request is
   // made to this ValueObject
-  virtual lldb::ValueObjectSP GetSyntheticValue() { return nullptr; }
+  virtual std::optional<lldb::ValueObjectSP> GetSyntheticValue() { return {}; }
 
   // if this function returns a non-empty ConstString, then clients are
   // expected to use the return as the name of the type of this ValueObject for
@@ -79,12 +79,12 @@ public:
   typedef std::unique_ptr<SyntheticChildrenFrontEnd> AutoPointer;
 
 protected:
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromExpression(llvm::StringRef name,
                                   llvm::StringRef expression,
                                   const ExecutionContext &exe_ctx);
 
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   CreateValueObjectFromAddress(llvm::StringRef name, uint64_t address,
                                const ExecutionContext &exe_ctx,
                                CompilerType type);
@@ -110,7 +110,9 @@ public:
 
   size_t CalculateNumChildren() override { return 0; }
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override { return nullptr; }
+  std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override {
+    return {};
+  }
 
   size_t GetIndexOfChildWithName(ConstString name) override {
     return UINT32_MAX;
@@ -120,7 +122,7 @@ public:
 
   bool MightHaveChildren() override { return false; }
 
-  lldb::ValueObjectSP GetSyntheticValue() override = 0;
+  std::optional<lldb::ValueObjectSP> GetSyntheticValue() override = 0;
 
 private:
   SyntheticValueProviderFrontEnd(const SyntheticValueProviderFrontEnd &) =
@@ -321,9 +323,9 @@ public:
 
     size_t CalculateNumChildren() override { return filter->GetCount(); }
 
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+    std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override {
       if (idx >= filter->GetCount())
-        return lldb::ValueObjectSP();
+        return {};
       return m_backend.GetSyntheticExpressionPathChild(
           filter->GetExpressionPathAtIndex(idx), true);
     }
@@ -425,7 +427,7 @@ public:
 
     size_t CalculateNumChildren(uint32_t max) override;
 
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+    std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override;
 
     bool Update() override;
 
@@ -433,7 +435,7 @@ public:
 
     size_t GetIndexOfChildWithName(ConstString name) override;
 
-    lldb::ValueObjectSP GetSyntheticValue() override;
+    std::optional<lldb::ValueObjectSP> GetSyntheticValue() override;
 
     ConstString GetSyntheticTypeName() override;
 

--- a/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
+++ b/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
@@ -101,7 +101,8 @@ protected:
 
   void PrintChildrenPostamble(bool print_dotdotdot);
 
-  lldb::ValueObjectSP GenerateChild(ValueObject *synth_valobj, size_t idx);
+  std::optional<lldb::ValueObjectSP> GenerateChild(ValueObject *synth_valobj,
+                                                   size_t idx);
 
   void PrintChild(lldb::ValueObjectSP child_sp,
                   const DumpValueObjectOptions::PointerDepth &curr_ptr_depth);

--- a/lldb/include/lldb/DataFormatters/VectorIterator.h
+++ b/lldb/include/lldb/DataFormatters/VectorIterator.h
@@ -26,7 +26,7 @@ public:
 
   size_t CalculateNumChildren() override;
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  std::optional<lldb::ValueObjectSP> GetChildAtIndex(size_t idx) override;
 
   bool Update() override;
 

--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -266,7 +266,7 @@ public:
   static lldb::ExpressionResults
   Evaluate(ExecutionContext &exe_ctx, const EvaluateExpressionOptions &options,
            llvm::StringRef expr_cstr, llvm::StringRef expr_prefix,
-           lldb::ValueObjectSP &result_valobj_sp, Status &error,
+           std::optional<lldb::ValueObjectSP> result_valobj_sp, Status &error,
            std::string *fixed_expression = nullptr,
            ValueObject *ctx_obj = nullptr);
 

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -425,9 +425,9 @@ public:
     return 0;
   }
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetChildAtIndex(const StructuredData::ObjectSP &implementor, uint32_t idx) {
-    return lldb::ValueObjectSP();
+    return {};
   }
 
   virtual int
@@ -446,9 +446,9 @@ public:
     return true;
   }
 
-  virtual lldb::ValueObjectSP
+  virtual std::optional<lldb::ValueObjectSP>
   GetSyntheticValue(const StructuredData::ObjectSP &implementor) {
-    return nullptr;
+    return {};
   }
 
   virtual ConstString

--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -149,9 +149,9 @@ public:
   static lldb::BreakpointPreconditionSP
   GetExceptionPrecondition(lldb::LanguageType language, bool throw_bp);
 
-  virtual lldb::ValueObjectSP GetExceptionObjectForThread(
-      lldb::ThreadSP thread_sp) {
-    return lldb::ValueObjectSP();
+  virtual std::optional<lldb::ValueObjectSP>
+  GetExceptionObjectForThread(lldb::ThreadSP thread_sp) {
+    return {};
   }
 
   virtual lldb::ThreadSP GetBacktraceThreadFromException(

--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -307,7 +307,7 @@ public:
   ///
   /// \return
   ///     A shared pointer to the ValueObject described by var_expr.
-  lldb::ValueObjectSP GetValueForVariableExpressionPath(
+  std::optional<lldb::ValueObjectSP> GetValueForVariableExpressionPath(
       llvm::StringRef var_expr, lldb::DynamicValueType use_dynamic,
       uint32_t options, lldb::VariableSP &var_sp, Status &error);
 
@@ -439,7 +439,7 @@ public:
   ///
   /// \return
   ///     A ValueObject for this variable.
-  lldb::ValueObjectSP
+  std::optional<lldb::ValueObjectSP>
   GetValueObjectForFrameVariable(const lldb::VariableSP &variable_sp,
                                  lldb::DynamicValueType use_dynamic);
 
@@ -463,7 +463,7 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.  If valid, it has a valid ExpressionPath.
-  lldb::ValueObjectSP GuessValueForAddress(lldb::addr_t addr);
+  std::optional<lldb::ValueObjectSP> GuessValueForAddress(lldb::addr_t addr);
 
   /// Attempt to reconstruct the ValueObject for the address contained in a
   /// given register plus an offset.  The ExpressionPath should indicate how
@@ -477,8 +477,8 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.  If valid, it has a valid ExpressionPath.
-  lldb::ValueObjectSP GuessValueForRegisterAndOffset(ConstString reg,
-                                                     int64_t offset);
+  std::optional<lldb::ValueObjectSP>
+  GuessValueForRegisterAndOffset(ConstString reg, int64_t offset);
 
   /// Attempt to reconstruct the ValueObject for a variable with a given \a name
   /// from within the current StackFrame, within the current block. The search
@@ -491,7 +491,7 @@ public:
   ///
   /// \return
   ///   The ValueObject if found.
-  lldb::ValueObjectSP FindVariable(ConstString name);
+  std::optional<lldb::ValueObjectSP> FindVariable(ConstString name);
 
   // lldb::ExecutionContextScope pure virtual functions
   lldb::TargetSP CalculateTarget() override;

--- a/lldb/include/lldb/Target/StackFrameRecognizer.h
+++ b/lldb/include/lldb/Target/StackFrameRecognizer.h
@@ -34,9 +34,7 @@ public:
   virtual lldb::ValueObjectListSP GetRecognizedArguments() {
     return m_arguments;
   }
-  virtual lldb::ValueObjectSP GetExceptionObject() {
-    return lldb::ValueObjectSP();
-  }
+  virtual std::optional<lldb::ValueObjectSP> GetExceptionObject() { return {}; }
   virtual lldb::StackFrameSP GetMostRelevantFrame() { return nullptr; };
   virtual ~RecognizedStackFrame() = default;
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1239,7 +1239,7 @@ public:
   // the execution context.
   lldb::ExpressionResults EvaluateExpression(
       llvm::StringRef expression, ExecutionContextScope *exe_scope,
-      lldb::ValueObjectSP &result_valobj_sp,
+      std::optional<lldb::ValueObjectSP> &result_valobj_sp,
       const EvaluateExpressionOptions &options = EvaluateExpressionOptions(),
       std::string *fixed_expression = nullptr, ValueObject *ctx_obj = nullptr);
 

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -414,7 +414,7 @@ public:
                                   bool broadcast = false);
 
   Status ReturnFromFrame(lldb::StackFrameSP frame_sp,
-                         lldb::ValueObjectSP return_value_sp,
+                         std::optional<lldb::ValueObjectSP> return_value_sp,
                          bool broadcast = false);
 
   Status JumpToLine(const FileSpec &file, uint32_t line,
@@ -1213,7 +1213,7 @@ public:
   ///     LLDB_INVALID_ADDRESS is returned if no token is available.
   virtual uint64_t GetExtendedBacktraceToken() { return LLDB_INVALID_ADDRESS; }
 
-  lldb::ValueObjectSP GetCurrentException();
+  std::optional<lldb::ValueObjectSP> GetCurrentException();
 
   lldb::ThreadSP GetCurrentExceptionBacktrace();
 

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -450,8 +450,8 @@ public:
   // (currently only ThreadPlanStepOut does this.) If so, the ReturnValueObject
   // can be retrieved from here.
 
-  virtual lldb::ValueObjectSP GetReturnValueObject() {
-    return lldb::ValueObjectSP();
+  virtual std::optional<lldb::ValueObjectSP> GetReturnValueObject() {
+    return {};
   }
 
   // If the thread plan managing the evaluation of a user expression lives

--- a/lldb/include/lldb/Target/ThreadPlanCallFunction.h
+++ b/lldb/include/lldb/Target/ThreadPlanCallFunction.h
@@ -59,7 +59,7 @@ public:
   // plan is complete, you can call "GetReturnValue()" to retrieve the value
   // that was extracted.
 
-  lldb::ValueObjectSP GetReturnValueObject() override {
+  std::optional<lldb::ValueObjectSP> GetReturnValueObject() override {
     return m_return_valobj_sp;
   }
 

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -9,7 +9,9 @@
 #ifndef LLDB_LLDB_FORWARD_H
 #define LLDB_LLDB_FORWARD_H
 
+#include <assert.h>
 #include <memory>
+#include <optional>
 
 // lldb forward declarations
 namespace lldb_private {
@@ -466,7 +468,16 @@ typedef std::shared_ptr<lldb_private::UnixSignals> UnixSignalsSP;
 typedef std::weak_ptr<lldb_private::UnixSignals> UnixSignalsWP;
 typedef std::shared_ptr<lldb_private::UnwindAssembly> UnwindAssemblySP;
 typedef std::shared_ptr<lldb_private::UnwindPlan> UnwindPlanSP;
-typedef std::shared_ptr<lldb_private::ValueObject> ValueObjectSP;
+class ValueObjectSP : public std::shared_ptr<lldb_private::ValueObject> {
+  ValueObjectSP() = delete;
+  operator bool() = delete;
+
+public:
+  ValueObjectSP(std::shared_ptr<lldb_private::ValueObject> &&pointer)
+      : std::shared_ptr<lldb_private::ValueObject>(std::move(pointer)) {
+    assert(pointer);
+  }
+};
 typedef std::shared_ptr<lldb_private::Value> ValueSP;
 typedef std::shared_ptr<lldb_private::Variable> VariableSP;
 typedef std::shared_ptr<lldb_private::VariableList> VariableListSP;

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -285,8 +285,6 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
   // We need to make sure the user sees any parse errors in their condition, so
   // we'll hook the constructor errors up to the debugger's Async I/O.
 
-  ValueObjectSP result_value_sp;
-
   EvaluateExpressionOptions options;
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
@@ -311,10 +309,10 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
       return false;
     }
 
-    result_value_sp = result_variable_sp->GetValueObject();
+    auto result_value_sp = result_variable_sp->GetValueObject();
 
     if (result_value_sp) {
-      ret = result_value_sp->IsLogicalTrue(error);
+      ret = result_value_sp.value()->IsLogicalTrue(error);
       if (log) {
         if (error.Success()) {
           LLDB_LOGF(log, "Condition successfully evaluated, result is %s.\n",

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -137,7 +137,7 @@ protected:
     Thread *thread = m_exe_ctx.GetThreadPtr();
     StackFrameSP frame_sp = thread->GetSelectedFrame(SelectMostRelevantFrame);
 
-    ValueObjectSP valobj_sp;
+    std::optional<lldb::ValueObjectSP> valobj_sp;
 
     if (m_options.address) {
       if (m_options.reg || m_options.offset) {
@@ -170,15 +170,15 @@ protected:
                      Stream &stream) -> bool {
       const ValueObject::GetExpressionPathFormat format = ValueObject::
           GetExpressionPathFormat::eGetExpressionPathFormatHonorPointers;
-      valobj_sp->GetExpressionPath(stream, format);
+      valobj_sp.value()->GetExpressionPath(stream, format);
       stream.PutCString(" =");
       return true;
     };
 
     DumpValueObjectOptions options;
     options.SetDeclPrintingHelper(helper);
-    ValueObjectPrinter printer(valobj_sp.get(), &result.GetOutputStream(),
-                               options);
+    ValueObjectPrinter printer(valobj_sp.value().get(),
+                               &result.GetOutputStream(), options);
     printer.PrintValueObject();
   }
 
@@ -544,7 +544,7 @@ protected:
       result.AppendError(error.AsCString());
 
     }
-    ValueObjectSP valobj_sp;
+    std::optional<ValueObjectSP> valobj_sp;
 
     TypeSummaryImplSP summary_format_sp;
     if (!m_option_variable.summary.IsCurrentValueEmpty())
@@ -606,7 +606,7 @@ protected:
                                                 show_module))
                       s.PutCString(": ");
                   }
-                  valobj_sp->Dump(result.GetOutputStream(), options);
+                  valobj_sp.value()->Dump(result.GetOutputStream(), options);
                 }
               }
             } else {
@@ -643,12 +643,12 @@ protected:
 
               options.SetFormat(format);
               options.SetVariableFormatDisplayLanguage(
-                  valobj_sp->GetPreferredDisplayLanguage());
+                  valobj_sp.value()->GetPreferredDisplayLanguage());
 
               Stream &output_stream = result.GetOutputStream();
               options.SetRootValueObjectName(
-                  valobj_sp->GetParent() ? entry.c_str() : nullptr);
-              valobj_sp->Dump(output_stream, options);
+                  valobj_sp.value()->GetParent() ? entry.c_str() : nullptr);
+              valobj_sp.value()->Dump(output_stream, options);
             } else {
               if (auto error_cstr = error.AsCString(nullptr))
                 result.AppendError(error_cstr);
@@ -679,10 +679,11 @@ protected:
             if (valobj_sp) {
               // When dumping all variables, don't print any variables that are
               // not in scope to avoid extra unneeded output
-              if (valobj_sp->IsInScope()) {
-                if (!valobj_sp->GetTargetSP()
+              if (valobj_sp.value()->IsInScope()) {
+                if (!valobj_sp.value()
+                         ->GetTargetSP()
                          ->GetDisplayRuntimeSupportValues() &&
-                    valobj_sp->IsRuntimeSupportValue())
+                    valobj_sp.value()->IsRuntimeSupportValue())
                   continue;
 
                 if (!scope_string.empty())
@@ -696,10 +697,10 @@ protected:
 
                 options.SetFormat(format);
                 options.SetVariableFormatDisplayLanguage(
-                    valobj_sp->GetPreferredDisplayLanguage());
+                    valobj_sp.value()->GetPreferredDisplayLanguage());
                 options.SetRootValueObjectName(
                     var_sp ? var_sp->GetName().AsCString() : nullptr);
-                valobj_sp->Dump(result.GetOutputStream(), options);
+                valobj_sp.value()->Dump(result.GetOutputStream(), options);
               }
             }
           }
@@ -718,9 +719,10 @@ protected:
           for (auto &rec_value_sp : recognized_arg_list->GetObjects()) {
             options.SetFormat(m_option_format.GetFormat());
             options.SetVariableFormatDisplayLanguage(
-                rec_value_sp->GetPreferredDisplayLanguage());
-            options.SetRootValueObjectName(rec_value_sp->GetName().AsCString());
-            rec_value_sp->Dump(result.GetOutputStream(), options);
+                rec_value_sp.value()->GetPreferredDisplayLanguage());
+            options.SetRootValueObjectName(
+                rec_value_sp.value()->GetName().AsCString());
+            rec_value_sp.value()->Dump(result.GetOutputStream(), options);
           }
         }
       }

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -807,21 +807,14 @@ protected:
         name_strm.Printf("0x%" PRIx64, item_addr);
         ValueObjectSP valobj_sp(ValueObjectMemory::Create(
             exe_scope, name_strm.GetString(), address, compiler_type));
-        if (valobj_sp) {
-          Format format = m_format_options.GetFormat();
-          if (format != eFormatDefault)
-            valobj_sp->SetFormat(format);
+        Format format = m_format_options.GetFormat();
+        if (format != eFormatDefault)
+          valobj_sp->SetFormat(format);
 
-          DumpValueObjectOptions options(m_varobj_options.GetAsDumpOptions(
-              eLanguageRuntimeDescriptionDisplayVerbosityFull, format));
+        DumpValueObjectOptions options(m_varobj_options.GetAsDumpOptions(
+            eLanguageRuntimeDescriptionDisplayVerbosityFull, format));
 
-          valobj_sp->Dump(*output_stream_p, options);
-        } else {
-          result.AppendErrorWithFormat(
-              "failed to create a value object for: (%s) %s\n",
-              view_as_type_cstr, name_strm.GetData());
-          return;
-        }
+        valobj_sp->Dump(*output_stream_p, options);
       }
       return;
     }
@@ -1052,16 +1045,16 @@ protected:
       buffer.CopyData(str);
     } else if (m_memory_options.m_expr.OptionWasSet()) {
       StackFrame *frame = m_exe_ctx.GetFramePtr();
-      ValueObjectSP result_sp;
+      std::optional<lldb::ValueObjectSP> result_sp;
       if ((eExpressionCompleted ==
            process->GetTarget().EvaluateExpression(
                m_memory_options.m_expr.GetValueAs<llvm::StringRef>().value_or(
                    ""),
                frame, result_sp)) &&
           result_sp) {
-        uint64_t value = result_sp->GetValueAsUnsigned(0);
+        uint64_t value = result_sp.value()->GetValueAsUnsigned(0);
         std::optional<uint64_t> size =
-            result_sp->GetCompilerType().GetByteSize(nullptr);
+            result_sp.value()->GetCompilerType().GetByteSize(nullptr);
         if (!size)
           return;
         switch (*size) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -854,8 +854,7 @@ protected:
       ValueObjectSP valobj_sp(ValueObjectVariable::Create(
           exe_ctx.GetBestExecutionContextScope(), var_sp));
 
-      if (valobj_sp)
-        DumpValueObject(s, var_sp, valobj_sp, var_sp->GetName().GetCString());
+      DumpValueObject(s, var_sp, valobj_sp, var_sp->GetName().GetCString());
     }
   }
 
@@ -897,14 +896,14 @@ protected:
           for (uint32_t global_idx = 0; global_idx < matches; ++global_idx) {
             VariableSP var_sp(variable_list.GetVariableAtIndex(global_idx));
             if (var_sp) {
-              ValueObjectSP valobj_sp(
+              std::optional<ValueObjectSP> valobj_sp(
                   valobj_list.GetValueObjectAtIndex(global_idx));
               if (!valobj_sp)
                 valobj_sp = ValueObjectVariable::Create(
                     m_exe_ctx.GetBestExecutionContextScope(), var_sp);
 
               if (valobj_sp)
-                DumpValueObject(s, var_sp, valobj_sp,
+                DumpValueObject(s, var_sp, valobj_sp.value(),
                                 use_var_name ? var_sp->GetName().GetCString()
                                              : arg.c_str());
             }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1422,10 +1422,8 @@ public:
     }
 
     Stream &strm = result.GetOutputStream();
-    ValueObjectSP exception_object_sp = thread_sp->GetCurrentException();
-    if (exception_object_sp) {
-      exception_object_sp->Dump(strm);
-    }
+    if (auto exception_object_sp = thread_sp->GetCurrentException())
+      exception_object_sp.value()->Dump(strm);
 
     ThreadSP exception_thread_sp = thread_sp->GetCurrentExceptionBacktrace();
     if (exception_thread_sp && exception_thread_sp->IsValid()) {
@@ -1476,10 +1474,7 @@ public:
       return false;
     }
     ValueObjectSP exception_object_sp = thread_sp->GetSiginfoValue();
-    if (exception_object_sp)
-      exception_object_sp->Dump(strm);
-    else
-      strm.Printf("(no siginfo)\n");
+    exception_object_sp->Dump(strm);
     strm.PutChar('\n');
 
     return true;
@@ -1601,7 +1596,7 @@ protected:
       return;
     }
 
-    ValueObjectSP return_valobj_sp;
+    std::optional<ValueObjectSP> return_valobj_sp;
 
     StackFrameSP frame_sp = m_exe_ctx.GetFrameSP();
     uint32_t frame_idx = frame_sp->GetFrameIndex();
@@ -1625,7 +1620,7 @@ protected:
         if (return_valobj_sp)
           result.AppendErrorWithFormat(
               "Error evaluating result expression: %s",
-              return_valobj_sp->GetError().AsCString());
+              return_valobj_sp.value()->GetError().AsCString());
         else
           result.AppendErrorWithFormat(
               "Unknown error evaluating result expression.");

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2855,28 +2855,30 @@ protected:
 
     StackFrameSP frame_sp =
         thread->GetSelectedFrame(DoNoSelectMostRelevantFrame);
-    ValueObjectSP result_valobj_sp;
+    std::optional<ValueObjectSP> result_valobj_sp;
     EvaluateExpressionOptions options;
     lldb::ExpressionResults expr_result = target_sp->EvaluateExpression(
         command, frame_sp.get(), result_valobj_sp, options);
     if (expr_result == eExpressionCompleted && result_valobj_sp) {
       result_valobj_sp =
-          result_valobj_sp->GetQualifiedRepresentationIfAvailable(
+          result_valobj_sp.value()->GetQualifiedRepresentationIfAvailable(
               target_sp->GetPreferDynamicValue(),
               target_sp->GetEnableSyntheticValue());
       typename FormatterType::SharedPointer formatter_sp =
-          m_discovery_function(*result_valobj_sp);
+          m_discovery_function(*result_valobj_sp.value());
       if (formatter_sp) {
         std::string description(formatter_sp->GetDescription());
         result.GetOutputStream()
             << m_formatter_name << " applied to ("
-            << result_valobj_sp->GetDisplayTypeName().AsCString("<unknown>")
+            << result_valobj_sp.value()->GetDisplayTypeName().AsCString(
+                   "<unknown>")
             << ") " << command << " is: " << description << "\n";
         result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
       } else {
         result.GetOutputStream()
             << "no " << m_formatter_name << " applies to ("
-            << result_valobj_sp->GetDisplayTypeName().AsCString("<unknown>")
+            << result_valobj_sp.value()->GetDisplayTypeName().AsCString(
+                   "<unknown>")
             << ") " << command << "\n";
         result.SetStatus(lldb::eReturnStatusSuccessFinishNoResult);
       }

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -608,8 +608,8 @@ static bool DumpRegister(Stream &s, StackFrame *frame, RegisterKind reg_kind,
   return false;
 }
 
-static ValueObjectSP ExpandIndexedExpression(ValueObject *valobj, size_t index,
-                                             bool deref_pointer) {
+static std::optional<ValueObjectSP>
+ExpandIndexedExpression(ValueObject *valobj, size_t index, bool deref_pointer) {
   Log *log = GetLog(LLDBLog::DataFormatters);
   std::string name_to_deref = llvm::formatv("[{0}]", index);
   LLDB_LOG(log, "[ExpandIndexedExpression] name to deref: {0}", name_to_deref);
@@ -619,7 +619,7 @@ static ValueObjectSP ExpandIndexedExpression(ValueObject *valobj, size_t index,
   ValueObject::ExpressionPathAftermath what_next =
       (deref_pointer ? ValueObject::eExpressionPathAftermathDereference
                      : ValueObject::eExpressionPathAftermathNothing);
-  ValueObjectSP item = valobj->GetValueForExpressionPath(
+  std::optional<ValueObjectSP> item = valobj->GetValueForExpressionPath(
       name_to_deref, &reason_to_stop, &final_value_type, options, &what_next);
   if (!item) {
     LLDB_LOGF(log,
@@ -690,8 +690,9 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
     custom_format = entry.fmt;
     val_obj_display = (ValueObject::ValueObjectRepresentationStyle)entry.number;
     if (!valobj->IsSynthetic()) {
-      valobj = valobj->GetSyntheticValue().get();
-      if (valobj == nullptr)
+      if (std::optional<ValueObjectSP> temp = valobj->GetSyntheticValue())
+        valobj = temp.value().get();
+      else
         return false;
     }
     break;
@@ -756,7 +757,7 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
         valobj
             ->GetValueForExpressionPath(expr_path.c_str(), &reason_to_stop,
                                         &final_value_type, options, &what_next)
-            .get();
+            ->get();
 
     if (!target) {
       LLDB_LOGF(log,
@@ -789,13 +790,13 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
     // I have not deref-ed yet, let's do it
     // this happens when we are not going through
     // GetValueForVariableExpressionPath to get to the target ValueObject
-    Status error;
-    target = target->Dereference(error).get();
-    if (error.Fail()) {
+    ValueObjectSP temp = target->Dereference();
+    if (temp->GetError().Fail()) {
       LLDB_LOGF(log, "[Debugger::FormatPrompt] ERROR: %s\n",
-                error.AsCString("unknown"));
+                temp->GetError().AsCString("unknown"));
       return false;
     }
+    target = temp.get();
     do_deref_pointer = false;
   }
 
@@ -933,7 +934,7 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
 
     bool success = true;
     for (int64_t index = index_lower; index <= index_higher; ++index) {
-      ValueObject *item = ExpandIndexedExpression(target, index, false).get();
+      ValueObject *item = ExpandIndexedExpression(target, index, false)->get();
 
       if (!item) {
         LLDB_LOGF(log,
@@ -1343,10 +1344,10 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
       if (thread) {
         StopInfoSP stop_info_sp = thread->GetStopInfo();
         if (stop_info_sp && stop_info_sp->IsValid()) {
-          ValueObjectSP return_valobj_sp =
+          std::optional<ValueObjectSP> return_valobj_sp =
               StopInfo::GetReturnValueObject(stop_info_sp);
           if (return_valobj_sp) {
-            return_valobj_sp->Dump(s);
+            return_valobj_sp.value()->Dump(s);
             return true;
           }
         }
@@ -1363,7 +1364,7 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
           ExpressionVariableSP expression_var_sp =
               StopInfo::GetExpressionVariable(stop_info_sp);
           if (expression_var_sp && expression_var_sp->GetValueObject()) {
-            expression_var_sp->GetValueObject()->Dump(s);
+            expression_var_sp->GetValueObject().value()->Dump(s);
             return true;
           }
         }

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -372,8 +372,8 @@ bool ValueObject::IsLogicalTrue(Status &error) {
   return ret;
 }
 
-ValueObjectSP ValueObject::GetChildAtIndex(size_t idx, bool can_create) {
-  ValueObjectSP child_sp;
+std::optional<ValueObjectSP> ValueObject::GetChildAtIndex(size_t idx,
+                                                          bool can_create) {
   // We may need to update our value if we are dynamic
   if (IsPossibleDynamicType())
     UpdateValueIfNeeded(false);
@@ -389,21 +389,19 @@ ValueObjectSP ValueObject::GetChildAtIndex(size_t idx, bool can_create) {
     if (child != nullptr)
       return child->GetSP();
   }
-  return child_sp;
+  return {};
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObject::GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names) {
-  if (names.size() == 0)
-    return GetSP();
-  ValueObjectSP root(GetSP());
+  ValueObjectSP value_object = GetSP();
   for (llvm::StringRef name : names) {
-    root = root->GetChildMemberWithName(name);
-    if (!root) {
-      return root;
-    }
+    auto child = value_object->GetChildMemberWithName(name);
+    if (!child)
+      return {};
+    value_object = child.value();
   }
-  return root;
+  return value_object;
 }
 
 size_t ValueObject::GetIndexOfChildWithName(llvm::StringRef name) {
@@ -412,8 +410,8 @@ size_t ValueObject::GetIndexOfChildWithName(llvm::StringRef name) {
                                                    omit_empty_base_classes);
 }
 
-ValueObjectSP ValueObject::GetChildMemberWithName(llvm::StringRef name,
-                                                  bool can_create) {
+std::optional<ValueObjectSP>
+ValueObject::GetChildMemberWithName(llvm::StringRef name, bool can_create) {
   // We may need to update our value if we are dynamic.
   if (IsPossibleDynamicType())
     UpdateValueIfNeeded(false);
@@ -425,19 +423,21 @@ ValueObjectSP ValueObject::GetChildMemberWithName(llvm::StringRef name,
   bool omit_empty_base_classes = true;
 
   if (!GetCompilerType().IsValid())
-    return ValueObjectSP();
+    return {};
 
   const size_t num_child_indexes =
       GetCompilerType().GetIndexOfChildMemberWithName(
           name, omit_empty_base_classes, child_indexes);
   if (num_child_indexes == 0)
-    return nullptr;
+    return {};
 
-  ValueObjectSP child_sp = GetSP();
-  for (uint32_t idx : child_indexes)
-    if (child_sp)
-      child_sp = child_sp->GetChildAtIndex(idx, can_create);
-  return child_sp;
+  ValueObjectSP value_object = GetSP();
+  for (uint32_t idx : child_indexes) {
+    auto child = value_object->GetChildAtIndex(idx, can_create);
+    if (child)
+      value_object = child.value();
+  }
+  return value_object;
 }
 
 size_t ValueObject::GetNumChildren(uint32_t max) {
@@ -519,10 +519,10 @@ ValueObject *ValueObject::CreateChildAtIndex(size_t idx,
   // In case of an incomplete type, try to use the ValueObject's
   // synthetic value to create the child ValueObject.
   if (!valobj && synthetic_array_member) {
-    if (ValueObjectSP synth_valobj_sp = GetSyntheticValue()) {
-      valobj = synth_valobj_sp
-                   ->GetChildAtIndex(synthetic_index, synthetic_array_member)
-                   .get();
+    if (auto synth_valobj_sp = GetSyntheticValue()) {
+      auto child = synth_valobj_sp.value()->GetChildAtIndex(
+          synthetic_index, synthetic_array_member);
+      valobj = child.has_value() ? child->get() : nullptr;
     }
   }
 
@@ -640,17 +640,17 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
   if (item_idx == 0 && item_count == 1) // simply a deref
   {
     if (is_pointer_type) {
-      Status error;
-      ValueObjectSP pointee_sp = Dereference(error);
-      if (error.Fail() || pointee_sp.get() == nullptr)
+      ValueObjectSP pointee_sp = Dereference();
+      if (pointee_sp->GetError().Fail() || pointee_sp.get() == nullptr)
         return 0;
+      Status error;
       return pointee_sp->GetData(data, error);
     } else {
-      ValueObjectSP child_sp = GetChildAtIndex(0);
-      if (child_sp.get() == nullptr)
+      auto child = GetChildAtIndex(0);
+      if (!child)
         return 0;
       Status error;
-      return child_sp->GetData(data, error);
+      return child.value()->GetData(data, error);
     }
     return true;
   } else /* (items > 1) */
@@ -1185,12 +1185,12 @@ bool ValueObject::DumpPrintableRepresentation(
             if (low)
               s << ',';
 
-            ValueObjectSP child = GetChildAtIndex(low);
-            if (!child.get()) {
+            auto child = GetChildAtIndex(low);
+            if (!child) {
               s << "<invalid child>";
               continue;
             }
-            child->DumpPrintableRepresentation(
+            child.value()->DumpPrintableRepresentation(
                 s, ValueObject::eValueObjectRepresentationStyleValue,
                 custom_format);
           }
@@ -1226,12 +1226,12 @@ bool ValueObject::DumpPrintableRepresentation(
             if (low)
               s << ',';
 
-            ValueObjectSP child = GetChildAtIndex(low);
-            if (!child.get()) {
+            auto child = GetChildAtIndex(low);
+            if (!child) {
               s << "<invalid child>";
               continue;
             }
-            child->DumpPrintableRepresentation(
+            child.value()->DumpPrintableRepresentation(
                 s, ValueObject::eValueObjectRepresentationStyleValue, format);
           }
 
@@ -1523,13 +1523,13 @@ void ValueObject::AddSyntheticChild(ConstString key,
   m_synthetic_children[key] = valobj;
 }
 
-ValueObjectSP ValueObject::GetSyntheticChild(ConstString key) const {
-  ValueObjectSP synthetic_child_sp;
-  std::map<ConstString, ValueObject *>::const_iterator pos =
+std::optional<ValueObjectSP>
+ValueObject::GetSyntheticChild(ConstString key) const {
+  std::map<ConstString, ValueObject *>::const_iterator position =
       m_synthetic_children.find(key);
-  if (pos != m_synthetic_children.end())
-    synthetic_child_sp = pos->second->GetSP();
-  return synthetic_child_sp;
+  if (position != m_synthetic_children.end())
+    return {};
+  return position->second->GetSP();
 }
 
 bool ValueObject::IsPossibleDynamicType() {
@@ -1581,72 +1581,70 @@ bool ValueObject::IsUninitializedReference() {
 // The size of the "item_array" is 1, but many times in practice there are more
 // items in "item_array".
 
-ValueObjectSP ValueObject::GetSyntheticArrayMember(size_t index,
-                                                   bool can_create) {
-  ValueObjectSP synthetic_child_sp;
+std::optional<ValueObjectSP>
+ValueObject::GetSyntheticArrayMember(size_t index, bool can_create) {
   if (IsPointerType() || IsArrayType()) {
     std::string index_str = llvm::formatv("[{0}]", index);
     ConstString index_const_str(index_str);
     // Check if we have already created a synthetic array member in this valid
     // object. If we have we will re-use it.
-    synthetic_child_sp = GetSyntheticChild(index_const_str);
-    if (!synthetic_child_sp) {
-      ValueObject *synthetic_child;
-      // We haven't made a synthetic array member for INDEX yet, so lets make
-      // one and cache it for any future reference.
-      synthetic_child = CreateChildAtIndex(0, true, index);
+    if (auto existing_synthetic_child = GetSyntheticChild(index_const_str))
+      return existing_synthetic_child;
 
-      // Cache the value if we got one back...
-      if (synthetic_child) {
-        AddSyntheticChild(index_const_str, synthetic_child);
-        synthetic_child_sp = synthetic_child->GetSP();
-        synthetic_child_sp->SetName(ConstString(index_str));
-        synthetic_child_sp->m_flags.m_is_array_item_for_pointer = true;
-      }
+    ValueObject *synthetic_child;
+    // We haven't made a synthetic array member for INDEX yet, so lets make
+    // one and cache it for any future reference.
+    synthetic_child = CreateChildAtIndex(0, true, index);
+
+    // Cache the value if we got one back...
+    if (synthetic_child) {
+      AddSyntheticChild(index_const_str, synthetic_child);
+      ValueObjectSP synthetic_child_sp = synthetic_child->GetSP();
+      synthetic_child_sp->SetName(ConstString(index_str));
+      synthetic_child_sp->m_flags.m_is_array_item_for_pointer = true;
+      return synthetic_child_sp;
     }
   }
-  return synthetic_child_sp;
+  return {};
 }
 
-ValueObjectSP ValueObject::GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
-                                                     bool can_create) {
-  ValueObjectSP synthetic_child_sp;
+std::optional<ValueObjectSP>
+ValueObject::GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
+                                       bool can_create) {
   if (IsScalarType()) {
     std::string index_str = llvm::formatv("[{0}-{1}]", from, to);
     ConstString index_const_str(index_str);
     // Check if we have already created a synthetic array member in this valid
     // object. If we have we will re-use it.
-    synthetic_child_sp = GetSyntheticChild(index_const_str);
-    if (!synthetic_child_sp) {
-      uint32_t bit_field_size = to - from + 1;
-      uint32_t bit_field_offset = from;
-      if (GetDataExtractor().GetByteOrder() == eByteOrderBig)
-        bit_field_offset =
-            GetByteSize().value_or(0) * 8 - bit_field_size - bit_field_offset;
-      // We haven't made a synthetic array member for INDEX yet, so lets make
-      // one and cache it for any future reference.
-      ValueObjectChild *synthetic_child = new ValueObjectChild(
-          *this, GetCompilerType(), index_const_str, GetByteSize().value_or(0),
-          0, bit_field_size, bit_field_offset, false, false,
-          eAddressTypeInvalid, 0);
+    if (auto existing_synthetic_child = GetSyntheticChild(index_const_str))
+      return existing_synthetic_child;
 
-      // Cache the value if we got one back...
-      if (synthetic_child) {
-        AddSyntheticChild(index_const_str, synthetic_child);
-        synthetic_child_sp = synthetic_child->GetSP();
-        synthetic_child_sp->SetName(ConstString(index_str));
-        synthetic_child_sp->m_flags.m_is_bitfield_for_scalar = true;
-      }
+    uint32_t bit_field_size = to - from + 1;
+    uint32_t bit_field_offset = from;
+    if (GetDataExtractor().GetByteOrder() == eByteOrderBig)
+      bit_field_offset =
+          GetByteSize().value_or(0) * 8 - bit_field_size - bit_field_offset;
+    // We haven't made a synthetic array member for INDEX yet, so lets make
+    // one and cache it for any future reference.
+    ValueObjectChild *synthetic_child = new ValueObjectChild(
+        *this, GetCompilerType(), index_const_str, GetByteSize().value_or(0), 0,
+        bit_field_size, bit_field_offset, false, false, eAddressTypeInvalid, 0);
+
+    // Cache the value if we got one back...
+    if (synthetic_child) {
+      AddSyntheticChild(index_const_str, synthetic_child);
+      ValueObjectSP synthetic_child_sp = synthetic_child->GetSP();
+      synthetic_child_sp->SetName(ConstString(index_str));
+      synthetic_child_sp->m_flags.m_is_bitfield_for_scalar = true;
+      return synthetic_child_sp;
     }
   }
-  return synthetic_child_sp;
+  return {};
 }
 
-ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
+std::optional<ValueObjectSP> ValueObject::GetSyntheticChildAtOffset(
     uint32_t offset, const CompilerType &type, bool can_create,
     ConstString name_const_str) {
-
-  ValueObjectSP synthetic_child_sp;
 
   if (name_const_str.IsEmpty()) {
     name_const_str.SetString("@" + std::to_string(offset));
@@ -1654,10 +1652,8 @@ ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
 
   // Check if we have already created a synthetic array member in this valid
   // object. If we have we will re-use it.
-  synthetic_child_sp = GetSyntheticChild(name_const_str);
-
-  if (synthetic_child_sp.get())
-    return synthetic_child_sp;
+  if (auto existing_synthetic_child = GetSyntheticChild(name_const_str))
+    return existing_synthetic_child;
 
   if (!can_create)
     return {};
@@ -1670,21 +1666,19 @@ ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
   ValueObjectChild *synthetic_child =
       new ValueObjectChild(*this, type, name_const_str, *size, offset, 0, 0,
                            false, false, eAddressTypeInvalid, 0);
-  if (synthetic_child) {
-    AddSyntheticChild(name_const_str, synthetic_child);
-    synthetic_child_sp = synthetic_child->GetSP();
-    synthetic_child_sp->SetName(name_const_str);
-    synthetic_child_sp->m_flags.m_is_child_at_offset = true;
-  }
+  if (!synthetic_child)
+    return {};
+
+  AddSyntheticChild(name_const_str, synthetic_child);
+  auto synthetic_child_sp = synthetic_child->GetSP();
+  synthetic_child_sp->SetName(name_const_str);
+  synthetic_child_sp->m_flags.m_is_child_at_offset = true;
   return synthetic_child_sp;
 }
 
-ValueObjectSP ValueObject::GetSyntheticBase(uint32_t offset,
-                                            const CompilerType &type,
-                                            bool can_create,
-                                            ConstString name_const_str) {
-  ValueObjectSP synthetic_child_sp;
-
+std::optional<ValueObjectSP>
+ValueObject::GetSyntheticBase(uint32_t offset, const CompilerType &type,
+                              bool can_create, ConstString name_const_str) {
   if (name_const_str.IsEmpty()) {
     char name_str[128];
     snprintf(name_str, sizeof(name_str), "base%s@%i",
@@ -1694,10 +1688,8 @@ ValueObjectSP ValueObject::GetSyntheticBase(uint32_t offset,
 
   // Check if we have already created a synthetic array member in this valid
   // object. If we have we will re-use it.
-  synthetic_child_sp = GetSyntheticChild(name_const_str);
-
-  if (synthetic_child_sp.get())
-    return synthetic_child_sp;
+  if (auto existing_synthetic_child = GetSyntheticChild(name_const_str))
+    return existing_synthetic_child;
 
   if (!can_create)
     return {};
@@ -1712,11 +1704,12 @@ ValueObjectSP ValueObject::GetSyntheticBase(uint32_t offset,
   ValueObjectChild *synthetic_child =
       new ValueObjectChild(*this, type, name_const_str, *size, offset, 0, 0,
                            is_base_class, false, eAddressTypeInvalid, 0);
-  if (synthetic_child) {
-    AddSyntheticChild(name_const_str, synthetic_child);
-    synthetic_child_sp = synthetic_child->GetSP();
-    synthetic_child_sp->SetName(name_const_str);
-  }
+  if (!synthetic_child)
+    return {};
+
+  AddSyntheticChild(name_const_str, synthetic_child);
+  auto synthetic_child_sp = synthetic_child->GetSP();
+  synthetic_child_sp->SetName(name_const_str);
   return synthetic_child_sp;
 }
 
@@ -1734,31 +1727,29 @@ static const char *SkipLeadingExpressionPathSeparators(const char *expression) {
   return expression;
 }
 
-ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObject::GetSyntheticExpressionPathChild(const char *expression,
                                              bool can_create) {
-  ValueObjectSP synthetic_child_sp;
   ConstString name_const_string(expression);
   // Check if we have already created a synthetic array member in this valid
   // object. If we have we will re-use it.
-  synthetic_child_sp = GetSyntheticChild(name_const_string);
-  if (!synthetic_child_sp) {
-    // We haven't made a synthetic array member for expression yet, so lets
-    // make one and cache it for any future reference.
-    synthetic_child_sp = GetValueForExpressionPath(
-        expression, nullptr, nullptr,
-        GetValueForExpressionPathOptions().SetSyntheticChildrenTraversal(
-            GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
-                None));
+  if (auto existing_synthetic_child = GetSyntheticChild(name_const_string))
+    return existing_synthetic_child;
 
-    // Cache the value if we got one back...
-    if (synthetic_child_sp.get()) {
-      // FIXME: this causes a "real" child to end up with its name changed to
-      // the contents of expression
-      AddSyntheticChild(name_const_string, synthetic_child_sp.get());
-      synthetic_child_sp->SetName(
-          ConstString(SkipLeadingExpressionPathSeparators(expression)));
-    }
+  // We haven't made a synthetic array member for expression yet, so lets
+  // make one and cache it for any future reference.
+  auto synthetic_child_sp = GetValueForExpressionPath(
+      expression, nullptr, nullptr,
+      GetValueForExpressionPathOptions().SetSyntheticChildrenTraversal(
+          GetValueForExpressionPathOptions::SyntheticChildrenTraversal::None));
+
+  // Cache the value if we got one back...
+  if (synthetic_child_sp) {
+    // FIXME: this causes a "real" child to end up with its name changed to
+    // the contents of expression
+    AddSyntheticChild(name_const_string, synthetic_child_sp.value().get());
+    synthetic_child_sp.value()->SetName(
+        ConstString(SkipLeadingExpressionPathSeparators(expression)));
   }
   return synthetic_child_sp;
 }
@@ -1798,9 +1789,10 @@ void ValueObject::CalculateDynamicValue(DynamicValueType use_dynamic) {
   }
 }
 
-ValueObjectSP ValueObject::GetDynamicValue(DynamicValueType use_dynamic) {
+std::optional<ValueObjectSP>
+ValueObject::GetDynamicValue(DynamicValueType use_dynamic) {
   if (use_dynamic == eNoDynamicValues)
-    return ValueObjectSP();
+    return {};
 
   if (!IsDynamic() && m_dynamic_value == nullptr) {
     CalculateDynamicValue(use_dynamic);
@@ -1808,16 +1800,16 @@ ValueObjectSP ValueObject::GetDynamicValue(DynamicValueType use_dynamic) {
   if (m_dynamic_value && m_dynamic_value->GetError().Success())
     return m_dynamic_value->GetSP();
   else
-    return ValueObjectSP();
+    return {};
 }
 
-ValueObjectSP ValueObject::GetSyntheticValue() {
+std::optional<ValueObjectSP> ValueObject::GetSyntheticValue() {
   CalculateSyntheticValue();
 
   if (m_synthetic_value)
     return m_synthetic_value->GetSP();
   else
-    return ValueObjectSP();
+    return {};
 }
 
 bool ValueObject::HasSyntheticValue() {
@@ -1951,7 +1943,7 @@ void ValueObject::GetExpressionPath(Stream &s,
   }
 }
 
-ValueObjectSP ValueObject::GetValueForExpressionPath(
+std::optional<ValueObjectSP> ValueObject::GetValueForExpressionPath(
     llvm::StringRef expression, ExpressionPathScanEndReason *reason_to_stop,
     ExpressionPathEndResultType *final_value_type,
     const GetValueForExpressionPathOptions &options,
@@ -1964,7 +1956,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath(
   ExpressionPathAftermath dummy_final_task_on_target =
       ValueObject::eExpressionPathAftermathNothing;
 
-  ValueObjectSP ret_val = GetValueForExpressionPath_Impl(
+  auto ret_val = GetValueForExpressionPath_Impl(
       expression, reason_to_stop ? reason_to_stop : &dummy_reason_to_stop,
       final_value_type ? final_value_type : &dummy_final_value_type, options,
       final_task_on_target ? final_task_on_target
@@ -1974,7 +1966,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath(
       *final_task_on_target == ValueObject::eExpressionPathAftermathNothing)
     return ret_val;
 
-  if (ret_val.get() &&
+  if (ret_val &&
       ((final_value_type ? *final_value_type : dummy_final_value_type) ==
        eExpressionPathEndResultTypePlain)) // I can only deref and takeaddress
                                            // of plain objects
@@ -1982,15 +1974,14 @@ ValueObjectSP ValueObject::GetValueForExpressionPath(
     if ((final_task_on_target ? *final_task_on_target
                               : dummy_final_task_on_target) ==
         ValueObject::eExpressionPathAftermathDereference) {
-      Status error;
-      ValueObjectSP final_value = ret_val->Dereference(error);
-      if (error.Fail() || !final_value.get()) {
+      auto final_value = ret_val.value()->Dereference();
+      if (final_value->GetError().Fail()) {
         if (reason_to_stop)
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonDereferencingFailed;
         if (final_value_type)
           *final_value_type = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return ValueObjectSP();
+        return {};
       } else {
         if (final_task_on_target)
           *final_task_on_target = ValueObject::eExpressionPathAftermathNothing;
@@ -1999,15 +1990,14 @@ ValueObjectSP ValueObject::GetValueForExpressionPath(
     }
     if (*final_task_on_target ==
         ValueObject::eExpressionPathAftermathTakeAddress) {
-      Status error;
-      ValueObjectSP final_value = ret_val->AddressOf(error);
-      if (error.Fail() || !final_value.get()) {
+      ValueObjectSP final_value = ret_val.value()->AddressOf();
+      if (final_value->GetError().Fail()) {
         if (reason_to_stop)
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonTakingAddressFailed;
         if (final_value_type)
           *final_value_type = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return ValueObjectSP();
+        return {};
       } else {
         if (final_task_on_target)
           *final_task_on_target = ValueObject::eExpressionPathAftermathNothing;
@@ -2019,15 +2009,12 @@ ValueObjectSP ValueObject::GetValueForExpressionPath(
                   // you know I did not do it
 }
 
-ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
+std::optional<ValueObjectSP> ValueObject::GetValueForExpressionPath_Impl(
     llvm::StringRef expression, ExpressionPathScanEndReason *reason_to_stop,
     ExpressionPathEndResultType *final_result,
     const GetValueForExpressionPathOptions &options,
     ExpressionPathAftermath *what_next) {
   ValueObjectSP root = GetSP();
-
-  if (!root)
-    return nullptr;
 
   llvm::StringRef remainder = expression;
 
@@ -2060,7 +2047,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         *reason_to_stop =
             ValueObject::eExpressionPathScanEndReasonArrowInsteadOfDot;
         *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return ValueObjectSP();
+        return {};
       }
       if (root_compiler_type_info.Test(eTypeIsObjC) && // if yo are trying to
                                                        // extract an ObjC IVar
@@ -2070,13 +2057,13 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         *reason_to_stop =
             ValueObject::eExpressionPathScanEndReasonFragileIVarNotAllowed;
         *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return ValueObjectSP();
+        return {};
       }
       if (!temp_expression.starts_with(">")) {
         *reason_to_stop =
             ValueObject::eExpressionPathScanEndReasonUnexpectedSymbol;
         *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return ValueObjectSP();
+        return {};
       }
     }
       [[fallthrough]];
@@ -2092,7 +2079,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         *reason_to_stop =
             ValueObject::eExpressionPathScanEndReasonDotInsteadOfArrow;
         *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return nullptr;
+        return {};
       }
       temp_expression = temp_expression.drop_front(); // skip . or >
 
@@ -2101,15 +2088,14 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
                                                  // expand this last layer
       {
         llvm::StringRef child_name = temp_expression;
-        ValueObjectSP child_valobj_sp =
-            root->GetChildMemberWithName(child_name);
 
-        if (child_valobj_sp.get()) // we know we are done, so just return
-        {
+        auto child = root->GetChildMemberWithName(child_name);
+        if (child) {
+          // we know we are done, so just return
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonEndOfString;
           *final_result = ValueObject::eExpressionPathEndResultTypePlain;
-          return child_valobj_sp;
+          return child;
         } else {
           switch (options.m_synthetic_children_traversal) {
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
@@ -2118,33 +2104,29 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               FromSynthetic:
             if (root->IsSynthetic()) {
-              child_valobj_sp = root->GetNonSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetNonSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               ToSynthetic:
             if (!root->IsSynthetic()) {
-              child_valobj_sp = root->GetSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               Both:
             if (root->IsSynthetic()) {
-              child_valobj_sp = root->GetNonSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetNonSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             } else {
-              child_valobj_sp = root->GetSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           }
@@ -2153,28 +2135,27 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         // if we are here and options.m_no_synthetic_children is true,
         // child_valobj_sp is going to be a NULL SP, so we hit the "else"
         // branch, and return an error
-        if (child_valobj_sp.get()) // if it worked, just return
+        if (child) // if it worked, just return
         {
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonEndOfString;
           *final_result = ValueObject::eExpressionPathEndResultTypePlain;
-          return child_valobj_sp;
+          return child;
         } else {
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonNoSuchChild;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         }
       } else // other layers do expand
       {
         llvm::StringRef next_separator = temp_expression.substr(next_sep_pos);
         llvm::StringRef child_name = temp_expression.slice(0, next_sep_pos);
 
-        ValueObjectSP child_valobj_sp =
-            root->GetChildMemberWithName(child_name);
-        if (child_valobj_sp.get()) // store the new root and move on
+        auto child = root->GetChildMemberWithName(child_name);
+        if (child) // store the new root and move on
         {
-          root = child_valobj_sp;
+          root = child.value();
           remainder = next_separator;
           *final_result = ValueObject::eExpressionPathEndResultTypePlain;
           continue;
@@ -2186,33 +2167,29 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               FromSynthetic:
             if (root->IsSynthetic()) {
-              child_valobj_sp = root->GetNonSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetNonSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               ToSynthetic:
             if (!root->IsSynthetic()) {
-              child_valobj_sp = root->GetSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           case GetValueForExpressionPathOptions::SyntheticChildrenTraversal::
               Both:
             if (root->IsSynthetic()) {
-              child_valobj_sp = root->GetNonSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetNonSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             } else {
-              child_valobj_sp = root->GetSyntheticValue();
-              if (child_valobj_sp.get())
-                child_valobj_sp =
-                    child_valobj_sp->GetChildMemberWithName(child_name);
+              child = root->GetSyntheticValue();
+              if (child)
+                child = child.value()->GetChildMemberWithName(child_name);
             }
             break;
           }
@@ -2221,9 +2198,9 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         // if we are here and options.m_no_synthetic_children is true,
         // child_valobj_sp is going to be a NULL SP, so we hit the "else"
         // branch, and return an error
-        if (child_valobj_sp.get()) // if it worked, move on
+        if (child) // if it worked, move on
         {
-          root = child_valobj_sp;
+          root = child.value();
           remainder = next_separator;
           *final_result = ValueObject::eExpressionPathEndResultTypePlain;
           continue;
@@ -2231,7 +2208,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonNoSuchChild;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         }
       }
       break;
@@ -2252,7 +2229,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonRangeOperatorInvalid;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return ValueObjectSP();
+            return {};
           }
         } else if (!options.m_allow_bitfields_syntax) // if this is a scalar,
                                                       // check that we can
@@ -2261,7 +2238,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonRangeOperatorNotAllowed;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return ValueObjectSP();
+          return {};
         }
       }
       if (temp_expression[1] ==
@@ -2271,7 +2248,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonEmptyRangeNotAllowed;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         } else // even if something follows, we cannot expand unbounded ranges,
                // just let the caller do it
         {
@@ -2290,7 +2267,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         *reason_to_stop =
             ValueObject::eExpressionPathScanEndReasonUnexpectedSymbol;
         *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-        return nullptr;
+        return {};
       }
 
       llvm::StringRef bracket_expr =
@@ -2309,21 +2286,23 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonUnexpectedSymbol;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         }
 
         // from here on we do have a valid index
         if (root_compiler_type_info.Test(eTypeIsArray)) {
-          ValueObjectSP child_valobj_sp = root->GetChildAtIndex(index);
-          if (!child_valobj_sp)
-            child_valobj_sp = root->GetSyntheticArrayMember(index, true);
-          if (!child_valobj_sp)
+          auto child = root->GetChildAtIndex(index);
+          if (!child)
+            child = root->GetSyntheticArrayMember(index, true);
+          if (!child)
             if (root->HasSyntheticValue() &&
-                root->GetSyntheticValue()->GetNumChildren() > index)
-              child_valobj_sp =
-                  root->GetSyntheticValue()->GetChildAtIndex(index);
-          if (child_valobj_sp) {
-            root = child_valobj_sp;
+                root->GetSyntheticValue().value()->GetNumChildren() > index)
+              child = root->GetSyntheticValue()
+                          .value()
+                          ->GetChildAtIndex(index)
+                          .value();
+          if (child) {
+            root = child.value();
             remainder =
                 temp_expression.substr(close_bracket_position + 1); // skip ]
             *final_result = ValueObject::eExpressionPathEndResultTypePlain;
@@ -2332,7 +2311,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonNoSuchChild;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           }
         } else if (root_compiler_type_info.Test(eTypeIsPointer)) {
           if (*what_next ==
@@ -2347,18 +2326,18 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
                                                              // and use this as
                                                              // a bitfield
               pointee_compiler_type_info.Test(eTypeIsScalar)) {
-            Status error;
-            root = root->Dereference(error);
-            if (error.Fail() || !root) {
+            root = root->Dereference();
+            if (root->GetError().Fail()) {
               *reason_to_stop =
                   ValueObject::eExpressionPathScanEndReasonDereferencingFailed;
               *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-              return nullptr;
+              return {};
             } else {
               *what_next = eExpressionPathAftermathNothing;
               continue;
             }
           } else {
+            std::optional<ValueObjectSP> child;
             if (root->GetCompilerType().GetMinimumLanguage() ==
                     eLanguageTypeObjC &&
                 pointee_compiler_type_info.AllClear(eTypeIsPointer) &&
@@ -2369,15 +2348,16 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
                  options.m_synthetic_children_traversal ==
                      GetValueForExpressionPathOptions::
                          SyntheticChildrenTraversal::Both)) {
-              root = root->GetSyntheticValue()->GetChildAtIndex(index);
+              child = root->GetSyntheticValue().value()->GetChildAtIndex(index);
             } else
-              root = root->GetSyntheticArrayMember(index, true);
-            if (!root) {
+              child = root->GetSyntheticArrayMember(index, true);
+            if (!child) {
               *reason_to_stop =
                   ValueObject::eExpressionPathScanEndReasonNoSuchChild;
               *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-              return nullptr;
+              return {};
             } else {
+              root = child.value();
               remainder =
                   temp_expression.substr(close_bracket_position + 1); // skip ]
               *final_result = ValueObject::eExpressionPathEndResultTypePlain;
@@ -2385,28 +2365,30 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
             }
           }
         } else if (root_compiler_type_info.Test(eTypeIsScalar)) {
-          root = root->GetSyntheticBitFieldChild(index, index, true);
-          if (!root) {
+          auto child = root->GetSyntheticBitFieldChild(index, index, true);
+          if (!child) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonNoSuchChild;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           } else // we do not know how to expand members of bitfields, so we
                  // just return and let the caller do any further processing
           {
+            root = child.value();
             *reason_to_stop = ValueObject::
                 eExpressionPathScanEndReasonBitfieldRangeOperatorMet;
             *final_result = ValueObject::eExpressionPathEndResultTypeBitfield;
             return root;
           }
         } else if (root_compiler_type_info.Test(eTypeIsVector)) {
-          root = root->GetChildAtIndex(index);
-          if (!root) {
+          auto child = root->GetChildAtIndex(index);
+          if (!child) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonNoSuchChild;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return ValueObjectSP();
+            return {};
           } else {
+            root = child.value();
             remainder =
                 temp_expression.substr(close_bracket_position + 1); // skip ]
             *final_result = ValueObject::eExpressionPathEndResultTypePlain;
@@ -2419,29 +2401,24 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
                        GetValueForExpressionPathOptions::
                            SyntheticChildrenTraversal::Both) {
           if (root->HasSyntheticValue())
-            root = root->GetSyntheticValue();
+            root = root->GetSyntheticValue().value();
           else if (!root->IsSynthetic()) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonSyntheticValueMissing;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           }
           // if we are here, then root itself is a synthetic VO.. should be
           // good to go
 
-          if (!root) {
-            *reason_to_stop =
-                ValueObject::eExpressionPathScanEndReasonSyntheticValueMissing;
-            *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
-          }
-          root = root->GetChildAtIndex(index);
-          if (!root) {
+          auto child = root->GetChildAtIndex(index);
+          if (!child) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonNoSuchChild;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           } else {
+            root = child.value();
             remainder =
                 temp_expression.substr(close_bracket_position + 1); // skip ]
             *final_result = ValueObject::eExpressionPathEndResultTypePlain;
@@ -2451,7 +2428,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonNoSuchChild;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         }
       } else {
         // we have a low and a high index
@@ -2463,7 +2440,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
           *reason_to_stop =
               ValueObject::eExpressionPathScanEndReasonUnexpectedSymbol;
           *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-          return nullptr;
+          return {};
         }
 
         if (low_index > high_index) // swap indices if required
@@ -2472,13 +2449,15 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
         if (root_compiler_type_info.Test(
                 eTypeIsScalar)) // expansion only works for scalars
         {
-          root = root->GetSyntheticBitFieldChild(low_index, high_index, true);
-          if (!root) {
+          auto child =
+              root->GetSyntheticBitFieldChild(low_index, high_index, true);
+          if (!child) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonNoSuchChild;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           } else {
+            root = child.value();
             *reason_to_stop = ValueObject::
                 eExpressionPathScanEndReasonBitfieldRangeOperatorMet;
             *final_result = ValueObject::eExpressionPathEndResultTypeBitfield;
@@ -2492,13 +2471,12 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
                    *what_next ==
                        ValueObject::eExpressionPathAftermathDereference &&
                    pointee_compiler_type_info.Test(eTypeIsScalar)) {
-          Status error;
-          root = root->Dereference(error);
-          if (error.Fail() || !root) {
+          root = root->Dereference();
+          if (root->GetError().Fail()) {
             *reason_to_stop =
                 ValueObject::eExpressionPathScanEndReasonDereferencingFailed;
             *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-            return nullptr;
+            return {};
           } else {
             *what_next = ValueObject::eExpressionPathAftermathNothing;
             continue;
@@ -2517,7 +2495,7 @@ ValueObjectSP ValueObject::GetValueForExpressionPath_Impl(
       *reason_to_stop =
           ValueObject::eExpressionPathScanEndReasonUnexpectedSymbol;
       *final_result = ValueObject::eExpressionPathEndResultTypeInvalid;
-      return nullptr;
+      return {};
     }
     }
   }
@@ -2531,8 +2509,6 @@ void ValueObject::Dump(Stream &s, const DumpValueObjectOptions &options) {
 }
 
 ValueObjectSP ValueObject::CreateConstantValue(ConstString name) {
-  ValueObjectSP valobj_sp;
-
   if (UpdateValueIfNeeded(false) && m_error.Success()) {
     ExecutionContext exe_ctx(GetExecutionContextRef());
 
@@ -2546,51 +2522,44 @@ ValueObjectSP ValueObject::CreateConstantValue(ConstString name) {
     } else
       m_error = m_value.GetValueAsData(&exe_ctx, data, GetModule().get());
 
-    valobj_sp = ValueObjectConstResult::Create(
+    return ValueObjectConstResult::Create(
         exe_ctx.GetBestExecutionContextScope(), GetCompilerType(), name, data,
         GetAddressOf());
-  }
-
-  if (!valobj_sp) {
+  } else {
     ExecutionContext exe_ctx(GetExecutionContextRef());
-    valobj_sp = ValueObjectConstResult::Create(
+    return ValueObjectConstResult::Create(
         exe_ctx.GetBestExecutionContextScope(), m_error);
   }
-  return valobj_sp;
 }
 
 ValueObjectSP ValueObject::GetQualifiedRepresentationIfAvailable(
     lldb::DynamicValueType dynValue, bool synthValue) {
-  ValueObjectSP result_sp;
+  ValueObjectSP result_sp = GetSP();
   switch (dynValue) {
   case lldb::eDynamicCanRunTarget:
   case lldb::eDynamicDontRunTarget: {
     if (!IsDynamic())
-      result_sp = GetDynamicValue(dynValue);
+      if (auto dynamic_value = GetDynamicValue(dynValue))
+        result_sp = dynamic_value.value();
   } break;
   case lldb::eNoDynamicValues: {
     if (IsDynamic())
       result_sp = GetStaticValue();
   } break;
   }
-  if (!result_sp)
-    result_sp = GetSP();
-  assert(result_sp);
 
   bool is_synthetic = result_sp->IsSynthetic();
   if (synthValue && !is_synthetic) {
     if (auto synth_sp = result_sp->GetSyntheticValue())
-      return synth_sp;
+      return synth_sp.value();
   }
-  if (!synthValue && is_synthetic) {
-    if (auto non_synth_sp = result_sp->GetNonSyntheticValue())
-      return non_synth_sp;
-  }
+  if (!synthValue && is_synthetic)
+    return result_sp->GetNonSyntheticValue();
 
   return result_sp;
 }
 
-ValueObjectSP ValueObject::Dereference(Status &error) {
+ValueObjectSP ValueObject::Dereference() {
   if (m_deref_valobj)
     return m_deref_valobj->GetSP();
 
@@ -2654,19 +2623,21 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
     }
 
   } else if (HasSyntheticValue()) {
-    m_deref_valobj =
-        GetSyntheticValue()->GetChildMemberWithName("$$dereference$$").get();
+    m_deref_valobj = GetSyntheticValue()
+                         .value()
+                         ->GetChildMemberWithName("$$dereference$$")
+                         ->get();
   } else if (IsSynthetic()) {
-    m_deref_valobj = GetChildMemberWithName("$$dereference$$").get();
+    m_deref_valobj = GetChildMemberWithName("$$dereference$$")->get();
   }
 
   if (m_deref_valobj) {
-    error.Clear();
     return m_deref_valobj->GetSP();
   } else {
     StreamString strm;
     GetExpressionPath(strm);
 
+    Status error;
     if (is_pointer_or_reference_type)
       error.SetErrorStringWithFormat("dereference failed: (%s) %s",
                                      GetTypeName().AsCString("<invalid type>"),
@@ -2675,26 +2646,42 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
       error.SetErrorStringWithFormat("not a pointer or reference type: (%s) %s",
                                      GetTypeName().AsCString("<invalid type>"),
                                      strm.GetData());
-    return ValueObjectSP();
+
+    ExecutionContext exe_ctx(GetExecutionContextRef());
+    auto scope = exe_ctx.GetBestExecutionContextScope();
+    return ValueObjectConstResult::Create(scope, error);
   }
 }
 
-ValueObjectSP ValueObject::AddressOf(Status &error) {
+ValueObjectSP ValueObject::AddressOf() {
   if (m_addr_of_valobj_sp)
-    return m_addr_of_valobj_sp;
+    return m_addr_of_valobj_sp.value();
 
   AddressType address_type = eAddressTypeInvalid;
   const bool scalar_is_load_address = false;
   addr_t addr = GetAddressOf(scalar_is_load_address, &address_type);
-  error.Clear();
-  if (addr != LLDB_INVALID_ADDRESS && address_type != eAddressTypeHost) {
+
+  StreamString expr_path_strm;
+  GetExpressionPath(expr_path_strm);
+
+  Status error;
+  ExecutionContext exe_ctx(GetExecutionContextRef());
+  auto scope = exe_ctx.GetBestExecutionContextScope();
+
+  if (addr != LLDB_INVALID_ADDRESS) {
     switch (address_type) {
     case eAddressTypeInvalid: {
       StreamString expr_path_strm;
       GetExpressionPath(expr_path_strm);
       error.SetErrorStringWithFormat("'%s' is not in memory",
                                      expr_path_strm.GetData());
-    } break;
+      return ValueObjectConstResult::Create(scope, error);
+    }
+    case eAddressTypeHost: {
+      error.SetErrorStringWithFormat("'%s' is in host process (LLDB) memory",
+                                     expr_path_strm.GetData());
+      return ValueObjectConstResult::Create(scope, error);
+    }
 
     case eAddressTypeFile:
     case eAddressTypeLoad: {
@@ -2703,23 +2690,26 @@ ValueObjectSP ValueObject::AddressOf(Status &error) {
         std::string name(1, '&');
         name.append(m_name.AsCString(""));
         ExecutionContext exe_ctx(GetExecutionContextRef());
-        m_addr_of_valobj_sp = ValueObjectConstResult::Create(
+
+        ValueObjectSP value_object_sp = ValueObjectConstResult::Create(
             exe_ctx.GetBestExecutionContextScope(),
             compiler_type.GetPointerType(), ConstString(name.c_str()), addr,
             eAddressTypeInvalid, m_data.GetAddressByteSize());
+        m_addr_of_valobj_sp = value_object_sp;
+        return value_object_sp;
       }
-    } break;
-    default:
-      break;
+      error.SetErrorStringWithFormat("'%s' doesn't have a compiler type",
+                                     expr_path_strm.GetData());
+      return ValueObjectConstResult::Create(scope, error);
+    }
     }
   } else {
     StreamString expr_path_strm;
     GetExpressionPath(expr_path_strm);
     error.SetErrorStringWithFormat("'%s' doesn't have a valid address",
                                    expr_path_strm.GetData());
+    return ValueObjectConstResult::Create(scope, error);
   }
-
-  return m_addr_of_valobj_sp;
 }
 
 ValueObjectSP ValueObject::DoCast(const CompilerType &compiler_type) {
@@ -2748,37 +2738,36 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
                        error);
 }
 
-lldb::ValueObjectSP ValueObject::Clone(ConstString new_name) {
+ValueObjectSP ValueObject::Clone(ConstString new_name) {
   return ValueObjectCast::Create(*this, new_name, GetCompilerType());
 }
 
-ValueObjectSP ValueObject::CastPointerType(const char *name,
-                                           CompilerType &compiler_type) {
-  ValueObjectSP valobj_sp;
+std::optional<ValueObjectSP>
+ValueObject::CastPointerType(const char *name, CompilerType &compiler_type) {
   AddressType address_type;
   addr_t ptr_value = GetPointerValue(&address_type);
 
   if (ptr_value != LLDB_INVALID_ADDRESS) {
     Address ptr_addr(ptr_value);
     ExecutionContext exe_ctx(GetExecutionContextRef());
-    valobj_sp = ValueObjectMemory::Create(
-        exe_ctx.GetBestExecutionContextScope(), name, ptr_addr, compiler_type);
+    return ValueObjectMemory::Create(exe_ctx.GetBestExecutionContextScope(),
+                                     name, ptr_addr, compiler_type);
   }
-  return valobj_sp;
+  return {};
 }
 
-ValueObjectSP ValueObject::CastPointerType(const char *name, TypeSP &type_sp) {
-  ValueObjectSP valobj_sp;
+std::optional<ValueObjectSP> ValueObject::CastPointerType(const char *name,
+                                                          TypeSP &type_sp) {
   AddressType address_type;
   addr_t ptr_value = GetPointerValue(&address_type);
 
   if (ptr_value != LLDB_INVALID_ADDRESS) {
     Address ptr_addr(ptr_value);
     ExecutionContext exe_ctx(GetExecutionContextRef());
-    valobj_sp = ValueObjectMemory::Create(
-        exe_ctx.GetBestExecutionContextScope(), name, ptr_addr, type_sp);
+    return ValueObjectMemory::Create(exe_ctx.GetBestExecutionContextScope(),
+                                     name, ptr_addr, type_sp);
   }
-  return valobj_sp;
+  return {};
 }
 
 ValueObject::EvaluationPoint::EvaluationPoint() : m_mod_id(), m_exe_ctx_ref() {}
@@ -2940,7 +2929,7 @@ SymbolContextScope *ValueObject::GetSymbolContextScope() {
   return nullptr;
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObject::CreateValueObjectFromExpression(llvm::StringRef name,
                                              llvm::StringRef expression,
                                              const ExecutionContext &exe_ctx) {
@@ -2948,10 +2937,10 @@ ValueObject::CreateValueObjectFromExpression(llvm::StringRef name,
                                          EvaluateExpressionOptions());
 }
 
-lldb::ValueObjectSP ValueObject::CreateValueObjectFromExpression(
+std::optional<ValueObjectSP> ValueObject::CreateValueObjectFromExpression(
     llvm::StringRef name, llvm::StringRef expression,
     const ExecutionContext &exe_ctx, const EvaluateExpressionOptions &options) {
-  lldb::ValueObjectSP retval_sp;
+  std::optional<ValueObjectSP> retval_sp;
   lldb::TargetSP target_sp(exe_ctx.GetTargetSP());
   if (!target_sp)
     return retval_sp;
@@ -2960,11 +2949,11 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromExpression(
   target_sp->EvaluateExpression(expression, exe_ctx.GetFrameSP().get(),
                                 retval_sp, options);
   if (retval_sp && !name.empty())
-    retval_sp->SetName(ConstString(name));
+    retval_sp.value()->SetName(ConstString(name));
   return retval_sp;
 }
 
-lldb::ValueObjectSP ValueObject::CreateValueObjectFromAddress(
+std::optional<ValueObjectSP> ValueObject::CreateValueObjectFromAddress(
     llvm::StringRef name, uint64_t address, const ExecutionContext &exe_ctx,
     CompilerType type) {
   if (type) {
@@ -2972,33 +2961,30 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromAddress(
     if (pointer_type) {
       lldb::DataBufferSP buffer(
           new lldb_private::DataBufferHeap(&address, sizeof(lldb::addr_t)));
-      lldb::ValueObjectSP ptr_result_valobj_sp(ValueObjectConstResult::Create(
+      ValueObjectSP ptr_result_valobj_sp(ValueObjectConstResult::Create(
           exe_ctx.GetBestExecutionContextScope(), pointer_type,
           ConstString(name), buffer, exe_ctx.GetByteOrder(),
           exe_ctx.GetAddressByteSize()));
-      if (ptr_result_valobj_sp) {
-        ptr_result_valobj_sp->GetValue().SetValueType(
-            Value::ValueType::LoadAddress);
-        Status err;
-        ptr_result_valobj_sp = ptr_result_valobj_sp->Dereference(err);
-        if (ptr_result_valobj_sp && !name.empty())
-          ptr_result_valobj_sp->SetName(ConstString(name));
-      }
+
+      ptr_result_valobj_sp->GetValue().SetValueType(
+          Value::ValueType::LoadAddress);
+      ptr_result_valobj_sp = ptr_result_valobj_sp->Dereference();
+      if (ptr_result_valobj_sp->GetError().Success() && !name.empty())
+        ptr_result_valobj_sp->SetName(ConstString(name));
       return ptr_result_valobj_sp;
     }
   }
-  return lldb::ValueObjectSP();
+  return {};
 }
 
-lldb::ValueObjectSP ValueObject::CreateValueObjectFromData(
+ValueObjectSP ValueObject::CreateValueObjectFromData(
     llvm::StringRef name, const DataExtractor &data,
     const ExecutionContext &exe_ctx, CompilerType type) {
-  lldb::ValueObjectSP new_value_sp;
-  new_value_sp = ValueObjectConstResult::Create(
+  ValueObjectSP new_value_sp = ValueObjectConstResult::Create(
       exe_ctx.GetBestExecutionContextScope(), type, ConstString(name), data,
       LLDB_INVALID_ADDRESS);
   new_value_sp->SetAddressTypeOfChildren(eAddressTypeLoad);
-  if (new_value_sp && !name.empty())
+  if (!name.empty())
     new_value_sp->SetName(ConstString(name));
   return new_value_sp;
 }
@@ -3090,22 +3076,20 @@ bool ValueObject::CanProvideValue() {
   return (!type.IsValid()) || (0 != (type.GetTypeInfo() & eTypeHasValue));
 }
 
-
-
-ValueObjectSP ValueObject::Persist() {
+std::optional<ValueObjectSP> ValueObject::Persist() {
   if (!UpdateValueIfNeeded())
-    return nullptr;
+    return {};
 
   TargetSP target_sp(GetTargetSP());
   if (!target_sp)
-    return nullptr;
+    return {};
 
   PersistentExpressionState *persistent_state =
       target_sp->GetPersistentExpressionStateForLanguage(
           GetPreferredDisplayLanguage());
 
   if (!persistent_state)
-    return nullptr;
+    return {};
 
   ConstString name = persistent_state->GetNextPersistentVariableName();
 
@@ -3120,6 +3104,6 @@ ValueObjectSP ValueObject::Persist() {
   return persistent_var_sp->GetValueObject();
 }
 
-lldb::ValueObjectSP ValueObject::GetVTable() {
+ValueObjectSP ValueObject::GetVTable() {
   return ValueObjectVTable::Create(*this);
 }

--- a/lldb/source/Core/ValueObjectConstResult.cpp
+++ b/lldb/source/Core/ValueObjectConstResult.cpp
@@ -244,19 +244,21 @@ bool ValueObjectConstResult::IsInScope() {
   return true;
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResult::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::GetSyntheticChildAtOffset(
-    uint32_t offset, const CompilerType &type, bool can_create,
-    ConstString name_const_str) {
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResult::GetSyntheticChildAtOffset(uint32_t offset,
+                                                  const CompilerType &type,
+                                                  bool can_create,
+                                                  ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResult::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResult::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 lldb::addr_t ValueObjectConstResult::GetAddressOf(bool scalar_is_load_address,
@@ -276,7 +278,7 @@ size_t ValueObjectConstResult::GetPointeeData(DataExtractor &data,
   return m_impl.GetPointeeData(data, item_idx, item_count);
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObjectConstResult::GetDynamicValue(lldb::DynamicValueType use_dynamic) {
   // Always recalculate dynamic values for const results as the memory that
   // they might point to might have changed at any time.
@@ -290,7 +292,7 @@ ValueObjectConstResult::GetDynamicValue(lldb::DynamicValueType use_dynamic) {
     if (m_dynamic_value && m_dynamic_value->GetError().Success())
       return m_dynamic_value->GetSP();
   }
-  return ValueObjectSP();
+  return {};
 }
 
 lldb::ValueObjectSP

--- a/lldb/source/Core/ValueObjectConstResultCast.cpp
+++ b/lldb/source/Core/ValueObjectConstResultCast.cpp
@@ -29,19 +29,20 @@ ValueObjectConstResultCast::ValueObjectConstResultCast(
 
 ValueObjectConstResultCast::~ValueObjectConstResultCast() = default;
 
-lldb::ValueObjectSP ValueObjectConstResultCast::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResultCast::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResultCast::GetSyntheticChildAtOffset(
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResultCast::GetSyntheticChildAtOffset(
     uint32_t offset, const CompilerType &type, bool can_create,
     ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResultCast::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResultCast::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 ValueObject *ValueObjectConstResultCast::CreateChildAtIndex(

--- a/lldb/source/Core/ValueObjectConstResultChild.cpp
+++ b/lldb/source/Core/ValueObjectConstResultChild.cpp
@@ -36,19 +36,20 @@ ValueObjectConstResultChild::ValueObjectConstResultChild(
 
 ValueObjectConstResultChild::~ValueObjectConstResultChild() = default;
 
-lldb::ValueObjectSP ValueObjectConstResultChild::Dereference(Status &error) {
-  return m_impl.Dereference(error);
+lldb::ValueObjectSP ValueObjectConstResultChild::Dereference() {
+  return m_impl.Dereference();
 }
 
-lldb::ValueObjectSP ValueObjectConstResultChild::GetSyntheticChildAtOffset(
+std::optional<lldb::ValueObjectSP>
+ValueObjectConstResultChild::GetSyntheticChildAtOffset(
     uint32_t offset, const CompilerType &type, bool can_create,
     ConstString name_const_str) {
   return m_impl.GetSyntheticChildAtOffset(offset, type, can_create,
                                           name_const_str);
 }
 
-lldb::ValueObjectSP ValueObjectConstResultChild::AddressOf(Status &error) {
-  return m_impl.AddressOf(error);
+lldb::ValueObjectSP ValueObjectConstResultChild::AddressOf() {
+  return m_impl.AddressOf();
 }
 
 lldb::addr_t ValueObjectConstResultChild::GetAddressOf(

--- a/lldb/source/Core/ValueObjectRegister.cpp
+++ b/lldb/source/Core/ValueObjectRegister.cpp
@@ -127,7 +127,7 @@ ValueObject *ValueObjectRegisterSet::CreateChildAtIndex(
   return valobj;
 }
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ValueObjectRegisterSet::GetChildMemberWithName(llvm::StringRef name,
                                                bool can_create) {
   ValueObject *valobj = nullptr;
@@ -139,7 +139,7 @@ ValueObjectRegisterSet::GetChildMemberWithName(llvm::StringRef name,
   if (valobj)
     return valobj->GetSP();
   else
-    return ValueObjectSP();
+    return {};
 }
 
 size_t ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -115,23 +115,25 @@ std::string CXXSyntheticChildren::GetDescription() {
   return std::string(sstr.GetString());
 }
 
-lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromExpression(
+std::optional<lldb::ValueObjectSP>
+SyntheticChildrenFrontEnd::CreateValueObjectFromExpression(
     llvm::StringRef name, llvm::StringRef expression,
     const ExecutionContext &exe_ctx) {
-  ValueObjectSP valobj_sp(
+  std::optional<ValueObjectSP> valobj_sp(
       ValueObject::CreateValueObjectFromExpression(name, expression, exe_ctx));
   if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+    valobj_sp.value()->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
-lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromAddress(
+std::optional<lldb::ValueObjectSP>
+SyntheticChildrenFrontEnd::CreateValueObjectFromAddress(
     llvm::StringRef name, uint64_t address, const ExecutionContext &exe_ctx,
     CompilerType type) {
-  ValueObjectSP valobj_sp(
+  std::optional<ValueObjectSP> valobj_sp(
       ValueObject::CreateValueObjectFromAddress(name, address, exe_ctx, type));
   if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+    valobj_sp.value()->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
@@ -140,8 +142,7 @@ lldb::ValueObjectSP SyntheticChildrenFrontEnd::CreateValueObjectFromData(
     const ExecutionContext &exe_ctx, CompilerType type) {
   ValueObjectSP valobj_sp(
       ValueObject::CreateValueObjectFromData(name, data, exe_ctx, type));
-  if (valobj_sp)
-    valobj_sp->SetSyntheticChildrenGenerated(true);
+  valobj_sp->SetSyntheticChildrenGenerated(true);
   return valobj_sp;
 }
 
@@ -166,10 +167,10 @@ ScriptedSyntheticChildren::FrontEnd::FrontEnd(std::string pclass,
 
 ScriptedSyntheticChildren::FrontEnd::~FrontEnd() = default;
 
-lldb::ValueObjectSP
+std::optional<ValueObjectSP>
 ScriptedSyntheticChildren::FrontEnd::GetChildAtIndex(size_t idx) {
   if (!m_wrapper_sp || !m_interpreter)
-    return lldb::ValueObjectSP();
+    return {};
 
   return m_interpreter->GetChildAtIndex(m_wrapper_sp, idx);
 }
@@ -212,9 +213,10 @@ size_t ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(
                                                 name.GetCString());
 }
 
-lldb::ValueObjectSP ScriptedSyntheticChildren::FrontEnd::GetSyntheticValue() {
+std::optional<ValueObjectSP>
+ScriptedSyntheticChildren::FrontEnd::GetSyntheticValue() {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return nullptr;
+    return {};
 
   return m_interpreter->GetSyntheticValue(m_wrapper_sp);
 }

--- a/lldb/source/Expression/ExpressionVariable.cpp
+++ b/lldb/source/Expression/ExpressionVariable.cpp
@@ -20,14 +20,18 @@ char ExpressionVariable::ID;
 ExpressionVariable::ExpressionVariable() : m_flags(0) {}
 
 uint8_t *ExpressionVariable::GetValueBytes() {
-  std::optional<uint64_t> byte_size = m_frozen_sp->GetByteSize();
+  if (!m_frozen_sp)
+    return nullptr;
+
+  std::optional<uint64_t> byte_size = m_frozen_sp.value()->GetByteSize();
   if (byte_size && *byte_size) {
-    if (m_frozen_sp->GetDataExtractor().GetByteSize() < *byte_size) {
-      m_frozen_sp->GetValue().ResizeData(*byte_size);
-      m_frozen_sp->GetValue().GetData(m_frozen_sp->GetDataExtractor());
+    if (m_frozen_sp.value()->GetDataExtractor().GetByteSize() < *byte_size) {
+      m_frozen_sp.value()->GetValue().ResizeData(*byte_size);
+      m_frozen_sp.value()->GetValue().GetData(
+          m_frozen_sp.value()->GetDataExtractor());
     }
     return const_cast<uint8_t *>(
-        m_frozen_sp->GetDataExtractor().GetDataStart());
+        m_frozen_sp.value()->GetDataExtractor().GetDataStart());
   }
   return nullptr;
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2656,7 +2656,7 @@ Target *Target::GetTargetFromContexts(const ExecutionContext *exe_ctx_ptr,
 
 ExpressionResults Target::EvaluateExpression(
     llvm::StringRef expr, ExecutionContextScope *exe_scope,
-    lldb::ValueObjectSP &result_valobj_sp,
+    std::optional<lldb::ValueObjectSP> &result_valobj_sp,
     const EvaluateExpressionOptions &options, std::string *fixed_expression,
     ValueObject *ctx_obj) {
   result_valobj_sp.reset();


### PR DESCRIPTION
> **Note**
> I originally proposed this change with [PR 74912](https://github.com/llvm/llvm-project/pull/74912) before renaming the branch.

### Purpose
For now, we'd like to get people's thought's on the goal, design, and scope of this PR by reviewing these preliminary changes.

I recommend focussing (or starting) on these files:
* `ValueObject.h`
* `ValueObject.cpp`


### Goal
Every `ValueObjectSP` will have an actual value and will never be equal to `nullptr`.


### Design
To force each `ValueObjectSP` to contain _something_, we're considering changing the type from a typedef…
```cpp
typedef std::shared_ptr<lldb_private::ValueObject> ValueObjectSP;

```

to this subclass:
```cpp
class ValueObjectSP : public std::shared_ptr<lldb_private::ValueObject> {
  ValueObjectSP() = delete;
  operator bool() = delete;

public:
  ValueObjectSP(std::shared_ptr<lldb_private::ValueObject> &&pointer)
      : std::shared_ptr<lldb_private::ValueObject>(std::move(pointer)) {
    assert(pointer);
  }
};
```

This class removes the default constructor to force each `ValueObjectSP` to point to a real `ValueObject` instance. It also removes `operator bool()` because no instance will ever equal `nullptr`. 


### Change Patterns
The bulk of the changes into one of these two camps:
1. For methods that have a `Status &error` parameter **and** return an `ValueObjectSP`, the return value *becomes* the container for the error state, which eliminate the need for a parameter.
* This means that callers of these methods need to check the return value's error state.
  * `return_value->GetError.Success()`
  * `return_value->GetError.Fail()`

2. For all other methods that return a `ValueObjectSP` but don't have a `Status &` parameter, they now return `std::optional<ValueObjectSP>`.
* This changes a fair amount of code in these ways:
  * Code which had been using the `std::shared_ptr` Boolean operator now uses the `std::optional` Boolean operator.
  * Nearby code has to call the optional's `value()` method to get the shared pointer inside.
  * Methods with lines that return `ValueObjectSP()` now return `{}`, which creates an optional with nothing in it.

Again, I recommend focussing (or starting) on these files:
* `ValueObject.h`
* `ValueObject.cpp`


### Remaining work
This is very much a work-in-progress for a proof of concept, which means:
* It doesn't compile (yet)
* So far I've modified 53 files
* I estimate another 100-250 more files need to change based on the ninja build progress indicator.

The remaining changes will just be more of the same but now's a good time to take a look at this sample to get a sense of the magnitude and trajectory of the remaining changes.