### PR TITLE
[hwasan] Fix a possible null dereference problem

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_report.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_report.cpp
@@ -222,7 +222,7 @@ static void PrintStackAllocations(const StackAllocationsRingBuffer *sa,
         if (!local.has_frame_offset || !local.has_size || !local.has_tag_offset)
           continue;
         if (!(local.name && internal_strlen(local.name)) &&
-            !(local.function_name && internal_strlen(local.name)) &&
+            !(local.function_name && internal_strlen(local.function_name)) &&
             !(local.decl_file && internal_strlen(local.decl_file)))
           continue;
         tag_t obj_tag = base_tag ^ local.tag_offset;


### PR DESCRIPTION
This is clearly a copy-paste mistake, fix it with this patch.
After checking the `local.function_name` is not null, it should check the len for `local.function_name`, not `local.name`. And this could lead to possible null dereference since the second `internal_strlen(local.name)` does not guarantee `local.name` is not null.