### PR TITLE
[llvm-readobj][Object][COFF] Include COFF import file machine type in format string.

### DIFF
--- a/llvm/include/llvm/Object/COFFImportFile.h
+++ b/llvm/include/llvm/Object/COFFImportFile.h
@@ -65,6 +65,8 @@ public:
 
   uint16_t getMachine() const { return getCOFFImportHeader()->Machine; }
 
+  StringRef getFileFormatName() const;
+
 private:
   bool isData() const {
     return getCOFFImportHeader()->getType() == COFF::IMPORT_DATA;

--- a/llvm/lib/Object/COFFImportFile.cpp
+++ b/llvm/lib/Object/COFFImportFile.cpp
@@ -33,6 +33,25 @@ using namespace llvm;
 namespace llvm {
 namespace object {
 
+StringRef COFFImportFile::getFileFormatName() const {
+  switch (getMachine()) {
+  case COFF::IMAGE_FILE_MACHINE_I386:
+    return "COFF-import-file-i386";
+  case COFF::IMAGE_FILE_MACHINE_AMD64:
+    return "COFF-import-file-x86-64";
+  case COFF::IMAGE_FILE_MACHINE_ARMNT:
+    return "COFF-import-file-ARM";
+  case COFF::IMAGE_FILE_MACHINE_ARM64:
+    return "COFF-import-file-ARM64";
+  case COFF::IMAGE_FILE_MACHINE_ARM64EC:
+    return "COFF-import-file-ARM64EC";
+  case COFF::IMAGE_FILE_MACHINE_ARM64X:
+    return "COFF-import-file-ARM64X";
+  default:
+    return "COFF-import-file-<unknown arch>";
+  }
+}
+
 static uint16_t getImgRelRelocation(MachineTypes Machine) {
   switch (Machine) {
   default:

--- a/llvm/test/tools/llvm-dlltool/coff-exports.def
+++ b/llvm/test/tools/llvm-dlltool/coff-exports.def
@@ -1,8 +1,8 @@
 ; RUN: llvm-dlltool -m i386:x86-64 --input-def %s --output-lib %t.a
-; RUN: llvm-readobj %t.a | FileCheck %s
+; RUN: llvm-readobj %t.a | FileCheck %s --check-prefixes=CHECK,CHECK-X64
 ; RUN: llvm-nm --print-armap %t.a | FileCheck --check-prefix=SYMTAB %s
 ; RUN: llvm-dlltool -m arm64 --input-def %s --output-lib %t.a
-; RUN: llvm-readobj %t.a | FileCheck %s
+; RUN: llvm-readobj %t.a | FileCheck %s --check-prefixes=CHECK,CHECK-ARM64
 ; RUN: llvm-nm --print-armap %t.a | FileCheck --check-prefix=SYMTAB %s
 
 LIBRARY test.dll
@@ -13,7 +13,8 @@ TestFunction3 ; This is a comment
 AnotherFunction
 
 ; CHECK: File: test.dll
-; CHECK: Format: COFF-import-file
+; CHECK-X64:   Format: COFF-import-file-x86-64
+; CHECK-ARM64: Format: COFF-import-file-ARM64
 ; CHECK: Type: code
 ; CHECK:      Name type: name
 ; CHECK-NEXT: Symbol: __imp_TestFunction1

--- a/llvm/test/tools/llvm-lib/arm64ec-implib.test
+++ b/llvm/test/tools/llvm-lib/arm64ec-implib.test
@@ -26,19 +26,19 @@ READOBJ-NEXT: Arch: aarch64
 READOBJ-NEXT: AddressSize: 64bit
 READOBJ-EMPTY:
 READOBJ-NEXT: File: test.lib(test.dll)
-READOBJ-NEXT: Format: COFF-ARM64
+READOBJ-NEXT: Format: COFF-ARM64EC
 READOBJ-NEXT: Arch: aarch64
 READOBJ-NEXT: AddressSize: 64bit
 READOBJ-EMPTY:
 READOBJ-NEXT: File: test.dll
-READOBJ-NEXT: Format: COFF-import-file
+READOBJ-NEXT: Format: COFF-import-file-ARM64EC
 READOBJ-NEXT: Type: code
 READOBJ-NEXT: Name type: name
 READOBJ-NEXT: Symbol: __imp_funcexp
 READOBJ-NEXT: Symbol: funcexp
 READOBJ-EMPTY:
 READOBJ-NEXT: File: test.dll
-READOBJ-NEXT: Format: COFF-import-file
+READOBJ-NEXT: Format: COFF-import-file-ARM64EC
 READOBJ-NEXT: Type: data
 READOBJ-NEXT: Name type: name
 READOBJ-NEXT: Symbol: __imp_dataexp

--- a/llvm/test/tools/llvm-readobj/COFF/exports-implib.test
+++ b/llvm/test/tools/llvm-readobj/COFF/exports-implib.test
@@ -1,25 +1,25 @@
 RUN: llvm-readobj --coff-exports %p/Inputs/library.lib | FileCheck %s
 
 CHECK: File: library.dll
-CHECK: Format: COFF-import-file
+CHECK: Format: COFF-import-file-i386
 CHECK: Type: const
 CHECK: Name type: undecorate
 CHECK: Symbol: __imp__constant
 
 CHECK: File: library.dll
-CHECK: Format: COFF-import-file
+CHECK: Format: COFF-import-file-i386
 CHECK: Type: data
 CHECK: Name type: noprefix
 CHECK: Symbol: __imp__data
 
 CHECK: File: library.dll
-CHECK: Format: COFF-import-file
+CHECK: Format: COFF-import-file-i386
 CHECK: Type: code
 CHECK: Name type: name
 CHECK: Symbol: __imp__function
 
 CHECK: File: library.dll
-CHECK: Format: COFF-import-file
+CHECK: Format: COFF-import-file-i386
 CHECK: Type: code
 CHECK: Name type: ordinal
 CHECK: Symbol: __imp__ordinal

--- a/llvm/test/tools/llvm-readobj/COFF/file-headers.test
+++ b/llvm/test/tools/llvm-readobj/COFF/file-headers.test
@@ -320,7 +320,7 @@ symbols:
 # RUN: llvm-readobj -h %p/Inputs/magic.coff-importlib \
 # RUN:   | FileCheck %s --strict-whitespace --match-full-lines --check-prefix IMPORTLIB
 
-#      IMPORTLIB:Format: COFF-import-file
+#      IMPORTLIB:Format: COFF-import-file-i386
 # IMPORTLIB-NEXT:Type: code
 # IMPORTLIB-NEXT:Name type: noprefix
 # IMPORTLIB-NEXT:Symbol: __imp__func

--- a/llvm/tools/llvm-readobj/COFFImportDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFImportDumper.cpp
@@ -23,7 +23,7 @@ namespace llvm {
 void dumpCOFFImportFile(const COFFImportFile *File, ScopedPrinter &Writer) {
   Writer.startLine() << '\n';
   Writer.printString("File", File->getFileName());
-  Writer.printString("Format", "COFF-import-file");
+  Writer.printString("Format", File->getFileFormatName());
 
   const coff_import_header *H = File->getCOFFImportHeader();
   switch (H->getType()) {


### PR DESCRIPTION
We currently don't print import library machine at all. It would would be useful for ARM64EC importlib llvm-lib and llvm-dlltool tests. ARM64EC  should use a mixture of ARM64 and ARM64EC files (both for ARM64X and pure ARM64EC). This PR makes COFFImportFile similar to COFFObjectFile in that regard.