### PR TITLE
[StackSafetyAnalysis] Bail out if MemIntrinsic length is -1

### DIFF
--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -331,7 +331,7 @@ ConstantRange StackSafetyLocalAnalysis::getMemIntrinsicAccessRange(
   const SCEV *Expr =
       SE.getTruncateOrZeroExtend(SE.getSCEV(MI->getLength()), CalculationTy);
   ConstantRange Sizes = SE.getSignedRange(Expr);
-  if (Sizes.getUpper().isNegative() || isUnsafe(Sizes))
+  if (!Sizes.getUpper().isStrictlyPositive() || isUnsafe(Sizes))
     return UnknownRange;
   Sizes = Sizes.sextOrTrunc(PointerSize);
   ConstantRange SizeRange(APInt::getZero(PointerSize), Sizes.getUpper() - 1);

--- a/llvm/test/Analysis/StackSafetyAnalysis/memintrin.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/memintrin.ll
@@ -98,6 +98,40 @@ entry:
   ret void
 }
 
+define void @MemsetHugeUpper_m1(i1 %bool) {
+; CHECK-LABEL: MemsetHugeUpper_m1 dso_preemptable{{$}}
+; CHECK-NEXT: args uses:
+; CHECK-NEXT: allocas uses:
+; CHECK-NEXT:   x[4]: full-set
+entry:
+  %x = alloca i32, align 4
+  br i1 %bool, label %if.then, label %if.end
+
+if.then:
+  call void @llvm.memset.p0.i64(ptr %x, i8 0, i64 -1, i1 false)
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+define void @MemsetHugeUpper_m2(i1 %bool) {
+; CHECK-LABEL: MemsetHugeUpper_m2 dso_preemptable{{$}}
+; CHECK-NEXT: args uses:
+; CHECK-NEXT: allocas uses:
+; CHECK-NEXT:   x[4]: full-set
+entry:
+  %x = alloca i32, align 4
+  br i1 %bool, label %if.then, label %if.end
+
+if.then:
+  call void @llvm.memset.p0.i64(ptr %x, i8 0, i64 -2, i1 false)
+  br label %if.end
+
+if.end:
+  ret void
+}
+
 define void @MemcpyInBounds() {
 ; CHECK-LABEL: MemcpyInBounds dso_preemptable{{$}}
 ; CHECK-NEXT: args uses:


### PR DESCRIPTION
Clang generates llvm.memset.p0.i64 with a length of -1 for the following code in
`-stdlib=libc++ -std=c++20` mode
(https://github.com/llvm/llvm-project/pull/77210#issuecomment-1887650010)
```cpp
bool strtof_clamp(const std::string &str);
void floatsuffix_check(char *yytext_r) {
  std::string text = yytext_r;
  text.resize(text.size() - 1);
  strtof_clamp(text);
}
```

`Sizes = [0xffffffffffffffff, 0)`. `SizeRange = [0, 0-1)`, leading to
`assert(!isUnsafe(SizeRange));` failure. Bail out if the length is -1.
Other negative values are handled by the existing condition.
