### PR TITLE
[llvm-readobj] enable demangle option for the xcoff object file

### DIFF
--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -61,6 +61,16 @@ file formats.
   Dump decompressed section content when used with ``-x`` or ``-p``.
   If the section(s) are not compressed, they are displayed as is.
 
+.. option:: --demangle, -C
+
+ Display demangled symbol names in the output; the option only is for ELF and
+ XCOFF file format.
+
+.. option:: --no-demangle (default)
+
+ Not demangle symbol names in the output; the option only is for ELF and
+ XCOFF file format.
+
 .. option:: --expand-relocs
 
  When used with :option:`--relocs`, display each relocation in an expanded

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -101,7 +101,7 @@ file formats.
 
 .. option:: --no-demangle
 
- Not demangle symbol names in the output; the option only is for ELF and
+ Not demangle symbol names in the output; the option is only for ELF and
  XCOFF file format. The option is enabled by default.
 
 .. option:: --relocations, --relocs, -r

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -66,11 +66,6 @@ file formats.
  Display demangled symbol names in the output; the option only is for ELF and
  XCOFF file format.
 
-.. option:: --no-demangle (default)
-
- Not demangle symbol names in the output; the option only is for ELF and
- XCOFF file format.
-
 .. option:: --expand-relocs
 
  When used with :option:`--relocs`, display each relocation in an expanded
@@ -103,6 +98,11 @@ file formats.
 .. option:: --needed-libs
 
  Display the needed libraries.
+
+.. option:: --no-demangle
+
+ Not demangle symbol names in the output; the option only is for ELF and
+ XCOFF file format. The option is enabled by default.
 
 .. option:: --relocations, --relocs, -r
 

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -63,8 +63,8 @@ file formats.
 
 .. option:: --demangle, -C
 
- Display demangled symbol names in the output; the option only is for ELF and
- XCOFF file format.
+ Display demangled symbol names in the output. This option is only for ELF and
+ XCOFF file formats.
 
 .. option:: --expand-relocs
 

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -101,8 +101,8 @@ file formats.
 
 .. option:: --no-demangle
 
- Not demangle symbol names in the output; the option is only for ELF and
- XCOFF file format. The option is enabled by default.
+ Do not demangle symbol names in the output. This option is only for ELF and
+ XCOFF file formats. The option is enabled by default.
 
 .. option:: --relocations, --relocs, -r
 

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -185,10 +185,6 @@ The following options are implemented only for the ELF file format.
 
  Requires :option:`--bb-addr-map` to have an effect.
 
-.. option:: --demangle, -C
-
- Display demangled symbol names in the output.
-
 .. option:: --dependent-libraries
 
  Display the dependent libraries section.

--- a/llvm/test/tools/llvm-readobj/XCOFF/loader-section-relocation.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/loader-section-relocation.test
@@ -2,18 +2,27 @@
 
 # RUN: yaml2obj --docnum=1 %s -o %t_xcoff32.o
 # RUN: yaml2obj --docnum=2  %s -o %t_xcoff64.o
