### PR TITLE
[clang-format] adds a space after not inside macros

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4842,7 +4842,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
     return true;
   }
   if (Left.is(TT_UnaryOperator)) {
-    if (!Right.isOneOf(tok::r_paren, tok::l_paren, tok::exclaim)) {
+    if (Right.isOneOf(tok::identifier, tok::numeric_constant)) {
       // The alternative operators for ~ and ! are "compl" and "not".
       // If they are used instead, we do not want to combine them with
       // the token to the right, unless that is a left paren.
@@ -4850,11 +4850,11 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
         return true;
       if (Left.is(tok::tilde) && Left.TokenText == "compl")
         return true;
-      // Lambda captures allow for a lone &, so "&]" needs to be properly
-      // handled.
-      if (Left.is(tok::amp) && Right.is(tok::r_square))
-        return Style.SpacesInSquareBrackets;
     }
+    // Lambda captures allow for a lone &, so "&]" needs to be properly
+    // handled.
+    if (Left.is(tok::amp) && Right.is(tok::r_square))
+      return Style.SpacesInSquareBrackets;
     return (Style.SpaceAfterLogicalNot && Left.is(tok::exclaim)) ||
            Right.is(TT_BinaryOperator);
   }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4842,7 +4842,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
     return true;
   }
   if (Left.is(TT_UnaryOperator)) {
-    if (Right.isNot(tok::l_paren)) {
+    if (!Right.isOneOf(tok::r_paren, tok::l_paren, tok::exclaim)) {
       // The alternative operators for ~ and ! are "compl" and "not".
       // If they are used instead, we do not want to combine them with
       // the token to the right, unless that is a left paren.

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24159,8 +24159,14 @@ TEST_F(FormatTest, AlternativeOperators) {
 
   verifyFormat("int a compl(5);");
   verifyFormat("int a not(5);");
+
   verifyFormat("v(not)");
   verifyFormat("v(not!)");
+  verifyFormat("Symbol(not, None)");
+  verifyFormat("Symbol(not!, None)");
+
+  verifyFormat("assert(!\"fail\")");
+  verifyFormat("assert(not\"fail\")");
 
   /* FIXME handle alternate tokens
    * https://en.cppreference.com/w/cpp/language/operator_alternative

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24159,6 +24159,8 @@ TEST_F(FormatTest, AlternativeOperators) {
 
   verifyFormat("int a compl(5);");
   verifyFormat("int a not(5);");
+  verifyFormat("v(not)");
+  verifyFormat("v(not!)");
 
   /* FIXME handle alternate tokens
    * https://en.cppreference.com/w/cpp/language/operator_alternative


### PR DESCRIPTION
No need to add an extract space if merging the characters doesn't cause a problem, hence ) and ! as well as ( do not require the extraneous space.

Fixes #78166 