### PR TITLE
[AArch64] Enable certain instruction aliases for SVE/SME

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4006,7 +4006,9 @@ defm WHILEHS_CXX  : sve2p1_int_while_rr_pn<"whilehs", 0b100>;
 defm WHILEHI_CXX  : sve2p1_int_while_rr_pn<"whilehi", 0b101>;
 defm WHILELO_CXX  : sve2p1_int_while_rr_pn<"whilelo", 0b110>;
 defm WHILELS_CXX  : sve2p1_int_while_rr_pn<"whilels", 0b111>;
+} // End HasSVE2p1_or_HasSME2
 
+let Predicates = [HasSVEorSME] in {
 
 // Aliases for existing SVE instructions for which predicate-as-counter are
 // accepted as an operand to the instruction
@@ -4025,7 +4027,7 @@ def : InstAlias<"mov $Pd, $Pn",
 
 def : InstAlias<"pfalse\t$Pd", (PFALSE PNRasPPR8:$Pd), 0>;
 
-} // End HasSVE2p1_or_HasSME2
+}
 
 //===----------------------------------------------------------------------===//
 // Non-widening BFloat16 to BFloat16 instructions

--- a/llvm/test/MC/AArch64/SVE/predicate-as-counter-aliases.s
+++ b/llvm/test/MC/AArch64/SVE/predicate-as-counter-aliases.s
@@ -1,50 +1,50 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p1 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p1 < %s \
-// RUN:        | llvm-objdump --no-print-imm-hex -d --mattr=+sve2p1 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p1 < %s \
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve < %s \
+// RUN:        | llvm-objdump --no-print-imm-hex -d --mattr=+sve - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve < %s \
 // RUN:   | llvm-objdump --no-print-imm-hex -d --mattr=-sve - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 
 
 ldr     pn0, [x0]
 // CHECK-INST: ldr     p0, [x0]
 // CHECK-ENCODING: [0x00,0x00,0x80,0x85]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: 85800000 <unknown>
 
 ldr     pn5, [x10, #255, mul vl]
 // CHECK-INST: ldr     p5, [x10, #255, mul vl]
 // CHECK-ENCODING: [0x45,0x1d,0x9f,0x85]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: 859f1d45 <unknown>
 
 
 str     pn0, [x0]
 // CHECK-INST: str     p0, [x0]
 // CHECK-ENCODING: [0x00,0x00,0x80,0xe5]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: e5800000 <unknown>
 
 str     pn5, [x10, #255, mul vl]
 // CHECK-INST: str     p5, [x10, #255, mul vl]
 // CHECK-ENCODING: [0x45,0x1d,0x9f,0xe5]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: e59f1d45 <unknown>
 
 
 mov     pn0.b, pn0.b
 // CHECK-INST: mov     p0.b, p0.b
 // CHECK-ENCODING: [0x00,0x40,0x80,0x25]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: 25804000 <unknown>
 
 
 pfalse pn15.b
 // CHECK-INST: pfalse  p15.b
 // CHECK-ENCODING: [0x0f,0xe4,0x18,0x25]
-// CHECK-ERROR: instruction requires: sme2 or sve2p1
+// CHECK-ERROR: instruction requires: sve or sme
 // CHECK-UNKNOWN: 2518e40f <unknown>


### PR DESCRIPTION
Several SVE instruction aliases accept predicate-as-counter register names as a convenience. These ought to be enabled with SVE/SME because the underlying encoding is valid and it's required by Arm ARM.