### PR TITLE
[clang][Parser] Pop scope prior VarDecl invalidating by invalid init

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -702,6 +702,9 @@ Bug Fixes in This Version
 - Fix assertion failure when initializing union containing struct with
   flexible array member using empty initializer list.
   Fixes (`#77085 <https://github.com/llvm/llvm-project/issues/77085>`_)
+- Fix assertion crash due to failed scope restoring caused by too-early VarDecl
+  invalidation by invalid initializer Expr.
+  Fixes (`#30908 <https://github.com/llvm/llvm-project/issues/30908>`_)
 
 
 Bug Fixes to Compiler Builtins

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2661,7 +2661,12 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
       // ProduceConstructorSignatureHelp only on VarDecls.
       ExpressionStarts = SetPreferredType;
     }
-    if (ParseExpressionList(Exprs, ExpressionStarts)) {
+
+    bool SawError = ParseExpressionList(Exprs, ExpressionStarts);
+
+    InitScope.pop();
+
+    if (SawError) {
       if (ThisVarDecl && PP.isCodeCompletionReached() && !CalledSignatureHelp) {
         Actions.ProduceConstructorSignatureHelp(
             ThisVarDecl->getType()->getCanonicalTypeInternal(),
@@ -2674,7 +2679,6 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
     } else {
       // Match the ')'.
       T.consumeClose();
-      InitScope.pop();
 
       ExprResult Initializer = Actions.ActOnParenListExpr(T.getOpenLocation(),
                                                           T.getCloseLocation(),

--- a/clang/test/Parser/gh30908-scope-balance-on-invalid-var-direct-init-1.cpp
+++ b/clang/test/Parser/gh30908-scope-balance-on-invalid-var-direct-init-1.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -ferror-limit 2 -fsyntax-only -verify %s
+
+// expected-error@* {{too many errors emitted}}
+
+namespace llvm {
+namespace Hexagon {}
+}
+void set() {
+  Hexagon::NoRegister;
+  // expected-error@-1 {{use of undeclared identifier}}
+  // expected-note@-5 {{declared here}}
+  // expected-error@-3 {{no member named 'NoRegister' in namespace}}
+}
+template <class> struct pair { pair(int, int); };
+struct HexagonMCChecker {
+  static pair<int> Unconditional;
+  void checkRegisters();
+};
+pair<int> HexagonMCChecker::Unconditional(Hexagon::NoRegister, 0);
+void HexagonMCChecker::checkRegisters() {}

--- a/clang/test/Parser/gh30908-scope-balance-on-invalid-var-direct-init-2.cpp
+++ b/clang/test/Parser/gh30908-scope-balance-on-invalid-var-direct-init-2.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+#include <non-exist-header> // expected-error {{file not found}}
+
+class S {};
+
+template <typename T>
+class E {
+public:
+  E(S* scope) {}
+  S &getS();
+};
+
+class Z {
+ private:
+  static E<Z> e;
+  static S& s();
+};
+
+E<Z> Z::e(&__UNKNOWN_ID__);
+
+S& Z::s() { return Z::e.getS(); }


### PR DESCRIPTION
Invalid (direct) initializer would invalid `VarDecl` so `InitializerScopeRAII` cannot restore scope stack balance.

As with other kind of initializer, `InitializerScopeRAII::pop()` is moved up before `Sema::ActOnInitializerError()` which invalidates the `VarDecl`, so scope can be balanced and current `DeclContext` can be restored.

Fixes #30908