### PR TITLE
[CodeGen][RISCV] Make default describeLoadedValue implementation call getConstValDefinedInReg

### DIFF
--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -1499,6 +1499,12 @@ TargetInstrInfo::describeLoadedValue(const MachineInstr &MI,
   assert(MF->getProperties().hasProperty(
       MachineFunctionProperties::Property::NoVRegs));
 
+  int64_t ImmVal;
+  // A simplified DIExpression can be produced if the register is being set to
+  // a known constant value.
+  if (getConstValDefinedInReg(MI, Reg, ImmVal))
+    return ParamLoadedValue(MachineOperand::CreateImm(ImmVal), Expr);
+
   if (auto DestSrc = isCopyInstr(MI)) {
     Register DestReg = DestSrc->Destination->getReg();
 

--- a/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
+++ b/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
@@ -257,11 +257,9 @@ TEST_P(RISCVInstrInfoTest, DescribeLoadedValue) {
   std::optional<ParamLoadedValue> MI2Res =
       TII->describeLoadedValue(*MI2, RISCV::X3);
   ASSERT_TRUE(MI2Res.has_value());
-  ASSERT_TRUE(MI2Res->first.isReg());
-  EXPECT_EQ(MI2Res->first.getReg(), RISCV::X0);
-  // TODO: Could be a DW_OP_constu if this is recognised as a immediate load
-  // rather than just an addi.
-  expectDIEPrintResult(MI2Res->second, "!DIExpression(DW_OP_plus_uconst, 111)");
+  ASSERT_TRUE(MI2Res->first.isImm());
+  EXPECT_EQ(MI2Res->first.getImm(), 111);
+  expectDIEPrintResult(MI2Res->second, "!DIExpression()");
 
   // Add immediate.
   auto *MI3 = BuildMI(*MBB, MBB->begin(), DL, TII->get(RISCV::ADDI), RISCV::X2)


### PR DESCRIPTION
This handles the same case that's supported in MipsInstrInfo::describeLoadedValue - allowing a simplified dwarf expression to be produced for when a register is set to a known constant value.