### PR TITLE
[clang]use correct this scope to evaluate noexcept expr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -610,7 +610,8 @@ Bug Fixes in This Version
   of template classes. Fixes
   (`#68543 <https://github.com/llvm/llvm-project/issues/68543>`_,
   `#42496 <https://github.com/llvm/llvm-project/issues/42496>`_,
-  `#77071 <https://github.com/llvm/llvm-project/issues/77071>`_)
+  `#77071 <https://github.com/llvm/llvm-project/issues/77071>`_,
+  `#77411 <https://github.com/llvm/llvm-project/issues/77411>`_)
 - Fixed an issue when a shift count larger than ``__INT64_MAX__``, in a right
   shift operation, could result in missing warnings about
   ``shift count >= width of type`` or internal compiler error.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6192,6 +6192,12 @@ bool TreeTransform<Derived>::TransformExceptionSpec(
 
   // Instantiate a dynamic noexcept expression, if any.
   if (isComputedNoexcept(ESI.Type)) {
+    // Update this scrope because ContextDecl in Sema will be used in TransformExpr.
+    auto *Method = dyn_cast_or_null<CXXMethodDecl>(ESI.SourceTemplate);
+    Sema::CXXThisScopeRAII ThisScope(
+        SemaRef, Method ? Method->getParent() : nullptr,
+        Method ? Method->getMethodQualifiers() : Qualifiers{},
+        Method != nullptr);
     EnterExpressionEvaluationContext Unevaluated(
         getSema(), Sema::ExpressionEvaluationContext::ConstantEvaluated);
     ExprResult NoexceptExpr = getDerived().TransformExpr(ESI.NoexceptExpr);

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6192,7 +6192,8 @@ bool TreeTransform<Derived>::TransformExceptionSpec(
 
   // Instantiate a dynamic noexcept expression, if any.
   if (isComputedNoexcept(ESI.Type)) {
-    // Update this scrope because ContextDecl in Sema will be used in TransformExpr.
+    // Update this scrope because ContextDecl in Sema will be used in
+    // TransformExpr.
     auto *Method = dyn_cast_or_null<CXXMethodDecl>(ESI.SourceTemplate);
     Sema::CXXThisScopeRAII ThisScope(
         SemaRef, Method ? Method->getParent() : nullptr,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6194,7 +6194,7 @@ bool TreeTransform<Derived>::TransformExceptionSpec(
   if (isComputedNoexcept(ESI.Type)) {
     // Update this scrope because ContextDecl in Sema will be used in
     // TransformExpr.
-    auto *Method = dyn_cast_or_null<CXXMethodDecl>(ESI.SourceTemplate);
+    auto *Method = dyn_cast_if_present<CXXMethodDecl>(ESI.SourceTemplate);
     Sema::CXXThisScopeRAII ThisScope(
         SemaRef, Method ? Method->getParent() : nullptr,
         Method ? Method->getMethodQualifiers() : Qualifiers{},

--- a/clang/test/SemaCXX/cxx1z-noexcept-function-type.cpp
+++ b/clang/test/SemaCXX/cxx1z-noexcept-function-type.cpp
@@ -64,6 +64,21 @@ namespace DependentDefaultCtorExceptionSpec {
   struct A { multimap<int> Map; } a;
 
   static_assert(noexcept(A()));
+
+  template <class> struct NoexceptWithThis {
+    int ca;
+    template <class T> auto foo(T) noexcept(ca) { return true; }
+    // expected-error@-1 {{noexcept specifier argument is not a constant expression}}
+    // expected-note@-2 {{in instantiation of exception specification}}
+    // expected-note@-3 {{implicit use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function}}
+  };
+  struct InstantiateFromAnotherClass {
+    template <class B, class T = decltype(static_cast<bool (B::*)(int)>(&B::foo))> // expected-note {{in instantiation of function template specialization}}
+    InstantiateFromAnotherClass(B *) {} // expected-note {{in instantiation of default argument}}
+  };
+  NoexceptWithThis<int> f{};
+  // Don't crash here.
+  InstantiateFromAnotherClass b{&f}; // expected-note {{while substituting deduced template arguments into function template}}
 }
 
 #endif


### PR DESCRIPTION
Fixes: #77411
When substituting deduced type, noexcept expr in method should be instantiated and evaluated.
ThisScrope should be switched to method context instead of origin sema context