### PR TITLE
[libclang/python] Add strict typing to clang Python bindings (#76664)

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -176,7 +176,7 @@ def b(x: str | bytes) -> bytes:
 # object. This is a problem, because it means that from_parameter will see an
 # integer and pass the wrong value on platforms where int != void*. Work around
 # this by marshalling object arguments as void**.
-c_object_p: TType[_Pointer[Any]] = POINTER(c_void_p)
+c_object_p: TType[CObjP] = POINTER(c_void_p)
 
 ### Exception Classes ###
 
@@ -212,7 +212,7 @@ class TranslationUnitSaveError(Exception):
     # Indicates that the translation unit was somehow invalid.
     ERROR_INVALID_TU = 3
 
-    def __init__(self, enumeration, message):
+    def __init__(self, enumeration: int, message: str):
         assert isinstance(enumeration, int)
 
         if enumeration < 1 or enumeration > 3:
@@ -443,22 +443,22 @@ class Diagnostic:
     DisplayCategoryName = 0x20
     _FormatOptionsMask = 0x3F
 
-    def __init__(self, ptr):
+    def __init__(self, ptr: CObjP):
         self.ptr = ptr
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_disposeDiagnostic(self)
 
     @property
-    def severity(self):
+    def severity(self) -> int:
         return conf.lib.clang_getDiagnosticSeverity(self)  # type: ignore [no-any-return]
 
     @property
-    def location(self):
+    def location(self) -> SourceLocation:
         return conf.lib.clang_getDiagnosticLocation(self)  # type: ignore [no-any-return]
 
     @property
-    def spelling(self):
+    def spelling(self) -> str:
         return _CXString.from_result(conf.lib.clang_getDiagnosticSpelling(self))
 
     @property
@@ -516,28 +516,28 @@ class Diagnostic:
         return ChildDiagnosticsIterator(self)
 
     @property
-    def category_number(self):
+    def category_number(self) -> int:
         """The category number for this diagnostic or 0 if unavailable."""
         return conf.lib.clang_getDiagnosticCategory(self)  # type: ignore [no-any-return]
 
     @property
-    def category_name(self):
+    def category_name(self) -> str:
         """The string name of the category for this diagnostic."""
         return _CXString.from_result(conf.lib.clang_getDiagnosticCategoryText(self))
 
     @property
-    def option(self):
+    def option(self) -> str:
         """The command-line option that enables this diagnostic."""
         return _CXString.from_result(conf.lib.clang_getDiagnosticOption(self, None))
 
     @property
-    def disable_option(self):
+    def disable_option(self) -> str:
         """The command-line option that disables this diagnostic."""
         disable = _CXString()
         conf.lib.clang_getDiagnosticOption(self, byref(disable))
         return _CXString.from_result(disable)
 
-    def format(self, options=None):
+    def format(self, options: int | None = None) -> str:
         """
         Format this diagnostic for display. The options argument takes
         Diagnostic.Display* flags, which can be combined using bitwise OR. If
@@ -550,15 +550,15 @@ class Diagnostic:
             raise ValueError("Invalid format options")
         return _CXString.from_result(conf.lib.clang_formatDiagnostic(self, options))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Diagnostic severity {}, location {}, spelling {}>".format(
             repr(self.severity), repr(self.location), repr(self.spelling)
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.format()
 
-    def from_param(self):
+    def from_param(self) -> CObjP:
         return self.ptr
 
 
@@ -569,11 +569,11 @@ class FixIt:
     with the given value.
     """
 
-    def __init__(self, range, value):
+    def __init__(self, range: SourceRange, value: str):
         self.range = range
         self.value = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<FixIt range {}, value {}>".format(repr(self.range), repr(self.value))
 
 
@@ -592,16 +592,16 @@ class TokenGroup:
     You should not instantiate this class outside of this module.
     """
 
-    def __init__(self, tu, memory, count):
+    def __init__(self, tu: TranslationUnit, memory: _Pointer[Token], count: c_uint):
         self._tu = tu
         self._memory = memory
         self._count = count
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_disposeTokens(self._tu, self._memory, self._count)
 
     @staticmethod
-    def get_tokens(tu, extent):
+    def get_tokens(tu: TranslationUnit, extent: SourceRange) -> Iterator[Token]:
         """Helper method to return all tokens in an extent.
 
         This functionality is needed multiple places in this module. We define
@@ -633,21 +633,25 @@ class TokenGroup:
             yield token
 
 
+TEnum = TypeVar("TEnum", bound="BaseEnumeration")
+
+
 ### Cursor Kinds ###
 class BaseEnumeration(Enum):
     """
     Common base class for named enumerations held in sync with Index.h values.
     """
 
+    value: int
 
-    def from_param(self):
+    def from_param(self) -> int:
         return self.value
 
     @classmethod
-    def from_id(cls, id):
+    def from_id(cls: type[TEnum], id: int) -> TEnum:
         return cls(id)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}.{}".format(self.__class__.__name__, self.name)
 
 
