### PR TITLE
[clang] emit an error when the same identifier appears with both internal and external linkage in a translation unit

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -918,6 +918,10 @@ Bug Fixes to C++ Support
   (`#57410 <https://github.com/llvm/llvm-project/issues/57410>`_) and
   (`#76604 <https://github.com/llvm/llvm-project/issues/57410>`_)
 
+- Emit an error when the same identifier appears with both internal and
+  external linkage in a translation unit Fixes:
+  (`#54215 <https://github.com/llvm/llvm-project/issues/54215>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5940,6 +5940,8 @@ def err_different_language_linkage : Error<
 def ext_retained_language_linkage : Extension<
   "friend function %0 retaining previous language linkage is an extension">,
   InGroup<DiagGroup<"retained-language-linkage">>;
+def err_multiple_linkage: Error<
+  "the same identifier %0 appears with both internal and external linkage">;
 def err_extern_c_global_conflict : Error<
   "declaration of %1 %select{with C language linkage|in global scope}0 "
   "conflicts with declaration %select{in global scope|with C language linkage}0">;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4754,6 +4754,11 @@ void Sema::MergeVarDecl(VarDecl *New, LookupResult &Previous) {
     return New->setInvalidDecl();
   }
 
+  if (Old->getFormalLinkage() != New->getFormalLinkage()) {
+    Diag(New->getLocation(), diag::err_multiple_linkage) << New->getDeclName();
+    return New->setInvalidDecl();
+  }
+
   if (New->isInline() && !Old->getMostRecentDecl()->isInline()) {
     if (VarDecl *Def = Old->getDefinition()) {
       // C++1z [dcl.fcn.spec]p4:

--- a/clang/test/Sema/private-extern.c
+++ b/clang/test/Sema/private-extern.c
@@ -5,10 +5,10 @@ static int g0; // expected-note{{previous definition}}
 int g0; // expected-error{{non-static declaration of 'g0' follows static declaration}}
 
 static int g1;
-extern int g1;
+extern int g1; // expected-error{{the same identifier 'g1' appears with both internal and external linkage}}
 
-static int g2; 
-__private_extern__ int g2;
+static int g2;
+__private_extern__ int g2; // expected-error{{the same identifier 'g2' appears with both internal and external linkage}}
 
 int g3; // expected-note{{previous definition}}
 static int g3; // expected-error{{static declaration of 'g3' follows non-static declaration}}
@@ -83,3 +83,15 @@ __private_extern__ int g19;
 int g19 = 0;
 
 __private_extern__ int g20 = 0;
+
+static int g21;
+extern int g21; // expected-error{{the same identifier 'g21' appears with both internal and external linkage}}
+
+static int g22;
+
+void f10(void) {
+  int g22;
+  {
+    extern int g22; // expected-error{{the same identifier 'g22' appears with both internal and external linkage}}
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/54215
