### PR TITLE
[MLIR][Presburger] Implement function to evaluate the number of terms in a generating function.

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -99,10 +99,10 @@ QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
                                                  ArrayRef<QuasiPolynomial> num,
                                                  ArrayRef<Fraction> den);
 
-/// Find the number of terms in a generating function, which is
+/// Find the number of terms in a generating function, as
 /// a quasipolynomial in the parameter space of the input function.
 /// The generating function must be such that for all values of the
-/// parameters, the number of terms is finite; else it returns 0.
+/// parameters, the number of terms is finite.
 QuasiPolynomial computeNumTerms(const GeneratingFunction &gf);
 
 } // namespace detail

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -99,6 +99,10 @@ QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
                                                  ArrayRef<QuasiPolynomial> num,
                                                  ArrayRef<Fraction> den);
 
+/// Substitute the generating function with the unit vector
+/// to find the number of terms.
+QuasiPolynomial substituteWithUnitVector(GeneratingFunction);
+
 } // namespace detail
 } // namespace presburger
 } // namespace mlir

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -99,9 +99,9 @@ QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
                                                  ArrayRef<QuasiPolynomial> num,
                                                  ArrayRef<Fraction> den);
 
-/// Substitute the generating function with the unit vector
-/// to find the number of terms.
-QuasiPolynomial substituteWithUnitVector(GeneratingFunction);
+/// Find the number of terms in the generating function corresponding to
+/// a polytope.
+QuasiPolynomial computeNumTerms(const GeneratingFunction& gf);
 
 } // namespace detail
 } // namespace presburger

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -101,7 +101,7 @@ QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
 
 /// Find the number of terms in the generating function corresponding to
 /// a polytope.
-QuasiPolynomial computeNumTerms(const GeneratingFunction& gf);
+QuasiPolynomial computeNumTerms(const GeneratingFunction &gf);
 
 } // namespace detail
 } // namespace presburger

--- a/mlir/include/mlir/Analysis/Presburger/Barvinok.h
+++ b/mlir/include/mlir/Analysis/Presburger/Barvinok.h
@@ -99,8 +99,10 @@ QuasiPolynomial getCoefficientInRationalFunction(unsigned power,
                                                  ArrayRef<QuasiPolynomial> num,
                                                  ArrayRef<Fraction> den);
 
-/// Find the number of terms in the generating function corresponding to
-/// a polytope.
+/// Find the number of terms in a generating function, which is
+/// a quasipolynomial in the parameter space of the input function.
+/// The generating function must be such that for all values of the
+/// parameters, the number of terms is finite; else it returns 0.
 QuasiPolynomial computeNumTerms(const GeneratingFunction &gf);
 
 } // namespace detail

--- a/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
@@ -62,13 +62,15 @@ public:
 #endif // NDEBUG
   }
 
-  unsigned getNumParams() { return numParam; }
+  unsigned getNumParams() const { return numParam; }
 
-  SmallVector<int> getSigns() { return signs; }
+  SmallVector<int> getSigns() const { return signs; }
 
-  std::vector<ParamPoint> getNumerators() { return numerators; }
+  std::vector<ParamPoint> getNumerators() const { return numerators; }
 
-  std::vector<std::vector<Point>> getDenominators() { return denominators; }
+  std::vector<std::vector<Point>> getDenominators() const {
+    return denominators;
+  }
 
   GeneratingFunction operator+(GeneratingFunction &gf) const {
     assert(numParam == gf.getNumParams() &&

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -59,8 +59,9 @@ public:
   QuasiPolynomial operator*(const QuasiPolynomial &x) const;
   QuasiPolynomial operator/(const Fraction x) const;
 
-  // Removes terms which evaluate to zero and affine functions
-  // which are constant from the expression.
+  // Removes terms which evaluate to zero from the expression
+  // and folds affine functions which are constant into the
+  // constant coefficients.
   QuasiPolynomial simplify();
 
   // Group together like terms in the expression.

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -59,7 +59,8 @@ public:
   QuasiPolynomial operator*(const QuasiPolynomial &x) const;
   QuasiPolynomial operator/(const Fraction x) const;
 
-  // Removes terms which evaluate to zero from the expression.
+  // Removes terms which evaluate to zero and affine functions
+  // which are constant from the expression.
   QuasiPolynomial simplify();
 
   Fraction getConstantTerm();

--- a/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
+++ b/mlir/include/mlir/Analysis/Presburger/QuasiPolynomial.h
@@ -63,6 +63,9 @@ public:
   // which are constant from the expression.
   QuasiPolynomial simplify();
 
+  // Group together like terms in the expression.
+  QuasiPolynomial collectTerms();
+
   Fraction getConstantTerm();
 
 private:

--- a/mlir/include/mlir/Analysis/Presburger/Utils.h
+++ b/mlir/include/mlir/Analysis/Presburger/Utils.h
@@ -281,7 +281,10 @@ SmallVector<MPInt, 8> getComplementIneq(ArrayRef<MPInt> ineq);
 /// The vectors must have the same sizes.
 Fraction dotProduct(ArrayRef<Fraction> a, ArrayRef<Fraction> b);
 
-std::vector<Fraction> convolution(ArrayRef<Fraction> a, ArrayRef<Fraction> b);
+/// Find the product of two polynomials, each given by an array of
+/// coefficients.
+std::vector<Fraction> multiplyPolynomials(ArrayRef<Fraction> a,
+                                          ArrayRef<Fraction> b);
 
 } // namespace presburger
 } // namespace mlir

--- a/mlir/include/mlir/Analysis/Presburger/Utils.h
+++ b/mlir/include/mlir/Analysis/Presburger/Utils.h
@@ -281,6 +281,8 @@ SmallVector<MPInt, 8> getComplementIneq(ArrayRef<MPInt> ineq);
 /// The vectors must have the same sizes.
 Fraction dotProduct(ArrayRef<Fraction> a, ArrayRef<Fraction> b);
 
+std::vector<Fraction> convolution(ArrayRef<Fraction> a, ArrayRef<Fraction> b);
+
 } // namespace presburger
 } // namespace mlir
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -467,8 +467,8 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
     std::vector<Fraction> denominatorCoefficients;
     denominatorCoefficients = eachTermDenCoefficients[0];
     for (unsigned j = 1, e = eachTermDenCoefficients.size(); j < e; ++j)
