### PR TITLE
[GISel] Fix #77762: extend correct source registers in combiner helper rule extend_through_phis

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -3939,7 +3939,8 @@ void CombinerHelper::applyExtendThroughPhis(MachineInstr &MI,
   SmallSetVector<MachineInstr *, 8> SrcMIs;
   SmallDenseMap<MachineInstr *, MachineInstr *, 8> OldToNewSrcMap;
   for (unsigned SrcIdx = 1; SrcIdx < MI.getNumOperands(); SrcIdx += 2) {
-    auto *SrcMI = MRI.getVRegDef(MI.getOperand(SrcIdx).getReg());
+    auto SrcReg = MI.getOperand(SrcIdx).getReg();
+    auto *SrcMI = MRI.getVRegDef(SrcReg);
     if (!SrcMIs.insert(SrcMI))
       continue;
 
@@ -3952,7 +3953,7 @@ void CombinerHelper::applyExtendThroughPhis(MachineInstr &MI,
     Builder.setInsertPt(*SrcMI->getParent(), InsertPt);
     Builder.setDebugLoc(MI.getDebugLoc());
     auto NewExt = Builder.buildExtOrTrunc(ExtMI->getOpcode(), ExtTy,
-                                          SrcMI->getOperand(0).getReg());
+                                          SrcReg);
     OldToNewSrcMap[SrcMI] = NewExt;
   }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/prelegalizercombiner-prop-extends-phi.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/prelegalizercombiner-prop-extends-phi.mir
@@ -489,3 +489,68 @@ body:             |
     RET_ReallyLR implicit $x0
 
 ...
+# Same as above but with a source MI with multiple destination operands.
+---
+name:            anyext_add_through_phi_multiple_operands
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: anyext_add_through_phi_multiple_operands
+  ; CHECK: bb.0.entry:
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   liveins: $w0, $w1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $w0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+  ; CHECK-NEXT:   %one:_(s32) = G_CONSTANT i32 2
+  ; CHECK-NEXT:   %cmp:_(s1) = G_ICMP intpred(sle), [[COPY]](s32), %one
+  ; CHECK-NEXT:   G_BRCOND %cmp(s1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   %big0:_(s64) = G_SEXT [[COPY]](s32)
+  ; CHECK-NEXT:   %big1:_(s64) = G_SEXT [[COPY1]](s32)
+  ; CHECK-NEXT:   %add:_(s64) = G_ADD %big0, %big1
+  ; CHECK-NEXT:   %first:_(s32), %second:_(s32) = G_UNMERGE_VALUES %add(s64)
+  ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT %second(s32)
+  ; CHECK-NEXT:   G_BR %bb.3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 10
+  ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(s64) = G_ANYEXT [[C]](s32)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   %ext:_(s64) = G_PHI [[ANYEXT]](s64), %bb.1, [[ANYEXT1]](s64), %bb.2
+  ; CHECK-NEXT:   $x0 = COPY %ext(s64)
+  ; CHECK-NEXT:   RET_ReallyLR implicit $x0
+  bb.1.entry:
+    liveins: $w0, $w1
+
+    %0:_(s32) = COPY $w0
+    %1:_(s32) = COPY $w1
+    %zero:_(s32) = G_CONSTANT i32 0
+    %one:_(s32) = G_CONSTANT i32 2
+    %cmp:_(s1) = G_ICMP intpred(sgt), %0(s32), %one
+    G_BRCOND %cmp(s1), %bb.2
+    G_BR %bb.3
+
+  bb.2:
+    %big0:_(s64) = G_SEXT %0
+    %big1:_(s64) = G_SEXT %1
+    %add:_(s64) = G_ADD %big0, %big1
+    %first:_(s32), %second:_(s32) = G_UNMERGE_VALUES %add:_(s64)
+    G_BR %bb.4
+
+  bb.3:
+    %cst32_10:_(s32) = G_CONSTANT i32 10
+
+  bb.4:
+    %phi:_(s32) = G_PHI %second, %bb.2, %cst32_10, %bb.3
+    %ext:_(s64) = G_ANYEXT %phi
+    $x0 = COPY %ext(s64)
+    RET_ReallyLR implicit $x0
+
+...


### PR DESCRIPTION
Since we already know which register we want to extend, we don't have to ask its defining MI about it