### PR TITLE
[mlir][complex] Convert complex.tan to libm ctan call

### DIFF
--- a/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
+++ b/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
@@ -117,6 +117,8 @@ void mlir::populateComplexToLibmConversionPatterns(RewritePatternSet &patterns,
       patterns.getContext(), "cabsf", "cabs", benefit);
   patterns.add<ScalarOpToLibmCall<complex::AngleOp, FloatTypeResolver>>(
       patterns.getContext(), "cargf", "carg", benefit);
+  patterns.add<ScalarOpToLibmCall<complex::TanOp>>(patterns.getContext(),
+                                                   "ctanf", "ctan", benefit);
 }
 
 namespace {
@@ -136,7 +138,8 @@ void ConvertComplexToLibmPass::runOnOperation() {
   target.addLegalDialect<func::FuncDialect>();
   target.addIllegalOp<complex::PowOp, complex::SqrtOp, complex::TanhOp,
                       complex::CosOp, complex::SinOp, complex::ConjOp,
-                      complex::LogOp, complex::AbsOp, complex::AngleOp>();
+                      complex::LogOp, complex::AbsOp, complex::AngleOp,
+                      complex::TanOp>();
   if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }

--- a/mlir/test/Conversion/ComplexToLibm/convert-to-libm.mlir
+++ b/mlir/test/Conversion/ComplexToLibm/convert-to-libm.mlir
@@ -12,6 +12,8 @@
 // CHECK-DAG: @cabs(complex<f64>) -> f64
 // CHECK-DAG: @carg(complex<f64>) -> f64
 // CHECK-DAG: @clog(complex<f64>) -> complex<f64>
+// CHECK-DAG: @ctanf(complex<f32>) -> complex<f32>
+// CHECK-DAG: @ctan(complex<f64>) -> complex<f64>
 
 // CHECK-LABEL: func @cpow_caller
 // CHECK-SAME: %[[FLOAT:.*]]: complex<f32>
@@ -117,6 +119,18 @@ func.func @clog_caller(%float: complex<f32>, %double: complex<f64>) -> (complex<
   %float_result = complex.log %float : complex<f32>
   // CHECK: %[[DOUBLE_RESULT:.*]] = call @clog(%[[DOUBLE]])
   %double_result = complex.log %double : complex<f64>
+  // CHECK: return %[[FLOAT_RESULT]], %[[DOUBLE_RESULT]]
+  return %float_result, %double_result : complex<f32>, complex<f64>
+}
+
+// CHECK-LABEL: func @ctan_caller
+// CHECK-SAME: %[[FLOAT:.*]]: complex<f32>
+// CHECK-SAME: %[[DOUBLE:.*]]: complex<f64>
+func.func @ctan_caller(%float: complex<f32>, %double: complex<f64>) -> (complex<f32>, complex<f64>)  {
+  // CHECK: %[[FLOAT_RESULT:.*]] = call @ctanf(%[[FLOAT]])
+  %float_result = complex.tan %float : complex<f32>
+  // CHECK: %[[DOUBLE_RESULT:.*]] = call @ctan(%[[DOUBLE]])
+  %double_result = complex.tan %double : complex<f64>
   // CHECK: return %[[FLOAT_RESULT]], %[[DOUBLE_RESULT]]
   return %float_result, %double_result : complex<f32>, complex<f64>
 }


### PR DESCRIPTION
We can convert `complex.tan` op to [ctan/ctanf](https://sourceware.org/newlib/libm.html#ctan) function in libm in the complex to libm conversion. 