### PR TITLE
[dsymutil][llvm-dwarfutil] Rename command line options to avoid using vendor names.

### DIFF
--- a/llvm/test/tools/dsymutil/ARM/DWARFLinkerParallel/accel-imported-declarations.test
+++ b/llvm/test/tools/dsymutil/ARM/DWARFLinkerParallel/accel-imported-declarations.test
@@ -1,7 +1,7 @@
-RUN: dsymutil --linker llvm -accelerator=Dwarf \
+RUN: dsymutil --linker parallel -accelerator=Dwarf \
 RUN:   -oso-prepend-path=%p/../../Inputs \
 RUN:   %p/../../Inputs/accel-imported-declaration.macho-arm64 -o %t.dwarf.dSYM
-RUN: dsymutil --linker llvm -accelerator=Apple \
+RUN: dsymutil --linker parallel -accelerator=Apple \
 RUN:   -oso-prepend-path=%p/../../Inputs \
 RUN:   %p/../../Inputs/accel-imported-declaration.macho-arm64 -o %t.apple.dSYM
 

--- a/llvm/test/tools/dsymutil/ARM/call-pc-reloc.test
+++ b/llvm/test/tools/dsymutil/ARM/call-pc-reloc.test
@@ -17,7 +17,7 @@ $ clang -arch arm64 main.arm64.o -o main.arm64 -g
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
 CHECK: DW_AT_call_pc (0x0000000100007f94)

--- a/llvm/test/tools/dsymutil/ARM/dwarf5-addr-base.test
+++ b/llvm/test/tools/dsymutil/ARM/dwarf5-addr-base.test
@@ -50,13 +50,13 @@ RUN: dsymutil -y %p/dummy-debug-map-amr64.map -oso-prepend-path=%p/../Inputs/DWA
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm --no-odr -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --no-odr -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \
@@ -68,14 +68,14 @@ RUN: dsymutil --update -y %p/dummy-debug-map-amr64.map -oso-prepend-path=%p/../I
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s --check-prefix=UPD
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm --no-odr --update -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --no-odr --update -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \
 RUN:   FileCheck %s --check-prefix=UPD
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm --update -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --update -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \

--- a/llvm/test/tools/dsymutil/ARM/dwarf5-addrx-0x0-last.test
+++ b/llvm/test/tools/dsymutil/ARM/dwarf5-addrx-0x0-last.test
@@ -28,7 +28,7 @@ RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 RUN: llvm-dwarfdump --verbose -debug-info %t.dSYM | FileCheck %s --check-prefix DEBUGINFO
 RUN: llvm-dwarfdump --verbose -debug-line %t.dSYM | FileCheck %s --check-prefix DEBUGLINE
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs \
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs \
 RUN:   %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx-0x0-last.out \
 RUN:   -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s

--- a/llvm/test/tools/dsymutil/ARM/dwarf5-dwarf4-combination-macho.test
+++ b/llvm/test/tools/dsymutil/ARM/dwarf5-dwarf4-combination-macho.test
@@ -34,7 +34,7 @@ RUN: dsymutil -y %p/dummy-debug-map-amr64.map -oso-prepend-path=%p/../Inputs/DWA
 RUN: llvm-dwarfdump %t.dir/dwarf5-dwarf4-combination-macho.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --no-odr --linker llvm -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --no-odr --linker parallel -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-DWARF4-combination \
 RUN:   -o %t.dir/dwarf5-dwarf4-combination-macho.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-dwarf4-combination-macho.dSYM \
@@ -43,7 +43,7 @@ RUN:   -a --verbose | FileCheck %s
 ### Uncomment following when llvm-dwarfdump will dump address ranges
 ### correctly for severall compile units case.
 COM: rm -rf %t.dir && mkdir -p %t.dir
-COM: dsymutil --linker llvm -y %p/dummy-debug-map-amr64.map \
+COM: dsymutil --linker parallel -y %p/dummy-debug-map-amr64.map \
 COM:   -oso-prepend-path=%p/../Inputs/DWARF5-DWARF4-combination \
 COM:   -o %t.dir/dwarf5-dwarf4-combination-macho.dSYM
 COM: llvm-dwarfdump %t.dir/dwarf5-dwarf4-combination-macho.dSYM \

--- a/llvm/test/tools/dsymutil/ARM/dwarf5-macho.test
+++ b/llvm/test/tools/dsymutil/ARM/dwarf5-macho.test
@@ -22,14 +22,14 @@ RUN: dsymutil -y %p/dummy-debug-map-amr64.map -oso-prepend-path=%p/../Inputs/DWA
 RUN: llvm-dwarfdump %t.dir/dwarf5-macho.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm --no-odr -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --no-odr -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5 -o %t.dir/dwarf5-macho.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-macho.dSYM -a --verbose | FileCheck %s
 
 ### Uncomment following when llvm-dwarfdump will print resolved address ranges
 ### for the case mutiplue compile units.
 COM: rm -rf %t.dir && mkdir -p %t.dir
-COM: dsymutil --linker llvm -y %p/dummy-debug-map-amr64.map \
+COM: dsymutil --linker parallel -y %p/dummy-debug-map-amr64.map \
 COM:   -oso-prepend-path=%p/../Inputs/DWARF5 -o %t.dir/dwarf5-macho.dSYM
 COM: llvm-dwarfdump %t.dir/dwarf5-macho.dSYM -a --verbose | FileCheck %s \
 COM: --check-prefixes=CHECK,CHECK-LLVM

--- a/llvm/test/tools/dsymutil/ARM/dwarf5-str-offsets-base-strx.test
+++ b/llvm/test/tools/dsymutil/ARM/dwarf5-str-offsets-base-strx.test
@@ -57,26 +57,26 @@ RUN: dsymutil --update -y %p/dummy-debug-map-amr64.map -oso-prepend-path=%p/../I
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s --check-prefixes=UPD,GLOBALUPD
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm --no-odr -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --no-odr -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \
 RUN:   FileCheck %s --check-prefixes=CHECK,LOCAL
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --linker llvm -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \
 RUN:   FileCheck %s --check-prefixes=CHECK,LOCAL,CHECK-LLVM
 
-RUN: dsymutil --linker llvm --no-odr --update -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --no-odr --update -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \
 RUN:   FileCheck %s --check-prefixes=UPD,LOCALUPD
 
-RUN: dsymutil --linker llvm --update -y %p/dummy-debug-map-amr64.map \
+RUN: dsymutil --linker parallel --update -y %p/dummy-debug-map-amr64.map \
 RUN:   -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base \
 RUN:   -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | \

--- a/llvm/test/tools/dsymutil/ARM/empty-map.test
+++ b/llvm/test/tools/dsymutil/ARM/empty-map.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 
 ---
 triple:          'thumbv7-apple-darwin'

--- a/llvm/test/tools/dsymutil/ARM/extern-alias.test
+++ b/llvm/test/tools/dsymutil/ARM/extern-alias.test
@@ -38,8 +38,8 @@ $ xcrun --sdk iphoneos clang private_extern.o main.o -target arm64-apple-ios14.0
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s
 
 CHECK-NOT: could not find symbol '_baz'
 CHECK: { sym: _baz, objAddr: 0x0, binAddr: 0x100007F58, size: 0x0 }

--- a/llvm/test/tools/dsymutil/ARM/fat-arch-name.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-arch-name.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
 
-# RUN: dsymutil --linker llvm -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
 
 # We detect thumb triples from the binaries, because those are the only ones
 # that are guaranteed to be able to generate a Target instance (for example

--- a/llvm/test/tools/dsymutil/ARM/fat-arch-not-found.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-arch-not-found.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 #
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 
 ---
 triple:          'armv7-apple-darwin'

--- a/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
@@ -6,11 +6,11 @@
 # RUN: dsymutil -u %t.dSYM -o %t1.dSYM
 # RUN: llvm-dwarfdump -a -v %t1.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
 #
-# RUN: dsymutil --linker llvm -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM
+# RUN: dsymutil --linker parallel -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM
 # RUN: llvm-dwarfdump -a -v %t.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
-# RUN: dsymutil --linker llvm -u %t.dSYM
+# RUN: dsymutil --linker parallel -u %t.dSYM
 # RUN: llvm-dwarfdump -a -v %t.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
-# RUN: dsymutil --linker llvm -u %t.dSYM -o %t1.dSYM
+# RUN: dsymutil --linker parallel -u %t.dSYM -o %t1.dSYM
 # RUN: llvm-dwarfdump -a -v %t1.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
 
 CHECK: /Contents/Resources/DWARF/fat-test.arm.dylib(armv7):	file format Mach-O arm

