### PR TITLE
[lldb] Add color support to StreamString

### DIFF
--- a/lldb/include/lldb/Utility/StreamString.h
+++ b/lldb/include/lldb/Utility/StreamString.h
@@ -22,7 +22,7 @@ namespace lldb_private {
 
 class StreamString : public Stream {
 public:
-  StreamString();
+  StreamString(bool colors = false);
 
   StreamString(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order);
 

--- a/lldb/source/Utility/StreamString.cpp
+++ b/lldb/source/Utility/StreamString.cpp
@@ -11,7 +11,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamString::StreamString() : Stream(0, 4, eByteOrderBig) {}
+StreamString::StreamString(bool colors) : Stream(0, 4, eByteOrderBig, colors) {}
 
 StreamString::StreamString(uint32_t flags, uint32_t addr_size,
                            ByteOrder byte_order)


### PR DESCRIPTION
This change just adds a `bool colors` parameter to the `StreamString` class's constructor, which it passes up to its superclass’s constructor.

I'm working on another patch that prints out error messages using a `StreamString` but I wasn't getting colorized text because of this missing implementation detail.

rdar://120671168