### PR TITLE
[OpenMP][omp_lib] Restore compatibility with more restrictive Fortran compilers

### DIFF
--- a/openmp/runtime/src/include/omp_lib.h.var
+++ b/openmp/runtime/src/include/omp_lib.h.var
@@ -741,10 +741,10 @@
           integer(c_int), value :: device_num
         end function
 
-        function omp_target_memset_async(ptr, val, count, device_num, &
-                                         depobj_count, depobj_list) bind(c)
+        function omp_target_memset_async(ptr, val, count, device_num,                                                               &
+     &      depobj_count, depobj_list) bind(c)
           use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_size_t
-          use omp_lib_kinds
+          import
           type(c_ptr) :: omp_target_memset_async
           type(c_ptr), value :: ptr
           integer(c_int), value :: val


### PR DESCRIPTION
The most recent changes to `omp_lib.h.var` have re-introduced some compatibility issues that had to be fixed due to the similar changes in the past. Namely:

1. D120707 has removed the "use omp_lib_kinds" statement and replaced it with import

2. D114537 added line continuation to the long lines

This patch introduces the same kind of changes in order to restore compatibility with some more restrictive Fortran compilers so their users could still benefit from the LLVM's OpenMP Fortran library.