### PR TITLE
[mlir] Add op printing flag to skip regions

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -183,6 +183,10 @@ struct AsmPrinterOptions {
       llvm::cl::desc("Print with local scope and inline information (eliding "
                      "aliases for attributes, types, and locations")};
 
+  llvm::cl::opt<bool> skipRegionsOpt{
+      "mlir-print-skip-regions", llvm::cl::init(false),
+      llvm::cl::desc("Skip regions when printing ops.")};
+
   llvm::cl::opt<bool> printValueUsers{
       "mlir-print-value-users", llvm::cl::init(false),
       llvm::cl::desc(
@@ -217,6 +221,7 @@ OpPrintingFlags::OpPrintingFlags()
   printGenericOpFormFlag = clOptions->printGenericOpFormOpt;
   assumeVerifiedFlag = clOptions->assumeVerifiedOpt;
   printLocalScope = clOptions->printLocalScopeOpt;
+  skipRegionsFlag = clOptions->skipRegionsOpt;
   printValueUsersFlag = clOptions->printValueUsers;
 }
 

--- a/mlir/test/IR/print-skip-regions.mlir
+++ b/mlir/test/IR/print-skip-regions.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt --no-implicit-module --mlir-print-skip-regions \
+// RUN:   --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @foo(%{{.+}}: i32, %{{.+}}: i32, %{{.+}}: i32) -> i32 {...}
+// CHECK-NOT:     return
+func.func @foo(%arg0: i32, %arg1: i32, %arg3: i32) -> i32 {
+  return %arg0: i32
+}
+
+// -----
+
+// CHECK: module {...}
+// CHECK-NOT: func.func
+module {
+  func.func @foo(%arg0: i32, %arg1: i32, %arg3: i32) -> i32 {
+    return %arg0: i32
+  }
+}


### PR DESCRIPTION
The new flag, `--mlir-print-skip-regions`, sets the op printing option that disables region printing. This results in the usual `--mlir-print-ir-*` debug options printing only the names of the executed passes and the signatures of the ops.

Example:
```mlir
// -----// IR Dump Before CSE (cse) //----- //
func.func @bar(%arg0: f32, %arg1: f32) -> f32 {...}

// -----// IR Dump Before Canonicalizer (canonicalize) //----- //
func.func @bar(%arg0: f32, %arg1: f32) -> f32 {...}
```

The main use-case is to be triage compilation issues (crashes, slowness) on very deep pass pipelines and with very large IR files, where printing IR is prohibitively slow otherwise.