### PR TITLE
[flang][driver] Limit the usage of -mvscale-max and -mvscale-min

### DIFF
--- a/flang/test/Driver/unsupported-vscale-max-min.f90
+++ b/flang/test/Driver/unsupported-vscale-max-min.f90
@@ -1,0 +1,8 @@
+! REQUIRES: x86-registered-target
+
+! RUN: not %flang_fc1 -triple x86_64-unknown-linux-gnu -mvscale-min=1 -mvscale-max=1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+! CHECK: `-mvscale-max` and `-mvscale-min` are not supported for this architecture: x86_64
+
+subroutine func
+end subroutine func


### PR DESCRIPTION
Make sure that `-mvscale-max` and `-mvscale-min` are only available for
targets that are known to support vscale and scalable vectors.

Also fix capitalization of function variables.
