### PR TITLE
[mlir] introduce debug transform dialect extension

### DIFF
--- a/mlir/docs/Dialects/Transform.md
+++ b/mlir/docs/Dialects/Transform.md
@@ -423,6 +423,10 @@ ops rather than having the methods directly act on the payload IR.
 
 [include "Dialects/BufferizationTransformOps.md"]
 
+## Debug Transform Operations
+
+[include "Dialects/DebugExtensionOps.md"]
+
 ## Func Transform Operations
 
 [include "Dialects/FuncTransformOps.md"]

--- a/mlir/docs/Tutorials/transform/Ch1.md
+++ b/mlir/docs/Tutorials/transform/Ch1.md
@@ -69,9 +69,9 @@ transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op,
      %arg1: !transform.op<"linalg.matmul">,
      %arg2: !transform.op<"linalg.elemwise_binary">):
-  transform.test_print_remark_at_operand %arg1, "matmul"
+  transform.debug.emit_remark_at %arg1, "matmul"
       : !transform.op<"linalg.matmul">
-  transform.test_print_remark_at_operand %arg2, "elemwise_binaries"
+  transform.debug.emit_remark_at %arg2, "elemwise_binaries"
       : !transform.op<"linalg.elemwise_binary">
   transform.yield
 }
@@ -180,7 +180,7 @@ transform.sequence failures(propagate) {
       : (!transform.op<"linalg.matmul">) -> (!transform.any_op, !transform.any_op)
 
   // This is trying to use an invalidated handle leading to undefined behavior.
-  transform.test_print_remark_at_operand %arg1, "remark" : !transform.op<"linalg.matmul">
+  transform.debug.emit_remark_at %arg1, "remark" : !transform.op<"linalg.matmul">
   transform.yield
 }
 ```
@@ -197,7 +197,7 @@ $ mlir-opt matmul.mlir --pass-pipeline="
 
 ```sh
 matmul.mlir:28:3: error: op uses a handle invalidated by a previously executed transform op
-  transform.test_print_remark_at_operand %mm, "elemwise_binaries" : !transform.any_op
+  transform.debug.emit_remark_at %mm, "elemwise_binaries" : !transform.any_op
   ^
 matmul.mlir:26:9: note: handle to invalidated ops
   %mm = transform.cast %matmul : !transform.op<"linalg.matmul"> to !transform.any_op
@@ -224,7 +224,7 @@ transform.sequence failures(propagate) {
 
   // Consuming an operand invalidates the consumed handle and any other handle that is
   // associated with the same payload operations, or payload operations nested in them.
-  transform.test_print_remark_at_operand %casted, "remark"
+  transform.debug.emit_remark_at %casted, "remark"
     : !transform.any_op
   transform.yield
 }
@@ -234,7 +234,7 @@ Both `%arg1` and `%casted` reference the same payload operation. Extending the r
 
 ```sh
 matmul.mlir:28:3: error: op uses a handle invalidated by a previously executed transform op
-  transform.test_print_remark_at_operand %matmul, "elemwise_binaries" : !transform.op<"linalg.matmul">
+  transform.debug.emit_remark_at %matmul, "elemwise_binaries" : !transform.op<"linalg.matmul">
   ^
 matmul.mlir:21:29: note: handle to invalidated ops
 ^bb0(%root: !transform.any_op, %matmul: !transform.op<"linalg.matmul">, %elemwise: !transform.op<"linalg.elemwise_binary">):
@@ -358,7 +358,7 @@ Attempting to access the fusion result after outlining produces the following er
 
 ```sh
 test/Examples/transform/Ch1/invalidation-2.mlir:109:3: error: op uses a handle invalidated by a previously executed transform op
-  transform.test_print_remark_at_operand %outline_target, "outlined loop" : !transform.any_op
+  transform.debug.emit_remark_at %outline_target, "outlined loop" : !transform.any_op
   ^
 test/Examples/transform/Ch1/invalidation-2.mlir:102:25: note: handle to invalidated ops
   %outline_target, %_ = transform.structured.tile_using_forall %tiled_2 tile_sizes [1]

