### PR TITLE
[flang] Allow different linker name

### DIFF
--- a/flang/test/Driver/isysroot.f90
+++ b/flang/test/Driver/isysroot.f90
@@ -6,7 +6,7 @@
 ! RUN: %flang -### --target=aarch64-linux-gnu -isysroot /path/to/sysroot \
 ! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-LINUX
 
-! CHECK-DARWIN: "{{.*[\/]}}ld" {{.*}}"-syslibroot" "/path/to/sysroot"
+! CHECK-DARWIN: "{{.*[\/]}}ld{{(64)?(.lld)?}}" {{.*}}"-syslibroot" "/path/to/sysroot"
 ! Unused on Linux.
 ! CHECK-LINUX: warning: argument unused during compilation: '-isysroot /path/to/sysroot'
 ! CHECK-LINUX-NOT: /path/to/sysroot

--- a/flang/test/Driver/isysroot.f90
+++ b/flang/test/Driver/isysroot.f90
@@ -6,7 +6,7 @@
 ! RUN: %flang -### --target=aarch64-linux-gnu -isysroot /path/to/sysroot \
 ! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-LINUX
 
-! CHECK-DARWIN: "{{.*[\/]}}ld{{(64)?(\.lld)?}}" {{.*}}"-syslibroot" "/path/to/sysroot"
+! CHECK-DARWIN: "{{.*}}ld{{(64)?(\.lld)?}}" {{.*}}"-syslibroot" "/path/to/sysroot"
 ! Unused on Linux.
 ! CHECK-LINUX: warning: argument unused during compilation: '-isysroot /path/to/sysroot'
 ! CHECK-LINUX-NOT: /path/to/sysroot

--- a/flang/test/Driver/isysroot.f90
+++ b/flang/test/Driver/isysroot.f90
@@ -6,7 +6,7 @@
 ! RUN: %flang -### --target=aarch64-linux-gnu -isysroot /path/to/sysroot \
 ! RUN:        %s 2>&1 | FileCheck %s --check-prefix=CHECK-LINUX
 
-! CHECK-DARWIN: "{{.*[\/]}}ld{{(64)?(.lld)?}}" {{.*}}"-syslibroot" "/path/to/sysroot"
+! CHECK-DARWIN: "{{.*[\/]}}ld{{(64)?(\.lld)?}}" {{.*}}"-syslibroot" "/path/to/sysroot"
 ! Unused on Linux.
 ! CHECK-LINUX: warning: argument unused during compilation: '-isysroot /path/to/sysroot'
 ! CHECK-LINUX-NOT: /path/to/sysroot


### PR DESCRIPTION
The linker name is different if  the `lld` project is enabled `-DLLVM_ENABLE_PROJECTS="...;lld"`.