### PR TITLE
[compiler-rt] Drop COMPILER_RT_BUILD_CRT workaround

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -910,11 +910,6 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
   add_dependencies(compiler-rt builtins-standalone-atomic)
 endif()
 
-# TODO: COMPILER_RT_BUILD_CRT used to be a cached variable so we need to unset
-# it first so cmake_dependent_option can set the local variable of the same
-# name. This statement can be removed in the future.
-unset(COMPILER_RT_BUILD_CRT CACHE)
-
 cmake_dependent_option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON "COMPILER_RT_HAS_CRT" OFF)
 
 if (COMPILER_RT_BUILD_CRT)


### PR DESCRIPTION
This variable was explicitly removed from the cache to ease transition from existing build directories but that breaks passing COMPILER_RT_BUILD_CRT=OFF on the command line. I was surprised to see the CRT builds being run for my builtins-only build config (I noticed because one of the tests was failing despite having `REQUIRES: crt`).

If I pass `-DCOMPILER_RT_BUILD_CRT=OFF` to cmake and add some prints around the `unset` statement it shows the following:
```
-- before unset(): COMPILER_RT_BUILD_CRT=OFF
-- after unset: COMPILER_RT_BUILD_CRT=
-- after cmake_dependent_option COMPILER_RT_BUILD_CRT=ON
```

Drop this temporary workaround now that over 6 months have passed.