### PR TITLE
[BasicAA] Handle disjoint or as add in DecomposeGEP.

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -393,10 +393,8 @@ static LinearExpression GetLinearExpression(
         // further.
         return Val;
       case Instruction::Or:
-        // X|C == X+C if all the bits in C are unset in X.  Otherwise we can't
-        // analyze it.
-        if (!MaskedValueIsZero(BOp->getOperand(0), RHSC->getValue(),
-                               SimplifyQuery(DL, DT, AC, BOp)))
+        // X|C == X+C if it is disjoint.  Otherwise we can't analyze it.
+        if (!cast<PossiblyDisjointInst>(BOp)->isDisjoint())
           return Val;
 
         [[fallthrough]];

--- a/llvm/test/Analysis/BasicAA/gep-alias.ll
+++ b/llvm/test/Analysis/BasicAA/gep-alias.ll
@@ -114,7 +114,7 @@ define i32 @test5_as1_same_size(ptr addrspace(1) %p, i16 %i) {
 define i32 @test6(ptr %p, i64 %i1) {
   %i = shl i64 %i1, 2
   %pi = getelementptr i32, ptr %p, i64 %i
-  %i.next = or i64 %i, 1
+  %i.next = or disjoint i64 %i, 1
   %pi.next = getelementptr i32, ptr %p, i64 %i.next
   %x = load i32, ptr %pi
   store i32 42, ptr %pi.next
@@ -122,6 +122,21 @@ define i32 @test6(ptr %p, i64 %i1) {
   %z = sub i32 %x, %y
   ret i32 %z
 ; CHECK-LABEL: @test6(
+; CHECK: ret i32 0
+}
+
+; P[i] != p[(i*4)|2048] with disjoint or
+define i32 @test6_higheror(ptr %p, i64 %i1) {
+  %i = shl nuw nsw i64 %i1, 2
+  %pi = getelementptr i32, ptr %p, i64 %i
+  %i.next = or disjoint i64 %i, 2048
+  %pi.next = getelementptr i32, ptr %p, i64 %i.next
+  %x = load i32, ptr %pi
+  store i32 42, ptr %pi.next
+  %y = load i32, ptr %pi
+  %z = sub i32 %x, %y
+  ret i32 %z
+; CHECK-LABEL: @test6_higheror(
 ; CHECK: ret i32 0
 }
 


### PR DESCRIPTION
This removes the MaskedValueIsZero check in decomposing geps in BasicAA, using the isDisjoint flags instead. This relies on the disjoint flags being present. The other alternative is to keep the old MaskedValueIsZero check too.