### PR TITLE
[clangd] Don't collect templated decls for builtin templates

### DIFF
--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -444,14 +444,15 @@ public:
           // Don't *traverse* the alias, which would result in traversing the
           // template of the underlying type.
 
+          TemplateDecl *TD = TST->getTemplateName().getAsTemplateDecl();
           // Builtin templates e.g. __make_integer_seq, __type_pack_element
           // are such that they don't have alias *decls*. Even then, we still
           // traverse their desugared *types* so that instantiated decls are
           // collected.
-          if (NamedDecl *D = TST->getTemplateName()
-                                 .getAsTemplateDecl()
-                                 ->getTemplatedDecl())
-            Outer.report(D, Flags | Rel::Alias | Rel::TemplatePattern);
+          if (llvm::isa<BuiltinTemplateDecl>(TD))
+            return;
+          Outer.report(TD->getTemplatedDecl(),
+                       Flags | Rel::Alias | Rel::TemplatePattern);
         }
         // specializations of template template parameters aren't instantiated
         // into decls, so they must refer to the parameter itself.

--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -443,9 +443,15 @@ public:
           Outer.add(TST->getAliasedType(), Flags | Rel::Underlying);
           // Don't *traverse* the alias, which would result in traversing the
           // template of the underlying type.
-          Outer.report(
-              TST->getTemplateName().getAsTemplateDecl()->getTemplatedDecl(),
-              Flags | Rel::Alias | Rel::TemplatePattern);
+
+          // Builtin templates e.g. __make_integer_seq, __type_pack_element
+          // are such that they don't have alias *decls*. Even then, we still
+          // traverse their desugared *types* so that instantiated decls are
+          // collected.
+          if (NamedDecl *D = TST->getTemplateName()
+                                 .getAsTemplateDecl()
+                                 ->getTemplatedDecl())
+            Outer.report(D, Flags | Rel::Alias | Rel::TemplatePattern);
         }
         // specializations of template template parameters aren't instantiated
         // into decls, so they must refer to the parameter itself.


### PR DESCRIPTION
Builtin templates e.g. `__make_integer_seq`, `__type_pack_element` are such that they don't have alias *Decls*. [D133262](https://reviews.llvm.org/D133262) marked these as alias templates, resulting in an attempt to collect their null "using" Decls within our `TargetFinder`.

This fixes https://github.com/clangd/clangd/issues/1906.