### PR TITLE
[Clang][Docs] Fix #40293 Add help text to coverage flag

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1112,7 +1112,8 @@ def config_user_dir_EQ : Joined<["--"], "config-user-dir=">,
   Visibility<[ClangOption, CLOption, DXCOption]>,
   HelpText<"User directory for configuration files">;
 def coverage : Flag<["-", "--"], "coverage">, Group<Link_Group>,
-  Visibility<[ClangOption, CLOption]>;
+  Visibility<[ClangOption, CLOption]>,
+  HelpText<"Compile with gcov code coverage">;
 def cpp_precomp : Flag<["-"], "cpp-precomp">, Group<clang_ignored_f_Group>;
 def current__version : JoinedOrSeparate<["-"], "current_version">;
 def cxx_isystem : JoinedOrSeparate<["-"], "cxx-isystem">, Group<clang_i_Group>,


### PR DESCRIPTION
As raised in https://github.com/llvm/llvm-project/issues/40293 `--coverage` does not have help text so it does not show up in `--help`. If you have suggestions to improve the help text I am more than happy to integrate them.