### PR TITLE
[flang] Add install target to install flang headers

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -474,6 +474,9 @@ if (FLANG_LIBS)
 endif()
 
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  add_llvm_install_targets(install-flang-headers
+    COMPONENT flang-headers)
+
   install(DIRECTORY include/flang
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT flang-headers


### PR DESCRIPTION
This makes it more convenient to install flang without using the general `ninja install` to install everything.

To install flang-new and associated things one needs `ninja install-flang-new install-flang-libraries install-flang-headers`. 