### PR TITLE
[Libomptarget] Do not abort on failed plugin init

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1662,8 +1662,8 @@ extern "C" {
 int32_t __tgt_rtl_init_plugin() {
   auto Err = Plugin::initIfNeeded();
   if (Err) {
-    REPORT("Failure to initialize plugin " GETNAME(TARGET_NAME) ": %s\n",
-           toString(std::move(Err)).data());
+    [[maybe_unused]] std::string ErrStr = toString(std::move(Err));
+    DP("Failed to init plugin: %s", ErrStr.c_str());
     return OFFLOAD_FAIL;
   }
 


### PR DESCRIPTION
Summary:
The current code logic is supposed to skip plugins that aren't found or
could not be loaded. However, the plugic ontained a call to `abort` if
it failed, which prevented us from continuing if initilalization the
plugin failed (such as if `dlopen` failed for the dyanmic plugins).
