### PR TITLE
[AArch64] Add native CPU detection for Microsoft Azure Cobalt 100.

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -310,6 +310,13 @@ StringRef sys::detail::getHostCPUNameForARM(StringRef ProcCpuinfoContent) {
     }
   }
 
+  if (Implementer == "0x6d") { // Microsoft Corporation.
+    // The Microsoft Azure Cobalt 100 CPU is handled as a Neoverse N2.
+    return StringSwitch<const char *>(Part)
+        .Case("0xd49", "neoverse-n2")
+        .Default("generic");
+  }
+
   if (Implementer == "0xc0") { // Ampere Computing
     return StringSwitch<const char *>(Part)
         .Case("0xac3", "ampere1")

--- a/llvm/unittests/TargetParser/Host.cpp
+++ b/llvm/unittests/TargetParser/Host.cpp
@@ -113,7 +113,9 @@ TEST(getLinuxHostCPUName, AArch64) {
   EXPECT_EQ(sys::detail::getHostCPUNameForARM("CPU implementer : 0x51\n"
                                               "CPU part        : 0xc01"),
             "saphira");
-
+  EXPECT_EQ(sys::detail::getHostCPUNameForARM("CPU implementer : 0x6d\n"
+                                              "CPU part        : 0xd49"),
+            "neoverse-n2");
   EXPECT_EQ(sys::detail::getHostCPUNameForARM("CPU implementer : 0xc0\n"
                                               "CPU part        : 0xac3"),
             "ampere1");


### PR DESCRIPTION
This patch extends the -mcpu/mtune=native support to handle the Microsoft Azure Cobalt 100 CPU as a Neoverse N2. We expect users to use -mcpu=neoverse-n2 when targeting this CPU and all the architecture and codegen decisions to be identical.

The only difference is that the Microsoft Azure Cobalt 100 has a different Implementer ID in the /proc/cpuinfo entry that needs to be detected in getHostCPUNameForARM appropriately.