### PR TITLE
[SHT_LLVM_BB_ADDR_MAP,NFC] Add SCOPED_TRACE for convenient mapping of failures to test cases.

### DIFF
--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -547,8 +547,11 @@ Sections:
             Metadata:      0x2
 )";
 
-  DoCheck(UnsupportedVersionYamlString,
-          "unsupported SHT_LLVM_BB_ADDR_MAP version: 3");
+  {
+    SCOPED_TRACE("unsupported version");
+    DoCheck(UnsupportedVersionYamlString,
+            "unsupported SHT_LLVM_BB_ADDR_MAP version: 3");
+  }
 
   SmallString<128> CommonVersionedYamlString(CommonYamlString);
   CommonVersionedYamlString += R"(
@@ -566,8 +569,12 @@ Sections:
   TruncatedYamlString += R"(
     ShSize: 0xb
 )";
-  DoCheck(TruncatedYamlString, "unable to decode LEB128 at offset 0x0000000b: "
-                               "malformed uleb128, extends past end");
+  {
+    SCOPED_TRACE("truncated section");
+    DoCheck(TruncatedYamlString,
+            "unable to decode LEB128 at offset 0x0000000b: "
+            "malformed uleb128, extends past end");
+  }
 
   // Check that we can detect when the encoded BB entry fields exceed the UINT32
   // limit.
@@ -594,12 +601,15 @@ Sections:
             Metadata:      0x100000000
 )";
 
-  DoCheck(OverInt32LimitYamlStrings[0],
-          "ULEB128 value at offset 0x10 exceeds UINT32_MAX (0x100000000)");
-  DoCheck(OverInt32LimitYamlStrings[1],
-          "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
-  DoCheck(OverInt32LimitYamlStrings[2],
-          "ULEB128 value at offset 0x1a exceeds UINT32_MAX (0x100000000)");
+  {
+    SCOPED_TRACE("overlimit fields");
+    DoCheck(OverInt32LimitYamlStrings[0],
+            "ULEB128 value at offset 0x10 exceeds UINT32_MAX (0x100000000)");
+    DoCheck(OverInt32LimitYamlStrings[1],
+            "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
+    DoCheck(OverInt32LimitYamlStrings[2],
+            "ULEB128 value at offset 0x1a exceeds UINT32_MAX (0x100000000)");
+  }
 
   // Check the proper error handling when the section has fields exceeding
   // UINT32 and is also truncated. This is for checking that we don't generate
@@ -619,13 +629,16 @@ Sections:
     ShSize: 0x1b
 )";
 
-  DoCheck(OverInt32LimitAndTruncated[0],
-          "unable to decode LEB128 at offset 0x00000015: malformed uleb128, "
-          "extends past end");
-  DoCheck(OverInt32LimitAndTruncated[1],
-          "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
-  DoCheck(OverInt32LimitAndTruncated[2],
-          "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
+  {
+    SCOPED_TRACE("overlimit fields, truncated section");
+    DoCheck(OverInt32LimitAndTruncated[0],
+            "unable to decode LEB128 at offset 0x00000015: malformed uleb128, "
+            "extends past end");
+    DoCheck(OverInt32LimitAndTruncated[1],
+            "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
+    DoCheck(OverInt32LimitAndTruncated[2],
+            "ULEB128 value at offset 0x15 exceeds UINT32_MAX (0x100000000)");
+  }
 
   // Check for proper error handling when the 'NumBlocks' field is overridden
   // with an out-of-range value.
@@ -634,8 +647,11 @@ Sections:
         NumBlocks: 0x100000000
 )";
 
-  DoCheck(OverLimitNumBlocks,
-          "ULEB128 value at offset 0xa exceeds UINT32_MAX (0x100000000)");
+  {
+    SCOPED_TRACE("overlimit 'NumBlocks' field");
+    DoCheck(OverLimitNumBlocks,
+            "ULEB128 value at offset 0xa exceeds UINT32_MAX (0x100000000)");
+  }
 }
 
 // Test for the ELFObjectFile::readBBAddrMap API.
@@ -708,6 +724,9 @@ Sections:
   auto DoCheckSucceeds = [&](StringRef YamlString,
                              std::optional<unsigned> TextSectionIndex,
                              std::vector<BBAddrMap> ExpectedResult) {
+    SCOPED_TRACE("for TextSectionIndex: " +
+                 (TextSectionIndex ? llvm::Twine(*TextSectionIndex) : "{}") +
+                 " and object yaml:\n" + YamlString);
     SmallString<0> Storage;
     Expected<ELFObjectFile<ELF64LE>> ElfOrErr =
         toBinary<ELF64LE>(Storage, YamlString);
@@ -724,6 +743,9 @@ Sections:
   auto DoCheckFails = [&](StringRef YamlString,
                           std::optional<unsigned> TextSectionIndex,
                           const char *ErrMsg) {
+    SCOPED_TRACE("for TextSectionIndex: " +
+                 (TextSectionIndex ? llvm::Twine(*TextSectionIndex) : "{}") +
+                 " and object yaml:\n" + YamlString);
     SmallString<0> Storage;
     Expected<ELFObjectFile<ELF64LE>> ElfOrErr =
         toBinary<ELF64LE>(Storage, YamlString);
@@ -736,15 +758,21 @@ Sections:
                       FailedWithMessage(ErrMsg));
   };
 
-  // Check that we can retrieve the data in the normal case.
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0, Section0BBAddrMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2, Section1BBAddrMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1, Section2BBAddrMaps);
-  // Check that when no bb-address-map section is found for a text section,
-  // we return an empty result.
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {});
+  {
+    SCOPED_TRACE("normal sections");
+    // Check that we can retrieve the data in the normal case.
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0,
+                    Section0BBAddrMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1,
+                    Section2BBAddrMaps);
+    // Check that when no bb-address-map section is found for a text section,
+    // we return an empty result.
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {});
+  }
 
   // Check that we detect when a bb-addr-map section is linked to an invalid
   // (not present) section.
