### PR TITLE
Enable direct methods and fast alloc calls for libobjc2.

### DIFF
--- a/clang/include/clang/Basic/ObjCRuntime.h
+++ b/clang/include/clang/Basic/ObjCRuntime.h
@@ -211,7 +211,13 @@ public:
     case GCC:
       return false;
     case GNUstep:
-      return false;
+      // This could be enabled for all versions, except for the fact that the
+      // implementation of `objc_retain` and friends prior to 2.2 call [object
+      // retain] in their fall-back paths, which leads to infinite recursion if
+      // the runtime is built with this enabled.  Since distributions typically
+      // build all Objective-C things with the same compiler version and flags,
+      // it's better to be conservative here.
+      return (getVersion() >= VersionTuple(2, 2));
     case ObjFW:
       return false;
     }
@@ -248,7 +254,7 @@ public:
     case GCC:
       return false;
     case GNUstep:
-      return false;
+      return getVersion() >= VersionTuple(2, 2);
     case ObjFW:
       return false;
     }
@@ -266,6 +272,8 @@ public:
       return getVersion() >= VersionTuple(12, 2);
     case WatchOS:
       return getVersion() >= VersionTuple(5, 2);
+    case GNUstep:
+      return getVersion() >= VersionTuple(2, 2);
     default:
       return false;
     }
@@ -463,7 +471,8 @@ public:
     case iOS: return true;
     case WatchOS: return true;
     case GCC: return false;
-    case GNUstep: return false;
+    case GNUstep:
+      return (getVersion() >= VersionTuple(2, 2));
     case ObjFW: return false;
     }
     llvm_unreachable("bad kind");

--- a/clang/test/CodeGenObjC/gnustep2-direct-method.m
+++ b/clang/test/CodeGenObjC/gnustep2-direct-method.m
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-freebsd -S -emit-llvm -fobjc-runtime=gnustep-2.2 -o - %s | FileCheck %s
+
+@interface X
+@end
+
+@implementation X
+//- (int)x __attribute__((objc_direct)) { return 12; }
+- (int)x __attribute__((objc_direct)) { return 12; }
+
+// Check that the name is mangled like Objective-C methods and contains a nil check
+// CHECK-LABEL: @_i_X__x
+// CHECK: icmp eq ptr %0, null
+
++ (int)clsMeth __attribute__((objc_direct)) { return 42; }
+// Check that the name is mangled like Objective-C methods and contains an initialisation check
+// CHECK-LABEL: @_c_X__clsMeth
+// CHECK: getelementptr inbounds { ptr, ptr, ptr, i64, i64 }, ptr %0, i32 0, i32 4
+// CHECK: load i64, ptr %1, align 64
+// CHECK: and i64 %2, 256
+// CHECK: objc_direct_method.class_uninitialized:
+// CHECK: call void @objc_send_initialize(ptr %0)
+
+@end
+
+// Check that the call sides are set up correctly.
+void callCls(void)
+{
+	// CHECK: call i32 @_c_X__clsMeth
+	[X clsMeth];
+}
+
+void callInstance(X *x)
+{
+	// CHECK: call i32 @_i_X__x
+	[x x];
+}
+


### PR DESCRIPTION
These will be supported in the upcoming 2.2 release and so are gated on that version.

Direct methods call `objc_send_initialize` if they are class methods that may not have called initialize.  This is guarded by checking for the class flag bit that is set on initialisation in the class.  This bit now forms part of the ABI, but it's been stable for 30+ years so that's fine as a contract going forwards.