### PR TITLE
[lldb][libc++] Adds missing C++20 calendar data formatters.

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1039,6 +1039,7 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
                                                     eTypeOptionHideValue,
                                                 "day=${var.__d_%u}")));
+
   AddCXXSummary(cpp_category_sp,
                 lldb_private::formatters::LibcxxChronoMonthSummaryProvider,
                 "libc++ std::chrono::month summary provider",
@@ -1050,6 +1051,23 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       TypeSummaryImplSP(new StringSummaryFormat(
           eTypeOptionHideChildren | eTypeOptionHideValue, "year=${var.__y_}")));
 
+  AddCXXSummary(cpp_category_sp,
+                lldb_private::formatters::LibcxxChronoWeekdaySummaryProvider,
+                "libc++ std::chrono::weekday summary provider",
+                "^std::__[[:alnum:]]+::chrono::weekday$",
+                eTypeOptionHideChildren | eTypeOptionHideValue, true);
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::weekday_indexed$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(
+          eTypeOptionHideChildren | eTypeOptionHideValue,
+          "${var.__wd_} index=${var.__idx_%u}")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::weekday_last$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
+                                                    eTypeOptionHideValue,
+                                                "${var.__wd_} index=last")));
   cpp_category_sp->AddTypeSummary(
       "^std::__[[:alnum:]]+::chrono::month_day$", eFormatterMatchRegex,
       TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
@@ -1060,12 +1078,51 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
                                                     eTypeOptionHideValue,
                                                 "${var.__m_} day=last")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::month_weekday$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
+                                                    eTypeOptionHideValue,
+                                                "${var.__m_} ${var.__wdi_}")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::month_weekday_last$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
+                                                    eTypeOptionHideValue,
+                                                "${var.__m_} ${var.__wdl_}")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::year_month$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
+                                                    eTypeOptionHideValue,
+                                                "${var.__y_} ${var.__m_}")));
+
   AddCXXSummary(
       cpp_category_sp,
       lldb_private::formatters::LibcxxChronoYearMonthDaySummaryProvider,
       "libc++ std::chrono::year_month_day summary provider",
       "^std::__[[:alnum:]]+::chrono::year_month_day$",
       eTypeOptionHideChildren | eTypeOptionHideValue, true);
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::year_month_day_last$",
+      eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(eTypeOptionHideChildren |
+                                                    eTypeOptionHideValue,
+                                                "${var.__y_} ${var.__mdl_}")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::year_month_weekday$", eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(
+          eTypeOptionHideChildren | eTypeOptionHideValue,
+          "${var.__y_} ${var.__m_} ${var.__wdi_}")));
+
+  cpp_category_sp->AddTypeSummary(
+      "^std::__[[:alnum:]]+::chrono::year_month_weekday_last$",
+      eFormatterMatchRegex,
+      TypeSummaryImplSP(new StringSummaryFormat(
+          eTypeOptionHideChildren | eTypeOptionHideValue,
+          "${var.__y_} ${var.__m_} ${var.__wdl_}")));
 }
 
 static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -1106,6 +1106,27 @@ bool lldb_private::formatters::LibcxxChronoMonthSummaryProvider(
   return true;
 }
 
+bool lldb_private::formatters::LibcxxChronoWeekdaySummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  // FIXME: These are the names used in the C++20 ostream operator. Since LLVM
+  // uses C++17 it's not possible to use the ostream operator directly.
+  static const std::array<std::string_view, 7> weekdays = {
+      "Sunday",   "Monday", "Tuesday", "Wednesday",
+      "Thursday", "Friday", "Saturday"};
+
+  ValueObjectSP ptr_sp = valobj.GetChildMemberWithName("__wd_");
+  if (!ptr_sp)
+    return false;
+
+  const unsigned weekday = ptr_sp->GetValueAsUnsigned(0);
+  if (weekday >= 0 && weekday < 7)
+    stream << "weekday=" << weekdays[weekday];
+  else
+    stream.Printf("weekday=%u", weekday);
+
+  return true;
+}
+
 bool lldb_private::formatters::LibcxxChronoYearMonthDaySummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   ValueObjectSP ptr_sp = valobj.GetChildMemberWithName("__y_");

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -265,6 +265,10 @@ bool LibcxxChronoMonthSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libc++ std::chrono::month
 
+bool LibcxxChronoWeekdaySummaryProvider(
+    ValueObject &valobj, Stream &stream,
+    const TypeSummaryOptions &options); // libc++ std::chrono::weekday
+
 bool LibcxxChronoYearMonthDaySummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libc++ std::chrono::year_month_day

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
@@ -66,6 +66,53 @@ class LibcxxChronoDataFormatterTestCase(TestBase):
         self.expect("frame variable month_13", substrs=["month_13 = month=13"])
         self.expect("frame variable month_255", substrs=["month_255 = month=255"])
 
