### PR TITLE
[LLVM][ADT] Explicitly convert size_t values to SmallVector's size type

### DIFF
--- a/llvm/lib/Support/SmallVector.cpp
+++ b/llvm/lib/Support/SmallVector.cpp
@@ -153,8 +153,7 @@ void SmallVectorBase<Size_T>::grow_pod(void *FirstEl, size_t MinSize,
       NewElts = replaceAllocation(NewElts, TSize, NewCapacity, size());
   }
 
-  this->BeginX = NewElts;
-  this->Capacity = NewCapacity;
+  this->set_allocation_range(NewElts, NewCapacity);
 }
 
 template class llvm::SmallVectorBase<uint32_t>;


### PR DESCRIPTION
Multiple places rely on implicit conversion when assigning 'size_t' values to the member fields (size or capacity) of SmallVector.

Depending on the platform / compiler configuration, this may result in narrowing conversion warnings (especially given that the size type of SmallVector's member fields is determined based on type T - in SmallVector<T>). To avoid the problem altogether, make the conversions explicit.