### PR TITLE
[libc] fix more -Wmissing-brace

### DIFF
--- a/libc/src/__support/HashTable/sse2/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/sse2/bitmask_impl.inc
@@ -33,7 +33,7 @@ struct Group {
   LIBC_INLINE IteratableBitMask match_byte(uint8_t byte) const {
     auto cmp = _mm_cmpeq_epi8(data, _mm_set1_epi8(byte));
     auto bitmask = static_cast<uint16_t>(_mm_movemask_epi8(cmp));
-    return {bitmask};
+    return {{bitmask}};
   }
 
   LIBC_INLINE BitMask mask_available() const {
@@ -42,7 +42,7 @@ struct Group {
   }
 
   LIBC_INLINE IteratableBitMask occupied() const {
-    return {static_cast<uint16_t>(~mask_available().word)};
+    return {{static_cast<uint16_t>(~mask_available().word)}};
   }
 };
 } // namespace internal


### PR DESCRIPTION
Similar to #77345, the buildbots are observing similar warnings for the sse2
implementation.

    llvm-project/libc/src/__support/HashTable/sse2/bitmask_impl.inc:36:13:
    error: suggest braces around initialization of subobject
    [-Werror,-Wmissing-braces]
    return {bitmask};
            ^~~~~~~
            {      }
    llvm-project/libc/src/__support/HashTable/sse2/bitmask_impl.inc:45:13:
    error: suggest braces around initialization of subobject
    [-Werror,-Wmissing-braces]
    return {static_cast<uint16_t>(~mask_available().word)};
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            {                                            }

Link: https://lab.llvm.org/buildbot/#/builders/163/builds/49350/steps/8/logs/stdio
Link: https://github.com/llvm/llvm-project/pull/74506