--- a/mlir/docs/Tutorials/transform/Ch4.md
+++ b/mlir/docs/Tutorials/transform/Ch4.md
@@ -110,13 +110,13 @@ module @transforms attributes { transform.with_named_sequence } {
   // This is a rewriter sequence.
   transform.named_sequence @print_elemwise(
       %elemwise_binary: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand
+    transform.debug.emit_remark_at
       %elemwise_binary, "elementwise binary" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_matmul(
       %matmul: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %matmul, "matmul" : !transform.any_op
+    transform.debug.emit_remark_at %matmul, "matmul" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/include/mlir/Dialect/Transform/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Transform/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(DebugExtension)
 add_subdirectory(IR)
 add_subdirectory(LoopExtension)
 add_subdirectory(PDLExtension)

--- a/mlir/include/mlir/Dialect/Transform/DebugExtension/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Transform/DebugExtension/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(LLVM_TARGET_DEFINITIONS DebugExtensionOps.td)
+mlir_tablegen(DebugExtensionOps.h.inc -gen-op-decls)
+mlir_tablegen(DebugExtensionOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRTransformDialectDebugExtensionOpsIncGen)
+
+add_mlir_doc(DebugExtensionOps DebugExtensionOps Dialects/ -gen-op-doc)

--- a/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtension.h
+++ b/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtension.h
@@ -1,0 +1,22 @@
+//===- DebugExtension.h - Debug extension for Transform dialect -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSION_H
+#define MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSION_H
+
+namespace mlir {
+class DialectRegistry;
+
+namespace transform {
+/// Registers the debug extension of the Transform dialect in the given
+/// registry.
+void registerDebugExtension(DialectRegistry &dialectRegistry);
+} // namespace transform
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSION_H

--- a/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h
+++ b/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h
@@ -1,0 +1,23 @@
+//===- DebugExtensionOps.h - Debug ext. for Transform dialect ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSIONOPS_H
+#define MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSIONOPS_H
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Transform/IR/MatchInterfaces.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h.inc"
+
+#endif // MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DEBUGEXTENSIONOPS_H

--- a/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.td
+++ b/mlir/include/mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.td
@@ -1,0 +1,67 @@
+//===- DebugExtensionOps.td - Transform Debug extension ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines operations of the transform dialect extension for debugging transform
+// scripts.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DBEUGEXTENSIONOPS
+#define MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DBEUGEXTENSIONOPS
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Dialect/Transform/IR/MatchInterfaces.td"
+include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
+include "mlir/Dialect/Transform/IR/TransformDialect.td"
+
+def DebugEmitRemarkAtOp : TransformDialectOp<"debug.emit_remark_at",
+  [MatchOpInterface,
+   DeclareOpInterfaceMethods<TransformOpInterface>,
+   MemoryEffectsOpInterface, NavigationTransformOpTrait]> {
+  let summary = "Print a message as diagnostic remark attached to payload";
+  let description = [{
+    This operation emits a diagnostic remark with the given message at the
+    location of each payload object associated with the argument. The argument
+    may be an operation or a value handle.
+
+    This operation always succeeds.
+  }];
+
+  let arguments = (ins
+    Transform_AnyHandleType:$at,
+    StrAttr:$message);
+  let assemblyFormat = "$at `,` $message attr-dict `:` type($at)";
+}
+
+def DebugEmitParamAsRemarkOp 
+  : TransformDialectOp<"debug.emit_param_as_remark",
+    [MatchOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     MemoryEffectsOpInterface, NavigationTransformOpTrait]> {
+  let summary = "Prints the parameter as a diagnostic remark";
+  let description = [{
+    This operation emits a diagnostic remark containing the string form of the
+    attributes associated with the parameter provided as attribute. It takes
+    as optional arguments:
+      - an additional message text to prepend;
+      - a handle pointing to operations the location of which will be used to
+        emit the diagnostic; if multiple operations are associated, the
+        diagnostic is emitted for all of their respective locations.
+
+    This operation always succeeds.
+  }];
+
+  let arguments = (ins TransformParamTypeInterface:$param,
+                       Optional<TransformHandleTypeInterface>:$anchor,
+                       OptionalAttr<StrAttr>:$message);
+  let assemblyFormat = "$param (`,` $message^)?  (`at` $anchor^)?"
+                       "attr-dict `:` type($param) (`,` type($anchor)^)?";
+}
+
+#endif // MLIR_DIALECT_TRANSFORM_DEBUGEXTENSION_DBEUGEXTENSIONOPS

--- a/mlir/include/mlir/Dialect/Transform/IR/TransformInterfaces.h
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformInterfaces.h
@@ -1282,9 +1282,9 @@ public:
   }
 };
 
-/// Trait implementing the MemoryEffectOpInterface for single-operand
-/// single-result operations that use their operand without consuming and
-/// without modifying the Payload IR to produce a new handle.
+/// Trait implementing the MemoryEffectOpInterface for operations that use their
+/// operands without consuming and without modifying the Payload IR to
+/// potentially produce new handles.
 template <typename OpTy>
 class NavigationTransformOpTrait
     : public OpTrait::TraitBase<OpTy, NavigationTransformOpTrait> {
@@ -1294,15 +1294,16 @@ public:
   void getEffects(SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
     onlyReadsHandle(this->getOperation()->getOperands(), effects);
     producesHandle(this->getOperation()->getResults(), effects);
-    onlyReadsPayload(effects);
+    if (llvm::any_of(this->getOperation()->getOperandTypes(), [](Type t) {
+          return isa<TransformHandleTypeInterface,
+                     TransformValueHandleTypeInterface>(t);
+        })) {
+      onlyReadsPayload(effects);
+    }
   }
 
   /// Checks that the op matches the expectation of this trait.
   static LogicalResult verifyTrait(Operation *op) {
-    static_assert(OpTy::template hasTrait<OpTrait::OneOperand>(),
-                  "expected single-operand op");
-    static_assert(OpTy::template hasTrait<OpTrait::OneResult>(),
-                  "expected single-result op");
     if (!op->getName().getInterface<MemoryEffectOpInterface>()) {
       op->emitError() << "NavigationTransformOpTrait should only be attached "
                          "to ops that implement MemoryEffectOpInterface";

--- a/mlir/include/mlir/Dialect/Transform/IR/TransformInterfaces.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformInterfaces.td
@@ -182,6 +182,11 @@ def Transform_AnyHandleOrParamType
              TransformValueHandleTypeInterface.predicate]>,
          "any transform handle or parameter">;
 
+def Transform_AnyHandleType
+  : Type<Or<[TransformHandleTypeInterface.predicate,
+             TransformValueHandleTypeInterface.predicate]>,
+         "any transform handle">;
+
 def FunctionalStyleTransformOpTrait
     : NativeOpTrait<"FunctionalStyleTransformOpTrait"> {
   let cppNamespace = "::mlir::transform";

--- a/mlir/include/mlir/Dialect/Transform/LoopExtension/LoopExtension.h
+++ b/mlir/include/mlir/Dialect/Transform/LoopExtension/LoopExtension.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef MLIR_DIALECT_TRANSFORM_LOOPEXTENSION_LOOPEXTENSION_H
+#define MLIR_DIALECT_TRANSFORM_LOOPEXTENSION_LOOPEXTENSION_H
+
 namespace mlir {
 class DialectRegistry;
 
@@ -14,3 +17,5 @@ namespace transform {
 void registerLoopExtension(DialectRegistry &dialectRegistry);
 } // namespace transform
 } // namespace mlir
+
+#endif // MLIR_DIALECT_TRANSFORM_LOOPEXTENSION_LOOPEXTENSION_H

--- a/mlir/include/mlir/InitAllExtensions.h
+++ b/mlir/include/mlir/InitAllExtensions.h
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/SCF/TransformOps/SCFTransformOps.h"
 #include "mlir/Dialect/SparseTensor/TransformOps/SparseTensorTransformOps.h"
 #include "mlir/Dialect/Tensor/TransformOps/TensorTransformOps.h"
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtension.h"
 #include "mlir/Dialect/Transform/LoopExtension/LoopExtension.h"
 #include "mlir/Dialect/Transform/PDLExtension/PDLExtension.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
@@ -75,6 +76,7 @@ inline void registerAllExtensions(DialectRegistry &registry) {
   scf::registerTransformDialectExtension(registry);
   sparse_tensor::registerTransformDialectExtension(registry);
   tensor::registerTransformDialectExtension(registry);
+  transform::registerDebugExtension(registry);
   transform::registerLoopExtension(registry);
   transform::registerPDLExtension(registry);
   vector::registerTransformDialectExtension(registry);

--- a/mlir/lib/Dialect/Transform/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(DebugExtension)
 add_subdirectory(IR)
 add_subdirectory(LoopExtension)
 add_subdirectory(PDLExtension)

--- a/mlir/lib/Dialect/Transform/DebugExtension/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/DebugExtension/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_dialect_library(MLIRTransformDebugExtension
+  DebugExtension.cpp
+  DebugExtensionOps.cpp
+
+  DEPENDS
+  MLIRTransformDialectDebugExtensionOpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRTransformDialect
+)

--- a/mlir/lib/Dialect/Transform/DebugExtension/DebugExtension.cpp
+++ b/mlir/lib/Dialect/Transform/DebugExtension/DebugExtension.cpp
@@ -1,0 +1,34 @@
+//===- DebugExtension.cpp - Debug extension for the Transform dialect -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtension.h"
+
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/IR/DialectRegistry.h"
+
+using namespace mlir;
+
+namespace {
+/// Debug extension of the Transform dialect. This provides operations for
+/// debugging transform dialect scripts.
+class DebugExtension
+    : public transform::TransformDialectExtension<DebugExtension> {
+public:
+  void init() {
+    registerTransformOps<
+#define GET_OP_LIST
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp.inc"
+        >();
+  }
+};
+} // namespace
+
+void mlir::transform::registerDebugExtension(DialectRegistry &dialectRegistry) {
+  dialectRegistry.addExtensions<DebugExtension>();
+}

--- a/mlir/lib/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp
@@ -1,0 +1,70 @@
+//===- DebugExtensionOps.cpp - Debug extension for the Transform dialect --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h"
+
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformTypes.h"
+#include "mlir/IR/OpImplementation.h"
+
+using namespace mlir;
+
+#define GET_OP_CLASSES
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp.inc"
+
+DiagnosedSilenceableFailure
+transform::DebugEmitRemarkAtOp::apply(transform::TransformRewriter &rewriter,
+                                      transform::TransformResults &results,
+                                      transform::TransformState &state) {
+  if (getAt().getType().isa<TransformHandleTypeInterface>()) {
+    auto payload = state.getPayloadOps(getAt());
+    for (Operation *op : payload)
+      op->emitRemark() << getMessage();
+    return DiagnosedSilenceableFailure::success();
+  }
+
+  assert(
+      getAt().getType().isa<transform::TransformValueHandleTypeInterface>() &&
+      "unhandled kind of transform type");
+
+  auto describeValue = [](Diagnostic &os, Value value) {
+    os << "value handle points to ";
+    if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
+      os << "a block argument #" << arg.getArgNumber() << " in block #"
+         << std::distance(arg.getOwner()->getParent()->begin(),
+                          arg.getOwner()->getIterator())
+         << " in region #" << arg.getOwner()->getParent()->getRegionNumber();
+    } else {
+      os << "an op result #" << llvm::cast<OpResult>(value).getResultNumber();
+    }
+  };
+
+  for (Value value : state.getPayloadValues(getAt())) {
+    InFlightDiagnostic diag = ::emitRemark(value.getLoc()) << getMessage();
+    describeValue(diag.attachNote(), value);
+  }
+
+  return DiagnosedSilenceableFailure::success();
+}
+
+DiagnosedSilenceableFailure transform::DebugEmitParamAsRemarkOp::apply(
+    transform::TransformRewriter &rewriter,
+    transform::TransformResults &results, transform::TransformState &state) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  if (getMessage())
+    os << *getMessage() << " ";
+  llvm::interleaveComma(state.getParams(getParam()), os);
+  if (!getAnchor()) {
+    emitRemark() << os.str();
+    return DiagnosedSilenceableFailure::success();
+  }
+  for (Operation *payload : state.getPayloadOps(getAnchor()))
+    ::mlir::emitRemark(payload->getLoc()) << os.str();
+  return DiagnosedSilenceableFailure::success();
+}

--- a/mlir/test/Dialect/Linalg/match-ops-interpreter.mlir
+++ b/mlir/test/Dialect/Linalg/match-ops-interpreter.mlir
@@ -2,7 +2,7 @@
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @print_structured(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "structured" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "structured" : !transform.any_op
     transform.yield
   }
 
@@ -94,8 +94,8 @@ module attributes { transform.with_named_sequence } {
     ^bb0(%arg1: !transform.any_op):
       transform.match.structured.yield %arg1 : !transform.any_op
     }
-    transform.test_print_remark_at_operand %0, "structured" : !transform.any_op
-    transform.test_print_remark_at_operand %arg0, "other" : !transform.any_op
+    transform.debug.emit_remark_at %0, "structured" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "other" : !transform.any_op
     transform.yield %0 : !transform.any_op
   }
 
@@ -132,7 +132,7 @@ module attributes { transform.with_named_sequence } {
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @print_passthrough(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "passthrough" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "passthrough" : !transform.any_op
     transform.yield
   }
 
@@ -182,7 +182,7 @@ module attributes { transform.with_named_sequence } {
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @print_reduction(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "reduction" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "reduction" : !transform.any_op
     transform.yield
   }
 
@@ -253,7 +253,7 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_dimension_size_match(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched sizes" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched sizes" : !transform.any_op
     transform.yield
   }
 
@@ -276,14 +276,14 @@ module attributes { transform.with_named_sequence } {
           : !transform.any_op, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
             !transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>
     }
-    transform.test_print_param %0#1, "dimensions all:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#2, "dimension 0:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#3, "dimension -1:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#4, "dimensions 0, 2:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#5, "dimensions 0, -1:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#6, "dimensions except -1:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#7, "dimensions except 0, -2:" at %0#0 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %0#8, "dimensions 0, -3:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#1, "dimensions all:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#2, "dimension 0:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#3, "dimension -1:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#4, "dimensions 0, 2:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#5, "dimensions 0, -1:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#6, "dimensions except -1:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#7, "dimensions except 0, -2:" at %0#0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %0#8, "dimensions 0, -3:" at %0#0 : !transform.param<i64>, !transform.any_op
     transform.yield %0#0 : !transform.any_op
   }
 
@@ -338,19 +338,19 @@ module attributes { transform.with_named_sequence } {
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @print_all_reduction(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "all reduction" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "all reduction" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_all_parallel(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "all parallel" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "all parallel" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_last_reduction(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "last reduction" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "last reduction" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_parallel_except_last(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "parallel except last" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "parallel except last" : !transform.any_op
     transform.yield
   }
 
@@ -435,7 +435,7 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_bitwidth(%arg0: !transform.any_op {transform.readonly}, %arg1: !transform.param<i64> {transform.readonly}) {
-    transform.test_print_param %arg1, "bitwidth:" at %arg0 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %arg1, "bitwidth:" at %arg0 : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 
@@ -474,9 +474,9 @@ module attributes { transform.with_named_sequence } {
                                          %arg1: !transform.any_value {transform.readonly},
                                          %arg2: !transform.any_value {transform.readonly},
                                          %arg3: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand_value %arg1, "output 0" : !transform.any_value
-    transform.test_print_remark_at_operand %arg3, "output producer" : !transform.any_op
-    transform.test_print_remark_at_operand_value %arg2, "all output" : !transform.any_value
+    transform.debug.emit_remark_at %arg1, "output 0" : !transform.any_value
+    transform.debug.emit_remark_at %arg3, "output producer" : !transform.any_op
+    transform.debug.emit_remark_at %arg2, "all output" : !transform.any_value
     transform.yield
   }
 
@@ -544,15 +544,15 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_init_0_permutation(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched output 0 permutation" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched output 0 permutation" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_init_1_permutation(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched output 1 permutation" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched output 1 permutation" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_init_2_projected_permutation(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched output 2 projected permutation" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched output 2 projected permutation" : !transform.any_op
     transform.yield
   }
 
@@ -618,8 +618,8 @@ module attributes { transform.with_named_sequence } {
       %arg0: !transform.param<i64> {transform.readonly},
       %arg1: !transform.param<i64> {transform.readonly},
       %arg2: !transform.any_op {transform.readonly}) {
-    transform.test_print_param %arg0, "inputs" at %arg2 : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %arg1, "outputs" at %arg2 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %arg0, "inputs" at %arg2 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %arg1, "outputs" at %arg2 : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 
@@ -680,7 +680,7 @@ module attributes { transform.with_named_sequence } {
 
   transform.named_sequence @print_rank(%arg0: !transform.param<i64> {transform.readonly},
                                        %arg2: !transform.any_op {transform.readonly}) {
-    transform.test_print_param %arg0, "rank" at %arg2 : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %arg0, "rank" at %arg2 : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 
@@ -738,18 +738,18 @@ module attributes { transform.with_named_sequence } {
 
   transform.named_sequence @print_single_result(%arg0: !transform.any_op {transform.readonly},
                                                 %arg2: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg2, "matched single result" : !transform.any_op
-    transform.test_print_remark_at_operand %arg0, "single user" : !transform.any_op
+    transform.debug.emit_remark_at %arg2, "matched single result" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "single user" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_result_value(%arg0: !transform.any_value {transform.readonly},
                                                %arg1: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg1, "matched result value" : !transform.any_op
-    transform.test_print_remark_at_operand_value %arg0, "op result" : !transform.any_value
+    transform.debug.emit_remark_at %arg1, "matched result value" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "op result" : !transform.any_value
     transform.yield
   }
   transform.named_sequence @print_any_result(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched any result" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched any result" : !transform.any_op
     transform.yield
   }
 
@@ -824,12 +824,12 @@ module attributes { transform.with_named_sequence } {
 
   transform.named_sequence @print_indexing_map_1(%arg0: !transform.affine_map {transform.readonly},
                                                %arg1: !transform.any_op {transform.readonly}) {
-    transform.test_print_param %arg0, "indexing map 1" at %arg1 : !transform.affine_map, !transform.any_op
+    transform.debug.emit_param_as_remark %arg0, "indexing map 1" at %arg1 : !transform.affine_map, !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_indexing_map_2(%arg0: !transform.affine_map {transform.readonly},
                                                %arg1: !transform.any_op {transform.readonly}) {
-    transform.test_print_param %arg0, "indexing map 2" at %arg1 : !transform.affine_map, !transform.any_op
+    transform.debug.emit_param_as_remark %arg0, "indexing map 2" at %arg1 : !transform.affine_map, !transform.any_op
     transform.yield
   }
 
@@ -875,11 +875,11 @@ module attributes { transform.with_named_sequence } {
       %m: !transform.param<i64> {transform.readonly},
       %n: !transform.param<i64> {transform.readonly},
       %k: !transform.param<i64> {transform.readonly}) {
-    transform.test_print_remark_at_operand %op, "contraction" : !transform.any_op
-    transform.test_print_param %batch, "batch dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %m, "m dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %n, "n dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %k, "k dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_remark_at %op, "contraction" : !transform.any_op
+    transform.debug.emit_param_as_remark %batch, "batch dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %m, "m dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %n, "n dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %k, "k dims" at %op : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 
@@ -967,15 +967,15 @@ module attributes { transform.with_named_sequence } {
       %depth: !transform.param<i64> {transform.readonly},
       %strides: !transform.param<i64> {transform.readonly},
       %dilations: !transform.param<i64> {transform.readonly}) {
-    transform.test_print_remark_at_operand %op, "convolution" : !transform.any_op
-    transform.test_print_param %batch, "batch dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %oi, "output image dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %oc, "output channel dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %fl, "filter loop dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %ic, "input channel dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %depth, "depth dims" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %strides, "strides" at %op : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %dilations, "dilations" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_remark_at %op, "convolution" : !transform.any_op
+    transform.debug.emit_param_as_remark %batch, "batch dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %oi, "output image dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %oc, "output channel dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %fl, "filter loop dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %ic, "input channel dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %depth, "depth dims" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %strides, "strides" at %op : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %dilations, "dilations" at %op : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Linalg/transform-op-bufferize-to-allocation.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-bufferize-to-allocation.mlir
@@ -38,13 +38,13 @@ module attributes {transform.with_named_sequence} {
     %fill_op = transform.select "linalg.fill" in %new : (!transform.any_op) -> !transform.any_op
     %p = transform.num_associations %fill_op : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     // Ensure that one linalg.copy was generated.
     %mat = transform.select "bufferization.materialize_in_destination" in %new : (!transform.any_op) -> !transform.any_op
     %p2 = transform.num_associations %mat : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
     transform.yield
   }
 }
@@ -77,19 +77,19 @@ module attributes {transform.with_named_sequence} {
     %fill_op = transform.select "linalg.fill" in %new : (!transform.any_op) -> !transform.any_op
     %p = transform.num_associations %fill_op : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     // Ensure that one linalg.copy was generated.
     %linalg_copy = transform.select "linalg.copy" in %new : (!transform.any_op) -> !transform.any_op
     %p2 = transform.num_associations %linalg_copy : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
 
     // Ensure that one memref.alloca was generated.
     %alloca = transform.select "memref.alloca" in %new : (!transform.any_op) -> !transform.any_op
     %p3 = transform.num_associations %alloca : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p3 : !transform.param<i64>
 
     // Make sure that One-Shot Bufferize can bufferize the rest.
     %4 = transform.bufferization.one_shot_bufferize %arg1 : (!transform.any_op) -> !transform.any_op

--- a/mlir/test/Dialect/Linalg/transform-op-fuse-into-containing.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-fuse-into-containing.mlir
@@ -365,7 +365,7 @@ module {
       // linalg.generic is tileable. The op is tiled and fused.
       %fused, %containing = transform.structured.fuse_into_containing_op %0 into %1
         : (!transform.op<"linalg.generic">, !transform.op<"scf.forall">) -> (!transform.any_op, !transform.any_op)
-      transform.test_print_remark_at_operand %containing, "new containing op" : !transform.any_op
+      transform.debug.emit_remark_at %containing, "new containing op" : !transform.any_op
       transform.yield
     }
   }

--- a/mlir/test/Dialect/Linalg/transform-op-match.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-match.mlir
@@ -12,11 +12,11 @@ func.func @bar() {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %match_name = transform.structured.match ops{["arith.constant"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
+    transform.debug.emit_remark_at %match_name, "matched op name" : !transform.any_op
     transform.test_consume_operand %match_name : !transform.any_op
 
     %match_attr = transform.structured.match ops{["arith.constant"]} attributes{my_attr} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_attr, "matched attr name" : !transform.any_op
+    transform.debug.emit_remark_at %match_attr, "matched attr name" : !transform.any_op
     transform.test_consume_operand %match_attr : !transform.any_op
     transform.yield
   }
@@ -35,7 +35,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %match_name = transform.structured.match
       ops{["arith.constant"]} filter_result_type = f32 in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
+    transform.debug.emit_remark_at %match_name, "matched op name" : !transform.any_op
     transform.test_consume_operand %match_name : !transform.any_op
     transform.yield
   }
@@ -58,22 +58,22 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %match_name1 = transform.structured.match
       ops{["arith.fptoui"]} filter_operand_types = [f32] in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_name1, "matched op name" : !transform.any_op
+    transform.debug.emit_remark_at %match_name1, "matched op name" : !transform.any_op
     transform.test_consume_operand %match_name1 : !transform.any_op
 
     %match_name2 = transform.structured.match
       ops{["arith.addf"]} filter_operand_types = [f32] in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_name2, "matched op name" : !transform.any_op
+    transform.debug.emit_remark_at %match_name2, "matched op name" : !transform.any_op
     transform.test_consume_operand %match_name2 : !transform.any_op
 
     %no_match_name1 = transform.structured.match
       ops{["arith.fptoui"]} filter_operand_types = [i32] in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %no_match_name1, "should not match" : !transform.any_op
+    transform.debug.emit_remark_at %no_match_name1, "should not match" : !transform.any_op
     transform.test_consume_operand %no_match_name1 : !transform.any_op
 
     %no_match_name2 = transform.structured.match
       ops{["math.fpowi"]} filter_operand_types = [f32] in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %no_match_name2, "should not match" : !transform.any_op
+    transform.debug.emit_remark_at %no_match_name2, "should not match" : !transform.any_op
     transform.test_consume_operand %no_match_name2 : !transform.any_op
     transform.yield
   }
@@ -93,7 +93,7 @@ func.func @foo(%a: tensor<4x4xf32>, %b: tensor<4x4xf32>, %c: tensor<4x4xf32>) {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
     %matched = transform.structured.match interface{TilingInterface} in %arg0 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %matched, "tileable" : !transform.any_op
+    transform.debug.emit_remark_at %matched, "tileable" : !transform.any_op
     transform.yield
   }
 }
@@ -125,7 +125,7 @@ module attributes {transform.with_named_sequence} {
           #linalg.iterator_type<parallel>,
           #linalg.iterator_type<parallel>]}
         in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %match_attr, "matched complex attr" : !transform.any_op
+    transform.debug.emit_remark_at %match_attr, "matched complex attr" : !transform.any_op
     transform.test_consume_operand %match_attr : !transform.any_op
 
     %no_match = transform.structured.match
@@ -136,7 +136,7 @@ module attributes {transform.with_named_sequence} {
         in %arg1 : (!transform.any_op) -> !transform.any_op
     %p = transform.num_associations %no_match : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{0}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
     transform.yield
   }
 }
@@ -166,7 +166,7 @@ func.func @foo(%lb: index, %ub: index, %step: index) {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
     %matched = transform.structured.match interface{LoopLikeInterface} in %arg0 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %matched, "loop-like" : !transform.any_op
+    transform.debug.emit_remark_at %matched, "loop-like" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/Linalg/transform-op-multitile-sizes.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-multitile-sizes.mlir
@@ -35,11 +35,11 @@ module attributes {transform.with_named_sequence} {
         transform.structured.multitile_sizes %0 { target_size = 3, dimension = 0 }
         : (!transform.any_op) -> !transform.param<i64>
       // expected-remark @below {{2 : i64}}
-      transform.test_print_param %low_tile : !transform.param<i64>
+      transform.debug.emit_param_as_remark %low_tile : !transform.param<i64>
       // expected-remark @below {{3 : i64}}
-      transform.test_print_param %high_tile : !transform.param<i64>
+      transform.debug.emit_param_as_remark %high_tile : !transform.param<i64>
       // expected-remark @below {{4 : i64}}
-      transform.test_print_param %split_point : !transform.param<i64>
+      transform.debug.emit_param_as_remark %split_point : !transform.param<i64>
       transform.yield
   }
 }

--- a/mlir/test/Dialect/Linalg/transform-op-pad.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-pad.mlir
@@ -43,7 +43,7 @@ module attributes {transform.with_named_sequence} {
     } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.op<"bufferization.materialize_in_destination">)
     %p = transform.num_associations %copy_back : (!transform.op<"bufferization.materialize_in_destination">) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
     transform.yield
   }
 }

--- a/mlir/test/Dialect/MemRef/extract-address-computations.mlir
+++ b/mlir/test/Dialect/MemRef/extract-address-computations.mlir
@@ -28,7 +28,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.memref.extract_address_computations
     } : !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %0, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %0, "transformed" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/MemRef/transform-ops.mlir
+++ b/mlir/test/Dialect/MemRef/transform-ops.mlir
@@ -66,7 +66,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["memref.alloc"]} in %arg1 : (!transform.any_op) -> !transform.op<"memref.alloc">
     %1 = transform.memref.multibuffer %0 {factor = 2 : i64} : (!transform.op<"memref.alloc">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %1, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %1, "transformed" : !transform.any_op
     transform.yield
   }
 }
@@ -103,7 +103,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["memref.alloc"]} in %arg1 : (!transform.any_op) -> !transform.op<"memref.alloc">
     %1 = transform.memref.multibuffer %0 {factor = 2 : i64} : (!transform.op<"memref.alloc">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %1, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %1, "transformed" : !transform.any_op
     transform.yield
   }
 }
@@ -224,7 +224,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["memref.alloc"]} in %arg1 : (!transform.any_op) -> !transform.op<"memref.alloc">
     %1 = transform.memref.multibuffer %0 {factor = 2 : i64} : (!transform.op<"memref.alloc">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %1, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %1, "transformed" : !transform.any_op
     transform.yield
   }
 }
@@ -260,7 +260,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["memref.alloc"]} in %arg1 : (!transform.any_op) -> !transform.op<"memref.alloc">
     %1 = transform.memref.multibuffer %0 {factor = 2 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %1, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %1, "transformed" : !transform.any_op
     transform.yield
   }
 }
@@ -299,7 +299,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["memref.alloc"]} in %arg1 : (!transform.any_op) -> !transform.op<"memref.alloc">
     %1 = transform.memref.multibuffer %0 {factor = 2 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %1, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %1, "transformed" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/SCF/transform-ops.mlir
+++ b/mlir/test/Dialect/SCF/transform-ops.mlir
@@ -69,8 +69,8 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.get_parent_op %0 {op_name = "scf.for"} : (!transform.any_op) -> !transform.op<"scf.for">
     %main_loop, %remainder = transform.loop.peel %1 : (!transform.op<"scf.for">) -> (!transform.op<"scf.for">, !transform.op<"scf.for">)
     // Make sure 
-    transform.test_print_remark_at_operand %main_loop, "main loop" : !transform.op<"scf.for">
-    transform.test_print_remark_at_operand %remainder, "remainder loop" : !transform.op<"scf.for">
+    transform.debug.emit_remark_at %main_loop, "main loop" : !transform.op<"scf.for">
+    transform.debug.emit_remark_at %remainder, "remainder loop" : !transform.op<"scf.for">
     transform.yield
   }
 }
@@ -137,7 +137,7 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.get_parent_op %0 {op_name = "scf.for"} : (!transform.any_op) -> !transform.op<"scf.for">
     %2 = transform.loop.pipeline %1 : (!transform.op<"scf.for">) -> !transform.any_op
     // Verify that the returned handle is usable.
-    transform.test_print_remark_at_operand %2, "transformed" : !transform.any_op
+    transform.debug.emit_remark_at %2, "transformed" : !transform.any_op
     transform.yield
   }
 }
@@ -185,7 +185,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_parent_op %0 {op_name = "affine.for"} : (!transform.any_op) -> !transform.op<"affine.for">
-    transform.test_print_remark_at_operand %1, "affine for loop" : !transform.op<"affine.for">
+    transform.debug.emit_remark_at %1, "affine for loop" : !transform.op<"affine.for">
     transform.loop.unroll %1 { factor = 4, affine = true } : !transform.op<"affine.for">
     transform.yield
   }
@@ -212,7 +212,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_parent_op %0 {op_name = "affine.for"} : (!transform.any_op) -> !transform.op<"affine.for">
-    transform.test_print_remark_at_operand %1, "affine for loop" : !transform.op<"affine.for">
+    transform.debug.emit_remark_at %1, "affine for loop" : !transform.op<"affine.for">
     transform.loop.unroll %1 { factor = 4 } : !transform.op<"affine.for">
     transform.yield
   }

