### PR TITLE
[libc] reverts for 32b arm

### DIFF
--- a/libc/include/llvm-libc-types/off_t.h
+++ b/libc/include/llvm-libc-types/off_t.h
@@ -9,10 +9,6 @@
 #ifndef __LLVM_LIBC_TYPES_OFF_T_H__
 #define __LLVM_LIBC_TYPES_OFF_T_H__
 
-#if defined(__LP64__) || defined(__riscv)
 typedef __INT64_TYPE__ off_t;
-#else
-typedef __INT32_TYPE__ off_t;
-#endif // __LP64__ || __riscv
 
 #endif // __LLVM_LIBC_TYPES_OFF_T_H__

--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -22,9 +22,6 @@ add_entrypoint_object(
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    # TODO: https://github.com/llvm/llvm-project/issues/77395
-    -Wno-shorten-64-to-32
 )
 
 add_entrypoint_object(


### PR DESCRIPTION
These were fixed properly by f1f1875c18b8.

- Revert "[libc] temporarily set -Wno-shorten-64-to-32 (#77396)"
- Revert "[libc] make off_t 32b for 32b arm (#77350)"
