### PR TITLE
[ScalarEvolutionExpander] Don't drop nowrap flags on addrec expansion

### DIFF
--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -1250,11 +1250,11 @@ Value *SCEVExpander::visitAddRecExpr(const SCEVAddRecExpr *S) {
 
   // If this is a simple linear addrec, emit it now as a special case.
   if (S->isAffine())    // {0,+,F} --> i*F
-    return
-      expand(SE.getTruncateOrNoop(
-        SE.getMulExpr(SE.getUnknown(CanonicalIV),
-                      SE.getNoopOrAnyExtend(S->getOperand(1),
-                                            CanonicalIV->getType())),
+    return expand(SE.getTruncateOrNoop(
+        SE.getMulExpr(
+            SE.getUnknown(CanonicalIV),
+            SE.getNoopOrAnyExtend(S->getOperand(1), CanonicalIV->getType()),
+            S->getNoWrapFlags(SCEV::FlagNW)),
         Ty));
 
   // If this is a chain of recurrences, turn it into a closed form, using the


### PR DESCRIPTION
When performing expand on a SCEVAddRecNode with nowrap applied (e.g. if deduced from an iv with an increment with nowrap), the generated multiply will not have the nowrap. This PR preserves the nowrap behavior on the generated code.