### PR TITLE
[UnrollAnalyzerTest] Remove dependency to pass managers

### DIFF
--- a/llvm/unittests/Analysis/UnrollAnalyzerTest.cpp
+++ b/llvm/unittests/Analysis/UnrollAnalyzerTest.cpp
@@ -6,60 +6,51 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/LoopUnrollAnalyzer.h"
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Dominators.h"
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/InitializePasses.h"
 #include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
 namespace llvm {
-void initializeUnrollAnalyzerTestPass(PassRegistry &);
 
 static SmallVector<DenseMap<Value *, Value *>, 16> SimplifiedValuesVector;
 static unsigned TripCount = 0;
 
-namespace {
-struct UnrollAnalyzerTest : public FunctionPass {
-  static char ID;
-  bool runOnFunction(Function &F) override {
-    LoopInfo *LI = &getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
-    ScalarEvolution *SE = &getAnalysis<ScalarEvolutionWrapperPass>().getSE();
+/// Build loop info and scalar evolution for the function and run the analysis.
+static void runUnrollAnalyzer(Module &M, StringRef FuncName) {
+  auto *F = M.getFunction(FuncName);
+  ASSERT_NE(F, nullptr) << "Could not find " << FuncName;
 
-    Function::iterator FI = F.begin();
-    FI++; // First basic block is entry - skip it.
-    BasicBlock *Header = &*FI++;
-    Loop *L = LI->getLoopFor(Header);
-    BasicBlock *Exiting = L->getExitingBlock();
+  TargetLibraryInfoImpl TLII;
+  TargetLibraryInfo TLI(TLII);
+  AssumptionCache AC(*F);
+  DominatorTree DT(*F);
+  LoopInfo LI(DT);
+  ScalarEvolution SE(*F, TLI, AC, DT, LI);
 
-    SimplifiedValuesVector.clear();
-    TripCount = SE->getSmallConstantTripCount(L, Exiting);
-    for (unsigned Iteration = 0; Iteration < TripCount; Iteration++) {
-      DenseMap<Value *, Value *> SimplifiedValues;
-      UnrolledInstAnalyzer Analyzer(Iteration, SimplifiedValues, *SE, L);
-      for (auto *BB : L->getBlocks())
-        for (Instruction &I : *BB)
-          Analyzer.visit(I);
-      SimplifiedValuesVector.push_back(SimplifiedValues);
-    }
-    return false;
+  Function::iterator FI = F->begin();
+  FI++; // First basic block is entry - skip it.
+  BasicBlock *Header = &*FI++;
+  Loop *L = LI.getLoopFor(Header);
+  BasicBlock *Exiting = L->getExitingBlock();
+
+  SimplifiedValuesVector.clear();
+  TripCount = SE.getSmallConstantTripCount(L, Exiting);
+  for (unsigned Iteration = 0; Iteration < TripCount; Iteration++) {
+    DenseMap<Value *, Value *> SimplifiedValues;
+    UnrolledInstAnalyzer Analyzer(Iteration, SimplifiedValues, SE, L);
+    for (auto *BB : L->getBlocks())
+      for (Instruction &I : *BB)
+        Analyzer.visit(I);
+    SimplifiedValuesVector.push_back(SimplifiedValues);
   }
-  void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<DominatorTreeWrapperPass>();
-    AU.addRequired<LoopInfoWrapperPass>();
-    AU.addRequired<ScalarEvolutionWrapperPass>();
-    AU.setPreservesAll();
-  }
-  UnrollAnalyzerTest() : FunctionPass(ID) {
-    initializeUnrollAnalyzerTestPass(*PassRegistry::getPassRegistry());
-  }
-};
 }
-
-char UnrollAnalyzerTest::ID = 0;
 
 std::unique_ptr<Module> makeLLVMModule(LLVMContext &Context,
                                        const char *ModuleStr) {
@@ -85,12 +76,9 @@ TEST(UnrollAnalyzerTest, BasicSimplifications) {
       "  %x.lcssa = phi i64 [ %x2, %loop ]\n"
       "  ret i64 %x.lcssa\n"
       "}\n";
-  UnrollAnalyzerTest *P = new UnrollAnalyzerTest();
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleStr);
-  legacy::PassManager Passes;
-  Passes.add(P);
-  Passes.run(*M);
+  runUnrollAnalyzer(*M, "propagate_loop_phis");
 
   // Perform checks
   Module::iterator MI = M->begin();
@@ -148,12 +136,9 @@ TEST(UnrollAnalyzerTest, OuterLoopSimplification) {
       "  ret void\n"
       "}\n";
 
-  UnrollAnalyzerTest *P = new UnrollAnalyzerTest();
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleStr);
-  legacy::PassManager Passes;
-  Passes.add(P);
-  Passes.run(*M);
+  runUnrollAnalyzer(*M, "foo");
 
   Module::iterator MI = M->begin();
   Function *F = &*MI++;
@@ -177,6 +162,7 @@ TEST(UnrollAnalyzerTest, OuterLoopSimplification) {
   auto I2 = SimplifiedValuesVector[0].find(Y2);
   EXPECT_TRUE(I2 == SimplifiedValuesVector[0].end());
 }
+
 TEST(UnrollAnalyzerTest, CmpSimplifications) {
   const char *ModuleStr =
       "target datalayout = \"e-m:o-i64:64-f80:128-n8:16:32:64-S128\"\n"
@@ -193,12 +179,9 @@ TEST(UnrollAnalyzerTest, CmpSimplifications) {
       "for.end:\n"
       "  ret void\n"
       "}\n";
-  UnrollAnalyzerTest *P = new UnrollAnalyzerTest();
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleStr);
-  legacy::PassManager Passes;
-  Passes.add(P);
-  Passes.run(*M);
+  runUnrollAnalyzer(*M, "branch_iv_trunc");
 
   // Perform checks
   Module::iterator MI = M->begin();
@@ -221,6 +204,7 @@ TEST(UnrollAnalyzerTest, CmpSimplifications) {
   EXPECT_TRUE(I2 != SimplifiedValuesVector[5].end());
   EXPECT_EQ(cast<ConstantInt>((*I2).second)->getZExtValue(), 1U);
 }
+
 TEST(UnrollAnalyzerTest, PtrCmpSimplifications) {
   const char *ModuleStr =
       "target datalayout = \"e-m:o-i64:64-f80:128-n8:16:32:64-S128\"\n"
@@ -240,12 +224,9 @@ TEST(UnrollAnalyzerTest, PtrCmpSimplifications) {
       "loop.exit:\n"
       "  ret void\n"
       "}\n";
-  UnrollAnalyzerTest *P = new UnrollAnalyzerTest();
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleStr);
-  legacy::PassManager Passes;
-  Passes.add(P);
-  Passes.run(*M);
+  runUnrollAnalyzer(*M, "ptr_cmp");
 
   // Perform checks
   Module::iterator MI = M->begin();
@@ -263,6 +244,7 @@ TEST(UnrollAnalyzerTest, PtrCmpSimplifications) {
   EXPECT_TRUE(I1 != SimplifiedValuesVector[5].end());
   EXPECT_EQ(cast<ConstantInt>((*I1).second)->getZExtValue(), 0U);
 }
+
 TEST(UnrollAnalyzerTest, CastSimplifications) {
   const char *ModuleStr =
       "target datalayout = \"e-m:o-i64:64-f80:128-n8:16:32:64-S128\"\n"
@@ -286,12 +268,9 @@ TEST(UnrollAnalyzerTest, CastSimplifications) {
       "  ret void\n"
       "}\n";
 
-  UnrollAnalyzerTest *P = new UnrollAnalyzerTest();
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleStr);
-  legacy::PassManager Passes;
-  Passes.add(P);
-  Passes.run(*M);
+  runUnrollAnalyzer(*M, "const_load_cast");
 
   // Perform checks
   Module::iterator MI = M->begin();
@@ -321,11 +300,3 @@ TEST(UnrollAnalyzerTest, CastSimplifications) {
 }
 
 } // end namespace llvm
-
-INITIALIZE_PASS_BEGIN(UnrollAnalyzerTest, "unrollanalyzertestpass",
-                      "unrollanalyzertestpass", false, false)
-INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(ScalarEvolutionWrapperPass)
-INITIALIZE_PASS_END(UnrollAnalyzerTest, "unrollanalyzertestpass",
-                    "unrollanalyzertestpass", false, false)


### PR DESCRIPTION
Remove use of LegacyPassManager in the UnrollAnalyzerTest unit test.

Given that the goal isn't to test pass manager interfaces, and since the LoopUnrollAnalyzer isn't even implemented as a pass, we do not really need the complexity of using a pass manager. Instead we just make sure that we run LoopUnrollAnalyzer and other needed analyses standalone (without any pass manager). This was inspired by the LoopInfoTest unit test.