### PR TITLE
[OpenMP] Add missing weak definitions of missing variables

### DIFF
--- a/openmp/libomptarget/DeviceRTL/include/Configuration.h
+++ b/openmp/libomptarget/DeviceRTL/include/Configuration.h
@@ -30,6 +30,12 @@ uint32_t getDeviceNum();
 /// Return the user choosen debug level.
 uint32_t getDebugKind();
 
+/// Return if teams oversubscription is assumed
+uint32_t getAssumeTeamsOversubscription();
+
+/// Return if threads oversubscription is assumed
+uint32_t getAssumeThreadsOversubscription();
+
 /// Return the amount of dynamic shared memory that was allocated at launch.
 uint64_t getDynamicMemorySize();
 

--- a/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
@@ -23,7 +23,8 @@ using namespace ompx;
 [[gnu::weak]] extern const uint32_t __omp_rtl_debug_kind = 0;
 [[gnu::weak]] extern const uint32_t __omp_rtl_assume_no_thread_state = 0;
 [[gnu::weak]] extern const uint32_t __omp_rtl_assume_no_nested_parallelism = 0;
-[[gnu::weak]] extern const uint32_t __omp_rtl_assume_threads_oversubscription = 0;
+[[gnu::weak]] extern const uint32_t __omp_rtl_assume_threads_oversubscription =
+    0;
 [[gnu::weak]] extern const uint32_t __omp_rtl_assume_teams_oversubscription = 0;
 
 // This variable should be visibile to the plugin so we override the default

--- a/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
@@ -23,6 +23,8 @@ using namespace ompx;
 [[gnu::weak]] extern const uint32_t __omp_rtl_debug_kind = 0;
 [[gnu::weak]] extern const uint32_t __omp_rtl_assume_no_thread_state = 0;
 [[gnu::weak]] extern const uint32_t __omp_rtl_assume_no_nested_parallelism = 0;
+[[gnu::weak]] extern const uint32_t __omp_rtl_assume_threads_oversubscription = 0;
+[[gnu::weak]] extern const uint32_t __omp_rtl_assume_teams_oversubscription = 0;
 
 // This variable should be visibile to the plugin so we override the default
 // hidden visibility.

--- a/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
@@ -33,6 +33,14 @@ using namespace ompx;
   gnu::visibility("protected")]] DeviceEnvironmentTy
     CONSTANT(__omp_rtl_device_environment);
 
+uint32_t config::getAssumeTeamsOversubscription() {
+  return __omp_rtl_assume_teams_oversubscription;
+}
+
+uint32_t config::getAssumeThreadsOversubscription() {
+  return __omp_rtl_assume_threads_oversubscription;
+}
+
 uint32_t config::getDebugKind() {
   return __omp_rtl_debug_kind & __omp_rtl_device_environment.DeviceDebugKind;
 }

--- a/openmp/libomptarget/DeviceRTL/src/Workshare.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/Workshare.cpp
@@ -45,9 +45,6 @@ struct DynamicScheduleTracker {
 
 #pragma omp begin declare target device_type(nohost)
 
-extern int32_t __omp_rtl_assume_teams_oversubscription;
-extern int32_t __omp_rtl_assume_threads_oversubscription;
-
 // TODO: This variable is a hack inherited from the old runtime.
 static uint64_t SHARED(Cnt);
 
@@ -746,7 +743,7 @@ public:
     // If we know we have more threads than iterations we can indicate that to
     // avoid an outer loop.
     bool OneIterationPerThread = false;
-    if (__omp_rtl_assume_threads_oversubscription) {
+    if (config::getAssumeThreadsOversubscription()) {
       ASSERT(NumThreads >= NumIters, "Broken assumption");
       OneIterationPerThread = true;
     }
@@ -788,7 +785,7 @@ public:
     // If we know we have more blocks than iterations we can indicate that to
     // avoid an outer loop.
     bool OneIterationPerThread = false;
-    if (__omp_rtl_assume_teams_oversubscription) {
+    if (config::getAssumeTeamsOversubscription()) {
       ASSERT(NumBlocks >= NumIters, "Broken assumption");
       OneIterationPerThread = true;
     }
@@ -839,8 +836,8 @@ public:
     // If we know we have more threads (across all blocks) than iterations we
     // can indicate that to avoid an outer loop.
     bool OneIterationPerThread = false;
-    if (__omp_rtl_assume_teams_oversubscription &
-        __omp_rtl_assume_threads_oversubscription) {
+    if (config::getAssumeTeamsOversubscription() &
+        config::getAssumeThreadsOversubscription()) {
       OneIterationPerThread = true;
       ASSERT(NumBlocks * NumThreads >= NumIters, "Broken assumption");
     }


### PR DESCRIPTION
Variables `__omp_rtl_assume_teams_oversubscription` and `__omp_rtl_assume_threads_oversubscription `are used by functions: `__kmpc_distribute_static_loop`, `__kmpc_distribute_for_static_loop `and `__kmpc_for_static_loop`.