### PR TITLE
[NFC][clang-tidy]improve performance for misc-unused-using-decls check

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.h
@@ -49,6 +49,7 @@ private:
   };
 
   std::vector<UsingDeclContext> Contexts;
+  llvm::SmallPtrSet<const Decl *, 32> UsingTargetDeclsCache;
 
   StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;


### PR DESCRIPTION
`UnusedUsingDeclsCheck::removeFromFoundDecls` will be called with high frequency. At current time it will check every `Context`.
This patch adds a cache to reduce algorithm complexity.