### PR TITLE
[MemProf][NFC] Explicitly specify llvm version of function_ref

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -577,7 +577,7 @@ class ModuleCallsiteContextGraph
 public:
   ModuleCallsiteContextGraph(
       Module &M,
-      function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter);
+      llvm::function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter);
 
 private:
   friend CallsiteContextGraph<ModuleCallsiteContextGraph, Function,
@@ -605,7 +605,7 @@ private:
                        unsigned CloneNo) const;
 
   const Module &Mod;
-  function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter;
+  llvm::function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter;
 };
 
 /// Represents a call in the summary index graph, which can either be an
@@ -640,7 +640,7 @@ class IndexCallsiteContextGraph
 public:
   IndexCallsiteContextGraph(
       ModuleSummaryIndex &Index,
-      function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
+      llvm::function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
           isPrevailing);
 
   ~IndexCallsiteContextGraph() {
@@ -686,7 +686,7 @@ private:
   std::map<const FunctionSummary *, ValueInfo> FSToVIMap;
 
   const ModuleSummaryIndex &Index;
-  function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
+  llvm::function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
       isPrevailing;
 
   // Saves/owns the callsite info structures synthesized for missing tail call
@@ -1523,7 +1523,8 @@ CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::getStackIdsWithContextNodes(
 }
 
 ModuleCallsiteContextGraph::ModuleCallsiteContextGraph(
-    Module &M, function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter)
+    Module &M,
+    llvm::function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter)
     : Mod(M), OREGetter(OREGetter) {
   for (auto &F : M) {
     std::vector<CallInfo> CallsWithMetadata;
@@ -1582,7 +1583,7 @@ ModuleCallsiteContextGraph::ModuleCallsiteContextGraph(
 
 IndexCallsiteContextGraph::IndexCallsiteContextGraph(
     ModuleSummaryIndex &Index,
-    function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
+    llvm::function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
         isPrevailing)
     : Index(Index), isPrevailing(isPrevailing) {
   for (auto &I : Index) {
@@ -3622,7 +3623,7 @@ bool CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::process() {
 
 bool MemProfContextDisambiguation::processModule(
     Module &M,
-    function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter) {
+    llvm::function_ref<OptimizationRemarkEmitter &(Function *)> OREGetter) {
 
   // If we have an import summary, then the cloning decisions were made during
   // the thin link on the index. Apply them and return.
@@ -3689,7 +3690,7 @@ PreservedAnalyses MemProfContextDisambiguation::run(Module &M,
 
 void MemProfContextDisambiguation::run(
     ModuleSummaryIndex &Index,
-    function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
+    llvm::function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
         isPrevailing) {
   // TODO: If/when other types of memprof cloning are enabled beyond just for
   // hot and cold, we will need to change this to individually control the


### PR DESCRIPTION
As suggested in https://github.com/llvm/llvm-project/pull/75823, to
avoid confusion with std::function_ref, qualify all uses with llvm::
(we were already using the llvm version, but this avoids ambiguity).
