### PR TITLE
[MC] Parse SHF_LINK_ORDER argument before section group name

### DIFF
--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -616,11 +616,11 @@ bool ELFAsmParser::ParseSectionArguments(bool IsPush, SMLoc loc) {
     if (Mergeable)
       if (parseMergeSize(Size))
         return true;
-    if (Group)
-      if (parseGroup(GroupName, IsComdat))
-        return true;
     if (Flags & ELF::SHF_LINK_ORDER)
       if (parseLinkedToSym(LinkedToSym))
+        return true;
+    if (Group)
+      if (parseGroup(GroupName, IsComdat))
         return true;
     if (maybeParseUniqueID(UniqueID))
       return true;

--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -90,7 +90,9 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << 'e';
   if (Flags & ELF::SHF_EXECINSTR)
     OS << 'x';
-  if (Flags & ELF::SHF_GROUP)
+  // TODO: Always print G after o to be clear that the 'G' argument is parsed
+  // after the 'o' argument.
+  if ((Flags & ELF::SHF_GROUP) && !(Flags & ELF::SHF_LINK_ORDER))
     OS << 'G';
   if (Flags & ELF::SHF_WRITE)
     OS << 'w';
@@ -102,6 +104,8 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << 'T';
   if (Flags & ELF::SHF_LINK_ORDER)
     OS << 'o';
+  if ((Flags & ELF::SHF_GROUP) && (Flags & ELF::SHF_LINK_ORDER))
+    OS << 'G';
   if (Flags & ELF::SHF_GNU_RETAIN)
     OS << 'R';
 
@@ -183,19 +187,19 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << "," << EntrySize;
   }
 
-  if (Flags & ELF::SHF_GROUP) {
-    OS << ",";
-    printName(OS, Group.getPointer()->getName());
-    if (isComdat())
-      OS << ",comdat";
-  }
-
   if (Flags & ELF::SHF_LINK_ORDER) {
     OS << ",";
     if (LinkedToSym)
       printName(OS, LinkedToSym->getName());
     else
       OS << '0';
+  }
+
+  if (Flags & ELF::SHF_GROUP) {
+    OS << ",";
+    printName(OS, Group.getPointer()->getName());
+    if (isComdat())
+      OS << ",comdat";
   }
 
   if (isUnique())

