### PR TITLE
Add the Linux "you can use this binary" bits to run_to_source_breakpoint

### DIFF
--- a/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
+++ b/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
@@ -41,7 +41,8 @@ class TestExecutableIsFirst(TestBase):
     def test_executable_is_first_during_run(self):
         self.build()
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
-            self, "break after function call", lldb.SBFileSpec("main.cpp")
+            self, "break after function call", lldb.SBFileSpec("main.cpp"),
+            extra_images=["bar"]
         )
 
         first_module = target.GetModuleAtIndex(0)


### PR DESCRIPTION
Follow-on to a4cd99ea8736eda2b8b4de34453f55008bcf9c30 - I forgot you have to add ANY shared library you want to use to extra_images...