@@ -757,10 +785,13 @@ Sections:
                "unable to get the linked-to section for "
                "SHT_LLVM_BB_ADDR_MAP_V0 section with index 4: invalid section "
                "index: 10");
-  // Linked sections are not checked when we don't target a specific text
-  // section.
-  DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps);
+  {
+    SCOPED_TRACE("invalid linked section");
+    // Linked sections are not checked when we don't target a specific text
+    // section.
+    DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps);
+  }
 
   // Check that we can detect when bb-address-map decoding fails.
   SmallString<128> TruncatedYamlString(CommonYamlString);
@@ -768,14 +799,18 @@ Sections:
     ShSize: 0x8
 )";
 
-  DoCheckFails(TruncatedYamlString, /*TextSectionIndex=*/std::nullopt,
-               "unable to read SHT_LLVM_BB_ADDR_MAP_V0 section with index 4: "
-               "unable to decode LEB128 at offset 0x00000008: malformed "
-               "uleb128, extends past end");
-  // Check that we can read the other section's bb-address-maps which are
-  // valid.
-  DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
-                  Section1BBAddrMaps);
+  {
+    SCOPED_TRACE("truncated section");
+    DoCheckFails(TruncatedYamlString, /*TextSectionIndex=*/std::nullopt,
+                 "unable to read SHT_LLVM_BB_ADDR_MAP_V0 section with index 4: "
+                 "unable to decode LEB128 at offset 0x00000008: malformed "
+                 "uleb128, extends past end");
+
+    // Check that we can read the other section's bb-address-maps which are
+    // valid.
+    DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps);
+  }
 }
 
 // Tests for error paths of the ELFFile::decodeBBAddrMap with PGOAnalysisMap
@@ -825,9 +860,12 @@ Sections:
             Metadata:      0x2
 )";
 
-  DoCheck(UnsupportedLowVersionYamlString,
-          "version should be >= 2 for SHT_LLVM_BB_ADDR_MAP when PGO features "
-          "are enabled: version = 1 feature = 4");
+  {
+    SCOPED_TRACE("unsupported version");
+    DoCheck(UnsupportedLowVersionYamlString,
+            "version should be >= 2 for SHT_LLVM_BB_ADDR_MAP when PGO features "
+            "are enabled: version = 1 feature = 4");
+  }
 
   SmallString<128> CommonVersionedYamlString(CommonYamlString);
   CommonVersionedYamlString += R"(
@@ -846,9 +884,12 @@ Sections:
         Feature: 0x01
 )";
 
-  DoCheck(MissingFuncEntryCount,
-          "unable to decode LEB128 at offset 0x0000000b: malformed uleb128, "
-          "extends past end");
+  {
+    SCOPED_TRACE("missing function entry count");
+    DoCheck(MissingFuncEntryCount,
+            "unable to decode LEB128 at offset 0x0000000b: malformed uleb128, "
+            "extends past end");
+  }
 
   // Check that we fail when basic block frequency is enabled but not provided.
   SmallString<128> MissingBBFreq(CommonYamlString);
@@ -862,8 +903,11 @@ Sections:
             Metadata:      0x2
 )";
 
