### PR TITLE
[lldb][NFCI] Remove CommandReturnObject from BreakpointIDList

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -12,11 +12,12 @@
 #include <utility>
 #include <vector>
 
-
-#include "lldb/lldb-enumerations.h"
 #include "lldb/Breakpoint/BreakpointID.h"
 #include "lldb/Breakpoint/BreakpointName.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
+
+#include "llvm/Support/Error.h"
 
 namespace lldb_private {
 

--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -54,12 +54,10 @@ public:
   static std::pair<llvm::StringRef, llvm::StringRef>
   SplitIDRangeExpression(llvm::StringRef in_string);
 
-  static void FindAndReplaceIDRanges(Args &old_args, Target *target,
-                                     bool allow_locations,
-                                     BreakpointName::Permissions
-                                       ::PermissionKinds purpose,
-                                     CommandReturnObject &result,
-                                     Args &new_args);
+  static llvm::Error
+  FindAndReplaceIDRanges(Args &old_args, Target *target, bool allow_locations,
+                         BreakpointName::Permissions ::PermissionKinds purpose,
+                         Args &new_args);
 
 private:
   BreakpointIDArray m_breakpoint_ids;

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -2488,8 +2488,12 @@ void CommandObjectMultiwordBreakpoint::VerifyIDs(
   // breakpoint ids in the range, and shove all of those breakpoint id strings
   // into TEMP_ARGS.
 
-  BreakpointIDList::FindAndReplaceIDRanges(args, target, allow_locations,
-                                           purpose, result, temp_args);
+  if (llvm::Error err = BreakpointIDList::FindAndReplaceIDRanges(
+          args, target, allow_locations, purpose, temp_args)) {
+    result.SetError(std::move(err));
+    return;
+  }
+  result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
   // NOW, convert the list of breakpoint id strings in TEMP_ARGS into an actual
   // BreakpointIDList:
@@ -2501,33 +2505,31 @@ void CommandObjectMultiwordBreakpoint::VerifyIDs(
   // At this point,  all of the breakpoint ids that the user passed in have
   // been converted to breakpoint IDs and put into valid_ids.
 
-  if (result.Succeeded()) {
-    // Now that we've converted everything from args into a list of breakpoint
-    // ids, go through our tentative list of breakpoint id's and verify that
-    // they correspond to valid/currently set breakpoints.
+  // Now that we've converted everything from args into a list of breakpoint
+  // ids, go through our tentative list of breakpoint id's and verify that
+  // they correspond to valid/currently set breakpoints.
 
-    const size_t count = valid_ids->GetSize();
-    for (size_t i = 0; i < count; ++i) {
-      BreakpointID cur_bp_id = valid_ids->GetBreakpointIDAtIndex(i);
-      Breakpoint *breakpoint =
-          target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
-      if (breakpoint != nullptr) {
-        const size_t num_locations = breakpoint->GetNumLocations();
-        if (static_cast<size_t>(cur_bp_id.GetLocationID()) > num_locations) {
-          StreamString id_str;
-          BreakpointID::GetCanonicalReference(
-              &id_str, cur_bp_id.GetBreakpointID(), cur_bp_id.GetLocationID());
-          i = valid_ids->GetSize() + 1;
-          result.AppendErrorWithFormat(
-              "'%s' is not a currently valid breakpoint/location id.\n",
-              id_str.GetData());
-        }
-      } else {
+  const size_t count = valid_ids->GetSize();
+  for (size_t i = 0; i < count; ++i) {
+    BreakpointID cur_bp_id = valid_ids->GetBreakpointIDAtIndex(i);
+    Breakpoint *breakpoint =
+        target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+    if (breakpoint != nullptr) {
+      const size_t num_locations = breakpoint->GetNumLocations();
+      if (static_cast<size_t>(cur_bp_id.GetLocationID()) > num_locations) {
+        StreamString id_str;
+        BreakpointID::GetCanonicalReference(
+            &id_str, cur_bp_id.GetBreakpointID(), cur_bp_id.GetLocationID());
         i = valid_ids->GetSize() + 1;
         result.AppendErrorWithFormat(
-            "'%d' is not a currently valid breakpoint ID.\n",
-            cur_bp_id.GetBreakpointID());
+            "'%s' is not a currently valid breakpoint/location id.\n",
+            id_str.GetData());
       }
+    } else {
+      i = valid_ids->GetSize() + 1;
+      result.AppendErrorWithFormat(
+          "'%d' is not a currently valid breakpoint ID.\n",
+          cur_bp_id.GetBreakpointID());
     }
   }
 }


### PR DESCRIPTION
BreakpointIDList does not need to know about CommandReturnObject. BreakpointIDList::FindAndReplaceIDRanges is the last place that uses it in BreakpointIDList.

Instead of passing in a CommandReturnObject, it now returns an llvm::Error. The callsite uses the Error to populate the CommandReturnObject as needed.