### PR TITLE
[LoopInterchange] Fix depends() check parameters

### DIFF
--- a/llvm/test/Transforms/LoopInterchange/interchange-s231.ll
+++ b/llvm/test/Transforms/LoopInterchange/interchange-s231.ll
@@ -1,0 +1,56 @@
+; REQUIRES: asserts
+; RUN: opt < %s -passes=loop-interchange -cache-line-size=64 -verify-dom-info -verify-loop-info \
+; RUN:     -S -debug 2>&1 | FileCheck %s
+
+@aa = global [256 x [256 x float]] zeroinitializer, align 64
+@bb = global [256 x [256 x float]] zeroinitializer, align 64
+
+;;  for (int nl = 0; nl < 10000000/256; nl++)
+;;    for (int i = 0; i < 256; ++i)
+;;      for (int j = 1; j < 256; j++)
+;;        aa[j][i] = aa[j - 1][i] + bb[j][i];
+
+; CHECK: Processing InnerLoopId = 2 and OuterLoopId = 1
+; CHECK: Not interchanging loops. Cannot prove legality.
+
+define float @s231() {
+entry:
+  br label %for.cond1.preheader
+
+; Loop:
+for.cond1.preheader:                              ; preds = %entry, %for.cond.cleanup3
+  %nl.036 = phi i32 [ 0, %entry ], [ %inc23, %for.cond.cleanup3 ]
+  br label %for.cond5.preheader
+
+for.cond.cleanup3:                                ; preds = %for.cond.cleanup7
+  %inc23 = add nuw nsw i32 %nl.036, 1
+  %exitcond41 = icmp ne i32 %inc23, 39062
+  br i1 %exitcond41, label %for.cond1.preheader, label %for.cond.cleanup
+
+for.cond.cleanup7:                                ; preds = %for.body8
+  %indvars.iv.next39 = add nuw nsw i64 %indvars.iv38, 1
+  %exitcond40 = icmp ne i64 %indvars.iv.next39, 256
+  br i1 %exitcond40, label %for.cond5.preheader, label %for.cond.cleanup3
+
+for.body8:                                        ; preds = %for.cond5.preheader, %for.body8
+  %indvars.iv = phi i64 [ 1, %for.cond5.preheader ], [ %indvars.iv.next, %for.body8 ]
+  %0 = add nsw i64 %indvars.iv, -1
+  %arrayidx10 = getelementptr inbounds [256 x [256 x float]], ptr @aa, i64 0, i64 %0, i64 %indvars.iv38
+  %1 = load float, ptr %arrayidx10, align 4
+  %arrayidx14 = getelementptr inbounds [256 x [256 x float]], ptr @bb, i64 0, i64 %indvars.iv, i64 %indvars.iv38
+  %2 = load float, ptr %arrayidx14, align 4
+  %add = fadd fast float %2, %1
+  %arrayidx18 = getelementptr inbounds [256 x [256 x float]], ptr @aa, i64 0, i64 %indvars.iv, i64 %indvars.iv38
+  store float %add, ptr %arrayidx18, align 4
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond = icmp ne i64 %indvars.iv.next, 256
+  br i1 %exitcond, label %for.body8, label %for.cond.cleanup7
+
+for.cond5.preheader:                              ; preds = %for.cond1.preheader, %for.cond.cleanup7
+  %indvars.iv38 = phi i64 [ 0, %for.cond1.preheader ], [ %indvars.iv.next39, %for.cond.cleanup7 ]
+  br label %for.body8
+
+; Exit blocks
+for.cond.cleanup:                                 ; preds = %for.cond.cleanup3
+  ret float undef
+}

--- a/llvm/test/Transforms/LoopInterchange/interchange-s231.ll
+++ b/llvm/test/Transforms/LoopInterchange/interchange-s231.ll
@@ -11,7 +11,7 @@
 ;;        aa[j][i] = aa[j - 1][i] + bb[j][i];
 
 ; CHECK: Processing InnerLoopId = 2 and OuterLoopId = 1
