### PR TITLE
[MC,ELF] .section: unconditionally print section flag 'G' after 'o'

### DIFF
--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -90,10 +90,6 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << 'e';
   if (Flags & ELF::SHF_EXECINSTR)
     OS << 'x';
-  // TODO: Always print G after o to be clear that the 'G' argument is parsed
-  // after the 'o' argument.
-  if ((Flags & ELF::SHF_GROUP) && !(Flags & ELF::SHF_LINK_ORDER))
-    OS << 'G';
   if (Flags & ELF::SHF_WRITE)
     OS << 'w';
   if (Flags & ELF::SHF_MERGE)
@@ -104,7 +100,7 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << 'T';
   if (Flags & ELF::SHF_LINK_ORDER)
     OS << 'o';
-  if ((Flags & ELF::SHF_GROUP) && (Flags & ELF::SHF_LINK_ORDER))
+  if (Flags & ELF::SHF_GROUP)
     OS << 'G';
   if (Flags & ELF::SHF_GNU_RETAIN)
     OS << 'R';

--- a/llvm/test/CodeGen/Mips/ehframe-indirect.ll
+++ b/llvm/test/CodeGen/Mips/ehframe-indirect.ll
@@ -62,7 +62,7 @@ declare void @foo()
 ; N64: .8byte _ZTISt9exception
 ; ALL: .hidden DW.ref.__gxx_personality_v0
 ; ALL: .weak DW.ref.__gxx_personality_v0
-; ALL: .section .data.DW.ref.__gxx_personality_v0,"aGw",@progbits,DW.ref.__gxx_personality_v0,comdat
+; ALL: .section .data.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
 ; O32: .p2align 2
 ; N32: .p2align 2
 ; N64: .p2align 3

--- a/llvm/test/CodeGen/PowerPC/ppc32-pic-large.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc32-pic-large.ll
@@ -49,9 +49,9 @@ entry:
 ; LARGE-SECUREPLT:   addi 30, 30, .LTOC-.L0$pb@l
 ; LARGE-SECUREPLT:   bl call_foo@PLT+32768
 
-; LARGE:      .section .bss.bar1,"aGw",@nobits,bar1,comdat
+; LARGE:      .section .bss.bar1,"awG",@nobits,bar1,comdat
 ; LARGE:      bar1:
-; LARGE:      .section .bss.bar2,"aGw",@nobits,bar1,comdat
+; LARGE:      .section .bss.bar2,"awG",@nobits,bar1,comdat
 ; LARGE:      bar2:
 ; LARGE:      .section .got2,"aw",@progbits
 ; LARGE-NEXT: .p2align 2

--- a/llvm/test/CodeGen/SPARC/constructor.ll
+++ b/llvm/test/CodeGen/SPARC/constructor.ll
@@ -17,11 +17,11 @@ entry:
 ; CTOR:      .section      .ctors,"aw"
 ; CTOR-NEXT: .p2align      2
 ; CTOR-NEXT: .word  f
-; CTOR-NEXT: .section      .ctors.65520,"aGw"
+; CTOR-NEXT: .section      .ctors.65520,"awG",@progbits,v,comdat{{$}}
 ; CTOR-NEXT: .p2align      2
 ; CTOR-NEXT: .word  g
 
-; INIT-ARRAY:    .section  .init_array.15,"aGw"
+; INIT-ARRAY:    .section  .init_array.15,"awG",@init_array,v,comdat{{$}}
 ; INIT-ARRAY-NEXT: .p2align  2
 ; INIT-ARRAY-NEXT: .word g
 ; INIT-ARRAY-NEXT: .section  .init_array,"aw"

--- a/llvm/test/CodeGen/X86/constructor.ll
+++ b/llvm/test/CodeGen/X86/constructor.ll
@@ -43,17 +43,17 @@ entry:
 ; CTOR-NEXT:	.quad	j
 ; CTOR-NEXT:	.quad	i
 ; CTOR-NEXT:	.quad	f
-; CTOR-NEXT:	.section	.ctors.09980,"aGw",@progbits,v,comdat
+; CTOR-NEXT:	.section	.ctors.09980,"awG",@progbits,v,comdat
 ; CTOR-NEXT:	.p2align	3
 ; CTOR-NEXT:	.quad	h
-; CTOR-NEXT:	.section	.ctors.65520,"aGw",@progbits,v,comdat
+; CTOR-NEXT:	.section	.ctors.65520,"awG",@progbits,v,comdat
 ; CTOR-NEXT:	.p2align	3
 ; CTOR-NEXT:	.quad	g
 
