### PR TITLE
[PGO] Fix `instrprof-api.c` on Windows

### DIFF
--- a/compiler-rt/test/profile/instrprof-api.c
+++ b/compiler-rt/test/profile/instrprof-api.c
@@ -29,8 +29,8 @@ int foo() {
 int main() {
   int z = foo() + 3;
   __llvm_profile_set_filename("rawprof.profraw");
-  // PROFGEN: call void @__llvm_profile_set_filename(ptr noundef @.str)
-  // PROFUSE-NOT: call void @__llvm_profile_set_filename(ptr noundef @.str)
+  // PROFGEN: call void @__llvm_profile_set_filename(ptr noundef @{{.*}})
+  // PROFUSE-NOT: call void @__llvm_profile_set_filename(ptr noundef @{{.*}})
   if (__llvm_profile_dump())
     return 2;
   // PROFGEN: %call1 = call {{(signext )*}}i32 @__llvm_profile_dump()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/76471 introduced a new test but the check lines have over-restrictive patterns for a string variable name that cause test failures on Windows (e.g. https://lab.llvm.org/buildbot/#/builders/127/builds/60637/steps/4/logs/stdio). This PR fixes the test.  