### PR TITLE
[libc] Build native libc-hdrgen when crosscompiling

### DIFF
--- a/libc/utils/HdrGen/CMakeLists.txt
+++ b/libc/utils/HdrGen/CMakeLists.txt
@@ -18,3 +18,5 @@ target_include_directories(libc-hdrgen PRIVATE ${LLVM_INCLUDE_DIR} ${LLVM_MAIN_I
 target_link_libraries(libc-hdrgen PRIVATE LibcTableGenUtil)
 
 add_subdirectory(PrototypeTestGen)
+
+setup_host_tool(libc-hdrgen LIBC_HDRGEN libc_hdrgen_exe libc_hdrgen_target)

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -67,6 +67,12 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "-DLLVM_EXTERNAL_${name}_SOURCE_DIR=${LLVM_EXTERNAL_${name}_SOURCE_DIR}")
   endforeach()
 
+  if("libc" IN_LIST LLVM_ENABLE_PROJECTS)
+    if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_HDRGEN_EXE)
+      set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON -DLIBC_HDRGEN_ONLY=ON)
+    endif()
+  endif()
+
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
         -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
@@ -86,7 +92,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
-        ${build_type_flags} ${linker_flag} ${external_clang_dir}
+        ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}
     DEPENDS CREATE_${project_name}_${target_name}

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -425,18 +425,14 @@ if(runtimes)
   endif()
   if("libc" IN_LIST LLVM_ENABLE_PROJECTS AND
       (LLVM_LIBC_FULL_BUILD OR LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES))
-    if(TARGET libc-hdrgen)
-      set(libc_tools libc-hdrgen)
-      set(libc_cmake_args "-DLIBC_HDRGEN_EXE=$<TARGET_FILE:libc-hdrgen>"
-                          "-DLLVM_LIBC_FULL_BUILD=ON")
-      list(APPEND extra_deps ${libc_tools})
-    else()
-      # We want to build the libc build tools before we can build the libc
-      # itself. So, the libc project should be included in LLVM_ENABLE_PROJECTS.
-      # This should have been done in llvm/CMakeLists.txt automatically when
-      # "libc" is detected in LLVM_ENABLE_RUNTIMES.
-      message(FATAL_ERROR "libc-hdrgen target missing unexpectedly")
+    get_host_tool_path(libc-hdrgen LIBC_HDRGEN libc_hdrgen_exe libc_hdrgen_target)
+    if(NOT libc_hdrgen_exe)
+      message(FATAL_ERROR "libc-hdrgen executable missing")
     endif()
+    set(libc_cmake_args "-DLIBC_HDRGEN_EXE=${libc_hdrgen_exe}"
+                        "-DLLVM_LIBC_FULL_BUILD=ON")
+    set(libc_tools libc_hdrgen_target)
+    list(APPEND extra_deps ${libc_hdrgen_target})
     if(LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES)
       foreach(dep clang-offload-packager nvptx-arch amdgpu-arch)
         if(TARGET ${dep})


### PR DESCRIPTION
When crosscompiling tools for a different architecture, we need to build native libc-hdrgen which can be achieved using the existing CMake support for crosscompiling tablegen tools.