### PR TITLE
[mlir][IR] `OperationFingerPrint`: Do not hash block pointers

### DIFF
--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -928,9 +928,10 @@ OperationFingerPrint::OperationFingerPrint(Operation *topOp) {
     //   - Blocks in Regions
     for (Region &region : op->getRegions()) {
       for (Block &block : region) {
-        addDataToHash(hasher, &block);
-        for (BlockArgument arg : block.getArguments())
+        for (BlockArgument arg : block.getArguments()) {
           addDataToHash(hasher, arg);
+          addDataToHash(hasher, arg.getLoc().getAsOpaquePointer());
+        }
       }
     }
     //   - Location


### PR DESCRIPTION
Two blocks can be equivalent even though their allocated `Block *` do not match. Therefore, they should not be taken into account when computing an operation finger print. (This is consistent with `OperationEquivalence`, which also does not compare `Block *`.)

Furthermore, in addition to operation locations, block argument location should also be hashed. (Block argument locations can differ from operation locations.)