### PR TITLE
[NFC][OpenMP][Flang] Add smoke test for omp target parallel

### DIFF
--- a/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-region.f90
+++ b/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-region.f90
@@ -1,0 +1,21 @@
+! Basic offloading test with a target region
+! REQUIRES: flang
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-pc-linux-gnu
+! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+program main
+   use omp_lib
+   integer :: x
+
+   !$omp target parallel map(from: x)
+         x = omp_get_num_threads()
+   !$omp end target parallel
+   print *,"parallel = ", (x .ne. 1)
+
+end program main
+
+! CHECK: parallel = T


### PR DESCRIPTION
Added test which proves that end-to-end compilation of omp target parallel costruct is successful for Flang compiler.