### PR TITLE
[libc++][utility][NFC] Refactored safe integer `cmp_xxxx` functions to use the `__libcpp_is_integer` concept

### DIFF
--- a/libcxx/include/__utility/cmp.h
+++ b/libcxx/include/__utility/cmp.h
@@ -9,14 +9,10 @@
 #ifndef _LIBCPP___UTILITY_CMP_H
 #define _LIBCPP___UTILITY_CMP_H
 
+#include <__concepts/arithmetic.h>
 #include <__config>
-#include <__type_traits/disjunction.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/is_same.h>
 #include <__type_traits/is_signed.h>
 #include <__type_traits/make_unsigned.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -29,28 +25,8 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
-template <class _Tp, class... _Up>
-struct _IsSameAsAny : _Or<_IsSame<_Tp, _Up>...> {};
 
-template <class _Tp>
-concept __is_safe_integral_cmp =
-    is_integral_v<_Tp> &&
-    !_IsSameAsAny<_Tp,
-                  bool,
-                  char,
-                  char16_t,
-                  char32_t
-#  ifndef _LIBCPP_HAS_NO_CHAR8_T
-                  ,
-                  char8_t
-#  endif
-#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-                  ,
-                  wchar_t
-#  endif
-                  >::value;
-
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept {
   if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t == __u;
@@ -60,12 +36,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept {
     return __u < 0 ? false : __t == make_unsigned_t<_Up>(__u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept {
   return !std::cmp_equal(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept {
   if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t < __u;
@@ -75,26 +51,27 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept {
     return __u < 0 ? false : __t < make_unsigned_t<_Up>(__u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_greater(_Tp __t, _Up __u) noexcept {
   return std::cmp_less(__u, __t);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_less_equal(_Tp __t, _Up __u) noexcept {
   return !std::cmp_greater(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_greater_equal(_Tp __t, _Up __u) noexcept {
   return !std::cmp_less(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <__libcpp_integer _Tp, __libcpp_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool in_range(_Up __u) noexcept {
   return std::cmp_less_equal(__u, numeric_limits<_Tp>::max()) &&
          std::cmp_greater_equal(__u, numeric_limits<_Tp>::min());
 }
+
 #endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
Replaced a functionally identical internal concept helper.

References:
- https://eel.is/c++draft/utility.intcmp
- https://eel.is/c++draft/basic.fundamental