-  DoCheck(MissingBBFreq, "unable to decode LEB128 at offset 0x0000000f: "
-                         "malformed uleb128, extends past end");
+  {
+    SCOPED_TRACE("missing bb frequency");
+    DoCheck(MissingBBFreq, "unable to decode LEB128 at offset 0x0000000f: "
+                           "malformed uleb128, extends past end");
+  }
 
   // Check that we fail when branch probability is enabled but not provided.
   SmallString<128> MissingBrProb(CommonYamlString);
@@ -895,8 +939,11 @@ Sections:
               BrProb:      0xF0000000
 )";
 
-  DoCheck(MissingBrProb, "unable to decode LEB128 at offset 0x00000017: "
-                         "malformed uleb128, extends past end");
+  {
+    SCOPED_TRACE("missing branch probability");
+    DoCheck(MissingBrProb, "unable to decode LEB128 at offset 0x00000017: "
+                           "malformed uleb128, extends past end");
+  }
 }
 
 // Test for the ELFObjectFile::readBBAddrMap API with PGOAnalysisMap.
@@ -1079,6 +1126,10 @@ Sections:
       [&](StringRef YamlString, std::optional<unsigned> TextSectionIndex,
           std::vector<BBAddrMap> ExpectedResult,
           std::optional<std::vector<PGOAnalysisMap>> ExpectedPGO) {
+        SCOPED_TRACE(
+            "for TextSectionIndex: " +
+            (TextSectionIndex ? llvm::Twine(*TextSectionIndex) : "{}") +
+            " and object yaml:\n" + YamlString);
         SmallString<0> Storage;
         Expected<ELFObjectFile<ELF64LE>> ElfOrErr =
             toBinary<ELF64LE>(Storage, YamlString);
@@ -1106,6 +1157,9 @@ Sections:
   auto DoCheckFails = [&](StringRef YamlString,
                           std::optional<unsigned> TextSectionIndex,
                           const char *ErrMsg) {
+    SCOPED_TRACE("for TextSectionIndex: " +
+                 (TextSectionIndex ? llvm::Twine(*TextSectionIndex) : "{}") +
+                 " and object yaml:\n" + YamlString);
     SmallString<0> Storage;
     Expected<ELFObjectFile<ELF64LE>> ElfOrErr =
         toBinary<ELF64LE>(Storage, YamlString);
@@ -1120,29 +1174,32 @@ Sections:
         FailedWithMessage(ErrMsg));
   };
 
-  // Check that we can retrieve the data in the normal case.
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps, std::nullopt);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0, Section0BBAddrMaps,
-                  std::nullopt);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2, Section1BBAddrMaps,
-                  std::nullopt);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1, Section2BBAddrMaps,
-                  std::nullopt);
+  {
+    SCOPED_TRACE("normal sections");
+    // Check that we can retrieve the data in the normal case.
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps, std::nullopt);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0,
+                    Section0BBAddrMaps, std::nullopt);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps, std::nullopt);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1,
+                    Section2BBAddrMaps, std::nullopt);
 
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps, AllPGOAnalysisMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0, Section0BBAddrMaps,
-                  Section0PGOAnalysisMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2, Section1BBAddrMaps,
-                  Section1PGOAnalysisMaps);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1, Section2BBAddrMaps,
-                  Section2PGOAnalysisMaps);
-  // Check that when no bb-address-map section is found for a text section,
-  // we return an empty result.
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {}, std::nullopt);
-  DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {},
-                  std::vector<PGOAnalysisMap>{});
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps, AllPGOAnalysisMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/0,
+                    Section0BBAddrMaps, Section0PGOAnalysisMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps, Section1PGOAnalysisMaps);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/1,
+                    Section2BBAddrMaps, Section2PGOAnalysisMaps);
+    // Check that when no bb-address-map section is found for a text section,
+    // we return an empty result.
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {}, std::nullopt);
+    DoCheckSucceeds(CommonYamlString, /*TextSectionIndex=*/3, {},
+                    std::vector<PGOAnalysisMap>{});
+  }
 
   // Check that we detect when a bb-addr-map section is linked to an invalid
   // (not present) section.
@@ -1151,16 +1208,20 @@ Sections:
     Link: 10
 )";
 
-  DoCheckFails(InvalidLinkedYamlString, /*TextSectionIndex=*/5,
-               "unable to get the linked-to section for "
-               "SHT_LLVM_BB_ADDR_MAP section with index 5: invalid section "
-               "index: 10");
-  // Linked sections are not checked when we don't target a specific text
-  // section.
-  DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps, std::nullopt);
-  DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
-                  AllBBAddrMaps, AllPGOAnalysisMaps);
+  {
+    SCOPED_TRACE("invalid linked section");
+    DoCheckFails(InvalidLinkedYamlString, /*TextSectionIndex=*/5,
+                 "unable to get the linked-to section for "
+                 "SHT_LLVM_BB_ADDR_MAP section with index 5: invalid section "
+                 "index: 10");
+
+    // Linked sections are not checked when we don't target a specific text
+    // section.
+    DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps, std::nullopt);
+    DoCheckSucceeds(InvalidLinkedYamlString, /*TextSectionIndex=*/std::nullopt,
+                    AllBBAddrMaps, AllPGOAnalysisMaps);
+  }
 
   // Check that we can detect when bb-address-map decoding fails.
   SmallString<128> TruncatedYamlString(CommonYamlString);
