### PR TITLE
[clang-tidy] Add option to ignore macros in `readability-simplify-boolean-expr` check

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.cpp
@@ -277,10 +277,13 @@ public:
   }
 
   bool dataTraverseStmtPre(Stmt *S) {
+    if (!S) {
+      return true;
+    }
     if (Check->IgnoreMacros && S->getBeginLoc().isMacroID()) {
       return false;
     }
-    if (S && !shouldIgnore(S))
+    if (!shouldIgnore(S))
       StmtStack.push_back(S);
     return true;
   }

--- a/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.cpp
@@ -277,6 +277,9 @@ public:
   }
 
   bool dataTraverseStmtPre(Stmt *S) {
+    if (Check->IgnoreMacros && S->getBeginLoc().isMacroID()) {
+      return false;
+    }
     if (S && !shouldIgnore(S))
       StmtStack.push_back(S);
     return true;
@@ -583,6 +586,7 @@ private:
 SimplifyBooleanExprCheck::SimplifyBooleanExprCheck(StringRef Name,
                                                    ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
+      IgnoreMacros(Options.get("IgnoreMacros", false)),
       ChainedConditionalReturn(Options.get("ChainedConditionalReturn", false)),
       ChainedConditionalAssignment(
           Options.get("ChainedConditionalAssignment", false)),
@@ -671,6 +675,7 @@ void SimplifyBooleanExprCheck::reportBinOp(const ASTContext &Context,
 }
 
 void SimplifyBooleanExprCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "IgnoreMacros", IgnoreMacros);
   Options.store(Opts, "ChainedConditionalReturn", ChainedConditionalReturn);
   Options.store(Opts, "ChainedConditionalAssignment",
                 ChainedConditionalAssignment);

--- a/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/SimplifyBooleanExprCheck.h
@@ -64,6 +64,7 @@ private:
                  StringRef Description, SourceRange ReplacementRange,
                  StringRef Replacement);
 
+  const bool IgnoreMacros;
   const bool ChainedConditionalReturn;
   const bool ChainedConditionalAssignment;
   const bool SimplifyDeMorgan;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -494,7 +494,8 @@ Changes in existing checks
 
 - Improved :doc:`readability-simplify-boolean-expr
   <clang-tidy/checks/readability/simplify-boolean-expr>` check by adding the
-  new option `IgnoreMacros` that ignores boolean expressions passed into macros.
+  new option `IgnoreMacros` that allows to ignore boolean expressions originating
+  from expanded macros.
 
 - Improved :doc:`readability-simplify-subscript-expr
   <clang-tidy/checks/readability/simplify-subscript-expr>` check by extending

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -492,9 +492,9 @@ Changes in existing checks
   <clang-tidy/checks/readability/non-const-parameter>` check to ignore
   false-positives in initializer list of record.
 
-- Added option `IgnoreMacros` to :doc:`readability-simplify-boolean-expr
-  <clang-tidy/checks/readability/simplify-boolean-expr>` check.
-  It makes the check ignore boolean expressions passed into macros.
+- Improved :doc:`readability-simplify-boolean-expr
+  <clang-tidy/checks/readability/simplify-boolean-expr>` check by adding the
+  new option `IgnoreMacros` that ignores boolean expressions passed into macros.
 
 - Improved :doc:`readability-simplify-subscript-expr
   <clang-tidy/checks/readability/simplify-subscript-expr>` check by extending

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -492,6 +492,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/non-const-parameter>` check to ignore
   false-positives in initializer list of record.
 
+- Added option `IgnoreMacros` to :doc:`readability-simplify-boolean-expr
+  <clang-tidy/checks/readability/simplify-boolean-expr>` check.
+  It makes the check ignore boolean expressions passed into macros.
+
 - Improved :doc:`readability-simplify-subscript-expr
   <clang-tidy/checks/readability/simplify-subscript-expr>` check by extending
   the default value of the `Types` option to include ``std::span``.