-; CHECK: Not interchanging loops. Cannot prove legality.
+; CHECK: Loops interchanged.
 
 define float @s231() {
 entry:

--- a/llvm/test/Transforms/LoopInterchange/pr56275.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr56275.ll
@@ -21,20 +21,14 @@ target triple = "aarch64-unknown-linux-gnu"
 define void @test1(ptr noalias noundef %a, ptr noalias noundef %b, ptr noalias noundef %c) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br label [[LOOP2_HEADER_PREHEADER:%.*]]
-; CHECK:       loop1.header.preheader:
 ; CHECK-NEXT:    br label [[LOOP1_HEADER:%.*]]
 ; CHECK:       loop1.header:
-; CHECK-NEXT:    [[I2:%.*]] = phi i64 [ [[I2_INC:%.*]], [[LOOP1_LATCH:%.*]] ], [ 1, [[LOOP1_HEADER_PREHEADER:%.*]] ]
+; CHECK-NEXT:    [[I2:%.*]] = phi i64 [ 1, [[ENTRY:%.*]] ], [ [[I2_INC:%.*]], [[LOOP1_LATCH:%.*]] ]
 ; CHECK-NEXT:    [[I2_ST:%.*]] = add i64 [[I2]], 1
 ; CHECK-NEXT:    [[I2_LD:%.*]] = add i64 [[I2]], 0
-; CHECK-NEXT:    br label [[LOOP2_HEADER_SPLIT1:%.*]]
-; CHECK:       loop2.header.preheader:
 ; CHECK-NEXT:    br label [[LOOP2_HEADER:%.*]]
 ; CHECK:       loop2.header:
-; CHECK-NEXT:    [[I1:%.*]] = phi i64 [ [[TMP0:%.*]], [[LOOP2_HEADER_SPLIT:%.*]] ], [ 1, [[LOOP2_HEADER_PREHEADER]] ]
-; CHECK-NEXT:    br label [[LOOP1_HEADER_PREHEADER]]
-; CHECK:       loop2.header.split1:
+; CHECK-NEXT:    [[I1:%.*]] = phi i64 [ 1, [[LOOP1_HEADER]] ], [ [[I1_INC:%.*]], [[LOOP2_HEADER]] ]
 ; CHECK-NEXT:    [[I1_ST:%.*]] = add i64 [[I1]], 0
 ; CHECK-NEXT:    [[I1_LD:%.*]] = add i64 [[I1]], 0
 ; CHECK-NEXT:    [[A_ST:%.*]] = getelementptr inbounds [64 x i32], ptr [[A:%.*]], i64 [[I1_ST]], i64 [[I2_ST]]
@@ -45,17 +39,13 @@ define void @test1(ptr noalias noundef %a, ptr noalias noundef %b, ptr noalias n
 ; CHECK-NEXT:    store i32 [[B_VAL]], ptr [[A_ST]], align 4
 ; CHECK-NEXT:    [[A_VAL:%.*]] = load i32, ptr [[A_LD]], align 4
 ; CHECK-NEXT:    store i32 [[A_VAL]], ptr [[C_ST]], align 4
-; CHECK-NEXT:    [[I1_INC:%.*]] = add nuw nsw i64 [[I1]], 1
+; CHECK-NEXT:    [[I1_INC]] = add nuw nsw i64 [[I1]], 1
 ; CHECK-NEXT:    [[LOOP2_EXITCOND_NOT:%.*]] = icmp eq i64 [[I1_INC]], 63
-; CHECK-NEXT:    br label [[LOOP1_LATCH]]
-; CHECK:       loop2.header.split:
-; CHECK-NEXT:    [[TMP0]] = add nuw nsw i64 [[I1]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[TMP0]], 63
-; CHECK-NEXT:    br i1 [[TMP1]], label [[EXIT:%.*]], label [[LOOP2_HEADER]]
+; CHECK-NEXT:    br i1 [[LOOP2_EXITCOND_NOT]], label [[LOOP1_LATCH]], label [[LOOP2_HEADER]]
 ; CHECK:       loop1.latch:
 ; CHECK-NEXT:    [[I2_INC]] = add nuw nsw i64 [[I2]], 1
 ; CHECK-NEXT:    [[LOOP1_EXITCOND_NOT:%.*]] = icmp eq i64 [[I2_INC]], 63
-; CHECK-NEXT:    br i1 [[LOOP1_EXITCOND_NOT]], label [[LOOP2_HEADER_SPLIT]], label [[LOOP1_HEADER]]
+; CHECK-NEXT:    br i1 [[LOOP1_EXITCOND_NOT]], label [[EXIT:%.*]], label [[LOOP1_HEADER]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
This commit enables loop-interchange with -enable-loopinterchange for the case in https://github.com/llvm/llvm-project/issues/71519.
With the loop-interchange, the case can be vectorized.

    for (int nl = 0; nl < 10000000/256; nl++)
      for (int i = 0; i < 256; ++i)
        for (int j = 1; j < 256; j++)
          aa[j][i] = aa[j - 1][i] + bb[j][i];

The commit address the issues that:
The reversed parameter order of depends() caused the distance between aa[j][i] and aa[j - 1][i] be -1 instead of 1.