### PR TITLE
[clangd] Support parsing comments without ASTContext

### DIFF
--- a/clang-tools-extra/clangd/CodeCompletionStrings.h
+++ b/clang-tools-extra/clangd/CodeCompletionStrings.h
@@ -19,6 +19,11 @@
 namespace clang {
 class ASTContext;
 
+namespace comments {
+class CommandTraits;
+class FullComment;
+} // namespace comments
+
 namespace clangd {
 
 /// Gets a minimally formatted documentation comment of \p Result, with comment
@@ -66,6 +71,12 @@ std::string formatDocumentation(const CodeCompletionString &CCS,
 /// Gets detail to be used as the detail field in an LSP completion item. This
 /// is usually the return type of a function.
 std::string getReturnType(const CodeCompletionString &CCS);
+
+/// Parse the \p Comment, storing the result in \p Allocator, assuming
+/// that comment markers have already been stripped (e.g. via getDocComment())
+comments::FullComment *parseComment(llvm::StringRef Comment,
+                                    llvm::BumpPtrAllocator &Allocator,
+                                    comments::CommandTraits &Traits);
 
 } // namespace clangd
 } // namespace clang

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1971,7 +1971,7 @@ public:
 };
 
 /// SourceManager and necessary dependencies (e.g. VFS, FileManager) for a
-/// single in-memorty file.
+/// single in-memory file.
 class SourceManagerForFile {
 public:
   /// Creates SourceManager and necessary dependencies (e.g. VFS, FileManager).


### PR DESCRIPTION
This is in preparation for implementing doxygen parsing, see discussion in https://github.com/clangd/clangd/issues/529.

(Old Phabricator review: https://reviews.llvm.org/D143112)