### PR TITLE
Revert "[libc++] Clang-tidy enable modernize-use-nullptr. (#76659)"

### DIFF
--- a/libcxx/.clang-tidy
+++ b/libcxx/.clang-tidy
@@ -15,7 +15,6 @@ Checks: >
 
   modernize-loop-convert,
   modernize-redundant-void-arg,
-  modernize-use-nullptr,
   modernize-use-override,
 
   readability-duplicate-include,
@@ -69,6 +68,7 @@ CheckOptions:
 # modernize-use-default-member-init,
 # modernize-use-equals-default,
 # modernize-use-equals-delete,
+# modernize-use-nullptr,
 # portability-restrict-system-includes,
 # readability-function-cognitive-complexity,
 # readability-implicit-bool-conversion,

--- a/libcxx/include/__atomic/is_always_lock_free.h
+++ b/libcxx/include/__atomic/is_always_lock_free.h
@@ -20,7 +20,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct __libcpp_is_always_lock_free {
   // __atomic_always_lock_free is available in all Standard modes
-  static const bool __value = __atomic_always_lock_free(sizeof(_Tp), nullptr);
+  static const bool __value = __atomic_always_lock_free(sizeof(_Tp), 0);
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -3421,7 +3421,7 @@ wbuffer_convert<_Codecvt, _Elem, _Tr>::~wbuffer_convert() {
 template <class _Codecvt, class _Elem, class _Tr>
 typename wbuffer_convert<_Codecvt, _Elem, _Tr>::int_type wbuffer_convert<_Codecvt, _Elem, _Tr>::underflow() {
   _LIBCPP_SUPPRESS_DEPRECATED_POP
-  if (__cv_ == 0 || __bufptr_ == nullptr)
+  if (__cv_ == 0 || __bufptr_ == 0)
     return traits_type::eof();
   bool __initial = __read_mode();
   char_type __1buf;
@@ -3478,7 +3478,7 @@ template <class _Codecvt, class _Elem, class _Tr>
 typename wbuffer_convert<_Codecvt, _Elem, _Tr>::int_type
 wbuffer_convert<_Codecvt, _Elem, _Tr>::pbackfail(int_type __c) {
   _LIBCPP_SUPPRESS_DEPRECATED_POP
-  if (__cv_ != 0 && __bufptr_ && this->eback() < this->gptr()) {
+  if (__cv_ != 0 && __bufptr_ != 0 && this->eback() < this->gptr()) {
     if (traits_type::eq_int_type(__c, traits_type::eof())) {
       this->gbump(-1);
       return traits_type::not_eof(__c);
@@ -3496,7 +3496,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Codecvt, class _Elem, class _Tr>
 typename wbuffer_convert<_Codecvt, _Elem, _Tr>::int_type wbuffer_convert<_Codecvt, _Elem, _Tr>::overflow(int_type __c) {
   _LIBCPP_SUPPRESS_DEPRECATED_POP
-  if (__cv_ == 0 || !__bufptr_)
+  if (__cv_ == 0 || __bufptr_ == 0)
     return traits_type::eof();
   __write_mode();
   char_type __1buf;
@@ -3588,7 +3588,7 @@ template <class _Codecvt, class _Elem, class _Tr>
 typename wbuffer_convert<_Codecvt, _Elem, _Tr>::pos_type
 wbuffer_convert<_Codecvt, _Elem, _Tr>::seekoff(off_type __off, ios_base::seekdir __way, ios_base::openmode __om) {
   int __width = __cv_->encoding();
-  if (__cv_ == 0 || !__bufptr_ || (__width <= 0 && __off != 0) || sync())
+  if (__cv_ == 0 || __bufptr_ == 0 || (__width <= 0 && __off != 0) || sync())
     return pos_type(off_type(-1));
   // __width > 0 || __off == 0, now check __way
   if (__way != ios_base::beg && __way != ios_base::cur && __way != ios_base::end)
@@ -3601,7 +3601,7 @@ wbuffer_convert<_Codecvt, _Elem, _Tr>::seekoff(off_type __off, ios_base::seekdir
 template <class _Codecvt, class _Elem, class _Tr>
 typename wbuffer_convert<_Codecvt, _Elem, _Tr>::pos_type
 wbuffer_convert<_Codecvt, _Elem, _Tr>::seekpos(pos_type __sp, ios_base::openmode __wch) {
-  if (__cv_ == 0 || !__bufptr_ || sync())
+  if (__cv_ == 0 || __bufptr_ == 0 || sync())
     return pos_type(off_type(-1));
   if (__bufptr_->pubseekpos(__sp, __wch) == pos_type(off_type(-1)))
     return pos_type(off_type(-1));
@@ -3611,7 +3611,7 @@ wbuffer_convert<_Codecvt, _Elem, _Tr>::seekpos(pos_type __sp, ios_base::openmode
 template <class _Codecvt, class _Elem, class _Tr>
 int wbuffer_convert<_Codecvt, _Elem, _Tr>::sync() {
   _LIBCPP_SUPPRESS_DEPRECATED_POP
-  if (__cv_ == 0 || !__bufptr_)
+  if (__cv_ == 0 || __bufptr_ == 0)
     return 0;
   if (__cm_ & ios_base::out) {
     if (this->pptr() != this->pbase())


### PR DESCRIPTION
This reverts commit 020ea3e8d1075ab4a388ecd0d6e7a9d4cd415392.

This seems to break `test/libcxx/clang_tidy.gen.py/regex.sh.cpp` (in
C++03 mode for some reason):

```
2024-01-17T07:32:22.1759374Z # RUN: at line 12
2024-01-17T07:32:22.1773919Z clang-tidy-18 /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/test/libcxx/clang_tidy.gen.py/regex.sh.cpp --warnings-as-errors=* -header-filter=.* --config-file=/home/runner/_work/llvm-project/llvm-project/libcxx/.clang-tidy -- -Wweak-vtables -nostdinc++ -I /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1 -I /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1 -I /home/runner/_work/llvm-project/llvm-project/libcxx/test/support -std=c++03 -Werror -Wall -Wctad-maybe-unsupported -Wextra -Wshadow -Wundef -Wunused-template -Wno-unused-command-line-argument -Wno-attributes -Wno-pessimizing-move -Wno-noexcept-type -Wno-atomic-alignment -Wno-reserved-module-identifier -Wdeprecated-copy -Wdeprecated-copy-dtor -Wno-user-defined-literals -Wno-tautological-compare -Wsign-compare -Wunused-variable -Wunused-parameter -Wunreachable-code -Wno-unused-local-typedef -Wno-local-type-template-args -Wno-c++11-extensions -Wno-unknown-pragmas -Wno-pass-failed -Wno-mismatched-new-delete -Wno-redundant-move -Wno-self-move -D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER -D_LIBCPP_ENABLE_EXPERIMENTAL -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE -Werror=thread-safety -Wuser-defined-warnings  -fno-modules
2024-01-17T07:32:22.1803227Z # executed command: clang-tidy-18 /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/test/libcxx/clang_tidy.gen.py/regex.sh.cpp '--warnings-as-errors=*' '-header-filter=.*' --config-file=/home/runner/_work/llvm-project/llvm-project/libcxx/.clang-tidy -- -Wweak-vtables -nostdinc++ -I /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1 -I /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1 -I /home/runner/_work/llvm-project/llvm-project/libcxx/test/support -std=c++03 -Werror -Wall -Wctad-maybe-unsupported -Wextra -Wshadow -Wundef -Wunused-template -Wno-unused-command-line-argument -Wno-attributes -Wno-pessimizing-move -Wno-noexcept-type -Wno-atomic-alignment -Wno-reserved-module-identifier -Wdeprecated-copy -Wdeprecated-copy-dtor -Wno-user-defined-literals -Wno-tautological-compare -Wsign-compare -Wunused-variable -Wunused-parameter -Wunreachable-code -Wno-unused-local-typedef -Wno-local-type-template-args -Wno-c++11-extensions -Wno-unknown-pragmas -Wno-pass-failed -Wno-mismatched-new-delete -Wno-redundant-move -Wno-self-move -D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER -D_LIBCPP_ENABLE_EXPERIMENTAL -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE -Werror=thread-safety -Wuser-defined-warnings -fno-modules
2024-01-17T07:32:22.1817757Z # .---command stdout------------
2024-01-17T07:32:22.1820160Z # | /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__iterator/iterator_traits.h:124:50: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
2024-01-17T07:32:22.1822498Z # |   124 |   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
2024-01-17T07:32:22.1823337Z # |       |                                                  ^
2024-01-17T07:32:22.1824052Z # |       |                                                  nullptr
2024-01-17T07:32:22.1826651Z # | /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__iterator/iterator_traits.h:124:53: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
2024-01-17T07:32:22.1829325Z # |   124 |   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
2024-01-17T07:32:22.1831137Z # |       |                                                     ^
2024-01-17T07:32:22.1831963Z # |       |                                                     nullptr
2024-01-17T07:32:22.1834149Z # | /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__iterator/iterator_traits.h:124:56: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
2024-01-17T07:32:22.1848711Z # |   124 |   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
2024-01-17T07:32:22.1849506Z # |       |                                                        ^
2024-01-17T07:32:22.1849997Z # |       |                                                        nullptr
2024-01-17T07:32:22.1851528Z # | /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__iterator/iterator_traits.h:124:59: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
2024-01-17T07:32:22.1853391Z # |   124 |   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
2024-01-17T07:32:22.1854277Z # |       |                                                           ^
2024-01-17T07:32:22.1854841Z # |       |                                                           nullptr
2024-01-17T07:32:22.1856314Z # | /home/runner/_work/llvm-project/llvm-project/build/generic-cxx03/include/c++/v1/__iterator/iterator_traits.h:124:62: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
2024-01-17T07:32:22.1857768Z # |   124 |   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
2024-01-17T07:32:22.1858493Z # |       |                                                              ^
2024-01-17T07:32:22.1858998Z # |       |                                                              nullptr
2024-01-17T07:32:22.1859503Z # `-----------------------------
2024-01-17T07:32:22.1859900Z # .---command stderr------------
2024-01-17T07:32:22.1860259Z # | 43 warnings generated.
2024-01-17T07:32:22.1860710Z # | Suppressed 33 warnings (33 in non-user code).
2024-01-17T07:32:22.1861809Z # | Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
2024-01-17T07:32:22.1862750Z # | 5 warnings treated as errors
2024-01-17T07:32:22.1863229Z # `-----------------------------
2024-01-17T07:32:22.1863622Z # error: command failed with exit status: 1
```

(see https://github.com/llvm/llvm-project/actions/runs/7552394884/job/20561192096)
