### PR TITLE
[Clang][Sema] Fix NULL dereferences for invalid references

### DIFF
--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -342,7 +342,12 @@ public:
     return IsProperty;
   }
 
-  bool isInvalid() const { return Invalid; }
+  bool isInvalid() const {
+    if (&Info == NULL) {
+      Invalid = true;
+    }
+    return Invalid;
+  }
   void setInvalid(bool b = true) const { Invalid = b; }
 
   bool hasProcessingCache() const { return HasProcessingCache; }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -4240,6 +4240,9 @@ IdentifierInfo *Sema::getNSErrorIdent() {
 /// attribute list.
 static bool hasNullabilityAttr(const ParsedAttributesView &attrs) {
   for (const ParsedAttr &AL : attrs) {
+    if (AL.isInvalid()) {
+      continue;
+    }
     if (AL.getKind() == ParsedAttr::AT_TypeNonNull ||
         AL.getKind() == ParsedAttr::AT_TypeNullable ||
         AL.getKind() == ParsedAttr::AT_TypeNullableResult ||


### PR DESCRIPTION
OSS-Fuzz has reported for a bit of time (since early 2020) a couple of NULL dereferences due to the Info reference becoming a reference to a NULL pointer.

Am not entirely sure if this is the desired fix since NULL checking on reference may not be considered a great practice, but am submitting for review in case it's acceptable.

Fixes:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20946
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20938