### PR TITLE
Reland [mlir][ExecutionEngine] Add support for global constructors and destructors #78070 

### DIFF
--- a/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -219,6 +219,9 @@ ExecutionEngine::ExecutionEngine(bool enableObjectDump,
 }
 
 ExecutionEngine::~ExecutionEngine() {
+  // Execute the global destructors from the module being processed.
+  if (jit)
+    llvm::consumeError(jit->deinitialize(jit->getMainJITDylib()));
   // Run all dynamic library destroy callbacks to prepare for the shutdown.
   for (LibraryDestroyFn destroy : destroyFns)
     destroy();
@@ -395,6 +398,9 @@ ExecutionEngine::create(Operation *m, const ExecutionEngineOptions &options,
     return symbolMap;
   };
   engine->registerSymbols(runtimeSymbolMap);
+
+  // Execute the global constructors from the module being processed.
+  cantFail(engine->jit->initialize(engine->jit->getMainJITDylib()));
 
   return std::move(engine);
 }

--- a/mlir/test/mlir-cpu-runner/global-constructors.mlir
+++ b/mlir/test/mlir-cpu-runner/global-constructors.mlir
@@ -1,0 +1,32 @@
+// RUN: mlir-cpu-runner %s -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%mlir_c_runner_utils | \
+// RUN: FileCheck %s
+
+// Test that the `ctor` executes before `entry` and that `dtor` executes last.
+module {
+  llvm.func @printNewline()
+  llvm.func @printI64(i64)
+  llvm.mlir.global_ctors {ctors = [@ctor], priorities = [0 : i32]}
+  llvm.mlir.global_dtors {dtors = [@dtor], priorities = [0 : i32]}
+  llvm.func @ctor() {
+    %0 = llvm.mlir.constant(1 : i64) : i64
+    llvm.call @printI64(%0) : (i64) -> ()
+    llvm.call @printNewline() : () -> ()
+    // CHECK: 1
+    llvm.return
+  }
+  llvm.func @entry() {
+    %0 = llvm.mlir.constant(2 : i64) : i64
+    llvm.call @printI64(%0) : (i64) -> ()
+    llvm.call @printNewline() : () -> ()
+    // CHECK: 2
+    llvm.return
+  }
+  llvm.func @dtor() {
+    %0 = llvm.mlir.constant(3 : i64) : i64
+    llvm.call @printI64(%0) : (i64) -> ()
+    llvm.call @printNewline() : () -> ()
+    // CHECK: 3
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-cpu-runner/global-constructors.mlir
+++ b/mlir/test/mlir-cpu-runner/global-constructors.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: target=aarch64{{.*}}
 // RUN: mlir-cpu-runner %s -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%mlir_c_runner_utils | \
 // RUN: FileCheck %s


### PR DESCRIPTION
This patch add support for executing global constructors and destructors in the ExecutionEngine.