### PR TITLE
[clang-tidy]fix readability-implicit-bool-conversion false-positives when comparison bool bitfield

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -274,8 +274,7 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
             allOf(anyOf(hasCastKind(CK_NullToPointer),
                         hasCastKind(CK_NullToMemberPointer)),
                   hasSourceExpression(cxxBoolLiteral()))),
-      hasSourceExpression(expr(hasType(booleanType()))),
-      unless(ExceptionCases));
+      hasSourceExpression(expr(hasType(booleanType()))));
   auto BoolXor =
       binaryOperator(hasOperatorName("^"), hasLHS(ImplicitCastFromBool),
                      hasRHS(ImplicitCastFromBool));
@@ -315,7 +314,7 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
       traverse(
           TK_AsIs,
           implicitCastExpr(
-              ImplicitCastFromBool,
+              ImplicitCastFromBool, unless(ExceptionCases),
               // Exclude comparisons of bools, as they are always cast to
               // integers in such context:
               //   bool_expr_a == bool_expr_b

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -478,7 +478,8 @@ Changes in existing checks
   <clang-tidy/checks/readability/implicit-bool-conversion>` check to take
   do-while loops into account for the `AllowIntegerConditions` and
   `AllowPointerConditions` options. It also now provides more consistent
-  suggestions when parentheses are added to the return value.
+  suggestions when parentheses are added to the return value. It also ignores
+  false-positives for comparison containing bool bitfield.
 
 - Improved :doc:`readability-misleading-indentation
   <clang-tidy/checks/readability/misleading-indentation>` check to ignore

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-allow-in-conditions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-allow-in-conditions.cpp
@@ -12,6 +12,7 @@ int* functionReturningPointer();
 struct Struct {
   int member;
   unsigned bitfield : 1;
+  bool boolfield : 1;
 };
 
 
@@ -28,6 +29,8 @@ void implicitConversionIntegerToBoolInConditionalsIsAllowed() {
   if (!s.member) {}
   if (s.bitfield) {}
   if (!s.bitfield) {}
+  if (s.boolfield == true) {}
+  if (s.boolfield != true) {}
   if (functionReturningInt()) {}
   if (!functionReturningInt()) {}
   if (functionReturningInt() && functionReturningPointer()) {}


### PR DESCRIPTION
Fixes: #76817
For ignoring comparison and xor operator, it needs to use ImplicitCastFromBool without ignoring exception cases. This patch splits ignoring exception cases logic from ImplicitCastFromBool and only applies it when add matcher