### PR TITLE
[flang][openacc] Fix clauses check with device_type

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -225,7 +225,8 @@ void AccStructureChecker::Leave(const parser::OpenACCCombinedConstruct &x) {
   case llvm::acc::Directive::ACCD_serial_loop:
     // Restriction - line 1004-1005
     CheckOnlyAllowedAfter(llvm::acc::Clause::ACCC_device_type,
-        computeConstructOnlyAllowedAfterDeviceTypeClauses);
+        computeConstructOnlyAllowedAfterDeviceTypeClauses |
+            loopOnlyAllowedAfterDeviceTypeClauses);
     if (doCons) {
       const parser::Block &block{std::get<parser::Block>(doCons->t)};
       CheckNoBranching(block, GetContext().directive, beginBlockDir.source);
@@ -388,11 +389,8 @@ CHECK_SIMPLE_CLAUSE(Nohost, ACCC_nohost)
 CHECK_SIMPLE_CLAUSE(Private, ACCC_private)
 CHECK_SIMPLE_CLAUSE(Read, ACCC_read)
 CHECK_SIMPLE_CLAUSE(Seq, ACCC_seq)
-CHECK_SIMPLE_CLAUSE(Tile, ACCC_tile)
 CHECK_SIMPLE_CLAUSE(UseDevice, ACCC_use_device)
-CHECK_SIMPLE_CLAUSE(Vector, ACCC_vector)
 CHECK_SIMPLE_CLAUSE(Wait, ACCC_wait)
-CHECK_SIMPLE_CLAUSE(Worker, ACCC_worker)
 CHECK_SIMPLE_CLAUSE(Write, ACCC_write)
 CHECK_SIMPLE_CLAUSE(Unknown, ACCC_unknown)
 
@@ -536,8 +534,28 @@ void AccStructureChecker::Enter(const parser::AccClause::DeviceType &d) {
   }
 }
 
