### PR TITLE
[IPSCCP] Variable not visible at Og:

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3586,7 +3586,8 @@ DIExpression *llvm::getExpressionForConstant(DIBuilder &DIB, const Constant &C,
     return createIntegerExpression(C);
 
   auto *FP = dyn_cast<ConstantFP>(&C);
-  if (FP && (Ty.isFloatTy() || Ty.isDoubleTy())) {
+  if (FP &&
+      (Ty.isFloatTy() || Ty.isDoubleTy() || Ty.isHalfTy() || Ty.isBFloatTy())) {
     const APFloat &APF = FP->getValueAPF();
     return DIB.createConstantValueExpression(
         APF.bitcastToAPInt().getZExtValue());

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3586,8 +3586,7 @@ DIExpression *llvm::getExpressionForConstant(DIBuilder &DIB, const Constant &C,
     return createIntegerExpression(C);
 
   auto *FP = dyn_cast<ConstantFP>(&C);
-  if (FP &&
-      (Ty.isFloatTy() || Ty.isDoubleTy() || Ty.isHalfTy() || Ty.isBFloatTy())) {
+  if (FP && Ty.isFloatingPointTy()) {
     const APFloat &APF = FP->getValueAPF();
     return DIB.createConstantValueExpression(
         APF.bitcastToAPInt().getZExtValue());

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3586,12 +3586,11 @@ DIExpression *llvm::getExpressionForConstant(DIBuilder &DIB, const Constant &C,
     return createIntegerExpression(C);
 
   auto *FP = dyn_cast<ConstantFP>(&C);
-  if (FP && Ty.isFloatingPointTy()) {
+  if (FP &&
+      (Ty.isBFloatTy() || Ty.isHalfTy() || Ty.isFloatTy() || Ty.isDoubleTy())) {
     const APFloat &APF = FP->getValueAPF();
     APInt const &API = APF.bitcastToAPInt();
     if (auto Temp = API.tryZExtValue())
-      return DIB.createConstantValueExpression(static_cast<uint64_t>(*Temp));
-    else if (auto Temp = API.trySExtValue())
       return DIB.createConstantValueExpression(static_cast<uint64_t>(*Temp));
     return DIB.createConstantValueExpression(*API.getRawData());
   }

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3586,12 +3586,11 @@ DIExpression *llvm::getExpressionForConstant(DIBuilder &DIB, const Constant &C,
     return createIntegerExpression(C);
 
   auto *FP = dyn_cast<ConstantFP>(&C);
-  if (FP &&
-      (Ty.isBFloatTy() || Ty.isHalfTy() || Ty.isFloatTy() || Ty.isDoubleTy())) {
+  if (FP && Ty.isFloatingPointTy() && Ty.getScalarSizeInBits() <= 64) {
     const APFloat &APF = FP->getValueAPF();
     APInt const &API = APF.bitcastToAPInt();
-    if (auto Temp = API.tryZExtValue())
-      return DIB.createConstantValueExpression(static_cast<uint64_t>(*Temp));
+    if (auto Temp = API.getZExtValue())
+      return DIB.createConstantValueExpression(static_cast<uint64_t>(Temp));
     return DIB.createConstantValueExpression(*API.getRawData());
   }
 

--- a/llvm/test/Transforms/SCCP/pr50901.ll
+++ b/llvm/test/Transforms/SCCP/pr50901.ll
@@ -52,6 +52,16 @@
 ; CHECK:     = !DIGlobalVariableExpression(var: ![[DBG_FLOAT_UNDEF:.+]], expr: !DIExpression())
 ; CHECK-DAG: ![[DBG_FLOAT_UNDEF]]  = distinct !DIGlobalVariable(name: "g_float_undef"
 
+; CHECK: ![[G8:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG8:[0-9]+]], expr: !DIExpression(DW_OP_constu, 22136, DW_OP_stack_value))
+; CHECK-DAG: ![[DBG8]] = distinct !DIGlobalVariable(name: "g_88", {{.*}}
+; CHECK: ![[G9:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG9:[0-9]+]], expr: !DIExpression(DW_OP_constu, 23726, DW_OP_stack_value))
+; CHECK-DAG: ![[DBG9]] = distinct !DIGlobalVariable(name: "g_99", {{.*}}
+
+; CHECK-DAG: ![[DBGA:[0-9]+]] = distinct !DIGlobalVariable(name: "g_i32_undef"
+; CHECK-DAG: ![[GA:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBGA]], expr: !DIExpression())
+; CHECK-DAG: ![[DBGB:[0-9]+]] = distinct !DIGlobalVariable(name: "g_ptr_undef"
+; CHECK-DAG: ![[GB:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBGB]], expr: !DIExpression())
+
 @g_1 = dso_local global i32 -4, align 4, !dbg !0
 @g_2 = dso_local global float 0x4011C28F60000000, align 4, !dbg !8
 @g_3 = dso_local global i8 97, align 1, !dbg !10
@@ -59,6 +69,8 @@
 @g_5 = dso_local global i8 1, align 1, !dbg !16
 @g_6 = dso_local global ptr null, align 8, !dbg !19
 @g_7 = dso_local global ptr null, align 8, !dbg !23
+@g_8 = dso_local global half 0xH4321, align 4, !dbg !86
+@g_9 = dso_local global bfloat 0xR3F80, align 4, !dbg !90
 @_ZL4g_11 = internal global i32 -5, align 4, !dbg !25
 @_ZL4g_22 = internal global float 0x4016333340000000, align 4, !dbg !27
 @_ZL4g_33 = internal global i8 98, align 1, !dbg !29
@@ -67,6 +79,10 @@
 @_ZL4g_66 = internal global ptr null, align 8, !dbg !35
 @_ZL4g_77 = internal global ptr inttoptr (i64 70 to ptr), align 8, !dbg !37
 @g_float_undef = internal global float undef, align 4, !dbg !83
+@_ZL4g_88 = internal global half 0xH5678, align 4, !dbg !88
+@_ZL4g_99 = internal global bfloat 0xR5CAE, align 4, !dbg !92
+@g_i32_undef = internal global i32 undef, align 4, !dbg !95
+@g_ptr_undef = internal global ptr undef, align 8, !dbg !97
 
 define dso_local void @_Z3barv() !dbg !46 {
 entry:
@@ -88,6 +104,15 @@ entry:
   store ptr %6, ptr @g_7, align 8, !dbg !59
   %l = load float, ptr @g_float_undef, align 8, !dbg !59
   store float %l, ptr @g_2, align 8, !dbg !59
+  %7 = load half, ptr @_ZL4g_88, align 4, !dbg !59
+  store half %7, ptr @g_8, align 4, !dbg !59
+  %8 = load bfloat, ptr @_ZL4g_99, align 4, !dbg !59
+  store bfloat %8, ptr @g_9, align 4, !dbg !59
+  %9 = load i32, ptr @g_i32_undef, align 4, !dbg !59
+  store i32 %9, ptr @g_1, align 4, !dbg !59
+  %10 = load ptr, ptr @g_ptr_undef, align 8, !dbg !59
+  store ptr %10, ptr @g_6, align 8, !dbg !59
+
   ret void, !dbg !59
 }
 
@@ -108,7 +133,7 @@ entry:
 !4 = !{!5}
 !5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, size: 64)
 !6 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
-!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83}
+!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83, !86, !88, !90, !92, !95, !97}
 !8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
 !9 = distinct !DIGlobalVariable(name: "g_2", scope: !2, file: !3, line: 2, type: !6, isLocal: false, isDefinition: true)
 !10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
@@ -159,3 +184,17 @@ entry:
 !82 = !DILocation(line: 31, column: 1, scope: !77)
 !83 = !DIGlobalVariableExpression(var: !84, expr: !DIExpression())
 !84 = distinct !DIGlobalVariable(name: "g_float_undef", linkageName: "g_float_undef", scope: !2, file: !3, line: 15, type: !6, isLocal: true, isDefinition: true)
+!85 = !DIBasicType(name: "float", size: 16, encoding: DW_ATE_float)
+!86 = !DIGlobalVariableExpression(var: !87, expr: !DIExpression())
+!87 = distinct !DIGlobalVariable(name: "g_8", scope: !2, file: !3, line: 2, type: !85, isLocal: false, isDefinition: true)
+!88 = !DIGlobalVariableExpression(var: !89, expr: !DIExpression())
+!89 = distinct !DIGlobalVariable(name: "g_88", linkageName: "_ZL4g_88", scope: !2, file: !3, line: 10, type: !85, isLocal: true, isDefinition: true)
+!90 = !DIGlobalVariableExpression(var: !91, expr: !DIExpression())
+!91 = distinct !DIGlobalVariable(name: "g_9", scope: !2, file: !3, line: 2, type: !85, isLocal: false, isDefinition: true)
+!92 = !DIGlobalVariableExpression(var: !93, expr: !DIExpression())
+!93 = distinct !DIGlobalVariable(name: "g_99", linkageName: "_ZL4g_99", scope: !2, file: !3, line: 10, type: !85, isLocal: true, isDefinition: true)
+
+!95 = !DIGlobalVariableExpression(var: !96, expr: !DIExpression())
+!96 = distinct !DIGlobalVariable(name: "g_i32_undef", linkageName: "g_i32_undef", scope: !2, file: !3, line: 9, type: !22, isLocal: true, isDefinition: true)
+!97 = !DIGlobalVariableExpression(var: !98, expr: !DIExpression())
+!98 = distinct !DIGlobalVariable(name: "g_ptr_undef", linkageName: "g_ptr_undef", scope: !2, file: !3, line: 14, type: !21, isLocal: true, isDefinition: true)

--- a/llvm/test/Transforms/SCCP/pr50901.ll
+++ b/llvm/test/Transforms/SCCP/pr50901.ll
@@ -62,6 +62,13 @@
 ; CHECK-DAG: ![[DBGB:[0-9]+]] = distinct !DIGlobalVariable(name: "g_ptr_undef"
 ; CHECK-DAG: ![[GB:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBGB]], expr: !DIExpression())
 
+; CHECK: ![[G10:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG10:[0-9]+]], expr: !DIExpression(DW_OP_constu, 17293822569102704640, DW_OP_stack_value))
+; CHECK-DAG: ![[DBG10]] = distinct !DIGlobalVariable(name: "g_1010", {{.*}}
+; CHECK: ![[G11:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG11:[0-9]+]], expr: !DIExpression(DW_OP_constu, 17293822569102704640, DW_OP_stack_value))
+; CHECK-DAG: ![[DBG11]] = distinct !DIGlobalVariable(name: "g_1111", {{.*}}
+; CHECK: ![[G12:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG12:[0-9]+]], expr: !DIExpression(DW_OP_constu, 14480694097861998592, DW_OP_stack_value))
+; CHECK-DAG: ![[DBG12]] = distinct !DIGlobalVariable(name: "g_1212", {{.*}}
+
 @g_1 = dso_local global i32 -4, align 4, !dbg !0
 @g_2 = dso_local global float 0x4011C28F60000000, align 4, !dbg !8
 @g_3 = dso_local global i8 97, align 1, !dbg !10
@@ -71,6 +78,9 @@
 @g_7 = dso_local global ptr null, align 8, !dbg !23
 @g_8 = dso_local global half 0xH4321, align 4, !dbg !86
 @g_9 = dso_local global bfloat 0xR3F80, align 4, !dbg !90
+@g_10 = dso_local global fp128 0xLF0000000000000004000921CAC083126, align 16, !dbg !100
+@g_11 = dso_local global ppc_fp128 0xMF0000000000000004000921CAC083126, align 16, !dbg !105
+@g_12 = dso_local global x86_fp80 0xK4000C8F5C28F5C28F800, align 16, !dbg !110
 @_ZL4g_11 = internal global i32 -5, align 4, !dbg !25
 @_ZL4g_22 = internal global float 0x4016333340000000, align 4, !dbg !27
 @_ZL4g_33 = internal global i8 98, align 1, !dbg !29
@@ -81,6 +91,9 @@
 @g_float_undef = internal global float undef, align 4, !dbg !83
 @_ZL4g_88 = internal global half 0xH5678, align 4, !dbg !88
 @_ZL4g_99 = internal global bfloat 0xR5CAE, align 4, !dbg !92
+@_ZL4g_1010 = internal global fp128 0xLF0000000000000004000921CAC083126, align 16, !dbg !102
+@_ZL4g_1111 = internal global ppc_fp128 0xMF0000000000000004000921CAC083126, align 16, !dbg !107
+@_ZL4g_1212 = internal global x86_fp80 0xK4000C8F5C28F5C28F800, align 16, !dbg !112
 @g_i32_undef = internal global i32 undef, align 4, !dbg !95
 @g_ptr_undef = internal global ptr undef, align 8, !dbg !97
 
@@ -112,6 +125,12 @@ entry:
   store i32 %9, ptr @g_1, align 4, !dbg !59
   %10 = load ptr, ptr @g_ptr_undef, align 8, !dbg !59
   store ptr %10, ptr @g_6, align 8, !dbg !59
+  %11 = load fp128, ptr @_ZL4g_1010, align 16, !dbg !59
+  store fp128 %11, ptr @g_10, align 16, !dbg !59
+  %12 = load ppc_fp128, ptr @_ZL4g_1111, align 16, !dbg !59
+  store ppc_fp128 %12, ptr @g_11, align 16, !dbg !59
+  %13 = load x86_fp80, ptr @_ZL4g_1212, align 16, !dbg !59
+  store x86_fp80 %13, ptr @g_12, align 16, !dbg !59
 
   ret void, !dbg !59
 }
@@ -133,7 +152,7 @@ entry:
 !4 = !{!5}
 !5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, size: 64)
 !6 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
-!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83, !86, !88, !90, !92, !95, !97}
+!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83, !86, !88, !90, !92, !95, !97, !100, !102, !105, !107, !110, !112}
 !8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
 !9 = distinct !DIGlobalVariable(name: "g_2", scope: !2, file: !3, line: 2, type: !6, isLocal: false, isDefinition: true)
 !10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
@@ -198,3 +217,20 @@ entry:
 !96 = distinct !DIGlobalVariable(name: "g_i32_undef", linkageName: "g_i32_undef", scope: !2, file: !3, line: 9, type: !22, isLocal: true, isDefinition: true)
 !97 = !DIGlobalVariableExpression(var: !98, expr: !DIExpression())
 !98 = distinct !DIGlobalVariable(name: "g_ptr_undef", linkageName: "g_ptr_undef", scope: !2, file: !3, line: 14, type: !21, isLocal: true, isDefinition: true)
+
+!99 = !DIBasicType(name: "float", size: 128, encoding: DW_ATE_float)
+!100 = !DIGlobalVariableExpression(var: !101, expr: !DIExpression())
+!101 = distinct !DIGlobalVariable(name: "g_10", scope: !2, file: !3, line: 2, type: !99, isLocal: false, isDefinition: true)
+!102 = !DIGlobalVariableExpression(var: !103, expr: !DIExpression())
+!103 = distinct !DIGlobalVariable(name: "g_1010", linkageName: "_ZL4g_1010", scope: !2, file: !3, line: 15, type: !99, isLocal: true, isDefinition: true)
+
+!105 = !DIGlobalVariableExpression(var: !106, expr: !DIExpression())
+!106 = distinct !DIGlobalVariable(name: "g_11", scope: !2, file: !3, line: 2, type: !99, isLocal: false, isDefinition: true)
+!107 = !DIGlobalVariableExpression(var: !108, expr: !DIExpression())
+!108 = distinct !DIGlobalVariable(name: "g_1111", linkageName: "_ZL4g_1111", scope: !2, file: !3, line: 15, type: !99, isLocal: true, isDefinition: true)
+
+!109 = !DIBasicType(name: "float", size: 80, encoding: DW_ATE_float)
+!110 = !DIGlobalVariableExpression(var: !111, expr: !DIExpression())
+!111 = distinct !DIGlobalVariable(name: "g_12", scope: !2, file: !3, line: 2, type: !109, isLocal: false, isDefinition: true)
+!112 = !DIGlobalVariableExpression(var: !113, expr: !DIExpression())
+!113 = distinct !DIGlobalVariable(name: "g_1212", linkageName: "_ZL4g_1212", scope: !2, file: !3, line: 15, type: !109, isLocal: true, isDefinition: true)

--- a/llvm/test/Transforms/SCCP/pr50901.ll
+++ b/llvm/test/Transforms/SCCP/pr50901.ll
@@ -62,13 +62,6 @@
 ; CHECK-DAG: ![[DBGB:[0-9]+]] = distinct !DIGlobalVariable(name: "g_ptr_undef"
 ; CHECK-DAG: ![[GB:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBGB]], expr: !DIExpression())
 
-; CHECK: ![[G10:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG10:[0-9]+]], expr: !DIExpression(DW_OP_constu, 17293822569102704640, DW_OP_stack_value))
-; CHECK-DAG: ![[DBG10]] = distinct !DIGlobalVariable(name: "g_1010", {{.*}}
-; CHECK: ![[G11:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG11:[0-9]+]], expr: !DIExpression(DW_OP_constu, 17293822569102704640, DW_OP_stack_value))
-; CHECK-DAG: ![[DBG11]] = distinct !DIGlobalVariable(name: "g_1111", {{.*}}
-; CHECK: ![[G12:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG12:[0-9]+]], expr: !DIExpression(DW_OP_constu, 14480694097861998592, DW_OP_stack_value))
-; CHECK-DAG: ![[DBG12]] = distinct !DIGlobalVariable(name: "g_1212", {{.*}}
-
 @g_1 = dso_local global i32 -4, align 4, !dbg !0
 @g_2 = dso_local global float 0x4011C28F60000000, align 4, !dbg !8
 @g_3 = dso_local global i8 97, align 1, !dbg !10
@@ -78,9 +71,6 @@
 @g_7 = dso_local global ptr null, align 8, !dbg !23
 @g_8 = dso_local global half 0xH4321, align 4, !dbg !86
 @g_9 = dso_local global bfloat 0xR3F80, align 4, !dbg !90
-@g_10 = dso_local global fp128 0xLF0000000000000004000921CAC083126, align 16, !dbg !100
-@g_11 = dso_local global ppc_fp128 0xMF0000000000000004000921CAC083126, align 16, !dbg !105
-@g_12 = dso_local global x86_fp80 0xK4000C8F5C28F5C28F800, align 16, !dbg !110
 @_ZL4g_11 = internal global i32 -5, align 4, !dbg !25
 @_ZL4g_22 = internal global float 0x4016333340000000, align 4, !dbg !27
 @_ZL4g_33 = internal global i8 98, align 1, !dbg !29
@@ -91,9 +81,6 @@
 @g_float_undef = internal global float undef, align 4, !dbg !83
 @_ZL4g_88 = internal global half 0xH5678, align 4, !dbg !88
 @_ZL4g_99 = internal global bfloat 0xR5CAE, align 4, !dbg !92
-@_ZL4g_1010 = internal global fp128 0xLF0000000000000004000921CAC083126, align 16, !dbg !102
-@_ZL4g_1111 = internal global ppc_fp128 0xMF0000000000000004000921CAC083126, align 16, !dbg !107
-@_ZL4g_1212 = internal global x86_fp80 0xK4000C8F5C28F5C28F800, align 16, !dbg !112
 @g_i32_undef = internal global i32 undef, align 4, !dbg !95
 @g_ptr_undef = internal global ptr undef, align 8, !dbg !97
 
@@ -125,12 +112,6 @@ entry:
   store i32 %9, ptr @g_1, align 4, !dbg !59
   %10 = load ptr, ptr @g_ptr_undef, align 8, !dbg !59
   store ptr %10, ptr @g_6, align 8, !dbg !59
-  %11 = load fp128, ptr @_ZL4g_1010, align 16, !dbg !59
-  store fp128 %11, ptr @g_10, align 16, !dbg !59
-  %12 = load ppc_fp128, ptr @_ZL4g_1111, align 16, !dbg !59
-  store ppc_fp128 %12, ptr @g_11, align 16, !dbg !59
-  %13 = load x86_fp80, ptr @_ZL4g_1212, align 16, !dbg !59
-  store x86_fp80 %13, ptr @g_12, align 16, !dbg !59
 
   ret void, !dbg !59
 }
@@ -152,7 +133,7 @@ entry:
 !4 = !{!5}
 !5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, size: 64)
 !6 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
-!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83, !86, !88, !90, !92, !95, !97, !100, !102, !105, !107, !110, !112}
+!7 = !{!0, !8, !10, !13, !16, !19, !23, !25, !27, !29, !31, !33, !35, !37, !83, !86, !88, !90, !92, !95, !97}
 !8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
 !9 = distinct !DIGlobalVariable(name: "g_2", scope: !2, file: !3, line: 2, type: !6, isLocal: false, isDefinition: true)
 !10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
@@ -217,20 +198,3 @@ entry:
 !96 = distinct !DIGlobalVariable(name: "g_i32_undef", linkageName: "g_i32_undef", scope: !2, file: !3, line: 9, type: !22, isLocal: true, isDefinition: true)
 !97 = !DIGlobalVariableExpression(var: !98, expr: !DIExpression())
 !98 = distinct !DIGlobalVariable(name: "g_ptr_undef", linkageName: "g_ptr_undef", scope: !2, file: !3, line: 14, type: !21, isLocal: true, isDefinition: true)
-
-!99 = !DIBasicType(name: "float", size: 128, encoding: DW_ATE_float)
-!100 = !DIGlobalVariableExpression(var: !101, expr: !DIExpression())
-!101 = distinct !DIGlobalVariable(name: "g_10", scope: !2, file: !3, line: 2, type: !99, isLocal: false, isDefinition: true)
-!102 = !DIGlobalVariableExpression(var: !103, expr: !DIExpression())
-!103 = distinct !DIGlobalVariable(name: "g_1010", linkageName: "_ZL4g_1010", scope: !2, file: !3, line: 15, type: !99, isLocal: true, isDefinition: true)
-
-!105 = !DIGlobalVariableExpression(var: !106, expr: !DIExpression())
-!106 = distinct !DIGlobalVariable(name: "g_11", scope: !2, file: !3, line: 2, type: !99, isLocal: false, isDefinition: true)
-!107 = !DIGlobalVariableExpression(var: !108, expr: !DIExpression())
-!108 = distinct !DIGlobalVariable(name: "g_1111", linkageName: "_ZL4g_1111", scope: !2, file: !3, line: 15, type: !99, isLocal: true, isDefinition: true)
-
-!109 = !DIBasicType(name: "float", size: 80, encoding: DW_ATE_float)
-!110 = !DIGlobalVariableExpression(var: !111, expr: !DIExpression())
-!111 = distinct !DIGlobalVariable(name: "g_12", scope: !2, file: !3, line: 2, type: !109, isLocal: false, isDefinition: true)
-!112 = !DIGlobalVariableExpression(var: !113, expr: !DIExpression())
-!113 = distinct !DIGlobalVariable(name: "g_1212", linkageName: "_ZL4g_1212", scope: !2, file: !3, line: 15, type: !109, isLocal: true, isDefinition: true)

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -1269,18 +1269,31 @@ TEST(Local, ExpressionForConstant) {
   EXPECT_NE(Expr, nullptr);
   EXPECT_EQ(Expr->getElement(1), 5678U);
 
-  // Others.
+  // FP128.
   Type *FP128Ty = Type::getFP128Ty(Context);
-  Expr = createExpression(ConstantFP::get(FP128Ty, 32), FP128Ty);
-  EXPECT_EQ(Expr, nullptr);
+  Expr = createExpression(
+      ConstantFP::get(FP128Ty, APFloat(APFloat::IEEEquad(), APInt(128, 12345))),
+      FP128Ty);
+  EXPECT_NE(Expr, nullptr);
+  EXPECT_EQ(Expr->getElement(1), 12345U);
 
+  // X86_FP80.
   Type *X86_FP80Ty = Type::getX86_FP80Ty(Context);
-  Expr = createExpression(ConstantFP::get(X86_FP80Ty, 32), X86_FP80Ty);
-  EXPECT_EQ(Expr, nullptr);
+  Expr = createExpression(
+      ConstantFP::get(X86_FP80Ty,
+                      APFloat(APFloat::x87DoubleExtended(), APInt(80, 67890))),
+      X86_FP80Ty);
+  EXPECT_NE(Expr, nullptr);
+  EXPECT_EQ(Expr->getElement(1), 67890U);
 
+  // PPC_FP128.
   Type *PPC_FP128Ty = Type::getPPC_FP128Ty(Context);
-  Expr = createExpression(ConstantFP::get(PPC_FP128Ty, 32), PPC_FP128Ty);
-  EXPECT_EQ(Expr, nullptr);
+  Expr = createExpression(
+      ConstantFP::get(PPC_FP128Ty,
+                      APFloat(APFloat::PPCDoubleDouble(), APInt(80, 123890))),
+      PPC_FP128Ty);
+  EXPECT_NE(Expr, nullptr);
+  EXPECT_EQ(Expr->getElement(1), 123890U);
 }
 
 TEST(Local, ReplaceDPValue) {

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -1241,6 +1241,18 @@ TEST(Local, ExpressionForConstant) {
   EXPECT_NE(Expr, nullptr);
   EXPECT_EQ(Expr->getElement(1), 13841306799765140275U);
 
+  // Half.
+  Type *HalfTy = Type::getHalfTy(Context);
+  Expr = createExpression(ConstantFP::get(HalfTy, 5.55), HalfTy);
+  EXPECT_NE(Expr, nullptr);
+  EXPECT_EQ(Expr->getElement(1), 17805U);
+
+  // BFloat.
+  Type *BFloatTy = Type::getBFloatTy(Context);
+  Expr = createExpression(ConstantFP::get(BFloatTy, -5.55), BFloatTy);
+  EXPECT_NE(Expr, nullptr);
+  EXPECT_EQ(Expr->getElement(1), 49330U);
+
   // Pointer.
   PointerType *PtrTy = PointerType::get(Context, 0);
   Expr = createExpression(ConstantPointerNull::get(PtrTy), PtrTy);
@@ -1258,14 +1270,6 @@ TEST(Local, ExpressionForConstant) {
   EXPECT_EQ(Expr->getElement(1), 5678U);
 
   // Others.
-  Type *HalfTy = Type::getHalfTy(Context);
-  Expr = createExpression(ConstantFP::get(HalfTy, 32), HalfTy);
-  EXPECT_EQ(Expr, nullptr);
-
-  Type *BFloatTy = Type::getBFloatTy(Context);
-  Expr = createExpression(ConstantFP::get(BFloatTy, 32), BFloatTy);
-  EXPECT_EQ(Expr, nullptr);
-
   Type *FP128Ty = Type::getFP128Ty(Context);
   Expr = createExpression(ConstantFP::get(FP128Ty, 32), FP128Ty);
   EXPECT_EQ(Expr, nullptr);

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -1268,32 +1268,6 @@ TEST(Local, ExpressionForConstant) {
   Expr = createExpression(ConstantExpr::getIntToPtr(K2, PtrTy), PtrTy);
   EXPECT_NE(Expr, nullptr);
   EXPECT_EQ(Expr->getElement(1), 5678U);
-
-  // FP128.
-  Type *FP128Ty = Type::getFP128Ty(Context);
-  Expr = createExpression(
-      ConstantFP::get(FP128Ty, APFloat(APFloat::IEEEquad(), APInt(128, 12345))),
-      FP128Ty);
-  EXPECT_NE(Expr, nullptr);
-  EXPECT_EQ(Expr->getElement(1), 12345U);
-
-  // X86_FP80.
-  Type *X86_FP80Ty = Type::getX86_FP80Ty(Context);
-  Expr = createExpression(
-      ConstantFP::get(X86_FP80Ty,
-                      APFloat(APFloat::x87DoubleExtended(), APInt(80, 67890))),
-      X86_FP80Ty);
-  EXPECT_NE(Expr, nullptr);
-  EXPECT_EQ(Expr->getElement(1), 67890U);
-
-  // PPC_FP128.
-  Type *PPC_FP128Ty = Type::getPPC_FP128Ty(Context);
-  Expr = createExpression(
-      ConstantFP::get(PPC_FP128Ty,
-                      APFloat(APFloat::PPCDoubleDouble(), APInt(80, 123890))),
-      PPC_FP128Ty);
-  EXPECT_NE(Expr, nullptr);
-  EXPECT_EQ(Expr->getElement(1), 123890U);
 }
 
 TEST(Local, ReplaceDPValue) {

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -1268,6 +1268,18 @@ TEST(Local, ExpressionForConstant) {
   Expr = createExpression(ConstantExpr::getIntToPtr(K2, PtrTy), PtrTy);
   EXPECT_NE(Expr, nullptr);
   EXPECT_EQ(Expr->getElement(1), 5678U);
+
+  Type *FP128Ty = Type::getFP128Ty(Context);
+  Expr = createExpression(ConstantFP::get(FP128Ty, 32), FP128Ty);
+  EXPECT_EQ(Expr, nullptr);
+
+  Type *X86_FP80Ty = Type::getX86_FP80Ty(Context);
+  Expr = createExpression(ConstantFP::get(X86_FP80Ty, 32), X86_FP80Ty);
+  EXPECT_EQ(Expr, nullptr);
+
+  Type *PPC_FP128Ty = Type::getPPC_FP128Ty(Context);
+  Expr = createExpression(ConstantFP::get(PPC_FP128Ty, 32), PPC_FP128Ty);
+  EXPECT_EQ(Expr, nullptr);
 }
 
 TEST(Local, ReplaceDPValue) {


### PR DESCRIPTION
https://bugs.llvm.org/show_bug.cgi?id=51559
https://github.com/llvm/llvm-project/issues/50901

IPSCCP pass removes the global variable and does not create a constant expression for the initializer value.

Extend test coverage to include:
- half, bfloat types.
- checks for undef (int32 and ptr).

There is no support for:
- fp128, x86_fp80, ppc_fp128  types.
https://github.com/llvm/llvm-project/issues/88102