-# RUN: llvm-readobj --loader-section-relocations --expand-relocs %t_xcoff32.o | FileCheck --check-prefixes=COMMON,EXPAND %s
-# RUN: llvm-readobj --loader-section-relocations --expand-relocs %t_xcoff64.o | FileCheck --check-prefixes=COMMON,EXPAND %s
-# RUN: llvm-readobj --loader-section-relocations %t_xcoff32.o | FileCheck --check-prefixes=COMMON,NOEXPAND32 %s
-# RUN: llvm-readobj --loader-section-relocations %t_xcoff64.o | FileCheck --check-prefixes=COMMON,NOEXPAND64 %s
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs %t_xcoff32.o | FileCheck --check-prefixes=COMMON,EXPAND,NODEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs %t_xcoff64.o | FileCheck --check-prefixes=COMMON,EXPAND,NODEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations %t_xcoff32.o | FileCheck --check-prefixes=COMMON,NOEXPAND32,NODEMAN32 %s
+# RUN: llvm-readobj --loader-section-relocations %t_xcoff64.o | FileCheck --check-prefixes=COMMON,NOEXPAND64,NODEMAN64 %s
 
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs --no-demangle %t_xcoff32.o | FileCheck --check-prefixes=COMMON,EXPAND,NODEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs --no-demangle %t_xcoff64.o | FileCheck --check-prefixes=COMMON,EXPAND,NODEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations --no-demangle %t_xcoff32.o | FileCheck --check-prefixes=COMMON,NOEXPAND32,NODEMAN32 %s
+# RUN: llvm-readobj --loader-section-relocations --no-demangle %t_xcoff64.o | FileCheck --check-prefixes=COMMON,NOEXPAND64,NODEMAN64 %s
+
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs --demangle %t_xcoff32.o | FileCheck --check-prefixes=COMMON,EXPAND,DEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations --expand-relocs --demangle %t_xcoff64.o | FileCheck --check-prefixes=COMMON,EXPAND,DEMANEXP %s
+# RUN: llvm-readobj --loader-section-relocations --demangle %t_xcoff32.o | FileCheck --check-prefixes=COMMON,NOEXPAND32,DEMAN32 %s
+# RUN: llvm-readobj --loader-section-relocations --demangle %t_xcoff64.o | FileCheck --check-prefixes=COMMON,NOEXPAND64,DEMAN64 %s
 --- !XCOFF
 FileHeader:
   MagicNumber:       0x1DF
 Sections:
   - Name:            .loader
     Flags:           [ STYP_LOADER ]
-    SectionData:     "0000000100000001000000020000016D00000001000000A400000000000000506d79696e747661722000028000021105000000000000000020000294000000011f0000022000029c000000031f000002"
+    SectionData:     "0000000100000001000000020000016D00000001000000A400000000000000505f5a3466756e63762000028000021105000000000000000020000294000000011f0000022000029c000000031f000002"
 ##                    ^-------                                                           -Version=1
 ##                            ^-------                                                   -NumberOfSymbolEntries=1
 ##                                    ^-------                                           -NumberOfRelocationEntries=2
@@ -22,7 +31,7 @@ Sections:
 ##                                                            ^-------                   -OffsetToImportFileIDs=0xA4
 ##                                                                    ^-------           -LengthOfStringTable=0
 ##                                                                            ^-------   -OffsetToStringTable=0
-##                                                                                    ^---------------         SymbolName=myintvar
+##                                                                                    ^---------------         SymbolName=_Z4funcv
 ##                                                                                                    ^------- Value=0x20000280
 ##                                                                                                            ^---  sectionNumber = 2
 ##                                                                                                                ^- SymbolType=0x11
@@ -44,7 +53,7 @@ FileHeader:
 Sections:
   - Name:            .loader
     Flags:           [ STYP_LOADER ]
-    SectionData:     "0000000200000001000000020000016D000000010000001200000000000000D000000000000000700000000000000038000000000000005000000001100003000000000200021105000000000000000000000000200002941f00000200000001000000002000029C1f0000020000000300096d79696e747661720000"
+    SectionData:     "0000000200000001000000020000016D000000010000001200000000000000D000000000000000700000000000000038000000000000005000000001100003000000000200021105000000000000000000000000200002941f00000200000001000000002000029C1f0000020000000300095f5a3466756e63760000"
 ##                    ^-------                                                           -Version=2
 ##                            ^-------                                                   -NumberOfSymbolEntries=1
 ##                                    ^-------                                           -NumberOfRelocationEntries=2
@@ -76,10 +85,12 @@ Sections:
 # COMMON-NEXT:     Loader Section Relocations {
 # NOEXPAND64-NEXT:           Vaddr            Type        SecNum  SymbolName (Index)
 # NOEXPAND64-NEXT:     0x0000000020000294 0x1f00 (R_POS)       2    .data (1)
