### PR TITLE
[flang] Handle missing LOGIN_NAME_MAX definition in runtime

### DIFF
--- a/flang/runtime/extensions.cpp
+++ b/flang/runtime/extensions.cpp
@@ -57,7 +57,14 @@ void FORTRAN_PROCEDURE_NAME(getarg)(
 // CALL GETLOG(USRNAME)
 void FORTRAN_PROCEDURE_NAME(getlog)(std::byte *arg, std::int64_t length) {
 #if _REENTRANT || _POSIX_C_SOURCE >= 199506L
-  const int nameMaxLen{LOGIN_NAME_MAX + 1};
+  int nameMaxLen;
+#ifdef LOGIN_NAME_MAX
+  nameMaxLen = LOGIN_NAME_MAX + 1;
+#else
+  nameMaxLen = sysconf(_SC_LOGIN_NAME_MAX) + 1;
+  if (nameMaxLen == -1)
+    nameMaxLen = _POSIX_LOGIN_NAME_MAX + 1;
+#endif
   char str[nameMaxLen];
 
   int error{getlogin_r(str, nameMaxLen)};

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -635,7 +635,14 @@ TEST_F(EnvironmentVariables, GetlogGetName) {
 #if _REENTRANT || _POSIX_C_SOURCE >= 199506L
 TEST_F(EnvironmentVariables, GetlogPadSpace) {
   // guarantee 1 char longer than max, last char should be pad space
-  const int charLen{LOGIN_NAME_MAX + 2};
+  int charLen;
+#ifdef LOGIN_NAME_MAX
+  charLen = LOGIN_NAME_MAX + 2;
+#else
+  charLen = sysconf(_SC_LOGIN_NAME_MAX) + 2;
+  if (charLen == -1)
+    charLen = _POSIX_LOGIN_NAME_MAX + 2;
+#endif
   char input[charLen];
 
   FORTRAN_PROCEDURE_NAME(getlog)


### PR DESCRIPTION
18af032c0e16252effeb6dfd02113812388f1d31 broke the Solaris build:
```
/vol/llvm/src/llvm-project/dist/flang/runtime/extensions.cpp:60:24: error: use of undeclared identifier 'LOGIN_NAME_MAX'
   60 |   const int nameMaxLen{LOGIN_NAME_MAX + 1};
      |                        ^
/vol/llvm/src/llvm-project/dist/flang/runtime/extensions.cpp:61:12: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
   61 |   char str[nameMaxLen];
      |            ^~~~~~~~~~
/vol/llvm/src/llvm-project/dist/flang/runtime/extensions.cpp:61:12: note: initializer of 'nameMaxLen' is unknown
/vol/llvm/src/llvm-project/dist/flang/runtime/extensions.cpp:60:13: note: declared here
   60 |   const int nameMaxLen{LOGIN_NAME_MAX + 1};
      |             ^
```
`flang/unittests/Runtime/CommandTest.cpp` has the same issue.

As documented in Solaris 11.4 `limits.h(3HEAD)`, `LOGIN_NAME_MAX` can be undefined.  To determine the value, `sysconf(3C)` needs to be used instead.

Beside that portable method, Solaris also provides a non-standard `LOGNAME_MAX` which could be used, but I've preferred the standard route instead which would support other targets with the same issue.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.