### PR TITLE
[compiler-rt] Add a prefix on the windows mmap symbols

### DIFF
--- a/compiler-rt/lib/profile/WindowsMMap.c
+++ b/compiler-rt/lib/profile/WindowsMMap.c
@@ -124,8 +124,7 @@ int madvise(void *addr, size_t length, int advice)
   return 0;
 }
 
-COMPILER_RT_VISIBILITY
-int lock(HANDLE handle, DWORD lockType, BOOL blocking) {
+static int lock(HANDLE handle, DWORD lockType, BOOL blocking) {
   DWORD flags = lockType;
   if (!blocking)
     flags |= LOCKFILE_FAIL_IMMEDIATELY;

--- a/compiler-rt/lib/profile/WindowsMMap.h
+++ b/compiler-rt/lib/profile/WindowsMMap.h
@@ -60,6 +60,12 @@
 # define DWORD_LO(x) (x)
 #endif
 
+#define mmap __llvm_profile_mmap
+#define munmap __llvm_profile_munmap
+#define msync __llvm_profile_msync
+#define madvise __llvm_profile_madvise
+#define flock __llvm_profile_flock
+
 void *mmap(void *start, size_t length, int prot, int flags, int fd,
            off_t offset);
 


### PR DESCRIPTION
For Windows, the compiler-rt profile library contains a polyfill reimplementation of the mmap family of functions.

Previously, the runtime library exposed those symbols like, "mmap", in the user symbol namespace. This could cause misdetections by configure scripts that check for the "mmap" function just by linking, without including headers.

Add a prefix on the symbols, and make an undeclared function static.

This fixes such an issue reported at https://github.com/mstorsjo/llvm-mingw/issues/390.