### PR TITLE
[clang] SyntaxWarning: invalid escape sequence '\s' with Python3.12

### DIFF
--- a/clang/tools/libclang/linker-script-to-export-list.py
+++ b/clang/tools/libclang/linker-script-to-export-list.py
@@ -6,6 +6,6 @@ input_file = open(sys.argv[1])
 output_file = open(sys.argv[2], "w")
 
 for line in input_file:
-    m = re.search("^\\s+(clang_[^;]+)", line)
+    m = re.search(r"^\s+(clang_[^;]+)", line)
     if m:
         output_file.write(m.group(1) + "\n")

--- a/clang/tools/libclang/linker-script-to-export-list.py
+++ b/clang/tools/libclang/linker-script-to-export-list.py
@@ -6,6 +6,6 @@ input_file = open(sys.argv[1])
 output_file = open(sys.argv[2], "w")
 
 for line in input_file:
-    m = re.search("^\s+(clang_[^;]+)", line)
+    m = re.search("^\\s+(clang_[^;]+)", line)
     if m:
         output_file.write(m.group(1) + "\n")


### PR DESCRIPTION
The following SyntaxWarning was observed with Python3.12 .
```
llvm-project/clang/tools/libclang/linker-script-to-export-list.py:9: SyntaxWarning: invalid escape sequence '\s'
  m = re.search("^\s+(clang_[^;]+)", line)
```

Similar problem had been reported here https://stackoverflow.com/questions/57645829/why-am-i-getting-a-syntaxwarning-invalid-escape-sequence-s-warning .

It would be better to fix it.
Thanks.