@@ -655,7 +659,7 @@ class TokenKind(BaseEnumeration):
     """Describes a specific type of a Token."""
 
     @classmethod
-    def from_value(cls, value):
+    def from_value(cls, value: int) -> TokenKind:
         """Obtain a registered TokenKind instance from its value."""
         return cls.from_id(value)
 
@@ -672,43 +676,43 @@ class CursorKind(BaseEnumeration):
     """
 
     @staticmethod
-    def get_all_kinds():
+    def get_all_kinds() -> list[CursorKind]:
         """Return all CursorKind enumeration instances."""
         return list(CursorKind)
 
-    def is_declaration(self):
+    def is_declaration(self) -> bool:
         """Test if this is a declaration kind."""
         return bool(conf.lib.clang_isDeclaration(self))
 
-    def is_reference(self):
+    def is_reference(self) -> bool:
         """Test if this is a reference kind."""
         return bool(conf.lib.clang_isReference(self))
 
-    def is_expression(self):
+    def is_expression(self) -> bool:
         """Test if this is an expression kind."""
         return bool(conf.lib.clang_isExpression(self))
 
-    def is_statement(self):
+    def is_statement(self) -> bool:
         """Test if this is a statement kind."""
         return bool(conf.lib.clang_isStatement(self))
 
-    def is_attribute(self):
+    def is_attribute(self) -> bool:
         """Test if this is an attribute kind."""
         return bool(conf.lib.clang_isAttribute(self))
 
-    def is_invalid(self):
+    def is_invalid(self) -> bool:
         """Test if this is an invalid kind."""
         return bool(conf.lib.clang_isInvalid(self))
 
-    def is_translation_unit(self):
+    def is_translation_unit(self) -> bool:
         """Test if this is a translation unit kind."""
         return bool(conf.lib.clang_isTranslationUnit(self))
 
-    def is_preprocessing(self):
+    def is_preprocessing(self) -> bool:
         """Test if this is a preprocessing kind."""
         return bool(conf.lib.clang_isPreprocessing(self))
 
-    def is_unexposed(self):
+    def is_unexposed(self) -> bool:
         """Test if this is an unexposed kind."""
         return bool(conf.lib.clang_isUnexposed(self))
 
@@ -1617,8 +1621,10 @@ class ExceptionSpecificationKind(BaseEnumeration):
 
 ### Cursors ###
 
+TGuardReturn = TypeVar("TGuardReturn")
 
-def cursor_null_guard(func):
+
+def cursor_null_guard(func: Callable[..., TGuardReturn]) -> Callable[..., TGuardReturn]:
     """
     This decorator is used to ensure that no methods are called on null-cursors.
     The bindings map null cursors to `None`, so users are not expected
@@ -1628,7 +1634,7 @@ def cursor_null_guard(func):
     calling its `is_null` method.
     """
 
-    def inner(self, *args, **kwargs):
+    def inner(self: Cursor, *args: Any, **kwargs: Any) -> TGuardReturn:
         if self.is_null():
             raise Exception("Tried calling method on a null-cursor.")
         return func(self, *args, **kwargs)
@@ -1668,7 +1674,7 @@ class Cursor(Structure):
 
     # This function is not null-guarded because it is used in cursor_null_guard itself
     def is_null(self) -> bool:
-        return self == conf.null_cursor
+        return self == conf.null_cursor  # type: ignore [no-any-return]
 
     @cursor_null_guard
     def is_definition(self) -> bool:
@@ -2282,7 +2288,7 @@ class Cursor(Structure):
         """Return an iterator for accessing the children of this cursor."""
 
         # FIXME: Expose iteration from CIndex, PR6125.
-        def visitor(child: Cursor, _: Cursor, children: list[Cursor]) -> int:
+        def visitor(child: Cursor, _: Cursor, children: list[Cursor]) -> Literal[1]:
             # FIXME: Document this assertion in API.
             assert not child.is_null()
 
@@ -2424,12 +2430,12 @@ class BinaryOperator(BaseEnumeration):
     Describes the BinaryOperator of a declaration
     """
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> bool:
         """Allows checks of the kind ```if cursor.binary_operator:```"""
         return self.value != 0
 
     @property
