### PR TITLE
[MLIR][Presburger] Helper functions to compute the constant term of a generating function

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -88,7 +88,7 @@ GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
 /// i.e., has nonzero dot product with those of the given vectors
 /// that are not null.
 /// If any of the vectors is null, it is ignored.
-Point getNonOrthogonalVector(std::vector<Point> vectors);
+Point getNonOrthogonalVector(ArrayRef<Point> vectors);
 
 /// Find the coefficient of a given power of s in a rational function
 /// given by P(s)/Q(s), where

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -91,11 +91,12 @@ GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
 Point getNonOrthogonalVector(std::vector<Point> vectors);
 
 /// Find the coefficient of a given power of s in a rational function
-/// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials,
+/// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials
+/// over d parameters (distinct from s).
 /// and those in Q are Fractions.
 QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
-                                                 std::vector<QuasiPolynomial>,
-                                                 std::vector<Fraction>);
+                                                 ArrayRef<QuasiPolynomial> num,
+                                                 ArrayRef<Fraction> den);
 
 } // namespace detail
 } // namespace presburger

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -27,6 +27,7 @@
 #include "mlir/Analysis/Presburger/GeneratingFunction.h"
 #include "mlir/Analysis/Presburger/IntegerRelation.h"
 #include "mlir/Analysis/Presburger/Matrix.h"
+#include "mlir/Analysis/Presburger/QuasiPolynomial.h"
 #include <optional>
 
 namespace mlir {
@@ -82,6 +83,13 @@ ConeH getDual(ConeV cone);
 /// The input cone must be unimodular; it assert-fails otherwise.
 GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
                                                     ConeH cone);
+
+/// Find the coefficient of a given power of s in a rational function
+/// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials,
+/// and those in Q are Fractions.
+QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
+                                                 std::vector<QuasiPolynomial>,
+                                                 std::vector<Fraction>);
 
 } // namespace detail
 } // namespace presburger

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -84,6 +84,12 @@ ConeH getDual(ConeV cone);
 GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
                                                     ConeH cone);
 
+/// Find a vector that is not orthogonal to any of the given vectors,
+/// i.e., has nonzero dot product with those of the given vectors
+/// that are not null.
+/// If any of the vectors is null, it is ignored.
+Point getNonOrthonalVector(std::vector<Point> vectors);
+
 /// Find the coefficient of a given power of s in a rational function
 /// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials,
 /// and those in Q are Fractions.

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -91,9 +91,10 @@ GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
 Point getNonOrthogonalVector(std::vector<Point> vectors);
 
 /// Find the coefficient of a given power of s in a rational function
