### PR TITLE
Revert "[InstCombine] Fold `icmp pred (inttoptr X), (inttoptr Y) -> icmp pred X, Y`"

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -5703,15 +5703,6 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
       return new ICmpInst(ICmp.getPredicate(), Op0Src, NewOp1);
   }
 
-  // Turn icmp pred (inttoptr x), (inttoptr y) into icmp pred x, y
-  if (CastOp0->getOpcode() == Instruction::IntToPtr &&
-      CompatibleSizes(DestTy, SrcTy)) {
-    Value *Op1Src;
-    if (match(ICmp.getOperand(1), m_IntToPtr(m_Value(Op1Src))) &&
-        Op1Src->getType() == SrcTy)
-      return new ICmpInst(ICmp.getPredicate(), Op0Src, Op1Src);
-  }
-
   if (Instruction *R = foldICmpWithTrunc(ICmp))
     return R;
 

--- a/llvm/test/Transforms/InstCombine/cast_ptr.ll
+++ b/llvm/test/Transforms/InstCombine/cast_ptr.ll
@@ -113,51 +113,6 @@ define i1 @test4(i32 %A) {
   ret i1 %C
 }
 
-define i1 @test4_icmp_with_var(i32 %A1, i32 %A2) {
-; CHECK-LABEL: @test4_icmp_with_var(
-; CHECK-NEXT:    [[C:%.*]] = icmp ugt i32 [[A1:%.*]], [[A2:%.*]]
-; CHECK-NEXT:    ret i1 [[C]]
-;
-  %B1 = inttoptr i32 %A1 to ptr
-  %B2 = inttoptr i32 %A2 to ptr
-  %C = icmp ugt ptr %B1, %B2
-  ret i1 %C
-}
-
-define i1 @test4_cmp_with_nonnull_constant(i32 %A) {
-; CHECK-LABEL: @test4_cmp_with_nonnull_constant(
-; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[A:%.*]], 1
-; CHECK-NEXT:    ret i1 [[C]]
-;
-  %B = inttoptr i32 %A to ptr
-  %C = icmp eq ptr %B, inttoptr (i32 1 to ptr)
-  ret i1 %C
-}
-
-define i1 @test4_cmp_eq_0_or_1(i32 %x) {
-; CHECK-LABEL: @test4_cmp_eq_0_or_1(
-; CHECK-NEXT:    [[OR:%.*]] = icmp ult i32 [[X:%.*]], 2
-; CHECK-NEXT:    ret i1 [[OR]]
-;
-  %cast = inttoptr i32 %x to ptr
-  %tobool = icmp eq i32 %x, 0
-  %cmp = icmp eq ptr %cast, inttoptr (i32 1 to ptr)
-  %or = or i1 %tobool, %cmp
-  ret i1 %or
-}
-
-define i1 @test4_icmp_with_var_mismatched_type(i32 %A1, i64 %A2) {
-; CHECK-LABEL: @test4_icmp_with_var_mismatched_type(
-; CHECK-NEXT:    [[TMP1:%.*]] = trunc i64 [[A2:%.*]] to i32
-; CHECK-NEXT:    [[C:%.*]] = icmp ult i32 [[TMP1]], [[A1:%.*]]
-; CHECK-NEXT:    ret i1 [[C]]
-;
-  %B1 = inttoptr i32 %A1 to ptr
-  %B2 = inttoptr i64 %A2 to ptr
-  %C = icmp ugt ptr %B1, %B2
-  ret i1 %C
-}
-
 define i1 @test4_as2(i16 %A) {
 ; CHECK-LABEL: @test4_as2(
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i16 [[A:%.*]], 0


### PR DESCRIPTION
Reverts llvm/llvm-project#77832

To fix https://lab.llvm.org/buildbot/#/builders/236/builds/8673

Also truncation to shorter type looks incorrect.

Issue for tracking #78024 .