### PR TITLE
[libc++] Deprecate removed features macros.

### DIFF
--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -123,6 +123,12 @@ Deprecations and Removals
   overload of ``allocate``. However, this led to the library being non-conforming due to incorrect
   constexpr-ness.
 
+- The macros ``_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES`` and
+  ``_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES`` have been deprecated and
+  will be removed in LLVM 19. These macros used to enable all features
+  removed in C++17 and C++20. Instead of using these macros, use the
+  macros to enable the individual features.
+
 Upcoming Deprecations and Removals
 ----------------------------------
 
@@ -148,6 +154,10 @@ LLVM 19
 
 - The ``_LIBCPP_ENABLE_CXX20_REMOVED_ALLOCATOR_MEMBERS`` macro has been deprecated in LLVM 18 and will be removed
   entirely in LLVM 19.
+
+- The ``_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES`` and
+  ``_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES`` macros have been deprecated
+  in LLVM 18 and will be removed entirely in LLVM 19.
 
 LLVM 20
 ~~~~~~~

--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -125,9 +125,9 @@ Deprecations and Removals
 
 - The macros ``_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES`` and
   ``_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES`` have been deprecated and
-  will be removed in LLVM 19. These macros used to enable all features
-  removed in C++17 and C++20. Instead of using these macros, use the
-  macros to enable the individual features.
+  will be removed in LLVM 19. These macros used to re-enable all features
+  that were removed in the C++17 and C++20 standards. Instead of using these
+  macros, please use the macros to re-enable individual features.
 
 Upcoming Deprecations and Removals
 ----------------------------------

--- a/libcxx/docs/UsingLibcxx.rst
+++ b/libcxx/docs/UsingLibcxx.rst
@@ -275,6 +275,8 @@ C++17 Specific Configuration Macros
 **_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES**:
   This macro is used to re-enable all the features removed in C++17. The effect
   is equivalent to manually defining each macro listed below.
+  This macro is deprecated and will be removed in LLVM-19. Use the
+  individual macros listed below.
 
 **_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR**:
   This macro is used to re-enable `auto_ptr`.
@@ -303,6 +305,8 @@ C++20 Specific Configuration Macros
 **_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES**:
   This macro is used to re-enable all the features removed in C++20. The effect
   is equivalent to manually defining each macro listed below.
+  This macro is deprecated and will be removed in LLVM-19. Use the
+  individual macros listed below.
 
 **_LIBCPP_ENABLE_CXX20_REMOVED_ALLOCATOR_MEMBERS**:
   This macro is used to re-enable redundant members of `allocator<T>`,

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -16,6 +16,17 @@
 #  pragma GCC system_header
 #endif
 
+#if defined(_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES) && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
+#  pragma clang deprecated(                                                                                            \
+      _LIBCPP_ENABLE_CXX17_REMOVED_FEATURES,                                                                           \
+      "_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES is deprecated in LLVM 18 and will be removed in LLVM 19")
+#endif
+#if defined(_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES) && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
+#  pragma clang deprecated(                                                                                            \
+      _LIBCPP_ENABLE_CXX20_REMOVED_FEATURES,                                                                           \
+      "_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES is deprecated in LLVM 18 and will be removed in LLVM 19")
+#endif
+
 #if defined(__apple_build_version__)
 // Given AppleClang XX.Y.Z, _LIBCPP_APPLE_CLANG_VER is XXYZ (e.g. AppleClang 14.0.3 => 1403)
 #  define _LIBCPP_COMPILER_CLANG_BASED

--- a/libcxx/test/libcxx/depr/enable_removed_cpp17_features.compile.pass.cpp
+++ b/libcxx/test/libcxx/depr/enable_removed_cpp17_features.compile.pass.cpp
@@ -9,7 +9,7 @@
 // Test that defining _LIBCPP_ENABLE_CXX17_REMOVED_FEATURES correctly defines
 // _LIBCPP_ENABLE_CXX17_REMOVED_FOO for each individual component macro.
 
-// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES -Wno-deprecated-pragma
 
 #include <__config>
 

--- a/libcxx/test/libcxx/depr/enable_removed_cpp17_features.deprecated.verify.cpp
+++ b/libcxx/test/libcxx/depr/enable_removed_cpp17_features.deprecated.verify.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <__config>
+
+// Ensure that defining _LIBCPP_ENABLE_CXX17_REMOVED_FEATURES yields a
+// deprecation warning. We intend to issue a deprecation warning in LLVM 18
+// and remove the macro entirely in LLVM 19. As such, this test will be quite
+// short lived.
+
+// UNSUPPORTED: clang-modules-build
+
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES
+
+#include <__config> // expected-warning@* 1+ {{macro '_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES' has been marked as deprecated}}

--- a/libcxx/test/libcxx/depr/enable_removed_cpp20_features.deprecated.verify.cpp
+++ b/libcxx/test/libcxx/depr/enable_removed_cpp20_features.deprecated.verify.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <__config>
+
+// Ensure that defining _LIBCPP_ENABLE_CXX20_REMOVED_FEATURES yields a
+// deprecation warning. We intend to issue a deprecation warning in LLVM 18
+// and remove the macro entirely in LLVM 19. As such, this test will be quite
+// short lived.
+
+// UNSUPPORTED: clang-modules-build
+
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES
+
+#include <version> // expected-warning@* 1+ {{macro '_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES' has been marked as deprecated}}


### PR DESCRIPTION
We discussed the removal of these enable-all macros in the libc++ monthly meeting and we agreed that we should deprecate these macros in LLVM 18, and then remove them in LLVM 19 since they can silently enable deprecated features that are implemented after the first release of the macro.

This patch does the first part of this -- it deprecates the macro.

Note that the file
  test/libcxx/depr/enable_removed_cpp20_features.compile.pass.cpp
does not exist so this file is not adapted. Since the feature is deprecated and slated for removal soon the missing test is not implemented.

Partly addresses: https://github.com/llvm/llvm-project/issues/75976