### PR TITLE
[clang][NFC] Improve comments in C++ DR test suite

### DIFF
--- a/clang/test/CXX/drs/dr17xx.cpp
+++ b/clang/test/CXX/drs/dr17xx.cpp
@@ -89,6 +89,8 @@ S s(q); // #dr1736-s
 #endif
 }
 
+// dr1748 is in dr1748.cpp
+
 namespace dr1753 { // dr1753: 11
   typedef int T;
   struct A { typedef int T; };
@@ -159,6 +161,8 @@ namespace dr1762 { // dr1762: 14
 #endif
 }
 
+// dr1772 is in dr177x.cpp
+
 namespace dr1778 { // dr1778: 9
   // Superseded by P1286R2.
 #if __cplusplus >= 201103L
@@ -173,6 +177,8 @@ namespace dr1778 { // dr1778: 9
   static_assert(noexcept(D()), "");
 #endif
 }
+
+// dr1779 is in dr177x.cpp
 
 namespace dr1794 { // dr1794: yes
                    // NB: dup 1710

--- a/clang/test/CXX/drs/dr1xx.cpp
+++ b/clang/test/CXX/drs/dr1xx.cpp
@@ -283,7 +283,7 @@ namespace dr116 { // dr116: yes
 }
 
 // dr117: na
-// dr118 is in its own file.
+// dr118 is in dr118.cpp
 // dr119: na
 // dr120: na
 
@@ -789,7 +789,7 @@ namespace dr155 { // dr155: dup 632
   // expected-warning@-1 {{braces around scalar initializer}}
 }
 
-// dr158 is in its own file.
+// dr158 is in dr158.cpp
 
 namespace dr159 { // dr159: 3.5
   namespace X { void f(); }

--- a/clang/test/CXX/drs/dr23xx.cpp
+++ b/clang/test/CXX/drs/dr23xx.cpp
@@ -213,6 +213,8 @@ namespace dr2387 { // dr2387: 9
 #endif
 }
 
+// dr2390 is in dr2390.cpp
+
 namespace dr2394 { // dr2394: 15
 
 struct A {};

--- a/clang/test/CXX/drs/dr4xx.cpp
+++ b/clang/test/CXX/drs/dr4xx.cpp
@@ -282,7 +282,7 @@ namespace dr410 { // dr410: no
   // expected-note@#dr410-z {{declared private here}}
 }
 
-// dr412 is in its own file.
+// dr412 is in dr412.cpp
 
 namespace dr413 { // dr413: yes
   struct S {


### PR DESCRIPTION
Previously, we've been mentioning tests that were placed in their own files in corresponding `drNNxx.cpp` file. This patch makes sure we do this consistently, and improves upon existing practice by specifying the name of the file test is placed in.