-; INIT-ARRAY:		.section	.init_array.15,"aGw",@init_array,v,comdat
+; INIT-ARRAY:		.section	.init_array.15,"awG",@init_array,v,comdat
 ; INIT-ARRAY-NEXT:	.p2align	3
 ; INIT-ARRAY-NEXT:	.quad	g
-; INIT-ARRAY-NEXT:	.section	.init_array.55555,"aGw",@init_array,v,comdat
+; INIT-ARRAY-NEXT:	.section	.init_array.55555,"awG",@init_array,v,comdat
 ; INIT-ARRAY-NEXT:	.p2align	3
 ; INIT-ARRAY-NEXT:	.quad	h
 ; INIT-ARRAY-NEXT:	.section	.init_array,"aw",@init_array
@@ -62,10 +62,10 @@ entry:
 ; INIT-ARRAY-NEXT:	.quad	i
 ; INIT-ARRAY-NEXT:	.quad	j
 
-; NACL:		.section	.init_array.15,"aGw",@init_array,v,comdat
+; NACL:		.section	.init_array.15,"awG",@init_array,v,comdat
 ; NACL-NEXT:	.p2align	2
 ; NACL-NEXT:	.long	g
-; NACL-NEXT:	.section	.init_array.55555,"aGw",@init_array,v,comdat
+; NACL-NEXT:	.section	.init_array.55555,"awG",@init_array,v,comdat
 ; NACL-NEXT:	.p2align	2
 ; NACL-NEXT:	.long	h
 ; NACL-NEXT:	.section	.init_array,"aw",@init_array

--- a/llvm/test/CodeGen/X86/elf-comdat.ll
+++ b/llvm/test/CodeGen/X86/elf-comdat.ll
@@ -7,5 +7,5 @@ define void @f() comdat($f) {
 }
 ; CHECK: .section        .text.f,"axG",@progbits,f,comdat
 ; CHECK: .globl  f
-; CHECK: .section        .bss.v,"aGw",@nobits,f,comdat
+; CHECK: .section        .bss.v,"awG",@nobits,f,comdat
 ; CHECK: .globl  v

--- a/llvm/test/CodeGen/X86/elf-comdat2.ll
+++ b/llvm/test/CodeGen/X86/elf-comdat2.ll
@@ -5,7 +5,7 @@ $foo = comdat any
 @foo = global i32 42
 
 ; CHECK:      .type   bar,@object
-; CHECK-NEXT: .section        .data.bar,"aGw",@progbits,foo,comdat
+; CHECK-NEXT: .section        .data.bar,"awG",@progbits,foo,comdat
 ; CHECK-NEXT: .globl  bar
 ; CHECK:      .type   foo,@object
 ; CHECK-NEXT: .data

--- a/llvm/test/CodeGen/X86/elf-group.ll
+++ b/llvm/test/CodeGen/X86/elf-group.ll
@@ -4,7 +4,7 @@
 
 ; CHECK: .section .text.f1,"axG",@progbits,f1{{$}}
 ; CHECK: .section .text.f2,"axG",@progbits,f1{{$}}
-; CHECK: .section .bss.g1,"aGw",@nobits,f1{{$}}
+; CHECK: .section .bss.g1,"awG",@nobits,f1{{$}}
 
 $f1 = comdat nodeduplicate
 

--- a/llvm/test/CodeGen/X86/explicit-section-mergeable.ll
+++ b/llvm/test/CodeGen/X86/explicit-section-mergeable.ll
@@ -139,9 +139,9 @@
 !4 = !{ptr @implicit_rodata_cst4}
 
 ;; Test implicit section assignment for globals in distinct comdat groups.
