### PR TITLE
Module documentation improvement: prebuilt module location can be directly fetched via CMake variable.

### DIFF
--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -183,8 +183,8 @@ This is a small sample program that uses the module ``std``. It consists of a
   # Adjust project compiler flags
   #
 
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fprebuilt-module-path=${CMAKE_BINARY_DIR}/_deps/std-build/CMakeFiles/std.dir/>)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fprebuilt-module-path=${CMAKE_BINARY_DIR}/_deps/std-build/CMakeFiles/std.compat.dir/>)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fprebuilt-module-path=${std_BINARY_DIR}/CMakeFiles/std.dir/>)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fprebuilt-module-path=${std_BINARY_DIR}/CMakeFiles/std.compat.dir/>)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
   # The include path needs to be set to be able to use macros from headers.
   # For example from, the headers <cassert> and <version>.


### PR DESCRIPTION
CMake officially supports binary directory variable of installed dependency using `FetchContent`. According to the current documentation, it fetches `std` module and use its binary directory as hardcoded string, `${CMAKE_BINARY_DIR}/_deps/std-build`, however it can be replaced with `${std_BINARY_DIR}`.

Reference: https://cmake.org/cmake/help/latest/module/FetchContent.html