### PR TITLE
[formatv][FmtAlign] Use fill count of type size_t instead of uint32_t

### DIFF
--- a/llvm/include/llvm/Support/FormatCommon.h
+++ b/llvm/include/llvm/Support/FormatCommon.h
@@ -66,8 +66,8 @@ struct FmtAlign {
   }
 
 private:
-  void fill(llvm::raw_ostream &S, uint32_t Count) {
-    for (uint32_t I = 0; I < Count; ++I)
+  void fill(llvm::raw_ostream &S, size_t Count) {
+    for (size_t I = 0; I < Count; ++I)
       S << Fill;
   }
 };


### PR DESCRIPTION
FmtAlign::fill() accepts a uint32_t variable while the usages operate on size_t values. On some platform / compiler combinations, this ends up being a narrowing conversion. Fix this by changing the function's signature.