### PR TITLE
[NameAnonGlobals] Mark the pass as required

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/NameAnonGlobals.h
+++ b/llvm/include/llvm/Transforms/Utils/NameAnonGlobals.h
@@ -24,6 +24,8 @@ public:
   NameAnonGlobalPass() = default;
 
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+
+  static bool isRequired() { return true; }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
NameAnonGlobals is required when emitting ThinLTO bitcode, otherwise the bitcode writer will crash.