### PR TITLE
[ASAN][sanitizers][win] Allow windows-asan to be built with /MDd and intercept functions from the debug runtimes.

### DIFF
--- a/compiler-rt/lib/asan/asan_win.cpp
+++ b/compiler-rt/lib/asan/asan_win.cpp
@@ -264,9 +264,7 @@ void PlatformTSDDtor(void *tsd) { AsanThread::TSDDtor(tsd); }
 // }}}
 
 // ---------------------- Various stuff ---------------- {{{
-void *AsanDoesNotSupportStaticLinkage() {
-  return 0;
-}
+void *AsanDoesNotSupportStaticLinkage() { return 0; }
 
 uptr FindDynamicShadowStart() {
   return MapDynamicShadow(MemToShadowSize(kHighMemEnd), ASAN_SHADOW_SCALE,

--- a/compiler-rt/lib/asan/asan_win.cpp
+++ b/compiler-rt/lib/asan/asan_win.cpp
@@ -265,9 +265,6 @@ void PlatformTSDDtor(void *tsd) { AsanThread::TSDDtor(tsd); }
 
 // ---------------------- Various stuff ---------------- {{{
 void *AsanDoesNotSupportStaticLinkage() {
-#if defined(_DEBUG)
-#error Please build the runtime with a non-debug CRT: /MD or /MT
-#endif
   return 0;
 }
 

--- a/compiler-rt/lib/interception/interception_win.cpp
+++ b/compiler-rt/lib/interception/interception_win.cpp
@@ -946,6 +946,11 @@ bool OverrideFunction(
 static void **InterestingDLLsAvailable() {
   static const char *InterestingDLLs[] = {
       "kernel32.dll",
+      "msvcr100d.dll",                // VS2010
+      "msvcr110d.dll",                // VS2012
+      "msvcr120d.dll",                // VS2013
+      "vcruntime140d.dll",            // VS2015
+      "ucrtbased.dll",  // Universal CRT
       "msvcr100.dll",      // VS2010
       "msvcr110.dll",      // VS2012
       "msvcr120.dll",      // VS2013

--- a/compiler-rt/lib/interception/interception_win.cpp
+++ b/compiler-rt/lib/interception/interception_win.cpp
@@ -945,24 +945,26 @@ bool OverrideFunction(
 
 static void **InterestingDLLsAvailable() {
   static const char *InterestingDLLs[] = {
-      "kernel32.dll",
-      "msvcr100d.dll",                // VS2010
-      "msvcr110d.dll",                // VS2012
-      "msvcr120d.dll",                // VS2013
-      "vcruntime140d.dll",            // VS2015
-      "ucrtbased.dll",  // Universal CRT
-      "msvcr100.dll",      // VS2010
-      "msvcr110.dll",      // VS2012
-      "msvcr120.dll",      // VS2013
-      "vcruntime140.dll",  // VS2015
-      "ucrtbase.dll",      // Universal CRT
-#if (defined(__MINGW32__) && defined(__i386__))
-      "libc++.dll",        // libc++
-      "libunwind.dll",     // libunwind
-#endif
-      // NTDLL should go last as it exports some functions that we should
-      // override in the CRT [presumably only used internally].
-      "ntdll.dll", NULL};
+    "kernel32.dll",
+    "msvcr100d.dll",      // VS2010
+    "msvcr110d.dll",      // VS2012
+    "msvcr120d.dll",      // VS2013
+    "vcruntime140d.dll",  // VS2015
+    "ucrtbased.dll",      // Universal CRT
+    "msvcr100.dll",       // VS2010
+    "msvcr110.dll",       // VS2012
+    "msvcr120.dll",       // VS2013
+    "vcruntime140.dll",   // VS2015
+    "ucrtbase.dll",       // Universal CRT
+#  if (defined(__MINGW32__) && defined(__i386__))
+    "libc++.dll",     // libc++
+    "libunwind.dll",  // libunwind
+#  endif
+    // NTDLL should go last as it exports some functions that we should
+    // override in the CRT [presumably only used internally].
+    "ntdll.dll",
+    NULL
+  };
   static void *result[ARRAY_SIZE(InterestingDLLs)] = { 0 };
   if (!result[0]) {
     for (size_t i = 0, j = 0; InterestingDLLs[i]; ++i) {


### PR DESCRIPTION
It turns out this works _mostly_ fine, even when mixing debug versions of asan with programs built with the release runtime. Using /MT (or /MTd) with a dynamically linked asan has never really worked that well, and I am planning on opening a PR that will completely remove the static-asan configuration for windows and make programs linked with the static CRT/runtime work with the DLL version of asan. This is better than the current situation because the static linked version of asan doesn't work well on windows if there are multiple DLLs in the process using it.

The check for building asan with only /MD or /MT has been removed. It was in AsanDoesNotSupportStaticLinkage, but was checking for debug CRTs, not static linkage. The kind of static linkage this function is supposed to check for (on linux for example) doesn't really exist on windows.

Note: There is one outstanding issue with this approach, if you mix a /MDd DLLs and /MD dlls in the same process then the "real" function called by asan interceptors will be the same for calls from both contexts, potentially screwing up things like errno. This only happens if you mix /MD and /MDd in the same process, because otherwise asan won't find functions from both runtimes to intercept. We are working on a fix for this, and it mainly hits with the CRT functions exported from both ucrtbase and ntdll.


This change is being upstreamed from our fork.