### PR TITLE
hurd: Fix build with -Werror,-Wswitch

### DIFF
--- a/clang/lib/Driver/ToolChains/Hurd.cpp
+++ b/clang/lib/Driver/ToolChains/Hurd.cpp
@@ -139,6 +139,8 @@ std::string Hurd::getDynamicLinker(const ArgList &Args) const {
     return "/lib/ld.so";
   case llvm::Triple::x86_64:
     return "/lib/ld-x86-64.so.1";
+  default:
+    break;
   }
 
   llvm_unreachable("unsupported architecture");


### PR DESCRIPTION
We do not handle all architectures, llvm_unreachable is called after the switch, so we can just break.

Fixes https://lab.llvm.org/buildbot/#/builders/19/builds/23702