### PR TITLE
Fix 'newline in constant' encoding issue in clangd sources

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.h
+++ b/clang-tools-extra/clangd/CodeComplete.h
@@ -1,4 +1,4 @@
-//===--- CodeComplete.h ------------------------------------------*- C++-*-===//
+﻿//===--- CodeComplete.h ------------------------------------------*- C++-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -1,4 +1,4 @@
-//===--- Diagnostics.cpp -----------------------------------------*- C++-*-===//
+﻿//===--- Diagnostics.cpp -----------------------------------------*- C++-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -1,4 +1,4 @@
-//===--- Selection.cpp ----------------------------------------------------===//
+﻿//===--- Selection.cpp ----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Files within clang-tools-extra/clangd encountered 'newline in constant' errors while compiling with Visual Studio Community 2022 Preview (amd64). The affected files were CodeComplete.h, Diagnostics.cpp, and Selection.cpp.

This issue stems from the MSVC compiler mishandling UTF-8 encoded files without a Byte Order Mark (BOM). To address this, the encoding of these three files has been changed from UTF-8 to UTF-8 with BOM.

Affected files:
- clang-tools-extra/clangd/CodeComplete.h
- clang-tools-extra/clangd/Diagnostics.cpp
- clang-tools-extra/clangd/Selection.cpp

The fix has been verified to resolve the build issues without introducing further problems in other parts of the LLVM project.