### PR TITLE
Edit Semantics Description of `@llvm.is.constant.*`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -27220,9 +27220,6 @@ obviously not constant. However, a call like
 function is inlined, if the value passed to the function parameter was
 a constant.
 
-On the other hand, if constant folding is not run, it will never
-evaluate to true, even in simple cases.
-
 .. _int_ptrmask:
 
 '``llvm.ptrmask``' Intrinsic


### PR DESCRIPTION
Fixes #77517 

I edited it from browser and didn't run any checks due to the triviality of the change.