### PR TITLE
Revert "[libc++] Fix `regex_search` to match `$` alone with `match_default` flag"

### DIFF
--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -1889,9 +1889,6 @@ void __r_anchor_multiline<_CharT>::__exec(__state& __s) const {
   if (__s.__current_ == __s.__last_ && !(__s.__flags_ & regex_constants::match_not_eol)) {
     __s.__do_   = __state::__accept_but_not_consume;
     __s.__node_ = this->first();
-  } else if (__s.__current_ == __s.__first_ && !(__s.__flags_ & regex_constants::match_not_eol)) {
-    __s.__do_   = __state::__accept_but_not_consume;
-    __s.__node_ = this->first();
   } else if (__multiline_ && std::__is_eol(*__s.__current_)) {
     __s.__do_   = __state::__accept_but_not_consume;
     __s.__node_ = this->first();

--- a/libcxx/test/std/re/re.const/re.matchflag/match_not_eol.pass.cpp
+++ b/libcxx/test/std/re/re.const/re.matchflag/match_not_eol.pass.cpp
@@ -47,19 +47,5 @@ int main(int, char**)
     assert( std::regex_search(target, re, std::regex_constants::match_not_eol));
     }
 
-    {
-      std::string target = "foo";
-      std::regex re("$");
-      assert(std::regex_search(target, re));
-      assert(!std::regex_search(target, re, std::regex_constants::match_not_eol));
-    }
-
-    {
-      std::string target = "foo";
-      std::regex re("$");
-      assert(!std::regex_match(target, re));
-      assert(!std::regex_match(target, re, std::regex_constants::match_not_eol));
-    }
-
   return 0;
 }


### PR DESCRIPTION
The behavior of `std::regex_search` for patterns anchored both to the start and to the end of the input went wrong after merging #77256 . Patterns like `"^b*$"` started matching the strings such as `"a"`, which is not expected. 

Reverts the PR: #77256