--- a/mlir/test/Dialect/SparseTensor/transform-ops.mlir
+++ b/mlir/test/Dialect/SparseTensor/transform-ops.mlir
@@ -12,7 +12,7 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_sparse_structured(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "sparse_kernel" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "sparse_kernel" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Transform/expensive-checks.mlir
+++ b/mlir/test/Dialect/Transform/expensive-checks.mlir
@@ -25,7 +25,7 @@ module attributes {transform.with_named_sequence} {
         // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
         test_consume_operand %1 : !transform.any_op
         // expected-error @below {{op uses a handle invalidated by a previously executed transform op}}
-        test_print_remark_at_operand %0, "remark" : !transform.any_op
+        transform.debug.emit_remark_at %0, "remark" : !transform.any_op
       }
     }
     transform.yield
@@ -64,7 +64,7 @@ module attributes {transform.with_named_sequence} {
         %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
         // expected-error @below {{a handle passed as operand #0 and consumed by this operation points to a payload entity more than once}}
         test_consume_operand %2 : !transform.any_op
-        test_print_remark_at_operand %0, "remark" : !transform.any_op
+        transform.debug.emit_remark_at %0, "remark" : !transform.any_op
       }
     }
     transform.yield
@@ -370,7 +370,7 @@ module attributes {transform.with_named_sequence} {
     // expected-note @below {{invalidated by this transform op that consumes its operand #0}}
     transform.test_consume_operand %0 : !transform.any_op
     // expected-error @below {{uses a handle associated with empty payload and invalidated by a previously executed transform op}}
-    transform.test_print_remark_at_operand %0, "remark" : !transform.any_op
+    transform.debug.emit_remark_at %0, "remark" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/Transform/include/test-interpreter-external-concurrent-source.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-external-concurrent-source.mlir
@@ -11,6 +11,6 @@ transform.with_pdl_patterns {
   sequence %arg0 : !transform.any_op failures(propagate) {
   ^bb1(%arg1: !transform.any_op):
     %0 = pdl_match @func_return in %arg1 : (!transform.any_op) -> !transform.op<"func.return">
-    test_print_remark_at_operand %0, "matched" : !transform.op<"func.return">
+    transform.debug.emit_remark_at %0, "matched" : !transform.op<"func.return">
   }
 }

--- a/mlir/test/Dialect/Transform/include/test-interpreter-external-source.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-external-source.mlir
@@ -3,9 +3,9 @@
 
 transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op):