-# NOEXPAND64-NEXT:     0x000000002000029c 0x1f00 (R_POS)       2    myintvar (3)
+# NODEMAN64-NEXT:      0x000000002000029c 0x1f00 (R_POS)       2    _Z4funcv (3)
+# DEMAN64-NEXT:        0x000000002000029c 0x1f00 (R_POS)       2    func() (3)
 # NOEXPAND32-NEXT:        Vaddr        Type        SecNum  SymbolName (Index)
 # NOEXPAND32-NEXT:      0x20000294 0x1f00 (R_POS)       2    .data (1)
-# NOEXPAND32-NEXT:      0x2000029c 0x1f00 (R_POS)       2    myintvar (3)
+# NODEMAN32-NEXT:       0x2000029c 0x1f00 (R_POS)       2    _Z4funcv (3)
+# DEMAN32-NEXT:         0x2000029c 0x1f00 (R_POS)       2    func() (3)
 # EXPAND-NEXT:       Relocation {
 # EXPAND-NEXT:         Virtual Address: 0x20000294
 # EXPAND-NEXT:         Symbol: .data (1)
@@ -91,7 +102,8 @@ Sections:
 # EXPAND-NEXT:       }
 # EXPAND-NEXT:       Relocation {
 # EXPAND-NEXT:         Virtual Address: 0x2000029C
-# EXPAND-NEXT:         Symbol: myintvar (3)
+# NODEMANEXP-NEXT:     Symbol: _Z4funcv (3)
+# DEMANEXP-NEXT:       Symbol: func() (3)
 # EXPAND-NEXT:         IsSigned: No
 # EXPAND-NEXT:         FixupBitValue: 0
 # EXPAND-NEXT:         Length: 32

--- a/llvm/test/tools/llvm-readobj/XCOFF/loader-section-symbol.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/loader-section-symbol.test
@@ -6,10 +6,18 @@
 
 # RUN: llvm-readobj --loader-section-symbols %t_xcoff32.o |\
 # RUN:   FileCheck %s --check-prefixes=CHECK32
+# RUN: llvm-readobj --loader-section-symbols --no-demangle %t_xcoff32.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK32
+# RUN: llvm-readobj --loader-section-symbols --demangle %t_xcoff32.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK32
 # RUN: llvm-readobj --loader-section-symbols %t_xcoff32_invalid.o 2>&1 |\
 # RUN:   FileCheck -DFILE=%t_xcoff32_invalid.o %s --check-prefixes=CHECK32,WARN
 # RUN: llvm-readobj --loader-section-symbols %t_xcoff64.o |\
-# RUN:   FileCheck %s --check-prefixes=CHECK64
+# RUN:   FileCheck %s --check-prefixes=CHECK64,NODEMAN64
+# RUN: llvm-readobj --loader-section-symbols --no-demangle %t_xcoff64.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK64,NODEMAN64
+# RUN: llvm-readobj --loader-section-symbols --demangle %t_xcoff64.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK64,DEMAN64
 
 --- !XCOFF
 FileHeader:
@@ -112,7 +120,8 @@ Sections:
 # CHECK64-NEXT:         ParameterTypeCheck: 0
 # CHECK64-NEXT:       }
 # CHECK64-NEXT:       Symbol {
-# CHECK64-NEXT:         Name: _Z5func0v
+# NODEMAN64-NEXT:       Name: _Z5func0v
+# DEMAN64-NEXT:         Name: func0()
 # CHECK64-NEXT:         Virtual Address: 0x110000308
 # CHECK64-NEXT:         SectionNum: 2
 # CHECK64-NEXT:         SymbolType: 0x11

--- a/llvm/test/tools/llvm-readobj/XCOFF/relocations.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/relocations.test
@@ -2,9 +2,19 @@
 
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-readobj --relocs --expand-relocs %t | \
-# RUN:   FileCheck %s --strict-whitespace --match-full-lines --check-prefix=RELOCSEXP
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCSEXP,NODEMANEXP
 # RUN: llvm-readobj --relocs %t | \
