### PR TITLE
[libc++][test] Fix a logical mistake introduced by #77058

### DIFF
--- a/libcxx/test/support/filesystem_test_helper.h
+++ b/libcxx/test/support/filesystem_test_helper.h
@@ -330,7 +330,7 @@ struct scoped_test_env
 // Android platform warns about tmpnam, since the problem does not appear
 // on Android, let's not apply it for Android.
 #  if !defined(__ANDROID__)
-    if (file.size() <= sizeof(address.sun_path)) {
+    if (file.size() > sizeof(address.sun_path)) {
       file = std::tmpnam(nullptr);
     }
 #  endif


### PR DESCRIPTION
A logical mistake is made in #77058, we should try to find a new file path for socket creation when the path's length generated is bigger than the socket length limit.