### PR TITLE
[Support] Give llvm_strlcpy restrict semantics

### DIFF
--- a/llvm/lib/Support/regex_impl.h
+++ b/llvm/lib/Support/regex_impl.h
@@ -99,7 +99,8 @@ size_t	llvm_regerror(int, const llvm_regex_t *, char *, size_t);
 int	llvm_regexec(const llvm_regex_t *, const char *, size_t,
                      llvm_regmatch_t [], int);
 void	llvm_regfree(llvm_regex_t *);
-size_t  llvm_strlcpy(char *dst, const char *src, size_t siz);
+size_t llvm_strlcpy(char *__restrict dst, const char *__restrict src,
+                    size_t siz);
 
 #ifdef __cplusplus
 }

--- a/llvm/lib/Support/regstrlcpy.c
+++ b/llvm/lib/Support/regstrlcpy.c
@@ -25,28 +25,27 @@
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-size_t
-llvm_strlcpy(char *dst, const char *src, size_t siz)
-{
-	char *d = dst;
-	const char *s = src;
-	size_t n = siz;
+size_t llvm_strlcpy(char *__restrict dst, const char *__restrict src,
+                    size_t siz) {
+  char *d = dst;
+  const char *s = src;
+  size_t n = siz;
 
-	/* Copy as many bytes as will fit */
-	if (n != 0) {
-		while (--n != 0) {
-			if ((*d++ = *s++) == '\0')
-				break;
-		}
-	}
+  /* Copy as many bytes as will fit */
+  if (n != 0) {
+    while (--n != 0) {
+      if ((*d++ = *s++) == '\0')
+        break;
+    }
+  }
 
-	/* Not enough room in dst, add NUL and traverse rest of src */
-	if (n == 0) {
-		if (siz != 0)
-			*d = '\0';		/* NUL-terminate dst */
-		while (*s++)
-			;
-	}
+  /* Not enough room in dst, add NUL and traverse rest of src */
+  if (n == 0) {
+    if (siz != 0)
+      *d = '\0'; /* NUL-terminate dst */
+    while (*s++)
+      ;
+  }
 
-	return(s - src - 1);	/* count does not include NUL */
+  return (s - src - 1); /* count does not include NUL */
 }


### PR DESCRIPTION
strlcpy has restrict semantics, so llvm_strlcpy should have them too.

Source: https://man.freebsd.org/cgi/man.cgi?strlcpy