-    def is_assignment(self):
+    def is_assignment(self) -> bool:
         return BinaryOperator.Assign.value <= self.value < BinaryOperator.Comma.value
 
     Invalid = 0
@@ -2517,7 +2523,7 @@ class TypeKind(BaseEnumeration):
     """
 
     @property
-    def spelling(self):
+    def spelling(self) -> str:
         """Retrieve the spelling of this TypeKind."""
         return _CXString.from_result(conf.lib.clang_getTypeKindSpelling(self.value))
 
@@ -3014,11 +3020,11 @@ class ClangObject:
     the ctypes library and the Clang CIndex library.
     """
 
-    def __init__(self, obj):
+    def __init__(self, obj: CObjP):
         assert isinstance(obj, c_object_p) and obj
         self.obj = self._as_parameter_ = obj
 
-    def from_param(self):
+    def from_param(self) -> CObjP:
         return self._as_parameter_
 
 
@@ -3391,7 +3397,7 @@ class Index(ClangObject):
     """
 
     @staticmethod
-    def create(excludeDecls=False):
+    def create(excludeDecls: bool = False) -> Index:
         """
         Create a new Index.
         Parameters:
@@ -3399,14 +3405,20 @@ class Index(ClangObject):
         """
         return Index(conf.lib.clang_createIndex(excludeDecls, 0))
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_disposeIndex(self)
 
-    def read(self, path):
+    def read(self, path: StrPath) -> TranslationUnit:
         """Load a TranslationUnit from the given AST file."""
         return TranslationUnit.from_ast_file(path, self)
 
-    def parse(self, path, args=None, unsaved_files=None, options=0):
+    def parse(
+        self,
+        path: StrPath | None,
+        args: list[str] | None = None,
+        unsaved_files: list[InMemoryFile] | None = None,
+        options: int = 0,
+    ) -> TranslationUnit:
         """Load the translation unit from the given source code file by running
         clang and generating the AST before loading. Additional command line
         parameters can be passed to clang via the args parameter.
@@ -3481,7 +3493,7 @@ class TranslationUnit(ClangObject):
     def from_source(
         cls,
         filename: StrBytesPath | None,
-        args: list[TUnion[str, bytes]] | None = None,
+        args: TUnion[list[str], list[str]] | None = None,
         unsaved_files: list[InMemoryFile] | None = None,
         options: int = 0,
         index: Index | None = None,
@@ -3849,39 +3861,41 @@ class File(ClangObject):
     translation unit.
     """
 
+    _tu: TranslationUnit
+
     @staticmethod
-    def from_name(translation_unit, file_name):
+    def from_name(translation_unit: TranslationUnit, file_name: StrBytesPath) -> File:
         """Retrieve a file handle within the given translation unit."""
         return File(
             conf.lib.clang_getFile(translation_unit, os.fspath(file_name)),
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the complete file and path name of the file."""
         return _CXString.from_result(conf.lib.clang_getFileName(self))
 
     @property
-    def time(self):
+    def time(self) -> int:
         """Return the last modification time of the file."""
         return conf.lib.clang_getFileTime(self)  # type: ignore [no-any-return]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<File: {}>".format(self.name)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, File) and bool(
             conf.lib.clang_File_isEqual(self, other)
         )
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
     @staticmethod
-    def from_result(res, arg):
+    def from_result(res: CObjP, arg: Cursor) -> File:
         assert isinstance(res, c_object_p)
         file = File(res)
 