-; CHECK: .section .rodata.cst4,"aGM",@progbits,4,f,comdat,unique,[[#U+7]]
+; CHECK: .section .rodata.cst4,"aMG",@progbits,4,f,comdat,unique,[[#U+7]]
 ; CHECK: implicit_rodata_cst4_comdat:
-; CHECK: .section .rodata.cst8,"aGM",@progbits,8,g,comdat,unique,[[#U+8]]
+; CHECK: .section .rodata.cst8,"aMG",@progbits,8,g,comdat,unique,[[#U+8]]
 ; CHECK: implicit_rodata_cst8_comdat:
 
 ;; Check that globals in distinct comdat groups that are explicitly assigned
@@ -153,11 +153,11 @@
 ;; are incorrect.
 ; CHECK: .section .explicit_comdat_distinct,"aM",@progbits,4,unique,[[#U+9]]
 ; CHECK: explicit_comdat_distinct_supply_uid:
-; CHECK: .section .explicit_comdat_distinct,"aGM",@progbits,4,f,comdat,unique,[[#U+10]]
+; CHECK: .section .explicit_comdat_distinct,"aMG",@progbits,4,f,comdat,unique,[[#U+10]]
 ; CHECK: explicit_comdat_distinct1:
-; CHECK: .section .explicit_comdat_distinct,"aGM",@progbits,4,g,comdat,unique,[[#U+10]]
+; CHECK: .section .explicit_comdat_distinct,"aMG",@progbits,4,g,comdat,unique,[[#U+10]]
 ; CHECK: explicit_comdat_distinct2:
-; CHECK: .section .explicit_comdat_distinct,"aGM",@progbits,8,h,comdat,unique,[[#U+11]]
+; CHECK: .section .explicit_comdat_distinct,"aMG",@progbits,8,h,comdat,unique,[[#U+11]]
 ; CHECK: explicit_comdat_distinct3:
 
 $f = comdat any
@@ -173,9 +173,9 @@ $h = comdat any
 @explicit_comdat_distinct3 = unnamed_addr constant [2 x i32] [i32 1, i32 1], section ".explicit_comdat_distinct", comdat($h)
 
 ;; Test implicit section assignment for globals in the same comdat group.
-; CHECK: .section .rodata.cst4,"aGM",@progbits,4,i,comdat,unique,[[#U+12]]
+; CHECK: .section .rodata.cst4,"aMG",@progbits,4,i,comdat,unique,[[#U+12]]
 ; CHECK: implicit_rodata_cst4_same_comdat:
-; CHECK: .section .rodata.cst8,"aGM",@progbits,8,i,comdat,unique,[[#U+13]]
+; CHECK: .section .rodata.cst8,"aMG",@progbits,8,i,comdat,unique,[[#U+13]]
 ; CHECK: implicit_rodata_cst8_same_comdat:
 
 ;; Check that globals in the same comdat group that are explicitly assigned
@@ -187,10 +187,10 @@ $h = comdat any
 ;; are incorrect.
 ; CHECK: .section .explicit_comdat_same,"aM",@progbits,4,unique,[[#U+14]]
 ; CHECK: explicit_comdat_same_supply_uid:
-; CHECK: .section .explicit_comdat_same,"aGM",@progbits,4,i,comdat,unique,[[#U+15]]
+; CHECK: .section .explicit_comdat_same,"aMG",@progbits,4,i,comdat,unique,[[#U+15]]
 ; CHECK: explicit_comdat_same1:
 ; CHECK: explicit_comdat_same2:
-; CHECK: .section .explicit_comdat_same,"aGM",@progbits,8,i,comdat,unique,[[#U+16]]
+; CHECK: .section .explicit_comdat_same,"aMG",@progbits,8,i,comdat,unique,[[#U+16]]
 ; CHECK: explicit_comdat_same3:
 
 $i = comdat any

--- a/llvm/test/CodeGen/X86/global-sections-comdat.ll
+++ b/llvm/test/CodeGen/X86/global-sections-comdat.ll
@@ -41,6 +41,6 @@ bb5:
 $G16 = comdat any
 @G16 = unnamed_addr constant i32 42, comdat
 
-; LINUX: .section	.rodata.cst4.G16,"aGM",@progbits,4,G16,comdat
-; LINUX-SECTIONS: .section	.rodata.cst4.G16,"aGM",@progbits,4,G16,comdat
-; LINUX-SECTIONS-SHORT: .section	.rodata.cst4,"aGM",@progbits,4,G16,comdat
+; LINUX: .section	.rodata.cst4.G16,"aMG",@progbits,4,G16,comdat
+; LINUX-SECTIONS: .section	.rodata.cst4.G16,"aMG",@progbits,4,G16,comdat
+; LINUX-SECTIONS-SHORT: .section	.rodata.cst4,"aMG",@progbits,4,G16,comdat

--- a/llvm/test/DebugInfo/SystemZ/eh_frame_personality.ll
+++ b/llvm/test/DebugInfo/SystemZ/eh_frame_personality.ll
@@ -39,7 +39,7 @@ clean:
 ; CHECK-REF: .cfi_lsda 27, .Lexception0
 ; CHECK-REF: .hidden	DW.ref.__gxx_personality_v0
 ; CHECK-REF: .weak	DW.ref.__gxx_personality_v0
-; CHECK-REF: .section	.data.DW.ref.__gxx_personality_v0,"aGw",@progbits,DW.ref.__gxx_personality_v0,comdat
+; CHECK-REF: .section	.data.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
 ; CHECK-REF-NEXT: .p2align	3
 ; CHECK-REF-NEXT: .type	DW.ref.__gxx_personality_v0,@object
 ; CHECK-REF-NEXT: .size	DW.ref.__gxx_personality_v0, 8

--- a/llvm/test/DebugInfo/SystemZ/eh_frame_personality.s
+++ b/llvm/test/DebugInfo/SystemZ/eh_frame_personality.s
@@ -25,7 +25,7 @@ foo:                                    # @foo
 
 	.hidden	DW.ref.__gxx_personality_v0
 	.weak	DW.ref.__gxx_personality_v0
-	.section	.data.DW.ref.__gxx_personality_v0,"aGw",@progbits,DW.ref.__gxx_personality_v0,comdat
+	.section	.data.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
 	.align	8
 	.type	DW.ref.__gxx_personality_v0,@object
 	.size	DW.ref.__gxx_personality_v0, 8

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_ehframe_basic.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_ehframe_basic.s
@@ -106,7 +106,7 @@ GCC_except_table1:
 	.quad	_ZTIi
 	.hidden	DW.ref.__gxx_personality_v0
 	.weak	DW.ref.__gxx_personality_v0
-	.section	.data.DW.ref.__gxx_personality_v0,"aGw",@progbits,DW.ref.__gxx_personality_v0,comdat
+	.section	.data.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
 	.p2align	3
 	.type	DW.ref.__gxx_personality_v0,@object
 	.size	DW.ref.__gxx_personality_v0, 8

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_ehframe_large_static_personality_encodings.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_ehframe_large_static_personality_encodings.s
@@ -190,7 +190,7 @@ GCC_except_table1:
 	.hidden	DW.ref.__gxx_personality_v0
 	.weak	DW.ref.__gxx_personality_v0
 
-	.section	.data.DW.ref.__gxx_personality_v0,"aGw",@progbits,DW.ref.__gxx_personality_v0,comdat
+	.section	.data.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
 	.p2align	3
 	.type	DW.ref.__gxx_personality_v0,@object
 	.size	DW.ref.__gxx_personality_v0, 8

--- a/llvm/test/MC/ELF/alias-to-local.s
+++ b/llvm/test/MC/ELF/alias-to-local.s
@@ -10,7 +10,7 @@ foo:
 	movl	$zed, %eax
 
 
-	.section	.data.bar,"aGw",@progbits,zed,comdat
+	.section	.data.bar,"awG",@progbits,zed,comdat
 bar:
 	.byte	42
 

--- a/llvm/test/MC/ELF/relocation.s
+++ b/llvm/test/MC/ELF/relocation.s
@@ -4,7 +4,7 @@
 // Test that we produce the correct relocation.
 
 
-        .section	.pr23272,"aGw",@progbits,pr23272,comdat
+        .section	.pr23272,"awG",@progbits,pr23272,comdat
 	.globl pr23272
 pr23272:
 pr23272_2:

--- a/llvm/test/tools/llvm-symbolizer/frame.s
+++ b/llvm/test/tools/llvm-symbolizer/frame.s
@@ -203,7 +203,7 @@ hwasan.module_ctor:                     // @hwasan.module_ctor
 	.size	hwasan.module_ctor, .Lfunc_end1-hwasan.module_ctor
 	.cfi_endproc
                                         // -- End function
-	.section	.init_array.0,"aGw",@init_array,hwasan.module_ctor,comdat
+	.section	.init_array.0,"awG",@init_array,hwasan.module_ctor,comdat
 	.p2align	3
 	.xword	hwasan.module_ctor
 	.section	.debug_str,"MS",@progbits,1


### PR DESCRIPTION
* Placing 'G' before 'M' (SHF_MERGE) can be misleading as the sh_entsize
  argument goes before the section group name, if a reader doesn't know
  that the order of extra arguments is not affected by the order of flags.
* 'a', 'w', and 'x' indicate basic permission-related flags. Separating
  them with 'G' is kinda ugly.

Simplify code and move 'G' after 'o'. The new output is more similar to
GCC.