### PR TITLE
[clang][FatLTO][UnifiedLTO] Pass -enable-matrix to the LTO driver

### DIFF
--- a/clang/test/Driver/matrix.c
+++ b/clang/test/Driver/matrix.c
@@ -6,3 +6,15 @@
 // RUN: %clang -flto=thin -fenable-matrix %t.o -### --target=x86_64-unknown-linux 2>&1 \
 // RUN:     | FileCheck %s -check-prefix=CHECK-THINLTO-MATRIX
 // CHECK-THINLTO-MATRIX: "-plugin-opt=-enable-matrix"
+
+// RUN: %clang -flto -ffat-lto-objects -fenable-matrix %t.o -### --target=x86_64-unknown-linux 2>&1 \
+// RUN:     | FileCheck %s -check-prefix=CHECK-THINLTO-MATRIX
+
+// RUN: %clang -flto=thin -ffat-lto-objects -fenable-matrix %t.o -### --target=x86_64-unknown-linux 2>&1 \
+// RUN:     | FileCheck %s -check-prefix=CHECK-THINLTO-MATRIX
+
+// RUN: %clang -flto -funified-lto -fenable-matrix %t.o -### --target=x86_64-unknown-linux 2>&1 \
+// RUN:     | FileCheck %s -check-prefix=CHECK-THINLTO-MATRIX
+
+// RUN: %clang -flto=thin -funified-lto -fenable-matrix %t.o -### --target=x86_64-unknown-linux 2>&1 \
+// RUN:     | FileCheck %s -check-prefix=CHECK-THINLTO-MATRIX


### PR DESCRIPTION
Unified LTO and Fat LTO do not use the regular LTO prelink pipeline when -flto/-flto=full is specified on the command line, thus they require LowerMatrixIntrinsicsPass to be run during the link stage. To enable this, we pass -enable-matrix to the LTO driver, replicating ThinLTO behavior.

This fixes #77621.