### PR TITLE
[libc] Give more functions restrict qualifiers (NFC)

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/string.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/string.h
@@ -51,13 +51,13 @@ char *strcpy(char *__restrict, const char *__restrict) __LIBC_ATTRS;
 size_t strcspn(const char *, const char *) __LIBC_ATTRS;
 char *strdup(const char *) __LIBC_ATTRS;
 size_t strlen(const char *) __LIBC_ATTRS;
-char *strncat(char *, const char *, size_t) __LIBC_ATTRS;
+char *strncat(char *__restrict, const char *__restrict, size_t) __LIBC_ATTRS;
 int strncmp(const char *, const char *, size_t) __LIBC_ATTRS;
 char *strncpy(char *__restrict, const char *__restrict, size_t) __LIBC_ATTRS;
 char *strndup(const char *, size_t) __LIBC_ATTRS;
 size_t strnlen(const char *, size_t) __LIBC_ATTRS;
 size_t strspn(const char *, const char *) __LIBC_ATTRS;
-char *strtok(char *__restrict, const char *) __LIBC_ATTRS;
+char *strtok(char *__restrict, const char *__restrict) __LIBC_ATTRS;
 char *strtok_r(char *__restrict, const char *__restrict,
                char **__restrict) __LIBC_ATTRS;
 size_t strxfrm(char *__restrict, const char *__restrict, size_t) __LIBC_ATTRS;

--- a/clang/test/Analysis/Inputs/system-header-simulator-for-simple-stream.h
+++ b/clang/test/Analysis/Inputs/system-header-simulator-for-simple-stream.h
@@ -8,9 +8,9 @@
 typedef struct __sFILE {
   unsigned char *_p;
 } FILE;
-FILE *fopen(const char * restrict, const char * restrict) __asm("_" "fopen" );
+FILE *fopen(const char *restrict, const char *restrict) __asm("_" "fopen" );
 int fputc(int, FILE *);
-int fputs(const char * restrict, FILE * restrict) __asm("_" "fputs" );
+int fputs(const char *restrict, FILE *restrict) __asm("_" "fputs" );
 int fclose(FILE *);
 void exit(int);
 

--- a/clang/test/Analysis/Inputs/system-header-simulator.h
+++ b/clang/test/Analysis/Inputs/system-header-simulator.h
@@ -71,9 +71,9 @@ int fflush(FILE *stream);
 size_t strlen(const char *);
 
 char *strcpy(char *restrict, const char *restrict);
-char *strncpy(char *dst, const char *src, size_t n);
-char *strsep(char **stringp, const char *delim);
-void *memcpy(void *dst, const void *src, size_t n);
+char *strncpy(char *restrict dst, const char *restrict src, size_t n);
+char *strsep(char **restrict stringp, const char *restrict delim);
+void *memcpy(void *restrict dst, const void *restrict src, size_t n);
 void *memset(void *s, int c, size_t n);
 
 typedef unsigned long __darwin_pthread_key_t;

--- a/clang/test/Analysis/bsd-string.c
+++ b/clang/test/Analysis/bsd-string.c
@@ -7,8 +7,8 @@
 #define NULL ((void *)0)
 
 typedef __typeof(sizeof(int)) size_t;
-size_t strlcpy(char *dst, const char *src, size_t n);
-size_t strlcat(char *dst, const char *src, size_t n);
+size_t strlcpy(char *restrict dst, const char *restrict src, size_t n);
+size_t strlcat(char *restrict dst, const char *restrict src, size_t n);
 size_t strlen(const char *s);
 void clang_analyzer_eval(int);
 

--- a/clang/test/Analysis/string.c
+++ b/clang/test/Analysis/string.c
@@ -71,7 +71,7 @@ void clang_analyzer_eval(int);
 int scanf(const char *restrict format, ...);
 void *malloc(size_t);
 void free(void *);
-void *memcpy(void *dest, const void *src, size_t n);
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 
 //===----------------------------------------------------------------------===
 // strlen()
@@ -1252,7 +1252,7 @@ int strncasecmp_null_argument(char *a, size_t n) {
 // strsep()
 //===----------------------------------------------------------------------===
 
-char *strsep(char **stringp, const char *delim);
+char *strsep(char ** restrict stringp, const char * restrict delim);
 
 void strsep_null_delim(char *s) {
   strsep(&s, NULL); // expected-warning{{Null pointer passed as 2nd argument to strsep()}}

--- a/libc/spec/bsd_ext.td
+++ b/libc/spec/bsd_ext.td
@@ -8,12 +8,12 @@ def BsdExtensions : StandardSpec<"BSDExtensions"> {
         FunctionSpec<
             "strlcat",
             RetValSpec<SizeTType>,
-            [ArgSpec<CharPtr>, ArgSpec<ConstCharPtr>, ArgSpec<SizeTType>]
+            [ArgSpec<ConstCharRestrictedPtr>, ArgSpec<ConstCharRestrictedPtr>, ArgSpec<SizeTType>]
         >,
         FunctionSpec<
             "strlcpy",
             RetValSpec<SizeTType>,
-            [ArgSpec<CharPtr>, ArgSpec<ConstCharPtr>, ArgSpec<SizeTType>]
+            [ArgSpec<ConstCharRestrictedPtr>, ArgSpec<ConstCharRestrictedPtr>, ArgSpec<SizeTType>]
         >,
         FunctionSpec<
             "strsep",

--- a/libc/src/string/strsep.cpp
+++ b/libc/src/string/strsep.cpp
@@ -12,7 +12,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(char *, strsep, (char **stringp, const char *delim)) {
+LLVM_LIBC_FUNCTION(char *, strsep,
+                   (char **__restrict stringp, const char *__restrict delim)) {
   if (!*stringp)
     return nullptr;
   return internal::string_token<false>(*stringp, delim, stringp);

--- a/libc/src/string/strsep.h
+++ b/libc/src/string/strsep.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-char *strsep(char **stringp, const char *delim);
+char *strsep(char **__restrict stringp, const char *__restrict delim);
 
 } // namespace LIBC_NAMESPACE
 


### PR DESCRIPTION
strsep, strtok_r, strlcpy, and strlcat take restricted pointers as parameters.
Add the restrict qualifiers to them.

Sources:
https://man7.org/linux/man-pages/man3/strsep.3.html
https://man7.org/linux/man-pages/man3/strtok_r.3.html
https://man.freebsd.org/cgi/man.cgi?strlcpy
