### PR TITLE
[LLVM][ADT] Convert llvm::hash_code to unsigned explicitly in DenseMapInfo

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -677,7 +677,9 @@ template <typename T> hash_code hash_value(const std::optional<T> &arg) {
 template <> struct DenseMapInfo<hash_code, void> {
   static inline hash_code getEmptyKey() { return hash_code(-1); }
   static inline hash_code getTombstoneKey() { return hash_code(-2); }
-  static unsigned getHashValue(hash_code val) { return val; }
+  static unsigned getHashValue(hash_code val) {
+    return static_cast<unsigned>(size_t(val));
+  }
   static bool isEqual(hash_code LHS, hash_code RHS) { return LHS == RHS; }
 };
 


### PR DESCRIPTION
The getHashValue() signature returns a value of type 'unsigned' while the hash_code could only be implicitly converted to 'size_t'. Depending on the C++ implementation, this may or may not be a narrowing conversion.

On some platform/compiler combination, this becomes a warning. To avoid the warning (and better highlight the narrowing), do an explicit conversion instead.