### PR TITLE
[libc++][NFC] Make AssertionInfoMatcher::CheckMessageMatches Stricter

### DIFF
--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.stride.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**) {
   {
     std::layout_left::mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
 
-    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");
+    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "layout_left::mapping::stride(): invalid rank index");
   }
   return 0;
 }

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.stride.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**) {
   {
     std::layout_right::mapping<std::dextents<int, 3>> m{std::dextents<int, 3>{100, 100, 100}};
 
-    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");
+    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "layout_right::mapping::stride(): invalid rank index");
   }
   return 0;
 }

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.stride.pass.cpp
@@ -30,7 +30,7 @@ int main(int, char**) {
     std::layout_stride::mapping<std::dextents<int, 3>> m(
         std::dextents<int, 3>(100, 100, 100), std::array<int, 3>{1, 100, 10000});
 
-    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "invalid rank index");
+    TEST_LIBCPP_ASSERT_FAILURE(m.stride(4), "layout_stride::mapping::stride(): invalid rank index");
   }
   return 0;
 }

--- a/libcxx/test/support/check_assertion.h
+++ b/libcxx/test/support/check_assertion.h
@@ -89,8 +89,7 @@ private:
     std::size_t found_at = got_msg.find(msg_);
     if (found_at == std::string_view::npos)
       return false;
-    // Allow any match
-    return true;
+    return found_at == 0 && got_msg.size() == msg_.size();
   }
 private:
   bool is_empty_;

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -349,6 +349,8 @@ function(llvm_ExternalProject_Add name source_dir)
                -DPACKAGE_VERSION=${PACKAGE_VERSION}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+               -DLLVM_ENABLE_SPHINX=${LLVM_ENABLE_SPHINX}
+               -DLLVM_BUILD_DOCS=${LLVM_BUILD_DOCS}
                -DCMAKE_EXPORT_COMPILE_COMMANDS=1
                ${cmake_args}
                ${PASSTHROUGH_VARIABLES}

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -349,8 +349,6 @@ function(llvm_ExternalProject_Add name source_dir)
                -DPACKAGE_VERSION=${PACKAGE_VERSION}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
-               -DLLVM_ENABLE_SPHINX=${LLVM_ENABLE_SPHINX}
-               -DLLVM_BUILD_DOCS=${LLVM_BUILD_DOCS}
                -DCMAKE_EXPORT_COMPILE_COMMANDS=1
                ${cmake_args}
                ${PASSTHROUGH_VARIABLES}


### PR DESCRIPTION
Rather than allow for a message to be considered a match for the actual assertion if it is anywhere in the assertion text, make sure that the expected and the actual assertion are identical.

Addresses #77701 