### PR TITLE
[flang][runtime] Emit leading space before zero-length list-directed …

### DIFF
--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -698,9 +698,6 @@ void FormattedIoStatementState<Direction::Input>::GotChar(int n) {
 
 bool ListDirectedStatementState<Direction::Output>::EmitLeadingSpaceOrAdvance(
     IoStatementState &io, std::size_t length, bool isCharacter) {
-  if (length == 0) {
-    return true;
-  }
   const ConnectionState &connection{io.GetConnectionState()};
   int space{connection.positionInRecord == 0 ||
       !(isCharacter && lastWasUndelimitedCharacter())};


### PR DESCRIPTION
…character

Don't omit the leading space in list-directed output before a line comprising only a zero-length character value.

Fixes https://github.com/llvm/llvm-project/issues/77736.