### PR TITLE
[Tools] Add yaml2Object fuzzer

### DIFF
--- a/llvm/tools/llvm-object-yaml-fuzzer/CMakeLists.txt
+++ b/llvm/tools/llvm-object-yaml-fuzzer/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  Object
+  ObjectYAML
+)
+add_llvm_fuzzer(llvm-object-yaml-fuzzer
+  llvm-object-yaml-fuzzer.cpp
+)

--- a/llvm/tools/llvm-object-yaml-fuzzer/llvm-object-yaml-fuzzer.cpp
+++ b/llvm/tools/llvm-object-yaml-fuzzer/llvm-object-yaml-fuzzer.cpp
@@ -1,0 +1,25 @@
+//===-- llvm-object-yaml-fuzzer.cpp - Fuzzer for llvm/lib/ObjectYaml ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/ObjectYAML/yaml2obj.h"
+
+using namespace llvm;
+using namespace object;
+using namespace yaml;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  bool ErrorReported = false;
+  auto ErrHandler = [&](const Twine &Msg) { ErrorReported = true; };
+  std::string Payload(reinterpret_cast<const char *>(Data), Size);
+  SmallString<0> Storage;
+  std::unique_ptr<ObjectFile> Obj =
+      yaml2ObjectFile(Storage, Payload, ErrHandler);
+  return 0;
+}


### PR DESCRIPTION
The goal is to have this fuzzer running as part of the LLVM OSS-Fuzz integration (https://github.com/google/oss-fuzz/tree/master/projects/llvm)