### PR TITLE
Reorder fields for better packing

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
@@ -116,22 +116,22 @@ public:
 /// linker.
 class RelocationEntry {
 public:
-  /// SectionID - the section this relocation points to.
-  unsigned SectionID;
-
   /// Offset - offset into the section.
   uint64_t Offset;
-
-  /// RelType - relocation type.
-  uint32_t RelType;
 
   /// Addend - the relocation addend encoded in the instruction itself.  Also
   /// used to make a relocation section relative instead of symbol relative.
   int64_t Addend;
 
+  /// SectionID - the section this relocation points to.
+  unsigned SectionID;
+
+  /// RelType - relocation type.
+  uint32_t RelType;
+
   struct SectionPair {
-      uint32_t SectionA;
-      uint32_t SectionB;
+    uint32_t SectionA;
+    uint32_t SectionB;
   };
 
   /// SymOffset - Section offset of the relocation entry's symbol (used for GOT
@@ -141,36 +141,36 @@ public:
     SectionPair Sections;
   };
 
-  /// True if this is a PCRel relocation (MachO specific).
-  bool IsPCRel;
-
   /// The size of this relocation (MachO specific).
   unsigned Size;
 
+  /// True if this is a PCRel relocation (MachO specific).
+  bool IsPCRel : 1;
+
   // ARM (MachO and COFF) specific.
-  bool IsTargetThumbFunc = false;
+  bool IsTargetThumbFunc : 1;
 
   RelocationEntry(unsigned id, uint64_t offset, uint32_t type, int64_t addend)
-      : SectionID(id), Offset(offset), RelType(type), Addend(addend),
-        SymOffset(0), IsPCRel(false), Size(0), IsTargetThumbFunc(false) {}
+      : Offset(offset), Addend(addend), SectionID(id), RelType(type),
+        SymOffset(0), Size(0), IsPCRel(false), IsTargetThumbFunc(false) {}
 
   RelocationEntry(unsigned id, uint64_t offset, uint32_t type, int64_t addend,
                   uint64_t symoffset)
-      : SectionID(id), Offset(offset), RelType(type), Addend(addend),
-        SymOffset(symoffset), IsPCRel(false), Size(0),
+      : Offset(offset), Addend(addend), SectionID(id), RelType(type),
+        SymOffset(symoffset), Size(0), IsPCRel(false),
         IsTargetThumbFunc(false) {}
 
   RelocationEntry(unsigned id, uint64_t offset, uint32_t type, int64_t addend,
                   bool IsPCRel, unsigned Size)
-      : SectionID(id), Offset(offset), RelType(type), Addend(addend),
-        SymOffset(0), IsPCRel(IsPCRel), Size(Size), IsTargetThumbFunc(false) {}
+      : Offset(offset), Addend(addend), SectionID(id), RelType(type),
+        SymOffset(0), Size(Size), IsPCRel(IsPCRel), IsTargetThumbFunc(false) {}
 
   RelocationEntry(unsigned id, uint64_t offset, uint32_t type, int64_t addend,
                   unsigned SectionA, uint64_t SectionAOffset, unsigned SectionB,
                   uint64_t SectionBOffset, bool IsPCRel, unsigned Size)
-      : SectionID(id), Offset(offset), RelType(type),
-        Addend(SectionAOffset - SectionBOffset + addend), IsPCRel(IsPCRel),
-        Size(Size), IsTargetThumbFunc(false) {
+      : Offset(offset), Addend(SectionAOffset - SectionBOffset + addend),
+        SectionID(id), RelType(type), Size(Size),
+        IsPCRel(IsPCRel), IsTargetThumbFunc(false) {
     Sections.SectionA = SectionA;
     Sections.SectionB = SectionB;
   }
@@ -179,9 +179,9 @@ public:
                   unsigned SectionA, uint64_t SectionAOffset, unsigned SectionB,
                   uint64_t SectionBOffset, bool IsPCRel, unsigned Size,
                   bool IsTargetThumbFunc)
-      : SectionID(id), Offset(offset), RelType(type),
-        Addend(SectionAOffset - SectionBOffset + addend), IsPCRel(IsPCRel),
-        Size(Size), IsTargetThumbFunc(IsTargetThumbFunc) {
+      : Offset(offset), Addend(SectionAOffset - SectionBOffset + addend),
+        SectionID(id), RelType(type), Size(Size),
+        IsPCRel(IsPCRel), IsTargetThumbFunc(IsTargetThumbFunc) {
     Sections.SectionA = SectionA;
     Sections.SectionB = SectionB;
   }

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
@@ -169,8 +169,8 @@ public:
                   unsigned SectionA, uint64_t SectionAOffset, unsigned SectionB,
                   uint64_t SectionBOffset, bool IsPCRel, unsigned Size)
       : Offset(offset), Addend(SectionAOffset - SectionBOffset + addend),
-        SectionID(id), RelType(type), Size(Size),
-        IsPCRel(IsPCRel), IsTargetThumbFunc(false) {
+        SectionID(id), RelType(type), Size(Size), IsPCRel(IsPCRel),
+        IsTargetThumbFunc(false) {
     Sections.SectionA = SectionA;
     Sections.SectionB = SectionB;
   }
@@ -180,8 +180,8 @@ public:
                   uint64_t SectionBOffset, bool IsPCRel, unsigned Size,
                   bool IsTargetThumbFunc)
       : Offset(offset), Addend(SectionAOffset - SectionBOffset + addend),
-        SectionID(id), RelType(type), Size(Size),
-        IsPCRel(IsPCRel), IsTargetThumbFunc(IsTargetThumbFunc) {
+        SectionID(id), RelType(type), Size(Size), IsPCRel(IsPCRel),
+        IsTargetThumbFunc(IsTargetThumbFunc) {
     Sections.SectionA = SectionA;
     Sections.SectionB = SectionB;
   }


### PR DESCRIPTION
I noticed this structure's fields are poorly ordered when considering padding.  This reordering reduces the size from 56 bytes to 40 bytes (on LP64).