### PR TITLE
[coroutine] Suppress unreachable-code warning on coroutine statements.

### DIFF
--- a/clang/lib/Analysis/ReachableCode.cpp
+++ b/clang/lib/Analysis/ReachableCode.cpp
@@ -456,7 +456,7 @@ bool DeadCodeScan::isDeadCodeRoot(const clang::CFGBlock *Block) {
 
 // Check if the given `DeadStmt` is a coroutine statement and is a substmt of
 // the coroutine statement. `Block` is the CFGBlock containing the `DeadStmt`.
-static bool isInCoroutineStmt(const Stmt* DeadStmt, const CFGBlock *Block) {
+static bool isInCoroutineStmt(const Stmt *DeadStmt, const CFGBlock *Block) {
   // The coroutine statement, co_return, co_await, or co_yield.
   const Stmt *CoroStmt = nullptr;
   // Find the first coroutine statement after the DeadStmt in the block.

--- a/clang/lib/Analysis/ReachableCode.cpp
+++ b/clang/lib/Analysis/ReachableCode.cpp
@@ -458,7 +458,7 @@ bool DeadCodeScan::isDeadCodeRoot(const clang::CFGBlock *Block) {
 // the coroutine statement. `Block` is the CFGBlock containing the `DeadStmt`.
 static bool isInCoroutineStmt(const Stmt* DeadStmt, const CFGBlock *Block) {
   // The coroutine statement, co_return, co_await, or co_yield.
-  const Stmt* CoroStmt = nullptr;
+  const Stmt *CoroStmt = nullptr;
   // Find the first coroutine statement after the DeadStmt in the block.
   bool AfterDeadStmt = false;
   for (CFGBlock::const_iterator I = Block->begin(), E = Block->end(); I != E;

--- a/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
+++ b/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
@@ -10,7 +10,7 @@ struct task {
     std::suspend_always final_suspend() noexcept;
     void return_void();
     std::suspend_always yield_value(int) { return {}; }
-      task get_return_object();
+    task get_return_object();
     void unhandled_exception();
   };
 };
@@ -47,4 +47,19 @@ task test6() {
   abort();
   1; // expected-warning {{code will never be executed}}
   co_await std::suspend_never{};
+}
+
+task test7() {
+  // coroutine statements are not considered unreachable.
+  co_await std::suspend_never{};
+  abort();
+  co_await std::suspend_never{};
+}
+
+task test8() {
+  // coroutine statements are not considered unreachable.
+  // co_await std::suspend_never{};
+  abort();
+  co_return;
+  1 + 1; // expected-warning {{code will never be executed}}
 }

--- a/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
+++ b/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
@@ -71,6 +71,6 @@ task test8() {
 
 task test9() {
   abort();
-  // This warning is emit on the declaration itself, rather the coroutine substmt.
+  // This warning is emitted on the declaration itself, rather the coroutine substmt.
   int x = co_await 1; // expected-warning {{code will never be executed}}
 }

--- a/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
+++ b/clang/test/SemaCXX/coroutine-unreachable-warning.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown %s -std=c++20 -fsyntax-only -verify -Wunreachable-code
+
+#include "Inputs/std-coroutine.h"
+
+extern void abort (void) __attribute__ ((__noreturn__));
+
+struct task {
+  struct promise_type {
+    std::suspend_always initial_suspend();
+    std::suspend_always final_suspend() noexcept;
+    void return_void();
+    std::suspend_always yield_value(int) { return {}; }
+      task get_return_object();
+    void unhandled_exception();
+  };
+};
+
+task test1() {
+  abort();
+  co_yield 1;
+}
+
+task test2() {
+  abort();
+  1; // expected-warning {{code will never be executed}}
+  co_yield 1;
+}
+
+task test3() {
+  abort();
+  co_return;
+}
+
+task test4() {
+  abort();
+  1; // expected-warning {{code will never be executed}}
+  co_return;
+}
+
+
+task test5() {
+  abort();
+  co_await std::suspend_never{};
+}
+
+task test6() {
+  abort();
+  1; // expected-warning {{code will never be executed}}
+  co_await std::suspend_never{};
+}


### PR DESCRIPTION
This fixes #69219.

Consider an example:

```
CoTask my_coroutine() {
    std::abort();
    co_return 1; // unreachable code warning.
}
```

Clang emits a CFG-based unreachable warning on the `co_return` statement (precisely the `1` subexpr). If we remove this statement, the program semantic is changed (my_coroutine is not a coroutine anymore).

This patch fixes this issue by never considering coroutine statements as dead statements.