### PR TITLE
[clang] Add test for CWG1350

### DIFF
--- a/clang/test/CXX/drs/dr13xx.cpp
+++ b/clang/test/CXX/drs/dr13xx.cpp
@@ -379,6 +379,48 @@ namespace dr1347 { // dr1347: 3.1
 #endif
 }
 
+namespace dr1350 { // dr1350: 3.5
+#if __cplusplus >= 201103L
+struct NoexceptCtor {
+  NoexceptCtor(int) noexcept {}
+};
+
+struct ThrowingNSDMI : NoexceptCtor {
+  int a = []() noexcept(false) { return 0; }();
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(ThrowingNSDMI, int), "");
+
+struct ThrowingCtor {
+  ThrowingCtor() noexcept(false) {}
+};
+
+struct ThrowingNSDM : NoexceptCtor {
+  ThrowingCtor c;
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(ThrowingNSDM, int), "");
+
+struct D : NoexceptCtor, ThrowingCtor {
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(D, int), "");
+
+struct ThrowingDefaultArg {
+  ThrowingDefaultArg(ThrowingCtor = {}) {}
+};
+
+struct D2 : NoexceptCtor, ThrowingDefaultArg {
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(D2, int), "");
+#endif
+} // namespace dr1350
+
 namespace dr1358 { // dr1358: 3.1
 #if __cplusplus >= 201103L
   struct Lit { constexpr operator int() const { return 0; } };

--- a/clang/test/CXX/drs/dr13xx.cpp
+++ b/clang/test/CXX/drs/dr13xx.cpp
@@ -403,21 +403,50 @@ struct ThrowingNSDM : NoexceptCtor {
 
 static_assert(!__is_nothrow_constructible(ThrowingNSDM, int), "");
 
-struct D : NoexceptCtor, ThrowingCtor {
+struct ThrowingCtorTemplate {
+  template <typename = int>
+  ThrowingCtorTemplate() noexcept(false) {}
+};
+
+struct ThrowingNSDM2 : NoexceptCtor {
+  ThrowingCtorTemplate c;
   using NoexceptCtor::NoexceptCtor;
 };
 
-static_assert(!__is_nothrow_constructible(D, int), "");
+static_assert(!__is_nothrow_constructible(ThrowingNSDM2, int), "");
+
+struct D1 : NoexceptCtor, ThrowingCtor {
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(D1, int), "");
+
+struct D2 : NoexceptCtor, ThrowingCtorTemplate {
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(D2, int), "");
 
 struct ThrowingDefaultArg {
   ThrowingDefaultArg(ThrowingCtor = {}) {}
 };
 
-struct D2 : NoexceptCtor, ThrowingDefaultArg {
+struct D3 : NoexceptCtor, ThrowingDefaultArg {
   using NoexceptCtor::NoexceptCtor;
 };
 
-static_assert(!__is_nothrow_constructible(D2, int), "");
+static_assert(!__is_nothrow_constructible(D3, int), "");
+
+struct ThrowingDefaultArgTemplate {
+  template <typename = int>
+  ThrowingDefaultArgTemplate(ThrowingCtor = {}) {}
+};
+
+struct D4 : NoexceptCtor, ThrowingDefaultArgTemplate {
+  using NoexceptCtor::NoexceptCtor;
+};
+
+static_assert(!__is_nothrow_constructible(D4, int), "");
 #endif
 } // namespace dr1350
 

--- a/clang/test/CXX/drs/dr15xx.cpp
+++ b/clang/test/CXX/drs/dr15xx.cpp
@@ -390,6 +390,13 @@ namespace dr1573 { // dr1573: 3.9
   H h(0);
   // since-cxx11-error@-1 {{constructor inherited by 'H' from base class 'G' is implicitly deleted}}
   //   since-cxx11-note@#dr1573-H {{constructor inherited by 'H' is implicitly deleted because field 'g' has no default constructor}}
+
+  // deleted definition of constructor is inherited
+  struct I { I(int) = delete; }; // #dr1573-I
+  struct J : I { using I::I; };
+  J j(0);
+  // since-cxx11-error@-1 {{call to deleted constructor of 'J'}}
+  //   since-cxx11-note@#dr1573-I {{'I' has been explicitly marked deleted here}}
 #endif
 }
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -7908,7 +7908,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1350.html">1350</a></td>
     <td>CD3</td>
     <td>Incorrect exception specification for inherited constructors</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.5</td>
   </tr>
   <tr id="1351">
     <td><a href="https://cplusplus.github.io/CWG/issues/1351.html">1351</a></td>


### PR DESCRIPTION
Test is based on [P0136R1](https://wg21.link/p0136r1) wording instead of proposed resolution in the issue itself.

This patch also expands related CWG1573 test with an additional test case. Existing `3.9` status of 1573 is still relevant even with this new test case.