-  transform.test_print_remark_at_operand %arg0, "outer" : !transform.any_op
+  transform.debug.emit_remark_at %arg0, "outer" : !transform.any_op
   transform.sequence %arg0 : !transform.any_op failures(propagate) attributes {transform.target_tag="transform"} {
   ^bb1(%arg1: !transform.any_op):
-    transform.test_print_remark_at_operand %arg1, "inner" : !transform.any_op
+    transform.debug.emit_remark_at %arg1, "inner" : !transform.any_op
   }
 }

--- a/mlir/test/Dialect/Transform/include/test-interpreter-external-symbol-def-invalid.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-external-symbol-def-invalid.mlir
@@ -3,7 +3,7 @@
 module attributes {transform.with_named_sequence} {
   // expected-note @below {{previously defined here}}
   transform.named_sequence @print_message(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "message" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "message" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-library-invalid/definitions-invalid.mlir
@@ -6,6 +6,6 @@
 module attributes {transform.with_named_sequence} {
   transform.named_sequence private @private_helper(%arg0: !transform.any_op {transform.readonly}) {
     // expected-error @below {{expected ','}}
-    transform.test_print_remark_at_operand %arg0 "should have ',' prior to this" : !transform.any_op
+    transform.debug.emit_remark_at %arg0 "should have ',' prior to this" : !transform.any_op
   }
 }

--- a/mlir/test/Dialect/Transform/include/test-interpreter-library/definitions-self-contained.mlir
+++ b/mlir/test/Dialect/Transform/include/test-interpreter-library/definitions-self-contained.mlir
@@ -3,33 +3,33 @@
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence private @private_helper(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "message" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "message" : !transform.any_op
     transform.yield
   }
 
   // These ops collide with ops from the other module before or after renaming.
   transform.named_sequence private @colliding(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding (without suffix)" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding (without suffix)" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_0(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding_0" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding_0" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_2(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding_2" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding_2" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_3(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding_3" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding_3" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_4(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding_4" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding_4" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @colliding_5(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "external colliding_5" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "external colliding_5" : !transform.any_op
     transform.yield
   }
 
@@ -44,7 +44,7 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @unannotated(%arg0: !transform.any_op) {
-    transform.test_print_remark_at_operand %arg0, "unannotated" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "unannotated" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Transform/infer-effects.mlir
+++ b/mlir/test/Dialect/Transform/infer-effects.mlir
@@ -7,7 +7,7 @@ module attributes { transform.with_named_sequence } {
   // CHECK-SAME: %{{.*}}: !transform.param<i32> {transform.readonly}
   transform.named_sequence @infer(%op: !transform.any_op, %other: !transform.any_op, %param: !transform.param<i32>) {
     transform.test_consume_operand %op : !transform.any_op
-    transform.test_print_remark_at_operand %other, "" : !transform.any_op
+    transform.debug.emit_remark_at %other, "" : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/Transform/multi-arg-top-level-ops.mlir
+++ b/mlir/test/Dialect/Transform/multi-arg-top-level-ops.mlir
@@ -3,8 +3,8 @@
 
 transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op, %arg1: !transform.any_op, %arg2: !transform.any_op):
-  transform.test_print_remark_at_operand %arg1, "first extra" : !transform.any_op
-  transform.test_print_remark_at_operand %arg2, "second extra" : !transform.any_op
+  transform.debug.emit_remark_at %arg1, "first extra" : !transform.any_op
+  transform.debug.emit_remark_at %arg2, "second extra" : !transform.any_op
 }
 
 // expected-remark @below {{first extra}}
@@ -59,8 +59,8 @@ transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op, %arg1: !transform.any_op, %arg2: !transform.any_op):
   transform.sequence %arg0, %arg1, %arg2 : !transform.any_op, !transform.any_op, !transform.any_op failures(propagate) {
   ^bb0(%arg3: !transform.any_op, %arg4: !transform.any_op, %arg5: !transform.any_op):
-    transform.test_print_remark_at_operand %arg4, "first extra" : !transform.any_op
-    transform.test_print_remark_at_operand %arg5, "second extra" : !transform.any_op
+    transform.debug.emit_remark_at %arg4, "first extra" : !transform.any_op
+    transform.debug.emit_remark_at %arg5, "second extra" : !transform.any_op
   }
 }
 

--- a/mlir/test/Dialect/Transform/multi-arg-top-level-params.mlir
+++ b/mlir/test/Dialect/Transform/multi-arg-top-level-params.mlir
@@ -4,9 +4,9 @@
 transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op, %arg1: !transform.param<i64>, %arg2: !transform.param<i64>):
   // expected-remark @below {{1 : i64, 2 : i64, 3 : i64}}
-  transform.test_print_param %arg1 : !transform.param<i64>
+  transform.debug.emit_param_as_remark %arg1 : !transform.param<i64>
   // expected-remark @below {{42 : i64, 45 : i64}}
-  transform.test_print_param %arg2 : !transform.param<i64>
+  transform.debug.emit_param_as_remark %arg2 : !transform.param<i64>
 }
 
 // -----

--- a/mlir/test/Dialect/Transform/multi-arg-top-level-values.mlir
+++ b/mlir/test/Dialect/Transform/multi-arg-top-level-values.mlir
@@ -23,8 +23,8 @@
 
 transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op, %arg1: !transform.any_value, %arg2: !transform.any_value):
-  test_print_remark_at_operand_value %arg1, "first extra" : !transform.any_value
-  test_print_remark_at_operand_value %arg2, "second extra" : !transform.any_value
+  transform.debug.emit_remark_at %arg1, "first extra" : !transform.any_value
+  transform.debug.emit_remark_at %arg2, "second extra" : !transform.any_value
 }
 
 // -----

--- a/mlir/test/Dialect/Transform/ops-invalid.mlir
+++ b/mlir/test/Dialect/Transform/ops-invalid.mlir
@@ -497,7 +497,7 @@ module attributes { transform.with_named_sequence } {
 module attributes { transform.with_named_sequence } {
   // expected-error @below {{must provide consumed/readonly status for arguments of external or called ops}}
   transform.named_sequence @foo(%op: !transform.any_op) {
-    transform.test_print_remark_at_operand %op, "message" : !transform.any_op
+    transform.debug.emit_remark_at %op, "message" : !transform.any_op
     transform.yield
   }
 
@@ -513,7 +513,7 @@ module attributes { transform.with_named_sequence } {
 module attributes { transform.with_named_sequence } {
   // expected-error @below {{argument #0 cannot be both readonly and consumed}}
   transform.named_sequence @foo(%op: !transform.any_op {transform.readonly, transform.consumed}) {
-    transform.test_print_remark_at_operand %op, "message" : !transform.any_op
+    transform.debug.emit_remark_at %op, "message" : !transform.any_op
     transform.yield
   }
 
@@ -532,7 +532,7 @@ module attributes { transform.with_named_sequence } {
   // CHECK-LABEL: transform.named_sequence @emit_warning_only
   // expected-warning @below {{argument #0 is not consumed in the body but is marked as consume}}
   transform.named_sequence @emit_warning_only(%op: !transform.any_op {transform.consumed}) {
-    transform.test_print_remark_at_operand %op, "message" : !transform.any_op
+    transform.debug.emit_remark_at %op, "message" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Transform/test-interpreter-debug.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-debug.mlir
@@ -50,13 +50,13 @@ module {
 module {
   transform.sequence failures(suppress) attributes {transform.target_tag="transform"} {
   ^bb0(%arg0: !transform.any_op):
-    transform.test_print_remark_at_operand %arg0, "payload" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "payload" : !transform.any_op
   }
 
   // This will not be executed because it's not tagged.
   transform.sequence failures(suppress)  {
   ^bb0(%arg0: !transform.any_op):
-    transform.test_print_remark_at_operand %arg0, "some other text that is not printed" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "some other text that is not printed" : !transform.any_op
   }
 
   module {

--- a/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl-invalid.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl-invalid.mlir
@@ -45,7 +45,7 @@ module attributes {transform.with_named_sequence} {
 module attributes {transform.with_named_sequence} {
   // expected-error @below {{doubly defined symbol @print_message}}
   transform.named_sequence @print_message(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "message" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "message" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl.mlir
@@ -27,34 +27,34 @@ module attributes {transform.with_named_sequence} {
 
   // These ops collide with ops from the other module before or after renaming.
   transform.named_sequence private @colliding(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding (without suffix)" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding (without suffix)" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_0(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding_0" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding_0" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_1(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding_1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding_1" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_3(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding_3" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding_3" : !transform.any_op
     transform.yield
   }
   // This symbol is public and thus can't be renamed.
   // CHECK-DAG: transform.named_sequence @colliding_4(
   transform.named_sequence @colliding_4(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding_4" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding_4" : !transform.any_op
     transform.yield
   }
   transform.named_sequence private @colliding_5(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "internal colliding_5" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "internal colliding_5" : !transform.any_op
     transform.yield
   }
 
   // CHECK-DAG: transform.named_sequence @unannotated(
-  // CHECK-DAG: test_print_remark_at_operand %{{.*}}, "unannotated"
+  // CHECK-DAG: transform.debug.emit_remark_at %{{.*}}, "unannotated"
   transform.named_sequence @unannotated(!transform.any_op {transform.readonly})
 
   transform.sequence failures(propagate) {

--- a/mlir/test/Dialect/Transform/test-interpreter-multiple-top-level-ops.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-multiple-top-level-ops.mlir
@@ -15,7 +15,7 @@ transform.sequence failures(propagate) {
 transform.sequence failures(propagate) {
 ^bb0(%arg0: !transform.any_op):
   %match = transform.structured.match ops{["transform.get_parent_op"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %match, "found get_parent_op" : !transform.any_op
+  transform.debug.emit_remark_at %match, "found get_parent_op" : !transform.any_op
 }
 
 transform.sequence failures(propagate) {

--- a/mlir/test/Dialect/Transform/test-interpreter.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter.mlir
@@ -126,7 +126,7 @@ module attributes {transform.with_named_sequence} {
       ^bb1(%arg1: !transform.any_op):
         %f = pdl_match @const in %arg1 : (!transform.any_op) -> !transform.any_op
         %m = get_parent_op %f {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-        test_print_remark_at_operand %m, "parent function" : !transform.any_op
+        transform.debug.emit_remark_at %m, "parent function" : !transform.any_op
       }
     }
     transform.yield
@@ -153,9 +153,9 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %f = transform.structured.match ops{["test.bar"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %parent = transform.get_parent_op %f {nth_parent = 1, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %parent, "1st parent" : !transform.any_op
+    transform.debug.emit_remark_at %parent, "1st parent" : !transform.any_op
     %parent2 = transform.get_parent_op %f {nth_parent = 2, op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %parent2, "2nd parent" : !transform.any_op
+    transform.debug.emit_remark_at %parent2, "2nd parent" : !transform.any_op
     transform.yield
   }
 }
@@ -271,7 +271,7 @@ module attributes {transform.with_named_sequence} {
         }, {
         ^bb2(%arg2: !transform.any_op):
           %2 = transform.pdl_match @match_call in %arg2 : (!transform.any_op) -> !transform.any_op
-          transform.test_print_remark_at_operand %2, "still here" : !transform.any_op
+          transform.debug.emit_remark_at %2, "still here" : !transform.any_op
           // This alternative succeeds.
         }, {
         ^bb2(%arg2: !transform.any_op):
@@ -627,7 +627,7 @@ module attributes {transform.with_named_sequence} {
         %0 = pdl_match @addi in %arg1 : (!transform.any_op) -> !transform.any_op
         %1 = pdl_match @subi in %arg1 : (!transform.any_op) -> !transform.any_op
         %2 = merge_handles %0, %1 : !transform.any_op
-        test_print_remark_at_operand %2, "matched" : !transform.any_op
+        transform.debug.emit_remark_at %2, "matched" : !transform.any_op
       }
     }
     transform.yield
@@ -659,7 +659,7 @@ module attributes {transform.with_named_sequence} {
         %2 = merge_handles deduplicate %0, %1 : !transform.any_op
         %3 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
         // expected-remark @below {{1}}
-        test_print_param %3 : !transform.param<i64>
+        transform.debug.emit_param_as_remark  %3 : !transform.param<i64>
       }
     }
     transform.yield
@@ -781,11 +781,11 @@ module attributes {transform.with_named_sequence} {
         %1 = replicate num(%0) %arg1 : !transform.any_op, !transform.any_op
         %p = num_associations %1 : (!transform.any_op) -> !transform.param<i64>
         // expected-remark @below {{2}}
-        test_print_param %p : !transform.param<i64>
+        transform.debug.emit_param_as_remark  %p : !transform.param<i64>
         %2 = replicate num(%0) %1 : !transform.any_op, !transform.any_op
         %p2 = num_associations %2 : (!transform.any_op) -> !transform.param<i64>
         // expected-remark @below {{4}}
-        test_print_param %p2 : !transform.param<i64>
+        transform.debug.emit_param_as_remark  %p2 : !transform.param<i64>
       }
     }
     transform.yield
@@ -819,8 +819,8 @@ module attributes {transform.with_named_sequence} {
         ^bb2(%arg2: !transform.any_op):
           %p = transform.num_associations %arg2 : (!transform.any_op) -> !transform.param<i64>
           // expected-remark @below {{1}}
-          transform.test_print_param %p : !transform.param<i64>
-          transform.test_print_remark_at_operand %arg2, "transform applied" : !transform.any_op
+          transform.debug.emit_param_as_remark  %p : !transform.param<i64>
+          transform.debug.emit_remark_at %arg2, "transform applied" : !transform.any_op
         }
       }
     }
@@ -899,8 +899,8 @@ module attributes {transform.with_named_sequence} {
 
         %p = transform.num_associations %results : (!transform.any_op) -> !transform.param<i64>
         // expected-remark @below {{3}}
-        transform.test_print_param %p : !transform.param<i64>
-        transform.test_print_remark_at_operand %results, "transform applied" : !transform.any_op
+        transform.debug.emit_param_as_remark  %p : !transform.param<i64>
+        transform.debug.emit_remark_at %results, "transform applied" : !transform.any_op
       }
     }
     transform.yield
@@ -920,7 +920,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %muli = transform.get_producer_of_operand %addi[0] : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %muli, "found muli" : !transform.any_op
+    transform.debug.emit_remark_at %muli, "found muli" : !transform.any_op
     transform.yield
   }
 }
@@ -955,7 +955,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %muli = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %addi = transform.get_consumers_of_result %muli[0] : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %addi, "found addi" : !transform.any_op
+    transform.debug.emit_remark_at %addi, "found addi" : !transform.any_op
     transform.yield
   }
 }
@@ -1007,7 +1007,7 @@ module attributes {transform.with_named_sequence} {
     %h:2 = transform.split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p : !transform.param<i64>
     %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
     // expected-error @below {{expected to contain 3 payload ops but it contains 2 payload ops}}
     %h_2:3 = transform.split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
@@ -1031,13 +1031,13 @@ module attributes {transform.with_named_sequence} {
       %h:2 = split_handle %muli : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
       %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
       // expected-remark @below {{1}}
-      transform.test_print_param %p : !transform.param<i64>
+      transform.debug.emit_param_as_remark  %p : !transform.param<i64>
       %muli_2 = transform.structured.match ops{["arith.muli"]} in %fun : (!transform.any_op) -> !transform.any_op
       // Silenceable failure and all handles are now empty.
       %h_2:3 = split_handle %muli_2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
       %p2 = transform.num_associations %h_2#0 : (!transform.any_op) -> !transform.param<i64>
       // expected-remark @below {{0}}
-      transform.test_print_param %p2 : !transform.param<i64>
+      transform.debug.emit_param_as_remark  %p2 : !transform.param<i64>
     }
     transform.yield
   }
@@ -1058,13 +1058,13 @@ module attributes {transform.with_named_sequence} {
     %h:3 = transform.split_handle %muli_2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p : !transform.param<i64>
     %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p2 : !transform.param<i64>
     %p3 = transform.num_associations %h#2 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{0}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p3 : !transform.param<i64>
     transform.yield
   }
 }
@@ -1085,10 +1085,10 @@ module attributes {transform.with_named_sequence} {
     %h:2 = transform.split_handle %muli_2 {overflow_result = 0} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     %p = transform.num_associations %h#0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{3}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p : !transform.param<i64>
     %p2 = transform.num_associations %h#1 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p2 : !transform.param<i64>
     transform.yield
   }
 }
@@ -1271,7 +1271,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %0 = transform.test_produce_param (0 : i32) : !transform.test_dialect_param
     // expected-remark @below {{0 : i32}}
-    transform.test_print_param %0 : !transform.test_dialect_param
+    transform.debug.emit_param_as_remark  %0 : !transform.test_dialect_param
     transform.yield
   }
 }
@@ -1294,7 +1294,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.test_add_to_param 40
     %1 = transform.test_add_to_param %0, 2
     // expected-remark @below {{42 : i32}}
-    transform.test_print_param %1 : !transform.test_dialect_param
+    transform.debug.emit_param_as_remark  %1 : !transform.test_dialect_param
     transform.yield
   }
 }
@@ -1306,10 +1306,10 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %1 = transform.test_produce_param_with_number_of_test_ops %0 : !transform.any_op
     // expected-remark @below {{1 : i32, 3 : i32}}
-    transform.test_print_param %1 : !transform.test_dialect_param
+    transform.debug.emit_param_as_remark  %1 : !transform.test_dialect_param
     %2 = transform.test_add_to_param %1, 100
     // expected-remark @below {{101 : i32, 103 : i32}}
-    transform.test_print_param %2 : !transform.test_dialect_param
+    transform.debug.emit_param_as_remark  %2 : !transform.test_dialect_param
     transform.yield
   }
 }
@@ -1422,7 +1422,7 @@ module attributes {transform.with_named_sequence} {
   // expected-note @below {{value handle points to a block argument #0 in block #0 in region #0}}
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %0 = transform.test_produce_value_handle_to_self_operand %arg0 : (!transform.any_op) -> !transform.any_value
-    transform.test_print_remark_at_operand_value %0, "value handle" : !transform.any_value
+    transform.debug.emit_remark_at %0, "value handle" : !transform.any_value
     transform.yield
   }
 }
@@ -1440,7 +1440,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %2 = transform.structured.match ops{["test.get_two_results", "test.get_three_results"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %3 = transform.test_produce_value_handle_to_result %2, 1 : (!transform.any_op) -> !transform.any_value
-    transform.test_print_remark_at_operand_value %3, "result handle" : !transform.any_value
+    transform.debug.emit_remark_at %3, "result handle" : !transform.any_value
     transform.yield
   }
 }
@@ -1464,7 +1464,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %2 = transform.structured.match ops{["test.match_anchor"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %3 = transform.test_produce_value_handle_to_argument_of_parent_block %2, 2 : (!transform.any_op) -> !transform.any_value
-    transform.test_print_remark_at_operand_value %3, "block argument handle" : !transform.any_value
+    transform.debug.emit_remark_at %3, "block argument handle" : !transform.any_value
     transform.yield
   }
 }
@@ -1494,7 +1494,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
-    transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+    transform.debug.emit_remark_at %result, "addi result" : !transform.any_value
     transform.yield
   }
 }
@@ -1512,7 +1512,7 @@ module attributes {transform.with_named_sequence} {
     %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     // expected-error @below {{targeted op does not have enough results}}
     %result = transform.get_result %addi[1] : (!transform.any_op) -> !transform.any_value
-    transform.test_print_remark_at_operand_value %result, "addi result" : !transform.any_value
+    transform.debug.emit_remark_at %result, "addi result" : !transform.any_value
     transform.yield
   }
 }
@@ -1530,7 +1530,7 @@ module attributes {transform.with_named_sequence} {
     %addi = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %result = transform.get_result %addi[0] : (!transform.any_op) -> !transform.any_value
     %op = transform.get_defining_op %result : (!transform.any_value) -> !transform.any_op
-    transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+    transform.debug.emit_remark_at %op, "matched" : !transform.any_op
     transform.yield
   }
 }
@@ -1549,7 +1549,7 @@ module attributes {transform.with_named_sequence} {
     %bbarg = transform.test_produce_value_handle_to_argument_of_parent_block %addi, 0 : (!transform.any_op) -> !transform.any_value
     // expected-error @below {{cannot get defining op of block argument}}
     %op = transform.get_defining_op %bbarg : (!transform.any_value) -> !transform.any_op
-    transform.test_print_remark_at_operand %op, "matched" : !transform.any_op
+    transform.debug.emit_remark_at %op, "matched" : !transform.any_op
     transform.yield
   }
 }
@@ -1600,8 +1600,8 @@ module @named_operands attributes { transform.with_named_sequence } {
 
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly},
                                 %arg1: !transform.any_value {transform.readonly}) -> () {
-    transform.test_print_remark_at_operand %arg0, "operation" : !transform.any_op
-    transform.test_print_remark_at_operand_value %arg1, "value" : !transform.any_value
+    transform.debug.emit_remark_at %arg0, "operation" : !transform.any_op
+    transform.debug.emit_remark_at %arg1, "value" : !transform.any_value
     transform.yield
   }
 