-# RUN:   FileCheck %s --strict-whitespace --match-full-lines --check-prefix=RELOCS
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCS,NODEMAN
+
+# RUN: llvm-readobj --relocs --expand-relocs --no-demangle %t | \
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCSEXP,NODEMANEXP
+# RUN: llvm-readobj --relocs --no-demangle %t | \
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCS,NODEMAN
+
+# RUN: llvm-readobj --relocs --expand-relocs --demangle %t | \
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCSEXP,DEMANEXP
+# RUN: llvm-readobj --relocs --demangle %t | \
+# RUN:   FileCheck %s --strict-whitespace --check-prefixes=RELOCS,DEMAN
 
 #      RELOCSEXP:Relocations [
 # RELOCSEXP-NEXT:  Section (index: 1) .text {
@@ -28,7 +38,8 @@
 # RELOCSEXP-NEXT:  Section (index: 2) .data {
 # RELOCSEXP-NEXT:    Relocation {
 # RELOCSEXP-NEXT:      Virtual Address: 0x200
-# RELOCSEXP-NEXT:      Symbol: bar (1)
+# NODEMANEXP-NEXT:     Symbol: _Z3fwpv (1)
+# DEMANEXP-NEXT:       Symbol: fwp() (1)
 # RELOCSEXP-NEXT:      IsSigned: No
 # RELOCSEXP-NEXT:      FixupBitValue: 0
 # RELOCSEXP-NEXT:      Length: 20
@@ -43,7 +54,8 @@
 # RELOCS-NEXT:    0x100 R_REL foo(0) 0x14
 # RELOCS-NEXT:  }
 # RELOCS-NEXT:  Section (index: 2) .data {
-# RELOCS-NEXT:    0x200 R_TOC bar(1) 0x13
+# NODEMAN-NEXT:  0x200 R_TOC _Z3fwpv(1) 0x13
+# DEMAN-NEXT:    0x200 R_TOC fwp()(1) 0x13
 # RELOCS-NEXT:  }
 # RELOCS-NEXT:]
 
@@ -73,6 +85,6 @@ Symbols:
   - Name:    foo
     Value:   0x0
     Section: .text
-  - Name:    bar
+  - Name:    _Z3fwpv
     Value:   0x80
     Section: .data

--- a/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
@@ -2,7 +2,9 @@
 ## 32-bit XCOFF object file.
 
 # RUN: yaml2obj %s -o %t
-# RUN: llvm-readobj --symbols %t | FileCheck --check-prefix=SYMBOL32 %s
+# RUN: llvm-readobj --symbols %t | FileCheck --check-prefixes=SYMBOL32,NODEMANGLE %s
+# RUN: llvm-readobj --symbols --no-demangle %t | FileCheck --check-prefixes=SYMBOL32,NODEMANGLE %s
+# RUN: llvm-readobj --symbols --demangle %t | FileCheck --check-prefixes=SYMBOL32,DEMANGLE %s
 
 --- !XCOFF
 FileHeader:
@@ -56,7 +58,7 @@ Symbols:
         StabInfoIndex:          5
         StabSectNum:            6
 ## The C_EXT symbol with a CSECT auxiliary entry.
-  - Name:               .fun1
+  - Name:               ._Z5func1i
     Value:              0x0
     Section:            .text
     Type:               0x20
@@ -224,7 +226,8 @@ Symbols:
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
 # SYMBOL32-NEXT:     Index: 8
-# SYMBOL32-NEXT:     Name: .fun1
+# NODEMANGLE-NEXT:   Name: ._Z5func1i
+# DEMANGLE-NEXT:     Name: .func1(int)
 # SYMBOL32-NEXT:     Value (RelocatableAddress): 0x0
 # SYMBOL32-NEXT:     Section: .text
 # SYMBOL32-NEXT:     Type: 0x20


### PR DESCRIPTION
 enable `--demangle` option for the xcoff object file for llvm-readobj