@@ -499,10 +503,6 @@ Changes in existing checks
 - Improved :doc:`readability-static-accessed-through-instance
   <clang-tidy/checks/readability/static-accessed-through-instance>` check to
   identify calls to static member functions with out-of-class inline definitions.
-
-- Added option `IgnoreMacros` to :doc:`readability-simplify-boolean-expr
-  <clang-tidy/checks/readability/simplify-boolean-expr>` check.
-  It makes the check ignore boolean expressions passed into macros.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -500,6 +500,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/static-accessed-through-instance>` check to
   identify calls to static member functions with out-of-class inline definitions.
 
+- Added option `IgnoreMacros` to :doc:`readability-simplify-boolean-expr
+  <clang-tidy/checks/readability/simplify-boolean-expr>` check.
+  It makes the check ignore boolean expressions passed into macros.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
@@ -82,6 +82,10 @@ Examples:
 Options
 -------
 
+.. option:: IgnoreMacros
+
+   If `true`, ignore boolean expressions passed into macros. Default is `false`.
+
 .. option:: ChainedConditionalReturn
 
    If `true`, conditional boolean return statements at the end of an
@@ -99,8 +103,8 @@ Options
 
 .. option:: SimplifyDeMorganRelaxed
 
-   If `true`, :option:`SimplifyDeMorgan` will also transform negated 
-   conjunctions and disjunctions where there is no negation on either operand. 
+   If `true`, :option:`SimplifyDeMorgan` will also transform negated
+   conjunctions and disjunctions where there is no negation on either operand.
    This option has no effect if :option:`SimplifyDeMorgan` is `false`.
    Default is `false`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-boolean-expr.rst
@@ -84,7 +84,8 @@ Options
 
 .. option:: IgnoreMacros
 
-   If `true`, ignore boolean expressions passed into macros. Default is `false`.
+   If `true`, ignore boolean expressions originating from expanded macros.
+   Default is `false`.
 
 .. option:: ChainedConditionalReturn
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
@@ -1,8 +1,8 @@
 // RUN: %check_clang_tidy -check-suffixes=,MACROS %s readability-simplify-boolean-expr %t
 
 // Ignore expressions in macros.
-// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
-// RUN:     -- -config="{CheckOptions: {readability-simplify-boolean-expr.IgnoreMacros: true}}"
+// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t \
+// RUN:     -- -config="{CheckOptions: {readability-simplify-boolean-expr.IgnoreMacros: true}}" \
 // RUN:     --
 
 #define NEGATE(expr) !(expr)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
@@ -2,7 +2,7 @@
 
 // Ignore expressions in macros.
 // RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
-// RUN:     -- -config="{CheckOptions: [{key: readability-simplify-boolean-expr.IgnoreMacros, value: true}]}"
+// RUN:     -- -config="{CheckOptions: {readability-simplify-boolean-expr.IgnoreMacros: true}}"
 // RUN:     --
 
 #define NEGATE(expr) !(expr)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-macros.cpp
@@ -1,0 +1,20 @@
+// RUN: %check_clang_tidy -check-suffixes=,MACROS %s readability-simplify-boolean-expr %t
+
+// Ignore expressions in macros.
+// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
+// RUN:     -- -config="{CheckOptions: [{key: readability-simplify-boolean-expr.IgnoreMacros, value: true}]}"
+// RUN:     --
+
+#define NEGATE(expr) !(expr)
+
+bool without_macro(bool a, bool b) {
+    return !(!a && b);
+    // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: boolean expression can be simplified by DeMorgan's theorem
+    // CHECK-FIXES: return a || !b;
+}
+
+bool macro(bool a, bool b) {
+    return NEGATE(!a && b);
+    // CHECK-MESSAGES-MACROS: :[[@LINE-1]]:12: warning: boolean expression can be simplified by DeMorgan's theorem
+    // CHECK-FIXES: return NEGATE(!a && b);
+}


### PR DESCRIPTION
Closes #57975.