@@ -1628,8 +1628,8 @@ module @named_return attributes { transform.with_named_sequence } {
 
   transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
     %0:2 = transform.include @foo failures(propagate) (%arg0) : (!transform.any_op) -> (!transform.any_op, !transform.any_value)
-    transform.test_print_remark_at_operand %0#0, "operation" : !transform.any_op
-    transform.test_print_remark_at_operand_value %0#1, "value" : !transform.any_value
+    transform.debug.emit_remark_at %0#0, "operation" : !transform.any_op
+    transform.debug.emit_remark_at %0#1, "value" : !transform.any_value
     transform.yield
   }
 }
@@ -1648,11 +1648,11 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @action1(%current: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %current, "matched1" : !transform.any_op
+    transform.debug.emit_remark_at %current, "matched1" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @action2(%current: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %current, "matched2" : !transform.any_op
+    transform.debug.emit_remark_at %current, "matched2" : !transform.any_op
     transform.yield
   }
 
@@ -1732,7 +1732,7 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_func(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "matched func" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched func" : !transform.any_op
     transform.yield
   }
 
@@ -1761,7 +1761,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant 1 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi eq %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched == 1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched == 1" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1771,7 +1771,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant 0 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi ne %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched != 0" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched != 0" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1781,7 +1781,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant -1 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi gt %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched > -1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched > -1" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1791,7 +1791,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant 1 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi ge %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched >= 1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched >= 1" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1801,7 +1801,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant 1 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi lt %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched < 1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched < 1" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1811,7 +1811,7 @@ module attributes { transform.with_named_sequence } {
     %0 = transform.test_produce_param_with_number_of_test_ops %arg0 : !transform.any_op
     %1 = transform.param.constant 1 : i32 -> !transform.test_dialect_param
     transform.match.param.cmpi le %0, %1 : !transform.test_dialect_param
-    transform.test_print_remark_at_operand %arg0, "matched <= 1" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "matched <= 1" : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 
@@ -1867,7 +1867,7 @@ module attributes {transform.with_named_sequence} {
     // One replacement op (test.drop_mapping) is dropped from the mapping.
     %p = transform.num_associations %0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below {{2}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark  %p : !transform.param<i64>
     transform.yield
   }
 }
@@ -1885,22 +1885,22 @@ module attributes {transform.with_named_sequence} {
     %4 = transform.merge_handles %1, %2 { deduplicate } : !transform.param<i64>
     %p = transform.num_associations %4 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     %5 = transform.merge_handles %1, %1 { deduplicate } : !transform.param<i64>
     %p2 = transform.num_associations %5 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
 
     %6 = transform.merge_handles %1, %3 { deduplicate } : !transform.param<i64>
     %p3 = transform.num_associations %6 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{2}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p3 : !transform.param<i64>
 
     %7 = transform.merge_handles %1, %1, %2, %3 : !transform.param<i64>
     %p4 = transform.num_associations %7 : (!transform.param<i64>) -> !transform.param<i64>
     // expected-remark @below {{4}}
-    transform.test_print_param %p4 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p4 : !transform.param<i64>
     transform.yield
   }
 }
@@ -1918,23 +1918,23 @@ module attributes {transform.with_named_sequence} {
     %4 = transform.merge_handles %2, %2 { deduplicate } : !transform.any_value
     %p = transform.num_associations %4 : (!transform.any_value) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     %5 = transform.merge_handles %2, %3 { deduplicate } : !transform.any_value
     %p2 = transform.num_associations %5 : (!transform.any_value) -> !transform.param<i64>
     // expected-remark @below {{2}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
 
     %6 = transform.test_produce_value_handle_to_result %1, 0 : (!transform.any_op) -> !transform.any_value
     %7 = transform.merge_handles %2, %6 { deduplicate } : !transform.any_value
     %p3 = transform.num_associations %6 : (!transform.any_value) -> !transform.param<i64>
     // expected-remark @below {{1}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p3 : !transform.param<i64>
 
     %8 = transform.merge_handles %2, %2, %3, %4 : !transform.any_value
     %p4 = transform.num_associations %8 : (!transform.any_value) -> !transform.param<i64>
     // expected-remark @below {{4}}
-    transform.test_print_param %p4 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p4 : !transform.param<i64>
     transform.yield
   }
 }