--- a/llvm/test/tools/dsymutil/ARM/inline-source.test
+++ b/llvm/test/tools/dsymutil/ARM/inline-source.test
@@ -2,7 +2,7 @@
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj -mtriple arm64-apple-darwin %p/../Inputs/inline.ll -o %t/inline.o
 # RUN: dsymutil -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
-# RUN: dsymutil --linker=llvm -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
+# RUN: dsymutil --linker=parallel -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 
 # Test inline source files.
 

--- a/llvm/test/tools/dsymutil/ARM/inlined-low_pc.c
+++ b/llvm/test/tools/dsymutil/ARM/inlined-low_pc.c
@@ -5,7 +5,7 @@ int bar(int a) { return foo(a); }
 
 // RUN: dsymutil -f -y %p/dummy-debug-map-amr64.map -oso-prepend-path %p/../Inputs/inlined-low_pc -o - | llvm-dwarfdump - | FileCheck %s
 
-// RUN: dsymutil --linker llvm -f -y %p/dummy-debug-map-amr64.map \
+// RUN: dsymutil --linker parallel -f -y %p/dummy-debug-map-amr64.map \
 // RUN: -oso-prepend-path %p/../Inputs/inlined-low_pc -o - | \
 // RUN: llvm-dwarfdump - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/ARM/obfuscated.test
+++ b/llvm/test/tools/dsymutil/ARM/obfuscated.test
@@ -29,20 +29,20 @@ RUN: rm %t.dSYM/Contents/Resources/E828A486-8433-3A5E-B6DB-A6294D28133D.plist
 RUN: dsymutil --symbol-map %t.mapdir %t.dSYM 2>&1 | FileCheck --check-prefix=NOTOBFUSCATING %s
 
 // ----------------------------------------
-// Repeat the same steps for --linker llvm.
-RUN: dsymutil --linker llvm --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
+// Repeat the same steps for --linker parallel.
+RUN: dsymutil --linker parallel --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
 RUN:     | llvm-dwarfdump -v - \
 RUN:     | FileCheck %s
 
-RUN: dsymutil --linker llvm --accelerator=Pub --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
+RUN: dsymutil --linker parallel --accelerator=Pub --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
 RUN:     | llvm-dwarfdump -v - \
 RUN:     | FileCheck --check-prefix=PUB %s
 
-RUN: dsymutil --linker llvm --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
+RUN: dsymutil --linker parallel --symbol-map %p/../Inputs/obfuscated.map %p/../Inputs/obfuscated.arm64 -f -o - \
 RUN:     | llvm-dwarfdump -v - \
 RUN:     | FileCheck --check-prefix=NOHIDDEN %s
 
-RUN: dsymutil --linker llvm --symbol-map %p/../Inputs/obfuscated.2.map %p/../Inputs/obfuscated.2.arm64 -f -o - \
+RUN: dsymutil --linker parallel --symbol-map %p/../Inputs/obfuscated.2.map %p/../Inputs/obfuscated.2.arm64 -f -o - \
 RUN:     | llvm-dwarfdump -v - \
 RUN:     | FileCheck --check-prefix=NOHIDDEN %s
 
@@ -52,11 +52,11 @@ RUN: mkdir -p %t.mapdir
 RUN: cp %p/../Inputs/obfuscated.arm64 %t.dSYM/Contents/Resources/DWARF/
 RUN: cp %p/../Inputs/E828A486-8433-3A5E-B6DB-A6294D28133D.plist %t.dSYM/Contents/Resources/
 RUN: cp %p/../Inputs/obfuscated.map %t.mapdir/506AA50A-6B26-3B37-86D2-DC6EBD57B720.bcsymbolmap
-RUN: dsymutil --linker llvm --symbol-map %t.mapdir %t.dSYM 2>&1 | FileCheck --check-prefix=OBFUSCATING %s
+RUN: dsymutil --linker parallel --symbol-map %t.mapdir %t.dSYM 2>&1 | FileCheck --check-prefix=OBFUSCATING %s
 
 // Run without plist and make sure dsymutil doesn't crash.
 RUN: rm %t.dSYM/Contents/Resources/E828A486-8433-3A5E-B6DB-A6294D28133D.plist
-RUN: dsymutil --linker llvm --symbol-map %t.mapdir %t.dSYM 2>&1 | FileCheck --check-prefix=NOTOBFUSCATING %s
+RUN: dsymutil --linker parallel --symbol-map %t.mapdir %t.dSYM 2>&1 | FileCheck --check-prefix=NOTOBFUSCATING %s
 
 OBFUSCATING-NOT: not unobfuscating
 

--- a/llvm/test/tools/dsymutil/ARM/preload.test
+++ b/llvm/test/tools/dsymutil/ARM/preload.test
@@ -8,7 +8,7 @@ RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/preload/fo
 RUN: llvm-nm %p/../Inputs/private/tmp/preload/foo | FileCheck %s
 RUN: llvm-nm %t.dSYM/Contents/Resources/DWARF/foo | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/preload/foo -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/preload/foo -o %t.dSYM
 RUN: llvm-nm %p/../Inputs/private/tmp/preload/foo | FileCheck %s
 RUN: llvm-nm %t.dSYM/Contents/Resources/DWARF/foo | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/ARM/scattered.c
+++ b/llvm/test/tools/dsymutil/ARM/scattered.c
@@ -2,7 +2,7 @@ RUN: dsymutil -y %p/dummy-debug-map.map -oso-prepend-path \
 RUN:  %p/../Inputs/scattered-reloc/ -f -o - | \
 RUN:  llvm-dwarfdump -debug-info - | FileCheck %s
 
-RUN: dsymutil --linker llvm -y %p/dummy-debug-map.map \
+RUN: dsymutil --linker parallel -y %p/dummy-debug-map.map \
 RUN:  -oso-prepend-path %p/../Inputs/scattered-reloc/ -f -o - \
 RUN:  | llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/ARM/thumb.c
+++ b/llvm/test/tools/dsymutil/ARM/thumb.c
@@ -1,9 +1,9 @@
 // RUN: dsymutil -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
 // RUN: dsymutil -arch armv7m -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
 
-// RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/.. \
+// RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/.. \
 // RUN:  %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
