### PR TITLE
[flang] Don't use \uXXXX encodings unless \-escapes are enabled

### DIFF
--- a/flang/include/flang/Parser/characters.h
+++ b/flang/include/flang/Parser/characters.h
@@ -237,7 +237,7 @@ void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
   }};
   if (ch <= 0x7f) {
     emitOneByte(ch);
-  } else if (useHexadecimalEscapeSequences) {
+  } else if (backslashEscapes && useHexadecimalEscapeSequences) {
     insert('\\');
     insert('u');
     if (ch > 0xffff) {


### PR DESCRIPTION
Don't put \uXXXX escapes into the cooked character stream while prescanning; it should always be UTF-8.