### PR TITLE
[mlir][OpenMP] Remove unnecessary hard dialect dependencies

### DIFF
--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -44,6 +45,9 @@ namespace fir::support {
 inline void registerNonCodegenDialects(mlir::DialectRegistry &registry) {
   registry.insert<FLANG_NONCODEGEN_DIALECT_LIST>();
   mlir::func::registerInlinerExtension(registry);
+  mlir::omp::registerBuiltinExternalModels(registry);
+  mlir::omp::registerFuncExternalModels(registry);
+  mlir::omp::registerLLVMExternalModels(registry);
 }
 
 /// Register all the dialects used by flang.

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -43,4 +43,7 @@ add_flang_library(FIRTransforms
   MLIROpenACCDialect
   MLIROpenACCToLLVMIRTranslation
   MLIROpenMPDialect
+  MLIROpenMPBuiltinExternalModels
+  MLIROpenMPFuncExternalModels
+  MLIROpenMPLLVMExternalModels
 )

--- a/mlir/include/mlir/Dialect/OpenMP/ExternalModels.h
+++ b/mlir/include/mlir/Dialect/OpenMP/ExternalModels.h
@@ -1,0 +1,37 @@
+//===- ExternalModels.h - External models owned by the OMP dialect --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the OpenMP external models for other dialects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_OPENMP_EXTERNALMODELS_H
+#define MLIR_DIALECT_OPENMP_EXTERNALMODELS_H
+
+namespace mlir {
+class DialectRegistry;
+namespace omp {
+/// Register OMP external models for the Builtin dialect.
+void registerBuiltinExternalModels(DialectRegistry &registry);
+/// Register OMP external models for the Func dialect.
+void registerFuncExternalModels(DialectRegistry &registry);
+/// Register OMP external models for the GPU dialect.
+void registerGPUExternalModels(DialectRegistry &registry);
+/// Register OMP external models for the LLVM dialect.
+void registerLLVMExternalModels(DialectRegistry &registry);
+/// Register all OMP external models.
+inline void registerAllExternalModels(DialectRegistry &registry) {
+  registerBuiltinExternalModels(registry);
+  registerFuncExternalModels(registry);
+  registerGPUExternalModels(registry);
+  registerLLVMExternalModels(registry);
+}
+} // namespace omp
+} // namespace mlir
+
+#endif // MLIR_DIALECT_OPENMP_EXTERNALMODELS_H

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
@@ -13,7 +13,6 @@
 #ifndef MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_
 #define MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPInterfaces.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPInterfaces.h
@@ -27,9 +27,10 @@ namespace mlir::omp {
 // You can override defaults here or implement more complex implementations of
 // functions. Or define a completely seperate external model implementation,
 // to override the existing implementation.
+template <typename T>
 struct OffloadModuleDefaultModel
-    : public OffloadModuleInterface::ExternalModel<OffloadModuleDefaultModel,
-                                                   mlir::ModuleOp> {};
+    : public OffloadModuleInterface::ExternalModel<OffloadModuleDefaultModel<T>,
+                                                   T> {};
 
 template <typename T>
 struct DeclareTargetDefaultModel

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -19,7 +19,6 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
-include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.td"
 include "mlir/Dialect/OpenMP/OpenMPOpsInterfaces.td"
 include "mlir/Dialect/OpenMP/OpenMPTypeInterfaces.td"
@@ -27,7 +26,6 @@ include "mlir/Dialect/OpenMP/OpenMPTypeInterfaces.td"
 def OpenMP_Dialect : Dialect {
   let name = "omp";
   let cppNamespace = "::mlir::omp";
-  let dependentDialects = ["::mlir::LLVM::LLVMDialect, ::mlir::func::FuncDialect"];
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 }

--- a/mlir/include/mlir/InitAllDialects.h
+++ b/mlir/include/mlir/InitAllDialects.h
@@ -57,6 +57,7 @@
 #include "mlir/Dialect/Mesh/IR/MeshOps.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
@@ -160,6 +161,7 @@ inline void registerAllDialects(DialectRegistry &registry) {
   memref::registerRuntimeVerifiableOpInterfaceExternalModels(registry);
   memref::registerValueBoundsOpInterfaceExternalModels(registry);
   memref::registerMemorySlotExternalModels(registry);
+  omp::registerAllExternalModels(registry);
   scf::registerBufferDeallocationOpInterfaceExternalModels(registry);
   scf::registerBufferizableOpInterfaceExternalModels(registry);
   scf::registerValueBoundsOpInterfaceExternalModels(registry);

--- a/mlir/include/mlir/Target/LLVMIR/Dialect/All.h
+++ b/mlir/include/mlir/Target/LLVMIR/Dialect/All.h
@@ -14,6 +14,7 @@
 #ifndef MLIR_TARGET_LLVMIR_DIALECT_ALL_H
 #define MLIR_TARGET_LLVMIR_DIALECT_ALL_H
 
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
 #include "mlir/Target/LLVMIR/Dialect/AMX/AMXToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/ArmNeon/ArmNeonToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/ArmSME/ArmSMEToLLVMIRTranslation.h"
@@ -52,6 +53,8 @@ static inline void registerAllToLLVMIRTranslations(DialectRegistry &registry) {
 
   // Extension required for translating GPU offloading Ops.
   gpu::registerOffloadingLLVMTranslationInterfaceExternalModels(registry);
+  // Extensions required for translating the OpenMP dialect.
+  omp::registerAllExternalModels(registry);
 }
 
 /// Registers all the translations to LLVM IR required by GPU passes.

--- a/mlir/lib/Dialect/OpenMP/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/CMakeLists.txt
@@ -11,7 +11,65 @@ add_mlir_dialect_library(MLIROpenMPDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRLLVMDialect
-  MLIRFuncDialect
+  MLIRControlFlowInterfaces
   MLIROpenACCMPCommon
   )
+
+add_mlir_dialect_library(MLIROpenMPBuiltinExternalModels
+  ExternalModels/BuiltinExternalModels.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenMP
+
+  DEPENDS
+  MLIROpenMPOpsInterfacesIncGen
+  MLIROpenMPTypeInterfacesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIROpenMPDialect
+)
+
+add_mlir_dialect_library(MLIROpenMPFuncExternalModels
+  ExternalModels/FuncExternalModels.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenMP
+
+  DEPENDS
+  MLIROpenMPOpsInterfacesIncGen
+  MLIROpenMPTypeInterfacesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIROpenMPDialect
+  MLIRFuncDialect
+)
+
+add_mlir_dialect_library(MLIROpenMPGPUExternalModels
+  ExternalModels/GPUExternalModels.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenMP
+
+  DEPENDS
+  MLIROpenMPOpsInterfacesIncGen
+  MLIROpenMPTypeInterfacesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIROpenMPDialect
+  MLIRGPUDialect
+)
+
+add_mlir_dialect_library(MLIROpenMPLLVMExternalModels
+  ExternalModels/LLVMExternalModels.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenMP
+
+  DEPENDS
+  MLIROpenMPOpsInterfacesIncGen
+  MLIROpenMPTypeInterfacesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIROpenMPDialect
+  MLIRLLVMDialect
+)

--- a/mlir/lib/Dialect/OpenMP/ExternalModels/BuiltinExternalModels.cpp
+++ b/mlir/lib/Dialect/OpenMP/ExternalModels/BuiltinExternalModels.cpp
@@ -1,0 +1,35 @@
+//===- BuiltinExternalModels.cpp - Impl of Builtin external models --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the OpenMP external models for the Builtin dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/BuiltinDialect.h"
+
+using namespace mlir;
+
+namespace {
+struct MemRefPointerLikeModel
+    : public omp::PointerLikeType::ExternalModel<MemRefPointerLikeModel,
+                                                 MemRefType> {
+  Type getElementType(Type pointer) const {
+    return llvm::cast<MemRefType>(pointer).getElementType();
+  }
+};
+} // namespace
+
+void omp::registerBuiltinExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, BuiltinDialect *dialect) {
+    MemRefType::attachInterface<MemRefPointerLikeModel>(*ctx);
+    mlir::ModuleOp::attachInterface<
+        mlir::omp::OffloadModuleDefaultModel<mlir::ModuleOp>>(*ctx);
+  });
+}