-// RUN: dsymutil --linker llvm -arch armv7m -f -oso-prepend-path=%p/.. \
+// RUN: dsymutil --linker parallel -arch armv7m -f -oso-prepend-path=%p/.. \
 // RUN:  %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
 
 /* Compile with:

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/dead-stripped.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/dead-stripped.cpp
@@ -1,9 +1,9 @@
-// RUN: dsymutil --linker llvm --no-odr -f -y %p/../dummy-debug-map.map -oso-prepend-path \
+// RUN: dsymutil --linker parallel --no-odr -f -y %p/../dummy-debug-map.map -oso-prepend-path \
 // RUN: %p/../../Inputs/dead-stripped -o - | llvm-dwarfdump - --debug-info | \
 // RUN: FileCheck %s --implicit-check-not \
 // RUN: "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}"
 //
-// RUN: dsymutil --linker llvm -f -y %p/../dummy-debug-map.map -oso-prepend-path \
+// RUN: dsymutil --linker parallel -f -y %p/../dummy-debug-map.map -oso-prepend-path \
 // RUN: %p/../../Inputs/dead-stripped -o - | llvm-dwarfdump - --debug-info | \
 // RUN: FileCheck %s --implicit-check-not \
 // RUN: "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}" \

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty-CU.test
@@ -1,5 +1,5 @@
 RUN: llvm-mc %p/../../Inputs/empty-CU.s -filetype obj -triple x86_64-apple-darwin -o %t.o
-RUN: dsymutil --linker llvm --update -f %t.o -o - | llvm-dwarfdump -v - -debug-info | FileCheck %s
+RUN: dsymutil --linker parallel --update -f %t.o -o - | llvm-dwarfdump -v - -debug-info | FileCheck %s
 
 CHECK: .debug_info contents:
 CHECK-NOT: DW_TAG_compile_unit

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty_range.s
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty_range.s
@@ -4,7 +4,7 @@
 # Compile with:
 #        llvm-mc -triple x86_64-apple-darwin -filetype=obj -o 1.o empty_range.o
 
-# RUN: dsymutil --linker llvm -f -y %p/../dummy-debug-map.map -oso-prepend-path %p/../../Inputs/empty_range -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -y %p/../dummy-debug-map.map -oso-prepend-path %p/../../Inputs/empty_range -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
         .section	__TEXT,__text,regular,pure_instructions
 	.macosx_version_min 10, 11

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/frame-1.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/frame-1.test
@@ -1,7 +1,7 @@
 # RUN: rm -rf %t
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj %p/../../Inputs/frame-dw2.ll -o %t/frame-dw2.o
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%t -y %s -o - | \
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%t -y %s -o - | \
 # RUN:   llvm-dwarfdump -debug-frame - | FileCheck %s
 
 # This test is meant to verify that identical CIEs will get reused

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/frame-2.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/frame-2.test
@@ -2,7 +2,7 @@
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj %p/../../Inputs/frame-dw2.ll -o %t/frame-dw2.o
 # RUN: llc -filetype=obj %p/../../Inputs/frame-dw4.ll -o %t/frame-dw4.o
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%t -y %s -o - | \
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%t -y %s -o - | \
 # RUN:   llvm-dwarfdump -debug-frame - | FileCheck %s
 
 # Check the handling of multiple different CIEs. To have CIEs that

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/inlined-static-variable.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/inlined-static-variable.cpp
@@ -1,4 +1,4 @@
-// RUN: dsymutil --linker llvm -f -y %p/../dummy-debug-map.map -oso-prepend-path \
+// RUN: dsymutil --linker parallel -f -y %p/../dummy-debug-map.map -oso-prepend-path \
 // RUN:   %p/../../Inputs/inlined-static-variable -o - -keep-function-for-static | \
 // RUN:   llvm-dwarfdump - | FileCheck %s --implicit-check-not \
 // RUN: "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}" \

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/keep-func.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/keep-func.test
@@ -20,8 +20,8 @@ int main()
 $ clang++ -O2 -g main.cpp -c -o main.o
 $ clang++ main.o -o main.out
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../../Inputs %p/../../Inputs/private/tmp/keep_func/main.out -o %t.omit.dSYM
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../../Inputs %p/../../Inputs/private/tmp/keep_func/main.out -o %t.keep.dSYM -keep-function-for-static
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../../Inputs %p/../../Inputs/private/tmp/keep_func/main.out -o %t.omit.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../../Inputs %p/../../Inputs/private/tmp/keep_func/main.out -o %t.keep.dSYM -keep-function-for-static
 RUN: llvm-dwarfdump %t.omit.dSYM | FileCheck %s --check-prefix OMIT
 RUN: llvm-dwarfdump %t.keep.dSYM | FileCheck %s --check-prefix KEEP
 

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-anon-namespace.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-anon-namespace.cpp
@@ -4,7 +4,7 @@
    done
  */
 
-// RUN: dsymutil --linker llvm -f \
+// RUN: dsymutil --linker parallel -f \
 // RUN:   -oso-prepend-path=%p/../../Inputs/odr-anon-namespace \
 // RUN:   -y %p/../dummy-debug-map.map -o - | \
 // RUN:   llvm-dwarfdump -debug-info - | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration.test
@@ -4,7 +4,7 @@
        Inputs/odr-fwd-declaration/$FILE.o done
 */
 
-// RUN: dsymutil --linker=llvm -f \
+// RUN: dsymutil --linker=parallel -f \
 // RUN: -oso-prepend-path=%p/../../Inputs/odr-fwd-declaration \
 // RUN: -y %p/../dummy-debug-map.map -o %t1.out
 // RUN: llvm-dwarfdump -v -debug-info %t1.out | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration2.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration2.test
@@ -4,7 +4,7 @@
        Inputs/odr-fwd-declaration2/$FILE.o done
 */
 
-// RUN: dsymutil --linker=llvm -f \
+// RUN: dsymutil --linker=parallel -f \
 // RUN: -oso-prepend-path=%p/../../Inputs/odr-fwd-declaration2 \
 // RUN: -y %p/../dummy-debug-map.map -o %t1.out
 // RUN: llvm-dwarfdump -v %t1.out -debug-info | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration3.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration3.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o %t1.out
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t1.out
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 
 ## This test checks debug info for the case when one compilation unit

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-member-functions.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-member-functions.cpp
@@ -4,7 +4,7 @@
    odr-member-functions/$FILE.o done
  */
 
-// RUN: dsymutil --linker=llvm -f \
+// RUN: dsymutil --linker=parallel -f \
 // RUN: -oso-prepend-path=%p/../../Inputs/odr-member-functions \
 // RUN: -y %p/../dummy-debug-map.map -o %t1.out
 // RUN: llvm-dwarfdump -debug-info %t1.out | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-namespace-extension.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-namespace-extension.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o %t1.out
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t1.out
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 
 ## This test checks that DW_TAG_namespace with DW_AT_extension

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-nested-types1.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-nested-types1.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o %t1.out
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t1.out
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 
 ## This test checks that nested structure containing field of anonymuos type

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-nested-types2.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-nested-types2.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o %t1.out
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t1.out
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 
 ## This test checks that nested structure containing field of type from other namespace

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-parents.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-parents.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 ## This test checks debug info for the equally named structures from
 ## different namespaces. The result should contain two variables which

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-predictable-output.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-predictable-output.test
@@ -1,11 +1,11 @@
-# RUN: dsymutil --linker=llvm -f -o %t1.o -oso-prepend-path=%p/ -y %s
+# RUN: dsymutil --linker=parallel -f -o %t1.o -oso-prepend-path=%p/ -y %s
 # RUN: llvm-dwarfdump --verify %t1.o | FileCheck -check-prefixes=VERIFY %s
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/ -y %s --num-threads 1 | llvm-dwarfdump -a - -o %t1
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/ -y %s --num-threads 3 | llvm-dwarfdump -a - -o %t2
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/ -y %s --num-threads 1 | llvm-dwarfdump -a - -o %t1
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/ -y %s --num-threads 3 | llvm-dwarfdump -a - -o %t2
 # RUN: diff %t1 %t2
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/ -y %s --num-threads 4 | llvm-dwarfdump -a - -o %t3
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/ -y %s --num-threads 4 | llvm-dwarfdump -a - -o %t3
 # RUN: diff %t1 %t3
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/ -y %s | llvm-dwarfdump -a - -o %t4
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/ -y %s | llvm-dwarfdump -a - -o %t4
 # RUN: diff %t1 %t4
 
 # This test checks that generated output does not differ between runs.

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-predictable-output2.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-predictable-output2.test
@@ -1,9 +1,9 @@
-# RUN: dsymutil --linker=llvm -f -o %t1.o -oso-prepend-path=%p/../ -y %s
+# RUN: dsymutil --linker=parallel -f -o %t1.o -oso-prepend-path=%p/../ -y %s
 # RUN: llvm-dwarfdump --verify %t1.o | FileCheck -check-prefixes=VERIFY %s
-# RUN: dsymutil --linker=llvm -f -o %t2.o -oso-prepend-path=%p/../ -y %s
-# RUN: dsymutil --linker=llvm -f -o %t3.o -oso-prepend-path=%p/../ -y %s \
+# RUN: dsymutil --linker=parallel -f -o %t2.o -oso-prepend-path=%p/../ -y %s
+# RUN: dsymutil --linker=parallel -f -o %t3.o -oso-prepend-path=%p/../ -y %s \
 # RUN:   --num-threads 1
-# RUN: dsymutil --linker=llvm -f -o %t4.o -oso-prepend-path=%p/../ -y %s \
+# RUN: dsymutil --linker=parallel -f -o %t4.o -oso-prepend-path=%p/../ -y %s \
 # RUN:   --num-threads 3
 # ### Following comparision will fail if files do not match
 # RUN: diff %t1.o %t2.o

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-recursive-dependence.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-recursive-dependence.test
@@ -12,7 +12,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker llvm -y %t2.map --num-threads 1 -f -o %t1.out 2>&1 \
+# RUN: dsymutil --linker parallel -y %t2.map --num-threads 1 -f -o %t1.out 2>&1 \
 # RUN:   | FileCheck --check-prefix ERROR %s
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-string.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-string.test
@@ -1,5 +1,5 @@
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/../ -y %s | llvm-dwarfdump --verify - | FileCheck -check-prefixes=VERIFY %s
-# RUN: dsymutil --linker=llvm -f -o - -oso-prepend-path=%p/../ -y %s | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/../ -y %s | llvm-dwarfdump --verify - | FileCheck -check-prefixes=VERIFY %s
+# RUN: dsymutil --linker=parallel -f -o - -oso-prepend-path=%p/../ -y %s | llvm-dwarfdump -a - | FileCheck %s
 
 # This test checks that types from several object files are
 # uniqued(moved into the artificial compile unit for types).

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-template-parameters.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-template-parameters.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 ## This test checks debug info for the template parameters of the class.
 ## (i.e. number of the parameters is correct, names of the parameters

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-two-units-in-single-file.test
@@ -11,7 +11,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker llvm -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-types-in-subprogram1.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-types-in-subprogram1.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=llvm -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 ## This test checks debug info for the types located into the subprograms.
 ## Subprogram "float foo(int)" contains type "clas1". First compile unit

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-uniquing.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-uniquing.cpp
@@ -12,18 +12,18 @@
  */
 
 /* Check by llvm-dwarfdump --verify */
