### PR TITLE
[GlobalISel] Revise 'assignCustomValue' interface

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
@@ -291,8 +291,8 @@ public:
     /// \p If the handler wants the assignments to be delayed until after
     /// mem loc assignments, then it sets \p Thunk to the thunk to do the
     /// assignment.
-    /// \return The number of \p VAs that have been assigned after the first
-    ///         one, and which should therefore be skipped from further
+    /// \return The number of \p VAs that have been assigned including the
+    ///         first one, and which should therefore be skipped from further
     ///         processing.
     virtual unsigned assignCustomValue(ArgInfo &Arg, ArrayRef<CCValAssign> VAs,
                                        std::function<void()> *Thunk = nullptr) {

--- a/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
@@ -694,7 +694,7 @@ bool CallLowering::handleAssignments(ValueHandler &Handler,
         DelayedOutgoingRegAssignments.emplace_back(Thunk);
       if (!NumArgRegs)
         return false;
-      j += NumArgRegs;
+      j += (NumArgRegs - 1);
       continue;
     }
 

--- a/llvm/lib/Target/ARM/ARMCallLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMCallLowering.cpp
@@ -166,11 +166,11 @@ struct ARMOutgoingValueHandler : public CallLowering::OutgoingValueHandler {
         assignValueToReg(NewRegs[0], VA.getLocReg(), VA);
         assignValueToReg(NewRegs[1], NextVA.getLocReg(), NextVA);
       };
-      return 1;
+      return 2;
     }
     assignValueToReg(NewRegs[0], VA.getLocReg(), VA);
     assignValueToReg(NewRegs[1], NextVA.getLocReg(), NextVA);
-    return 1;
+    return 2;
   }
 
   MachineInstrBuilder MIB;
@@ -341,7 +341,7 @@ struct ARMIncomingValueHandler : public CallLowering::IncomingValueHandler {
 
     MIRBuilder.buildMergeLikeInstr(Arg.Regs[0], NewRegs);
 
-    return 1;
+    return 2;
   }
 
   /// Marking a physical register as used is different between formal

--- a/llvm/lib/Target/Mips/MipsCallLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsCallLowering.cpp
@@ -185,7 +185,7 @@ MipsIncomingValueHandler::assignCustomValue(CallLowering::ArgInfo &Arg,
 
   markPhysRegUsed(VALo.getLocReg());
   markPhysRegUsed(VAHi.getLocReg());
-  return 1;
+  return 2;
 }
 
 namespace {

--- a/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
@@ -146,11 +146,11 @@ struct RISCVOutgoingValueHandler : public CallLowering::OutgoingValueHandler {
 
     if (Thunk) {
       *Thunk = assignFunc;
-      return 1;
+      return 2;
     }
 
     assignFunc();
-    return 1;
+    return 2;
   }
 
 private:
@@ -266,7 +266,7 @@ struct RISCVIncomingValueHandler : public CallLowering::IncomingValueHandler {
 
     MIRBuilder.buildMergeLikeInstr(Arg.Regs[0], NewRegs);
 
-    return 1;
+    return 2;
   }
 
   /// How the physical register gets marked varies between formal


### PR DESCRIPTION
- Previously, 'assignCustomValue' requests the number of assigned VAs minus 1 is returned and treats 0 as the assignment failure. However, under that arrangment, we cannot tell a successful *single* VA custom assignment from the failure case.
- This change requests that 'assignCustomValue' just return the number of all VAs assigned, including the first WA so that it won't be ambigous to tell the failure case from the single VA custom assignment.