### PR TITLE
[mlir][ArmSME][nfc] Add custom CMake targets to group tests

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -215,7 +215,8 @@ add_lit_testsuites(MLIR ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}
 )
 
-# Convenience targets to group related tests.
+# Convenience targets to group related tests. To find targets use
+# 'ninja -t targets'.
 
 # Run all ArmSME unit tests.
 add_custom_target(check-mlir-unit-armsme DEPENDS

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -214,3 +214,26 @@ set_target_properties(check-mlir PROPERTIES FOLDER "Tests")
 add_lit_testsuites(MLIR ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}
 )
+
+# Convenience targets to group related tests.
+
+# Run all ArmSME unit tests.
+add_custom_target(check-mlir-unit-armsme DEPENDS
+  check-mlir-dialect-armsme
+  check-mlir-dialect-llvmir
+  check-mlir-conversion-armsmetollvm
+  check-mlir-conversion-armsmetoscf
+  check-mlir-conversion-vectortoarmsme
+)
+
+# Run all ArmSME integration tests.
+add_custom_target(check-mlir-integration-armsme DEPENDS
+  check-mlir-integration-dialect-linalg-cpu-armsme
+  check-mlir-integration-dialect-vector-cpu-armsme
+)
+
+# Run all ArmSME tests.
+add_custom_target(check-mlir-armsme DEPENDS
+  check-mlir-unit-armsme
+  check-mlir-integration-armsme
+)


### PR DESCRIPTION
These targets conveniently group ArmSME related tests and can be used as follows:

  ninja check-mlir-unit-armsme        # unit only
  ninja check-mlir-integration-armsme # integration only
  ninja check-mlir-armsme             # all