--- a/llvm/test/CodeGen/AArch64/patchable-function-entry.ll
+++ b/llvm/test/CodeGen/AArch64/patchable-function-entry.ll
@@ -48,7 +48,7 @@ define void @f3() "patchable-function-entry"="3" comdat {
 ; CHECK-NEXT: .Lfunc_begin3:
 ; CHECK-COUNT-3: nop
 ; CHECK-NEXT:  ret
-; CHECK:       .section __patchable_function_entries,"aGwo",@progbits,f3,comdat,f3{{$}}
+; CHECK:       .section __patchable_function_entries,"awoG",@progbits,f3,f3,comdat{{$}}
 ; CHECK-NEXT:  .p2align 3
 ; CHECK-NEXT:  .xword .Lfunc_begin3
   ret void
@@ -60,7 +60,7 @@ define void @f5() "patchable-function-entry"="5" comdat {
 ; CHECK-NEXT: .Lfunc_begin4:
 ; CHECK-COUNT-5: nop
 ; CHECK-NEXT:  sub sp, sp, #16
-; CHECK:       .section __patchable_function_entries,"aGwo",@progbits,f5,comdat,f5{{$}}
+; CHECK:       .section __patchable_function_entries,"awoG",@progbits,f5,f5,comdat{{$}}
 ; CHECK:       .p2align 3
 ; CHECK-NEXT:  .xword .Lfunc_begin4
   %frame = alloca i8, i32 16

--- a/llvm/test/CodeGen/LoongArch/patchable-function-entry.ll
+++ b/llvm/test/CodeGen/LoongArch/patchable-function-entry.ll
@@ -31,7 +31,7 @@ define void @f5() "patchable-function-entry"="5" comdat {
 ; CHECK-NEXT:    .Lfunc_begin2:
 ; CHECK-COUNT-5:   nop
 ; CHECK-NEXT:      ret
-; CHECK:         .section __patchable_function_entries,"aGwo",@progbits,f5,comdat,f5{{$}}
+; CHECK:         .section __patchable_function_entries,"awoG",@progbits,f5,f5,comdat{{$}}
 ; LA32:          .p2align 2
 ; LA32-NEXT:     .word .Lfunc_begin2
 ; LA64:          .p2align 3

--- a/llvm/test/CodeGen/Mips/xray-section-group.ll
+++ b/llvm/test/CodeGen/Mips/xray-section-group.ll
@@ -24,7 +24,7 @@ $bar = comdat any
 define i32 @bar() nounwind noinline uwtable "function-instrument"="xray-always" comdat($bar) {
 ; CHECK: .section .text.bar,"axG",@progbits,bar,comdat
   ret i32 1
-; CHECK: .section xray_instr_map,"aGo",@progbits,bar,comdat,bar{{$}}
+; CHECK: .section xray_instr_map,"aoG",@progbits,bar,bar,comdat{{$}}
 }
 
 ; CHECK-OBJ: Section {

--- a/llvm/test/CodeGen/RISCV/patchable-function-entry.ll
+++ b/llvm/test/CodeGen/RISCV/patchable-function-entry.ll
@@ -37,7 +37,7 @@ define void @f5() "patchable-function-entry"="5" comdat {
 ; NORVC-NEXT:    jalr zero, 0(ra)
 ; RVC-COUNT-5:   c.nop
 ; RVC-NEXT:      c.jr ra
-; CHECK:       .section __patchable_function_entries,"aGwo",@progbits,f5,comdat,f5{{$}}
+; CHECK:       .section __patchable_function_entries,"awoG",@progbits,f5,f5,comdat{{$}}
 ; RV32:        .p2align 2
 ; RV32-NEXT:   .word .Lfunc_begin2
 ; RV64:        .p2align 3

--- a/llvm/test/CodeGen/X86/basic-block-sections-labels-functions-sections.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-labels-functions-sections.ll
@@ -35,7 +35,7 @@ define linkonce_odr dso_local i32 @_Z4fooTIiET_v() comdat {
 ; CHECK:		.section .text._Z4fooTIiET_v,"axG",@progbits,_Z4fooTIiET_v,comdat
 ; CHECK-LABEL:	_Z4fooTIiET_v:
 ; CHECK-NEXT:	[[FOOCOMDAT_BEGIN:.Lfunc_begin[0-9]+]]:
-; CHECK:		.section .llvm_bb_addr_map,"Go",@llvm_bb_addr_map,_Z4fooTIiET_v,comdat,.text._Z4fooTIiET_v{{$}}
+; CHECK:		.section .llvm_bb_addr_map,"oG",@llvm_bb_addr_map,.text._Z4fooTIiET_v,_Z4fooTIiET_v,comdat{{$}}
 ; CHECK-NEXT:		.byte 2				# version
 ; CHECK-NEXT:		.byte 0				# feature
 ; CHECK-NEXT:		.quad [[FOOCOMDAT_BEGIN]]	# function address

--- a/llvm/test/CodeGen/X86/gcc_except_table-multi.ll
+++ b/llvm/test/CodeGen/X86/gcc_except_table-multi.ll
@@ -17,7 +17,7 @@ define i32 @group() uwtable comdat personality ptr @__gxx_personality_v0 {
 ; CHECK:             .cfi_endproc
 ; NORMAL-NEXT:       .section .gcc_except_table.group,"aG",@progbits,group,comdat{{$}}
 ; SEP_BFD-NEXT:      .section .gcc_except_table.group,"aG",@progbits,group,comdat{{$}}
-; SEP-NEXT:          .section .gcc_except_table.group,"aGo",@progbits,group,comdat,group{{$}}
+; SEP-NEXT:          .section .gcc_except_table.group,"aoG",@progbits,group,group,comdat{{$}}
 ; SEP_NOUNIQUE-NEXT: .section .gcc_except_table,"aG",@progbits,group,comdat{{$}}
 ; NOUNIQUE-NEXT:     .section .gcc_except_table,"aG",@progbits,group,comdat{{$}}
 entry:
@@ -61,7 +61,7 @@ define i32 @zero() uwtable comdat personality ptr @__gxx_personality_v0 {
 ; CHECK:             .cfi_endproc
 ; NORMAL-NEXT:       .section .gcc_except_table.zero,"aG",@progbits,zero{{$}}
 ; SEP_BFD-NEXT:      .section .gcc_except_table.zero,"aG",@progbits,zero{{$}}
-; SEP-NEXT:          .section .gcc_except_table.zero,"aGo",@progbits,zero,zero{{$}}
+; SEP-NEXT:          .section .gcc_except_table.zero,"aoG",@progbits,zero,zero{{$}}
 ; SEP_NOUNIQUE-NEXT: .section .gcc_except_table,"aG",@progbits,zero{{$}}
 ; NOUNIQUE-NEXT:     .section .gcc_except_table,"aG",@progbits,zero{{$}}
 entry:

--- a/llvm/test/CodeGen/X86/patchable-function-entry.ll
+++ b/llvm/test/CodeGen/X86/patchable-function-entry.ll
@@ -50,7 +50,7 @@ define void @f3() "patchable-function-entry"="3" comdat {
 ; 32-NEXT:     nop
 ; 64:          nopl (%rax)
 ; CHECK:       ret
-; CHECK:       .section __patchable_function_entries,"aGwo",@progbits,f3,comdat,f3{{$}}
+; CHECK:       .section __patchable_function_entries,"awoG",@progbits,f3,f3,comdat{{$}}
 ; 32:          .p2align 2
 ; 32-NEXT:     .long .Lfunc_begin3
 ; 64:          .p2align 3
@@ -66,7 +66,7 @@ define void @f5() "patchable-function-entry"="5" comdat {
 ; 32-NEXT:     nop
 ; 64:          nopl 8(%rax,%rax)
 ; CHECK-NEXT:  ret
-; CHECK:       .section __patchable_function_entries,"aGwo",@progbits,f5,comdat,f5{{$}}
+; CHECK:       .section __patchable_function_entries,"awoG",@progbits,f5,f5,comdat{{$}}
 ; 32:          .p2align 2
 ; 32-NEXT:     .long .Lfunc_begin4
 ; 64:          .p2align 3

--- a/llvm/test/CodeGen/X86/stack-size-section-function-sections.ll
+++ b/llvm/test/CodeGen/X86/stack-size-section-function-sections.ll
@@ -15,9 +15,9 @@
 
 ; Check we add .stack_size section to a COMDAT group with the corresponding .text section if such a COMDAT exists.
 ; UNIQ:   .section        .text._Z4fooTIiET_v,"axG",@progbits,_Z4fooTIiET_v,comdat{{$}}
-; UNIQ:   .section        .stack_sizes,"Go",@progbits,_Z4fooTIiET_v,comdat,.text._Z4fooTIiET_v{{$}}
+; UNIQ:   .section        .stack_sizes,"oG",@progbits,.text._Z4fooTIiET_v,_Z4fooTIiET_v,comdat{{$}}
 ; NOUNIQ: .section        .text,"axG",@progbits,_Z4fooTIiET_v,comdat,unique,3
-; NOUNIQ: .section        .stack_sizes,"Go",@progbits,_Z4fooTIiET_v,comdat,.text,unique,3
+; NOUNIQ: .section        .stack_sizes,"oG",@progbits,.text,_Z4fooTIiET_v,comdat,unique,3
 
 $_Z4fooTIiET_v = comdat any
 

--- a/llvm/test/CodeGen/X86/stack-size-section.ll
+++ b/llvm/test/CodeGen/X86/stack-size-section.ll
@@ -29,7 +29,7 @@ define void @func2() #0 {
 
 ; Check that we still put .stack_sizes into the corresponding COMDAT group if any.
 ; CHECK: .section .text._Z4fooTIiET_v,"axG",@progbits,_Z4fooTIiET_v,comdat
-; GROUPS: .section .stack_sizes,"Go",@progbits,_Z4fooTIiET_v,comdat,.text._Z4fooTIiET_v{{$}}
+; GROUPS: .section .stack_sizes,"oG",@progbits,.text._Z4fooTIiET_v,_Z4fooTIiET_v,comdat{{$}}
 ; NOGROUPS: .section .stack_sizes,"",@progbits
 $_Z4fooTIiET_v = comdat any
 define linkonce_odr dso_local i32 @_Z4fooTIiET_v() comdat {

--- a/llvm/test/CodeGen/X86/xray-section-group.ll
+++ b/llvm/test/CodeGen/X86/xray-section-group.ll
@@ -12,7 +12,7 @@ $bar = comdat any
 define i32 @bar() nounwind noinline uwtable "function-instrument"="xray-always" comdat($bar) {
 ; CHECK: .section .text.bar,"axG",@progbits,bar,comdat
   ret i32 1
-; CHECK: .section xray_instr_map,"aGo",@progbits,bar,comdat,bar{{$}}
+; CHECK: .section xray_instr_map,"aoG",@progbits,bar,bar,comdat{{$}}
 }
 
 ; CHECK-OBJ:      section xray_instr_map:

--- a/llvm/test/MC/ELF/section-combine.s
+++ b/llvm/test/MC/ELF/section-combine.s
@@ -39,10 +39,10 @@ bar:
 .section .foo,"o",@progbits,bar,unique,1
 .byte 5
 
-.section .foo,"Go",@progbits,comdat0,comdat,bar,unique,1
+.section .foo,"Go",@progbits,bar,comdat0,comdat,unique,1
 .byte 6
 
-.section .foo,"Go",@progbits,comdat1,comdat,bar,unique,1
+.section .foo,"Go",@progbits,bar,comdat1,comdat,unique,1
 .byte 7
-.section .foo,"Go",@progbits,comdat1,comdat,bar,unique,1
+.section .foo,"oG",@progbits,bar,comdat1,comdat,unique,1
 .byte 8

--- a/llvm/test/MC/ELF/section.s
+++ b/llvm/test/MC/ELF/section.s
@@ -166,9 +166,11 @@ bar:
 .section .shf_metadata1,"ao",@progbits,.Lshf_metadata_target2_1
 .section .shf_metadata2,"ao",@progbits,.Lshf_metadata_target2_2
 .section .shf_metadata3,"ao",@progbits,.shf_metadata_target1
+.section .linkorder_group_zero,"aoG",@progbits,.shf_metadata_target1,foo
 // ASM: .section .shf_metadata1,"ao",@progbits,.Lshf_metadata_target2_1
 // ASM: .section .shf_metadata2,"ao",@progbits,.Lshf_metadata_target2_2
 // ASM: .section .shf_metadata3,"ao",@progbits,.shf_metadata_target1
+// ASM: .section .linkorder_group_zero,"aoG",@progbits,.shf_metadata_target1,foo{{$}}
 
 // CHECK:      Section {
 // CHECK:        Index: 22
@@ -213,6 +215,20 @@ bar:
 // CHECK-NEXT:   Type: SHT_PROGBITS
 // CHECK-NEXT:   Flags [
 // CHECK-NEXT:     SHF_ALLOC
+// CHECK-NEXT:     SHF_LINK_ORDER
+// CHECK-NEXT:   ]
+// CHECK-NEXT:   Address:
+// CHECK-NEXT:   Offset:
+// CHECK-NEXT:   Size:
+// CHECK-NEXT:   Link:    22
+// CHECK-NEXT:   Info:    0
+
+// CHECK:      Section {
+// CHECK:        Name: .linkorder_group_zero
+// CHECK-NEXT:   Type: SHT_PROGBITS
+// CHECK-NEXT:   Flags [
+// CHECK-NEXT:     SHF_ALLOC
+// CHECK-NEXT:     SHF_GROUP
 // CHECK-NEXT:     SHF_LINK_ORDER
 // CHECK-NEXT:   ]
 // CHECK-NEXT:   Address:


### PR DESCRIPTION
When both SHF_LINK_ORDER | SHF_GROUP flags are set, GNU assembler from
2.35 onwards (https://sourceware.org/PR25381
https://sourceware.org/binutils/docs/as/Section.html) parses the
SHF_LINK_ORDER argument before section group name, different from us.

This is unfortunate, but does not matter because the `.section` flag `o`
is a niche feature only used by compiler instrumentations, not adopted
by hand-written assembly, and using both flags is extremely rare. Let's
just match GNU assembler. There is another benefit: we now support
zero-flag section group with the SHF_LINK_ORDER flag, while previously
there isn't a syntax.

While here, print 'G' after 'o' to be clear that the 'G' argument is
parsed after the 'o' argument. To make the diff smaller, we don't print
'G' after 'w' in the absence of 'o' for now.