### PR TITLE
[libc] temporarily set -Wno-shorten-64-to-32

### DIFF
--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -22,6 +22,9 @@ add_entrypoint_object(
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
+  COMPILE_OPTIONS
+    # TODO: https://github.com/llvm/llvm-project/issues/77395
+    -Wno-shorten-64-to-32
 )
 
 add_entrypoint_object(


### PR DESCRIPTION
This is still broken after #77350. Disable the warning for now, and fix
properly once the buildbot it back to green.

Link: https://github.com/llvm/llvm-project/issues/77395
