### PR TITLE
[RISCV] Assert extensions are sorted at compile time. NFCI

### DIFF
--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -214,9 +214,9 @@ template <typename T> constexpr bool isSorted(T &&Extensions) {
   return true;
 }
 
-static_assert(isSorted(SupportedExtensions) &&
+static_assert(isSorted(SupportedExtensions),
               "Extensions are not sorted by name");
-static_assert(isSorted(SupportedExperimentalExtensions) &&
+static_assert(isSorted(SupportedExperimentalExtensions),
               "Experimental extensions are not sorted by name");
 
 static void PrintExtension(StringRef Name, StringRef Version,
@@ -1132,7 +1132,7 @@ static constexpr ImpliedExtsEntry ImpliedExts[] = {
     {"zvl8192b", {ImpliedExtsZvl8192b}},
 };
 
-static_assert(isSorted(ImpliedExts) &&
+static_assert(isSorted(ImpliedExts),
               "Implied extensions are not sorted by name");
 
 void RISCVISAInfo::updateImplication() {


### PR DESCRIPTION
This replaces verifyTables and assert(llvm::is_sorted) with a constexpr
static_assert, so that adding an extension or implication in the wrong order
will be a compile time failure rather than a runtime failure.