+void AccStructureChecker::Enter(const parser::AccClause::Vector &g) {
+  CheckAllowed(llvm::acc::Clause::ACCC_vector);
+  CheckAllowedOncePerGroup(
+      llvm::acc::Clause::ACCC_vector, llvm::acc::Clause::ACCC_device_type);
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::Worker &g) {
+  CheckAllowed(llvm::acc::Clause::ACCC_worker);
+  CheckAllowedOncePerGroup(
+      llvm::acc::Clause::ACCC_worker, llvm::acc::Clause::ACCC_device_type);
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::Tile &g) {
+  CheckAllowed(llvm::acc::Clause::ACCC_tile);
+  CheckAllowedOncePerGroup(
+      llvm::acc::Clause::ACCC_tile, llvm::acc::Clause::ACCC_device_type);
+}
+
 void AccStructureChecker::Enter(const parser::AccClause::Gang &g) {
   CheckAllowed(llvm::acc::Clause::ACCC_gang);
+  CheckAllowedOncePerGroup(
+      llvm::acc::Clause::ACCC_gang, llvm::acc::Clause::ACCC_device_type);
 
   if (g.v) {
     bool hasNum = false;
@@ -665,6 +683,8 @@ void AccStructureChecker::Enter(const parser::AccClause::Self &x) {
 
 void AccStructureChecker::Enter(const parser::AccClause::Collapse &x) {
   CheckAllowed(llvm::acc::Clause::ACCC_collapse);
+  CheckAllowedOncePerGroup(
+      llvm::acc::Clause::ACCC_collapse, llvm::acc::Clause::ACCC_device_type);
   const parser::AccCollapseArg &accCollapseArg = x.v;
   const auto &collapseValue{
       std::get<parser::ScalarIntConstantExpr>(accCollapseArg.t)};

--- a/flang/test/Semantics/OpenACC/acc-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-loop.f90
@@ -63,7 +63,7 @@ program openacc_loop_validity
   !$acc end parallel
 
   !$acc parallel
-  !ERROR: At most one VECTOR clause can appear on the LOOP directive
+  !ERROR: At most one VECTOR clause can appear on the LOOP directive or in group separated by the DEVICE_TYPE clause
   !$acc loop vector vector(128)
   do i = 1, N
     a(i) = 3.14
@@ -99,7 +99,7 @@ program openacc_loop_validity
   !$acc end parallel
 
   !$acc parallel
-  !ERROR: At most one WORKER clause can appear on the LOOP directive
+  !ERROR: At most one WORKER clause can appear on the LOOP directive or in group separated by the DEVICE_TYPE clause
   !$acc loop worker worker(10)
   do i = 1, N
     a(i) = 3.14
@@ -135,12 +135,28 @@ program openacc_loop_validity
   !$acc end parallel
 
   !$acc parallel
-  !ERROR: At most one GANG clause can appear on the LOOP directive
+  !ERROR: At most one GANG clause can appear on the LOOP directive or in group separated by the DEVICE_TYPE clause
   !$acc loop gang gang(gang_size)
   do i = 1, N
     a(i) = 3.14
   end do
   !$acc end parallel
+
+  !$acc loop gang device_type(default) gang(gang_size)
+  do i = 1, N
+    a(i) = 3.14
+  end do
+
+  !ERROR: At most one GANG clause can appear on the PARALLEL LOOP directive or in group separated by the DEVICE_TYPE clause
+  !$acc parallel loop gang gang(gang_size)
+  do i = 1, N
+    a(i) = 3.14
+  end do
+
+  !$acc parallel loop gang device_type(default) gang(gang_size)
+  do i = 1, N
+    a(i) = 3.14
+  end do
 
   !$acc parallel
   !$acc loop gang(gang_size)
@@ -282,5 +298,23 @@ program openacc_loop_validity
     if(i == 10) cycle
   end do
   !$acc end parallel
+
+  !$acc loop gang device_type(nvidia) gang(num: 8)
+  DO i = 1, n
+  END DO
+
+  !$acc loop vector device_type(default) vector(16)
+  DO i = 1, n
+  END DO
+
+  !$acc loop worker device_type(*) worker(8)
+  DO i = 1, n
+  END DO
+
+  !$acc loop device_type(multicore) collapse(2)
+  DO i = 1, n
+    DO j = 1, n
+    END DO
+  END DO
 
 end program openacc_loop_validity

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -391,9 +391,7 @@ def ACC_Loop : Directive<"loop"> {
   let allowedClauses = [
     VersionedClause<ACCC_DeviceType>,
     VersionedClause<ACCC_Private>,
-    VersionedClause<ACCC_Reduction>
-  ];
-  let allowedOnceClauses = [
+    VersionedClause<ACCC_Reduction>,
     VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_Tile>,
@@ -421,14 +419,16 @@ def ACC_Init : Directive<"init"> {
 
 // 2.15.1
 def ACC_Routine : Directive<"routine"> {
-  let allowedOnceClauses = [
+  let allowedClauses = [
     VersionedClause<ACCC_Bind>,
     VersionedClause<ACCC_DeviceType>,
-    VersionedClause<ACCC_NoHost>,
     VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_Seq>,
     VersionedClause<ACCC_Vector>,
     VersionedClause<ACCC_Worker>
+  ];
+  let allowedOnceClauses = [
+    VersionedClause<ACCC_NoHost>
   ];
 }
 
@@ -532,32 +532,32 @@ def ACC_HostData : Directive<"host_data"> {
 // 2.11
 def ACC_KernelsLoop : Directive<"kernels loop"> {
   let allowedClauses = [
+    VersionedClause<ACCC_Attach>,
+    VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Copy>,
     VersionedClause<ACCC_Copyin>,
     VersionedClause<ACCC_Copyout>,
     VersionedClause<ACCC_Create>,
+    VersionedClause<ACCC_DevicePtr>,
     VersionedClause<ACCC_DeviceType>,
+    VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_NoCreate>,
+    VersionedClause<ACCC_NumGangs>,
+    VersionedClause<ACCC_NumWorkers>,
     VersionedClause<ACCC_Present>,
     VersionedClause<ACCC_Private>,
     VersionedClause<ACCC_Reduction>,
-    VersionedClause<ACCC_DevicePtr>,
-    VersionedClause<ACCC_Attach>,
-    VersionedClause<ACCC_Wait>
-  ];
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_Collapse>,
-    VersionedClause<ACCC_Default>,
-    VersionedClause<ACCC_Gang>,
-    VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_NumGangs>,
-    VersionedClause<ACCC_NumWorkers>,
-    VersionedClause<ACCC_Self>,
     VersionedClause<ACCC_Tile>,
     VersionedClause<ACCC_Vector>,
     VersionedClause<ACCC_VectorLength>,
+    VersionedClause<ACCC_Wait>,
     VersionedClause<ACCC_Worker>
+  ];
+  let allowedOnceClauses = [
+    VersionedClause<ACCC_Async>,
+    VersionedClause<ACCC_Default>,
+    VersionedClause<ACCC_If>,
+    VersionedClause<ACCC_Self>
   ];
   let allowedExclusiveClauses = [
     VersionedClause<ACCC_Auto>,
@@ -570,6 +570,7 @@ def ACC_KernelsLoop : Directive<"kernels loop"> {
 def ACC_ParallelLoop : Directive<"parallel loop"> {
   let allowedClauses = [
     VersionedClause<ACCC_Attach>,
+    VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Copy>,
     VersionedClause<ACCC_Copyin>,
     VersionedClause<ACCC_Copyout>,
@@ -577,25 +578,24 @@ def ACC_ParallelLoop : Directive<"parallel loop"> {
     VersionedClause<ACCC_DevicePtr>,
     VersionedClause<ACCC_DeviceType>,
     VersionedClause<ACCC_FirstPrivate>,
+    VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_NoCreate>,
+    VersionedClause<ACCC_NumGangs>,
+    VersionedClause<ACCC_NumWorkers>,
     VersionedClause<ACCC_Present>,
     VersionedClause<ACCC_Private>,
     VersionedClause<ACCC_Reduction>,
     VersionedClause<ACCC_Tile>,
-    VersionedClause<ACCC_Wait>
+    VersionedClause<ACCC_Vector>,
+    VersionedClause<ACCC_VectorLength>,
+    VersionedClause<ACCC_Wait>,
+    VersionedClause<ACCC_Worker>
   ];
   let allowedOnceClauses = [
     VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Default>,
-    VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_NumGangs>,
-    VersionedClause<ACCC_NumWorkers>,
-    VersionedClause<ACCC_Self>,
-    VersionedClause<ACCC_Vector>,
-    VersionedClause<ACCC_VectorLength>,
-    VersionedClause<ACCC_Worker>
+    VersionedClause<ACCC_Self>
   ];
   let allowedExclusiveClauses = [
     VersionedClause<ACCC_Auto>,
@@ -608,6 +608,7 @@ def ACC_ParallelLoop : Directive<"parallel loop"> {
 def ACC_SerialLoop : Directive<"serial loop"> {
   let allowedClauses = [
     VersionedClause<ACCC_Attach>,
+    VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Copy>,
     VersionedClause<ACCC_Copyin>,
     VersionedClause<ACCC_Copyout>,
@@ -615,22 +616,21 @@ def ACC_SerialLoop : Directive<"serial loop"> {
     VersionedClause<ACCC_DevicePtr>,
     VersionedClause<ACCC_DeviceType>,
     VersionedClause<ACCC_FirstPrivate>,
+    VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_NoCreate>,
     VersionedClause<ACCC_Present>,
     VersionedClause<ACCC_Private>,
     VersionedClause<ACCC_Reduction>,
-    VersionedClause<ACCC_Wait>
+    VersionedClause<ACCC_Tile>,
+    VersionedClause<ACCC_Vector>,
+    VersionedClause<ACCC_Wait>,
+    VersionedClause<ACCC_Worker>
   ];
   let allowedOnceClauses = [
     VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_Collapse>,
     VersionedClause<ACCC_Default>,
-    VersionedClause<ACCC_Gang>,
     VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_Self>,
-    VersionedClause<ACCC_Tile>,
-    VersionedClause<ACCC_Vector>,
-    VersionedClause<ACCC_Worker>
+    VersionedClause<ACCC_Self>
   ];
   let allowedExclusiveClauses = [
     VersionedClause<ACCC_Auto>,


### PR DESCRIPTION
A couple of clauses are allowed multiple times when they are separated by a device_type clause. This patch updates the ACC.td file to move these clauses to the `allowedClause` list and the `CheckAllowedOncePerGroup` function is used to make sure they appear only once on the directive or for each device_type. 