@@ -1993,7 +1993,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match attributes{original} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.structured.match attributes{replacement} in %arg1 : (!transform.any_op) -> !transform.any_op
     transform.test_notify_payload_op_replaced %0, %1 : (!transform.any_op, !transform.any_op) -> ()
-    transform.test_print_remark_at_operand %0, "updated handle" : !transform.any_op
+    transform.debug.emit_remark_at %0, "updated handle" : !transform.any_op
     transform.yield
   }
 }
@@ -2036,12 +2036,12 @@ module attributes {transform.with_named_sequence} {
     %all = transform.structured.match ops{["arith.constant"]} in %0 : (!transform.any_op) -> !transform.any_op
     %p = transform.num_associations %all : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{3}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
     // "deduplicate" has no effect because these are 3 different ops.
     %merged_before = transform.merge_handles deduplicate %all : !transform.any_op
     %p2 = transform.num_associations %merged_before : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{3}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
 
     // Apply CSE.
     transform.apply_cse to %0 : !transform.any_op
@@ -2049,22 +2049,22 @@ module attributes {transform.with_named_sequence} {
     // The handle is still mapped to 3 arith.constant ops.
     %p3 = transform.num_associations %all : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{3}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p3 : !transform.param<i64>
     // But they are all the same op.
     %merged_after = transform.merge_handles deduplicate %all : !transform.any_op
     %p4 = transform.num_associations %merged_after : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p4 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p4 : !transform.param<i64>
 
     // The other handles were also updated.
-    transform.test_print_remark_at_operand %elim_first, "eliminated 1" : !transform.any_op
+    transform.debug.emit_remark_at %elim_first, "eliminated 1" : !transform.any_op
     %p5 = transform.num_associations %elim_first : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p5 : !transform.param<i64>
-    transform.test_print_remark_at_operand %elim_second, "eliminated 2" : !transform.any_op
+    transform.debug.emit_param_as_remark %p5 : !transform.param<i64>
+    transform.debug.emit_remark_at %elim_second, "eliminated 2" : !transform.any_op
     %p6 = transform.num_associations %elim_second : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p6 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p6 : !transform.param<i64>
     transform.yield
   }
 }
@@ -2126,21 +2126,21 @@ module attributes {transform.with_named_sequence} {
 
     // Get parent by name.
     %1 = transform.get_parent_op %0 {op_name = "test.foo"} : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %1, "found test.foo parent" : !transform.any_op
+    transform.debug.emit_remark_at %1, "found test.foo parent" : !transform.any_op
 
     // Get immediate parent.
     %2 = transform.get_parent_op %0 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %2, "direct parent" : !transform.any_op
+    transform.debug.emit_remark_at %2, "direct parent" : !transform.any_op
     %p = transform.num_associations %2 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{2}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     // Deduplicate results.
     %3 = transform.structured.match ops{["test.qux"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %4 = transform.get_parent_op %3 {deduplicate} : (!transform.any_op) -> !transform.any_op
     %p2 = transform.num_associations %4 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
     transform.yield
   }
 }
@@ -2170,7 +2170,7 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match ops{["arith.extf"]} in %arg0 : (!transform.any_op) -> !transform.op<"arith.extf">
     %1 = transform.get_result %0[0] : (!transform.op<"arith.extf">) -> !transform.any_value
     %2 = transform.get_type %1 : (!transform.any_value) -> !transform.type
-    transform.test_print_param %2 at %0 : !transform.type, !transform.op<"arith.extf">
+    transform.debug.emit_param_as_remark %2 at %0 : !transform.type, !transform.op<"arith.extf">
     transform.yield
   }
 }