-// RUN: dsymutil --linker=llvm -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
+// RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
 // RUN: -y %p/../dummy-debug-map.map -o - | llvm-dwarfdump --verify - | \
 // RUN: FileCheck -check-prefixes=VERIFY %s
-// RUN: dsymutil --linker=llvm -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
+// RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
 // RUN: -y %p/../dummy-debug-map.map -no-odr -o - | llvm-dwarfdump --verify - | \
 // RUN: FileCheck -check-prefixes=VERIFY %s
 
 /* Check for llvm-dwarfdump -a output */
-// RUN: dsymutil --linker=llvm -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
+// RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
 // RUN: -y %p/../dummy-debug-map.map -o - | llvm-dwarfdump -v -a - | \
 // RUN: FileCheck -check-prefixes=CHECK %s
-// RUN: dsymutil --linker=llvm -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
+// RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../../Inputs/odr-uniquing \
 // RUN: -y %p/../dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -a - | \
 // RUN: FileCheck -check-prefixes=CHECK-NOODR %s
 

--- a/llvm/test/tools/dsymutil/X86/alias.test
+++ b/llvm/test/tools/dsymutil/X86/alias.test
@@ -1,7 +1,7 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/alias \
 # RUN: %p/../Inputs/alias/foobar -o - | llvm-dwarfdump - 2>&1 | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs/alias \
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/alias \
 # RUN: %p/../Inputs/alias/foobar -o - | llvm-dwarfdump - 2>&1 | FileCheck %s
 
 # CHECK-NOT: could not find symbol

--- a/llvm/test/tools/dsymutil/X86/basic-linking-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/basic-linking-bundle.test
@@ -20,13 +20,13 @@ RUN: llvm-dwarfdump -a %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Resources/DW
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist
 
 ### --------------------------------------------
-### Repeat the steps for --linker llvm
+### Repeat the steps for --linker parallel
 
 RUN: rm -rf %t
 RUN: mkdir -p %t/dsymdest
 RUN: cp %p/../Inputs/basic.macho.x86_64 %t/basic.macho.x86_64
 
-RUN: dsymutil --linker llvm -accelerator=Pub -oso-prepend-path=%p/.. %t/basic.macho.x86_64
+RUN: dsymutil --linker parallel -accelerator=Pub -oso-prepend-path=%p/.. %t/basic.macho.x86_64
 
 Check that the object file in the bundle exists and is sane:
 RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 | FileCheck %S/basic-linking-x86.test
@@ -39,7 +39,7 @@ RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dSYM | FileCheck %S/basic-linking-x
 
 RUN: FileCheck %s --input-file %t/basic.macho.x86_64.dSYM/Contents/Info.plist
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/.. %t/basic.macho.x86_64 \
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %t/basic.macho.x86_64 \
 RUN:   -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: llvm-dwarfdump -a %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 | FileCheck %S/basic-linking-x86.test
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist

--- a/llvm/test/tools/dsymutil/X86/basic-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-linking-x86.test
@@ -20,24 +20,24 @@ RUN:   -f -o - -y - | llvm-dwarfdump -a - | FileCheck %s \
 RUN:   --check-prefixes=CHECK,ARCHIVE,PUB
 
 ### ---------------------------------------
-### Repeat the same steps for --linker llvm
+### Repeat the same steps for --linker parallel
 
-RUN: dsymutil --linker llvm -accelerator=Pub -f -oso-prepend-path=%p/.. %t1
+RUN: dsymutil --linker parallel -accelerator=Pub -f -oso-prepend-path=%p/.. %t1
 RUN: llvm-dwarfdump -a %t1.dwarf | FileCheck %s
-RUN: dsymutil --linker llvm  -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel  -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic.macho.x86_64
 RUN: llvm-dwarfdump -a %t2 | FileCheck %s
-RUN: dsymutil --linker llvm  -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel  -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | \
 RUN:   FileCheck %s --check-prefixes=CHECK,BASIC,PUB
-RUN: dsymutil --linker llvm -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-archive.macho.x86_64 | llvm-dwarfdump -a - | \
 RUN:   FileCheck %s --check-prefixes=CHECK,ARCHIVE,PUB
-RUN: dsymutil --linker llvm -accelerator=Pub -dump-debug-map \
+RUN: dsymutil --linker parallel -accelerator=Pub -dump-debug-map \
 RUN:  -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 \
 RUN:  | dsymutil -accelerator=Pub -f -y -o - - | llvm-dwarfdump \
 RUN:  -a - | FileCheck %s --check-prefixes=CHECK,BASIC,PUB
-RUN: dsymutil --linker llvm -accelerator=Pub -dump-debug-map \
+RUN: dsymutil --linker parallel -accelerator=Pub -dump-debug-map \
 RUN:   -oso-prepend-path=%p/.. %p/../Inputs/basic-archive.macho.x86_64 \
 RUN:   | dsymutil -accelerator=Pub -f -o - -y - | llvm-dwarfdump -a - | \
 RUN:   FileCheck %s --check-prefixes=CHECK,ARCHIVE,PUB

--- a/llvm/test/tools/dsymutil/X86/basic-lto-dw4-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-lto-dw4-linking-x86.test
@@ -1,6 +1,6 @@
 RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto-dw4.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
-RUN: dsymutil --linker llvm -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-lto-dw4.macho.x86_64 | llvm-dwarfdump -a - \
 RUN:   | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/basic-lto-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-lto-linking-x86.test
@@ -1,9 +1,9 @@
 RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 RUN: dsymutil -oso-prepend-path=%p/.. -dump-debug-map %p/../Inputs/basic-lto.macho.x86_64 | dsymutil -f -o - -y - | llvm-dwarfdump -a - | FileCheck %s
 
-RUN: dsymutil --linker llvm -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-lto.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/.. -dump-debug-map \
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. -dump-debug-map \
 RUN:   %p/../Inputs/basic-lto.macho.x86_64 | dsymutil -f -o - -y - | \
 RUN:   llvm-dwarfdump -a - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/basic-with-libfat-test.test
+++ b/llvm/test/tools/dsymutil/X86/basic-with-libfat-test.test
@@ -1,6 +1,6 @@
 RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-with-libfat-test.macho.x86_64 | llvm-dwarfdump - | FileCheck %s
 
-RUN: dsymutil --linker llvm -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-with-libfat-test.macho.x86_64 | llvm-dwarfdump - \
 RUN:   | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/call-site-entry-linking.test
+++ b/llvm/test/tools/dsymutil/X86/call-site-entry-linking.test
@@ -1,7 +1,7 @@
 RUN: dsymutil -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 CHECK: DW_AT_call_return_pc  (0x0000000100000fa4)

--- a/llvm/test/tools/dsymutil/X86/call-site-entry-reloc.test
+++ b/llvm/test/tools/dsymutil/X86/call-site-entry-reloc.test
@@ -22,7 +22,7 @@ twice.
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 CHECK: DW_AT_call_return_pc  (0x0000000100000f72)

--- a/llvm/test/tools/dsymutil/X86/common-sym-multi.test
+++ b/llvm/test/tools/dsymutil/X86/common-sym-multi.test
@@ -1,8 +1,8 @@
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP
 
 The test was compiled from two source files:
 $ cd /private/tmp/common

--- a/llvm/test/tools/dsymutil/X86/common-sym.test
+++ b/llvm/test/tools/dsymutil/X86/common-sym.test
@@ -1,6 +1,6 @@
 RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 The test was compiled from a single source:
 $ cat common.c 

--- a/llvm/test/tools/dsymutil/X86/custom-line-table.test
+++ b/llvm/test/tools/dsymutil/X86/custom-line-table.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
 #
-# RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
+# RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
 
 # This test runs dsymutil on an object file with non-standard (as far
 # as llvm is concerned) line table settings.

--- a/llvm/test/tools/dsymutil/X86/darwin-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/darwin-bundle.test
@@ -11,10 +11,10 @@ RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info
 RUN: dsymutil -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -toolchain "toolchain&and'some<symbols" -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist --check-prefix=CHECK --check-prefix=TOOLCHAIN
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -toolchain "toolchain&and'some<symbols" -o %t/dsymdest/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -toolchain "toolchain&and'some<symbols" -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist --check-prefix=CHECK --check-prefix=TOOLCHAIN
 
 

