### PR TITLE
[WasmObjectFile] fix NULL-dereference

### DIFF
--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -753,6 +753,10 @@ Error WasmObjectFile::parseLinkingSectionSymtab(ReadContext &Ctx) {
             "section symbols must have local binding",
             object_error::parse_failed);
       Info.ElementIndex = readVaruint32(Ctx);
+      if (Info.ElementIndex >= Sections.size()) {
+        return make_error<GenericBinaryError>("invalid section index index",
+                                              object_error::parse_failed);
+      }
       // Use somewhat unique section name as symbol name.
       StringRef SectionName = Sections[Info.ElementIndex].Name;
       Info.Name = SectionName;


### PR DESCRIPTION
If the element index is above `Sections.size()` then a NULL-dereference may happen. This fixes it by ensuring the index is within bound and returns an error in case.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30789