-/// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials
-/// over d parameters (distinct from s).
-/// and those in Q are Fractions.
+/// given by P(s)/Q(s), where
+/// P is a polynomial, in which the coefficients are QuasiPolynomials
+/// over d parameters (distinct from s), and
+/// and Q is a polynomial with Fraction coefficients.
 QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
                                                  ArrayRef<QuasiPolynomial> num,
                                                  ArrayRef<Fraction> den);

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -88,7 +88,7 @@ GeneratingFunction unimodularConeGeneratingFunction(ParamPoint vertex, int sign,
 /// i.e., has nonzero dot product with those of the given vectors
 /// that are not null.
 /// If any of the vectors is null, it is ignored.
-Point getNonOrthonalVector(std::vector<Point> vectors);
+Point getNonOrthogonalVector(std::vector<Point> vectors);
 
 /// Find the coefficient of a given power of s in a rational function
 /// given by P(s)/Q(s), where the coefficients in P are QuasiPolynomials,

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -62,7 +62,6 @@ public:
   // Removes terms which evaluate to zero from the expression.
   QuasiPolynomial simplify();
 
-  // Find the constant term of the expression.
   Fraction getConstantTerm();
 
 private:

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -39,6 +39,8 @@ public:
   QuasiPolynomial(unsigned numVars, SmallVector<Fraction> coeffs = {},
                   std::vector<std::vector<SmallVector<Fraction>>> aff = {});
 
+  QuasiPolynomial(unsigned numVars, Fraction constant);
+
   // Find the number of inputs (numDomain) to the polynomial.
   // numSymbols is set to zero.
   unsigned getNumInputs() const {

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -62,6 +62,9 @@ public:
   // Removes terms which evaluate to zero from the expression.
   QuasiPolynomial simplify();
 
+  // Find the constant term of the expression.
+  Fraction getConstantTerm();
+
 private:
   SmallVector<Fraction> coefficients;
   std::vector<std::vector<SmallVector<Fraction>>> affine;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -178,33 +178,28 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
   SmallVector<Fraction> newPoint = {Fraction(1, 1)};
   std::vector<Fraction> lowerDimDotProducts;
   Fraction dotProduct;
-  Fraction maxDisallowedValue = Fraction(-1, 0),
+  Fraction maxDisallowedValue = -Fraction(1, 0),
            disallowedValue = Fraction(0, 1);
   Fraction newValue;
 
   for (unsigned d = 1; d < dim; ++d) {
-    lowerDimDotProducts.clear();
 
-    // Compute the set of dot products <x_i[:d-1], vs> for each i.
+    // Compute the disallowed values  - <x_i[:d-1], vs> / x_i[d] for each i.
+    maxDisallowedValue = -Fraction(1, 0);
     for (const Point &vector : vectors) {
-      dotProduct = Fraction(0, 1);
-      for (unsigned i = 0; i < d; i++)
-        dotProduct = dotProduct + vector[i] * newPoint[i];
-      lowerDimDotProducts.push_back(dotProduct);
-    }
-
-    // Compute - <x_i[:d-1], vs> / x_i[d] for each i,
-    // and find the biggest such value.
-    for (unsigned i = 0, e = vectors.size(); i < e; ++i) {
-      if (vectors[i][d] == 0)
+      if (vector[d] == 0)
         continue;
-      disallowedValue = -lowerDimDotProducts[i] / vectors[i][d];
-      if (maxDisallowedValue < disallowedValue)
-        maxDisallowedValue = disallowedValue;
+      dotProduct = Fraction(0, 1);
+      for (unsigned i = 0; i < d; ++i)
+        dotProduct = dotProduct + vector[i] * newPoint[i];
+      disallowedValue = -dotProduct / vector[d];
+
+      // Find the biggest such value
+      maxDisallowedValue = std::max(maxDisallowedValue, disallowedValue);
     }
 
     newValue = Fraction(ceil(maxDisallowedValue + Fraction(1, 1)), 1);
-    newPoint.append(1, newValue);
+    newPoint.push_back(newValue);
   }
   return newPoint;
 }

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -165,7 +165,7 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 /// The base case is given in one dimension,
 /// where the vector [1] is not orthogonal to any
 /// of the input vectors (since they are all nonzero).
-Point mlir::presburger::detail::getNonOrthonalVector(
+Point mlir::presburger::detail::getNonOrthogonalVector(
     std::vector<Point> vectors) {
   unsigned dim = vectors[0].size();
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -177,7 +177,7 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
 
   SmallVector<Fraction> newPoint = {Fraction(1, 1)};
   std::vector<Fraction> lowerDimDotProducts;
-  Fraction dotProduct;
+  Fraction dotP;
   Fraction maxDisallowedValue = -Fraction(1, 0),
            disallowedValue = Fraction(0, 1);
   Fraction newValue;
@@ -189,10 +189,9 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
     for (const Point &vector : vectors) {
       if (vector[d] == 0)
         continue;
-      dotProduct = Fraction(0, 1);
-      for (unsigned i = 0; i < d; ++i)
-        dotProduct = dotProduct + vector[i] * newPoint[i];
-      disallowedValue = -dotProduct / vector[d];
+      dotP = dotProduct(ArrayRef(vector).slice(0, d), newPoint);
+      disallowedValue =
+          -dotProduct(ArrayRef(vector).slice(0, d), newPoint) / vector[d];
 
       // Find the biggest such value
       maxDisallowedValue = std::max(maxDisallowedValue, disallowedValue);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -229,9 +229,7 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 
   std::vector<QuasiPolynomial> coefficients(power + 1,
                                             QuasiPolynomial(numParam, 0));
-
   coefficients[0] = num[0] / den[0];
-
   for (unsigned i = 1; i <= power; ++i) {
     // If the i'th power is not in the numerator, coefficients[i]
     // remains zero.
@@ -239,7 +237,6 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
       coefficients[i] = num[i];
 
     unsigned limit = std::min<unsigned long>(i, den.size() - 1);
-
     for (unsigned j = 1; j <= limit; ++j)
       coefficients[i] = coefficients[i] -
                         coefficients[i - j] * QuasiPolynomial(numParam, den[j]);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -165,7 +165,8 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 /// The base case is given in one dimension,
 /// where the vector [1] is not orthogonal to any
 /// of the input vectors (since they are all nonzero).
-Point getNonOrthogonalVector(std::vector<Point> vectors) {
+Point mlir::presburger::detail::getNonOrthonalVector(
+    std::vector<Point> vectors) {
   unsigned dim = vectors[0].size();
 
   SmallVector<Fraction> newPoint = {Fraction(1, 1)};
@@ -179,7 +180,7 @@ Point getNonOrthogonalVector(std::vector<Point> vectors) {
     lowerDimDotProducts.clear();
 
     // Compute the set of dot products <x_i[:d-1], vs> for each i.
-    for (Point vector : vectors) {
+    for (const Point &vector : vectors) {
       dotProduct = Fraction(0, 1);
       for (unsigned i = 0; i < d - 1; i++)
         dotProduct = dotProduct + vector[i] * newPoint[i];
@@ -188,10 +189,10 @@ Point getNonOrthogonalVector(std::vector<Point> vectors) {
 
     // Compute - <x_i[:n-1], vs> / x_i[-1] for each i,
     // and find the biggest such value.
-    for (unsigned i = 0; i < vectors.size(); i++) {
+    for (unsigned i = 0, e = vectors.size(); i < e; ++i) {
       if (vectors[i][d - 1] == 0)
         continue;
-      disallowedValue = - lowerDimDotProducts[i] / vectors[i][d - 1];
+      disallowedValue = -lowerDimDotProducts[i] / vectors[i][d - 1];
       if (maxDisallowedValue < disallowedValue)
         maxDisallowedValue = disallowedValue;
     }

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -156,7 +156,7 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 /// vs ++ [v] means the vector vs with the new element v appended to it.
 ///
 /// We proceed iteratively; for steps d = 0, ... n-1, we construct a vector
-/// which is not orthogonal to any of {x_1[:i], ..., x_n[:i]}, ignoring
+/// which is not orthogonal to any of {x_1[:d], ..., x_n[:d]}, ignoring
 /// the null vectors.
 /// At step d = 0, we let vs = [1]. Clearly this is not orthogonal to
 /// any vector in the set {x_1[0], ..., x_n[0]}, except the null ones,
@@ -223,7 +223,8 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
 /// barvinokalgorithm-latte1.pdf, p. 1285
 QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     unsigned power, ArrayRef<QuasiPolynomial> num, ArrayRef<Fraction> den) {
-  assert(den.size() != 0 && "division by empty denominator in rational function!");
+  assert(den.size() != 0 &&
+         "division by empty denominator in rational function!");
 
   unsigned numParam = num[0].getNumInputs();
   for (const QuasiPolynomial &qp : num)

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -223,6 +223,7 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
 /// barvinokalgorithm-latte1.pdf, p. 1285
 QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     unsigned power, ArrayRef<QuasiPolynomial> num, ArrayRef<Fraction> den) {
+  assert(den.size() != 0 && "division by empty denominator in rational function!");
 
   unsigned numParam = num[0].getNumInputs();
   for (const QuasiPolynomial &qp : num)
@@ -238,7 +239,7 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     if (i < num.size())
       coefficients[i] = num[i];
 
-    unsigned limit = fmin(i, den.size() - 1);
+    unsigned limit = std::min<unsigned long>(i, den.size() - 1);
 
     for (unsigned j = 1; j <= limit; ++j)
       coefficients[i] = coefficients[i] -
@@ -246,5 +247,5 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 
     coefficients[i] = coefficients[i] / den[0];
   }
-  return (coefficients[power]).simplify();
+  return coefficients[power].simplify();
 }

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -147,21 +147,28 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 }
 
 /// We use a recursive procedure to find a vector not orthogonal
-/// to a given set. Let the inputs be {x_1, ..., x_k}, all vectors of length n.
+/// to a given set, ignoring the null vectors.
+/// Let the inputs be {x_1, ..., x_k}, all vectors of length n.
 ///
 /// In the following,
 /// vs[:i] means the elements of vs up to (not including) the i'th one,
 /// <vs, us> means the dot product of vs and us,
 /// vs ++ [v] means the vector vs with the new element v appended to it.
 ///
-/// Suppose we have a vector vs which is not orthogonal to
-/// any of {x_1[:n-1], ..., x_k[:n-1]}.
-/// Then we need v s.t. <x_i, vs++[v]> != 0 for all i.
-/// => <x_i[:n-1], vs> + x_i[n-1]*v != 0
-/// => v != - <x_i[:n-1], vs> / x_i[n-1]
-/// We compute this value for all i, and then
+/// We proceed iteratively; for steps i = 2, ... n, we construct a vector
+/// which is not orthogonal to any of {x_1[:i], ..., x_n[:i]}, ignoring
+/// the null vectors.
+/// At step i = 2, we let vs = [1]. Clearly this is not orthogonal to
+/// any vector in the set {x_1[0], ..., x_n[0]}, except the null ones,
+/// which we ignore.
+/// At step i = k + 1, we need a number v
+/// s.t. <x_i[:k+1], vs++[v]> != 0 for all i.
+/// => <x_i[:k], vs> + x_i[k]*v != 0
+/// => v != - <x_i[:k], vs> / x_i[k]
+/// We compute this value for all x_i, and then
 /// set v to be the maximum element of this set plus one. Thus
-/// v is outside the set as desired, and we append it to vs.
+/// v is outside the set as desired, and we append it to vs
+/// to obtain the result of the k+1'th step.
 ///
 /// The base case is given in one dimension,
 /// where the vector [1] is not orthogonal to any

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -233,6 +233,8 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
   coefficients[0] = num[0] / den[0];
 
   for (unsigned i = 1; i <= power; ++i) {
+    // If the i'th power is not in the numerator, coefficients[i]
+    // remains zero.
     if (i < num.size())
       coefficients[i] = num[i];
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -161,14 +161,14 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 /// At step d = 0, we let vs = [1]. Clearly this is not orthogonal to
 /// any vector in the set {x_1[0], ..., x_n[0]}, except the null ones,
 /// which we ignore.
-/// At step d = t + 1, we need a number v
-/// s.t. <x_i[:t+1], vs++[v]> != 0 for all i.
-/// => <x_i[:t], vs> + x_i[t+1]*v != 0
-/// => v != - <x_i[:t], vs> / x_i[t+1]
+/// At step d > 0 , we need a number v
+/// s.t. <x_i[:d], vs++[v]> != 0 for all i.
+/// => <x_i[:d-1], vs> + x_i[d]*v != 0
+/// => v != - <x_i[:d-1], vs> / x_i[d]
 /// We compute this value for all x_i, and then
 /// set v to be the maximum element of this set plus one. Thus
 /// v is outside the set as desired, and we append it to vs
-/// to obtain the result of the t+1'th step.
+/// to obtain the result of the d'th step.
 Point mlir::presburger::detail::getNonOrthogonalVector(
     std::vector<Point> vectors) {
   unsigned dim = vectors[0].size();
@@ -223,8 +223,7 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
 /// barvinokalgorithm-latte1.pdf, p. 1285
 QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     unsigned power, ArrayRef<QuasiPolynomial> num, ArrayRef<Fraction> den) {
-  assert(den.size() != 0 &&
-         "division by empty denominator in rational function!");
+  assert(den.size() != 0 && "division by empty denominator in rational function!");
 
   unsigned numParam = num[0].getNumInputs();
   for (const QuasiPolynomial &qp : num)

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -231,10 +231,7 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
                                             QuasiPolynomial(numParam, 0));
   coefficients[0] = num[0] / den[0];
   for (unsigned i = 1; i <= power; ++i) {
-    // If the i'th power is not in the numerator, coefficients[i]
-    // remains zero.
-    if (i < num.size())
-      coefficients[i] = num[i];
+    coefficients[i] = i < num.size() ? num[i] : QuasiPolynomial(numParam, 0);
 
     unsigned limit = std::min<unsigned long>(i, den.size() - 1);
     for (unsigned j = 1; j <= limit; ++j)

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -170,8 +170,10 @@ GeneratingFunction mlir::presburger::detail::unimodularConeGeneratingFunction(
 /// v is outside the set as desired, and we append it to vs
 /// to obtain the result of the d'th step.
 Point mlir::presburger::detail::getNonOrthogonalVector(
-    std::vector<Point> vectors) {
+    ArrayRef<Point> vectors) {
   unsigned dim = vectors[0].size();
+  for (const Point &vector : vectors)
+    assert(vector.size() == dim && "all vectors need to be the same size!");
 
   SmallVector<Fraction> newPoint = {Fraction(1, 1)};
   std::vector<Fraction> lowerDimDotProducts;
@@ -223,7 +225,8 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
 /// barvinokalgorithm-latte1.pdf, p. 1285
 QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     unsigned power, ArrayRef<QuasiPolynomial> num, ArrayRef<Fraction> den) {
-  assert(den.size() != 0 && "division by empty denominator in rational function!");
+  assert(den.size() != 0 &&
+         "division by empty denominator in rational function!");
 
   unsigned numParam = num[0].getNumInputs();
   for (const QuasiPolynomial &qp : num)

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -176,11 +176,8 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
     assert(vector.size() == dim && "all vectors need to be the same size!");
 
   SmallVector<Fraction> newPoint = {Fraction(1, 1)};
-  std::vector<Fraction> lowerDimDotProducts;
-  Fraction dotP;
   Fraction maxDisallowedValue = -Fraction(1, 0),
            disallowedValue = Fraction(0, 1);
-  Fraction newValue;
 
   for (unsigned d = 1; d < dim; ++d) {
 
@@ -189,16 +186,13 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
     for (const Point &vector : vectors) {
       if (vector[d] == 0)
         continue;
-      dotP = dotProduct(ArrayRef(vector).slice(0, d), newPoint);
       disallowedValue =
           -dotProduct(ArrayRef(vector).slice(0, d), newPoint) / vector[d];
 
       // Find the biggest such value
       maxDisallowedValue = std::max(maxDisallowedValue, disallowedValue);
     }
-
-    newValue = maxDisallowedValue + 1;
-    newPoint.push_back(newValue);
+    newPoint.push_back(maxDisallowedValue + 1);
   }
   return newPoint;
 }

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -180,7 +180,6 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
            disallowedValue = Fraction(0, 1);
 
   for (unsigned d = 1; d < dim; ++d) {
-
     // Compute the disallowed values  - <x_i[:d-1], vs> / x_i[d] for each i.
     maxDisallowedValue = -Fraction(1, 0);
     for (const Point &vector : vectors) {

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -224,7 +224,9 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 
   unsigned numParam = num[0].getNumInputs();
   for (const QuasiPolynomial &qp : num)
-    assert(numParam == qp.getNumInputs() &&
+    // We use the `isEqual` method of PresburgerSpace, which QuasiPolynomial
+    // inherits from.
+    assert(num[0].isEqual(qp) &&
            "the quasipolynomials should all belong to the same space!");
 
   std::vector<QuasiPolynomial> coefficients;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -197,7 +197,7 @@ Point mlir::presburger::detail::getNonOrthogonalVector(
       maxDisallowedValue = std::max(maxDisallowedValue, disallowedValue);
     }
 
-    newValue = Fraction(ceil(maxDisallowedValue + Fraction(1, 1)), 1);
+    newValue = maxDisallowedValue + 1;
     newPoint.push_back(newValue);
   }
   return newPoint;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -232,9 +232,12 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 
   coefficients.push_back(num[0] / den[0]);
   for (unsigned i = 1; i <= power; ++i) {
+    // If the power is not there in the numerator, the coefficient is zero.
     coefficients.push_back(i < num.size() ? num[i]
                                           : QuasiPolynomial(numParam, 0));
 
+    // After den.size(), the coefficients are zero, so we stop
+    // subtracting at that point (if it is less than i).
     unsigned limit = std::min<unsigned long>(i, den.size() - 1);
     for (unsigned j = 1; j <= limit; ++j)
       coefficients[i] = coefficients[i] -

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -227,11 +227,13 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
     assert(numParam == qp.getNumInputs() &&
            "the quasipolynomials should all belong to the same space!");
 
-  std::vector<QuasiPolynomial> coefficients(power + 1,
-                                            QuasiPolynomial(numParam, 0));
-  coefficients[0] = num[0] / den[0];
+  std::vector<QuasiPolynomial> coefficients;
+  coefficients.reserve(power + 1);
+
+  coefficients.push_back(num[0] / den[0]);
   for (unsigned i = 1; i <= power; ++i) {
-    coefficients[i] = i < num.size() ? num[i] : QuasiPolynomial(numParam, 0);
+    coefficients.push_back(i < num.size() ? num[i]
+                                          : QuasiPolynomial(numParam, 0));
 
     unsigned limit = std::min<unsigned long>(i, den.size() - 1);
     for (unsigned j = 1; j <= limit; ++j)

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -119,3 +119,13 @@ QuasiPolynomial QuasiPolynomial::simplify() {
   }
   return QuasiPolynomial(getNumInputs(), newCoeffs, newAffine);
 }
+
+// Check the constant term of the quasipolynomial against a constant.
+Fraction QuasiPolynomial::getConstantTerm() {
+  Fraction t = 0;
+  for (unsigned i = 0, e = coefficients.size(); i < e; ++i) {
+    if (affine[i].size() == 0)
+      t += coefficients[i];
+  }
+  return t;
+}

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -122,9 +122,8 @@ QuasiPolynomial QuasiPolynomial::simplify() {
 
 Fraction QuasiPolynomial::getConstantTerm() {
   Fraction t = 0;
-  for (unsigned i = 0, e = coefficients.size(); i < e; ++i) {
+  for (unsigned i = 0, e = coefficients.size(); i < e; ++i)
     if (affine[i].size() == 0)
       t += coefficients[i];
-  }
   return t;
 }

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -120,7 +120,6 @@ QuasiPolynomial QuasiPolynomial::simplify() {
   return QuasiPolynomial(getNumInputs(), newCoeffs, newAffine);
 }
 
-// Check the constant term of the quasipolynomial against a constant.
 Fraction QuasiPolynomial::getConstantTerm() {
   Fraction t = 0;
   for (unsigned i = 0, e = coefficients.size(); i < e; ++i) {

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -36,6 +36,12 @@ QuasiPolynomial::QuasiPolynomial(
 #endif // NDEBUG
 }
 
+/// Define a quasipolynomial which is a single constant.
+QuasiPolynomial::QuasiPolynomial(unsigned numVars, Fraction constant)
+    : PresburgerSpace(/*numDomain=*/numVars, /*numRange=*/1, /*numSymbols=*/0,
+                      /*numLocals=*/0),
+      coefficients({constant}), affine({{}}) {}
+
 QuasiPolynomial QuasiPolynomial::operator+(const QuasiPolynomial &x) const {
   assert(getNumInputs() == x.getNumInputs() &&
          "two quasi-polynomials with different numbers of symbols cannot "

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -121,9 +121,9 @@ QuasiPolynomial QuasiPolynomial::simplify() {
 }
 
 Fraction QuasiPolynomial::getConstantTerm() {
-  Fraction t = 0;
+  Fraction constTerm = 0;
   for (unsigned i = 0, e = coefficients.size(); i < e; ++i)
     if (affine[i].size() == 0)
-      t += coefficients[i];
-  return t;
+      constTerm += coefficients[i];
+  return constTerm;
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -83,4 +83,4 @@ TEST(BarvinokTest, unimodularConeGeneratingFunction) {
           {{{8, 47, -17}, {-7, -41, 15}, {1, 5, -2}}}));
 }
 
-TEST(BarvinokTest, non)
+TEST(BarvinokTest, getNonOrthonalVector)

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -126,7 +126,7 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
   QuasiPolynomial coeff =
       getCoefficientInRationalFunction(1, numerator, denominator);
 
-  EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(coeff, 3);
+  EXPECT_EQ(coeff.getConstantTerm(), 3);
 
   numerator = {QuasiPolynomial(0, -1), QuasiPolynomial(0, 4),
                QuasiPolynomial(0, -2), QuasiPolynomial(0, 5),
@@ -136,5 +136,5 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
 
   coeff = getCoefficientInRationalFunction(3, numerator, denominator);
 
-  EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(coeff, Fraction(55, 64));
+  EXPECT_EQ(coeff.getConstantTerm(), Fraction(55, 64));
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -119,22 +119,16 @@ Fraction getC(QuasiPolynomial q) {
 TEST(BarvinokTest, getCoefficientInRationalFunction) {
   std::vector<QuasiPolynomial> numerator = {
       QuasiPolynomial(0, 2), QuasiPolynomial(0, 3), QuasiPolynomial(0, 5)};
-
   std::vector<Fraction> denominator = {Fraction(1), Fraction(0), Fraction(4),
                                        Fraction(3)};
-
   QuasiPolynomial coeff =
       getCoefficientInRationalFunction(1, numerator, denominator);
-
   EXPECT_EQ(coeff.getConstantTerm(), 3);
 
   numerator = {QuasiPolynomial(0, -1), QuasiPolynomial(0, 4),
                QuasiPolynomial(0, -2), QuasiPolynomial(0, 5),
                QuasiPolynomial(0, 6)};
-
   denominator = {Fraction(8), Fraction(4), Fraction(0), Fraction(-2)};
-
   coeff = getCoefficientInRationalFunction(3, numerator, denominator);
-
   EXPECT_EQ(coeff.getConstantTerm(), Fraction(55, 64));
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -82,3 +82,5 @@ TEST(BarvinokTest, unimodularConeGeneratingFunction) {
           1, {1}, {makeFracMatrix(2, 3, {{-83, -100, -41}, {-22, -27, -15}})},
           {{{8, 47, -17}, {-7, -41, 15}, {1, 5, -2}}}));
 }
+
+TEST(BarvinokTest, non)

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -83,4 +83,18 @@ TEST(BarvinokTest, unimodularConeGeneratingFunction) {
           {{{8, 47, -17}, {-7, -41, 15}, {1, 5, -2}}}));
 }
 
-TEST(BarvinokTest, getNonOrthonalVector)
+TEST(BarvinokTest, getNonOrthogonalVector) {
+  std::vector<Point> vectors = {Point({1, 2, 3, 4}), Point({-1, 0, 1, 1}),
+                                Point({2, 7, 0, 0}), Point({0, 0, 0, 0})};
+  Point nonOrth = getNonOrthogonalVector(vectors);
+
+  for (unsigned i = 0; i < 3; i++)
+    EXPECT_FALSE(dotProduct(nonOrth, vectors[i]) == 0);
+
+  vectors = {Point({0, 1, 3}), Point({-2, -1, 1}), Point({6, 3, 0}),
+             Point({0, 0, -3}), Point({5, 0, -1})};
+  nonOrth = getNonOrthogonalVector(vectors);
+
+  for (const Point &vector : vectors)
+    EXPECT_FALSE(dotProduct(nonOrth, vector) == 0);
+}

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -83,6 +83,9 @@ TEST(BarvinokTest, unimodularConeGeneratingFunction) {
           {{{8, 47, -17}, {-7, -41, 15}, {1, 5, -2}}}));
 }
 
+// The following vectors are randomly generated.
+// We then check that the output of the function has nonzero
+// dot product with all non-null vectors.
 TEST(BarvinokTest, getNonOrthogonalVector) {
   std::vector<Point> vectors = {Point({1, 2, 3, 4}), Point({-1, 0, 1, 1}),
                                 Point({2, 7, 0, 0}), Point({0, 0, 0, 0})};
@@ -97,4 +100,41 @@ TEST(BarvinokTest, getNonOrthogonalVector) {
 
   for (const Point &vector : vectors)
     EXPECT_FALSE(dotProduct(nonOrth, vector) == 0);
+}
+
+Fraction getC(QuasiPolynomial q) {
+  Fraction t = 0;
+  for (const Fraction &c : q.getCoefficients())
+    t += c;
+
+  return t;
+}
+
+// The following polynomials are randomly generated and the
+// coefficients are computed by hand.
+// Although the function allows the coefficients of the numerator
+// to be arbitrary quasipolynomials, we stick to constants for simplicity,
+// as the relevant arithmetic operations on quasipolynomials
+// are tested separately.
+TEST(BarvinokTest, getCoefficientInRationalFunction) {
+  std::vector<QuasiPolynomial> numerator = {
+      QuasiPolynomial(0, 2), QuasiPolynomial(0, 3), QuasiPolynomial(0, 5)};
+
+  std::vector<Fraction> denominator = {Fraction(1), Fraction(0), Fraction(4),
+                                       Fraction(3)};
+
+  QuasiPolynomial coeff =
+      getCoefficientInRationalFunction(1, numerator, denominator);
+
+  EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(coeff, 3);
+
+  numerator = {QuasiPolynomial(0, -1), QuasiPolynomial(0, 4),
+               QuasiPolynomial(0, -2), QuasiPolynomial(0, 5),
+               QuasiPolynomial(0, 6)};
+
+  denominator = {Fraction(8), Fraction(4), Fraction(0), Fraction(-2)};
+
+  coeff = getCoefficientInRationalFunction(3, numerator, denominator);
+
+  EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(coeff, Fraction(55, 64));
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -84,7 +84,7 @@ TEST(BarvinokTest, unimodularConeGeneratingFunction) {
 }
 
 // The following vectors are randomly generated.
-// We then check that the output of the function has nonzero
+// We then check that the output of the function has non-zero
 // dot product with all non-null vectors.
 TEST(BarvinokTest, getNonOrthogonalVector) {
   std::vector<Point> vectors = {Point({1, 2, 3, 4}), Point({-1, 0, 1, 1}),
@@ -92,14 +92,14 @@ TEST(BarvinokTest, getNonOrthogonalVector) {
   Point nonOrth = getNonOrthogonalVector(vectors);
 
   for (unsigned i = 0; i < 3; i++)
-    EXPECT_FALSE(dotProduct(nonOrth, vectors[i]) == 0);
+    EXPECT_NE(dotProduct(nonOrth, vectors[i]), 0);
 
   vectors = {Point({0, 1, 3}), Point({-2, -1, 1}), Point({6, 3, 0}),
              Point({0, 0, -3}), Point({5, 0, -1})};
   nonOrth = getNonOrthogonalVector(vectors);
 
   for (const Point &vector : vectors)
-    EXPECT_FALSE(dotProduct(nonOrth, vector) == 0);
+    EXPECT_NE(dotProduct(nonOrth, vector), 0);
 }
 
 // The following polynomials are randomly generated and the

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -102,14 +102,6 @@ TEST(BarvinokTest, getNonOrthogonalVector) {
     EXPECT_FALSE(dotProduct(nonOrth, vector) == 0);
 }
 
-Fraction getC(QuasiPolynomial q) {
-  Fraction t = 0;
-  for (const Fraction &c : q.getCoefficients())
-    t += c;
-
-  return t;
-}
-
 // The following polynomials are randomly generated and the
 // coefficients are computed by hand.
 // Although the function allows the coefficients of the numerator

--- a/mlir/unittests/Analysis/Presburger/Utils.h
+++ b/mlir/unittests/Analysis/Presburger/Utils.h
@@ -128,20 +128,6 @@ inline void EXPECT_EQ_REPR_QUASIPOLYNOMIAL(QuasiPolynomial a,
   }
 }
 
-// Check the constant term of the quasipolynomial against a constant.
-inline void EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(QuasiPolynomial qp,
-                                                 Fraction f) {
-  SmallVector<Fraction> coeffs = qp.getCoefficients();
-  std::vector<std::vector<SmallVector<Fraction>>> aff = qp.getAffine();
-
-  Fraction t = 0;
-  for (unsigned i = 0, e = coeffs.size(); i < e; ++i) {
-    if (aff[i].size() == 0)
-      t += coeffs[i];
-  }
-  EXPECT_EQ(t, f);
-}
-
 /// lhs and rhs represent non-negative integers or positive infinity. The
 /// infinity case corresponds to when the Optional is empty.
 inline bool infinityOrUInt64LE(std::optional<MPInt> lhs,

--- a/mlir/unittests/Analysis/Presburger/Utils.h
+++ b/mlir/unittests/Analysis/Presburger/Utils.h
@@ -128,6 +128,20 @@ inline void EXPECT_EQ_REPR_QUASIPOLYNOMIAL(QuasiPolynomial a,
   }
 }
 
+// Check the constant term of the quasipolynomial against a constant.
+inline void EXPECT_CONSTANT_TERM_QUASIPOLYNOMIAL(QuasiPolynomial qp,
+                                                 Fraction f) {
+  SmallVector<Fraction> coeffs = qp.getCoefficients();
+  std::vector<std::vector<SmallVector<Fraction>>> aff = qp.getAffine();
+
+  Fraction t = 0;
+  for (unsigned i = 0, e = coeffs.size(); i < e; ++i) {
+    if (aff[i].size() == 0)
+      t += coeffs[i];
+  }
+  EXPECT_EQ(t, f);
+}
+
 /// lhs and rhs represent non-negative integers or positive infinity. The
 /// infinity case corresponds to when the Optional is empty.
 inline bool infinityOrUInt64LE(std::optional<MPInt> lhs,


### PR DESCRIPTION
We implement two functions that are needed to compute the constant term of a GF.
One finds a vector not orthogonal to all the non-null vectors in a given set.
One computes the coefficient of any term in an arbitrary rational function (quotient of two polynomials).