--- a/llvm/test/tools/dsymutil/X86/debug-loc-base-addr.test
+++ b/llvm/test/tools/dsymutil/X86/debug-loc-base-addr.test
@@ -1,6 +1,6 @@
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 
 The test was compiled from a single source:
 $ cat loc1.cpp

--- a/llvm/test/tools/dsymutil/X86/dwarf4-linetable.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf4-linetable.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 
 # Source:
 #   int main() {

--- a/llvm/test/tools/dsymutil/X86/dwarf5-addrx.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-addrx.test
@@ -52,12 +52,12 @@ RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 
 RUN: llvm-dwarfdump --verbose %t.dSYM | FileCheck %s --check-prefix UPDATE-DWARF
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 
 RUN: llvm-dwarfdump --verbose %t.dSYM | FileCheck %s --check-prefix DWARF
 
-RUN: dsymutil --linker llvm --update -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker parallel --update -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 
 RUN: llvm-dwarfdump --verbose %t.dSYM | FileCheck %s --check-prefix UPDATE-DWARF

--- a/llvm/test/tools/dsymutil/X86/dwarf5-call-site-entry-reloc.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-call-site-entry-reloc.test
@@ -22,7 +22,7 @@
 #RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
-#RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 #CHECK: DW_AT_call_return_pc  (0x0000000100000f72)

--- a/llvm/test/tools/dsymutil/X86/dwarf5-dw-op-addrx.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-dw-op-addrx.test
@@ -25,11 +25,11 @@
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-#RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --linker llvm --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-linetable.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-linetable.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
 
 # Source:
 #   int main() {

--- a/llvm/test/tools/dsymutil/X86/dwarf5-loclists.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-loclists.test
@@ -24,11 +24,11 @@
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-#RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --linker llvm --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-rnglists.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-rnglists.test
@@ -37,11 +37,11 @@
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-#RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --linker llvm --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/eh_frame.test
+++ b/llvm/test/tools/dsymutil/X86/eh_frame.test
@@ -18,7 +18,7 @@ RUN: llvm-dwarfdump --verify %t.dSYM
 RUN: llvm-otool -s __TEXT __eh_frame %p/../Inputs/private/tmp/eh_frame/eh_frame.out | FileCheck %s
 RUN: llvm-otool -s __TEXT __eh_frame %t.dSYM/Contents/Resources/DWARF/eh_frame.out | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/eh_frame/eh_frame.out -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/eh_frame/eh_frame.out -o %t.dSYM
 RUN: llvm-dwarfdump --verify %t.dSYM
 RUN: llvm-otool -s __TEXT __eh_frame %p/../Inputs/private/tmp/eh_frame/eh_frame.out | FileCheck %s
 RUN: llvm-otool -s __TEXT __eh_frame %t.dSYM/Contents/Resources/DWARF/eh_frame.out | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/fat-archive-input-i386.test
+++ b/llvm/test/tools/dsymutil/X86/fat-archive-input-i386.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 ---
 triple:          'i386-apple-darwin'

--- a/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 ---
 triple:          'x86_64-apple-darwin'

--- a/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64h.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64h.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 ---
 triple:          'x86_64h-apple-darwin'

--- a/llvm/test/tools/dsymutil/X86/generate-empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/generate-empty-CU.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
+# RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
 
 # This test on links the Dwarf for an LTO binary and on purpose doesn't retain
 # any symbol in the second CU out of 3. To be valid DWARF dsymutil must not

--- a/llvm/test/tools/dsymutil/X86/global_downgraded_to_static.c
+++ b/llvm/test/tools/dsymutil/X86/global_downgraded_to_static.c
@@ -2,7 +2,7 @@
 // RUN: dsymutil -oso-prepend-path %p/.. -dump-debug-map \
 // RUN: %p/../Inputs/global_downgraded_to_static.x86_64 2>&1 | FileCheck %s
 //
-// RUN: dsymutil --linker llvm -oso-prepend-path %p/.. -dump-debug-map \
+// RUN: dsymutil --linker parallel -oso-prepend-path %p/.. -dump-debug-map \
 // RUN: %p/../Inputs/global_downgraded_to_static.x86_64 2>&1 | FileCheck %s
 //
 //  To build:

--- a/llvm/test/tools/dsymutil/X86/inlined-static-variable.cpp
+++ b/llvm/test/tools/dsymutil/X86/inlined-static-variable.cpp
@@ -4,7 +4,7 @@
 // RUN:   "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}" \
 // RUN:   --check-prefixes=CHECK
 //
-// RUN: dsymutil --linker llvm --no-odr -f -y %p/dummy-debug-map.map \
+// RUN: dsymutil --linker parallel --no-odr -f -y %p/dummy-debug-map.map \
 // RUN:   -oso-prepend-path %p/../Inputs/inlined-static-variable -o - \
 // RUN:   -keep-function-for-static | llvm-dwarfdump - | FileCheck %s \
 // RUN:   --implicit-check-not \

--- a/llvm/test/tools/dsymutil/X86/label.test
+++ b/llvm/test/tools/dsymutil/X86/label.test
@@ -1,6 +1,6 @@
 # RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
 
-# RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
+# RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
 
 # Compile with:
 #  echo -e ".global _foo;\nfoo:\nnop" | clang -x assembler -g - -c -o /tmp/label.o

--- a/llvm/test/tools/dsymutil/X86/label2.test
+++ b/llvm/test/tools/dsymutil/X86/label2.test
@@ -14,7 +14,7 @@ $ clang label.o -o label.out
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s
 
 CHECK:      DW_TAG_label

--- a/llvm/test/tools/dsymutil/X86/lc_build_version.test
+++ b/llvm/test/tools/dsymutil/X86/lc_build_version.test
@@ -1,7 +1,7 @@
 # RUN: dsymutil -f %p/../Inputs/lc_build_version.x86_64 -o - \
 # RUN:   -oso-prepend-path=%p/.. | obj2yaml | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f %p/../Inputs/lc_build_version.x86_64 -o - \
+# RUN: dsymutil --linker parallel -f %p/../Inputs/lc_build_version.x86_64 -o - \
 # RUN:   -oso-prepend-path=%p/.. | obj2yaml | FileCheck %s
 
 CHECK: LoadCommands:

--- a/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
+++ b/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
@@ -45,7 +45,7 @@ $ clang++ use.o container.o -o a.out
 
 Note that the link order in the last command matters for this test.
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
 RUN: llvm-dwarfdump --debug-info %t.dSYM | FileCheck %s
 
 CHECK:       DW_TAG_compile_unit

--- a/llvm/test/tools/dsymutil/X86/location-expression.test
+++ b/llvm/test/tools/dsymutil/X86/location-expression.test
@@ -11,7 +11,7 @@
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
-# RUN: dsymutil --linker llvm -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/X86/mismatch.m
+++ b/llvm/test/tools/dsymutil/X86/mismatch.m
@@ -19,7 +19,7 @@
 // RUN: cp %p/../Inputs/mismatch/1.o %t.dir/2.o
 // RUN: dsymutil --verbose -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o %t.bin 2>&1 | FileCheck %s
-// RUN: dsymutil --linker llvm --verbose -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker parallel --verbose -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o %t.bin 2>&1 | FileCheck %s
 
 @import mismatch;

--- a/llvm/test/tools/dsymutil/X86/modules-dwarf-version.m
+++ b/llvm/test/tools/dsymutil/X86/modules-dwarf-version.m
@@ -11,7 +11,7 @@
 // RUN: dsymutil -verify -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s
-// RUN: dsymutil --linker llvm -verify -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/modules-empty.m
+++ b/llvm/test/tools/dsymutil/X86/modules-empty.m
@@ -18,7 +18,7 @@ EOF
 // RUN:   -verify \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s
-// RUN: dsymutil --linker llvm -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker parallel -f -oso-prepend-path=%t.dir \
 // RUN:   -verify \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/multiple-inputs.test
+++ b/llvm/test/tools/dsymutil/X86/multiple-inputs.test
@@ -28,7 +28,7 @@ RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-lto-dw4.macho.x86_
 RUN: not dsymutil -f -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
 
 ## ---------------------------------------
-## Repeat the same steps for --linker llvm
+## Repeat the same steps for --linker parallel
 
 RUN: rm -rf %t
 RUN: mkdir -p %t
