### PR TITLE
[LLD] [MinGW] Add support for more ThinLTO specific options

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -270,8 +270,6 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     add("-lldmap:" + StringRef(a->getValue()));
   if (auto *a = args.getLastArg(OPT_reproduce))
     add("-reproduce:" + StringRef(a->getValue()));
-  if (auto *a = args.getLastArg(OPT_thinlto_cache_dir))
-    add("-lldltocache:" + StringRef(a->getValue()));
   if (auto *a = args.getLastArg(OPT_file_alignment))
     add("-filealign:" + StringRef(a->getValue()));
   if (auto *a = args.getLastArg(OPT_section_alignment))
@@ -440,8 +438,6 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
   if (auto *arg = args.getLastArg(OPT_plugin_opt_mcpu_eq))
     add("-mllvm:-mcpu=" + StringRef(arg->getValue()));
-  if (auto *arg = args.getLastArg(OPT_thinlto_jobs_eq))
-    add("-opt:lldltojobs=" + StringRef(arg->getValue()));
   if (auto *arg = args.getLastArg(OPT_lto_O))
     add("-opt:lldlto=" + StringRef(arg->getValue()));
   if (auto *arg = args.getLastArg(OPT_lto_CGO))
@@ -452,6 +448,23 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     add("-lto-cs-profile-generate");
   if (auto *arg = args.getLastArg(OPT_lto_cs_profile_file))
     add("-lto-cs-profile-file:" + StringRef(arg->getValue()));
+
+  if (auto *a = args.getLastArg(OPT_thinlto_cache_dir))
+    add("-lldltocache:" + StringRef(a->getValue()));
+  if (auto *a = args.getLastArg(OPT_thinlto_cache_policy))
+    add("-lldltocachepolicy:" + StringRef(a->getValue()));
+  if (args.hasArg(OPT_thinlto_emit_imports_files))
+    add("-thinlto-emit-imports-files");
+  if (args.hasArg(OPT_thinlto_index_only))
+    add("-thinlto-index-only");
+  if (auto *arg = args.getLastArg(OPT_thinlto_index_only_eq))
+    add("-thinlto-index-only:" + StringRef(arg->getValue()));
+  if (auto *arg = args.getLastArg(OPT_thinlto_jobs_eq))
+    add("-opt:lldltojobs=" + StringRef(arg->getValue()));
+  if (auto *arg = args.getLastArg(OPT_thinlto_object_suffix_replace_eq))
+    add("-thinlto-object-suffix-replace:" + StringRef(arg->getValue()));
+  if (auto *arg = args.getLastArg(OPT_thinlto_prefix_replace_eq))
+    add("-thinlto-prefix-replace:" + StringRef(arg->getValue()));
 
   for (auto *a : args.filtered(OPT_plugin_opt_eq_minus))
     add("-mllvm:-" + StringRef(a->getValue()));

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -149,6 +149,7 @@ defm wrap: Eq<"wrap", "Use wrapper functions for symbol">,
      MetaVarName<"<symbol>">;
 
 
+// LLD specific options, for LTO, shared with the ELF backend
 def lto_O: JJ<"lto-O">, MetaVarName<"<opt-level>">,
   HelpText<"Optimization level for LTO">;
 def lto_CGO: JJ<"lto-CGO">, MetaVarName<"<cgopt-level>">,
@@ -158,8 +159,16 @@ def lto_cs_profile_generate: FF<"lto-cs-profile-generate">,
 def lto_cs_profile_file: JJ<"lto-cs-profile-file=">,
   HelpText<"Context sensitive profile file path">;
 
+def thinlto_cache_dir: JJ<"thinlto-cache-dir=">,
+  HelpText<"Path to ThinLTO cached object file directory">;
+defm thinlto_cache_policy: EEq<"thinlto-cache-policy", "Pruning policy for the ThinLTO cache">;
+def thinlto_emit_imports_files: FF<"thinlto-emit-imports-files">;
+def thinlto_index_only: FF<"thinlto-index-only">;
+def thinlto_index_only_eq: JJ<"thinlto-index-only=">;
 def thinlto_jobs_eq: JJ<"thinlto-jobs=">,
   HelpText<"Number of ThinLTO jobs. Default to --threads=">;
+def thinlto_object_suffix_replace_eq: JJ<"thinlto-object-suffix-replace=">;
+def thinlto_prefix_replace_eq: JJ<"thinlto-prefix-replace=">;
 
 def plugin_opt_eq_minus: J<"plugin-opt=-">,
   HelpText<"Specify an LLVM option for compatibility with LLVMgold.so">;
@@ -186,8 +195,6 @@ def appcontainer: F<"appcontainer">, HelpText<"Set the appcontainer flag in the 
 defm delayload: Eq<"delayload", "DLL to load only on demand">;
 defm mllvm: EqNoHelp<"mllvm">;
 defm pdb: Eq<"pdb", "Output PDB debug info file, chosen implicitly if the argument is empty">;
