### PR TITLE
[clang]not lookup name containing a dependent type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -708,7 +708,9 @@ Bug Fixes in This Version
 - Clang now emits correct source location for code-coverage regions in `if constexpr`
   and `if consteval` branches.
   Fixes (`#54419 <https://github.com/llvm/llvm-project/issues/54419>`_)
-
+- Fix an issue where clang cannot find conversion function with template
+  parameter when instantiation of template class.
+  Fixes (`#77583 <https://github.com/llvm/llvm-project/issues/77583>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -782,7 +782,8 @@ Sema::BuildMemberReferenceExpr(Expr *Base, QualType BaseType,
                                const Scope *S,
                                ActOnMemberAccessExtraArgs *ExtraArgs) {
   if (BaseType->isDependentType() ||
-      (SS.isSet() && isDependentScopeSpecifier(SS)))
+      (SS.isSet() && isDependentScopeSpecifier(SS)) ||
+      NameInfo.getName().isDependentName())
     return ActOnDependentMemberExpr(Base, BaseType,
                                     IsArrow, OpLoc,
                                     SS, TemplateKWLoc, FirstQualifierInScope,

--- a/clang/test/SemaCXX/conversion-function.cpp
+++ b/clang/test/SemaCXX/conversion-function.cpp
@@ -475,21 +475,22 @@ struct S {
 
 #if __cplusplus >= 201103L
 namespace dependent_conversion_function_id_lookup {
-  struct A1 {
-    operator int();
-  };
-  template<class T> struct C {
-    template <typename U> using Lookup = decltype(T{}.operator U());
-  };
-  C<A1> v{};
-
-  template<typename T> struct A2 {
-    operator T();
-  };
-  template<typename T> struct B : A2<T> {
-    template<typename U> using Lookup = decltype(&B::operator U);
-  };
-  using Result = B<int>::Lookup<int>;
-  using Result = int (A2<int>::*)();
+namespace gh77583 {
+struct A1 {
+  operator int();
+};
+template<class T> struct C {
+  template <typename U> using Lookup = decltype(T{}.operator U());
+};
+C<A1> v{};
+}
+template<typename T> struct A2 {
+  operator T();
+};
+template<typename T> struct B : A2<T> {
+  template<typename U> using Lookup = decltype(&B::operator U);
+};
+using Result = B<int>::Lookup<int>;
+using Result = int (A2<int>::*)();
 }
 #endif

--- a/clang/test/SemaCXX/conversion-function.cpp
+++ b/clang/test/SemaCXX/conversion-function.cpp
@@ -475,13 +475,21 @@ struct S {
 
 #if __cplusplus >= 201103L
 namespace dependent_conversion_function_id_lookup {
-  template<typename T> struct A {
+  struct A1 {
+    operator int();
+  };
+  template<class T> struct C {
+    template <typename U> using Lookup = decltype(T{}.operator U());
+  };
+  C<A1> v{};
+
+  template<typename T> struct A2 {
     operator T();
   };
-  template<typename T> struct B : A<T> {
+  template<typename T> struct B : A2<T> {
     template<typename U> using Lookup = decltype(&B::operator U);
   };
   using Result = B<int>::Lookup<int>;
-  using Result = int (A<int>::*)();
+  using Result = int (A2<int>::*)();
 }
 #endif


### PR DESCRIPTION
Fixes: #77583
bcd51aaaf8bde4b0ae7a4155d9ce3dec78fe2598 fixed part of template instantiation dependent name issues but still missing some cases This patch want to enhance the dependent name check