### PR TITLE
[libc] Fix libc-hdrgen crosscompiling

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -34,6 +34,10 @@ if(LLVM_LIBC_FULL_BUILD OR LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES)
     # We need to set up hdrgen first since other targets depend on it.
     add_subdirectory(utils/LibcTableGenUtil)
     add_subdirectory(utils/HdrGen)
+    # Calling add_tablegen sets variables like LIBC_TABLEGEN_EXE in
+    # PARENT_SCOPE which get lost until saved in the cache.
+    set(LIBC_TABLEGEN_EXE "${LIBC_TABLEGEN_EXE}" CACHE INTERNAL "")
+    set(LIBC_TABLEGEN_TARGET "${LIBC_TABLEGEN_TARGET}" CACHE INTERNAL "")
   else()
     message(STATUS "Will use ${LIBC_HDRGEN_EXE} for libc header generation.")
   endif()

--- a/libc/utils/HdrGen/CMakeLists.txt
+++ b/libc/utils/HdrGen/CMakeLists.txt
@@ -18,5 +18,3 @@ target_include_directories(libc-hdrgen PRIVATE ${LLVM_INCLUDE_DIR} ${LLVM_MAIN_I
 target_link_libraries(libc-hdrgen PRIVATE LibcTableGenUtil)
 
 add_subdirectory(PrototypeTestGen)
-
-setup_host_tool(libc-hdrgen LIBC_HDRGEN libc_hdrgen_exe libc_hdrgen_target)

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -67,10 +67,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "-DLLVM_EXTERNAL_${name}_SOURCE_DIR=${LLVM_EXTERNAL_${name}_SOURCE_DIR}")
   endforeach()
 
-  if("libc" IN_LIST LLVM_ENABLE_PROJECTS)
-    if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_HDRGEN_EXE)
-      set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON -DLIBC_HDRGEN_ONLY=ON)
-    endif()
+  if("libc" IN_LIST LLVM_ENABLE_PROJECTS AND NOT LIBC_HDRGEN_EXE)
+    set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON -DLIBC_HDRGEN_ONLY=ON)
   endif()
 
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -425,14 +425,22 @@ if(runtimes)
   endif()
   if("libc" IN_LIST LLVM_ENABLE_PROJECTS AND
       (LLVM_LIBC_FULL_BUILD OR LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES))
-    get_host_tool_path(libc-hdrgen LIBC_HDRGEN libc_hdrgen_exe libc_hdrgen_target)
-    if(NOT libc_hdrgen_exe)
+    if(LIBC_HDRGEN_EXE)
+      set(hdrgen_exe ${LIBC_HDRGEN_EXE})
+    else()
+      if(TARGET ${LIBC_TABLEGEN_EXE})
+        set(hdrgen_exe $<TARGET_FILE:${LIBC_TABLEGEN_EXE}>)
+      else()
+        set(hdrgen_exe ${LIBC_TABLEGEN_EXE})
+      endif()
+      set(hdrgen_deps ${LIBC_TABLEGEN_TARGET})
+    endif()
+    if(NOT hdrgen_exe)
       message(FATAL_ERROR "libc-hdrgen executable missing")
     endif()
-    set(libc_cmake_args "-DLIBC_HDRGEN_EXE=${libc_hdrgen_exe}"
+    set(libc_cmake_args "-DLIBC_HDRGEN_EXE=${hdrgen_exe}"
                         "-DLLVM_LIBC_FULL_BUILD=ON")
-    set(libc_tools libc_hdrgen_target)
-    list(APPEND extra_deps ${libc_hdrgen_target})
+    list(APPEND extra_deps ${hdrgen_deps})
     if(LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES)
       foreach(dep clang-offload-packager nvptx-arch amdgpu-arch)
         if(TARGET ${dep})
@@ -485,7 +493,7 @@ if(runtimes)
       check_apple_target(${name} runtime)
 
       runtime_register_target(${name}
-        DEPENDS ${builtins_dep_name} ${libc_tools}
+        DEPENDS ${builtins_dep_name} ${hdrgen_deps}
         CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${libc_cmake_args}
         EXTRA_ARGS TARGET_TRIPLE ${name})
     endforeach()


### PR DESCRIPTION
The support introduced in 675702f356b0c3a540fa2e8af4192f7d658b2988 is not working correctly in all scenarios. Instead of setup_host_tool function, we can use the existing targets introduced by add_tablegen macro.