### PR TITLE
[flang][driver] Allow explicit specification of -lFortran_main

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1200,6 +1200,14 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
   // TODO: Find an equivalent of `--whole-archive` for Darwin and AIX.
   if (!isWholeArchivePresent(Args) && !TC.getTriple().isMacOSX() &&
       !TC.getTriple().isOSAIX()) {
+    // Adding -lFortran_main with --whole-archive will create an error if the
+    // user specifies -lFortran_main explicitly. Remove the user's
+    // -lFortran_main arguments to avoid this (making sure -lFortran_main
+    // behaves the same as -lFortranRuntime)
+    llvm::erase_if(CmdArgs, [](const char *arg) {
+      return strcmp(arg, "-lFortran_main") == 0;
+    });
+
     CmdArgs.push_back("--whole-archive");
     CmdArgs.push_back("-lFortran_main");
     CmdArgs.push_back("--no-whole-archive");

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1200,16 +1200,17 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
   // TODO: Find an equivalent of `--whole-archive` for Darwin and AIX.
   if (!isWholeArchivePresent(Args) && !TC.getTriple().isMacOSX() &&
       !TC.getTriple().isOSAIX()) {
+    const char *LinkFlag = "-lFortran_main";
     // Adding -lFortran_main with --whole-archive will create an error if the
     // user specifies -lFortran_main explicitly. Remove the user's
     // -lFortran_main arguments to avoid this (making sure -lFortran_main
     // behaves the same as -lFortranRuntime)
-    llvm::erase_if(CmdArgs, [](const char *arg) {
-      return strcmp(arg, "-lFortran_main") == 0;
+    llvm::erase_if(CmdArgs, [LinkFlag](const char *arg) {
+      return strncmp(arg, LinkFlag, strlen(LinkFlag)) == 0;
     });
 
     CmdArgs.push_back("--whole-archive");
-    CmdArgs.push_back("-lFortran_main");
+    CmdArgs.push_back(LinkFlag);
     CmdArgs.push_back("--no-whole-archive");
     return;
   }

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -12,6 +12,9 @@
 ! RUN: %flang -### --target=x86_64-unknown-haiku %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,HAIKU
 ! RUN: %flang -### --target=x86_64-windows-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MINGW
 
+! Verify that linking the runtime explicitly doesn't result in a multiple definitions of main error
+! RUN: %flang -lFortran_main -lFortranRuntime -lFortranDecimal %S/Inputs/hello.f90 -o %s.out
+
 ! NOTE: Clang's driver library, clangDriver, usually adds 'oldnames' on Windows,
 !       but it is not needed when compiling Fortran code and they might bring in
 !       additional dependencies. Make sure its not added.

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -16,6 +16,9 @@
 ! UNSUPPORTED: system-windows
 ! RUN: %flang -lFortran_main -lFortranRuntime -lFortranDecimal %S/Inputs/hello.f90 -o %s.out
 
+! Verify that -fno-fortran-main -lFortran_main does link Fortran_main
+! RUN: %flang -### -fno-fortran-main -lFortran_main --target=aarch64-unknown-linux-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MANUAL_MAIN
+
 ! NOTE: Clang's driver library, clangDriver, usually adds 'oldnames' on Windows,
 !       but it is not needed when compiling Fortran code and they might bring in
 !       additional dependencies. Make sure its not added.
@@ -57,3 +60,5 @@
 ! MSVC-LABEL: link
 ! MSVC-SAME: /subsystem:console
 ! MSVC-SAME: "[[object_file]]"
+
+! MANUAL_MAIN: -lFortran_main

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -13,6 +13,7 @@
 ! RUN: %flang -### --target=x86_64-windows-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MINGW
 
 ! Verify that linking the runtime explicitly doesn't result in a multiple definitions of main error
+! UNSUPPORTED: system-windows
 ! RUN: %flang -lFortran_main -lFortranRuntime -lFortranDecimal %S/Inputs/hello.f90 -o %s.out
 
 ! NOTE: Clang's driver library, clangDriver, usually adds 'oldnames' on Windows,


### PR DESCRIPTION
Currently, `flang-new -lFortran_main` will fail on multiple definitions of `main`.

I can understand there might be differing opinions on whether this is actually a bug.

My thinking is that `-lFortran_main` should behave the same as `-lFortranRuntime`.