### PR TITLE
[lldb][ValueObject][NFC] Remove unused parameter to ReadPointedString

### DIFF
--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -670,8 +670,7 @@ public:
 
   std::pair<size_t, bool>
   ReadPointedString(lldb::WritableDataBufferSP &buffer_sp, Status &error,
-                    uint32_t max_length = 0, bool honor_array = true,
-                    lldb::Format item_format = lldb::eFormatCharArray);
+                    uint32_t max_length = 0, bool honor_array = true);
 
   virtual size_t GetPointeeData(DataExtractor &data, uint32_t item_idx = 0,
                                 uint32_t item_count = 1);

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -814,7 +814,7 @@ static bool CopyStringDataToBufferSP(const StreamString &source,
 std::pair<size_t, bool>
 ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
                                Status &error, uint32_t max_length,
-                               bool honor_array, Format item_format) {
+                               bool honor_array) {
   bool was_capped = false;
   StreamString s;
   ExecutionContext exe_ctx(GetExecutionContextRef());


### PR DESCRIPTION
All its usages were removed in `2206b48d6ddabad61979fa69ba09e6b6fb19b0b2`.