### PR TITLE
[clang][analyzer] Fix incorrect range of 'ftell' in the StdLibraryFunctionsChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -2274,7 +2274,7 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
     addToFunctionSummaryMap(
         "ftell", Signature(ArgTypes{FilePtrTy}, RetType{LongTy}),
         Summary(NoEvalCall)
-            .Case({ReturnValueCondition(WithinRange, Range(1, LongMax))},
+            .Case({ReturnValueCondition(WithinRange, Range(0, LongMax))},
                   ErrnoUnchanged, GenericSuccessMsg)
             .Case(ReturnsMinusOne, ErrnoNEZeroIrrelevant, GenericFailureMsg)
             .ArgConstraint(NotNull(ArgNo(0))));


### PR DESCRIPTION
According to https://pubs.opengroup.org/onlinepubs/9699919799/, the return value of `ftell` is not restricted to `> 0`, and may return `0` in real world.

And the corresponding unit test also show `Ret >= 0` not `Ret > 0`.

https://github.com/llvm/llvm-project/blob/main/clang/test/Analysis/stream-errno.c#L194