### PR TITLE
[flang] allow _POSIX_SOURCE to be defined without a value

### DIFF
--- a/flang/runtime/extensions.cpp
+++ b/flang/runtime/extensions.cpp
@@ -24,7 +24,7 @@ inline void CtimeBuffer(char *buffer, size_t bufsize, const time_t cur_time,
   RUNTIME_CHECK(terminator, error == 0);
 }
 #elif _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || \
-    _POSIX_SOURCE
+    defined(_POSIX_SOURCE)
 inline void CtimeBuffer(char *buffer, size_t bufsize, const time_t cur_time,
     Fortran::runtime::Terminator terminator) {
   const char *res{ctime_r(&cur_time, buffer)};

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -233,7 +233,7 @@ protected:
 };
 
 #if _WIN32 || _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || \
-    _SVID_SOURCE || _POSIX_SOURCE
+    _SVID_SOURCE || defined(_POSIX_SOURCE)
 TEST_F(NoArgv, FdateGetDate) {
   char input[]{"24LengthCharIsJustRight"};
   const std::size_t charLen = sizeof(input);


### PR DESCRIPTION
The `_POSIX_SOURCE` macro is defined without a value on AIX.