### PR TITLE
Make getAttr, getSpecificAttr, hasAttr, and hasSpecificAttr variadic

### DIFF
--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -560,27 +560,29 @@ public:
 
   template <typename T> void dropAttr() { dropAttrs<T>(); }
 
-  template <typename T>
-  llvm::iterator_range<specific_attr_iterator<T>> specific_attrs() const {
-    return llvm::make_range(specific_attr_begin<T>(), specific_attr_end<T>());
+  template <typename... Ts>
+  llvm::iterator_range<specific_attr_iterator<AttrVec, Ts...>>
+  specific_attrs() const {
+    return llvm::make_range(specific_attr_begin<Ts...>(),
+                            specific_attr_end<Ts...>());
   }
 
-  template <typename T>
-  specific_attr_iterator<T> specific_attr_begin() const {
-    return specific_attr_iterator<T>(attr_begin());
+  template <typename... Ts>
+  specific_attr_iterator<AttrVec, Ts...> specific_attr_begin() const {
+    return specific_attr_iterator<AttrVec, Ts...>(attr_begin());
   }
 
-  template <typename T>
-  specific_attr_iterator<T> specific_attr_end() const {
-    return specific_attr_iterator<T>(attr_end());
+  template <typename... Ts>
+  specific_attr_iterator<AttrVec, Ts...> specific_attr_end() const {
+    return specific_attr_iterator<AttrVec, Ts...>(attr_end());
   }
 
-  template<typename T> T *getAttr() const {
-    return hasAttrs() ? getSpecificAttr<T>(getAttrs()) : nullptr;
+  template <typename... Ts> auto *getAttr() const {
+    return hasAttrs() ? getSpecificAttr<Ts...>(getAttrs()) : nullptr;
   }
 
-  template<typename T> bool hasAttr() const {
-    return hasAttrs() && hasSpecificAttr<T>(getAttrs());
+  template <typename... Ts> bool hasAttr() const {
+    return hasAttrs() && hasSpecificAttr<Ts...>(getAttrs());
   }
 
   /// getMaxAlignment - return the maximum alignment specified by attributes

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1478,11 +1478,10 @@ static bool IsOverloadOrOverrideImpl(Sema &SemaRef, FunctionDecl *New,
     return true;
 
   // enable_if attributes are an order-sensitive part of the signature.
-  for (specific_attr_iterator<EnableIfAttr>
-         NewI = New->specific_attr_begin<EnableIfAttr>(),
-         NewE = New->specific_attr_end<EnableIfAttr>(),
-         OldI = Old->specific_attr_begin<EnableIfAttr>(),
-         OldE = Old->specific_attr_end<EnableIfAttr>();
+  for (auto NewI = New->specific_attr_begin<EnableIfAttr>(),
+            NewE = New->specific_attr_end<EnableIfAttr>(),
+            OldI = Old->specific_attr_begin<EnableIfAttr>(),
+            OldE = Old->specific_attr_end<EnableIfAttr>();
        NewI != NewE || OldI != OldE; ++NewI, ++OldI) {
     if (NewI == NewE || OldI == OldE)
       return true;


### PR DESCRIPTION
Discussed elsewhere, it makes sense to have these functions be variadic. They work as an 'or', that is, 'has*Attr' is "one of the set", and "get*Attr" means "first of the set".

This is accomplished by extracting specific_attr_iterator into a _impl version, and creating a version + partial specialization for the _iterator version that inherits from the _impl.  The result is that all of the 'existing' code 'just works'.

One exception (see the change in SemaOverload.cpp) could be solved with a conversion function, but instead I put 'auto' in.  Else, I could specify the 'AttrVec' if it were preferential.