@@ -3899,14 +3913,14 @@ class FileInclusion:
     file in the stack. Note that the input file has depth 0.
     """
 
-    def __init__(self, src, tgt, loc, depth):
+    def __init__(self, src: File | None, tgt: File, loc: SourceLocation, depth: int):
         self.source = src
         self.include = tgt
         self.location = loc
         self.depth = depth
 
     @property
-    def is_input_file(self):
+    def is_input_file(self) -> bool:
         """True if the included file is the input file."""
         return self.depth == 0
 
@@ -3925,7 +3939,7 @@ class CompilationDatabaseError(Exception):
     # The database could not be loaded
     ERROR_CANNOTLOADDATABASE = 1
 
-    def __init__(self, enumeration, message):
+    def __init__(self, enumeration: int, message: str):
         assert isinstance(enumeration, int)
 
         if enumeration > 1:
@@ -3941,28 +3955,28 @@ class CompilationDatabaseError(Exception):
 class CompileCommand:
     """Represents the compile command used to build a file"""
 
-    def __init__(self, cmd, ccmds):
+    def __init__(self, cmd: CObjP, ccmds: CompileCommands):
         self.cmd = cmd
         # Keep a reference to the originating CompileCommands
         # to prevent garbage collection
         self.ccmds = ccmds
 
     @property
-    def directory(self):
+    def directory(self) -> str:
         """Get the working directory for this CompileCommand"""
         return _CXString.from_result(
             conf.lib.clang_CompileCommand_getDirectory(self.cmd)
         )
 
     @property
-    def filename(self):
+    def filename(self) -> str:
         """Get the working filename for this CompileCommand"""
         return _CXString.from_result(
             conf.lib.clang_CompileCommand_getFilename(self.cmd)
         )
 
     @property
-    def arguments(self):
+    def arguments(self) -> Iterator[str]:
         """
         Get an iterable object providing each argument in the
         command line for the compiler invocation as a string.
@@ -3982,23 +3996,23 @@ class CompileCommands:
     that can be used for building a specific file.
     """
 
-    def __init__(self, ccmds):
+    def __init__(self, ccmds: CObjP):
         self.ccmds = ccmds
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_CompileCommands_dispose(self.ccmds)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return int(conf.lib.clang_CompileCommands_getSize(self.ccmds))
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int) -> CompileCommand:
         cc = conf.lib.clang_CompileCommands_getCommand(self.ccmds, i)
         if not cc:
             raise IndexError
         return CompileCommand(cc, self)
 
     @staticmethod
-    def from_result(res):
+    def from_result(res: CObjP) -> CompileCommands | None:
         if not res:
             return None
         return CompileCommands(res)
@@ -4012,17 +4026,17 @@ class CompilationDatabase(ClangObject):
     It enables querying how a specific source file can be built.
     """
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_CompilationDatabase_dispose(self)
 
     @staticmethod
-    def from_result(res):
+    def from_result(res: CObjP) -> CompilationDatabase:
         if not res:
             raise CompilationDatabaseError(0, "CompilationDatabase loading failed")
         return CompilationDatabase(res)
 
     @staticmethod
-    def fromDirectory(buildDir):
+    def fromDirectory(buildDir: StrPath) -> CompilationDatabase:
         """Builds a CompilationDatabase from the database found in buildDir"""
         errorCode = c_uint()
         try:
@@ -4037,24 +4051,24 @@ class CompilationDatabase(ClangObject):
             )
         return cdb
 
