### PR TITLE
On Windows, make the release script work with the local git checkout

### DIFF
--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -112,7 +112,7 @@ echo Using VS devcmd: %vsdevcmd%
 
 set python32_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python310-32
 set python64_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python310
-set pythonarm64_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python310-arm64
+set pythonarm64_dir=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python311-arm64
 
 set revision=llvmorg-%version%
 set package_version=%version%


### PR DESCRIPTION
This PR adds a new flag, `--test` to the release script, to let it use the local git checkout instead of downloading the source package. If LLVM is checked out in `c:\git\llvm-project`, then in a admin prompt I do:
```
C:\git>llvm-project\llvm\utils\release\build_llvm_release.bat --version 18.0.0 --x64 --test
...
```
Before this PR, this didn't work.

Also fix some warnings on the second stage build (`-Wbackend-plugin`).