@@ -39,7 +39,7 @@ RUN: cat %p/../Inputs/basic-lto.macho.x86_64 > %t/basic-lto.macho.x86_64
 RUN: cat %p/../Inputs/basic-lto-dw4.macho.x86_64 > %t/basic-lto-dw4.macho.x86_64
 
 # Multiple inputs in flat mode
-RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/.. \
 RUN:   %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 \
 RUN:   %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64
 RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dwarf \
@@ -50,7 +50,7 @@ RUN: llvm-dwarfdump -a %t/basic-lto.macho.x86_64.dwarf | FileCheck %S/basic-lto-
 RUN: llvm-dwarfdump -a %t/basic-lto-dw4.macho.x86_64.dwarf | FileCheck %S/basic-lto-dw4-linking-x86.test
 
 # Multiple inputs that end up in the same named bundle
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/.. %t/basic.macho.x86_64 \
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %t/basic.macho.x86_64 \
 RUN:   %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 \
 RUN:   %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 \
@@ -61,7 +61,7 @@ RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-lto.macho.x86_64 |
 RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-lto-dw4.macho.x86_64 | FileCheck %S/basic-lto-dw4-linking-x86.test
 
 # Multiple inputs in a named bundle in flat mode... impossible.
-RUN: not dsymutil --linker llvm -f -oso-prepend-path=%p/.. \
+RUN: not dsymutil --linker parallel -f -oso-prepend-path=%p/.. \
 RUN:   %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 \
 RUN:   %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 \
 RUN:   -o %t.dSYM 2>&1 | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/object-prefix-path.test
+++ b/llvm/test/tools/dsymutil/X86/object-prefix-path.test
@@ -7,7 +7,7 @@ RUN:   %p/dummy-debug-map.map -o %t \
 RUN:   -object-prefix-map=/ModuleCache=/ModuleCacheRenamed \
 RUN:   2>&1 | FileCheck %s
 
-RUN: dsymutil --linker llvm -verify -f -oso-prepend-path=%t.dir -y \
+RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir -y \
 RUN:   %p/dummy-debug-map.map -o %t \
 RUN:   -object-prefix-map=/ModuleCache=/ModuleCacheRenamed \
 RUN:   2>&1 | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/odr-uniquing.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-uniquing.cpp
@@ -14,7 +14,7 @@
 // RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=ODR,CHECK %s
 // RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
 
-// RUN: dsymutil --linker llvm -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
+// RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
 
 // The first compile unit contains all the types:
 // CHECK: TAG_compile_unit

--- a/llvm/test/tools/dsymutil/X86/op-convert-offset.test
+++ b/llvm/test/tools/dsymutil/X86/op-convert-offset.test
@@ -24,7 +24,7 @@ RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/op-convert
 RUN: llvm-dwarfdump %p/../Inputs/private/tmp/op-convert-offset/op-convert-offset.o 2>&1 | FileCheck %s --check-prefix OBJ
 RUN: llvm-dwarfdump %t.dSYM 2>&1 | FileCheck %s --check-prefix DSYM
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs \
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs \
 RUN:  %p/../Inputs/private/tmp/op-convert-offset/op-convert-offset \
 RUN:  -o %t.dSYM 2>&1
 RUN: llvm-dwarfdump \

--- a/llvm/test/tools/dsymutil/X86/op-convert.test
+++ b/llvm/test/tools/dsymutil/X86/op-convert.test
@@ -1,7 +1,7 @@
 # RUN: dsymutil -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s
 # RUN: llvm-dwarfdump %t | FileCheck %s
 
-# RUN: dsymutil --linker llvm -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s
+# RUN: dsymutil --linker parallel -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s
 # RUN: llvm-dwarfdump %t | FileCheck %s
 
 ---

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -9,7 +9,7 @@ RUN: yaml2obj %p/../Inputs/reflection_metadata.yaml -o %t.dir/tmp/reflection_met
 RUN: dsymutil -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
 RUN: llvm-objdump -s %t.dir/main.dSYM/Contents/Resources/DWARF/main | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
 RUN: llvm-objdump -s %t.dir/main.dSYM/Contents/Resources/DWARF/main | FileCheck %s
 
 REQUIRES: host-byteorder-little-endian

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-archive.text
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-archive.text
@@ -7,7 +7,7 @@ RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.archive.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.archive.x86_64 | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64
 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.archive.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.archive.x86_64 | FileCheck %s
@@ -16,7 +16,7 @@ Check that we don't error if we're missing remark files from an archive, but we 
 Instead of creating a new binary, just remove the remarks prepend path.
 RUN: dsymutil -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-MISSING
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-MISSING
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-MISSING
 
 CHECK: <Meta
 CHECK: <Remark Num

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-bundle-empty.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-bundle-empty.test
@@ -7,7 +7,7 @@ RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs 
 Check that the remark file in the bundle does not exist:
 RUN: not cat %t/basic.macho.remarks.empty.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.empty.x86_64 2>&1
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.empty.x86_64
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.empty.x86_64
 
 Check that the remark file in the bundle does not exist:
 RUN: not cat %t/basic.macho.remarks.empty.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.empty.x86_64 2>&1

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-bundle.test
@@ -7,7 +7,7 @@ RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s
@@ -16,7 +16,7 @@ Now emit it in a different format: YAML.
 RUN: dsymutil -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
 RUN: cat %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s --check-prefix=CHECK-YAML
 
-RUN: dsymutil --linker llvm -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
+RUN: dsymutil --linker parallel -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
 RUN: cat %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s --check-prefix=CHECK-YAML
 
 CHECK: <Meta

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
@@ -11,7 +11,7 @@ RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Rema
 RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64 | FileCheck %s
 RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-i386 | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-i386
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/fat.macho.remarks.x86
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/fat.macho.remarks.x86
 
 Check that the remark files in the bundle exist and are all sane:
 RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64h | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -33,16 +33,16 @@ RUN: ls %t.diags | grep 'dsymutil-' | count 1
 RUN: rm -rf %t
 RUN: not dsymutil -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
 
-RUN: not dsymutil --linker llvm -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
+RUN: not dsymutil --linker parallel -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
 
 # Use the reproducer.
 RUN: dsymutil -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
-RUN: dsymutil --linker llvm -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker parallel -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 # Using a reproducer takes precedence.
 RUN: dsymutil -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
-RUN: dsymutil --linker llvm -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker parallel -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 CHECK: .debug_info
 CHECK:  DW_TAG_compile_unit

--- a/llvm/test/tools/dsymutil/X86/statistics.test
+++ b/llvm/test/tools/dsymutil/X86/statistics.test
@@ -1,5 +1,5 @@
 # RUN: dsymutil -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
-# RUN: dsymutil --linker llvm -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
 #
 # CHECK: -------------------------------------------------------------------------------
 # CHECK-NEXT: Filename                                           Object         dSYM   Change

--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -3,8 +3,8 @@ RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/
 RUN: llvm-readobj --sections --section-data %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
 RUN: llvm-dwarfdump --show-section-sizes %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil --linker llvm -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
 RUN: llvm-readobj --sections --section-data %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
 RUN: llvm-dwarfdump --show-section-sizes %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 

--- a/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
+++ b/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
@@ -1,6 +1,6 @@
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
 
 This test checks that dsymutil generates a valid dwarf location for a symbol with no flags set.
 

--- a/llvm/test/tools/dsymutil/X86/tail-call-linking.test
+++ b/llvm/test/tools/dsymutil/X86/tail-call-linking.test
@@ -1,7 +1,7 @@
 RUN: dsymutil -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
 CHECK: DW_AT_call_pc  (0x0000000100000f95)

--- a/llvm/test/tools/dsymutil/X86/thinlto.test
+++ b/llvm/test/tools/dsymutil/X86/thinlto.test
@@ -21,7 +21,7 @@ $ xcrun clang++ -flto=thin foo.o bar.o -Xlinker -object_path_lto -Xlinker lto -s
 
 RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 
-RUN: dsymutil --linker llvm -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 
 CHECK-NOT: could not find symbol '__ZZ9function2vE12magic_static'
 CHECK-NOT: could not find symbol 'symbol __ZGVZ9function2vE12magic_static'

--- a/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
+++ b/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
@@ -5,7 +5,7 @@ RUN: cp %p/../Inputs/basic2.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
 RUN: dsymutil -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
 
-RUN: dsymutil --linker llvm -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
 
 CHECK: warning: {{.*}}/Inputs/basic1.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
 CHECK: warning: {{.*}}/Inputs/basic2.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})