+        self.expect("frame variable sun", substrs=["sun = weekday=Sunday"])
+        self.expect("frame variable mon", substrs=["mon = weekday=Monday"])
+        self.expect("frame variable tue", substrs=["tue = weekday=Tuesday"])
+        self.expect("frame variable wed", substrs=["wed = weekday=Wednesday"])
+        self.expect("frame variable thu", substrs=["thu = weekday=Thursday"])
+        self.expect("frame variable fri", substrs=["fri = weekday=Friday"])
+        self.expect("frame variable sat", substrs=["sat = weekday=Saturday"])
+
+        self.expect("frame variable weekday_0", substrs=["weekday_0 = weekday=Sunday"])
+        self.expect("frame variable weekday_1", substrs=["weekday_1 = weekday=Monday"])
+        self.expect("frame variable weekday_2", substrs=["weekday_2 = weekday=Tuesday"])
+        self.expect(
+            "frame variable weekday_3", substrs=["weekday_3 = weekday=Wednesday"]
+        )
+        self.expect(
+            "frame variable weekday_4", substrs=["weekday_4 = weekday=Thursday"]
+        )
+        self.expect("frame variable weekday_5", substrs=["weekday_5 = weekday=Friday"])
+        self.expect(
+            "frame variable weekday_6", substrs=["weekday_6 = weekday=Saturday"]
+        )
+        self.expect("frame variable weekday_7", substrs=["weekday_7 = weekday=Sunday"])
+        self.expect("frame variable weekday_8", substrs=["weekday_8 = weekday=8"])
+        self.expect("frame variable weekday_255", substrs=["weekday_255 = weekday=255"])
+
+        self.expect(
+            "frame variable wdi_saturday_0",
+            substrs=["wdi_saturday_0 = weekday=Saturday index=0"],
+        )
+        self.expect(
+            "frame variable wdi_monday_1",
+            substrs=["wdi_monday_1 = weekday=Monday index=1"],
+        )
+        self.expect(
+            "frame variable wdi_invalid",
+            substrs=["wdi_invalid = weekday=255 index=255"],
+        )
+
+        self.expect(
+            "frame variable wdl_monday",
+            substrs=["wdl_monday = weekday=Monday index=last"],
+        )
+        self.expect(
+            "frame variable wdl_invalid",
+            substrs=["wdl_invalid = weekday=255 index=last"],
+        )
+
         self.expect("frame variable y_min", substrs=["y_min = year=-32767"])
         self.expect("frame variable y_0", substrs=["y_0 = year=0"])
         self.expect("frame variable y_1970", substrs=["y_1970 = year=1970"])
@@ -91,6 +138,21 @@ class LibcxxChronoDataFormatterTestCase(TestBase):
             substrs=["mdl_new_years_eve = month=December day=last"],
         )
 
+        self.expect(
+            "frame variable mwd_first_thursday",
+            substrs=["mwd_first_thursday = month=January weekday=Thursday index=1"],
+        )
+
+        self.expect(
+            "frame variable mwdl_last_saturday",
+            substrs=["mwdl_last_saturday = month=December weekday=Saturday index=last"],
+        )
+
+        self.expect(
+            "frame variable ym_year_zero",
+            substrs=["ym_year_zero = year=0 month=January"],
+        )
+
         self.expect("frame variable ymd_bc", substrs=["ymd_bc = date=-0001-03-255"])
         self.expect(
             "frame variable ymd_year_zero", substrs=["ymd_year_zero = date=0000-255-25"]
@@ -98,4 +160,35 @@ class LibcxxChronoDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable ymd_unix_epoch",
             substrs=["ymd_unix_epoch = date=1970-01-01"],
+        )
+
+        self.expect(
+            "frame variable ymdl_bc",
+            substrs=["ymdl_bc = year=-1 month=December day=last"],
+        )
+        self.expect(
+            "frame variable ymdl_may_1970",
+            substrs=["ymdl_may_1970 = year=1970 month=May day=last"],
+        )
+
+        self.expect(
+            "frame variable ymwd_bc",
+            substrs=["ymwd_bc = year=-1 month=June weekday=Wednesday index=2"],
+        )
+        self.expect(
+            "frame variable ymwd_forth_tuesday_2024",
+            substrs=[
+                "ymwd_forth_tuesday_2024 = year=2024 month=January weekday=Tuesday index=4"
+            ],
+        )
+
+        self.expect(
+            "frame variable ymwdl_bc",
+            substrs=["ymwdl_bc = year=-1 month=April weekday=Friday index=last"],
+        )
+        self.expect(
+            "frame variable ymwdl_2024_last_tuesday_january",
+            substrs=[
+                "ymwdl_2024_last_tuesday_january = year=2024 month=January weekday=Tuesday index=last"
+            ],
         )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/main.cpp