@@ -2272,15 +2272,15 @@ module attributes {transform.with_named_sequence} {
     %0 = transform.structured.match in %func_op : (!transform.any_op) -> !transform.any_op
     %p = transform.num_associations %0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{5}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
 
     // Select "test.foo".
     %foo = transform.select "test.foo" in %0 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %foo, "found foo" : !transform.any_op
+    transform.debug.emit_remark_at %foo, "found foo" : !transform.any_op
 
     // Select "test.bar".
     %bar = transform.select "test.bar" in %0 : (!transform.any_op) -> !transform.any_op
-    transform.test_print_remark_at_operand %bar, "found bar" : !transform.any_op
+    transform.debug.emit_remark_at %bar, "found bar" : !transform.any_op
     transform.yield
   }
 }
@@ -2306,7 +2306,7 @@ module attributes {transform.with_named_sequence} {
 
     %p = transform.num_associations %empty_op : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{0}}
-    transform.test_print_param %p : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
     transform.yield
   }
 }
@@ -2326,7 +2326,7 @@ module @named_inclusion attributes { transform.with_named_sequence } {
 // there are none in the program
 
   transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %root, "matched func" : !transform.any_op
+    transform.debug.emit_remark_at %root, "matched func" : !transform.any_op
     transform.yield
   }
 
@@ -2360,7 +2360,7 @@ module @named_inclusion attributes { transform.with_named_sequence } {
   // there are none in the program
 
   transform.named_sequence @print(%root: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %root, "no parent scf.for" : !transform.any_op
+    transform.debug.emit_remark_at %root, "no parent scf.for" : !transform.any_op
     transform.yield
   }
 
@@ -2415,12 +2415,12 @@ module attributes { transform.with_named_sequence } {
     // expected-remark @below {{matched}}
     %0 = transform.collect_matching @matcher in %arg0 : (!transform.any_op) -> !transform.any_op
     // expected-remark @below {{matched}}
-    transform.test_print_remark_at_operand %0, "matched" : !transform.any_op
+    transform.debug.emit_remark_at %0, "matched" : !transform.any_op
     transform.yield
   }
 
   transform.named_sequence @matcher(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.match.operation_name %arg0 ["transform.test_print_remark_at_operand", "transform.collect_matching"] : !transform.any_op
+    transform.match.operation_name %arg0 ["transform.debug.emit_remark_at", "transform.collect_matching"] : !transform.any_op
     transform.yield %arg0 : !transform.any_op
   }
 }

--- a/mlir/test/Dialect/Transform/test-loop-transforms.mlir
+++ b/mlir/test/Dialect/Transform/test-loop-transforms.mlir
@@ -39,14 +39,14 @@ module attributes {transform.with_named_sequence} {
 
     %p = transform.num_associations %0 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p : !transform.param<i64>
-    transform.test_print_remark_at_operand %0, "new loop op" : !transform.any_op
+    transform.debug.emit_param_as_remark %p : !transform.param<i64>
+    transform.debug.emit_remark_at %0, "new loop op" : !transform.any_op
     %p2 = transform.num_associations %1 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p2 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p2 : !transform.param<i64>
     %p3 = transform.num_associations %2 : (!transform.any_op) -> !transform.param<i64>
     // expected-remark @below{{1}}
-    transform.test_print_param %p3 : !transform.param<i64>
+    transform.debug.emit_param_as_remark %p3 : !transform.param<i64>
 
     transform.yield
   }

