### PR TITLE
[PowerPC] lower partial vector store cost

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
@@ -788,7 +788,7 @@ InstructionCost PPCTTIImpl::getMemoryOpCost(unsigned Opcode, Type *Src,
   // VSX has 32b/64b load instructions. Legalization can handle loading of
   // 32b/64b to VSR correctly and cheaply. But BaseT::getMemoryOpCost and
   // PPCTargetLowering can't compute the cost appropriately. So here we
-  // explicitly check this case. There are also corresponding store 
+  // explicitly check this case. There are also corresponding store
   // instructions.
   unsigned MemBytes = Src->getPrimitiveSizeInBits();
   if (ST->hasVSX() && IsAltivecType &&

--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
@@ -788,9 +788,10 @@ InstructionCost PPCTTIImpl::getMemoryOpCost(unsigned Opcode, Type *Src,
   // VSX has 32b/64b load instructions. Legalization can handle loading of
   // 32b/64b to VSR correctly and cheaply. But BaseT::getMemoryOpCost and
   // PPCTargetLowering can't compute the cost appropriately. So here we
-  // explicitly check this case.
+  // explicitly check this case. There are also corresponding store 
+  // instructions.
   unsigned MemBytes = Src->getPrimitiveSizeInBits();
-  if (Opcode == Instruction::Load && ST->hasVSX() && IsAltivecType &&
+  if (ST->hasVSX() && IsAltivecType &&
       (MemBytes == 64 || (ST->hasP8Vector() && MemBytes == 32)))
     return 1;
 

--- a/llvm/test/Analysis/CostModel/PowerPC/load_store.ll
+++ b/llvm/test/Analysis/CostModel/PowerPC/load_store.ll
@@ -43,3 +43,22 @@ define i32 @loads(i32 %arg) {
   ret i32 undef
 }
 
+define i32 @partialvector32(i32 %arg) #0 {
+
+  ; CHECK: cost of 1 {{.*}} store
+  store <4 x i8> undef, ptr undef, align 16
+
+  ret i32 undef
+}
+
+define i32 @partialvector64(i32 %arg) #1 {
+
+  ; CHECK: cost of 1 {{.*}} store
+  store <4 x i16> undef, ptr undef, align 16
+
+  ret i32 undef
+}
+
+attributes #0 = { "target-features"="+power8-vector,+vsx" }
+
+attributes #1 = { "target-features"="+vsx" }


### PR DESCRIPTION
There are matching store opcodes (stfd, stxsiwx) for the load opcodes that make
32-bit and 64-bit vector operations cheap with VSX, so stores
should also be cheap.