--- a/llvm/test/tools/dsymutil/X86/tls-variable.test
+++ b/llvm/test/tools/dsymutil/X86/tls-variable.test
@@ -10,7 +10,7 @@
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
-# RUN: dsymutil --linker llvm -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/X86/verify.test
+++ b/llvm/test/tools/dsymutil/X86/verify.test
@@ -27,22 +27,22 @@
 # BOGUS: error: invalid verify type specified: 'bogus'
 #
 # Positive tests in regular and verbose mode.
-# RUN: dsymutil --linker llvm -verify -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --allow-empty --check-prefix=QUIET-SUCCESS
-# RUN: dsymutil --linker llvm -verify -verbose -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS,VERBOSE
+# RUN: dsymutil --linker parallel -verify -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --allow-empty --check-prefix=QUIET-SUCCESS
+# RUN: dsymutil --linker parallel -verify -verbose -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS,VERBOSE
 #
 # # Negative output tests in regular and verbose mode.
 # (Invalid object generated from ../Inputs/invalid.s by modified the low PC.)
-# RUN: not dsymutil --linker llvm -verify -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
-# RUN: not dsymutil --linker llvm -verify-dwarf=output -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
-# RUN: not dsymutil --linker llvm -verify -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,VERBOSE
+# RUN: not dsymutil --linker parallel -verify -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
+# RUN: not dsymutil --linker parallel -verify-dwarf=output -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
+# RUN: not dsymutil --linker parallel -verify -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,VERBOSE
 #
 # # Negative input & output tests in regular and verbose mode. Only output failures result in a non-zero exit code.
-# RUN: dsymutil --linker llvm -verify-dwarf=input -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
-# RUN: dsymutil --linker llvm -verify-dwarf=input -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
-# RUN: dsymutil --linker llvm -verify-dwarf=none -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS
-# RUN: not dsymutil --linker llvm -verify-dwarf=bogus -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=BOGUS
-# RUN: not dsymutil --linker llvm -verify-dwarf=all -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,QUIET-INPUT-FAIL
-# RUN: not dsymutil --linker llvm -verify-dwarf=all -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=VERBOSE-INPUT-FAIL
+# RUN: dsymutil --linker parallel -verify-dwarf=input -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
+# RUN: dsymutil --linker parallel -verify-dwarf=input -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
+# RUN: dsymutil --linker parallel -verify-dwarf=none -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS
+# RUN: not dsymutil --linker parallel -verify-dwarf=bogus -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=BOGUS
+# RUN: not dsymutil --linker parallel -verify-dwarf=all -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,QUIET-INPUT-FAIL
+# RUN: not dsymutil --linker parallel -verify-dwarf=all -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=VERBOSE-INPUT-FAIL
 
 
 ---

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/accelerator-dwarf4.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/accelerator-dwarf4.test
@@ -12,12 +12,12 @@
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 #
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection \
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection \
 # RUN:   --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --garbage-collection \
+# RUN: llvm-dwarfutil --linker parallel --garbage-collection \
 # RUN:   --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/accelerator-dwarf5.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/accelerator-dwarf5.test
@@ -10,12 +10,12 @@
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 #
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection \
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection \
 # RUN:   --build-accelerator=DWARF %p/Inputs/dwarf5.out %t1
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --garbage-collection \
+# RUN: llvm-dwarfutil --linker parallel --garbage-collection \
 # RUN:   --build-accelerator=DWARF %p/Inputs/dwarf5.out %t1
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf4-macro-short.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf4-macro-short.test
@@ -7,7 +7,7 @@
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf4-macro.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf4-macro.test
@@ -39,7 +39,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACINFO
 
-#RUN: llvm-dwarfutil --linker llvm --garbage-collection %p/Inputs/dwarf4-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --garbage-collection %p/Inputs/dwarf4-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACINFO
 
@@ -49,7 +49,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACINFO
 
-#RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %p/Inputs/dwarf4-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %p/Inputs/dwarf4-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACINFO
 
@@ -58,7 +58,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefixes=MACINFO
 
-#RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %p/Inputs/dwarf4-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %p/Inputs/dwarf4-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefixes=MACINFO
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-addresses.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-addresses.test
@@ -13,7 +13,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix DWARF-CHECK
 
@@ -21,7 +21,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
@@ -29,7 +29,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-attributes.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-attributes.test
@@ -7,7 +7,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
@@ -15,7 +15,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
@@ -23,7 +23,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-line-str.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-line-str.test
@@ -15,15 +15,15 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s --check-prefix VERIFY-CHECK
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-loclists.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-loclists.test
@@ -16,15 +16,15 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro-opcodeop.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro-opcodeop.test
@@ -6,7 +6,7 @@
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1 2>&1 | FileCheck --check-prefix=ERR %s
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1 2>&1 | FileCheck --check-prefix=ERR %s
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro-short.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro-short.test
@@ -8,7 +8,7 @@
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1 2>&1 | FileCheck --check-prefix=WARN %s
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1 2>&1 | FileCheck --check-prefix=WARN %s
 # RUN: llvm-dwarfdump --verify %t1 | FileCheck --check-prefix=VERIFY %s
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-macro.test
@@ -39,7 +39,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACRO
 
-#RUN: llvm-dwarfutil --linker llvm --garbage-collection %p/Inputs/dwarf5-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --garbage-collection %p/Inputs/dwarf5-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACRO
 
@@ -49,7 +49,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACRO
 
-#RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %p/Inputs/dwarf5-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %p/Inputs/dwarf5-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefix=MACRO
 
@@ -58,7 +58,7 @@
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefixes=MACRO
 
-#RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %p/Inputs/dwarf5-macro.out %t1
+#RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %p/Inputs/dwarf5-macro.out %t1
 #RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 #RUN: llvm-dwarfdump -a  %t1 | FileCheck %s --check-prefixes=MACRO
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-rnglists.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-rnglists.test
@@ -8,7 +8,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix DWARF-CHECK
 
@@ -16,7 +16,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
@@ -24,7 +24,7 @@
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 
-# RUN: llvm-dwarfutil --linker llvm --no-garbage-collection --build-accelerator=DWARF %t.o %t1
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t1
 # RUN: llvm-dwarfdump -verify %t1 | FileCheck %s
 # RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-default.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-default.test
@@ -5,9 +5,9 @@
 
 # RUN: llvm-dwarfutil --no-odr %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
-# RUN: llvm-dwarfutil --no-odr --linker apple %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
+# RUN: llvm-dwarfutil --no-odr --linker classic %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
+# RUN: llvm-dwarfutil --no-odr --linker parallel %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
 # RUN: llvm-dwarfutil --no-odr --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
@@ -15,11 +15,11 @@
 
 # RUN: llvm-dwarfutil --no-odr --garbage-collection --no-garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-NOGC
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm --garbage-collection --no-garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-NOGC
+# RUN: llvm-dwarfutil --no-odr --linker parallel --garbage-collection --no-garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-NOGC
 
 # RUN: llvm-dwarfutil --no-odr %t.o --tombstone=universal - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm %t.o --tombstone=universal - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
+# RUN: llvm-dwarfutil --no-odr --linker parallel %t.o --tombstone=universal - | llvm-dwarfdump -a - | FileCheck %s --check-prefixes=CHECK,CHECK-GC
 
 # CHECK: DW_TAG_compile_unit
 # CHECK: DW_AT_name{{.*}}"CU1"

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-func-overlapping-address-ranges.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-func-overlapping-address-ranges.test
@@ -5,7 +5,7 @@
 # RUN: llvm-dwarfutil --no-odr --garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm --garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --no-odr --linker parallel --garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
 # CHECK: DW_TAG_compile_unit

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-maxpc.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-maxpc.test
@@ -6,8 +6,8 @@
 # RUN: llvm-dwarfutil --no-odr --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
 # RUN: llvm-dwarfutil --no-odr --tombstone=universal --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
-# RUN: llvm-dwarfutil --no-odr --linker llvm --tombstone=universal --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: llvm-dwarfutil --no-odr --linker parallel --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: llvm-dwarfutil --no-odr --linker parallel --tombstone=universal --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: DW_TAG_compile_unit
 # CHECK: DW_AT_name{{.*}}"CU1"

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-no-garbage.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-no-garbage.test
@@ -4,7 +4,7 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: llvm-dwarfutil --no-odr --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: llvm-dwarfutil --no-odr --linker parallel --tombstone=maxpc --garbage-collection %t.o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: DW_TAG_compile_unit
 # CHECK: DW_AT_name{{.*}}"CU1"

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-unit-overlapping-address-ranges.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/gc-unit-overlapping-address-ranges.test
@@ -6,7 +6,7 @@
 # RUN: llvm-dwarfutil --no-odr --garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
