### PR TITLE
[Clang][RISCV][RVV Intrinsic] Fix codegen redundant intrinsic names

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2479,9 +2479,11 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       }
       }] in {
 
-    defm : RVVNonTupleVCreateBuiltin<1, [0]>;
-    defm : RVVNonTupleVCreateBuiltin<2, [0, 1]>;
-    defm : RVVNonTupleVCreateBuiltin<3, [0, 1, 2]>;
+    let Log2LMUL = [-3] in {
+      defm : RVVNonTupleVCreateBuiltin<1, [0]>;
+      defm : RVVNonTupleVCreateBuiltin<2, [0, 1]>;
+      defm : RVVNonTupleVCreateBuiltin<3, [0, 1, 2]>;
+    }
 
     foreach nf = NFList in {
       let NF = nf in {

--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2479,6 +2479,8 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       }
       }] in {
 
+    // Since the vcreate_v uses LFixedLog2LMUL, setting the Log2LMUL to [-3] can
+    // avoid creating the intrinsics which contain the same name and prototype.
     let Log2LMUL = [-3] in {
       defm : RVVNonTupleVCreateBuiltin<1, [0]>;
       defm : RVVNonTupleVCreateBuiltin<2, [0, 1]>;


### PR DESCRIPTION
This patch avoids adding redundant vcreate_v intrinsics to the RISCV IntrinsicList.
Since vcreate_v uses LFixedLog2LMUL, I believe we can simply set Log2LMUL to the smallest value (-3) to prevent the creation of redundant vcreate_v instances with the same intrinsic name and prototype in the IntrinsicList when clang creates it.