### PR TITLE
[lldb] Support dSYMs as modules

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -698,6 +698,10 @@ public:
   /// file to be complete.
   virtual bool CanTrustAddressRanges() { return false; }
 
+  /// Can this object file serve as a valid target module. If a Status is passed
+  /// and the answer is no, it will be populated with the reason.
+  virtual bool CanBeTargetModule(Status *status = nullptr);
+
   static lldb::SymbolType GetSymbolTypeFromName(
       llvm::StringRef name,
       lldb::SymbolType symbol_type_hint = lldb::eSymbolTypeUndefined);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6128,6 +6128,12 @@ Section *ObjectFileMachO::GetMachHeaderSection() {
   return nullptr;
 }
 
+bool ObjectFileMachO::CanBeTargetModule(Status *status) {
+  if (m_header.filetype == MH_DSYM)
+    return true;
+  return ObjectFile::CanBeTargetModule(status);
+}
+
 bool ObjectFileMachO::SectionIsLoadable(const Section *section) {
   if (!section)
     return false;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -160,6 +160,9 @@ public:
 
   lldb_private::Section *GetMachHeaderSection();
 
+  virtual bool
+  CanBeTargetModule(lldb_private::Status *status = nullptr) override;
+
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -764,6 +764,39 @@ uint32_t ObjectFile::GetCacheHash() {
   return *m_cache_hash;
 }
 
+bool ObjectFile::CanBeTargetModule(Status *status) {
+  switch (GetType()) {
+  case ObjectFile::eTypeCoreFile:      /// A core file that has a checkpoint of
+                                       /// a program's execution state
+  case ObjectFile::eTypeExecutable:    /// A normal executable
+  case ObjectFile::eTypeDynamicLinker: /// The platform's dynamic linker
+                                       /// executable
+  case ObjectFile::eTypeObjectFile:    /// An intermediate object file
+  case ObjectFile::eTypeSharedLibrary: /// A shared library that can be
+                                       /// used during execution
+    return true;
+  case ObjectFile::eTypeDebugInfo: /// An object file that contains only
+                                   /// debug information
+    if (status)
+      status->SetErrorString("debug info files aren't valid target "
+                             "modules, please specify an executable");
+    return false;
+  case ObjectFile::eTypeStubLibrary: /// A library that can be linked
+                                     /// against but not used for
+                                     /// execution
+    if (status)
+      status->SetErrorString("stub libraries aren't valid target "
+                             "modules, please specify an executable");
+    return false;
+  default:
+    if (status)
+      status->SetErrorString(
+          "unsupported file type, please specify an executable");
+    return false;
+  }
+  llvm_unreachable("Fully covered switch above!");
+}
+
 namespace llvm {
 namespace json {
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2254,37 +2254,10 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &module_spec, bool notify,
     // there wasn't an equivalent module in the list already, and if there was,
     // let's remove it.
     if (module_sp) {
-      ObjectFile *objfile = module_sp->GetObjectFile();
-      if (objfile) {
-        switch (objfile->GetType()) {
-        case ObjectFile::eTypeCoreFile: /// A core file that has a checkpoint of
-                                        /// a program's execution state
-        case ObjectFile::eTypeExecutable:    /// A normal executable
-        case ObjectFile::eTypeDynamicLinker: /// The platform's dynamic linker
-                                             /// executable
-        case ObjectFile::eTypeObjectFile:    /// An intermediate object file
-        case ObjectFile::eTypeSharedLibrary: /// A shared library that can be
-                                             /// used during execution
-          break;
-        case ObjectFile::eTypeDebugInfo: /// An object file that contains only
-                                         /// debug information
-          if (error_ptr)
-            error_ptr->SetErrorString("debug info files aren't valid target "
-                                      "modules, please specify an executable");
+      if (ObjectFile *objfile = module_sp->GetObjectFile()) {
+        if (!objfile->CanBeTargetModule(error_ptr))
           return ModuleSP();
-        case ObjectFile::eTypeStubLibrary: /// A library that can be linked
-                                           /// against but not used for
-                                           /// execution
-          if (error_ptr)
-            error_ptr->SetErrorString("stub libraries aren't valid target "
-                                      "modules, please specify an executable");
-          return ModuleSP();
-        default:
-          if (error_ptr)
-            error_ptr->SetErrorString(
-                "unsupported file type, please specify an executable");
-          return ModuleSP();
-        }
+
         // GetSharedModule is not guaranteed to find the old shared module, for
         // instance in the common case where you pass in the UUID, it is only
         // going to find the one module matching the UUID.  In fact, it has no

--- a/lldb/test/API/macosx/dsym-module/Makefile
+++ b/lldb/test/API/macosx/dsym-module/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/macosx/dsym-module/TestTargetModuleAddDsym.py
+++ b/lldb/test/API/macosx/dsym-module/TestTargetModuleAddDsym.py
@@ -1,0 +1,21 @@
+import os
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+@skipUnlessDarwin
+class TargetModuleAddDsymTest(TestBase):
+    @no_debug_info_test
+    def test_target_module_add(self):
+        """Test that you can add a dSYM as a module."""
+        self.build(debug_info="dsym")
+
+        exe_path = self.getBuildArtifact("a.out")
+        dsym_path = exe_path + ".dSYM"
+        sym_path = os.path.join(dsym_path, "Contents", "Resources", "DWARF", "a.out")
+
+        exe = self.getBuildArtifact("a.out")
+        self.dbg.CreateTarget(exe)
+
+        self.runCmd("target module add %s" % sym_path)
+        self.expect("image list", substrs=[sym_path])

--- a/lldb/test/API/macosx/dsym-module/main.c
+++ b/lldb/test/API/macosx/dsym-module/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(int argc, char const *argv[]) {
+  return argc + 1;
+}


### PR DESCRIPTION
Generally, separate debug info files are not object files. The exception
are dSYMs which are Mach-O and often contain enough information to be
used as a module.

This patch allows users to add dSYM symbol files as target modules to
support use cases where the executable isn't available. This scenario is
common when doing core file debugging and Jason has a follow up patch
that allows core file debugging without just the dSYM.

rdar://117773589