### PR TITLE
[Clang][Sema] improve sema check of clang::musttail attribute

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -768,6 +768,9 @@ Bug Fixes in This Version
 - Fix crashes when using the binding decl from an invalid structured binding.
   Fixes (`#67495 <https://github.com/llvm/llvm-project/issues/67495>`_) and
   (`#72198 <https://github.com/llvm/llvm-project/issues/72198>`_)
+- Fix assertion failure when call noreturn-attribute function with musttail
+  attribute.
+  Fixes (`#76631 <https://github.com/llvm/llvm-project/issues/76631>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3113,6 +3113,8 @@ def err_musttail_scope : Error<
   "cannot perform a tail call from this return statement">;
 def err_musttail_no_variadic : Error<
   "%0 attribute may not be used with variadic functions">;
+def err_musttail_no_return : Error<
+  "%0 attribute may not be used with no-return-attribute functions">;
 
 def err_nsobject_attribute : Error<
   "'NSObject' attribute is for pointer types only">;

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -786,6 +786,12 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
     return false;
   }
 
+  const auto *CalleeDecl = CE->getCalleeDecl();
+  if (CalleeDecl && CalleeDecl->hasAttr<CXX11NoReturnAttr>()) {
+    Diag(St->getBeginLoc(), diag::err_musttail_no_return) << &MTA;
+    return false;
+  }
+
   // Caller and callee must match in whether they have a "this" parameter.
   if (CallerType.This.isNull() != CalleeType.This.isNull()) {
     if (const auto *ND = dyn_cast_or_null<NamedDecl>(CE->getCalleeDecl())) {

--- a/clang/test/SemaCXX/PR76631.cpp
+++ b/clang/test/SemaCXX/PR76631.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -verify -std=c++11 -fsyntax-only %s
+
+[[noreturn]] void throw_int() {
+  throw int(); // expected-error {{cannot use 'throw' with exceptions disabled}}
+}
+
+void throw_int_wrapper() {
+  [[clang::musttail]] return throw_int(); // expected-error {{'musttail' attribute may not be used with no-return-attribute functions}}
+}


### PR DESCRIPTION
Call function with no-return attribute generates code with unreachable instruction instead of return and if the call  statement  has  `clang::musttail` attribute, it would crash in `VerifyPass`. Check this condition in Sema ahead.
Fix [issue](https://github.com/llvm/llvm-project/issues/76631)