-# RUN: llvm-dwarfutil --no-odr --linker llvm --garbage-collection %t.o %t1
+# RUN: llvm-dwarfutil --no-odr --linker parallel --garbage-collection %t.o %t1
 # RUN: llvm-dwarfdump -a %t1 | FileCheck %s
 
 # CHECK: DW_TAG_compile_unit

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/verify.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/verify.test
@@ -7,23 +7,23 @@
 
 ## Verify resulting debug info after --garbage-collection optimisation.
 # RUN: llvm-dwarfutil %t.o %t1 --verify
-# RUN: llvm-dwarfutil --linker llvm %t.o %t1 --verify
+# RUN: llvm-dwarfutil --linker parallel %t.o %t1 --verify
 
 ## Verify separate debug file after --garbage-collection optimisation.
 # RUN: llvm-dwarfutil %t.o --separate-debug-file %t1 --verify
-# RUN: llvm-dwarfutil --linker llvm %t.o --separate-debug-file %t1 --verify
+# RUN: llvm-dwarfutil --linker parallel %t.o --separate-debug-file %t1 --verify
 
 ## Verify not optimised resulting debug info.
 # RUN: not llvm-dwarfutil --no-garbage-collection %t.o %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1
-# RUN: not llvm-dwarfutil --linker llvm --no-garbage-collection %t.o %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1
+# RUN: not llvm-dwarfutil --linker parallel --no-garbage-collection %t.o %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1
 
 ## Verify not optimised resulting separate debug file.
 # RUN: not llvm-dwarfutil --no-garbage-collection %t.o --separate-debug-file %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1.debug
-# RUN: not llvm-dwarfutil --linker llvm --no-garbage-collection %t.o --separate-debug-file %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1.debug
+# RUN: not llvm-dwarfutil --linker parallel --no-garbage-collection %t.o --separate-debug-file %t1 --verify 2>&1 | FileCheck %s -DFILE=%t1.debug
 
 ## Check that verification is disabled when destination is stdout.
 # RUN: llvm-dwarfutil %t.o - --verify 2>&1 | FileCheck %s --check-prefix=CHECK-STDOUT
-# RUN: llvm-dwarfutil --linker llvm %t.o - --verify 2>&1 | FileCheck %s --check-prefix=CHECK-STDOUT
+# RUN: llvm-dwarfutil --linker parallel %t.o - --verify 2>&1 | FileCheck %s --check-prefix=CHECK-STDOUT
 
 # CHECK: error: '[[FILE]]': output verification failed
 # CHECK-STDOUT: warning: verification skipped because writing to stdout

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -593,7 +593,7 @@ void DwarfLinkerForBinary::copySwiftReflectionMetadata(
 }
 
 bool DwarfLinkerForBinary::link(const DebugMap &Map) {
-  if (Options.DWARFLinkerType == DsymutilDWARFLinkerType::LLVM)
+  if (Options.DWARFLinkerType == DsymutilDWARFLinkerType::Parallel)
     return linkImpl<parallel::DWARFLinker>(Map, Options.FileType);
 
   return linkImpl<classic::DWARFLinker>(Map, Options.FileType);

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -32,8 +32,8 @@ enum class DsymutilAccelTableKind : uint8_t {
 };
 
 enum class DsymutilDWARFLinkerType : uint8_t {
-  Apple, /// Apple`s implementation of DWARFLinker.
-  LLVM   /// LLVM implementation of DWARFLinker.
+  Classic, /// Classic implementation of DWARFLinker.
+  Parallel /// Implementation of DWARFLinker heavily using parallel execution.
 };
 
 struct LinkOptions {
@@ -63,7 +63,7 @@ struct LinkOptions {
   bool KeepFunctionForStatic = false;
 
   /// Type of DWARFLinker to use.
-  DsymutilDWARFLinkerType DWARFLinkerType = DsymutilDWARFLinkerType::Apple;
+  DsymutilDWARFLinkerType DWARFLinkerType = DsymutilDWARFLinkerType::Classic;
 
   /// Use a 64-bit header when emitting universal binaries.
   bool Fat64 = false;

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -198,7 +198,7 @@ def remarks_drop_without_debug: Flag<["--", "-"], "remarks-drop-without-debug">,
 
 def linker: Separate<["--", "-"], "linker">,
   MetaVarName<"<DWARF linker type>">,
-  HelpText<"Specify the desired type of DWARF linker. Defaults to 'apple'">,
+  HelpText<"Specify the desired type of DWARF linker. Defaults to 'classic'">,
   Group<grp_general>;
 def: Joined<["--", "-"], "linker=">, Alias<linker>;
 

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -232,18 +232,18 @@ static Expected<DsymutilDWARFLinkerType>
 getDWARFLinkerType(opt::InputArgList &Args) {
   if (opt::Arg *LinkerType = Args.getLastArg(OPT_linker)) {
     StringRef S = LinkerType->getValue();
-    if (S == "apple")
-      return DsymutilDWARFLinkerType::Apple;
-    if (S == "llvm")
-      return DsymutilDWARFLinkerType::LLVM;
+    if (S == "classic")
+      return DsymutilDWARFLinkerType::Classic;
+    if (S == "parallel")
+      return DsymutilDWARFLinkerType::Parallel;
     return make_error<StringError>("invalid DWARF linker type specified: '" +
                                        S +
-                                       "'. Supported values are 'apple', "
-                                       "'llvm'.",
+                                       "'. Supported values are 'classic', "
+                                       "'parallel'.",
                                    inconvertibleErrorCode());
   }
 
-  return DsymutilDWARFLinkerType::Apple;
+  return DsymutilDWARFLinkerType::Classic;
 }
 
 static Expected<ReproducerMode> getReproducerMode(opt::InputArgList &Args) {

--- a/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
+++ b/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
@@ -451,7 +451,7 @@ Error linkDebugInfoImpl(object::ObjectFile &File, const Options &Options,
 
 Error linkDebugInfo(object::ObjectFile &File, const Options &Options,
                     raw_pwrite_stream &OutStream) {
-  if (Options.UseLLVMDWARFLinker)
+  if (Options.UseDWARFLinkerParallel)
     return linkDebugInfoImpl<parallel::DWARFLinker>(File, Options, OutStream);
   else
     return linkDebugInfoImpl<classic::DWARFLinker>(File, Options, OutStream);

--- a/llvm/tools/llvm-dwarfutil/Options.h
+++ b/llvm/tools/llvm-dwarfutil/Options.h
@@ -40,7 +40,7 @@ struct Options {
   bool Verbose = false;
   int NumThreads = 0;
   bool Verify = false;
-  bool UseLLVMDWARFLinker = false;
+  bool UseDWARFLinkerParallel = false;
   DwarfUtilAccelKind AccelTableKind = DwarfUtilAccelKind::None;
 
   std::string getSeparateDebugFileName() const {

--- a/llvm/tools/llvm-dwarfutil/Options.td
+++ b/llvm/tools/llvm-dwarfutil/Options.td
@@ -22,7 +22,7 @@ def h : Flag<["-"], "h">,
 
 def linker: Separate<["--", "-"], "linker">,
   MetaVarName<"<DWARF linker type>">,
-  HelpText<"Specify the desired type of DWARF linker. Defaults to 'apple'">;
+  HelpText<"Specify the desired type of DWARF linker. Defaults to 'classic'">;
 def: Joined<["--", "-"], "linker=">, Alias<linker>;
 
 defm odr_deduplication : BB<"odr-deduplication",

--- a/llvm/tools/llvm-dwarfutil/llvm-dwarfutil.cpp
+++ b/llvm/tools/llvm-dwarfutil/llvm-dwarfutil.cpp
@@ -118,10 +118,10 @@ static Error validateAndSetOptions(opt::InputArgList &Args, Options &Options) {
 
   if (opt::Arg *LinkerKind = Args.getLastArg(OPT_linker)) {
     StringRef S = LinkerKind->getValue();
-    if (S == "apple")
-      Options.UseLLVMDWARFLinker = false;
-    else if (S == "llvm")
-      Options.UseLLVMDWARFLinker = true;
+    if (S == "classic")
+      Options.UseDWARFLinkerParallel = false;
+    else if (S == "parallel")
+      Options.UseDWARFLinkerParallel = true;
     else
       return createStringError(
           std::errc::invalid_argument,


### PR DESCRIPTION
This patch renames values of dsymutil/llvm-dwarfutil options:

--linker apple -> --linker classic
--linker llvm -> --linker parallel

The purpose to rename options is to avoid using vendor names and to match with library names. It should be safe to rename options at current stage as they are not seemed widely used(we may not preserve backward compatibility).