### PR TITLE
[lldb][Progress] Fix test for trimmed progress reports

### DIFF
--- a/lldb/test/API/functionalities/progress_reporting/TestTrimmedProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestTrimmedProgressReporting.py
@@ -33,24 +33,19 @@ class TestTrimmedProgressReporting(PExpectTest):
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan
-    @skipUnlessDarwin
     @skipIfEditlineSupportMissing
     def test_trimmed_progress_message(self):
-        self.do_test(
-            19, ["Locating externa...", "Loading Apple DW...", "Parsing symbol t..."]
-        )
+        self.do_test(19, ["Locating e...", "Parsing sy..."])
 
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan
-    @skipUnlessDarwin
     @skipIfEditlineSupportMissing
     def test_long_progress_message(self):
         self.do_test(
             80,
             [
-                "Locating external symbol file for a.out...",
-                "Loading Apple DWARF index for a.out...",
-                "Parsing symbol table for dyld...",
+                "Locating external symbol file",
+                "Parsing symbol table",
             ],
         )


### PR DESCRIPTION
The test TestTrimmedProgressReporting tests that progress reports are being sent by listening for events with the titles of specific progress reports. Commit f1ef910b removed the report for Apple DWARF indices which was one of the reports being listened for in this test, so that report is removed here as well.

That commit also now creates all progress reports with details so reports string are prepended with the details count. This changes the length of the trimmed progress report title string that's checked for here so this commit changes the string to match as well.

This test was skipped on non-Apple platforms, but since the progress report for Apple DWARF indices has been removed this commit removes that decorator.