@@ -55,6 +55,32 @@ int main() {
   std::chrono::year y_2038{2038};
   std::chrono::year y_max{std::chrono::year::max()};
 
+  std::chrono::weekday sun = std::chrono::Sunday;
+  std::chrono::weekday mon = std::chrono::Monday;
+  std::chrono::weekday tue = std::chrono::Tuesday;
+  std::chrono::weekday wed = std::chrono::Wednesday;
+  std::chrono::weekday thu = std::chrono::Thursday;
+  std::chrono::weekday fri = std::chrono::Friday;
+  std::chrono::weekday sat = std::chrono::Saturday;
+
+  std::chrono::weekday weekday_0{0};
+  std::chrono::weekday weekday_1{1};
+  std::chrono::weekday weekday_2{2};
+  std::chrono::weekday weekday_3{3};
+  std::chrono::weekday weekday_4{4};
+  std::chrono::weekday weekday_5{5};
+  std::chrono::weekday weekday_6{6};
+  std::chrono::weekday weekday_7{7};
+  std::chrono::weekday weekday_8{8};
+  std::chrono::weekday weekday_255{255};
+
+  std::chrono::weekday_indexed wdi_saturday_0{std::chrono::Saturday, 0};
+  std::chrono::weekday_indexed wdi_monday_1{std::chrono::Monday, 1};
+  std::chrono::weekday_indexed wdi_invalid{std::chrono::weekday{255}, 255};
+
+  std::chrono::weekday_last wdl_monday{std::chrono::Monday};
+  std::chrono::weekday_last wdl_invalid{std::chrono::weekday{255}};
+
   std::chrono::month_day md_new_years_eve{std::chrono::December / 31};
   std::chrono::month_day md_new_year{std::chrono::January / 1};
   std::chrono::month_day md_invalid{std::chrono::month{255} / 255};
@@ -62,12 +88,42 @@ int main() {
   std::chrono::month_day_last mdl_jan{std::chrono::January};
   std::chrono::month_day_last mdl_new_years_eve{std::chrono::December};
 
+  std::chrono::month_weekday mwd_first_thursday{
+      std::chrono::January,
+      std::chrono::weekday_indexed{std::chrono::Thursday, 1}};
+
+  std::chrono::month_weekday_last mwdl_last_saturday{
+      std::chrono::December, std::chrono::weekday_last{std::chrono::Saturday}};
+
+  std::chrono::year_month ym_year_zero{std::chrono::year{0},
+                                       std::chrono::January};
+
   std::chrono::year_month_day ymd_bc{std::chrono::year{-1}, std::chrono::March,
                                      std::chrono::day{255}};
   std::chrono::year_month_day ymd_year_zero{
       std::chrono::year{0}, std::chrono::month{255}, std::chrono::day{25}};
   std::chrono::year_month_day ymd_unix_epoch{
       std::chrono::year{1970}, std::chrono::January, std::chrono::day{1}};
+
+  std::chrono::year_month_day_last ymdl_bc{
+      std::chrono::year{-1},
+      std::chrono::month_day_last{std::chrono::December}};
+  std::chrono::year_month_day_last ymdl_may_1970{
+      std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::May}};
+
+  std::chrono::year_month_weekday ymwd_bc{
+      std::chrono::year{-1}, std::chrono::June,
+      std::chrono::weekday_indexed{std::chrono::Wednesday, 2}};
+  std::chrono::year_month_weekday ymwd_forth_tuesday_2024{
+      std::chrono::year{2024}, std::chrono::January,
+      std::chrono::weekday_indexed{std::chrono::Tuesday, 4}};
+
+  std::chrono::year_month_weekday_last ymwdl_bc{
+      std::chrono::year{-1}, std::chrono::April,
+      std::chrono::weekday_last{std::chrono::Friday}};
+  std::chrono::year_month_weekday_last ymwdl_2024_last_tuesday_january{
+      std::chrono::year{2024}, std::chrono::January,
+      std::chrono::weekday_last{std::chrono::Tuesday}};
 
   std::cout << "break here\n";
 }


### PR DESCRIPTION
This is a followup of #76983 and adds the libc++ data formatters for
- weekday,
- weekday_indexed,
- weekday_last,
- month_weekday,
- month_weekday_last,
- year_month,
- year_month_day_last
- year_month_weekday, and
- year_month_weekday_last.