### PR TITLE
[CompilerRT][ASan] Add new substitutions for tests while using lto to

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/odr-lto.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/odr-lto.cpp
@@ -5,7 +5,7 @@
 
 // RUN: %clangxx_asan -DPART=0 -c %s -o %t-1.o -flto -mllvm -asan-use-private-alias
 // RUN: %clangxx_asan -DPART=1 -c %s -o %t-2.o -flto -mllvm -asan-use-private-alias
-// RUN: %clangxx_asan %t-1.o %t-2.o -o %t -flto -mlinker-version=133
+// RUN: %clangxx_asan_lto %t-1.o %t-2.o -o %t -flto -mlinker-version=133
 // RUN: %run %t 2>&1 | FileCheck %s
 
 #include <stdio.h>

--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -101,14 +101,24 @@ if platform.system() == "Windows":
     config.available_features.add(win_runtime_feature)
 
 
-def build_invocation(compile_flags):
-    return " " + " ".join([config.clang] + compile_flags) + " "
+def build_invocation(compile_flags, with_lto=False):
+    lto_flags = []
+    if with_lto and config.lto_supported:
+        lto_flags += config.lto_flags
+
+    return " " + " ".join([config.clang] + lto_flags + compile_flags) + " "
 
 
 config.substitutions.append(("%clang ", build_invocation(target_cflags)))
 config.substitutions.append(("%clangxx ", build_invocation(target_cxxflags)))
 config.substitutions.append(("%clang_asan ", build_invocation(clang_asan_cflags)))
 config.substitutions.append(("%clangxx_asan ", build_invocation(clang_asan_cxxflags)))
+config.substitutions.append(
+    ("%clang_asan_lto ", build_invocation(clang_asan_cflags, True))
+)
+config.substitutions.append(
+    ("%clangxx_asan_lto ", build_invocation(clang_asan_cxxflags, True))
+)
 if config.asan_dynamic:
     if config.host_os in ["Linux", "FreeBSD", "NetBSD", "SunOS"]:
         shared_libasan_path = os.path.join(


### PR DESCRIPTION
explicitly pass libLTO path. This fixes a failure in swift-ci where libLTO was being picked from the system instead which was an older version and caused issues.

rdar://117474861