### PR TITLE
[DWARFLinker][NFC] Rename libraries to match with directories name.

### DIFF
--- a/bolt/lib/Rewrite/CMakeLists.txt
+++ b/bolt/lib/Rewrite/CMakeLists.txt
@@ -5,8 +5,8 @@ set(LLVM_LINK_COMPONENTS
   MC
   Object
   Support
-  DWARFLinkerBase
   DWARFLinker
+  DWARFLinkerClassic
   AsmPrinter
   TargetParser
   )

--- a/llvm/lib/DWARFLinker/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llvm_component_library(LLVMDWARFLinkerBase
+add_llvm_component_library(LLVMDWARFLinker
   Utils.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/llvm/lib/DWARFLinker/Classic/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/Classic/CMakeLists.txt
@@ -5,7 +5,7 @@ add_llvm_component_library(LLVMDWARFLinkerClassic
   DWARFStreamer.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker/Classic
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker
 
   DEPENDS
   intrinsics_gen

--- a/llvm/lib/DWARFLinker/Classic/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/Classic/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_llvm_component_library(LLVMDWARFLinker
+add_llvm_component_library(LLVMDWARFLinkerClassic
   DWARFLinkerCompileUnit.cpp
   DWARFLinkerDeclContext.cpp
   DWARFLinker.cpp
   DWARFStreamer.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker/Classic
 
   DEPENDS
   intrinsics_gen
@@ -16,7 +16,7 @@ add_llvm_component_library(LLVMDWARFLinker
   CodeGen
   CodeGenTypes
   DebugInfoDWARF
-  DWARFLinkerBase
+  DWARFLinker
   MC
   Object
   Support

--- a/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
@@ -12,7 +12,7 @@ add_llvm_component_library(LLVMDWARFLinkerParallel
   SyntheticTypeNameBuilder.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker/Parallel
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinkerParallel
 
   DEPENDS
   intrinsics_gen

--- a/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
@@ -12,7 +12,7 @@ add_llvm_component_library(LLVMDWARFLinkerParallel
   SyntheticTypeNameBuilder.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinkerParallel
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/DWARFLinker/Parallel
 
   DEPENDS
   intrinsics_gen
@@ -22,7 +22,7 @@ add_llvm_component_library(LLVMDWARFLinkerParallel
   BinaryFormat
   CodeGen
   DebugInfoDWARF
-  DWARFLinkerBase
+  DWARFLinker
   MC
   Object
   Support

--- a/llvm/tools/dsymutil/CMakeLists.txt
+++ b/llvm/tools/dsymutil/CMakeLists.txt
@@ -9,8 +9,8 @@ set(LLVM_LINK_COMPONENTS
   AsmPrinter
   CodeGen
   CodeGenTypes
-  DWARFLinkerBase
   DWARFLinker
+  DWARFLinkerClassic
   DWARFLinkerParallel
   DebugInfoDWARF
   MC

--- a/llvm/tools/llvm-dwarfutil/CMakeLists.txt
+++ b/llvm/tools/llvm-dwarfutil/CMakeLists.txt
@@ -7,8 +7,8 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsDescs
   AllTargetsInfos
   CodeGenTypes
-  DWARFLinkerBase
   DWARFLinker
+  DWARFLinkerClassic
   DWARFLinkerParallel
   DebugInfoDWARF
   MC

--- a/llvm/unittests/DWARFLinkerParallel/CMakeLists.txt
+++ b/llvm/unittests/DWARFLinkerParallel/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
+  DWARFLinker
   DWARFLinkerParallel
   Support
   )


### PR DESCRIPTION
It was noted that new DWARFLinker libraries do not follow naming agreement - https://github.com/llvm/llvm-project/pull/75925#issuecomment-1883301659 This patch rename libraries to match with the agreement.

Rename LLVMDWARFLinkerBase library into the LLVMDWARFLinker. Rename LLVMDWARFLinker library into the LLVMDWARFLinkerClassic. Correct include path according to the new directory structure.