-    def getCompileCommands(self, filename):
+    def getCompileCommands(self, filename: StrPath) -> CompileCommands | None:
         """
         Get an iterable object providing all the CompileCommands available to
         build filename. Returns None if filename is not found in the database.
         """
         return CompileCommands.from_result(
-            conf.lib.clang_CompilationDatabase_getCompileCommands(  # type: ignore [no-any-return]
+            conf.lib.clang_CompilationDatabase_getCompileCommands(
                 self, os.fspath(filename)
             )
         )
 
-    def getAllCompileCommands(self):
+    def getAllCompileCommands(self) -> CompileCommands | None:
         """
         Get an iterable object providing all the CompileCommands available from
         the database.
         """
         return CompileCommands.from_result(
-            conf.lib.clang_CompilationDatabase_getAllCompileCommands(self)  # type: ignore [no-any-return]
+            conf.lib.clang_CompilationDatabase_getAllCompileCommands(self)
         )
 
 
@@ -4071,7 +4085,7 @@ class Token(Structure):
     _fields_ = [("int_data", c_uint * 4), ("ptr_data", c_void_p)]
 
     @property
-    def spelling(self):
+    def spelling(self) -> str:
         """The spelling of this token.
 
         This is the textual representation of the token in source.
@@ -4079,22 +4093,22 @@ class Token(Structure):
         return _CXString.from_result(conf.lib.clang_getTokenSpelling(self._tu, self))
 
     @property
-    def kind(self):
+    def kind(self) -> TokenKind:
         """Obtain the TokenKind of the current token."""
         return TokenKind.from_value(conf.lib.clang_getTokenKind(self))
 
     @property
-    def location(self):
+    def location(self) -> SourceLocation:
         """The SourceLocation this Token occurs at."""
         return conf.lib.clang_getTokenLocation(self._tu, self)  # type: ignore [no-any-return]
 
     @property
-    def extent(self):
+    def extent(self) -> SourceRange:
         """The SourceRange this Token occupies."""
         return conf.lib.clang_getTokenExtent(self._tu, self)  # type: ignore [no-any-return]
 
     @property
-    def cursor(self):
+    def cursor(self) -> Cursor | None:
         """The Cursor this Token corresponds to."""
         cursor = Cursor()
         cursor._tu = self._tu
@@ -4114,7 +4128,7 @@ class Rewriter(ClangObject):
     """
 
     @staticmethod
-    def create(tu):
+    def create(tu: TranslationUnit) -> Rewriter:
         """
         Creates a new Rewriter
         Parameters:
@@ -4122,33 +4136,33 @@ class Rewriter(ClangObject):
         """
         return Rewriter(conf.lib.clang_CXRewriter_create(tu))
 
-    def __init__(self, ptr):
+    def __init__(self, ptr: CObjP):
         ClangObject.__init__(self, ptr)
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_CXRewriter_dispose(self)
 
-    def insert_text_before(self, loc, insert):
+    def insert_text_before(self, loc: SourceLocation, insert: str) -> None:
         """
         Insert the specified string at the specified location in
         the original buffer.
         """
         conf.lib.clang_CXRewriter_insertTextBefore(self, loc, insert)
 
-    def replace_text(self, extent, replacement):
+    def replace_text(self, extent: SourceRange, replacement: str) -> None:
         """
         This method replaces a range of characters in the input buffer with
         a new string.
         """
         conf.lib.clang_CXRewriter_replaceText(self, extent, replacement)
 
-    def remove_text(self, extent):
+    def remove_text(self, extent: SourceRange) -> None:
         """
         Remove the specified text region.
         """
         conf.lib.clang_CXRewriter_removeText(self, extent)
 
-    def overwrite_changed_files(self):
+    def overwrite_changed_files(self) -> int:
         """
         Save all changed files to disk.
 
@@ -4157,7 +4171,7 @@ class Rewriter(ClangObject):
         """
         return conf.lib.clang_CXRewriter_overwriteChangedFiles(self)  # type: ignore [no-any-return]
 
-    def write_main_file_to_stdout(self):
+    def write_main_file_to_stdout(self) -> None:
         """
         Writes the main file to stdout.
         """
@@ -4208,7 +4222,7 @@ class PrintingPolicy(ClangObject):
     """
 
     @staticmethod
-    def create(cursor):
+    def create(cursor: Cursor) -> PrintingPolicy:
         """
         Creates a new PrintingPolicy
         Parameters:
@@ -4216,17 +4230,17 @@ class PrintingPolicy(ClangObject):
         """
         return PrintingPolicy(conf.lib.clang_getCursorPrintingPolicy(cursor))
 
-    def __init__(self, ptr):
+    def __init__(self, ptr: CObjP):
         ClangObject.__init__(self, ptr)
 
-    def __del__(self):
+    def __del__(self) -> None:
         conf.lib.clang_PrintingPolicy_dispose(self)
 
-    def get_property(self, property):
+    def get_property(self, property: PrintingPolicyProperty) -> int:
         """Get a property value for the given printing policy."""
-        return conf.lib.clang_PrintingPolicy_getProperty(self, property.value)
+        return conf.lib.clang_PrintingPolicy_getProperty(self, property.value)  # type: ignore [no-any-return]
 
-    def set_property(self, property, value):
+    def set_property(self, property: PrintingPolicyProperty, value: bool) -> None:
         """Set a property value for the given printing policy."""
         conf.lib.clang_PrintingPolicy_setProperty(self, property.value, value)
 


### PR DESCRIPTION
This PR adds type annotations to the clang Python bindings, to the point that they pass a strict MyPy check.
This utilizes Python features up to 3.7, thus ending support of the bindings for versions <= 3.6 (see also discussion here: https://discourse.llvm.org/t/type-annotations-for-libclang-python-bindings/70644). I thus removed some compatibility stuff for older Python versions.

I tried to change as little as possible, but sometimes passing the type check without changing semantics would have been impossible. Such changes mostly come down to e.g. returning an empty string instead of `None` and similar.
Some changes might look unrelated at first glance, but everything was done specifically to resolve typing errors.

I've left comments in some other places where I'm unsure about my changes, especially where they affect semantics.

I know that this is a massive PR, if there's anything I can do to make reviewing this easier etc. please do tell.

This resolves #76664 