### PR TITLE
[flang] include sys/wait.h for EXECUTE_COMMAND_LINE

### DIFF
--- a/flang/runtime/execute.cpp
+++ b/flang/runtime/execute.cpp
@@ -21,6 +21,7 @@
 #include <windows.h>
 #else
 #include <signal.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Linux defines WEXITSTATUS in stdlib.h, but at least FreeBSD and NetBSD only define it in sys/wait.h. Include this header unconditionally, since it is required on the BSDs and should be harmless on other platforms.

Fixes FreeBSD build after #74077.