--- a/mlir/lib/Dialect/OpenMP/ExternalModels/FuncExternalModels.cpp
+++ b/mlir/lib/Dialect/OpenMP/ExternalModels/FuncExternalModels.cpp
@@ -1,0 +1,31 @@
+//===- FuncExternalModels.cpp - Implementation of Func external models ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the OpenMP external models for the Func dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+using namespace mlir;
+
+void omp::registerFuncExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, func::FuncDialect *dialect) {
+    // Attach default declare target interfaces to operations which can be
+    // marked as declare target (Global Operations and Functions/Subroutines in
+    // dialects that Fortran (or other languages that lower to MLIR) translates
+    // too
+    mlir::func::FuncOp::attachInterface<
+        mlir::omp::DeclareTargetDefaultModel<mlir::func::FuncOp>>(*ctx);
+    // Attach default early outlining interface to func ops.
+    mlir::func::FuncOp::attachInterface<
+        mlir::omp::EarlyOutliningDefaultModel<mlir::func::FuncOp>>(*ctx);
+  });
+}

--- a/mlir/lib/Dialect/OpenMP/ExternalModels/GPUExternalModels.cpp
+++ b/mlir/lib/Dialect/OpenMP/ExternalModels/GPUExternalModels.cpp
@@ -1,0 +1,24 @@
+//===- GPUExternalModels.cpp - Implementation of GPU external models ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the OpenMP external models for the GPU dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+using namespace mlir;
+
+void omp::registerGPUExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, gpu::GPUDialect *dialect) {
+    gpu::GPUModuleOp::attachInterface<
+        omp::OffloadModuleDefaultModel<gpu::GPUModuleOp>>(*ctx);
+  });
+}