-      denominatorCoefficients =
-          convolution(denominatorCoefficients, eachTermDenCoefficients[j]);
+      denominatorCoefficients = multiplyPolynomials(denominatorCoefficients,
+                                                    eachTermDenCoefficients[j]);
 
     totalTerm =
         totalTerm + getCoefficientInRationalFunction(r, numeratorCoefficients,

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -408,9 +408,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
     // sign_i * (s+1)^numExp / (\prod_j (1 - (s+1)^dens[j]))
     // For the i'th term, we first normalize the denominator to have only
     // positive exponents. We convert all the dens[j] to their
-    // absolute values by multiplying and dividing by (s+1)^(-dens[j]) if it is
-    // negative. We change the sign accordingly to keep the denominator in the
-    // same form.
+    // absolute values and change the sign and exponent in the numerator.
     normalizeDenominatorExponents(sign, numExp, dens);
 
     // Then, using the formula for geometric series, we replace each (1 -

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -432,7 +432,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
     // This means that
     // the numerator is a polynomial in s, with coefficients as
     // quasipolynomials (given by binomial coefficients), and the denominator
-    // is polynomial in s, with fractional coefficients (given by taking the
+    // is polynomial in s, with integral coefficients (given by taking the
     // convolution over all j).
 
     // Step (3) We need to find the constant term in the expansion of each

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -397,7 +397,8 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
   for (unsigned i = 0, e = ds.size(); i < e; ++i) {
     int sign = gf.getSigns()[i];
 
-    // Compute the new numerator and denominator after substituting μ.
+    // Compute the new exponents of (s+1) for the numerator and the
+    // denominator after substituting μ.
     auto [numExp, dens] =
         substituteMuInTerm(numParams, gf.getNumerators()[i], ds[i], mu);
     // Now the numerator is (s+1)^numExp
@@ -442,8 +443,8 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
     // we need to find the coefficient of s^r in P(s)/Q(s),
     // for which we use the `getCoefficientInRationalFunction()` function.
 
-    // First, we compute the coefficients of P(s),
-    // which are binomial coefficients.
+    // First, we compute the coefficients of P(s), which are binomial
+    // coefficients.
     // We only need the first r+1 of these, as higher-order terms do not
     // contribute to the coefficient of s^r.
     std::vector<QuasiPolynomial> numeratorCoefficients =

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -247,15 +247,12 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
   return coefficients[power].simplify();
 }
 
-/// Substitute x_i = t^μ_i in one term of a generating function,
-/// returning
+/// Substitute x_i = t^μ_i in one term of a generating function, returning
 /// a quasipolynomial which represents the exponent of the numerator
-/// of the result, and
-/// a vector which represents the exponents of the denominator of the
-/// result.
-/// v represents the affine functions whose floors are multiplied by
-/// by the generators, and
-/// ds represents the list of generators.
+/// of the result, and a vector which represents the exponents of the
+/// denominator of the result.
+/// v represents the affine functions whose floors are multiplied by the
+/// generators, and ds represents the list of generators.
 std::pair<QuasiPolynomial, std::vector<Fraction>>
 substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
                    Point mu) {
@@ -405,7 +402,6 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
   Point mu = getNonOrthogonalVector(allDenominators);
 
   unsigned numParams = gf.getNumParams();
-
   const std::vector<std::vector<Point>> &ds = gf.getDenominators();
   QuasiPolynomial totalTerm(numParams, 0);
   for (unsigned i = 0, e = ds.size(); i < e; ++i) {

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -290,7 +290,7 @@ substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
   for (const Point &d : ds)
     coefficients.push_back(-dotProduct(mu, d));
 
-  // Then, the affine fn is a single floor expression, given by the
+  // Then, the affine function is a single floor expression, given by the
   // corresponding column of v.
   ParamPoint vTranspose = v.transpose();
   std::vector<std::vector<SmallVector<Fraction>>> affine;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -248,7 +248,7 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 
 static std::vector<Fraction> convolution(std::vector<Fraction> a,
                                          std::vector<Fraction> b) {
-  // The length of the convolution is the maximum of the lengths
+  // The length of the convolution is the sum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
   unsigned len = a.size() + b.size();
   a.resize(len);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -324,12 +324,12 @@ QuasiPolynomial substituteMuInTerm(unsigned numParams, ParamPoint v,
 /// Step (1) We need to find a μ_i such that we can substitute x_i =
 /// (s+1)^μ_i. After this substitution, the exponent of (s+1) in the
 /// denominator is (μ_i • d_{ij}) in each term. Clearly, this cannot become
-/// zero. Thus we find a vector μ that is not orthogonal to any of the
+/// zero. Hence we find a vector μ that is not orthogonal to any of the
 /// d_{ij} and substitute x accordingly.
 ///
 /// Step (2) We need to express the terms in the function as quotients of
 /// polynomials. Each term is now of the form
-/// sign_i * (s+1)^n_i / (\prod_j (1 - (s+1)^d'_{ij}))
+/// sign_i * (s+1)^n'_i / (\prod_j (1 - (s+1)^d'_{ij}))
 /// For the i'th term, we first convert all the d'_{ij} to their
 /// absolute values by multiplying and dividing by (s+1)^(-d'_{ij}) if it is
 /// negative. We change the sign accordingly to keep the denominator in the

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -304,7 +304,8 @@ QuasiPolynomial substituteMuInTerm(unsigned numParams, ParamPoint v,
 /// f_p(x) = \sum_i sign_i * (x^n_i(p)) / (\prod_j (1 - x^d_{ij})
 ///
 /// where sign_i is ±1,
-/// n_i \in Q^p -> Q^d is a d-vector of affine functions on p parameters, and
+/// n_i \in Q^p -> Q^d is the sum of the vectors d_{ij}, weighted by the
+/// floors of d affine functions.
 /// d_{ij} \in Q^d are vectors.
 ///
 /// We need to find the number of terms of the form x^t in the expansion of

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -250,7 +250,7 @@ static std::vector<Fraction> convolution(std::vector<Fraction> a,
                                          std::vector<Fraction> b) {
   // The length of the convolution is the maximum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
-  unsigned len = std::max(a.size(), b.size());
+  unsigned len = a.size() + b.size();
   a.resize(len);
   b.resize(len);
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -314,7 +314,7 @@ QuasiPolynomial substituteMuInTerm(unsigned numParams, ParamPoint v,
 ///
 /// We therefore use the following procedure instead:
 /// 1. Substitute x_i = (s+1)^μ_i for some vector μ. This makes the generating
-/// a function of a scalar s.
+/// function a function of a scalar s.
 /// 2. Write each term in this function as P(s)/Q(s), where P and Q are
 /// polynomials. P has coefficients as quasipolynomials in d parameters, while
 /// Q has coefficients as scalars.

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -319,7 +319,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     // We have d terms, each of whose coefficient is the negative dot product,
     SmallVector<Fraction> coefficients;
     coefficients.reserve(num_dims);
-    for (Point d : ds)
+    for (const Point &d : ds)
       coefficients.push_back(-dotProduct(mu, d));
 
     // and whose affine fn is a single floor expression, given by the
@@ -337,7 +337,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     dens.clear();
     // Similarly, each term in the denominator has exponent
     // given by the dot product of μ with u_i.
-    for (Point d : ds)
+    for (const Point &d : ds)
       dens.push_back(dotProduct(d, mu));
     // This term in the denominator is
     // (1 - (s+1)^dens.back())
@@ -399,7 +399,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     // Then the coefficients of each individual term in Q(s),
     // which are (di+1) C (k+1) for 0 ≤ k ≤ di
     eachTermDenCoefficients.clear();
-    for (Fraction den : dens) {
+    for (const Fraction &den : dens) {
       singleTermDenCoefficients.clear();
       singleTermDenCoefficients.push_back(den + 1);
       for (unsigned j = 1; j <= den; ++j)

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -288,7 +288,7 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
 QuasiPolynomial
 mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
   std::vector<Point> allDenominators;
-  for (std::vector<Point> den : gf.getDenominators())
+  for (ArrayRef<Point> den : gf.getDenominators())
     allDenominators.insert(allDenominators.end(), den.begin(), den.end());
   Point mu = getNonOrthogonalVector(allDenominators);
 
@@ -304,7 +304,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
   std::vector<Fraction> convolution;
 
   QuasiPolynomial totalTerm(num_params, 0);
-  for (unsigned i = 0; i < num_terms; i++) {
+  for (unsigned i = 0; i < num_terms; ++i) {
     int sign = gf.getSigns()[i];
     ParamPoint v = gf.getNumerators()[i];
     std::vector<Point> ds = gf.getDenominators()[i];
@@ -326,7 +326,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     // corresponding column of v.
     std::vector<std::vector<SmallVector<Fraction>>> affine;
     affine.reserve(num_dims);
-    for (unsigned j = 0; j < num_dims; j++)
+    for (unsigned j = 0; j < num_dims; ++j)
       affine.push_back({SmallVector<Fraction>(v.transpose().getRow(j))});
 
     QuasiPolynomial num(num_params, coefficients, affine);
@@ -347,10 +347,10 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     // (see lines 362-72).
     unsigned numNegExps = 0;
     Fraction sumNegExps(0, 1);
-    for (unsigned j = 0; j < dens.size(); j++) {
-      if (dens[j] < Fraction(0, 1)) {
+    for (unsigned j = 0, e = dens.size(); j < e; ++j) {
+      if (dens[j] < 0) {
         numNegExps += 1;
-        sumNegExps = sumNegExps + dens[j];
+        sumNegExps += dens[j];
       }
       // All exponents will be made positive; then reduce
       // (1 - (s+1)^x)
@@ -389,7 +389,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     numeratorCoefficients.clear();
     numeratorCoefficients.push_back(
         QuasiPolynomial(num_params, 1)); // Coeff of s^0
-    for (unsigned j = 1; j <= r; j++)
+    for (unsigned j = 1; j <= r; ++j)
       numeratorCoefficients.push_back(
           (numeratorCoefficients[j - 1] *
            (num - QuasiPolynomial(num_params, j - 1)) / Fraction(j, 1))
@@ -402,7 +402,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     for (Fraction den : dens) {
       singleTermDenCoefficients.clear();
       singleTermDenCoefficients.push_back(den + 1);
-      for (unsigned j = 1; j <= den; j++)
+      for (unsigned j = 1; j <= den; ++j)
         singleTermDenCoefficients.push_back(singleTermDenCoefficients[j - 1] *
                                             (den - (j - 1)) / (j + 1));
 
@@ -414,20 +414,20 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
     // of all the terms.
     denominatorCoefficients.clear();
     denominatorCoefficients = eachTermDenCoefficients[0];
-    for (unsigned j = 1; j < eachTermDenCoefficients.size(); j++) {
+    for (unsigned j = 1, e = eachTermDenCoefficients.size(); j < e; ++j) {
       // The length of the convolution is the maximum of the lengths
       // of the two sequences. We pad the shorter one with zeroes.
       unsigned convlen = std::max(denominatorCoefficients.size(),
                                   eachTermDenCoefficients[j].size());
-      for (unsigned k = denominatorCoefficients.size(); k < convlen; k++)
+      for (unsigned k = denominatorCoefficients.size(); k < convlen; ++k)
         denominatorCoefficients.push_back(0);
-      for (unsigned k = eachTermDenCoefficients[j].size(); k < convlen; k++)
+      for (unsigned k = eachTermDenCoefficients[j].size(); k < convlen; ++k)
         eachTermDenCoefficients[j].push_back(0);
 
       convolution.clear();
-      for (unsigned k = 0; k < convlen; k++) {
+      for (unsigned k = 0; k < convlen; ++k) {
         Fraction sum(0, 1);
-        for (unsigned l = 0; l <= k; l++)
+        for (unsigned l = 0; l <= k; ++l)
           sum = sum +
                 denominatorCoefficients[l] * eachTermDenCoefficients[j][k - l];
         convolution.push_back(sum);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -265,7 +265,7 @@ static std::vector<Fraction> convolution(std::vector<Fraction> a,
   return convolution;
 }
 
-/// Substitute x_i = (s+1)^μ_i in one term of a generating function,
+/// Substitute x_i = t^μ_i in one term of a generating function,
 /// returning
 /// a quasipolynomial which represents the exponent of the numerator
 /// of the result, and
@@ -307,7 +307,7 @@ substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
   // given by the dot product of μ with u_i.
   for (const Point &d : ds) {
     // This term in the denominator is
-    // (1 - (s+1)^dens.back())
+    // (1 - t^dens.back())
     dens.push_back(dotProduct(d, mu));
   }
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -330,7 +330,8 @@ QuasiPolynomial substituteMuInTerm(unsigned numParams, ParamPoint v,
 /// Step (2) We need to express the terms in the function as quotients of
 /// polynomials. Each term is now of the form
 /// sign_i * (s+1)^n'_i / (\prod_j (1 - (s+1)^d'_{ij}))
-/// For the i'th term, we first convert all the d'_{ij} to their
+/// For the i'th term, we first normalize the denominator to have only
+/// positive exponents. We convert all the d'_{ij} to their
 /// absolute values by multiplying and dividing by (s+1)^(-d'_{ij}) if it is
 /// negative. We change the sign accordingly to keep the denominator in the
 /// same form.
@@ -366,7 +367,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
   QuasiPolynomial totalTerm(numParams, 0);
   for (unsigned i = 0; i < numTerms; ++i) {
     int sign = gf.getSigns()[i];
-    std::vector<Point> ds = gf.getDenominators()[i];
+    const std::vector<Point> &ds = gf.getDenominators()[i];
 
     QuasiPolynomial num =
         substituteMuInTerm(numParams, gf.getNumerators()[i], ds, mu);
@@ -382,8 +383,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
     // (1 - (s+1)^dens.back())
 
     // We track the number of exponents that are negative in the
-    // denominator, and convert them to their absolute values
-    // (see lines 356-66).
+    // denominator, and convert them to their absolute values.
     unsigned numNegExps = 0;
     Fraction sumNegExps(0, 1);
     for (unsigned j = 0, e = dens.size(); j < e; ++j) {
@@ -410,7 +410,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
       sign = -sign;
     num = num - QuasiPolynomial(numParams, sumNegExps);
 
-    // Take all the (-s) out, from line 353.
+    // Take all the (-s) out.
     unsigned r = dens.size();
     if (r % 2 == 1)
       sign = -sign;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -469,7 +469,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
         getBinomialCoefficients(numExp, r);
 
     // Then the coefficients of each individual term in Q(s),
-    // which are (di+1) C (k+1) for 0 ≤ k ≤ di.
+    // which are (dens[i]+1) C (k+1) for 0 ≤ k ≤ dens[i].
     std::vector<std::vector<Fraction>> eachTermDenCoefficients;
     std::vector<Fraction> singleTermDenCoefficients;
     eachTermDenCoefficients.reserve(r);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -367,7 +367,7 @@ mlir::presburger::detail::computeNumTerms(const GeneratingFunction &gf) {
   QuasiPolynomial totalTerm(numParams, 0);
   for (unsigned i = 0; i < numTerms; ++i) {
     int sign = gf.getSigns()[i];
-    const std::vector<Point> &ds = gf.getDenominators()[i];
+    std::vector<Point> ds = gf.getDenominators()[i];
 
     QuasiPolynomial num =
         substituteMuInTerm(numParams, gf.getNumerators()[i], ds, mu);

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -278,6 +278,10 @@ std::pair<QuasiPolynomial, std::vector<Fraction>>
 substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
                    Point mu) {
   unsigned numDims = mu.size();
+  for (const Point &d : ds)
+    assert(d.size() == numDims &&
+           "μ has to have the same number of dimensions as the generators!");
+
   // First, the exponent in the numerator becomes
   // - (μ • u_1) * (floor(first col of v))
   // - (μ • u_2) * (floor(second col of v)) - ...

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -250,19 +250,16 @@ static std::vector<Fraction> convolution(std::vector<Fraction> a,
                                          std::vector<Fraction> b) {
   // The length of the convolution is the maximum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
-  unsigned convlen = std::max(a.size(), b.size());
-  for (unsigned k = a.size(); k < convlen; ++k)
-    a.push_back(0);
-  for (unsigned k = b.size(); k < convlen; ++k)
-    b.push_back(0);
+  unsigned len = std::max(a.size(), b.size());
+  a.resize(len);
+  b.resize(len);
 
   std::vector<Fraction> convolution;
-  convolution.reserve(convlen);
-  convolution.clear();
-  for (unsigned k = 0; k < convlen; ++k) {
+  convolution.reserve(len);
+  for (unsigned k = 0; k < len; ++k) {
     Fraction sum(0, 1);
     for (unsigned l = 0; l <= k; ++l)
-      sum = sum + a[l] * b[k - l];
+      sum += a[l] * b[k - l];
     convolution.push_back(sum);
   }
   return convolution;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -246,20 +246,32 @@ QuasiPolynomial mlir::presburger::detail::getCoefficientInRationalFunction(
   return coefficients[power].simplify();
 }
 
-static std::vector<Fraction> convolution(std::vector<Fraction> a,
-                                         std::vector<Fraction> b) {
+static std::vector<Fraction> convolution(ArrayRef<Fraction> a,
+                                         ArrayRef<Fraction> b) {
   // The length of the convolution is the sum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
   unsigned len = a.size() + b.size();
-  a.resize(len);
-  b.resize(len);
+
+  // We define accessors to avoid out-of-bounds errors.
+  std::function<Fraction(unsigned i)> aGetItem = [a](unsigned i) -> Fraction {
+    if (i < a.size())
+      return a[i];
+    else
+      return 0;
+  };
+  std::function<Fraction(unsigned i)> bGetItem = [b](unsigned i) -> Fraction {
+    if (i < b.size())
+      return b[i];
+    else
+      return 0;
+  };
 
   std::vector<Fraction> convolution;
   convolution.reserve(len);
   for (unsigned k = 0; k < len; ++k) {
     Fraction sum(0, 1);
     for (unsigned l = 0; l <= k; ++l)
-      sum += a[l] * b[k - l];
+      sum += aGetItem(l) * bGetItem(k - l);
     convolution.push_back(sum);
   }
   return convolution;

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -271,6 +271,9 @@ static std::vector<Fraction> convolution(std::vector<Fraction> a,
 /// of the result, and
 /// a vector which represents the exponents of the denominator of the
 /// result.
+/// v represents the affine functions whose floors are multiplied by
+/// by the generators, and
+/// ds represents the list of generators.
 std::pair<QuasiPolynomial, std::vector<Fraction>>
 substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
                    Point mu) {
@@ -302,12 +305,13 @@ substituteMuInTerm(unsigned numParams, ParamPoint v, std::vector<Point> ds,
   dens.reserve(ds.size());
   // Similarly, each term in the denominator has exponent
   // given by the dot product of μ with u_i.
-  for (const Point &d : ds)
+  for (const Point &d : ds) {
+    // This term in the denominator is
+    // (1 - (s+1)^dens.back())
     dens.push_back(dotProduct(d, mu));
-  // This term in the denominator is
-  // (1 - (s+1)^dens.back())
+  }
 
-  return std::make_pair(num, dens);
+  return {num, dens};
 }
 
 /// Normalize all denominator exponents `dens` to their absolute values

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -324,9 +324,10 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
 
     // and whose affine fn is a single floor expression, given by the
     // corresponding column of v.
-    std::vector<std::vector<SmallVector<Fraction>>> affine(num_dims);
+    std::vector<std::vector<SmallVector<Fraction>>> affine;
+    affine.reserve(num_dims);
     for (unsigned j = 0; j < num_dims; j++)
-      SmallVector<Fraction> jthCol(v.transpose().getRow(j));
+      affine.push_back({SmallVector<Fraction>(v.transpose().getRow(j))});
 
     QuasiPolynomial num(num_params, coefficients, affine);
     num = num.simplify();
@@ -343,7 +344,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
 
     // We track the number of exponents that are negative in the
     // denominator, and convert them to their absolute values
-    // (see lines 361-71).
+    // (see lines 362-72).
     unsigned numNegExps = 0;
     Fraction sumNegExps(0, 1);
     for (unsigned j = 0; j < dens.size(); j++) {
@@ -370,7 +371,7 @@ mlir::presburger::detail::substituteWithUnitVector(GeneratingFunction gf) {
       sign = -sign;
     num = num - QuasiPolynomial(num_params, sumNegExps);
 
-    // Take all the (-s) out, from line 328.
+    // Take all the (-s) out, from line 359.
     unsigned r = dens.size();
     if (r % 2 == 1)
       sign = -sign;

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -126,7 +126,7 @@ QuasiPolynomial QuasiPolynomial::simplify() {
     // Now, we know the term is nonzero.
 
     // We now eliminate the affine functions which are constant
-    // by integrating them into the coefficients.
+    // by merging them into the coefficients.
     newAffineTerm = {};
     newCoeff = coefficients[i];
     for (ArrayRef<Fraction> term : affine[i]) {

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -144,6 +144,27 @@ QuasiPolynomial QuasiPolynomial::simplify() {
   return QuasiPolynomial(getNumInputs(), newCoeffs, newAffine);
 }
 
+QuasiPolynomial QuasiPolynomial::collectTerms() {
+  SmallVector<Fraction> newCoeffs({});
+  std::vector<std::vector<SmallVector<Fraction>>> newAffine({});
+
+  for (unsigned i = 0, e = affine.size(); i < e; i++) {
+    bool alreadyPresent = false;
+    for (unsigned j = 0, f = newAffine.size(); j < f; j++) {
+      if (affine[i] == newAffine[j]) {
+        newCoeffs[j] += coefficients[i];
+        alreadyPresent = true;
+      }
+    }
+    if (alreadyPresent)
+      continue;
+    newCoeffs.push_back(coefficients[i]);
+    newAffine.push_back(affine[i]);
+  }
+
+  return QuasiPolynomial(getNumInputs(), newCoeffs, newAffine);
+}
+
 Fraction QuasiPolynomial::getConstantTerm() {
   Fraction constTerm = 0;
   for (unsigned i = 0, e = coefficients.size(); i < e; ++i)

--- a/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
+++ b/mlir/lib/Analysis/Presburger/QuasiPolynomial.cpp
@@ -97,10 +97,18 @@ QuasiPolynomial QuasiPolynomial::operator/(const Fraction x) const {
   return qp;
 }
 
-// Removes terms which evaluate to zero from the expression.
+// Removes terms which evaluate to zero from the expression and
+// integrate affine functions which are constants into the
+// coefficients.
 QuasiPolynomial QuasiPolynomial::simplify() {
+  Fraction newCoeff = 0;
   SmallVector<Fraction> newCoeffs({});
+
+  std::vector<SmallVector<Fraction>> newAffineTerm({});
   std::vector<std::vector<SmallVector<Fraction>>> newAffine({});
+
+  unsigned numParam = getNumInputs();
+
   for (unsigned i = 0, e = coefficients.size(); i < e; i++) {
     // A term is zero if its coefficient is zero, or
     if (coefficients[i] == Fraction(0, 1))
@@ -114,8 +122,24 @@ QuasiPolynomial QuasiPolynomial::simplify() {
         });
     if (product_is_zero)
       continue;
-    newCoeffs.push_back(coefficients[i]);
-    newAffine.push_back(affine[i]);
+
+    // Now, we know the term is nonzero.
+
+    // We now eliminate the affine functions which are constant
+    // by integrating them into the coefficients.
+    newAffineTerm = {};
+    newCoeff = coefficients[i];
+    for (ArrayRef<Fraction> term : affine[i]) {
+      bool allCoeffsZero = llvm::all_of(
+          term.slice(0, numParam), [](const Fraction c) { return c == 0; });
+      if (allCoeffsZero)
+        newCoeff *= term[numParam];
+      else
+        newAffineTerm.push_back(SmallVector<Fraction>(term));
+    }
+
+    newCoeffs.push_back(newCoeff);
+    newAffine.push_back(newAffineTerm);
   }
   return QuasiPolynomial(getNumInputs(), newCoeffs, newAffine);
 }

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -548,7 +548,7 @@ std::vector<Fraction> presburger::multiplyPolynomials(ArrayRef<Fraction> a,
   unsigned len = a.size() + b.size() - 1;
 
   // We define accessors to avoid out-of-bounds errors.
-  auto getItem = [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {
+  auto getCoeff = [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {
     if (i < arr.size())
       return arr[i];
     else
@@ -560,7 +560,7 @@ std::vector<Fraction> presburger::multiplyPolynomials(ArrayRef<Fraction> a,
   for (unsigned k = 0; k < len; ++k) {
     Fraction sum(0, 1);
     for (unsigned l = 0; l <= k; ++l)
-      sum += getItem(a, l) * getItem(b, k - l);
+      sum += getCoeff(a, l) * getCoeff(b, k - l);
     convolution.push_back(sum);
   }
   return convolution;

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -546,8 +546,7 @@ std::vector<Fraction> presburger::convolution(ArrayRef<Fraction> a,
   unsigned len = a.size() + b.size();
 
   // We define accessors to avoid out-of-bounds errors.
-  std::function<Fraction(ArrayRef<Fraction>, unsigned)> getItem =
-      [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {
+  auto getItem = [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {
     if (i < arr.size())
       return arr[i];
     else

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -546,15 +546,10 @@ std::vector<Fraction> presburger::convolution(ArrayRef<Fraction> a,
   unsigned len = a.size() + b.size();
 
   // We define accessors to avoid out-of-bounds errors.
-  std::function<Fraction(unsigned i)> aGetItem = [a](unsigned i) -> Fraction {
-    if (i < a.size())
-      return a[i];
-    else
-      return 0;
-  };
-  std::function<Fraction(unsigned i)> bGetItem = [b](unsigned i) -> Fraction {
-    if (i < b.size())
-      return b[i];
+  std::function<Fraction(ArrayRef<Fraction>, unsigned)> getItem =
+      [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {
+    if (i < arr.size())
+      return arr[i];
     else
       return 0;
   };
@@ -564,7 +559,7 @@ std::vector<Fraction> presburger::convolution(ArrayRef<Fraction> a,
   for (unsigned k = 0; k < len; ++k) {
     Fraction sum(0, 1);
     for (unsigned l = 0; l <= k; ++l)
-      sum += aGetItem(l) * bGetItem(k - l);
+      sum += getItem(a, l) * getItem(b, k - l);
     convolution.push_back(sum);
   }
   return convolution;

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -545,7 +545,7 @@ std::vector<Fraction> presburger::multiplyPolynomials(ArrayRef<Fraction> a,
                                                       ArrayRef<Fraction> b) {
   // The length of the convolution is the sum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
-  unsigned len = a.size() + b.size();
+  unsigned len = a.size() + b.size() - 1;
 
   // We define accessors to avoid out-of-bounds errors.
   auto getItem = [](ArrayRef<Fraction> arr, unsigned i) -> Fraction {

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -539,8 +539,10 @@ Fraction presburger::dotProduct(ArrayRef<Fraction> a, ArrayRef<Fraction> b) {
   return sum;
 }
 
-std::vector<Fraction> presburger::convolution(ArrayRef<Fraction> a,
-                                              ArrayRef<Fraction> b) {
+/// Find the product of two polynomials, each given by an array of
+/// coefficients, by taking the convolution.
+std::vector<Fraction> presburger::multiplyPolynomials(ArrayRef<Fraction> a,
+                                                      ArrayRef<Fraction> b) {
   // The length of the convolution is the sum of the lengths
   // of the two sequences. We pad the shorter one with zeroes.
   unsigned len = a.size() + b.size();

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -538,3 +538,34 @@ Fraction presburger::dotProduct(ArrayRef<Fraction> a, ArrayRef<Fraction> b) {
     sum += a[i] * b[i];
   return sum;
 }
+
+std::vector<Fraction> presburger::convolution(ArrayRef<Fraction> a,
+                                              ArrayRef<Fraction> b) {
+  // The length of the convolution is the sum of the lengths
+  // of the two sequences. We pad the shorter one with zeroes.
+  unsigned len = a.size() + b.size();
+
+  // We define accessors to avoid out-of-bounds errors.
+  std::function<Fraction(unsigned i)> aGetItem = [a](unsigned i) -> Fraction {
+    if (i < a.size())
+      return a[i];
+    else
+      return 0;
+  };
+  std::function<Fraction(unsigned i)> bGetItem = [b](unsigned i) -> Fraction {
+    if (i < b.size())
+      return b[i];
+    else
+      return 0;
+  };
+
+  std::vector<Fraction> convolution;
+  convolution.reserve(len);
+  for (unsigned k = 0; k < len; ++k) {
+    Fraction sum(0, 1);
+    for (unsigned l = 0; l <= k; ++l)
+      sum += aGetItem(l) * bGetItem(k - l);
+    convolution.push_back(sum);
+  }
+  return convolution;
+}

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -169,8 +169,7 @@ TEST(BarvinokTest, computeNumTerms) {
   EXPECT_EQ(numPoints.getConstantTerm(), Fraction(1, 1));
 
   // The following generating function corresponds to a cuboid
-  // with length (x-axis) M, width (y-axis) N, and height (z-axis)
-  // P.
+  // with length M (x-axis), width N (y-axis), and height P (z-axis).
   // There are eight terms.
   gf = GeneratingFunction(
       3, {1, 1, 1, 1, 1, 1, 1, 1},

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -157,11 +157,12 @@ TEST(BarvinokTest, computeNumTerms) {
   // the coefficient of total ⌊p/2⌋ is the sum of coefficients of all
   // terms with 1 affine function,
   Fraction pSquaredCoeff = 0, pCoeff = 0, constantTerm = 0;
+  SmallVector<Fraction> coefficients = numPoints.getCoefficients();
   for (unsigned i = 0; i < numPoints.getCoefficients().size(); i++)
     if (numPoints.getAffine()[i].size() == 2)
-      pSquaredCoeff = pSquaredCoeff + numPoints.getCoefficients()[i];
+      pSquaredCoeff = pSquaredCoeff + coefficients[i];
     else if (numPoints.getAffine()[i].size() == 1)
-      pCoeff = pCoeff + numPoints.getCoefficients()[i];
+      pCoeff = pCoeff + coefficients[i];
 
   // We expect the answer to be (1/2)⌊p/2⌋^2 + (3/2)⌊p/2⌋ + 1.
   EXPECT_EQ(pSquaredCoeff, Fraction(1, 2));
@@ -199,13 +200,11 @@ TEST(BarvinokTest, computeNumTerms) {
     for (const SmallVector<Fraction> &aff : term)
       EXPECT_EQ(aff[0] + aff[1] + aff[2] + aff[3], 1);
 
-  Fraction m = 0, n = 0, p = 0, mn = 0, np = 0, pm = 0, mnp = 0;
-
   // We store the coefficients of M, N and P in this array.
   Fraction count[2][2][2];
-  unsigned mIndex, nIndex, pIndex;
-  for (unsigned i = 0, e = numPoints.getCoefficients().size(); i < e; i++) {
-    mIndex = nIndex = pIndex = 0;
+  coefficients = numPoints.getCoefficients();
+  for (unsigned i = 0, e = coefficients.size(); i < e; i++) {
+    unsigned mIndex = 0, nIndex = 0, pIndex = 0;
     for (const SmallVector<Fraction> &aff : numPoints.getAffine()[i]) {
       if (aff[0] == 1)
         mIndex = 1;
@@ -215,7 +214,7 @@ TEST(BarvinokTest, computeNumTerms) {
         pIndex = 1;
       EXPECT_EQ(aff[3], 0);
     }
-    count[mIndex][nIndex][pIndex] += numPoints.getCoefficients()[i];
+    count[mIndex][nIndex][pIndex] += coefficients[i];
   }
 
   // We expect the answer to be

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -195,10 +195,19 @@ TEST(BarvinokTest, computeNumTerms) {
   numPoints = numPoints.collectTerms().simplify();
 
   // First, we make sure all the affine functions are either
-  // M, N, or P.
-  for (const std::vector<SmallVector<Fraction>> &term : numPoints.getAffine())
-    for (const SmallVector<Fraction> &aff : term)
+  // M, N, P, or 1.
+  for (const std::vector<SmallVector<Fraction>> &term : numPoints.getAffine()) {
+    for (const SmallVector<Fraction> &aff : term) {
+      // First, ensure that the coefficients are all nonnegative integers.
+      for (const Fraction &c : aff) {
+        EXPECT_TRUE(c >= 0);
+        EXPECT_EQ(c, c.getAsInteger());
+      }
+      // Now, if the coefficients add up to 1, we can be sure the term is
+      // either M, N, P, or 1.
       EXPECT_EQ(aff[0] + aff[1] + aff[2] + aff[3], 1);
+    }
+  }
 
   // We store the coefficients of M, N and P in this array.
   Fraction count[2][2][2];

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -195,7 +195,7 @@ TEST(BarvinokTest, computeNumTerms) {
   numPoints = numPoints.collectTerms().simplify();
 
   // First, we make sure all the affine functions are either
-  // ⌊M⌋, ⌊N⌋, or ⌊P⌋.
+  // M, N, or P.
   for (const std::vector<SmallVector<Fraction>> &term : numPoints.getAffine())
     for (const SmallVector<Fraction> &aff : term)
       EXPECT_EQ(aff[0] + aff[1] + aff[2] + aff[3], 1);

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -202,61 +202,28 @@ TEST(BarvinokTest, computeNumTerms) {
 
   Fraction m = 0, n = 0, p = 0, mn = 0, np = 0, pm = 0, mnp = 0;
 
-  for (unsigned i = 0, e = numPoints.getAffine().size(); i < e; i++) {
-    if (numPoints.getAffine()[i].size() == 1u) {
-      if (numPoints.getAffine()[i][0][0] == 1)
-        m += numPoints.getCoefficients()[i];
-      if (numPoints.getAffine()[i][0][1] == 1)
-        n += numPoints.getCoefficients()[i];
-      if (numPoints.getAffine()[i][0][2] == 1)
-        p += numPoints.getCoefficients()[i];
-    } else if (numPoints.getAffine()[i].size() == 2u) {
-      if ((numPoints.getAffine()[i][0][0] == 1 &&
-           numPoints.getAffine()[i][1][1] == 1) ||
-          (numPoints.getAffine()[i][0][1] == 1 &&
-           numPoints.getAffine()[i][1][0] == 1))
-        mn += numPoints.getCoefficients()[i];
-      if ((numPoints.getAffine()[i][0][1] == 1 &&
-           numPoints.getAffine()[i][1][2] == 1) ||
-          (numPoints.getAffine()[i][0][2] == 1 &&
-           numPoints.getAffine()[i][1][1] == 1))
-        np += numPoints.getCoefficients()[i];
-      if ((numPoints.getAffine()[i][0][2] == 1 &&
-           numPoints.getAffine()[i][1][0] == 1) ||
-          (numPoints.getAffine()[i][0][0] == 1 &&
-           numPoints.getAffine()[i][1][2] == 1))
-        pm += numPoints.getCoefficients()[i];
-    } else if (numPoints.getAffine()[i].size() == 3u) {
-      if ((numPoints.getAffine()[i][0][0] == 1 &&
-           numPoints.getAffine()[i][1][1] == 1 &&
-           numPoints.getAffine()[i][2][2] == 1) ||
-          (numPoints.getAffine()[i][0][0] == 1 &&
-           numPoints.getAffine()[i][1][2] == 1 &&
-           numPoints.getAffine()[i][2][1] == 1) ||
-          (numPoints.getAffine()[i][0][1] == 1 &&
-           numPoints.getAffine()[i][1][0] == 1 &&
-           numPoints.getAffine()[i][2][2] == 1) ||
-          (numPoints.getAffine()[i][0][1] == 1 &&
-           numPoints.getAffine()[i][1][2] == 1 &&
-           numPoints.getAffine()[i][2][0] == 1) ||
-          (numPoints.getAffine()[i][0][2] == 1 &&
-           numPoints.getAffine()[i][1][1] == 1 &&
-           numPoints.getAffine()[i][2][0] == 1) ||
-          (numPoints.getAffine()[i][0][2] == 1 &&
-           numPoints.getAffine()[i][1][0] == 1 &&
-           numPoints.getAffine()[i][2][1] == 1))
-        mnp += numPoints.getCoefficients()[i];
+  // We store the coefficients of M, N and P in this array.
+  Fraction count[2][2][2];
+  unsigned mIndex, nIndex, pIndex;
+  for (unsigned i = 0, e = numPoints.getCoefficients().size(); i < e; i++) {
+    mIndex = nIndex = pIndex = 0;
+    for (const SmallVector<Fraction> &aff : numPoints.getAffine()[i]) {
+      if (aff[0] == 1)
+        mIndex = 1;
+      if (aff[1] == 1)
+        nIndex = 1;
+      if (aff[2] == 1)
+        pIndex = 1;
+      EXPECT_EQ(aff[3], 0);
     }
+    count[mIndex][nIndex][pIndex] += numPoints.getCoefficients()[i];
   }
 
   // We expect the answer to be
   // (⌊M⌋ + 1)(⌊N⌋ + 1)(⌊P⌋ + 1) =
   // ⌊M⌋⌊N⌋⌊P⌋ + ⌊M⌋⌊N⌋ + ⌊N⌋⌊P⌋ + ⌊M⌋⌊P⌋ + ⌊M⌋ + ⌊N⌋ + ⌊P⌋ + 1.
-  EXPECT_EQ(mn, 1);
-  EXPECT_EQ(np, 1);
-  EXPECT_EQ(pm, 1);
-  EXPECT_EQ(m, 1);
-  EXPECT_EQ(n, 1);
-  EXPECT_EQ(p, 1);
-  EXPECT_EQ(numPoints.getConstantTerm(), 1);
+  for (unsigned i = 0; i < 2; i++)
+    for (unsigned j = 0; j < 2; j++)
+      for (unsigned k = 0; k < 2; k++)
+        EXPECT_EQ(count[i][j][k], 1);
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -127,7 +127,7 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
 
 // The following test is taken from
 //
-TEST(BarvinokTest, substituteWithUnitVector) {
+TEST(BarvinokTest, computeNumTerms) {
   GeneratingFunction gf(
       1, {1, 1, 1},
       {makeFracMatrix(2, 2, {{0, Fraction(1, 2)}, {0, 0}}),
@@ -135,7 +135,7 @@ TEST(BarvinokTest, substituteWithUnitVector) {
        makeFracMatrix(2, 2, {{0, 0}, {0, 0}})},
       {{{-1, 1}, {-1, 0}}, {{1, -1}, {0, -1}}, {{1, 0}, {0, 1}}});
 
-  QuasiPolynomial numPoints = substituteWithUnitVector(gf);
+  QuasiPolynomial numPoints = computeNumTerms(gf);
 
   // First, we make sure that all the affine functions are of the form ⌊p/2⌋.
   for (const std::vector<SmallVector<Fraction>> &term : numPoints.getAffine()) {

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -124,3 +124,59 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
   coeff = getCoefficientInRationalFunction(3, numerator, denominator);
   EXPECT_EQ(coeff.getConstantTerm(), Fraction(55, 64));
 }
+
+// The following test is taken from
+// 
+TEST(BarvinokTest, substituteWithUnitVector) {
+  GeneratingFunction gf(
+      1, {1, 1, 1},
+      {makeFracMatrix(2, 2, {{0, Fraction(1, 2)}, {0, 0}}),
+       makeFracMatrix(2, 2, {{0, Fraction(1, 2)}, {0, 0}}),
+       makeFracMatrix(2, 2, {{0, 0}, {0, 0}})},
+      {{{-1, 1}, {-1, 0}},
+       {{1, -1}, {0, -1}},
+       {{1, 0}, {0, 1}}});
+
+  QuasiPolynomial numPoints = substituteWithUnitVector(gf);
+  EXPECT_EQ(
+      numPoints.getCoefficients(),
+      SmallVector<Fraction>(
+          {Fraction(-1, 2), Fraction(-1, 2), Fraction(1, 2), Fraction(-1, 2),
+           Fraction(-1, 2), Fraction(1, 2), Fraction(1, 1), Fraction(3, 2),
+           Fraction(-1, 2), Fraction(3, 2), Fraction(9, 4), Fraction(-3, 4),
+           Fraction(-1, 2), Fraction(-3, 4), Fraction(1, 8), Fraction(1, 8)}));
+  EXPECT_EQ(
+      numPoints.getAffine(),
+      std::vector<std::vector<Point>>(
+          {{{Fraction(1, 2), Fraction(0, 1)}, {Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {},
+           {},
+           {{Fraction(1, 2), Fraction(0, 1)}, {Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {},
+           {},
+           {{Fraction(1, 2), Fraction(0, 1)}},
+           {},
+           {},
+           {}}));
+
+  // We can gather the like terms because we know there's only
+  // either ⌊p/2⌋^2, ⌊p/2⌋, or constants.
+  Fraction pSquaredCoeff = 0, pCoeff = 0, constantTerm = 0;
+  for (unsigned i = 0; i < numPoints.getCoefficients().size(); i++)
+    if (numPoints.getAffine()[i].size() == 2)
+      pSquaredCoeff = pSquaredCoeff + numPoints.getCoefficients()[i];
+    else if (numPoints.getAffine()[i].size() == 1)
+      pCoeff = pCoeff + numPoints.getCoefficients()[i];
+    else
+      constantTerm = constantTerm + numPoints.getCoefficients()[i];
+
+  EXPECT_EQ(pSquaredCoeff, Fraction(1, 2));
+  EXPECT_EQ(pCoeff, Fraction(3, 2));
+  EXPECT_EQ(constantTerm, Fraction(1, 1));
+}

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -126,57 +126,41 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
 }
 
 // The following test is taken from
-// 
+//
 TEST(BarvinokTest, substituteWithUnitVector) {
   GeneratingFunction gf(
       1, {1, 1, 1},
       {makeFracMatrix(2, 2, {{0, Fraction(1, 2)}, {0, 0}}),
        makeFracMatrix(2, 2, {{0, Fraction(1, 2)}, {0, 0}}),
        makeFracMatrix(2, 2, {{0, 0}, {0, 0}})},
-      {{{-1, 1}, {-1, 0}},
-       {{1, -1}, {0, -1}},
-       {{1, 0}, {0, 1}}});
+      {{{-1, 1}, {-1, 0}}, {{1, -1}, {0, -1}}, {{1, 0}, {0, 1}}});
 
   QuasiPolynomial numPoints = substituteWithUnitVector(gf);
-  EXPECT_EQ(
-      numPoints.getCoefficients(),
-      SmallVector<Fraction>(
-          {Fraction(-1, 2), Fraction(-1, 2), Fraction(1, 2), Fraction(-1, 2),
-           Fraction(-1, 2), Fraction(1, 2), Fraction(1, 1), Fraction(3, 2),
-           Fraction(-1, 2), Fraction(3, 2), Fraction(9, 4), Fraction(-3, 4),
-           Fraction(-1, 2), Fraction(-3, 4), Fraction(1, 8), Fraction(1, 8)}));
-  EXPECT_EQ(
-      numPoints.getAffine(),
-      std::vector<std::vector<Point>>(
-          {{{Fraction(1, 2), Fraction(0, 1)}, {Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {},
-           {},
-           {{Fraction(1, 2), Fraction(0, 1)}, {Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {},
-           {},
-           {{Fraction(1, 2), Fraction(0, 1)}},
-           {},
-           {},
-           {}}));
 
-  // We can gather the like terms because we know there's only
+  // First, we make sure that all the affine functions are of the form ⌊p/2⌋.
+  for (const std::vector<SmallVector<Fraction>> &term : numPoints.getAffine()) {
+    for (const SmallVector<Fraction> &aff : term) {
+      EXPECT_EQ(aff.size(), 2u);
+      EXPECT_EQ(aff[0], Fraction(1, 2));
+      EXPECT_EQ(aff[1], Fraction(0, 1));
+    }
+  }
+
+  // Now, we can gather the like terms because we know there's only
   // either ⌊p/2⌋^2, ⌊p/2⌋, or constants.
+  // The total coefficient of ⌊p/2⌋^2 is the sum of coefficients of all
+  // terms with 2 affine functions, and
+  // the coefficient of total ⌊p/2⌋ is the sum of coefficients of all
+  // terms with 1 affine function,
   Fraction pSquaredCoeff = 0, pCoeff = 0, constantTerm = 0;
   for (unsigned i = 0; i < numPoints.getCoefficients().size(); i++)
     if (numPoints.getAffine()[i].size() == 2)
       pSquaredCoeff = pSquaredCoeff + numPoints.getCoefficients()[i];
     else if (numPoints.getAffine()[i].size() == 1)
       pCoeff = pCoeff + numPoints.getCoefficients()[i];
-    else
-      constantTerm = constantTerm + numPoints.getCoefficients()[i];
 
+  // We expect the answer to be (1/2)⌊p/2⌋^2 + (3/2)⌊p/2⌋ + 1.
   EXPECT_EQ(pSquaredCoeff, Fraction(1, 2));
   EXPECT_EQ(pCoeff, Fraction(3, 2));
-  EXPECT_EQ(constantTerm, Fraction(1, 1));
+  EXPECT_EQ(numPoints.getConstantTerm(), Fraction(1, 1));
 }

--- a/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/BarvinokTest.cpp
@@ -126,7 +126,9 @@ TEST(BarvinokTest, getCoefficientInRationalFunction) {
 }
 
 // The following test is taken from
-//
+/// Verdoolaege, Sven, et al. "Counting integer points in parametric
+/// polytopes using Barvinok's rational functions." Algorithmica 48 (2007):
+/// 37-66.
 TEST(BarvinokTest, computeNumTerms) {
   GeneratingFunction gf(
       1, {1, 1, 1},

--- a/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
@@ -68,10 +68,20 @@ TEST(UtilsTest, DivisionReprNormalizeTest) {
 }
 
 TEST(UtilsTest, convolution) {
-  ArrayRef<Fraction> x({1, 2, 3, 4});
-  ArrayRef<Fraction> y({7, 3, 1, 6});
+  std::vector<Fraction> aVals({1, 2, 3, 4});
+  std::vector<Fraction> bVals({7, 3, 1, 6});
+  ArrayRef<Fraction> a(aVals);
+  ArrayRef<Fraction> b(bVals);
 
-  std::vector<Fraction> conv = multiplyPolynomials(x, y);
+  std::vector<Fraction> conv = multiplyPolynomials(a, b);
 
   EXPECT_EQ(conv, std::vector<Fraction>({7, 17, 28, 45, 27, 22, 24}));
+
+  aVals = {3, 6, 0, 2, 5};
+  bVals = {2, 0, 6};
+  a = aVals;
+  b = bVals;
+
+  conv = multiplyPolynomials(a, b);
+  EXPECT_EQ(conv, std::vector<Fraction>({6, 12, 18, 40, 10, 12, 30}));
 }

--- a/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
@@ -71,7 +71,7 @@ TEST(UtilsTest, convolution) {
   ArrayRef<Fraction> x({1, 2, 3, 4});
   ArrayRef<Fraction> y({7, 3, 1, 6});
 
-  std::vector<Fraction> conv = convolution(x, y);
+  std::vector<Fraction> conv = multiplyPolynomials(x, y);
 
   EXPECT_EQ(conv, std::vector<Fraction>({7, 17, 28, 45, 27, 22, 24}));
 }

--- a/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/UtilsTest.cpp
@@ -66,3 +66,12 @@ TEST(UtilsTest, DivisionReprNormalizeTest) {
   checkEqual(a, b);
   checkEqual(c, d);
 }
+
+TEST(UtilsTest, convolution) {
+  ArrayRef<Fraction> x({1, 2, 3, 4});
+  ArrayRef<Fraction> y({7, 3, 1, 6});
+
+  std::vector<Fraction> conv = convolution(x, y);
+
+  EXPECT_EQ(conv, std::vector<Fraction>({7, 17, 28, 45, 27, 22, 24}));
+}


### PR DESCRIPTION
We implement `computeNumTerms()`, which counts the number of terms in a generating function by substituting the unit vector in it.
This is the main function in Barvinok's algorithm – the number of points in a polytope is given by the number of terms in the generating function corresponding to it.
We also modify the GeneratingFunction class to have `const` getters and improve the simplification of QuasiPolynomials.