### PR TITLE
[flang] Get ProvenanceRange from CharBlock starting with expanded macro

### DIFF
--- a/flang/include/flang/Parser/provenance.h
+++ b/flang/include/flang/Parser/provenance.h
@@ -161,6 +161,10 @@ public:
       ProvenanceRange def, ProvenanceRange use, const std::string &expansion);
   ProvenanceRange AddCompilerInsertion(std::string);
 
+  // If provenance is in an expanded macro, return the starting provenance of
+  // the replaced macro. Otherwise, return the input provenance.
+  Provenance GetReplacedProvenance(Provenance) const;
+
   bool IsValid(Provenance at) const { return range_.Contains(at); }
   bool IsValid(ProvenanceRange range) const {
     return range.size() > 0 && range_.Contains(range);
@@ -229,7 +233,8 @@ public:
   void set_number(int n) { number_ = n; }
 
   CharBlock AsCharBlock() const { return CharBlock{data_}; }
-  std::optional<ProvenanceRange> GetProvenanceRange(CharBlock) const;
+  std::optional<ProvenanceRange> GetProvenanceRange(
+      CharBlock, const AllSources &) const;
   std::optional<CharBlock> GetCharBlock(ProvenanceRange) const;
 
   // The result of a Put() is the offset that the new data

--- a/flang/include/flang/Parser/provenance.h
+++ b/flang/include/flang/Parser/provenance.h
@@ -229,12 +229,13 @@ private:
 // single instances of CookedSource.
 class CookedSource {
 public:
+  explicit CookedSource(AllSources &allSources) : allSources_{allSources} {};
+
   int number() const { return number_; }
   void set_number(int n) { number_ = n; }
 
   CharBlock AsCharBlock() const { return CharBlock{data_}; }
-  std::optional<ProvenanceRange> GetProvenanceRange(
-      CharBlock, const AllSources &) const;
+  std::optional<ProvenanceRange> GetProvenanceRange(CharBlock) const;
   std::optional<CharBlock> GetCharBlock(ProvenanceRange) const;
 
   // The result of a Put() is the offset that the new data
@@ -261,6 +262,7 @@ public:
   llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
+  AllSources &allSources_;
   int number_{0}; // for sorting purposes
   CharBuffer buffer_; // before Marshal()
   std::string data_; // all of it, prescanned and preprocessed

--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -132,8 +132,7 @@ void Parsing::EmitPreprocessedSource(
       ++sourceLine;
       directive.clear();
     } else {
-      auto provenance{
-          cooked().GetProvenanceRange(CharBlock{&atChar, 1}, allSources)};
+      auto provenance{cooked().GetProvenanceRange(CharBlock{&atChar, 1})};
 
       // Preserves original case of the character
       const auto getOriginalChar{[&](char ch) {

--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -132,7 +132,8 @@ void Parsing::EmitPreprocessedSource(
       ++sourceLine;
       directive.clear();
     } else {
-      auto provenance{cooked().GetProvenanceRange(CharBlock{&atChar, 1})};
+      auto provenance{
+          cooked().GetProvenanceRange(CharBlock{&atChar, 1}, allSources)};
 
       // Preserves original case of the character
       const auto getOriginalChar{[&](char ch) {

--- a/flang/lib/Parser/provenance.cpp
+++ b/flang/lib/Parser/provenance.cpp
@@ -461,7 +461,7 @@ Provenance AllSources::GetReplacedProvenance(Provenance provenance) const {
 }
 
 std::optional<ProvenanceRange> CookedSource::GetProvenanceRange(
-    CharBlock cookedRange, const AllSources &allSources) const {
+    CharBlock cookedRange) const {
   if (!AsCharBlock().Contains(cookedRange)) {
     return std::nullopt;
   }
@@ -476,8 +476,8 @@ std::optional<ProvenanceRange> CookedSource::GetProvenanceRange(
     // cookedRange may start (resp. end) in a macro expansion while it does not
     // end (resp. start) in this macro expansion. Attempt to build a range
     // over the replaced source.
-    Provenance firstStart{allSources.GetReplacedProvenance(first.start())};
-    Provenance lastStart{allSources.GetReplacedProvenance(last.start())};
+    Provenance firstStart{allSources_.GetReplacedProvenance(first.start())};
+    Provenance lastStart{allSources_.GetReplacedProvenance(last.start())};
     if (firstStart <= lastStart) {
       return {ProvenanceRange{firstStart, lastStart - firstStart + 1}};
     } else {
@@ -595,7 +595,7 @@ AllCookedSources::AllCookedSources(AllSources &s) : allSources_{s} {}
 AllCookedSources::~AllCookedSources() {}
 
 CookedSource &AllCookedSources::NewCookedSource() {
-  return cooked_.emplace_back();
+  return cooked_.emplace_back(allSources_);
 }
 
 const CookedSource *AllCookedSources::Find(CharBlock x) const {
@@ -611,7 +611,7 @@ const CookedSource *AllCookedSources::Find(CharBlock x) const {
 std::optional<ProvenanceRange> AllCookedSources::GetProvenanceRange(
     CharBlock cb) const {
   if (const CookedSource * c{Find(cb)}) {
-    return c->GetProvenanceRange(cb, allSources());
+    return c->GetProvenanceRange(cb);
   } else {
     return std::nullopt;
   }

--- a/flang/lib/Parser/provenance.cpp
+++ b/flang/lib/Parser/provenance.cpp
@@ -452,8 +452,16 @@ const AllSources::Origin &AllSources::MapToOrigin(Provenance at) const {
   return origin_[low];
 }
 
+Provenance AllSources::GetReplacedProvenance(Provenance provenance) const {
+  const Origin &origin{MapToOrigin(provenance)};
+  if (std::holds_alternative<Macro>(origin.u)) {
+    return origin.replaces.start();
+  }
+  return provenance;
+}
+
 std::optional<ProvenanceRange> CookedSource::GetProvenanceRange(
-    CharBlock cookedRange) const {
+    CharBlock cookedRange, const AllSources &allSources) const {
   if (!AsCharBlock().Contains(cookedRange)) {
     return std::nullopt;
   }
@@ -465,7 +473,16 @@ std::optional<ProvenanceRange> CookedSource::GetProvenanceRange(
   if (first.start() <= last.start()) {
     return {ProvenanceRange{first.start(), last.start() - first.start() + 1}};
   } else {
-    return std::nullopt;
+    // cookedRange may start (resp. end) in a macro expansion while it does not
+    // end (resp. start) in this macro expansion. Attempt to build a range
+    // over the replaced source.
+    Provenance firstStart = allSources.GetReplacedProvenance(first.start());
+    Provenance lastStart = allSources.GetReplacedProvenance(last.start());
+    if (firstStart <= lastStart) {
+      return {ProvenanceRange{firstStart, lastStart - firstStart + 1}};
+    } else {
+      return std::nullopt;
+    }
   }
 }
 
@@ -594,7 +611,7 @@ const CookedSource *AllCookedSources::Find(CharBlock x) const {
 std::optional<ProvenanceRange> AllCookedSources::GetProvenanceRange(
     CharBlock cb) const {
   if (const CookedSource * c{Find(cb)}) {
-    return c->GetProvenanceRange(cb);
+    return c->GetProvenanceRange(cb, allSources());
   } else {
     return std::nullopt;
   }

--- a/flang/lib/Parser/provenance.cpp
+++ b/flang/lib/Parser/provenance.cpp
@@ -476,8 +476,8 @@ std::optional<ProvenanceRange> CookedSource::GetProvenanceRange(
     // cookedRange may start (resp. end) in a macro expansion while it does not
     // end (resp. start) in this macro expansion. Attempt to build a range
     // over the replaced source.
-    Provenance firstStart = allSources.GetReplacedProvenance(first.start());
-    Provenance lastStart = allSources.GetReplacedProvenance(last.start());
+    Provenance firstStart{allSources.GetReplacedProvenance(first.start())};
+    Provenance lastStart{allSources.GetReplacedProvenance(last.start())};
     if (firstStart <= lastStart) {
       return {ProvenanceRange{firstStart, lastStart - firstStart + 1}};
     } else {

--- a/flang/test/Lower/macro-debug-file-loc.f90
+++ b/flang/test/Lower/macro-debug-file-loc.f90
@@ -10,4 +10,18 @@ subroutine test()
   ! CHECK: fir.call @_QPfoo() fastmath<contract> : () -> () loc(#[[CALL_LOC:.*]])
   call CMD(foo)
 end subroutine
+
+#define IVAR i
+
+integer function ifoo()
+  ifoo = 0
+end function
+
+subroutine test2()
+  integer :: i
+  ! CHECK: fir.call @_QPifoo(){{.*}} loc(#[[IFOO_CALL_LOC:.*]])
+  IVAR = ifoo()
+end subroutine
+
 ! CHECK: #[[CALL_LOC]] = loc("{{.*}}macro-debug-file-loc.f90":11:3)
+! CHECK: #[[IFOO_CALL_LOC]] = loc("{{.*}}macro-debug-file-loc.f90":23:3)

--- a/flang/test/Semantics/assign15.f90
+++ b/flang/test/Semantics/assign15.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Test error location when assignment starts with macro expansion.
+
+#define X_VAR x
+program main
+  real(4) :: x
+  character(10) :: c
+  !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types REAL(4) and CHARACTER(KIND=1)
+  X_VAR = c
+  !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types CHARACTER(KIND=1) and REAL(4)
+  c = X_VAR
+end


### PR DESCRIPTION
When a CharBlock starts with an expanded macro but does not end in this macro expansion, GetProvenanceRange fails to return a ProvenanceRange which may cause error message to be emitted without location or lowering to emit code without source location (which is problematic if this code contains calls to procedures defined in the same file since LLVM will later crash with the error:
"inlinable function call in a function with a DISubprogram location must have a debug location"

Fix this situation by returning the ProvenanceRange starting at the replaced macro reference.