### PR TITLE
[flang] Fix const cast issue in FreeMemory function call in execute_command_line

### DIFF
--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -847,7 +847,7 @@ used in constant expressions have currently no folding support at all.
 
 #### Usage and Info
 
-- **Standard:** Fortran 2008 and later, specified in 16.9.73
+- **Standard:** Fortran 2008 and later, specified in Section 16.9.73
 - **Class:** Subroutine
 - **Syntax:** `CALL EXECUTE_COMMAND_LINE(COMMAND [, WAIT, EXITSTAT, CMDSTAT, CMDMSG ])`
 - **Arguments:**
@@ -862,28 +862,50 @@ used in constant expressions have currently no folding support at all.
 
 #### Implementation Specifics
 
-- **`COMMAND`:**
-  - Must be preset.
+##### `COMMAND`:
 
-- **`WAIT`:**
-  - If set to `false`, the command is executed asynchronously. If not preset or set to `false`, it is executed synchronously.
-  - Sync: achieved by passing command into `std::system` on all systems.
-  - Async: achieved by calling a `fork()` on POSIX-compatible systems, or `CreateProcess()` on Windows.
+- Must be preset.
 
-- **`CMDSTAT`:**
+##### `WAIT`:
+
+- If set to `false`, the command is executed asynchronously.
+- If not preset or set to `true`, it is executed synchronously.
+- Synchronous execution is achieved by passing the command into `std::system` on all systems.
+- Asynchronous execution is achieved by calling `fork()` on POSIX-compatible systems or `CreateProcess()` on Windows.
+
+##### `EXITSTAT`:
+
+- Synchronous execution:
+  - Inferred by the return value of `std::system(cmd)`.
+    - On POSIX-compatible systems: return value is first passed into `WEXITSTATUS(status)`, then assigned to `EXITSTAT`.
+    - On Windows, the value is directly assigned as the return value of `std::system()`.
+- Asynchronous execution:
+  - Value is not modified.
+
+##### `CMDSTAT`:
+
+- Synchronous execution:
   - -2: No error condition occurs, but `WAIT` is present with the value `false`, and the processor does not support asynchronous execution.
   - -1: The processor does not support command line execution.
   - \+ (positive value): An error condition occurs.
-    - 1: Fork Error, where `pid_t < 0`, would only occur on POSIX-compatible systems.
-    - 2: Execution Error, a command exits with status -1.
-    - 3: Invalid Command Error, determined by the exit code depending on the system.
-      - On Windows, if the exit code is 1.
-      - On POSIX-compatible systems, if the exit code is 127 or 126.
-    - 4: Signal error, either it is stopped or killed by signal, would only occur on POSIX-compatible systems.
+    - 1: Fork Error (occurs only on POSIX-compatible systems).
+    - 2: Execution Error (command exits with status -1).
+    - 3: Invalid Command Error (determined by the exit code depending on the system).
+      - On Windows: exit code is 1.
+      - On POSIX-compatible systems: exit code is 127 or 126.
+    - 4: Signal error (either stopped or killed by signal, occurs only on POSIX-compatible systems).
   - 0: Otherwise.
+- Asynchronous execution:
+  - 0 will always be assigned.
 
-- **`CMDMSG`:**
-  - If an error condition occurs, it is assigned an explanatory message. Otherwise, it remains unchanged.
+##### `CMDMSG`:
+
+- Synchronous execution:
+  - If an error condition occurs, it is assigned an explanatory message; otherwise, it remains unchanged.
+  - If a condition occurs that would assign a nonzero value to `CMDSTAT` but the `CMDSTAT` variable is not present, error termination is initiated (applies to both POSIX-compatible systems and Windows).
+- Asynchronous execution:
+  - The value is unchanged.
   - If a condition occurs that would assign a nonzero value to `CMDSTAT` but the `CMDSTAT` variable is not present, error termination is initiated.
