### PR TITLE
clarify semantics of masked.load/store

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -23611,7 +23611,8 @@ Semantics:
 """"""""""
 
 The '``llvm.masked.load``' intrinsic is designed for conditional reading of selected vector elements in a single IR operation. It is useful for targets that support vector masked loads and allows vectorizing predicated basic blocks on these targets. Other targets may support this intrinsic differently, for example by lowering it into a sequence of branches that guard scalar load operations.
-The result of this operation is equivalent to a regular vector load instruction followed by a 'select' between the loaded and the passthru values, predicated on the same mask. However, using this intrinsic prevents exceptions on memory access to masked-off lanes.
+The result of this operation is equivalent to a regular vector load instruction followed by a 'select' between the loaded and the passthru values, predicated on the same mask.
+However, masked-off lanes may be out-of-bounds and they are not considered accessed for the purpose of data races or `noalias` constraints.
 
 
 ::
@@ -23653,7 +23654,8 @@ Semantics:
 """"""""""
 
 The '``llvm.masked.store``' intrinsics is designed for conditional writing of selected vector elements in a single IR operation. It is useful for targets that support vector masked store and allows vectorizing predicated basic blocks on these targets. Other targets may support this intrinsic differently, for example by lowering it into a sequence of branches that guard scalar store operations.
-The result of this operation is equivalent to a load-modify-store sequence. However, using this intrinsic prevents exceptions and data races on memory access to masked-off lanes.
+The result of this operation is equivalent to a load-modify-store sequence.
+However, masked-off lanes may be out-of-bounds and they are not considered accessed for the purpose of data races or `noalias` constraints.
 
 ::
 


### PR DESCRIPTION
Talking about exceptions ignores IR-level concerns such as out-of-bounds accesses being UB even when they are guaranteed to not raise an exception. So clarify the semantics of masked.load and masked.store by focusing on IR-level semantics.