### PR TITLE
[libc++][NFC] Centralize test for support of == and != in ranges

### DIFF
--- a/libcxx/test/std/ranges/range.adaptors/range.elements/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.elements/iterator/compare.pass.cpp
@@ -140,7 +140,7 @@ constexpr bool test() {
     auto it = ev.begin();
 
     using ElemIter = decltype(it);
-    static_assert(!weakly_equality_comparable_with<ElemIter>);
+    static_assert(!weakly_equality_comparable_with<ElemIter, ElemIter>);
     inequalityOperatorsDoNotExistTest(it, it);
   }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.elements/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.elements/iterator/compare.pass.cpp
@@ -27,6 +27,7 @@
 #include <tuple>
 
 #include "test_iterators.h"
+#include "test_range.h"
 
 constexpr void compareOperatorTest(const auto& iter1, const auto& iter2) {
   assert(!(iter1 < iter1));
@@ -139,8 +140,7 @@ constexpr bool test() {
     auto it = ev.begin();
 
     using ElemIter = decltype(it);
-    static_assert(!std::invocable<std::equal_to<>, ElemIter, ElemIter>);
-    static_assert(!std::invocable<std::not_equal_to<>, ElemIter, ElemIter>);
+    static_assert(!weakly_equality_comparable_with<ElemIter>);
     inequalityOperatorsDoNotExistTest(it, it);
   }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
@@ -80,8 +80,8 @@ static_assert(!weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, 
 static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<R, 0>>, //
                                               sentinel_t<const elements_view<R, 0>>>);
 
-static_assert(weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
-                                              sentinel_t<elements_view<R, 0>>>);
+static_assert(weakly_equality_comparable_with<iterator_t<elements_view<CrossComparableR, 0>>, //
+                                              sentinel_t<elements_view<CrossComparableR, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<CrossComparableR, 0>>, //
                                               sentinel_t<elements_view<CrossComparableR, 0>>>);

--- a/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
@@ -17,6 +17,7 @@
 #include <ranges>
 
 #include "../types.h"
+#include "test_range.h"
 
 template <bool Const>
 struct Iter {
@@ -63,36 +64,32 @@ struct Range : TupleBufferView {
 using R                = Range<Sent>;
 using CrossComparableR = Range<CrossComparableSent>;
 
-// Test Constraint
-template <class I, class S>
-concept HasEqual = requires(const I i, const S s) { i == s; };
-
 using std::ranges::elements_view;
 using std::ranges::iterator_t;
 using std::ranges::sentinel_t;
 
-static_assert(HasEqual<iterator_t<elements_view<R, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
                        sentinel_t<elements_view<R, 0>>>);
 
-static_assert(!HasEqual<iterator_t<const elements_view<R, 0>>, //
+static_assert(!weakly_equality_comparable_with<iterator_t<const elements_view<R, 0>>, //
                         sentinel_t<elements_view<R, 0>>>);
 
-static_assert(!HasEqual<iterator_t<elements_view<R, 0>>, //
+static_assert(!weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
                         sentinel_t<const elements_view<R, 0>>>);
 
-static_assert(HasEqual<iterator_t<const elements_view<R, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<R, 0>>, //
                        sentinel_t<const elements_view<R, 0>>>);
 
-static_assert(HasEqual<iterator_t<elements_view<R, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
                        sentinel_t<elements_view<R, 0>>>);
 
-static_assert(HasEqual<iterator_t<const elements_view<CrossComparableR, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<CrossComparableR, 0>>, //
                        sentinel_t<elements_view<CrossComparableR, 0>>>);
 
-static_assert(HasEqual<iterator_t<elements_view<CrossComparableR, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<elements_view<CrossComparableR, 0>>, //
                        sentinel_t<const elements_view<CrossComparableR, 0>>>);
 
-static_assert(HasEqual<iterator_t<const elements_view<CrossComparableR, 0>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<CrossComparableR, 0>>, //
                        sentinel_t<const elements_view<CrossComparableR, 0>>>);
 
 template <class R, bool ConstIter, bool ConstSent>

--- a/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.elements/sentinel/equality.pass.cpp
@@ -69,28 +69,28 @@ using std::ranges::iterator_t;
 using std::ranges::sentinel_t;
 
 static_assert(weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
-                       sentinel_t<elements_view<R, 0>>>);
+                                              sentinel_t<elements_view<R, 0>>>);
 
 static_assert(!weakly_equality_comparable_with<iterator_t<const elements_view<R, 0>>, //
-                        sentinel_t<elements_view<R, 0>>>);
+                                               sentinel_t<elements_view<R, 0>>>);
 
 static_assert(!weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
-                        sentinel_t<const elements_view<R, 0>>>);
+                                               sentinel_t<const elements_view<R, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<R, 0>>, //
-                       sentinel_t<const elements_view<R, 0>>>);
+                                              sentinel_t<const elements_view<R, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<elements_view<R, 0>>, //
-                       sentinel_t<elements_view<R, 0>>>);
+                                              sentinel_t<elements_view<R, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<CrossComparableR, 0>>, //
-                       sentinel_t<elements_view<CrossComparableR, 0>>>);
+                                              sentinel_t<elements_view<CrossComparableR, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<elements_view<CrossComparableR, 0>>, //
-                       sentinel_t<const elements_view<CrossComparableR, 0>>>);
+                                              sentinel_t<const elements_view<CrossComparableR, 0>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const elements_view<CrossComparableR, 0>>, //
-                       sentinel_t<const elements_view<CrossComparableR, 0>>>);
+                                              sentinel_t<const elements_view<CrossComparableR, 0>>>);
 
 template <class R, bool ConstIter, bool ConstSent>
 constexpr void testOne() {

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -24,7 +24,6 @@
 
 #include "../types.h"
 
-
 template <class Iterator>
 constexpr void test() {
   using Sentinel = sentinel_wrapper<Iterator>;

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -76,7 +76,7 @@ constexpr bool tests() {
     using Sentinel = sentinel_wrapper<Iterator>;
     using FilterView = std::ranges::filter_view<minimal_view<Iterator, Sentinel>, AlwaysTrue>;
     using FilterIterator = std::ranges::iterator_t<FilterView>;
-    static_assert(!weakly_equality_comparable_with<FilterIterator>);
+    static_assert(!weakly_equality_comparable_with<FilterIterator, FilterIterator>);
   }
 
   return true;

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -17,12 +17,13 @@
 #include <cassert>
 #include <concepts>
 #include <utility>
+
 #include "test_iterators.h"
 #include "test_macros.h"
+#include "test_range.h"
+
 #include "../types.h"
 
-template <class T>
-concept has_equal = requires (T const& x, T const& y) { { x == y }; };
 
 template <class Iterator>
 constexpr void test() {
@@ -76,7 +77,7 @@ constexpr bool tests() {
     using Sentinel = sentinel_wrapper<Iterator>;
     using FilterView = std::ranges::filter_view<minimal_view<Iterator, Sentinel>, AlwaysTrue>;
     using FilterIterator = std::ranges::iterator_t<FilterView>;
-    static_assert(!has_equal<FilterIterator>);
+    static_assert(!weakly_equality_comparable_with<FilterIterator>);
   }
 
   return true;

--- a/libcxx/test/std/ranges/range.adaptors/range.join/range.join.sentinel/eq.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.join/range.join.sentinel/eq.pass.cpp
@@ -52,9 +52,9 @@ struct ConstComparableView : BufferView<BufferView<int*>*> {
 };
 
 static_assert(weakly_equality_comparable_with<std::ranges::iterator_t<ConstComparableView>,
-                                 std::ranges::sentinel_t<const ConstComparableView>>);
+                                              std::ranges::sentinel_t<const ConstComparableView>>);
 static_assert(weakly_equality_comparable_with<std::ranges::iterator_t<const ConstComparableView>,
-                                 std::ranges::sentinel_t<ConstComparableView>>);
+                                              std::ranges::sentinel_t<ConstComparableView>>);
 
 constexpr bool test() {
   int buffer[4][4] = {{1111, 2222, 3333, 4444}, {555, 666, 777, 888}, {99, 1010, 1111, 1212}, {13, 14, 15, 16}};

--- a/libcxx/test/std/ranges/range.adaptors/range.join/range.join.sentinel/eq.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.join/range.join.sentinel/eq.pass.cpp
@@ -19,9 +19,7 @@
 #include <type_traits>
 
 #include "../types.h"
-
-template <class Iter, class Sent>
-concept EqualityComparable = std::invocable<std::equal_to<>, const Iter&, const Sent&> ;
+#include "test_range.h"
 
 using Iterator = random_access_iterator<BufferView<int*>*>;
 using ConstIterator = random_access_iterator<const BufferView<int*>*>;
@@ -53,9 +51,9 @@ struct ConstComparableView : BufferView<BufferView<int*>*> {
   constexpr auto end() const { return ConstComparableSentinel<true>(ConstIterator(data_ + size_)); }
 };
 
-static_assert(EqualityComparable<std::ranges::iterator_t<ConstComparableView>,
+static_assert(weakly_equality_comparable_with<std::ranges::iterator_t<ConstComparableView>,
                                  std::ranges::sentinel_t<const ConstComparableView>>);
-static_assert(EqualityComparable<std::ranges::iterator_t<const ConstComparableView>,
+static_assert(weakly_equality_comparable_with<std::ranges::iterator_t<const ConstComparableView>,
                                  std::ranges::sentinel_t<ConstComparableView>>);
 
 constexpr bool test() {

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/equal.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/equal.pass.cpp
@@ -53,7 +53,7 @@ constexpr bool test() {
     auto b = val.begin();
     std::same_as<std::default_sentinel_t> decltype(auto) e = val.end();
 
-    static_assert(!weakly_equality_comparable_with<decltype(b)>);
+    static_assert(!weakly_equality_comparable_with<decltype(b), decltype(b)>);
 
     assert(!(b == std::default_sentinel));
     assert(b != std::default_sentinel);

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/equal.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/equal.pass.cpp
@@ -17,13 +17,10 @@
 
 #include <concepts>
 #include <string_view>
+
 #include "../types.h"
 
-template <class Iter>
-concept CanCallEquals = requires(const Iter& i) {
-  i == i;
-  i != i;
-};
+#include "test_range.h"
 
 constexpr bool test() {
   // When `View` is a forward range, `inner-iterator` supports both overloads of `operator==`.
@@ -56,7 +53,7 @@ constexpr bool test() {
     auto b = val.begin();
     std::same_as<std::default_sentinel_t> decltype(auto) e = val.end();
 
-    static_assert(!CanCallEquals<decltype(b)>);
+    static_assert(!weakly_equality_comparable_with<decltype(b)>);
 
     assert(!(b == std::default_sentinel));
     assert(b != std::default_sentinel);

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/equal.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/equal.pass.cpp
@@ -17,13 +17,10 @@
 
 #include <concepts>
 #include <string_view>
+
 #include "../types.h"
 
-template <class Iter>
-concept CanCallEquals = requires(const Iter& i) {
-  i == i;
-  i != i;
-};
+#include "test_range.h"
 
 constexpr bool test() {
   // Forward range supports both overloads of `operator==`.
@@ -69,7 +66,7 @@ constexpr bool test() {
     auto b = v.begin();
     std::same_as<std::default_sentinel_t> decltype(auto) e = v.end();
 
-    static_assert(!CanCallEquals<decltype(b)>);
+    static_assert(!weakly_equality_comparable_with<decltype(b)>);
 
     assert(!(b == std::default_sentinel));
     assert(b != std::default_sentinel);

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/equal.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/equal.pass.cpp
@@ -66,7 +66,7 @@ constexpr bool test() {
     auto b = v.begin();
     std::same_as<std::default_sentinel_t> decltype(auto) e = v.end();
 
-    static_assert(!weakly_equality_comparable_with<decltype(b)>);
+    static_assert(!weakly_equality_comparable_with<decltype(b), decltype(b)>);
 
     assert(!(b == std::default_sentinel));
     assert(b != std::default_sentinel);

--- a/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
@@ -70,36 +70,32 @@ struct LessThan3 {
   constexpr bool operator()(int i) const { return i < 3; }
 };
 
-// Test Constraint
-template <class I, class S>
-concept HasEqual = requires(const I i, const S s) { i == s; };
-
 using std::ranges::iterator_t;
 using std::ranges::sentinel_t;
 using std::ranges::take_while_view;
 
-static_assert(HasEqual<iterator_t<take_while_view<R, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
                        sentinel_t<take_while_view<R, LessThan3>>>);
 
-static_assert(!HasEqual<iterator_t<const take_while_view<R, LessThan3>>, //
+static_assert(!weakly_equality_comparable_with<iterator_t<const take_while_view<R, LessThan3>>, //
                         sentinel_t<take_while_view<R, LessThan3>>>);
 
-static_assert(!HasEqual<iterator_t<take_while_view<R, LessThan3>>, //
+static_assert(!weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
                         sentinel_t<const take_while_view<R, LessThan3>>>);
 
-static_assert(HasEqual<iterator_t<const take_while_view<R, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<R, LessThan3>>, //
                        sentinel_t<const take_while_view<R, LessThan3>>>);
 
-static_assert(HasEqual<iterator_t<take_while_view<R, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
                        sentinel_t<take_while_view<R, LessThan3>>>);
 
-static_assert(HasEqual<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
                        sentinel_t<take_while_view<CrossComparableR, LessThan3>>>);
 
-static_assert(HasEqual<iterator_t<take_while_view<CrossComparableR, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<CrossComparableR, LessThan3>>, //
                        sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
 
-static_assert(HasEqual<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
+static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
                        sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
 
 template <class R, bool ConstIter, bool ConstSent>

--- a/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
@@ -75,28 +75,28 @@ using std::ranges::sentinel_t;
 using std::ranges::take_while_view;
 
 static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
-                       sentinel_t<take_while_view<R, LessThan3>>>);
+                                              sentinel_t<take_while_view<R, LessThan3>>>);
 
 static_assert(!weakly_equality_comparable_with<iterator_t<const take_while_view<R, LessThan3>>, //
-                        sentinel_t<take_while_view<R, LessThan3>>>);
+                                               sentinel_t<take_while_view<R, LessThan3>>>);
 
 static_assert(!weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
-                        sentinel_t<const take_while_view<R, LessThan3>>>);
+                                               sentinel_t<const take_while_view<R, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<R, LessThan3>>, //
-                       sentinel_t<const take_while_view<R, LessThan3>>>);
+                                              sentinel_t<const take_while_view<R, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
-                       sentinel_t<take_while_view<R, LessThan3>>>);
+                                              sentinel_t<take_while_view<R, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
-                       sentinel_t<take_while_view<CrossComparableR, LessThan3>>>);
+                                              sentinel_t<take_while_view<CrossComparableR, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<CrossComparableR, LessThan3>>, //
-                       sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
+                                              sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
-                       sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
+                                              sentinel_t<const take_while_view<CrossComparableR, LessThan3>>>);
 
 template <class R, bool ConstIter, bool ConstSent>
 constexpr void testOne() {

--- a/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take.while/sentinel/equality.pass.cpp
@@ -86,8 +86,8 @@ static_assert(!weakly_equality_comparable_with<iterator_t<take_while_view<R, Les
 static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<R, LessThan3>>, //
                                               sentinel_t<const take_while_view<R, LessThan3>>>);
 
-static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<R, LessThan3>>, //
-                                              sentinel_t<take_while_view<R, LessThan3>>>);
+static_assert(weakly_equality_comparable_with<iterator_t<take_while_view<CrossComparableR, LessThan3>>, //
+                                              sentinel_t<take_while_view<CrossComparableR, LessThan3>>>);
 
 static_assert(weakly_equality_comparable_with<iterator_t<const take_while_view<CrossComparableR, LessThan3>>, //
                                               sentinel_t<take_while_view<CrossComparableR, LessThan3>>>);

--- a/libcxx/test/std/ranges/range.adaptors/range.take/range.take.sentinel/eq.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/range.take.sentinel/eq.pass.cpp
@@ -21,6 +21,7 @@
 
 #include "test_comparisons.h"
 #include "test_iterators.h"
+#include "test_range.h"
 
 template <bool Const>
 using MaybeConstIterator = cpp20_input_iterator<std::conditional_t<Const, const int*, int*>>;
@@ -76,14 +77,6 @@ struct NonCrossConstComparableView : std::ranges::view_base {
 
 static_assert(std::ranges::range<NonCrossConstComparableView>);
 static_assert(std::ranges::range<const NonCrossConstComparableView>);
-
-template <class T, class U>
-concept weakly_equality_comparable_with = requires(const T& t, const U& u) {
-  t == u;
-  t != u;
-  u == t;
-  u != t;
-};
 
 constexpr bool test() {
   int buffer[8]                      = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp
@@ -242,7 +242,7 @@ constexpr bool test() {
     std::ranges::zip_view r(IterNoEqualView{buffer});
     auto it = r.begin();
     using Iter = decltype(it);
-    static_assert(!weakly_equality_comparable_with<Iter>);
+    static_assert(!weakly_equality_comparable_with<Iter, Iter>);
     inequalityOperatorsDoNotExistTest(it, it);
   }
   return true;

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp
@@ -26,6 +26,8 @@
 #include <compare>
 
 #include "test_iterators.h"
+#include "test_range.h"
+
 #include "../types.h"
 
 // This is for testing that zip iterator never calls underlying iterator's >, >=, <=, !=.
@@ -240,7 +242,7 @@ constexpr bool test() {
     std::ranges::zip_view r(IterNoEqualView{buffer});
     auto it = r.begin();
     using Iter = decltype(it);
-    static_assert(!std::invocable<std::equal_to<>, Iter, Iter>);
+    static_assert(!weakly_equality_comparable_with<Iter>);
     inequalityOperatorsDoNotExistTest(it, it);
   }
   return true;

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/sentinel/eq.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/sentinel/eq.pass.cpp
@@ -18,6 +18,7 @@
 #include <tuple>
 
 #include "../types.h"
+#include "test_range.h"
 
 using Iterator = random_access_iterator<int*>;
 using ConstIterator = random_access_iterator<const int*>;
@@ -53,11 +54,6 @@ struct ConstIncompatibleView : std::ranges::view_base {
   sentinel_wrapper<cpp17_input_iterator<int*>> end();
   sentinel_wrapper<forward_iterator<const int*>> end() const;
 };
-
-// clang-format off
-template <class Iter, class Sent>
-concept EqualComparable = std::invocable<std::equal_to<>, const Iter&, const Sent&>;
-// clang-format on
 
 constexpr bool test() {
   int buffer1[4] = {1, 2, 3, 4};
@@ -95,10 +91,10 @@ constexpr bool test() {
     using ConstSentinel = std::ranges::sentinel_t<const decltype(v)>;
     static_assert(!std::is_same_v<Sentinel, ConstSentinel>);
 
-    static_assert(EqualComparable<Iter, Sentinel>);
-    static_assert(!EqualComparable<ConstIter, Sentinel>);
-    static_assert(EqualComparable<Iter, ConstSentinel>);
-    static_assert(EqualComparable<ConstIter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<Iter, Sentinel>);
+    static_assert(!weakly_equality_comparable_with<ConstIter, Sentinel>);
+    static_assert(weakly_equality_comparable_with<Iter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<ConstIter, ConstSentinel>);
   }
 
   {
@@ -120,10 +116,10 @@ constexpr bool test() {
     using ConstSentinel = std::ranges::sentinel_t<const decltype(v)>;
     static_assert(!std::is_same_v<Sentinel, ConstSentinel>);
 
-    static_assert(EqualComparable<Iter, Sentinel>);
-    static_assert(EqualComparable<ConstIter, Sentinel>);
-    static_assert(EqualComparable<Iter, ConstSentinel>);
-    static_assert(EqualComparable<ConstIter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<Iter, Sentinel>);
+    static_assert(weakly_equality_comparable_with<ConstIter, Sentinel>);
+    static_assert(weakly_equality_comparable_with<Iter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<ConstIter, ConstSentinel>);
   }
 
   {
@@ -139,10 +135,10 @@ constexpr bool test() {
     using ConstSentinel = std::ranges::sentinel_t<const decltype(v)>;
     static_assert(!std::is_same_v<Sentinel, ConstSentinel>);
 
-    static_assert(EqualComparable<Iter, Sentinel>);
-    static_assert(!EqualComparable<ConstIter, Sentinel>);
-    static_assert(!EqualComparable<Iter, ConstSentinel>);
-    static_assert(EqualComparable<ConstIter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<Iter, Sentinel>);
+    static_assert(!weakly_equality_comparable_with<ConstIter, Sentinel>);
+    static_assert(!weakly_equality_comparable_with<Iter, ConstSentinel>);
+    static_assert(weakly_equality_comparable_with<ConstIter, ConstSentinel>);
   }
   return true;
 }

--- a/libcxx/test/support/test_range.h
+++ b/libcxx/test/support/test_range.h
@@ -97,11 +97,12 @@ concept CanBePiped = requires(View&& view, T&& t) {
 };
 
 template <class T, class U>
-concept weakly_equality_comparable_with = requires(const std::remove_reference_t<T>& t, const std::remove_reference_t<U>& u) {
-  { t == u } -> std::same_as<bool>;
-  { t != u } -> std::same_as<bool>;
-  { u == t } -> std::same_as<bool>;
-  { u != t } -> std::same_as<bool>;
-};
+concept weakly_equality_comparable_with =
+    requires(const std::remove_reference_t<T>& t, const std::remove_reference_t<U>& u) {
+      { t == u } -> std::same_as<bool>;
+      { t != u } -> std::same_as<bool>;
+      { u == t } -> std::same_as<bool>;
+      { u != t } -> std::same_as<bool>;
+    };
 
 #endif // LIBCXX_TEST_SUPPORT_TEST_RANGE_H

--- a/libcxx/test/support/test_range.h
+++ b/libcxx/test/support/test_range.h
@@ -10,9 +10,11 @@
 #define LIBCXX_TEST_SUPPORT_TEST_RANGE_H
 
 #include <concepts>
+#include <functional>
 #include <iterator>
 #include <ranges>
 
+#include "__concepts/invocable.h"
 #include "test_iterators.h"
 
 #if TEST_STD_VER < 17
@@ -92,6 +94,14 @@ concept simple_view =
 template <class View, class T>
 concept CanBePiped = requires(View&& view, T&& t) {
   { std::forward<View>(view) | std::forward<T>(t) };
+};
+
+template <class T, class U = T>
+concept weakly_equality_comparable_with = requires(const T& t, const U& u) {
+  { t == u } -> std::same_as<bool>;
+  { t != u } -> std::same_as<bool>;
+  { u == t } -> std::same_as<bool>;
+  { u != t } -> std::same_as<bool>;
 };
 
 #endif // LIBCXX_TEST_SUPPORT_TEST_RANGE_H

--- a/libcxx/test/support/test_range.h
+++ b/libcxx/test/support/test_range.h
@@ -13,8 +13,8 @@
 #include <functional>
 #include <iterator>
 #include <ranges>
+#include <type_traits>
 
-#include "__concepts/invocable.h"
 #include "test_iterators.h"
 
 #if TEST_STD_VER < 17
@@ -96,8 +96,8 @@ concept CanBePiped = requires(View&& view, T&& t) {
   { std::forward<View>(view) | std::forward<T>(t) };
 };
 
-template <class T, class U = T>
-concept weakly_equality_comparable_with = requires(const T& t, const U& u) {
+template <class T, class U>
+concept weakly_equality_comparable_with = requires(const std::remove_reference_t<T>& t, const std::remove_reference_t<U>& u) {
   { t == u } -> std::same_as<bool>;
   { t != u } -> std::same_as<bool>;
   { u == t } -> std::same_as<bool>;

--- a/libcxx/test/support/test_range.h
+++ b/libcxx/test/support/test_range.h
@@ -96,6 +96,7 @@ concept CanBePiped = requires(View&& view, T&& t) {
   { std::forward<View>(view) | std::forward<T>(t) };
 };
 
+// See [concept.equalitycomparable]
 template <class T, class U>
 concept weakly_equality_comparable_with =
     requires(const std::remove_reference_t<T>& t, const std::remove_reference_t<U>& u) {

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -281,7 +281,6 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
             for test in self._generateGenTest(testSuite, pathInSuite, litConfig, localConfig):
                 yield test
         else:
-            print(f"{localConfig.substitutions=}")
             yield lit.Test.Test(testSuite, pathInSuite, localConfig)
 
     def execute(self, test, litConfig):

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -281,6 +281,7 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
             for test in self._generateGenTest(testSuite, pathInSuite, litConfig, localConfig):
                 yield test
         else:
+            print(f"{localConfig.substitutions=}")
             yield lit.Test.Test(testSuite, pathInSuite, localConfig)
 
     def execute(self, test, litConfig):


### PR DESCRIPTION
Previously, tests for whether comparison using == was supported by iterators derived from ranges adaptors was spread throughout the testing codebase. This PR centralizes the implementation of those tests.