### PR TITLE
[clang][parse] Fix UAF in MaybeDestroyTemplates

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -311,8 +311,7 @@ class Parser : public CodeCompletionHandler {
   SmallVector<TemplateIdAnnotation *, 16> TemplateIds;
 
   void MaybeDestroyTemplateIds() {
-    if (!TemplateIds.empty() &&
-        (Tok.is(tok::eof) || !PP.mightHavePendingAnnotationTokens()))
+    if (!TemplateIds.empty() && !PP.mightHavePendingAnnotationTokens())
       DestroyTemplateIds();
   }
   void DestroyTemplateIds();


### PR DESCRIPTION
There are cases where `Tok.is(tok::eof)` is true and `PP.mightHavePendingAnnotationTokens()` is also true, and in these cases a UAF may happen on the destroyed template IDs.

Fixes: 
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23204
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52018

Am not sure if a unit-test is needed? I can add one in similar style to https://github.com/llvm/llvm-project/pull/76676 but am not sure if this is actually desired for OSS-Fuzz issues? In the end OSS-Fuzz will catch the regressions in case and will also verify the UAF is fixed.