### PR TITLE
[FileCheck]: Fix diagnostics for NOT prefixes

### DIFF
--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -823,9 +823,19 @@ struct FileCheckString {
   /// The location in the match file that the check string was specified.
   SMLoc Loc;
 
-  /// All of the strings that are disallowed from occurring between this match
-  /// string and the previous one (or start of file).
-  std::vector<Pattern> DagNotStrings;
+  /// Hold the information about the DAG/NOT strings in the program, which are
+  /// not explicitly stored otherwise. This allows for better and more accurate
+  /// diagnostic messages.
+  struct DagNotPrefixInfo {
+    Pattern DagNotPat;
+    StringRef DagNotPrefix;
+
+    DagNotPrefixInfo(const Pattern &P, StringRef S)
+        : DagNotPat(P), DagNotPrefix(S) {}
+  };
+
+  /// Hold the DAG/NOT strings occurring in the input file.
+  std::vector<DagNotPrefixInfo> DagNotStrings;
 
   FileCheckString(const Pattern &P, StringRef S, SMLoc L)
       : Pat(P), Prefix(S), Loc(L) {}
@@ -845,12 +855,12 @@ struct FileCheckString {
   /// \p Buffer. Errors are reported against \p SM and diagnostics recorded in
   /// \p Diags according to the verbosity level set in \p Req.
   bool CheckNot(const SourceMgr &SM, StringRef Buffer,
-                const std::vector<const Pattern *> &NotStrings,
+                const std::vector<const DagNotPrefixInfo *> &NotStrings,
                 const FileCheckRequest &Req,
                 std::vector<FileCheckDiag> *Diags) const;
   /// Matches "dag strings" and their mixed "not strings".
   size_t CheckDag(const SourceMgr &SM, StringRef Buffer,
-                  std::vector<const Pattern *> &NotStrings,
+                  std::vector<const DagNotPrefixInfo *> &NotStrings,
                   const FileCheckRequest &Req,
                   std::vector<FileCheckDiag> *Diags) const;
 };

--- a/llvm/test/FileCheck/check-ignore-case.txt
+++ b/llvm/test/FileCheck/check-ignore-case.txt
@@ -43,6 +43,6 @@ One Line To Match
 # LINE: {{o}}ne line
 # LINE-SAME: {{t}}o match
 
-# ERROR: command line:1:{{[0-9]+}}: error: CHECK-NOT: excluded string found in input
+# ERROR: command line:1:{{[0-9]+}}: error: IMPLICIT-CHECK-NOT: excluded string found in input
 # ERROR-NEXT: -implicit-check-not='sTrInG'
 # ERROR: note: found here

--- a/llvm/test/FileCheck/check-not-custom-prefix.txt
+++ b/llvm/test/FileCheck/check-not-custom-prefix.txt
@@ -1,0 +1,69 @@
+; Test two trailing NOT strings
+; RUN: rm -f %t && \
+; RUN: echo "LEADING: placeholder1" >>%t && echo "MIDDLE-NOT: placeholder2" >>%t && echo "TRAILING-NOT: placeholder3" >>%t && \
+; RUN: %ProtectFileCheckOutput not FileCheck --strict-whitespace --check-prefixes LEADING,MIDDLE,TRAILING --dump-input=never --input-file  %t %t 2>&1 | \
+; RUN: FileCheck --check-prefix TEST1 %s
+
+; Test NOT string occurring in between two allowable strings
+; RUN: rm -f %t && \
+; RUN: echo "LEADING: placeholder1" >>%t && echo "MIDDLE-NOT: placeholder2" >>%t && echo "TRAILING: placeholder3" >>%t && \
+; RUN: %ProtectFileCheckOutput not FileCheck --strict-whitespace --check-prefixes LEADING,MIDDLE,TRAILING --dump-input=never --input-file  %t %t 2>&1 | \
+; RUN: FileCheck --check-prefix TEST2 %s
+
+; Test first prefix found being the NOT string
+; RUN: rm -f %t && \
+; RUN: echo "LEADING-NOT: placeholder1" >>%t && echo "MIDDLE: placeholder2" >>%t && echo "TRAILING: placeholder3" >>%t && \
+; RUN: %ProtectFileCheckOutput not FileCheck --strict-whitespace --check-prefixes LEADING,MIDDLE,TRAILING --dump-input=never --input-file  %t %t 2>&1 | \
+; RUN: FileCheck --check-prefix TEST3 %s
+
+; Test all given prefixes being NOT strings
+; RUN: rm -f %t && \
+; RUN: echo "LEADING-NOT: placeholder1" >>%t && echo "MIDDLE-NOT: placeholder2" >>%t && echo "TRAILING-NOT: placeholder3" >>%t && \
+; RUN: %ProtectFileCheckOutput not FileCheck --strict-whitespace --check-prefixes LEADING,MIDDLE,TRAILING --dump-input=never --input-file  %t %t 2>&1 | \
+; RUN: FileCheck --check-prefix TEST4 %s
+
+; TEST1:           error: MIDDLE-NOT: excluded string found in input
+; TEST1-NEXT:      MIDDLE-NOT: placeholder2
+; TEST1-NEXT: {{^}}            ^{{$}}
+; TEST1-NEXT:      note: found here
+; TEST1-NEXT:      MIDDLE-NOT: placeholder2
+; TEST1-NEXT: {{^}}            ^~~~~~~~~~~~{{$}}
+; TEST1-NEXT:      error: TRAILING-NOT: excluded string found in input
+; TEST1-NEXT:      TRAILING-NOT: placeholder3
+; TEST1-NEXT: {{^}}              ^{{$}}
+; TEST1-NEXT:      note: found here
+; TEST1-NEXT:      TRAILING-NOT: placeholder3
+; TEST1-NEXT: {{^}}              ^~~~~~~~~~~~{{$}}
+
+; TEST2:           error: MIDDLE-NOT: excluded string found in input
+; TEST2-NEXT:      MIDDLE-NOT: placeholder2
+; TEST2-NEXT: {{^}}            ^{{$}}
+; TEST2-NEXT:      note: found here
+; TEST2-NEXT:      MIDDLE-NOT: placeholder2
+; TEST2-NEXT: {{^}}            ^~~~~~~~~~~~{{$}}
+
+; TEST3:           error: LEADING-NOT: excluded string found in input
+; TEST3-NEXT:      LEADING-NOT: placeholder1
+; TEST3-NEXT: {{^}}            ^{{$}}
+; TEST3-NEXT:      note: found here
+; TEST3-NEXT:      LEADING-NOT: placeholder1
+; TEST3-NEXT: {{^}}            ^~~~~~~~~~~~{{$}}
+
+; TEST4:           error: LEADING-NOT: excluded string found in input
+; TEST4-NEXT:      LEADING-NOT: placeholder1
+; TEST4-NEXT: {{^}}            ^{{$}}
+; TEST4-NEXT:      note: found here
+; TEST4-NEXT:      LEADING-NOT: placeholder1
+; TEST4-NEXT: {{^}}            ^~~~~~~~~~~~{{$}}
+; TEST4-NEXT:      error: MIDDLE-NOT: excluded string found in input
+; TEST4-NEXT:      MIDDLE-NOT: placeholder2
+; TEST4-NEXT: {{^}}            ^{{$}}
+; TEST4-NEXT:      note: found here
+; TEST4-NEXT:      MIDDLE-NOT: placeholder2
+; TEST4-NEXT: {{^}}            ^~~~~~~~~~~~{{$}}
+; TEST4-NEXT:      error: TRAILING-NOT: excluded string found in input
+; TEST4-NEXT:      TRAILING-NOT: placeholder3
+; TEST4-NEXT: {{^}}              ^{{$}}
+; TEST4-NEXT:      note: found here
+; TEST4-NEXT:      TRAILING-NOT: placeholder3
+; TEST4-NEXT: {{^}}              ^~~~~~~~~~~~{{$}}

--- a/llvm/test/FileCheck/dump-input/annotations.txt
+++ b/llvm/test/FileCheck/dump-input/annotations.txt
@@ -650,7 +650,7 @@
 ; RUN:             -implicit-check-not='{{remark:|error:}}'
 
 ; Verbose diagnostics are suppressed but not errors.
-; IMPNOT:{{.*}}command line:1:22: error: CHECK-NOT: excluded string found in input
+; IMPNOT:{{.*}}command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 
 ;         IMPNOT:<<<<<<
 ;    IMPNOT-NEXT:            1: hello world again! 

--- a/llvm/test/FileCheck/implicit-check-not.txt
+++ b/llvm/test/FileCheck/implicit-check-not.txt
@@ -21,26 +21,26 @@
 
 warning: aaa
 ; CHECK-PASS: warning: aaa
-; CHECK-ERROR1: command line:1:22: error: CHECK-FAIL1-NOT: excluded string found in input
+; CHECK-ERROR1: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR1-NEXT: -implicit-check-not='warning:'
 ; CHECK-ERROR1: note: found here
 ; CHECK-FAIL2: warning: aaa
 ; CHECK-FAIL3: warning: aaa
-; CHECK-ERROR4: command line:1:22: error: CHECK-FAIL1-NOT: excluded string found in input
+; CHECK-ERROR4: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR4-NEXT: {{-implicit-check-not='\{\{aaa\|bbb\|ccc\}\}'}}
 ; CHECK-ERROR4: note: found here
-; CHECK-ERROR5: command line:1:22: error: CHECK-FAIL1-NOT: excluded string found in input
+; CHECK-ERROR5: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR5-NEXT: -implicit-check-not='aaa'
 ; CHECK-ERROR5: note: found here
 
 warning: bbb
 ; CHECK-PASS: warning: bbb
 ; CHECK-FAIL1: warning: bbb
-; CHECK-ERROR2: command line:1:22: error: CHECK-FAIL2-NOT: excluded string found in input
+; CHECK-ERROR2: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR2-NEXT: -implicit-check-not='warning:'
 ; CHECK-ERROR2: note: found here
 ; CHECK-FAIL3: warning: bbb
-; CHECK-ERROR6: command line:1:22: error: CHECK-FAIL2-NOT: excluded string found in input
+; CHECK-ERROR6: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR6-NEXT: -implicit-check-not='bbb'
 ; CHECK-ERROR6: note: found here
 
@@ -48,9 +48,9 @@ warning: ccc
 ; CHECK-PASS: warning: ccc
 ; CHECK-FAIL1: warning: ccc
 ; CHECK-FAIL2: warning: ccc
-; CHECK-ERROR3: command line:1:22: error: CHECK-FAIL3-NOT: excluded string found in input
+; CHECK-ERROR3: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR3-NEXT: -implicit-check-not='warning:'
 ; CHECK-ERROR3: note: found here
-; CHECK-ERROR7: command line:1:22: error: CHECK-FAIL3-NOT: excluded string found in input
+; CHECK-ERROR7: command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 ; CHECK-ERROR7-NEXT: -implicit-check-not='ccc'
 ; CHECK-ERROR7: note: found here


### PR DESCRIPTION
Fixes #70221 

Fix a bug in FileCheck that corrects the error message when multiple prefixes are provided
through --check-prefixes and one of them is a PREFIX-NOT.

Earlier, only the first of the provided prefixes was displayed as the erroneous prefix, while the
actual error might be on the prefix that occurred at the end of the prefix list in the input file.

Now, the right NOT prefix is shown in the error message.