### PR TITLE
[mlir][scf] Fix `for-loop-peeling` crash

### DIFF
--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -123,8 +123,9 @@ static LogicalResult peelForLoop(RewriterBase &b, ForOp forOp,
   auto ubInt = getConstantIntValue(forOp.getUpperBound());
   auto stepInt = getConstantIntValue(forOp.getStep());
 
-  // No specialization necessary if step size is 1. Also bail out in case of a zero step which might have happened during folding.
-  if (stepInt == static_cast<int64_t>(1) || stepInt == static_cast<int64_t>(0))
+  // No specialization necessary if step size is 1. Also bail out in case of an
+  // invalid zero or negative step which might have happened during folding.
+  if (stepInt && *stepInt <= 1)
     return failure();
 
   // No specialization necessary if step already divides upper bound evenly.

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -123,8 +123,8 @@ static LogicalResult peelForLoop(RewriterBase &b, ForOp forOp,
   auto ubInt = getConstantIntValue(forOp.getUpperBound());
   auto stepInt = getConstantIntValue(forOp.getStep());
 
-  // No specialization necessary if step size is 1.
-  if (getConstantIntValue(forOp.getStep()) == static_cast<int64_t>(1))
+  // No specialization necessary if step size is 1. Also bail out in case of a zero step which might have happened during folding.
+  if (stepInt == static_cast<int64_t>(1) || stepInt == static_cast<int64_t>(0))
     return failure();
 
   // No specialization necessary if step already divides upper bound evenly.


### PR DESCRIPTION
Before applying the peeling patterns, it can happen that the `ForOp`
gets a step of zero during folding. This leads to a division-by-zero
down the line.

This patch adds an additional check for a constant-zero step and a
 test.

Fix https://github.com/llvm/llvm-project/issues/75758