### PR TITLE
[OpenMP] Fix or disable NVPTX tests failing currently

### DIFF
--- a/openmp/libomptarget/test/libc/assert.c
+++ b/openmp/libomptarget/test/libc/assert.c
@@ -3,6 +3,8 @@
 
 // REQUIRES: libc
 
+// NVPTX without LTO uses the implementation in OpenMP currently.
+// UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: powerpc64-ibm-linux-gnu
 // UNSUPPORTED: powerpc64-ibm-linux-gnu-LTO
 // UNSUPPORTED: aarch64-unknown-linux-gnu

--- a/openmp/libomptarget/test/mapping/target_derefence_array_pointrs.cpp
+++ b/openmp/libomptarget/test/mapping/target_derefence_array_pointrs.cpp
@@ -2,7 +2,10 @@
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
 
+// FIXME: This is currently broken on all GPU targets
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/libomptarget/test/mapping/target_uses_allocator.c
+++ b/openmp/libomptarget/test/mapping/target_uses_allocator.c
@@ -1,6 +1,9 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 
+// FIXME: https://github.com/llvm/llvm-project/issues/77841
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/libomptarget/test/mapping/target_wrong_use_device_addr.c
+++ b/openmp/libomptarget/test/mapping/target_wrong_use_device_addr.c
@@ -2,6 +2,9 @@
 // RUN: env LIBOMPTARGET_INFO=64 %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
 
+// FIXME: Fails due to optimized debugging in 'ptxas'
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+
 #include <stdio.h>
 
 int main() {

--- a/openmp/libomptarget/test/offloading/bug64959.c
+++ b/openmp/libomptarget/test/offloading/bug64959.c
@@ -1,8 +1,11 @@
-// RUN: %libomptarget-compilexx-run-and-check-generic
-// RUN: %libomptarget-compileoptxx-run-and-check-generic
+// RUN: %libomptarget-compile-run-and-check-generic
+// RUN: %libomptarget-compileopt-run-and-check-generic
 
 // TODO: This requires malloc support for the threads states.
+// FIXME: Flaky on all GPU targets.
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/libomptarget/test/offloading/info.c
+++ b/openmp/libomptarget/test/offloading/info.c
@@ -5,6 +5,9 @@
 // RUN: env LIBOMPTARGET_INFO=63 %libomptarget-run-amdgcn-amd-amdhsa 2>&1 | \
 // RUN:   %fcheck-amdgcn-amd-amdhsa -allow-empty -check-prefixes=INFO,AMDGPU
 
+// FIXME: Fails due to optimized debugging in 'ptxas'.
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/openmp/libomptarget/test/offloading/std_complex_arithmetic.cpp
+++ b/openmp/libomptarget/test/offloading/std_complex_arithmetic.cpp
@@ -6,6 +6,7 @@
 // FIXME: This fails to link due to missing math symbols. We should provide the
 //        needed math functions in the GPU `libm` and require the GPU C library.
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <cassert>
 #include <complex>

--- a/openmp/libomptarget/test/unified_shared_memory/close_enter_exit.c
+++ b/openmp/libomptarget/test/unified_shared_memory/close_enter_exit.c
@@ -4,7 +4,10 @@
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
 
 // Fails on amdgpu with error: GPU Memory Error
+// Fails on nvptx with error: an illegal memory access was encountered
 // XFAIL: amdgcn-amd-amdhsa
+// XFAIL: nvptx64-nvidia-cuda
+// XFAIL: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/libomptarget/test/unified_shared_memory/close_modifier.c
+++ b/openmp/libomptarget/test/unified_shared_memory/close_modifier.c
@@ -4,7 +4,10 @@
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
 
 // amdgpu runtime crash
+// Fails on nvptx with error: an illegal memory access was encountered
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/libomptarget/test/unified_shared_memory/shared_update.c
+++ b/openmp/libomptarget/test/unified_shared_memory/shared_update.c
@@ -3,7 +3,10 @@
 // REQUIRES: unified_shared_memory
 
 // amdgpu runtime crash
+// Fails on nvptx with error: an illegal memory access was encountered
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Summary:
This patch is an attempt to get a clean run of `check-openmp` running on
an NVPTX machine. I simply took the lists of tests that failed on my
`sm_89` machine and disabled them or fixed them. A lot of these tests
are disabled on AMDGPU already, so it makes sense that NVPTX fails. The
others are simply problems with NVPTX optimized debugging which will
need to be fixed. I opened an issue on one of them.
