### PR TITLE
Return high address masks correctly in Process

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5694,12 +5694,16 @@ lldb::addr_t Process::GetDataAddressMask() {
 lldb::addr_t Process::GetHighmemCodeAddressMask() {
   if (uint32_t num_bits_setting = GetHighmemVirtualAddressableBits())
     return ~((1ULL << num_bits_setting) - 1);
+  if (m_highmem_code_address_mask)
+    return m_highmem_code_address_mask;
   return GetCodeAddressMask();
 }
 
 lldb::addr_t Process::GetHighmemDataAddressMask() {
   if (uint32_t num_bits_setting = GetHighmemVirtualAddressableBits())
     return ~((1ULL << num_bits_setting) - 1);
+  if (m_highmem_data_address_mask)
+    return m_highmem_data_address_mask;
   return GetDataAddressMask();
 }
 


### PR DESCRIPTION
In https://reviews.llvm.org/D151292 I added the ability to track address masks separately for high and low memory addresses, a capability of AArch64.  I did my testing with manual address mask settings (via target.process.highmem-virtual-addressable-bits) but didn't have a real corefile that included this metadata and required it.

My intention is that when the high address mask isn't specified, by the user (via the setting) or the Process plugin, we fall back to using the low address mask.  The low and high address mask is the same for almost all environments.

But the patch I wrote never uses the Process plugin high address mask if it was set, e.g. from corefile metadata.  This patch corrects that.

I also have an old patch in Phabractor that was approved to add FixAddress methods to SBProcess; I need to pick that patch up and finish it (I wanted to add an enum to specify which mask is being requested iirc), so I can do address masks tests in API tests.

rdar://120926000