### PR TITLE
[RISCV] Rename X10_PD register to X10_X11.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -546,19 +546,20 @@ def DUMMY_REG_PAIR_WITH_X0 : RISCVReg<0, "0">;
 def GPRAll : GPRRegisterClass<(add GPR, DUMMY_REG_PAIR_WITH_X0)>;
 
 let RegAltNameIndices = [ABIRegAltName] in {
-  def X0_PD : RISCVRegWithSubRegs<0, X0.AsmName,
-                                     [X0, DUMMY_REG_PAIR_WITH_X0],
-                                     X0.AltNames> {
+  def X0_Pair : RISCVRegWithSubRegs<0, X0.AsmName,
+                                    [X0, DUMMY_REG_PAIR_WITH_X0],
+                                    X0.AltNames> {
     let SubRegIndices = [sub_32, sub_32_hi];
     let CoveredBySubRegs = 1;
   }
   foreach I = 1-15 in {
     defvar Index = !shl(I, 1);
+    defvar IndexP1 = !add(Index,1);
     defvar Reg = !cast<Register>("X"#Index);
-    defvar RegP1 = !cast<Register>("X"#!add(Index,1));
-    def X#Index#_PD : RISCVRegWithSubRegs<Index, Reg.AsmName,
-                                          [Reg, RegP1],
-                                          Reg.AltNames> {
+    defvar RegP1 = !cast<Register>("X"#IndexP1);
+    def "X" # Index # "_X" # IndexP1 : RISCVRegWithSubRegs<Index, Reg.AsmName,
+                                                           [Reg, RegP1],
+                                                           Reg.AltNames> {
       let SubRegIndices = [sub_32, sub_32_hi];
       let CoveredBySubRegs = 1;
     }
@@ -567,12 +568,12 @@ let RegAltNameIndices = [ABIRegAltName] in {
 
 let RegInfos = RegInfoByHwMode<[RV64], [RegInfo<64, 64, 64>]> in
 def GPRPF64 : RegisterClass<"RISCV", [f64], 64, (add
-    X10_PD, X12_PD, X14_PD, X16_PD,
-    X6_PD,
-    X28_PD, X30_PD,
-    X8_PD,
-    X18_PD, X20_PD, X22_PD, X24_PD, X26_PD,
-    X0_PD, X2_PD, X4_PD
+    X10_X11, X12_X13, X14_X15, X16_X17,
+    X6_X7,
+    X28_X29, X30_X31,
+    X8_X9,
+    X18_X19, X20_X21, X22_X23, X24_X25, X26_X27,
+    X0_Pair, X2_X3, X4_X5
 )>;
 
 // The register class is added for inline assembly for vector mask types.


### PR DESCRIPTION
Similar for other paired registers with one exception. X0_PD is now X0_Pair since it is not paired with X1.