### PR TITLE
[clang][modules] Objective-C test lacks support on AIX/zOS

### DIFF
--- a/clang/test/Modules/autolink_private_module.m
+++ b/clang/test/Modules/autolink_private_module.m
@@ -1,3 +1,5 @@
+// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
+
 // Test that autolink hints for frameworks don't use the private module name.
 // RUN: rm -rf %t && mkdir %t
 // RUN: split-file %s %t


### PR DESCRIPTION
To fix error: `fatal error: error in backend: Objective-C support is unimplemented for object file format`

Same rationale as 22f01cd.