### PR TITLE
[mlir][ROCDL] Stop setting amdgpu-implicitarg-num-bytes

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
@@ -93,15 +93,12 @@ public:
       // 1. Insert AMDGPU_KERNEL calling convention.
       // 2. Insert amdgpu-flat-work-group-size(1, 256) attribute unless the user
       // has overriden this value - 256 is the default in clang
-      // 3. Insert amdgpu-implicitarg-num-bytes=56 (which must be set on OpenCL
-      // and HIP kernels per Clang)
       llvm::Function *llvmFunc =
           moduleTranslation.lookupFunction(func.getName());
       llvmFunc->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
       if (!llvmFunc->hasFnAttribute("amdgpu-flat-work-group-size")) {
         llvmFunc->addFnAttr("amdgpu-flat-work-group-size", "1,256");
       }
-      llvmFunc->addFnAttr("amdgpu-implicitarg-num-bytes", "56");
     }
     // Override flat-work-group-size
     // TODO: update clients to rocdl.flat_work_group_size instead,

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -489,7 +489,7 @@ llvm.func @rocdl_8bit_floats(%source: i32, %stoch: i32) -> i32 {
   llvm.return %source5 : i32
 }
 
-// CHECK-DAG: attributes #[[$KERNEL_ATTRS]] = { "amdgpu-flat-work-group-size"="1,256" "amdgpu-implicitarg-num-bytes"="56" }
+// CHECK-DAG: attributes #[[$KERNEL_ATTRS]] = { "amdgpu-flat-work-group-size"="1,256" }
 // CHECK-DAG: attributes #[[$KERNEL_WORKGROUP_ATTRS]] = { "amdgpu-flat-work-group-size"="1,1024"
 // CHECK-DAG: attributes #[[$KNOWN_BLOCK_SIZE_ATTRS]] = { "amdgpu-flat-work-group-size"="128,128"
 // CHECK-DAG: ![[$RANGE]] = !{i32 0, i32 64}


### PR DESCRIPTION
Clang stopped doing this late 2021 back in 33315ef3216b, and no other frontent does this, so stop doing it.