### PR TITLE
[AMDGPU] Do not run GCNNSAReassign pass for GFX12

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
@@ -237,7 +237,7 @@ GCNNSAReassign::CheckNSA(const MachineInstr &MI, bool Fast) const {
 
 bool GCNNSAReassign::runOnMachineFunction(MachineFunction &MF) {
   ST = &MF.getSubtarget<GCNSubtarget>();
-  if (!ST->hasNSAEncoding() || ST->getGeneration() > GCNSubtarget::GFX11)
+  if (!ST->hasNSAEncoding() || !ST->hasNonNSAEncoding())
     return false;
 
   MRI = &MF.getRegInfo();

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
@@ -237,7 +237,7 @@ GCNNSAReassign::CheckNSA(const MachineInstr &MI, bool Fast) const {
 
 bool GCNNSAReassign::runOnMachineFunction(MachineFunction &MF) {
   ST = &MF.getSubtarget<GCNSubtarget>();
-  if (!ST->hasNSAEncoding())
+  if (!ST->hasNSAEncoding() || ST->getGeneration() > GCNSubtarget::GFX11)
     return false;
 
   MRI = &MF.getRegInfo();

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -992,6 +992,10 @@ public:
 
   bool hasNSAEncoding() const { return HasNSAEncoding; }
 
+  bool hasNonNSAEncoding() const {
+    return getGeneration() < GFX12;
+  }
+
   bool hasPartialNSAEncoding() const { return HasPartialNSAEncoding; }
 
   unsigned getNSAMaxSize(bool HasSampler = false) const {

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -992,9 +992,7 @@ public:
 
   bool hasNSAEncoding() const { return HasNSAEncoding; }
 
-  bool hasNonNSAEncoding() const {
-    return getGeneration() < GFX12;
-  }
+  bool hasNonNSAEncoding() const { return getGeneration() < GFX12; }
 
   bool hasPartialNSAEncoding() const { return HasPartialNSAEncoding; }
 


### PR DESCRIPTION
GFX12 does not have separate NSA and non-NSA encodings.
