### PR TITLE
Replace `exec_tools` with `tools` in bazel genrule.

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/BUILD.bazel
@@ -57,7 +57,7 @@ genrule(
     srcs = ["misc/ConfusableTable/confusables.txt"],
     outs = ["Confusables.inc"],
     cmd = "$(location :confusable_table_builder) $(SRCS) $(OUTS)",
-    exec_tools = [":confusable_table_builder"],
+    tools = [":confusable_table_builder"],
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
As of the Bazel 6.x series, there is no difference between the `exec_tools` and `tools`. Bazel 7 removes the `exec_tools` attribute entirely. This commit updates to use the cannonical attribute name to allow building `clang-tidy``with bazel 7.0.0, though it does not change the default bazel version which remains at 6.1.2.

See also https://github.com/bazelbuild/bazel/issues/19132 for more information.