--- a/mlir/lib/Dialect/OpenMP/ExternalModels/LLVMExternalModels.cpp
+++ b/mlir/lib/Dialect/OpenMP/ExternalModels/LLVMExternalModels.cpp
@@ -1,0 +1,42 @@
+//===- LLVMExternalModels.cpp - Implementation of LLVM external models ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the OpenMP external models for the LLVM dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/OpenMP/ExternalModels.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+using namespace mlir;
+
+namespace {
+struct LLVMPointerPointerLikeModel
+    : public omp::PointerLikeType::ExternalModel<LLVMPointerPointerLikeModel,
+                                                 LLVM::LLVMPointerType> {
+  Type getElementType(Type pointer) const { return Type(); }
+};
+} // namespace
+
+void omp::registerLLVMExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, LLVM::LLVMDialect *dialect) {
+    LLVM::LLVMPointerType::attachInterface<LLVMPointerPointerLikeModel>(*ctx);
+    // Attach default declare target interfaces to operations which can be
+    // marked as declare target (Global Operations and Functions/Subroutines in
+    // dialects that Fortran (or other languages that lower to MLIR) translates
+    // too
+    mlir::LLVM::GlobalOp::attachInterface<
+        mlir::omp::DeclareTargetDefaultModel<mlir::LLVM::GlobalOp>>(*ctx);
+    mlir::LLVM::LLVMFuncOp::attachInterface<
+        mlir::omp::DeclareTargetDefaultModel<mlir::LLVM::LLVMFuncOp>>(*ctx);
+    // Attach default early outlining interface to func ops.
+    mlir::LLVM::LLVMFuncOp::attachInterface<
+        mlir::omp::EarlyOutliningDefaultModel<mlir::LLVM::LLVMFuncOp>>(*ctx);
+  });
+}

--- a/mlir/lib/Target/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/CMakeLists.txt
@@ -57,6 +57,10 @@ add_mlir_translation_library(MLIRToLLVMIRTranslationRegistration
   MLIRNVVMToLLVMIRTranslation
   MLIROpenACCToLLVMIRTranslation
   MLIROpenMPToLLVMIRTranslation
+  MLIROpenMPBuiltinExternalModels
+  MLIROpenMPFuncExternalModels
+  MLIROpenMPGPUExternalModels
+  MLIROpenMPLLVMExternalModels
   MLIRROCDLToLLVMIRTranslation
   MLIRSPIRVToLLVMIRTranslation
   )


### PR DESCRIPTION
This patch removes dialect dependencies from the OpenMP dialect; all external models were moved to independent libraries to accomplish this change. Consequently, OpenMP dialect users can pull only the desired external models; for example, a user might choose not to include OpenMP Func external models. However, all external models still reside inside the OpenMP dialect, as it's the owner of those interfaces.

Additionally, an external model was included for the GPUModule operation.