### PR TITLE
[Flang] Remove dead -mvscale-{min,max} logic from getVScaleRange. NFCI

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -769,7 +769,6 @@ getRISCVVScaleRange(CompilerInstance &ci) {
 // too much of clang, so for now, replicate the functionality.
 static std::optional<std::pair<unsigned, unsigned>>
 getVScaleRange(CompilerInstance &ci) {
-  const auto &langOpts = ci.getInvocation().getLangOpts();
   const llvm::Triple triple(ci.getInvocation().getTargetOpts().triple);
 
   if (triple.isAArch64())
@@ -777,10 +776,8 @@ getVScaleRange(CompilerInstance &ci) {
   if (triple.isRISCV())
     return getRISCVVScaleRange(ci);
 
-  if (langOpts.VScaleMin || langOpts.VScaleMax)
-    return std::pair<unsigned, unsigned>(
-        langOpts.VScaleMin ? langOpts.VScaleMin : 1, langOpts.VScaleMax);
-
+  // All other architectures that don't support scalable vectors (i.e. don't
+  // need vscale)
   return std::nullopt;
 }
 


### PR DESCRIPTION
After #77905, setting -mvscale-min or -mvscale-max on targets other than
AArch64 and RISC-V should be an error now, so we no longer need this
target-agnostic code in getVScaleRange.