@@ -1168,16 +1229,19 @@ Sections:
     ShSize: 0xa
 )";
 
-  DoCheckFails(TruncatedYamlString, /*TextSectionIndex=*/std::nullopt,
-               "unable to read SHT_LLVM_BB_ADDR_MAP section with index 5: "
-               "unable to decode LEB128 at offset 0x0000000a: malformed "
-               "uleb128, extends past end");
-  // Check that we can read the other section's bb-address-maps which are
-  // valid.
-  DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
-                  Section1BBAddrMaps, std::nullopt);
-  DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
-                  Section1BBAddrMaps, Section1PGOAnalysisMaps);
+  {
+    SCOPED_TRACE("truncated section");
+    DoCheckFails(TruncatedYamlString, /*TextSectionIndex=*/std::nullopt,
+                 "unable to read SHT_LLVM_BB_ADDR_MAP section with index 5: "
+                 "unable to decode LEB128 at offset 0x0000000a: malformed "
+                 "uleb128, extends past end");
+    // Check that we can read the other section's bb-address-maps which are
+    // valid.
+    DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps, std::nullopt);
+    DoCheckSucceeds(TruncatedYamlString, /*TextSectionIndex=*/2,
+                    Section1BBAddrMaps, Section1PGOAnalysisMaps);
+  }
 }
 
 // Test for ObjectFile::getRelocatedSection: check that it returns a relocated


### PR DESCRIPTION
Although parameterized gtests are preferred for this, our tests are not very straightforward. So I decided to add SCOPED_TRACE for different test cases and the lambda checks as well.

Typical test failure message now looks like:

```
...llvm-project/llvm/unittests/Object/ELFObjectFileTest.cpp:737
Expected equality of these values:
  *BBAddrMaps
    Which is: { 32-byte object <11-11 01-00 00-00 00-00 C0-A9 FB-3E E4-55 00-00 D0-A9 FB-3E E4-55 00-00 D0-A9 FB-3E E4-55 00-00>, 32-byte object <22-22 02-00 00-00 00-00 F0-8E FB-3E E4-55 00-00 00-8F FB-3E E4-55 00-00 00-8F FB-3E E4-55 00-00> }
  ExpectedResult
    Which is: { 32-byte object <33-33 03-00 00-00 00-00 50-A7 FB-3E E4-55 00-00 60-A7 FB-3E E4-55 00-00 60-A7 FB-3E E4-55 00-00> }
Google Test trace:
...llvm-project/llvm/unittests/Object/ELFObjectFileTest.cpp:726: for TextSectionIndex: 1 and object yaml:

--- !ELF
FileHeader:
  Class: ELFCLASS64
  Data:  ELFDATA2LSB
  Type:  ET_EXEC
Sections:
  - Name: .llvm_bb_addr_map_1
    Type: SHT_LLVM_BB_ADDR_MAP
    Link: 1
    Entries:
      - Version: 2
        Address: 0x11111
        BBEntries:
          - ID:            1
            AddressOffset: 0x0
            Size:          0x1
            Metadata:      0x2
  - Name: .llvm_bb_addr_map_2
    Type: SHT_LLVM_BB_ADDR_MAP
    Link: 1
    Entries:
      - Version: 2
        Address: 0x22222
        BBEntries:
          - ID:            2
            AddressOffset: 0x0
            Size:          0x2
            Metadata:      0x4
  - Name: .llvm_bb_addr_map_3
    Type: SHT_LLVM_BB_ADDR_MAP
    Link: 2
    Entries:
      - Version: 1
        Address: 0x33333
        BBEntries:
          - ID:            0
            AddressOffset: 0x0
            Size:          0x3
            Metadata:      0x6
  - Name: .llvm_bb_addr_map_4
    Type: SHT_LLVM_BB_ADDR_MAP_V0
  # Link: 0 (by default, can be overriden)
    Entries:
      - Version: 0
        Address: 0x44444
        BBEntries:
          - ID:            0
            AddressOffset: 0x0
            Size:          0x4
            Metadata:      0x18

...llvm-project/llvm/unittests/Object/ELFObjectFileTest.cpp:757: normal sections
```