### PR TITLE
[NFC][OpenMP][Flang] Add test for OpenMP target parallel do

### DIFF
--- a/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-do.f90
+++ b/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-do.f90
@@ -1,0 +1,31 @@
+! Basic offloading test with a target region
+! REQUIRES: flang
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-pc-linux-gnu
+! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+program main
+   use omp_lib
+   integer :: x(100)
+   integer :: errors = 0
+   integer :: i
+
+   !$omp target parallel do map(from: x)
+   do i = 1, 100
+       x(i) = i
+   end do
+   !$omp end target parallel do
+   do i = 1, 100
+       if ( x(i) .ne. i ) then
+           errors = errors + 1
+       end if
+   end do
+
+   print *,"number of errors: ", errors
+
+end program main
+
+! CHECK: number of errors: 0

--- a/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-do.f90
+++ b/openmp/libomptarget/test/offloading/fortran/basic-target-parallel-do.f90
@@ -6,7 +6,8 @@
 ! UNSUPPORTED: x86_64-pc-linux-gnu
 ! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
 
-! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
 program main
    use omp_lib
    integer :: x(100)
@@ -28,4 +29,5 @@ program main
 
 end program main
 
-! CHECK: number of errors: 0
+! CHECK:  "PluginInterface" device {{[0-9]+}} info: Launching kernel {{.*}}
+! CHECKi: number of errors: 0


### PR DESCRIPTION
Added test which proves that end-to-end compilation of `omp target parallel do` costruct is successful for Flang compiler.