### PR TITLE
[llvm] Indirect symbol replacement with GOTPCREL for aarch64 and risc…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
@@ -25,6 +25,16 @@ void AArch64_ELFTargetObjectFile::Initialize(MCContext &Ctx,
   SupportDebugThreadLocalLocation = false;
 }
 
+const MCExpr *AArch64_ELFTargetObjectFile::getIndirectSymViaGOTPCRel(
+    const GlobalValue *GV, const MCSymbol *Sym, const MCValue &MV,
+    int64_t Offset, MachineModuleInfo *MMI, MCStreamer &Streamer) const {
+  int64_t FinalOffset = Offset + MV.getConstant();
+  const MCExpr *Res =
+      MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_GOTPCREL, getContext());
+  const MCExpr *Off = MCConstantExpr::create(FinalOffset, getContext());
+  return MCBinaryExpr::createAdd(Res, Off, getContext());
+}
+
 AArch64_MachoTargetObjectFile::AArch64_MachoTargetObjectFile() {
   SupportGOTPCRelWithOffset = false;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
@@ -21,7 +21,14 @@ class AArch64_ELFTargetObjectFile : public TargetLoweringObjectFileELF {
 public:
   AArch64_ELFTargetObjectFile() {
     PLTRelativeVariantKind = MCSymbolRefExpr::VK_PLT;
+    SupportIndirectSymViaGOTPCRel = true;
   }
+
+  const MCExpr *getIndirectSymViaGOTPCRel(const GlobalValue *GV,
+                                          const MCSymbol *Sym,
+                                          const MCValue &MV, int64_t Offset,
+                                          MachineModuleInfo *MMI,
+                                          MCStreamer &Streamer) const override;
 };
 
 /// AArch64_MachoTargetObjectFile - This TLOF implementation is used for Darwin.

--- a/llvm/lib/Target/RISCV/RISCVTargetObjectFile.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetObjectFile.h
@@ -42,6 +42,12 @@ public:
   void getModuleMetadata(Module &M) override;
 
   bool isInSmallSection(uint64_t Size) const;
+
+  const MCExpr *getIndirectSymViaGOTPCRel(const GlobalValue *GV,
+                                          const MCSymbol *Sym,
+                                          const MCValue &MV, int64_t Offset,
+                                          MachineModuleInfo *MMI,
+                                          MCStreamer &Streamer) const override;
 };
 
 } // end namespace llvm

--- a/llvm/test/MC/ELF/rtti-proxy-gotpcrel.ll
+++ b/llvm/test/MC/ELF/rtti-proxy-gotpcrel.ll
@@ -1,4 +1,7 @@
-; RUN: llc %s -mtriple=x86_64-unknown-fuchsia  -o - | FileCheck %s
+; REQUIRES: x86-registered-target && aarch64-registered-target && riscv-registered-target
+; RUN: llc %s -mtriple=x86_64 -o - | FileCheck %s
+; RUN: llc %s -mtriple=aarch64 -o - | FileCheck %s
+; RUN: llc %s -mtriple=riscv64 -o - | FileCheck %s
 
 @vtable = dso_local unnamed_addr constant i32 trunc (i64 sub (i64 ptrtoint (ptr @rtti.proxy to i64), i64 ptrtoint (ptr @vtable to i64)) to i32), align 4
 @vtable_with_offset = dso_local unnamed_addr constant [2 x i32] [i32 0, i32 trunc (i64 sub (i64 ptrtoint (ptr @rtti.proxy to i64), i64 ptrtoint (ptr @vtable_with_offset to i64)) to i32)], align 4


### PR DESCRIPTION
…v64 ELF

This is similar to https://github.com/llvm/llvm-project/pull/67754 but adds support for ELF aarch64 and riscv64 now that GOTPCREL-equivalent relocations have been added for those archs.