### PR TITLE
[clang-format] Handle possible crash in `getCells`

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1451,8 +1451,10 @@ WhitespaceManager::CellDescriptions WhitespaceManager::getCells(unsigned Start,
       } else if (C.Tok->is(tok::comma)) {
         if (!Cells.empty())
           Cells.back().EndIndex = i;
-        if (C.Tok->getNextNonComment()->isNot(tok::r_brace)) // dangling comma
+        if (const auto *Next = C.Tok->getNextNonComment();
+            Next && Next->isNot(tok::r_brace)) { // dangling comma
           ++Cell;
+        }
       }
     } else if (Depth == 1) {
       if (C.Tok == MatchingParen) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -20931,6 +20931,11 @@ TEST_F(FormatTest, CatchAlignArrayOfStructuresRightAlignment) {
       "};",
       Style);
 
+  verifyNoCrash("Foo f[] = {\n"
+                "    [0] = { 1, },\n"
+                "    [1] { 1, },\n"
+                "};",
+                Style);
   verifyNoCrash("Foo foo[] = {\n"
                 "    [0] = {1, 1},\n"
                 "    [1] { 1, 1, },\n"
@@ -21179,6 +21184,11 @@ TEST_F(FormatTest, CatchAlignArrayOfStructuresLeftAlignment) {
       "};",
       Style);
 
+  verifyNoCrash("Foo f[] = {\n"
+                "    [0] = { 1, },\n"
+                "    [1] { 1, },\n"
+                "};",
+                Style);
   verifyNoCrash("Foo foo[] = {\n"
                 "    [0] = {1, 1},\n"
                 "    [1] { 1, 1, },\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -20933,7 +20933,7 @@ TEST_F(FormatTest, CatchAlignArrayOfStructuresRightAlignment) {
 
   verifyNoCrash("Foo f[] = {\n"
                 "    [0] = { 1, },\n"
-                "    [1] { 1, },\n"
+                "    [i] { 1, },\n"
                 "};",
                 Style);
   verifyNoCrash("Foo foo[] = {\n"
@@ -21186,7 +21186,7 @@ TEST_F(FormatTest, CatchAlignArrayOfStructuresLeftAlignment) {
 
   verifyNoCrash("Foo f[] = {\n"
                 "    [0] = { 1, },\n"
-                "    [1] { 1, },\n"
+                "    [i] { 1, },\n"
                 "};",
                 Style);
   verifyNoCrash("Foo foo[] = {\n"


### PR DESCRIPTION
Done as requested in llvm/llvm-project#77045

I have changed the test a bit, because since the root problem was fixed, the original test would possibly never crash.