-    - On POSIX-compatible systems, this applies to both synchronous and asynchronous error termination. When the execution mode is set to async with error termination, the child process (async process) will be terminated with no effect on the parent process (continues).
-    - On Windows, this only applies to synchronous error termination.
+    - On POSIX-compatible systems, the child process (async process) will be terminated with no effect on the parent process (continues).
+    - On Windows, error termination is not initiated.
+

--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -847,7 +847,7 @@ used in constant expressions have currently no folding support at all.
 
 #### Usage and Info
 
-- **Standard:** Fortran 2008 and later, specified in Section 16.9.73
+- **Standard:** Fortran 2008 and later, specified in subclause 16.9.73
 - **Class:** Subroutine
 - **Syntax:** `CALL EXECUTE_COMMAND_LINE(COMMAND [, WAIT, EXITSTAT, CMDSTAT, CMDMSG ])`
 - **Arguments:**

--- a/flang/runtime/execute.cpp
+++ b/flang/runtime/execute.cpp
@@ -116,7 +116,7 @@ void RTNAME(ExecuteCommandLine)(const Descriptor &command, bool wait,
     const Descriptor *exitstat, const Descriptor *cmdstat,
     const Descriptor *cmdmsg, const char *sourceFile, int line) {
   Terminator terminator{sourceFile, line};
-  const char *newCmd{EnsureNullTerminated(
+  char *newCmd{EnsureNullTerminated(
       command.OffsetElement(), command.ElementBytes(), terminator)};
 
   if (exitstat) {
@@ -199,7 +199,7 @@ void RTNAME(ExecuteCommandLine)(const Descriptor &command, bool wait,
   }
   // Deallocate memory if EnsureNullTerminated dynamically allocated memory
   if (newCmd != command.OffsetElement()) {
-    FreeMemory(const_cast<void *>(static_cast<const void *>(newCmd)));
+    FreeMemory((void *)newCmd);
   }
 }
 

--- a/flang/runtime/execute.cpp
+++ b/flang/runtime/execute.cpp
@@ -199,7 +199,7 @@ void RTNAME(ExecuteCommandLine)(const Descriptor &command, bool wait,
   }
   // Deallocate memory if EnsureNullTerminated dynamically allocated memory
   if (newCmd != command.OffsetElement()) {
-    FreeMemory((void *)newCmd);
+    FreeMemory(const_cast<void *>(static_cast<const void *>(newCmd)));
   }
 }
 

--- a/flang/runtime/tools.cpp
+++ b/flang/runtime/tools.cpp
@@ -173,8 +173,8 @@ RT_API_ATTRS void ShallowCopy(const Descriptor &to, const Descriptor &from) {
   ShallowCopy(to, from, to.IsContiguous(), from.IsContiguous());
 }
 
-RT_API_ATTRS const char *EnsureNullTerminated(
-    const char *str, std::size_t length, Terminator &terminator) {
+RT_API_ATTRS char *EnsureNullTerminated(
+    char *str, std::size_t length, Terminator &terminator) {
   if (std::memchr(str, '\0', length) == nullptr) {
     char *newCmd{(char *)AllocateMemoryOrCrash(terminator, length + 1)};
     std::memcpy(newCmd, str, length);

--- a/flang/runtime/tools.h
+++ b/flang/runtime/tools.h
@@ -441,8 +441,8 @@ RT_API_ATTRS void ShallowCopy(const Descriptor &to, const Descriptor &from);
 // size memory for null-terminator if necessary. Returns the original or a newly
 // allocated null-terminated string (responsibility for deallocation is on the
 // caller).
-RT_API_ATTRS const char *EnsureNullTerminated(
-    const char *str, std::size_t length, Terminator &terminator);
+RT_API_ATTRS char *EnsureNullTerminated(
+    char *str, std::size_t length, Terminator &terminator);
 
 RT_API_ATTRS bool IsValidCharDescriptor(const Descriptor *value);
 


### PR DESCRIPTION
The FreeMemory function only accepts a void pointer, but it was being called with a const char pointer, resulting in a type-casting issue.
To address this, the const was removed, use char * instead.