### PR TITLE
Update Clang.cpp

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -951,7 +951,7 @@ static void handleAMDGPUCodeObjectVersionOptions(const Driver &D,
 static bool hasClangPchSignature(const Driver &D, StringRef Path) {
   if (llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> MemBuf =
           D.getVFS().getBufferForFile(Path))
-    return (*MemBuf)->getBuffer().starts_with("CPCH");
+    return (*MemBuf)->getBuffer().contains("CPCH");
   return false;
 }
 


### PR DESCRIPTION
fix error: .gch' was ignored because it is not a clang PCH file   https://github.com/llvm/llvm-project/issues/76923