### PR TITLE
Set dllstorage on ObjectiveC ivar offsets

### DIFF
--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1851,6 +1851,8 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
                     llvm::GlobalValue::HiddenVisibility :
                     llvm::GlobalValue::DefaultVisibility;
         OffsetVar->setVisibility(ivarVisibility);
+        if (ivarVisibility != llvm::GlobalValue::HiddenVisibility)
+          CGM.setGVProperties(OffsetVar, OID->getClassInterface());
         ivarBuilder.add(OffsetVar);
         // Ivar size
         ivarBuilder.addInt(Int32Ty,


### PR DESCRIPTION
Mark instance variable offset symbols with `dllexport`/`dllimport` if they are not hidden and the interface declaration is marked with `dllexport`/`dllimport`, when using the GNUstep 2.x ABI.

/cc @davidchisnall 