### PR TITLE
[Flang][Parser] Add missing #include "flang/Common/idioms.h"

### DIFF
--- a/flang/include/flang/Parser/format-specification.h
+++ b/flang/include/flang/Parser/format-specification.h
@@ -19,7 +19,6 @@
 // TODO: support Q formatting extension?
 
 #include "flang/Common/idioms.h"
-
 #include <cinttypes>
 #include <list>
 #include <optional>

--- a/flang/include/flang/Parser/format-specification.h
+++ b/flang/include/flang/Parser/format-specification.h
@@ -18,6 +18,8 @@
 // dependences on other parts of the compiler's source code.
 // TODO: support Q formatting extension?
 
+#include "flang/Common/idioms.h"
+
 #include <cinttypes>
 #include <list>
 #include <optional>


### PR DESCRIPTION
The file format-specification.h uses definitions from Fortran::common, but doesn't include any headers that provide them.