### PR TITLE
[mlir][sparse] allow unknown ops in one-shot bufferization in mini-pipeline

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparsificationAndBufferizationPass.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparsificationAndBufferizationPass.cpp
@@ -201,6 +201,12 @@ mlir::getBufferizationOptionsForSparsification(bool analysisOnly) {
     options.testAnalysisOnly = true;
     options.printConflicts = true;
   }
+  // Since this mini-pipeline may be used in alternative pipelines (viz.
+  // different from the default "sparsifier" pipeline) where unknown ops
+  // are handled by alternative bufferization methods that are downstream
+  // of this mini-pipeline, we allow unknown ops by default (failure to
+  // bufferize is eventually apparent by failing to convert to LLVM IR).
+  options.allowUnknownOps = true;
   return options;
 }
 


### PR DESCRIPTION
Rationale:
Since this mini-pipeline may be used in alternative pipelines (viz. different from the default "sparsifier" pipeline) where unknown ops are handled by alternative bufferization methods that are downstream of this mini-pipeline, we allow unknown ops by default (failure to bufferize is eventually apparent by failing to convert to LLVM IR).

This is part of enabling e2e testing for TORCH-MLIR tests using a sparsifier backend