### PR TITLE
[flang][openacc] Apply mutually exclusive clauses restriction to routine

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -69,7 +69,12 @@ static constexpr inline AccClauseSet updateOnlyAllowedAfterDeviceTypeClauses{
 
 static constexpr inline AccClauseSet routineOnlyAllowedAfterDeviceTypeClauses{
     llvm::acc::Clause::ACCC_bind, llvm::acc::Clause::ACCC_gang,
-    llvm::acc::Clause::ACCC_vector, llvm::acc::Clause::ACCC_worker};
+    llvm::acc::Clause::ACCC_vector, llvm::acc::Clause::ACCC_worker,
+    llvm::acc::Clause::ACCC_seq};
+
+static constexpr inline AccClauseSet routineMutuallyExclusiveClauses{
+    llvm::acc::Clause::ACCC_gang, llvm::acc::Clause::ACCC_worker,
+    llvm::acc::Clause::ACCC_vector, llvm::acc::Clause::ACCC_seq};
 
 bool AccStructureChecker::CheckAllowedModifier(llvm::acc::Clause clause) {
   if (GetContext().directive == llvm::acc::ACCD_enter_data ||
@@ -388,7 +393,6 @@ CHECK_SIMPLE_CLAUSE(NoCreate, ACCC_no_create)
 CHECK_SIMPLE_CLAUSE(Nohost, ACCC_nohost)
 CHECK_SIMPLE_CLAUSE(Private, ACCC_private)
 CHECK_SIMPLE_CLAUSE(Read, ACCC_read)
-CHECK_SIMPLE_CLAUSE(Seq, ACCC_seq)
 CHECK_SIMPLE_CLAUSE(UseDevice, ACCC_use_device)
 CHECK_SIMPLE_CLAUSE(Wait, ACCC_wait)
 CHECK_SIMPLE_CLAUSE(Write, ACCC_write)
@@ -532,18 +536,40 @@ void AccStructureChecker::Enter(const parser::AccClause::DeviceType &d) {
                 .str()),
         ContextDirectiveAsFortran());
   }
