### PR TITLE
[ADT] Make StringRef std::string_view conversion operator constexpr. NFC

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -128,7 +128,7 @@ namespace llvm {
 
     /// data - Get a pointer to the start of the string (which may not be null
     /// terminated).
-    [[nodiscard]] const char *data() const { return Data; }
+    [[nodiscard]] constexpr const char *data() const { return Data; }
 
     /// empty - Check if the string is empty.
     [[nodiscard]] constexpr bool empty() const { return Length == 0; }
@@ -245,7 +245,7 @@ namespace llvm {
     /// @name Type Conversions
     /// @{
 
-    operator std::string_view() const {
+    constexpr operator std::string_view() const {
       return std::string_view(data(), size());
     }
 

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -59,6 +59,7 @@ TEST(StringRefTest, Construction) {
 TEST(StringRefTest, Conversion) {
   EXPECT_EQ("hello", std::string(StringRef("hello")));
   EXPECT_EQ("hello", std::string_view(StringRef("hello")));
+  static_assert(std::string_view(StringRef("hello")) == "hello");
 }
 
 TEST(StringRefTest, EmptyInitializerList) {
@@ -78,9 +79,22 @@ TEST(StringRefTest, Iteration) {
 
 TEST(StringRefTest, StringOps) {
   const char *p = "hello";
+
   EXPECT_EQ(p, StringRef(p, 0).data());
+  static_assert(StringRef("hello").data()[0] == 'h');
+  static_assert(StringRef("hello").data()[1] == 'e');
+  static_assert(StringRef("hello").data()[2] == 'l');
+  static_assert(StringRef("hello").data()[3] == 'l');
+  static_assert(StringRef("hello").data()[4] == 'o');
+  static_assert(StringRef("hello").data()[5] == '\0');
+
   EXPECT_TRUE(StringRef().empty());
+  static_assert(StringRef("").empty());
+  static_assert(!StringRef("hello").empty());
+
   EXPECT_EQ((size_t) 5, StringRef("hello").size());
+  static_assert(StringRef("hello").size() == 5);
+
   EXPECT_GT( 0, StringRef("aab").compare("aad"));
   EXPECT_EQ( 0, StringRef("aab").compare("aab"));
   EXPECT_LT( 0, StringRef("aab").compare("aaa"));


### PR DESCRIPTION
This would allow us to compare StringRefs via std::string_view, avoiding having
to make the existing StringRef compare machinery constexpr for now, which we
could then use in #77442
