### PR TITLE
generate a name of an unnamed global variable for Instruction Selection

### DIFF
--- a/llvm/test/CodeGen/SPIRV/unnamed-global.ll
+++ b/llvm/test/CodeGen/SPIRV/unnamed-global.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; TODO: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK: %[[TyInt:.*]] = OpTypeInt 8 0
 ; CHECK: %[[ConstInt:.*]] = OpConstant %[[TyInt]] 123

--- a/llvm/test/CodeGen/SPIRV/unnamed_global.ll
+++ b/llvm/test/CodeGen/SPIRV/unnamed_global.ll
@@ -1,0 +1,15 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+
+; CHECK: %[[TyInt:.*]] = OpTypeInt 8 0
+; CHECK: %[[ConstInt:.*]] = OpConstant %[[TyInt]] 123
+; CHECK: %[[TyPtr:.*]] = OpTypePointer {{[a-zA-Z]+}} %[[TyInt]]
+; CHECK: %[[VarId:.*]] = OpVariable %[[TyPtr]] {{[a-zA-Z]+}} %[[ConstInt]]
+
+@0 = addrspace(1) global i8 123
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() #0 {
+  ret void
+}
+
+attributes #0 = { nounwind }


### PR DESCRIPTION
The goal of this PR is to fix the issue of global unnamed variables causing SPIR-V Backend code generation to crash: https://github.com/llvm/llvm-project/issues/78278

The reason for the crash is that GlobalValue's getGlobalIdentifier() would fail for unnamed global variable when trying to access the first character of the name (see lib/IR/Globals.cpp:150). This leads to assert in Debug and undefined behaviour in Release builds.

The proposed fix generates a name of an unnamed global variable as __unnamed_<unsigned number>, in a style of similar existing LLVM implementation (see lib/IR/Mangler.cpp:131). A new class member variable is added into `SPIRVInstructionSelector` class to keep track of the number we give to anonymous global values to generate the same name every time when this is needed.

The patch adds a new LIT test with the smallest implementation of reproducer ll code.