--- a/mlir/test/Dialect/Transform/test-pattern-application.mlir
+++ b/mlir/test/Dialect/Transform/test-pattern-application.mlir
@@ -129,12 +129,12 @@ transform.sequence failures(propagate) {
 ^bb1(%arg1: !transform.any_op):
   %0 = transform.structured.match ops{["test.container"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   %1 = transform.structured.match ops{["test.erase_op"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %1, "matched op" : !transform.any_op
+  transform.debug.emit_remark_at %1, "matched op" : !transform.any_op
   transform.apply_patterns to %0 {
     transform.apply_patterns.transform.test_patterns
   } : !transform.any_op
   // No marker should be printed.
-  transform.test_print_remark_at_operand %1, "op was deleted" : !transform.any_op
+  transform.debug.emit_remark_at %1, "op was deleted" : !transform.any_op
 }
 
 // -----
@@ -164,10 +164,10 @@ module {
     ^bb1(%arg1: !transform.any_op):
       %0 = transform.structured.match ops{["test.container"]} in %arg1 : (!transform.any_op) -> !transform.any_op
       %1 = transform.structured.match ops{["test.erase_op"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-      transform.test_print_remark_at_operand %1, "matched op" : !transform.any_op
+      transform.debug.emit_remark_at %1, "matched op" : !transform.any_op
       include @foo failures(propagate) (%0) : (!transform.any_op) -> ()
       // No marker should be printed.
-      transform.test_print_remark_at_operand %1, "op was deleted" : !transform.any_op
+      transform.debug.emit_remark_at %1, "op was deleted" : !transform.any_op
     }
   }
 }

--- a/mlir/test/Dialect/Transform/test-pdl-extension.mlir
+++ b/mlir/test/Dialect/Transform/test-pdl-extension.mlir
@@ -5,7 +5,7 @@ transform.with_pdl_patterns {
   sequence %arg0 : !transform.any_op failures(propagate) {
   ^bb0(%arg1: !transform.any_op):
     %0 = pdl_match @some in %arg1 : (!transform.any_op) -> !transform.any_op
-    test_print_remark_at_operand %0, "matched" : !transform.any_op
+    transform.debug.emit_remark_at %0, "matched" : !transform.any_op
   }
 
   pdl.pattern @some : benefit(1) {

--- a/mlir/test/Dialect/Transform/test-repro-dump.mlir
+++ b/mlir/test/Dialect/Transform/test-repro-dump.mlir
@@ -7,7 +7,7 @@
 module {
   transform.sequence failures(propagate) {
   ^bb0(%arg0: !transform.any_op):
-    transform.test_print_remark_at_operand %arg0, "remark" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "remark" : !transform.any_op
   }
 }
 

--- a/mlir/test/Examples/transform/Ch1/invalidation-1.mlir
+++ b/mlir/test/Examples/transform/Ch1/invalidation-1.mlir
@@ -24,7 +24,7 @@ transform.sequence failures(propagate) {
 
   // This is trying to use an invalidated handle leading to undefined behavior.
   // expected-error @below {{uses a handle invalidated by a previously executed transform op}}
-  transform.test_print_remark_at_operand %arg1, "remark" : !transform.op<"linalg.matmul">
+  transform.debug.emit_remark_at %arg1, "remark" : !transform.op<"linalg.matmul">
   transform.yield
 }
 
@@ -70,7 +70,7 @@ transform.sequence failures(propagate) {
   // Consuming an operand invalidates the consumed handle and any other handle that is
   // associated with the same payload operations, or payload operations nested in them.
   // expected-error @below {{uses a handle invalidated by a previously executed transform op}}
-  transform.test_print_remark_at_operand %casted, "remark"
+  transform.debug.emit_remark_at %casted, "remark"
     : !transform.any_op
   transform.yield
 }

--- a/mlir/test/Examples/transform/Ch1/invalidation-2.mlir
+++ b/mlir/test/Examples/transform/Ch1/invalidation-2.mlir
@@ -96,7 +96,7 @@ transform.sequence failures(propagate) {
       : (!transform.any_op) -> (!transform.any_op, !transform.op<"func.call">)
 
   // expected-error @below {{uses a handle invalidated by a previously executed transform op}}
-  transform.test_print_remark_at_operand %f, "fused" : !transform.any_op
+  transform.debug.emit_remark_at %f, "fused" : !transform.any_op
 
   transform.yield
 }

--- a/mlir/test/Examples/transform/Ch4/features.mlir
+++ b/mlir/test/Examples/transform/Ch4/features.mlir
@@ -59,7 +59,7 @@ module @transforms attributes { transform.with_named_sequence } {
   // This is an action sequence.
   transform.named_sequence @print_generic_matmul(
       %matmul: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %matmul, "matmul" : !transform.any_op
+    transform.debug.emit_remark_at %matmul, "matmul" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Examples/transform/Ch4/multiple.mlir
+++ b/mlir/test/Examples/transform/Ch4/multiple.mlir
@@ -79,11 +79,11 @@ module @transforms attributes { transform.with_named_sequence } {
       %add: !transform.any_op {transform.readonly},
       %max: !transform.any_op {transform.readonly},
       %pos: !transform.param<i32> {transform.readonly}) {
-    transform.test_print_param %pos, "matmul #" at %matmul
+    transform.debug.emit_param_as_remark %pos, "matmul #" at %matmul
       : !transform.param<i32>, !transform.any_op
-    transform.test_print_param %pos, "add #" at %add
+    transform.debug.emit_param_as_remark %pos, "add #" at %add
       : !transform.param<i32>, !transform.any_op
-    transform.test_print_param %pos, "max #" at %max
+    transform.debug.emit_param_as_remark %pos, "max #" at %max
       : !transform.param<i32>, !transform.any_op
     transform.yield
   }

--- a/mlir/test/Examples/transform/Ch4/sequence.mlir
+++ b/mlir/test/Examples/transform/Ch4/sequence.mlir
@@ -95,13 +95,13 @@ module @transforms attributes { transform.with_named_sequence } {
   // This is an action sequence.
   transform.named_sequence @print_elemwise(
       %elemwise_binary: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand
+    transform.debug.emit_remark_at
       %elemwise_binary, "elementwise binary" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_matmul(
       %matmul: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %matmul, "matmul" : !transform.any_op
+    transform.debug.emit_remark_at %matmul, "matmul" : !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Integration/Dialect/Transform/match_batch_matmul.mlir
+++ b/mlir/test/Integration/Dialect/Transform/match_batch_matmul.mlir
@@ -32,13 +32,13 @@ module attributes { transform.with_named_sequence } {
       %rhs_type: !transform.type {transform.readonly},
       %res_type: !transform.type {transform.readonly},
       %batch: !transform.param<i64> {transform.readonly}) {
-    transform.test_print_remark_at_operand %fill, "fill" : !transform.any_op
-    transform.test_print_remark_at_operand %bmm, "batch matmul" : !transform.any_op
-    transform.test_print_param %dims, "dimensions" at %bmm : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %lhs_type, "LHS type" at %bmm : !transform.type, !transform.any_op
-    transform.test_print_param %rhs_type, "RHS type" at %bmm : !transform.type, !transform.any_op
-    transform.test_print_param %res_type, "result type" at %bmm : !transform.type, !transform.any_op
-    transform.test_print_param %batch, "batch dimension" at %bmm : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_remark_at %fill, "fill" : !transform.any_op
+    transform.debug.emit_remark_at %bmm, "batch matmul" : !transform.any_op
+    transform.debug.emit_param_as_remark %dims, "dimensions" at %bmm : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %lhs_type, "LHS type" at %bmm : !transform.type, !transform.any_op
+    transform.debug.emit_param_as_remark %rhs_type, "RHS type" at %bmm : !transform.type, !transform.any_op
+    transform.debug.emit_param_as_remark %res_type, "result type" at %bmm : !transform.type, !transform.any_op
+    transform.debug.emit_param_as_remark %batch, "batch dimension" at %bmm : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Integration/Dialect/Transform/match_matmul.mlir
+++ b/mlir/test/Integration/Dialect/Transform/match_matmul.mlir
@@ -31,12 +31,12 @@ module attributes { transform.with_named_sequence } {
       %lhs_type: !transform.type {transform.readonly},
       %rhs_type: !transform.type {transform.readonly},
       %res_type: !transform.type {transform.readonly}) {
-    transform.test_print_remark_at_operand %fill, "fill" : !transform.any_op
-    transform.test_print_remark_at_operand %matmul, "matmul" : !transform.any_op
-    transform.test_print_param %dims, "dimensions" at %matmul : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %lhs_type, "LHS type" at %matmul : !transform.type, !transform.any_op
-    transform.test_print_param %rhs_type, "RHS type" at %matmul : !transform.type, !transform.any_op
-    transform.test_print_param %res_type, "result type" at %matmul : !transform.type, !transform.any_op
+    transform.debug.emit_remark_at %fill, "fill" : !transform.any_op
+    transform.debug.emit_remark_at %matmul, "matmul" : !transform.any_op
+    transform.debug.emit_param_as_remark %dims, "dimensions" at %matmul : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %lhs_type, "LHS type" at %matmul : !transform.type, !transform.any_op
+    transform.debug.emit_param_as_remark %rhs_type, "RHS type" at %matmul : !transform.type, !transform.any_op
+    transform.debug.emit_param_as_remark %res_type, "result type" at %matmul : !transform.type, !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/Integration/Dialect/Transform/match_reduction.mlir
+++ b/mlir/test/Integration/Dialect/Transform/match_reduction.mlir
@@ -104,13 +104,13 @@ module attributes { transform.with_named_sequence } {
       %rank: !transform.param<i64> {transform.readonly},
       %dims: !transform.param<i64> {transform.readonly},
       %bitwidth: !transform.param<i64> {transform.readonly}) {
-    transform.test_print_remark_at_operand %leading, "leading" : !transform.any_op
-    transform.test_print_remark_at_operand %fill, "fill" : !transform.any_op
-    transform.test_print_remark_at_operand %reduction, "reduction" : !transform.any_op
-    transform.test_print_remark_at_operand %trailing, "trailing" : !transform.any_op
-    transform.test_print_param %rank, "rank" at %reduction : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %dims, "dimensions" at %reduction : !transform.param<i64>, !transform.any_op
-    transform.test_print_param %bitwidth, "bitwidth" at %reduction : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_remark_at %leading, "leading" : !transform.any_op
+    transform.debug.emit_remark_at %fill, "fill" : !transform.any_op
+    transform.debug.emit_remark_at %reduction, "reduction" : !transform.any_op
+    transform.debug.emit_remark_at %trailing, "trailing" : !transform.any_op
+    transform.debug.emit_param_as_remark %rank, "rank" at %reduction : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %dims, "dimensions" at %reduction : !transform.param<i64>, !transform.any_op
+    transform.debug.emit_param_as_remark %bitwidth, "bitwidth" at %reduction : !transform.param<i64>, !transform.any_op
     transform.yield
   }
 

--- a/mlir/test/lib/Dialect/Transform/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Transform/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_library(MLIRTestTransformDialect
   MLIRIR
   MLIRPass
   MLIRPDLDialect
+  MLIRTransformDebugExtension
   MLIRTransformDialect
   MLIRTransformDialectTransforms
   MLIRTransformLoopExtension

--- a/mlir/test/lib/Dialect/Transform/TestTransformDialectExtension.cpp
+++ b/mlir/test/lib/Dialect/Transform/TestTransformDialectExtension.cpp
@@ -246,48 +246,6 @@ void mlir::test::TestSucceedIfOperandOfOpKind::getEffects(
   transform::onlyReadsPayload(effects);
 }
 
-DiagnosedSilenceableFailure mlir::test::TestPrintRemarkAtOperandOp::apply(
-    transform::TransformRewriter &rewriter,
-    transform::TransformResults &results, transform::TransformState &state) {
-  auto payload = state.getPayloadOps(getOperand());
-  for (Operation *op : payload)
-    op->emitRemark() << getMessage();
-
-  return DiagnosedSilenceableFailure::success();
-}
-
-void mlir::test::TestPrintRemarkAtOperandOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getOperand(), effects);
-  transform::onlyReadsPayload(effects);
-}
-
-DiagnosedSilenceableFailure mlir::test::TestPrintRemarkAtOperandValue::apply(
-    transform::TransformRewriter &rewriter,
-    transform::TransformResults &results, transform::TransformState &state) {
-  for (Value value : state.getPayloadValues(getIn())) {
-    std::string note;
-    llvm::raw_string_ostream os(note);
-    if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
-      os << "a block argument #" << arg.getArgNumber() << " in block #"
-         << std::distance(arg.getOwner()->getParent()->begin(),
-                          arg.getOwner()->getIterator())
-         << " in region #" << arg.getOwner()->getParent()->getRegionNumber();
-    } else {
-      os << "an op result #" << llvm::cast<OpResult>(value).getResultNumber();
-    }
-    InFlightDiagnostic diag = ::emitRemark(value.getLoc()) << getMessage();
-    diag.attachNote() << "value handle points to " << os.str();
-  }
-  return DiagnosedSilenceableFailure::success();
-}
-
-void mlir::test::TestPrintRemarkAtOperandValue::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getIn(), effects);
-  transform::onlyReadsPayload(effects);
-}
-
 DiagnosedSilenceableFailure mlir::test::TestAddTestExtensionOp::apply(
     transform::TransformRewriter &rewriter,
     transform::TransformResults &results, transform::TransformState &state) {
@@ -518,32 +476,6 @@ mlir::test::TestReportNumberOfTrackedHandlesNestedUnder::apply(
     });
   }
   emitRemark() << count << " handles nested under";
-  return DiagnosedSilenceableFailure::success();
-}
-
-void mlir::test::TestPrintParamOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getParam(), effects);
-  if (getAnchor())
-    transform::onlyReadsHandle(getAnchor(), effects);
-  transform::onlyReadsPayload(effects);
-}
-
-DiagnosedSilenceableFailure
-mlir::test::TestPrintParamOp::apply(transform::TransformRewriter &rewriter,
-                                    transform::TransformResults &results,
-                                    transform::TransformState &state) {
-  std::string str;
-  llvm::raw_string_ostream os(str);
-  if (getMessage())
-    os << *getMessage() << " ";
-  llvm::interleaveComma(state.getParams(getParam()), os);
-  if (!getAnchor()) {
-    emitRemark() << os.str();
-    return DiagnosedSilenceableFailure::success();
-  }
-  for (Operation *payload : state.getPayloadOps(getAnchor()))
-    ::mlir::emitRemark(payload->getLoc()) << os.str();
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/mlir/test/lib/Dialect/Transform/TestTransformDialectExtension.td
+++ b/mlir/test/lib/Dialect/Transform/TestTransformDialectExtension.td
@@ -153,29 +153,6 @@ def TestSucceedIfOperandOfOpKind
   let cppNamespace = "::mlir::test";
 }
 
-def TestPrintRemarkAtOperandOp
-  : Op<Transform_Dialect, "test_print_remark_at_operand",
-       [MatchOpInterface,
-        DeclareOpInterfaceMethods<TransformOpInterface>,
-        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let arguments = (ins
-    TransformHandleTypeInterface:$operand,
-    StrAttr:$message);
-  let assemblyFormat =
-    "$operand `,` $message attr-dict `:` type($operand)";
-  let cppNamespace = "::mlir::test";
-}
-
-def TestPrintRemarkAtOperandValue
-  : Op<Transform_Dialect, "test_print_remark_at_operand_value",
-       [DeclareOpInterfaceMethods<TransformOpInterface>,
-        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let arguments = (ins TransformValueHandleTypeInterface:$in,
-                       StrAttr:$message);
-  let assemblyFormat = "$in `,` $message attr-dict `:` type($in)";
-  let cppNamespace = "::mlir::test";
-}
-
 def TestAddTestExtensionOp
   : Op<Transform_Dialect, "test_add_test_extension",
        [DeclareOpInterfaceMethods<TransformOpInterface>,
@@ -360,19 +337,6 @@ def TestReportNumberOfTrackedHandlesNestedUnder
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let arguments = (ins TransformHandleTypeInterface:$target);
   let assemblyFormat = "$target attr-dict `:` type($target)";
-  let cppNamespace = "::mlir::test";
-}
-
-def TestPrintParamOp
-  : Op<Transform_Dialect, "test_print_param",
-       [MatchOpInterface,
-        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-        DeclareOpInterfaceMethods<TransformOpInterface>]> {
-  let arguments = (ins TransformParamTypeInterface:$param,
-                       Optional<TransformHandleTypeInterface>:$anchor,
-                       OptionalAttr<StrAttr>:$message);
-  let assemblyFormat = "$param (`,` $message^)?  (`at` $anchor^)?"
-                       "attr-dict `:` type($param) (`,` type($anchor)^)?";
   let cppNamespace = "::mlir::test";
 }
 

--- a/mlir/test/lib/Dialect/Transform/TestTransformDialectInterpreter.cpp
+++ b/mlir/test/lib/Dialect/Transform/TestTransformDialectInterpreter.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TestTransformDialectExtension.h"
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtensionOps.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterPassBase.h"
@@ -101,8 +102,8 @@ public:
         loc, TypeRange(), transform::FailurePropagationMode::Propagate,
         builder.getType<transform::AnyOpType>(),
         [](OpBuilder &b, Location nested, Value rootH) {
-          b.create<mlir::test::TestPrintRemarkAtOperandOp>(
-              nested, rootH, "remark from generated");
+          b.create<transform::DebugEmitRemarkAtOp>(nested, rootH,
+                                                   "remark from generated");
           b.create<transform::YieldOp>(nested, ValueRange());
         });
     return success();

--- a/mlir/unittests/Dialect/Transform/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Transform/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(MLIRTransformDialectTests
   PRIVATE
   MLIRFuncDialect
   MLIRTestTransformDialect
+  MLIRTransformDebugExtension
   MLIRTransformDialect
   MLIRTransformDialectTransforms
 )

--- a/mlir/unittests/Dialect/Transform/Preload.cpp
+++ b/mlir/unittests/Dialect/Transform/Preload.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Transform/DebugExtension/DebugExtension.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/Utils.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
@@ -29,14 +30,11 @@ namespace test {
 std::unique_ptr<Pass> createTestTransformDialectInterpreterPass();
 } // namespace test
 } // namespace mlir
-namespace test {
-void registerTestTransformDialectExtension(DialectRegistry &registry);
-} // namespace test
 
 const static llvm::StringLiteral library = R"MLIR(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence private @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-    transform.test_print_remark_at_operand %arg0, "from external symbol" : !transform.any_op
+    transform.debug.emit_remark_at %arg0, "from external symbol" : !transform.any_op
     transform.yield
   }
 })MLIR";
@@ -57,7 +55,7 @@ TEST(Preload, ContextPreloadConstructedLibrary) {
   MLIRContext context;
   auto *dialect = context.getOrLoadDialect<transform::TransformDialect>();
   DialectRegistry registry;
-  ::test::registerTestTransformDialectExtension(registry);
+  mlir::transform::registerDebugExtension(registry);
   registry.applyExtensions(&context);
   ParserConfig parserConfig(&context);
 


### PR DESCRIPTION
Introduce a new extension for simple print-debugging of the transform dialect scripts. The initial version of this extension consists of two ops that are printing the payload objects associated with transform dialect values. Similar ops were already available in the test extenion and several downstream projects, and were extensively used for testing.