### PR TITLE
[flang] fix VLA using malloc and avoid using std::vector, arg input type change to char * from std::byte

### DIFF
--- a/flang/include/flang/Runtime/extensions.h
+++ b/flang/include/flang/Runtime/extensions.h
@@ -33,7 +33,7 @@ void FORTRAN_PROCEDURE_NAME(getarg)(
     std::int32_t &n, std::int8_t *arg, std::int64_t length);
 
 // GNU extension subroutine GETLOG(C).
-void FORTRAN_PROCEDURE_NAME(getlog)(std::byte *name, std::int64_t length);
+void FORTRAN_PROCEDURE_NAME(getlog)(char *name, std::int64_t length);
 
 } // extern "C"
 #endif // FORTRAN_RUNTIME_EXTENSIONS_H_

--- a/flang/runtime/extensions.cpp
+++ b/flang/runtime/extensions.cpp
@@ -109,7 +109,7 @@ void FORTRAN_PROCEDURE_NAME(getlog)(char *arg, std::int64_t length) {
     nameMaxLen = _POSIX_LOGIN_NAME_MAX + 1;
 #endif
   Terminator terminator{__FILE__, __LINE__};
-  char *str{(char *)AllocateMemoryOrCrash(terminator, nameMaxLen)};
+  char *str{static_cast<char *>(AllocateMemoryOrCrash(terminator, nameMaxLen))};
   str[nameMaxLen] = '\0';
 
   int error{getlogin_r(str, nameMaxLen)};

--- a/flang/runtime/extensions.cpp
+++ b/flang/runtime/extensions.cpp
@@ -48,8 +48,7 @@ extern "C" {
 
 namespace Fortran::runtime {
 
-void GetUsernameEnvVar(
-    const char *envName, char *arg, std::int64_t length) {
+void GetUsernameEnvVar(const char *envName, char *arg, std::int64_t length) {
   Descriptor name{*Descriptor::Create(
       1, std::strlen(envName) + 1, const_cast<char *>(envName), 0)};
   Descriptor value{*Descriptor::Create(1, length, arg, 0)};
@@ -121,7 +120,7 @@ void FORTRAN_PROCEDURE_NAME(getlog)(char *arg, std::int64_t length) {
     // error occur: get username from environment variable
     GetUsernameEnvVar("LOGNAME", arg, length);
   }
-  FreeMemory((void*)str);
+  FreeMemory((void *)str);
 #elif _WIN32
   // Get username from environment to avoid link to Advapi32.lib
   GetUsernameEnvVar("USERNAME", arg, length);

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -9,12 +9,12 @@
 #include "flang/Runtime/command.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "../../runtime/terminator.h"
 #include "flang/Runtime/descriptor.h"
 #include "flang/Runtime/execute.h"
 #include "flang/Runtime/extensions.h"
 #include "flang/Runtime/main.h"
 #include "flang/Runtime/memory.h"
-#include "../../runtime/terminator.h"
 #include <cstddef>
 #include <cstdlib>
 


### PR DESCRIPTION
The extension getlog https://github.com/llvm/llvm-project/pull/74628 introduce a issue where in Solarias system, `LOGIN_NAME_MAX` can be undefined. this problem was fixed in https://github.com/llvm/llvm-project/pull/77775. 
But due to the use of variable-length-array (VLA), two further patch went in with the use of `std::vector`. fb09447132cb192a0ef5082d4a4bae30f893e501 and 18734f606635f4f4270f911b68060890ce3dd94a. 

This fix use malloc (AllocatedOrCrash and FreeMemory) instead, and change the input type from `std::byte *` to `char *`