### PR TITLE
[scudo] Condition variable can be disabled by setting the flag to off

### DIFF
--- a/compiler-rt/lib/scudo/standalone/condition_variable.h
+++ b/compiler-rt/lib/scudo/standalone/condition_variable.h
@@ -51,7 +51,7 @@ struct ConditionVariableState {
 
 template <typename Config>
 struct ConditionVariableState<Config, decltype(Config::UseConditionVariable)> {
-  static constexpr bool enabled() { return true; }
+  static constexpr bool enabled() { return Config::UseConditionVariable; }
   using ConditionVariableT = typename Config::ConditionVariableT;
 };
 


### PR DESCRIPTION
To enable the condition variable, you have to define both UseConditionVariable and the ConditionVariableT. Otherwise, it'll be disabled. However, you may want to disable the condition variable by setting UseConditionVariable=false, for example, while measuring the performance and you want to turn it off temporarily. Instead of requiring the removal of the variable, examining its value makes more sense.