### PR TITLE
[libunwind][WebAssembly] Fix libunwind.cpp guard

### DIFF
--- a/libunwind/src/libunwind.cpp
+++ b/libunwind/src/libunwind.cpp
@@ -26,7 +26,7 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
-#if !defined(__USING_SJLJ_EXCEPTIONS__) || !defined(__USING_WASM_EXCEPTIONS__)
+#if !defined(__USING_SJLJ_EXCEPTIONS__) && !defined(__USING_WASM_EXCEPTIONS__)
 #include "AddressSpace.hpp"
 #include "UnwindCursor.hpp"
 
@@ -347,7 +347,7 @@ void __unw_remove_dynamic_eh_frame_section(unw_word_t eh_frame_start) {
 }
 
 #endif // defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
-#endif // !defined(__USING_SJLJ_EXCEPTIONS__) ||
+#endif // !defined(__USING_SJLJ_EXCEPTIONS__) &&
        // !defined(__USING_WASM_EXCEPTIONS__)
 
 #ifdef __APPLE__


### PR DESCRIPTION
This should have been `&&`, meaning neither SjLj nor Wasm uses this file.