+  ResetCrtGroup();
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::Seq &g) {
+  llvm::acc::Clause crtClause = llvm::acc::Clause::ACCC_seq;
+  if (GetContext().directive == llvm::acc::Directive::ACCD_routine) {
+    CheckMutuallyExclusivePerGroup(crtClause,
+        llvm::acc::Clause::ACCC_device_type, routineMutuallyExclusiveClauses);
+  }
+  CheckAllowed(crtClause);
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Vector &g) {
-  CheckAllowed(llvm::acc::Clause::ACCC_vector);
-  CheckAllowedOncePerGroup(
-      llvm::acc::Clause::ACCC_vector, llvm::acc::Clause::ACCC_device_type);
+  llvm::acc::Clause crtClause = llvm::acc::Clause::ACCC_vector;
+  if (GetContext().directive == llvm::acc::Directive::ACCD_routine) {
+    CheckMutuallyExclusivePerGroup(crtClause,
+        llvm::acc::Clause::ACCC_device_type, routineMutuallyExclusiveClauses);
+  }
+  CheckAllowed(crtClause);
+  if (GetContext().directive != llvm::acc::Directive::ACCD_routine) {
+    CheckAllowedOncePerGroup(crtClause, llvm::acc::Clause::ACCC_device_type);
+  }
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Worker &g) {
-  CheckAllowed(llvm::acc::Clause::ACCC_worker);
-  CheckAllowedOncePerGroup(
-      llvm::acc::Clause::ACCC_worker, llvm::acc::Clause::ACCC_device_type);
+  llvm::acc::Clause crtClause = llvm::acc::Clause::ACCC_worker;
+  if (GetContext().directive == llvm::acc::Directive::ACCD_routine) {
+    CheckMutuallyExclusivePerGroup(crtClause,
+        llvm::acc::Clause::ACCC_device_type, routineMutuallyExclusiveClauses);
+  }
+  CheckAllowed(crtClause);
+  if (GetContext().directive != llvm::acc::Directive::ACCD_routine) {
+    CheckAllowedOncePerGroup(crtClause, llvm::acc::Clause::ACCC_device_type);
+  }
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Tile &g) {
@@ -553,24 +579,32 @@ void AccStructureChecker::Enter(const parser::AccClause::Tile &g) {
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Gang &g) {
-  CheckAllowed(llvm::acc::Clause::ACCC_gang);
-  CheckAllowedOncePerGroup(
-      llvm::acc::Clause::ACCC_gang, llvm::acc::Clause::ACCC_device_type);
+  llvm::acc::Clause crtClause = llvm::acc::Clause::ACCC_gang;
+  if (GetContext().directive == llvm::acc::Directive::ACCD_routine) {
+    CheckMutuallyExclusivePerGroup(crtClause,
+        llvm::acc::Clause::ACCC_device_type, routineMutuallyExclusiveClauses);
+  }
+  CheckAllowed(crtClause);
+  if (GetContext().directive != llvm::acc::Directive::ACCD_routine) {
+    CheckAllowedOncePerGroup(crtClause, llvm::acc::Clause::ACCC_device_type);
+  }
 
   if (g.v) {
     bool hasNum = false;
     bool hasDim = false;
     const Fortran::parser::AccGangArgList &x = *g.v;
     for (const Fortran::parser::AccGangArg &gangArg : x.v) {
-      if (std::get_if<Fortran::parser::AccGangArg::Num>(&gangArg.u))
+      if (std::get_if<Fortran::parser::AccGangArg::Num>(&gangArg.u)) {
         hasNum = true;
-      else if (std::get_if<Fortran::parser::AccGangArg::Dim>(&gangArg.u))
+      } else if (std::get_if<Fortran::parser::AccGangArg::Dim>(&gangArg.u)) {
         hasDim = true;
+      }
     }
 
-    if (hasDim && hasNum)
+    if (hasDim && hasNum) {
       context_.Say(GetContext().clauseSource,
           "The num argument is not allowed when dim is specified"_err_en_US);
+    }
   }
 }
 

--- a/flang/test/Semantics/OpenACC/acc-routine.f90
+++ b/flang/test/Semantics/OpenACC/acc-routine.f90
@@ -13,3 +13,114 @@ end subroutine
 subroutine sub3()
   !$acc routine bind(sub1)
 end subroutine
+
+subroutine sub6()
+  !ERROR: Clause GANG is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang gang
+
+  !ERROR: Clause GANG is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker gang
+
+  !ERROR: Clause GANG is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector gang
+
+  !ERROR: Clause GANG is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq gang
+
+  !ERROR: Clause WORKER is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker worker
+
+  !ERROR: Clause WORKER is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang worker
+
+  !ERROR: Clause WORKER is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector worker
+
+  !ERROR: Clause WORKER is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq worker
+
+  !ERROR: Clause VECTOR is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector vector
+
+  !ERROR: Clause VECTOR is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang vector
+
+  !ERROR: Clause VECTOR is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker vector
+
+  !ERROR: Clause VECTOR is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq vector
+
+  !ERROR: Clause SEQ is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq seq
+
+  !ERROR: Clause SEQ is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang seq
+
+  !ERROR: Clause SEQ is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker seq
+
+  !ERROR: Clause SEQ is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector seq
+
+end subroutine
+
+subroutine sub7()
+  !$acc routine device_type(*) gang device_type(host) worker
+
+  !ERROR: Clause SEQ is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine device_type(*) gang seq
+
+  !ERROR: Clause WORKER is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine device_type(*) gang worker
+
+  !ERROR: Clause GANG is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang device_type(*) gang
+
+  !ERROR: Clause WORKER is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang device_type(*) worker
+
+  !ERROR: Clause VECTOR is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang device_type(*) vector
+
+  !ERROR: Clause SEQ is not allowed if clause GANG appears on the ROUTINE directive
+  !$acc routine gang device_type(*) seq
+
+  !ERROR: Clause WORKER is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker device_type(*) worker
+
+  !ERROR: Clause GANG is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker device_type(*) gang
+
+  !ERROR: Clause VECTOR is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker device_type(*) vector
+
+  !ERROR: Clause SEQ is not allowed if clause WORKER appears on the ROUTINE directive
+  !$acc routine worker device_type(*) seq
+
+  !ERROR: Clause VECTOR is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector device_type(*) vector
+
+  !ERROR: Clause GANG is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector device_type(*) gang
+
+  !ERROR: Clause VECTOR is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector device_type(*) vector
+
+  !ERROR: Clause SEQ is not allowed if clause VECTOR appears on the ROUTINE directive
+  !$acc routine vector device_type(*) seq
+
+  !ERROR: Clause SEQ is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq device_type(*) seq
+
+  !ERROR: Clause GANG is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq device_type(*) gang
+
+  !ERROR: Clause VECTOR is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq device_type(*) vector
+
+  !ERROR: Clause WORKER is not allowed if clause SEQ appears on the ROUTINE directive
+  !$acc routine seq device_type(*) worker
+
+  !$acc routine device_type(host) seq device_type(nvidia) gang device_type(multicore) vector device_type(*) worker
+end subroutine


### PR DESCRIPTION
this patch enforce or fix the enforcement of two restrictions from section 2.15.1:

> Only the gang, worker, vector, seq and bind clauses may follow a device_type clause.

`seq` was not allowed after `device_type` with the current implementation.

> Exactly one of the gang, worker, vector, or seq clauses must appear.

This was not properly checked. This patch check correctly for mutually exclusion as described in section 2.4. Mutually exclusive clauses may appear on the same directive if they apply for different device_type. 
