### PR TITLE
[acc] Fix OpenACC documentation

### DIFF
--- a/mlir/docs/Dialects/OpenACCDialect.md
+++ b/mlir/docs/Dialects/OpenACCDialect.md
@@ -1,3 +1,5 @@
+# 'acc' Dialect
+
 The `acc` dialect is an MLIR dialect for representing the OpenACC
 programming model. OpenACC is a standardized directive-based model which
 is used with C, C++, and Fortran to enable programmers to expose
@@ -446,4 +448,6 @@ operations are intended to be optimized in the following ways:
 dominates another.
 * Be able to hoist/sink such operations out of loops.
 
-[include "Dialects/OpenACCDialect.md"]
+## Operations TOC
+
+[include "Dialects/OpenACCDialectOps.md"]

--- a/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
@@ -4,8 +4,8 @@ add_public_tablegen_target(acc_common_td)
 
 add_mlir_dialect(OpenACCOps acc)
 
-add_mlir_doc(OpenACCOps OpenACCDialect Dialects/ -gen-dialect-doc -dialect=acc)
-add_dependencies(OpenACCDialectDocGen acc_common_td)
+add_mlir_doc(OpenACCOps OpenACCDialectOps Dialects/ -gen-dialect-doc -dialect=acc)
+add_dependencies(OpenACCDialectOpsDocGen acc_common_td)
 
 set(LLVM_TARGET_DEFINITIONS OpenACCOps.td)
 mlir_tablegen(OpenACCOpsEnums.h.inc -gen-enum-decls)


### PR DESCRIPTION
After PR#75548, the OpenACC documentation on the MLIR website has a few issues. This change corrects them:
- Renames OpenACC.md to OpenACCDialect.md so that links remain unchanged. In its current state, the links to
https://mlir.llvm.org/docs/Dialects/OpenACCDialect/ no longer work.
- Since the old OpenACCDialect.md (the one with operation definitions) is being included in the new file, rename the old file to prevent name ambiguity.
- A header is needed in the .md file, otherwise the index on website is not properly created.
- Add a new section before including the operations .md file because otherwise the separation is not clear.