### PR TITLE
[flang] Add portability warning for F'2008 feature

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -451,6 +451,9 @@ end
 * A `SEQUENCE` derived type is required (F'2023 C745) to have
   at least one component.  No compiler enforces this constraint;
   this compiler emits a warning.
+* Many compilers disallow a `VALUE` assumed-length character dummy
+  argument, which has been standard since F'2008.
+  We accept this usage with an optional portability warning.
 
 ## Behavior in cases where the standard is ambiguous or indefinite
 

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -572,6 +572,12 @@ void CheckHelper::CheckValue(
     messages_.Say(
         "VALUE attribute may not apply to an assumed-rank array"_err_en_US);
   }
+  if (context_.ShouldWarn(common::UsageWarning::Portability) &&
+      IsAssumedLengthCharacter(symbol)) {
+    // F'2008 feature not widely implemented
+    messages_.Say(
+        "VALUE attribute on assumed-length CHARACTER may not be portable"_port_en_US);
+  }
 }
 
 void CheckHelper::CheckAssumedTypeEntity( // C709

--- a/flang/test/Semantics/call14.f90
+++ b/flang/test/Semantics/call14.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Test 8.5.18 constraints on the VALUE attribute
 
 module m
@@ -7,7 +7,7 @@ module m
   end type
  contains
   !ERROR: VALUE attribute may apply only to a dummy data object
-  subroutine C863(notData,assumedSize,coarray,coarrayComponent,assumedRank)
+  subroutine C863(notData,assumedSize,coarray,coarrayComponent,assumedRank,assumedLen)
     external :: notData
     !ERROR: VALUE attribute may apply only to a dummy argument
     real, value :: notADummy
@@ -20,6 +20,8 @@ module m
     type(hasCoarray), value :: coarrayComponent
     !ERROR: VALUE attribute may not apply to an assumed-rank array
     real, value :: assumedRank(..)
+    !PORTABILITY: VALUE attribute on assumed-length CHARACTER may not be portable
+    character(*), value :: assumedLen
   end subroutine
   subroutine C864(allocatable, inout, out, pointer, volatile)
     !ERROR: VALUE attribute may not apply to an ALLOCATABLE


### PR DESCRIPTION
Using the VALUE attribute for assumed-length CHARACTER dummy arguments became standard in F'2008 but still lacks widespread implementation; emit a portability warning when they are enabled.

Resolves llvm-test-suite/Fortran/gfortran/regression/value_5.f90.