### PR TITLE
[AArch64] Fix missing `pfalse` diagnostic

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -6110,6 +6110,9 @@ bool AArch64AsmParser::showMatchError(SMLoc Loc, unsigned ErrCode,
   case Match_AddSubLSLImm3ShiftLarge:
     return Error(Loc,
       "expected 'lsl' with optional integer in range [0, 7]");
+  case Match_InvalidSVEPNRasPPRPredicateBReg:
+    return Error(Loc,
+                 "Expected predicate-as-counter register name with .B suffix");
   default:
     llvm_unreachable("unexpected error code!");
   }
@@ -6690,6 +6693,7 @@ bool AArch64AsmParser::MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   case Match_InvalidSVEVectorListStrided4x16:
   case Match_InvalidSVEVectorListStrided4x32:
   case Match_InvalidSVEVectorListStrided4x64:
+  case Match_InvalidSVEPNRasPPRPredicateBReg:
   case Match_MSR:
   case Match_MRS: {
     if (ErrorInfo >= Operands.size())

--- a/llvm/test/MC/AArch64/SVE/pfalse-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE/pfalse-diagnostics.s
@@ -15,3 +15,8 @@ pfalse pn16.b
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // CHECK-NEXT: pfalse pn16.b
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+pfalse pn5.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Expected predicate-as-counter register name with .B suffix
+// CHECK-NEXT: pfalse pn5.d
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:


### PR DESCRIPTION
The missing diagnostic causes a ICE when a suffix other than `.B`
is used in a `pfalse` instruction with a predicate-as-counter operand