-def thinlto_cache_dir: JJ<"thinlto-cache-dir=">,
-  HelpText<"Path to ThinLTO cached object file directory">;
 defm Xlink : Eq<"Xlink", "Pass <arg> to the COFF linker">, MetaVarName<"<arg>">;
 defm guard_cf : B<"guard-cf", "Enable Control Flow Guard" ,
   "Do not enable Control Flow Guard (default)">;

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -297,9 +297,6 @@ RUN: ld.lld -### -m i386pep foo.o --disable-runtime-pseudo-reloc 2>&1 | FileChec
 RUN: ld.lld -### -m i386pep foo.o -disable-runtime-pseudo-reloc 2>&1 | FileCheck -check-prefix DISABLE_RUNTIME_PSEUDO_RELOC %s
 DISABLE_RUNTIME_PSEUDO_RELOC: -runtime-pseudo-reloc:no
 
-RUN: ld.lld -### foo.o -m i386pe --thinlto-cache-dir=_foo 2>&1 | FileCheck -check-prefix=THINLTO_CACHEDIR %s
-THINLTO_CACHEDIR: -lldltocache:_foo
-
 RUN: ld.lld -### -m i386pep foo.o --file-alignment 0x1000 2>&1 | FileCheck -check-prefix FILEALIGN %s
 RUN: ld.lld -### -m i386pep foo.o -file-alignment 0x1000 2>&1 | FileCheck -check-prefix FILEALIGN %s
 RUN: ld.lld -### -m i386pep foo.o --file-alignment=0x1000 2>&1 | FileCheck -check-prefix FILEALIGN %s
@@ -382,9 +379,29 @@ RUN: ld.lld -### foo.o -m i386pep --guard-longjmp 2>&1 | FileCheck -check-prefix
 RUN: ld.lld -### foo.o -m i386pep --no-guard-cf --guard-longjmp 2>&1 | FileCheck -check-prefix=GUARD_LONGJMP_NO_CF %s
 GUARD_LONGJMP_NO_CF: warning: parameter --guard-longjmp only takes effect when used with --guard-cf
 
+RUN: ld.lld -### foo.o -m i386pe --thinlto-cache-dir=_foo 2>&1 | FileCheck -check-prefix=THINLTO_CACHEDIR %s
+THINLTO_CACHEDIR: -lldltocache:_foo
+
+RUN: ld.lld -### foo.o -m i386pe --thinlto-cache-policy=_foo 2>&1 | FileCheck -check-prefix=THINLTO_CACHE_POLICY %s
+THINLTO_CACHE_POLICY: -lldltocachepolicy:_foo
+
+RUN: ld.lld -### foo.o -m i386pe --thinlto-emit-imports-files 2>&1 | FileCheck -check-prefix=THINLTO_EMIT_IMPORTS_FILES %s
+THINLTO_EMIT_IMPORTS_FILES: -thinlto-emit-imports-files
+
+RUN: ld.lld -### foo.o -m i386pe --thinlto-index-only 2>&1 | FileCheck -check-prefix=THINLTO_INDEX_ONLY %s
+THINLTO_INDEX_ONLY: -thinlto-index-only{{ }}
+RUN: ld.lld -### foo.o -m i386pe --thinlto-index-only=_foo 2>&1 | FileCheck -check-prefix=THINLTO_INDEX_ONLY_EQ %s
+THINLTO_INDEX_ONLY_EQ: -thinlto-index-only:_foo
+
 RUN: ld.lld -### foo.o -m i386pep --threads 3 --thinlto-jobs=4 2>&1 | FileCheck -check-prefix=THREADS %s
 RUN: ld.lld -### foo.o -m i386pep --threads 3 -plugin-opt=jobs=4 2>&1 | FileCheck -check-prefix=THREADS %s
 THREADS: -threads:3 {{.*}} -opt:lldltojobs=4
+
+RUN: ld.lld -### foo.o -m i386pe --thinlto-object-suffix-replace=_foo 2>&1 | FileCheck -check-prefix=THINLTO_OBJECT_SUFFIX_REPLACE %s
+THINLTO_OBJECT_SUFFIX_REPLACE: -thinlto-object-suffix-replace:_foo
+
+RUN: ld.lld -### foo.o -m i386pe --thinlto-prefix-replace=_foo 2>&1 | FileCheck -check-prefix=THINLTO_PREFIX_REPLACE %s
+THINLTO_PREFIX_REPLACE: -thinlto-prefix-replace:_foo
 
 RUN: ld.lld -### foo.o -m i386pep -plugin-opt=mcpu=x86-64 -plugin-opt=-emulated-tls -plugin-opt=thinlto -plugin-opt=O2 -plugin-opt=dwo_dir=foo -plugin-opt=cs-profile-generate -plugin-opt=cs-profile-path=bar 2>&1 | FileCheck -check-prefix=LTO_OPTS %s
 LTO_OPTS: -mllvm:-mcpu=x86-64 -opt:lldlto=2 -dwodir:foo -lto-cs-profile-generate -lto-cs-profile-file:bar -mllvm:-emulated-tls


### PR DESCRIPTION
This was missed when mass-adding support for other LTO options in 0b51e648307cf6c21c463d3e73e51c03aaa8c9e2.

Group the existing thinlto_cache_dir with these other options in a new group, next to the other LTO options.

This skips adding the options --thinlto-emit-index-files and --thinlto-single-module=, which don't seem to have corresponding options on the lld-link level currently.

This should fix https://github.com/mstorsjo/llvm-mingw/issues/386.