### PR TITLE
[lldb] Build the TestRosetta.py executable with system stdlib

### DIFF
--- a/lldb/test/API/macosx/rosetta/Makefile
+++ b/lldb/test/API/macosx/rosetta/Makefile
@@ -1,4 +1,6 @@
 C_SOURCES := main.c
 override ARCH = x86_64
 
+USE_SYSTEM_STDLIB := 1
+
 include Makefile.rules


### PR DESCRIPTION
This is a speculative fix for TestRosetta.py which is currently failing on Green Dragon.

TestRosetta just makes sure we can debug an x86_64 process on Apple Silicon. However, we're failing to build the x86_64 test binary. The linker is failing with some warnings about libc++ and libunwind being build for arm64 while the target binary is x86_64. I'm going to try building with the system standard libraries instead of the just-built ones to workaround it.