### PR TITLE
[Clang] Correct __builtin_dynamic_object_size for subobject types

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -744,11 +744,13 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
       // FIXME: Get object address space
       llvm::Type *Tys[2] = { IntPtrTy, Int8PtrTy };
       llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::objectsize, Tys);
+      llvm::Value *WholeObj = Builder.getTrue();
       llvm::Value *Min = Builder.getFalse();
       llvm::Value *NullIsUnknown = Builder.getFalse();
       llvm::Value *Dynamic = Builder.getFalse();
       llvm::Value *LargeEnough = Builder.CreateICmpUGE(
-          Builder.CreateCall(F, {Ptr, Min, NullIsUnknown, Dynamic}), Size);
+          Builder.CreateCall(F, {Ptr, WholeObj, Min, NullIsUnknown, Dynamic}),
+          Size);
       Checks.push_back(std::make_pair(LargeEnough, SanitizerKind::ObjectSize));
     }
   }

--- a/clang/test/CodeGen/catch-undef-behavior.c
+++ b/clang/test/CodeGen/catch-undef-behavior.c
@@ -35,7 +35,7 @@
 void foo(void) {
   union { int i; } u;
 
-  // CHECK-COMMON: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64.p0(ptr %[[PTR:.*]], i1 false, i1 false, i1 false)
+  // CHECK-COMMON: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64.p0(ptr %[[PTR:.*]], i1 true, i1 false, i1 false, i1 false)
   // CHECK-COMMON-NEXT: %[[OK:.*]] = icmp uge i64 %[[SIZE]], 4
 
   // CHECK-UBSAN: br i1 %[[OK]], {{.*}} !prof ![[WEIGHT_MD:.*]], !nosanitize

--- a/clang/test/CodeGen/pass-object-size.c
+++ b/clang/test/CodeGen/pass-object-size.c
@@ -85,16 +85,16 @@ void test1(unsigned long sz) {
 
   char *ptr = (char *)malloc(sz);
 
-  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0({{.*}}, i1 false, i1 true, i1 true)
+  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0({{.*}}, i1 true, i1 false, i1 true, i1 true)
   // CHECK: call i32 @DynamicObjectSize0(ptr noundef %{{.*}}, i64 noundef [[REG]])
   gi = DynamicObjectSize0(ptr);
 
   // CHECK: [[WITH_OFFSET:%.*]] = getelementptr
-  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[WITH_OFFSET]], i1 false, i1 true, i1 true)
+  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[WITH_OFFSET]], i1 true, i1 false, i1 true, i1 true)
   // CHECK: call i32 @DynamicObjectSize0(ptr noundef {{.*}}, i64 noundef [[REG]])
   gi = DynamicObjectSize0(ptr+10);
 
-  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0({{.*}}, i1 true, i1 true, i1 true)
+  // CHECK: [[REG:%.*]] = call i64 @llvm.objectsize.i64.p0({{.*}}, i1 true, i1 true, i1 true, i1 true)
   // CHECK: call i32 @DynamicObjectSize2(ptr noundef {{.*}}, i64 noundef [[REG]])
   gi = DynamicObjectSize2(ptr);
 }

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -26538,19 +26538,26 @@ Arguments:
 The ``llvm.objectsize`` intrinsic takes five arguments:
 
 - The first argument is a pointer to or into the ``object``.
+
 - The second argument controls which size ``llvm.objectsize`` returns:
-  - If it's ``false``, ``llvm.objectsize`` returns the size of the closest
-    surrounding subobject.
-  - If it's ``true``, ``llvm.objectsize`` returns the size of the whole object.
+
+    - If it's ``false``, ``llvm.objectsize`` returns the size of the closest
+      surrounding subobject.
+    - If it's ``true``, ``llvm.objectsize`` returns the size of the whole object.
+
 - The third argument controls which value to return when the size is unknown:
-  - If it's ``false``, ``llvm.objectsize`` returns ``-1``.
-  - If it's ``true``, ``llvm.objectsize`` returns ``0``.
+
+    - If it's ``false``, ``llvm.objectsize`` returns ``-1``.
+    - If it's ``true``, ``llvm.objectsize`` returns ``0``.
+
 - The fourth argument controls how ``llvm.objectsize`` acts when ``null`` in
   address space 0 is used as its pointer argument:
-  - If it's ``false``, ``llvm.objectsize`` reports 0 bytes available when given
-    ``null``.
-  - If it's ``true``, or the ``null`` pointer is in a non-zero address space,
-    the size is assumed to be unknown.
+
+    - If it's ``false``, ``llvm.objectsize`` reports 0 bytes available when given
+      ``null``.
+    - If it's ``true``, or the ``null`` pointer is in a non-zero address space,
+      the size is assumed to be unknown.
+
 - The fifth argument to ``llvm.objectsize`` determines if the value should be
   evaluated at runtime.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -26520,8 +26520,8 @@ Syntax:
 
 ::
 
-      declare i32 @llvm.objectsize.i32(ptr <object>, i1 <min>, i1 <nullunknown>, i1 <dynamic>)
-      declare i64 @llvm.objectsize.i64(ptr <object>, i1 <min>, i1 <nullunknown>, i1 <dynamic>)
+      declare i32 @llvm.objectsize.i32(ptr <object>, i1 <wholeobj>, i1 <min>, i1 <nullunknown>, i1 <dynamic>)
+      declare i64 @llvm.objectsize.i64(ptr <object>, i1 <wholeobj>, i1 <min>, i1 <nullunknown>, i1 <dynamic>)
 
 Overview:
 """""""""
@@ -26535,18 +26535,26 @@ class, structure, array, or other object.
 Arguments:
 """"""""""
 
-The ``llvm.objectsize`` intrinsic takes four arguments. The first argument is a
-pointer to or into the ``object``. The second argument determines whether
-``llvm.objectsize`` returns 0 (if true) or -1 (if false) when the object size is
-unknown. The third argument controls how ``llvm.objectsize`` acts when ``null``
-in address space 0 is used as its pointer argument. If it's ``false``,
-``llvm.objectsize`` reports 0 bytes available when given ``null``. Otherwise, if
-the ``null`` is in a non-zero address space or if ``true`` is given for the
-third argument of ``llvm.objectsize``, we assume its size is unknown. The fourth
-argument to ``llvm.objectsize`` determines if the value should be evaluated at
-runtime.
+The ``llvm.objectsize`` intrinsic takes five arguments:
 
-The second, third, and fourth arguments only accept constants.
+- The first argument is a pointer to or into the ``object``.
+- The second argument controls which size ``llvm.objectsize`` returns:
+  - If it's ``false``, ``llvm.objectsize`` returns the size of the closest
+    surrounding subobject.
+  - If it's ``true``, ``llvm.objectsize`` returns the size of the whole object.
+- The third argument controls which value to return when the size is unknown:
+  - If it's ``false``, ``llvm.objectsize`` returns ``-1``.
+  - If it's ``true``, ``llvm.objectsize`` returns ``0``.
+- The fourth argument controls how ``llvm.objectsize`` acts when ``null`` in
+  address space 0 is used as its pointer argument:
+  - If it's ``false``, ``llvm.objectsize`` reports 0 bytes available when given
+    ``null``.
+  - If it's ``true``, or the ``null`` pointer is in a non-zero address space,
+    the size is assumed to be unknown.
+- The fifth argument to ``llvm.objectsize`` determines if the value should be
+  evaluated at runtime.
+
+The second, third, fourth, and fifth arguments accept only constants.
 
 Semantics:
 """"""""""

--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -157,6 +157,11 @@ struct ObjectSizeOpts {
   /// Whether to round the result up to the alignment of allocas, byval
   /// arguments, and global variables.
   bool RoundToAlign = false;
+  /// If this is true, return the whole size of the object. Otherwise, return
+  /// the size of the closest surrounding subobject.
+  /// FIXME: The default before being added was to return the whole size of the
+  /// object. Review if this is the correct default.
+  bool WholeObjectSize = true;
   /// If this is true, null pointers in address space 0 will be treated as
   /// though they can't be evaluated. Otherwise, null is always considered to
   /// point to a 0 byte region of memory.
@@ -231,6 +236,7 @@ class ObjectSizeOffsetVisitor
   APInt Zero;
   SmallDenseMap<Instruction *, SizeOffsetAPInt, 8> SeenInsts;
   unsigned InstructionsVisited;
+  const StructType *AllocaTy = nullptr;
 
   APInt align(APInt Size, MaybeAlign Align);
 
@@ -241,6 +247,8 @@ public:
                           LLVMContext &Context, ObjectSizeOpts Options = {});
 
   SizeOffsetAPInt compute(Value *V);
+
+  const StructType *getAllocaType() const { return AllocaTy; }
 
   // These are "private", except they can't actually be made private. Only
   // compute() should be used by external users.
@@ -313,6 +321,7 @@ class ObjectSizeOffsetEvaluator
   PtrSetTy SeenVals;
   ObjectSizeOpts EvalOpts;
   SmallPtrSet<Instruction *, 8> InsertedInstructions;
+  const StructType *AllocaTy = nullptr;
 
   SizeOffsetValue compute_(Value *V);
 

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1071,7 +1071,7 @@ def int_maximum : DefaultAttrsIntrinsic<[llvm_anyfloat_ty],
 
 // Internal interface for object size checking
 def int_objectsize : DefaultAttrsIntrinsic<[llvm_anyint_ty],
-                               [llvm_anyptr_ty, llvm_i1_ty,
+                               [llvm_anyptr_ty, llvm_i1_ty, llvm_i1_ty,
                                 llvm_i1_ty, llvm_i1_ty],
                                [IntrNoMem, IntrSpeculatable, IntrWillReturn,
                                 ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>,

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -732,8 +732,8 @@ SizeOffsetAPInt ObjectSizeOffsetVisitor::computeImpl(Value *V) {
   if (!Options.WholeObjectSize && AllocaTy) {
     // At this point, SOT.Size is the size of the whole struct. However, we
     // want the size of the sub-object.
-    const StructLayout &SL = *DL.getStructLayout(
-        const_cast<StructType *>(AllocaTy));
+    const StructLayout &SL =
+        *DL.getStructLayout(const_cast<StructType *>(AllocaTy));
 
     unsigned Idx = SL.getElementContainingOffset(Offset.getLimitedValue());
 

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4427,9 +4427,9 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
       break;
     }
 
-    NewCall = Builder.CreateCall(NewFn, {CI->getArgOperand(0), WholeObj,
-                                         UnknownVal, NullIsUnknownSize,
-                                         Dynamic});
+    NewCall =
+        Builder.CreateCall(NewFn, {CI->getArgOperand(0), WholeObj, UnknownVal,
+                                   NullIsUnknownSize, Dynamic});
     break;
   }
 

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4393,12 +4393,16 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     break;
 
   case Intrinsic::objectsize: {
+    // The default behavior before the addition of the '<wholeobj>' argument
+    // was to return the size of the whole object.
+    Value *WholeObj = Builder.getTrue();
     Value *NullIsUnknownSize =
         CI->arg_size() == 2 ? Builder.getFalse() : CI->getArgOperand(2);
     Value *Dynamic =
         CI->arg_size() < 4 ? Builder.getFalse() : CI->getArgOperand(3);
-    NewCall = Builder.CreateCall(
-        NewFn, {CI->getArgOperand(0), CI->getArgOperand(1), NullIsUnknownSize, Dynamic});
+    NewCall = Builder.CreateCall(NewFn, {CI->getArgOperand(0), WholeObj,
+                                         CI->getArgOperand(1),
+                                         NullIsUnknownSize, Dynamic});
     break;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -1486,8 +1486,8 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(AllocaInst &I,
            PointerType::get(Context, AMDGPUAS::LOCAL_ADDRESS)});
 
       CallInst *NewCall = Builder.CreateCall(
-          ObjectSize,
-          {Src, Intr->getOperand(1), Intr->getOperand(2), Intr->getOperand(3)});
+          ObjectSize, {Src, Intr->getOperand(1), Intr->getOperand(2),
+                       Intr->getOperand(3), Intr->getOperand(4)});
       Intr->replaceAllUsesWith(NewCall);
       Intr->eraseFromParent();
       continue;

--- a/llvm/test/Analysis/CostModel/X86/free-intrinsics.ll
+++ b/llvm/test/Analysis/CostModel/X86/free-intrinsics.ll
@@ -18,7 +18,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 undef
@@ -38,7 +38,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i32 undef
@@ -58,7 +58,7 @@ define i32 @trivially_free() {
   %a4 = call i1 @llvm.is.constant.i32(i32 undef)
   call void @llvm.lifetime.start.p0(i64 1, ptr undef)
   call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1)
+  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1, i1 1)
   %a6 = call ptr @llvm.ptr.annotation.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   call void @llvm.var.annotation(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   ret i32 undef
@@ -79,7 +79,7 @@ declare ptr @llvm.strip.invariant.group.p0(ptr)
 declare i1 @llvm.is.constant.i32(i32)
 declare void @llvm.lifetime.start.p0(i64, ptr)
 declare void @llvm.lifetime.end.p0(i64, ptr)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 declare ptr @llvm.ptr.annotation.p0(ptr, ptr, ptr, i32, ptr)
 declare void @llvm.var.annotation(ptr, ptr, ptr, i32, ptr)
 

--- a/llvm/test/Analysis/CostModel/free-intrinsics-datalayout.ll
+++ b/llvm/test/Analysis/CostModel/free-intrinsics-datalayout.ll
@@ -20,7 +20,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 undef
@@ -40,7 +40,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 undef
@@ -60,7 +60,7 @@ define i32 @trivially_free() {
   %a4 = call i1 @llvm.is.constant.i32(i32 undef)
   call void @llvm.lifetime.start.p0(i64 1, ptr undef)
   call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1)
+  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1, i1 1)
   %a6 = call ptr @llvm.ptr.annotation.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   call void @llvm.var.annotation(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   ret i32 undef
@@ -81,7 +81,7 @@ declare ptr @llvm.strip.invariant.group.p0(ptr)
 declare i1 @llvm.is.constant.i32(i32)
 declare void @llvm.lifetime.start.p0(i64, ptr)
 declare void @llvm.lifetime.end.p0(i64, ptr)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 declare ptr @llvm.ptr.annotation.p0(ptr, ptr, ptr, i32, ptr)
 declare void @llvm.var.annotation(ptr, ptr, ptr, i32, ptr)
 

--- a/llvm/test/Analysis/CostModel/free-intrinsics-no_info.ll
+++ b/llvm/test/Analysis/CostModel/free-intrinsics-no_info.ll
@@ -18,7 +18,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 undef
@@ -38,7 +38,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a4 = call i1 @llvm.is.constant.i32(i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 true, i1 true, i1 true, i1 true)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a6 = call ptr @llvm.ptr.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.var.annotation.p0.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 undef
@@ -58,7 +58,7 @@ define i32 @trivially_free() {
   %a4 = call i1 @llvm.is.constant.i32(i32 undef)
   call void @llvm.lifetime.start.p0(i64 1, ptr undef)
   call void @llvm.lifetime.end.p0(i64 1, ptr undef)
-  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1)
+  %a5 = call i64 @llvm.objectsize.i64.p0(ptr undef, i1 1, i1 1, i1 1, i1 1)
   %a6 = call ptr @llvm.ptr.annotation.p0(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   call void @llvm.var.annotation(ptr undef, ptr undef, ptr undef, i32 undef, ptr undef)
   ret i32 undef
@@ -79,7 +79,7 @@ declare ptr @llvm.strip.invariant.group.p0(ptr)
 declare i1 @llvm.is.constant.i32(i32)
 declare void @llvm.lifetime.start.p0(i64, ptr)
 declare void @llvm.lifetime.end.p0(i64, ptr)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 declare ptr @llvm.ptr.annotation.p0(ptr, ptr, ptr, i32, ptr)
 declare void @llvm.var.annotation(ptr, ptr, ptr, i32, ptr)
 

--- a/llvm/test/Assembler/auto_upgrade_intrinsics.ll
+++ b/llvm/test/Assembler/auto_upgrade_intrinsics.ll
@@ -60,7 +60,7 @@ define void @test.coro.end(ptr %ptr) {
 declare i32 @llvm.objectsize.i32(ptr, i1) nounwind readonly
 define i32 @test.objectsize() {
 ; CHECK-LABEL: @test.objectsize(
-; CHECK: @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+; CHECK: @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %s = call i32 @llvm.objectsize.i32(ptr @a, i1 false)
   ret i32 %s
 }
@@ -68,7 +68,7 @@ define i32 @test.objectsize() {
 declare i64 @llvm.objectsize.i64.p0(ptr, i1) nounwind readonly
 define i64 @test.objectsize.2() {
 ; CHECK-LABEL: @test.objectsize.2(
-; CHECK: @llvm.objectsize.i64.p0(ptr @a, i1 false, i1 false, i1 false)
+; CHECK: @llvm.objectsize.i64.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %s = call i64 @llvm.objectsize.i64.p0(ptr @a, i1 false)
   ret i64 %s
 }
@@ -78,14 +78,14 @@ define i64 @test.objectsize.2() {
 declare i32 @llvm.objectsize.i32.unnamed(ptr, i1) nounwind readonly
 define i32 @test.objectsize.unnamed() {
 ; CHECK-LABEL: @test.objectsize.unnamed(
-; CHECK: @llvm.objectsize.i32.p0(ptr @u, i1 false, i1 false, i1 false)
+; CHECK: @llvm.objectsize.i32.p0(ptr @u, i1 true, i1 false, i1 false, i1 false)
   %s = call i32 @llvm.objectsize.i32.unnamed(ptr @u, i1 false)
   ret i32 %s
 }
 
 define i64 @test.objectsize.unnamed.2() {
 ; CHECK-LABEL: @test.objectsize.unnamed.2(
-; CHECK: @llvm.objectsize.i64.p0(ptr @u, i1 false, i1 false, i1 false)
+; CHECK: @llvm.objectsize.i64.p0(ptr @u, i1 true, i1 false, i1 false, i1 false)
   %s = call i64 @llvm.objectsize.i64.p0(ptr @u, i1 false)
   ret i64 %s
 }

--- a/llvm/test/Bitcode/objectsize-upgrade-7.0.ll
+++ b/llvm/test/Bitcode/objectsize-upgrade-7.0.ll
@@ -3,10 +3,10 @@
 ; Bitcode compatibility test for 'dynamic' parameter to llvm.objectsize.
 
 define void @callit(i8* %ptr) {
+; CHECK: %sz = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 true, i1 false, i1 true, i1 false)
   %sz = call i64 @llvm.objectsize.i64.p0i8(i8* %ptr, i1 false, i1 true)
-  ; CHECK: %sz = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 false, i1 true, i1 false)
   ret void
 }
 
+; CHECK: declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1)
 declare i64 @llvm.objectsize.i64.p0i8(i8*, i1, i1)
-; CHECK: declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/memcpy_chk_no_tail.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/memcpy_chk_no_tail.ll
@@ -11,7 +11,7 @@ target triple = "arm64-apple-ios13.0.0"
 ; CHECK: bl _memcpy
 define void @usqrt(i32 %x, ptr %q) local_unnamed_addr #0 {
   %a = alloca i32, align 4
-  %obj = tail call i64 @llvm.objectsize.i64.p0(ptr %q, i1 false, i1 true, i1 false)
+  %obj = tail call i64 @llvm.objectsize.i64.p0(ptr %q, i1 true, i1 false, i1 true, i1 false)
   %call = call ptr @__memcpy_chk(ptr %q, ptr nonnull %a, i64 1000, i64 %obj) #4
   ret void
 }
@@ -20,7 +20,7 @@ define void @usqrt(i32 %x, ptr %q) local_unnamed_addr #0 {
 declare ptr @__memcpy_chk(ptr, ptr, i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind readnone speculatable willreturn
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg) #3
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg) #3
 attributes #0 = { optsize "disable-tail-calls"="false" "frame-pointer"="all" }
 attributes #2 = { nofree nounwind "disable-tail-calls"="false" "frame-pointer"="all" }
 attributes #3 = { nounwind readnone speculatable willreturn }

--- a/llvm/test/CodeGen/AArch64/memsize-remarks.ll
+++ b/llvm/test/CodeGen/AArch64/memsize-remarks.ll
@@ -8,7 +8,7 @@ target triple = "arm64-apple-ios7.0.0"
 declare ptr @__memmove_chk(ptr, ptr, i64, i64) #1
 declare ptr @__memcpy_chk(ptr, ptr, i64, i64) #1
 declare ptr @__memset_chk(ptr, i32, i64, i64) #1
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg) #2
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg) #2
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg) argmemonly nounwind willreturn writeonly
 declare void @llvm.memmove.p0.p0.i64(ptr nocapture, ptr nocapture readonly, i64, i1 immarg) argmemonly nounwind willreturn
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) argmemonly nounwind willreturn
@@ -18,7 +18,7 @@ declare ptr @memset(ptr, i32, i64)
 
 define void @memcpy_dynamic(ptr %d, ptr %s, i64 %l) #0 !dbg !14 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !16
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !16
 ; GISEL: remark: memsize.c:4:3: Call to memcpy.{{$}}
   %call = call ptr @__memcpy_chk(ptr %d, ptr %s, i64 %l, i64 %0) #4, !dbg !17
   ret void, !dbg !18
@@ -26,7 +26,7 @@ entry:
 
 define void @memcpy_single(ptr %d, ptr %s, i64 %l) #0 !dbg !23 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !24
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !24
 ; GISEL: remark: memsize.c:10:3: Call to memcpy. Memory operation size: 1 bytes.
   %call = call ptr @__memcpy_chk(ptr %d, ptr %s, i64 1, i64 %0) #4, !dbg !25
   ret void, !dbg !26
@@ -34,7 +34,7 @@ entry:
 
 define void @memcpy_intrinsic(ptr %d, ptr %s, i64 %l) #0 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false)
 ; GISEL: remark: <unknown>:0:0: Call to memcpy. Memory operation size: 1 bytes.
   call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 1, i1 false)
   ret void
@@ -42,7 +42,7 @@ entry:
 
 define void @memcpy_static(ptr %d, ptr %s, i64 %l) #0 !dbg !27 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !28
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !28
 ; GISEL: remark: memsize.c:13:3: Call to memcpy. Memory operation size: 100 bytes.
   %call = call ptr @__memcpy_chk(ptr %d, ptr %s, i64 100, i64 %0) #4, !dbg !29
   ret void, !dbg !30
@@ -50,7 +50,7 @@ entry:
 
 define void @memcpy_huge(ptr %d, ptr %s, i64 %l) #0 !dbg !31 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !32
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !32
 ; GISEL: remark: memsize.c:16:3: Call to memcpy. Memory operation size: 100000 bytes.
   %call = call ptr @__memcpy_chk(ptr %d, ptr %s, i64 100000, i64 %0) #4, !dbg !33
   ret void, !dbg !34
@@ -58,7 +58,7 @@ entry:
 
 define void @memmove_dynamic(ptr %d, ptr %s, i64 %l) #0 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false)
 ; GISEL: remark: <unknown>:0:0: Call to memmove.{{$}}
   %call = call ptr @__memmove_chk(ptr %d, ptr %s, i64 %l, i64 %0) #4
   ret void
@@ -66,7 +66,7 @@ entry:
 
 define void @memmove_single(ptr %d, ptr %s, i64 %l) #0 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false)
 ; GISEL: remark: <unknown>:0:0: Call to memmove. Memory operation size: 1 bytes.
   %call = call ptr @__memmove_chk(ptr %d, ptr %s, i64 1, i64 %0) #4
   ret void
@@ -74,7 +74,7 @@ entry:
 
 define void @memmove_static(ptr %d, ptr %s, i64 %l) #0 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false)
 ; GISEL: remark: <unknown>:0:0: Call to memmove. Memory operation size: 100 bytes.
   %call = call ptr @__memmove_chk(ptr %d, ptr %s, i64 100, i64 %0) #4
   ret void
@@ -82,7 +82,7 @@ entry:
 
 define void @memmove_huge(ptr %d, ptr %s, i64 %l) #0 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false)
 ; GISEL: remark: <unknown>:0:0: Call to memmove. Memory operation size: 100000 bytes.
   %call = call ptr @__memmove_chk(ptr %d, ptr %s, i64 100000, i64 %0) #4
   ret void
@@ -90,7 +90,7 @@ entry:
 
 define void @memset_dynamic(ptr %d, i64 %l) #0 !dbg !38 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !39
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !39
 ; GISEL: remark: memsize.c:22:3: Call to memset.{{$}}
   %call = call ptr @__memset_chk(ptr %d, i32 0, i64 %l, i64 %0) #4, !dbg !40
   ret void, !dbg !41
@@ -98,7 +98,7 @@ entry:
 
 define void @memset_single(ptr %d, i64 %l) #0 !dbg !46 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !47
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !47
 ; GISEL: remark: memsize.c:28:3: Call to memset. Memory operation size: 1 bytes.
   %call = call ptr @__memset_chk(ptr %d, i32 0, i64 1, i64 %0) #4, !dbg !48
   ret void, !dbg !49
@@ -106,7 +106,7 @@ entry:
 
 define void @memset_static(ptr %d, i64 %l) #0 !dbg !50 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !51
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !51
 ; GISEL: remark: memsize.c:31:3: Call to memset. Memory operation size: 100 bytes.
   %call = call ptr @__memset_chk(ptr %d, i32 0, i64 100, i64 %0) #4, !dbg !52
   ret void, !dbg !53
@@ -114,7 +114,7 @@ entry:
 
 define void @memset_huge(ptr %d, i64 %l) #0 !dbg !54 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !55
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !55
 ; GISEL: remark: memsize.c:34:3: Call to memset. Memory operation size: 100000 bytes.
   %call = call ptr @__memset_chk(ptr %d, i32 0, i64 100000, i64 %0) #4, !dbg !56
   ret void, !dbg !57
@@ -122,7 +122,7 @@ entry:
 
 define void @memset_empty(ptr %d, i64 %l) #0 !dbg !42 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !43
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !43
 ; GISEL: remark: memsize.c:25:3: Call to memset. Memory operation size: 0 bytes.
   %call = call ptr @__memset_chk(ptr %d, i32 0, i64 0, i64 %0) #4, !dbg !44
   ret void, !dbg !45
@@ -131,7 +131,7 @@ entry:
 ; YAML-LABEL: Function:        memcpy_empty
 define void @memcpy_empty(ptr %d, ptr %s, i64 %l) #0 !dbg !19 {
 entry:
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 false, i1 true, i1 false), !dbg !20
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %d, i1 true, i1 false, i1 true, i1 false), !dbg !20
 ; GISEL: remark: memsize.c:7:3: Call to memcpy. Memory operation size: 0 bytes.
   %call = call ptr @__memcpy_chk(ptr %d, ptr %s, i64 0, i64 %0) #4, !dbg !21
   ret void, !dbg !22

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-mem-intrinsics.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-mem-intrinsics.ll
@@ -10,7 +10,7 @@ declare void @llvm.memmove.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5
 
 declare void @llvm.memset.p5.i32(ptr addrspace(5) nocapture, i8, i32, i1) #0
 
-declare i32 @llvm.objectsize.i32.p5(ptr addrspace(5), i1, i1, i1) #1
+declare i32 @llvm.objectsize.i32.p5(ptr addrspace(5), i1, i1, i1, i1) #1
 
 ; CHECK-LABEL: @promote_with_memcpy(
 ; CHECK: [[GEP:%[0-9]+]] = getelementptr inbounds [64 x [17 x i32]], ptr addrspace(3) @promote_with_memcpy.alloca, i32 0, i32 %{{[0-9]+}}
@@ -45,10 +45,10 @@ define amdgpu_kernel void @promote_with_memset(ptr addrspace(1) %out, ptr addrsp
 
 ; CHECK-LABEL: @promote_with_objectsize(
 ; CHECK: [[PTR:%[0-9]+]] = getelementptr inbounds [64 x [17 x i32]], ptr addrspace(3) @promote_with_objectsize.alloca, i32 0, i32 %{{[0-9]+}}
-; CHECK: call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) [[PTR]], i1 false, i1 false, i1 false)
+; CHECK: call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) [[PTR]], i1 true, i1 false, i1 false, i1 false)
 define amdgpu_kernel void @promote_with_objectsize(ptr addrspace(1) %out) #0 {
   %alloca = alloca [17 x i32], align 4, addrspace(5)
-  %size = call i32 @llvm.objectsize.i32.p5(ptr addrspace(5) %alloca, i1 false, i1 false, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p5(ptr addrspace(5) %alloca, i1 true, i1 false, i1 false, i1 false)
   store i32 %size, ptr addrspace(1) %out
   ret void
 }
@@ -57,7 +57,7 @@ define amdgpu_kernel void @promote_with_objectsize(ptr addrspace(1) %out) #0 {
 ; CHECK: store i32 32, ptr addrspace(1) %out, align 4
 define amdgpu_kernel void @promote_with_objectsize_8(ptr addrspace(1) %out) #0 {
   %alloca = alloca [8 x i32], align 4, addrspace(5)
-  %size = call i32 @llvm.objectsize.i32.p5(ptr addrspace(5) %alloca, i1 false, i1 false, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p5(ptr addrspace(5) %alloca, i1 true, i1 false, i1 false, i1 false)
   store i32 %size, ptr addrspace(1) %out
   ret void
 }

--- a/llvm/test/Other/cgscc-libcall-update.ll
+++ b/llvm/test/Other/cgscc-libcall-update.ll
@@ -14,7 +14,7 @@ bb:
   %tmp = alloca [1024 x i8], align 16
   call void @llvm.memcpy.p0.p0.i64(ptr %tmp, ptr %arg1, i64 1024, i1 false)
 ; CHECK:         call void @llvm.memcpy.p0.p0.i64(ptr noundef nonnull align 16 dereferenceable(1024) 
-  %tmp3 = call i64 @llvm.objectsize.i64.p0(ptr %tmp, i1 false, i1 true, i1 false)
+  %tmp3 = call i64 @llvm.objectsize.i64.p0(ptr %tmp, i1 true, i1 false, i1 true, i1 false)
   %tmp4 = call ptr @__strncpy_chk(ptr %arg2, ptr %tmp, i64 1023, i64 %tmp3)
 ; CHECK-NOT:     call
 ; CHECK:         call ptr @strncpy(ptr noundef nonnull dereferenceable(1) %arg2, ptr noundef nonnull dereferenceable(1) %tmp, i64 1023)
@@ -34,7 +34,7 @@ bb:
 
 declare ptr @my_special_strncpy(ptr %arg1, ptr %arg2, i64 %size)
 
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 
 declare ptr @__strncpy_chk(ptr, ptr, i64, i64)
 

--- a/llvm/test/Transforms/InferAddressSpaces/AMDGPU/debug-info.ll
+++ b/llvm/test/Transforms/InferAddressSpaces/AMDGPU/debug-info.ll
@@ -25,10 +25,10 @@ define void @simplified_constexpr_gep_addrspacecast(i64 %idx0, i64 %idx1) #0 !db
 }
 
 ; CHECK-LABEL: @objectsize_group_to_flat_i32(
-; CHECK: %val = call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) %group.ptr, i1 true, i1 false, i1 false), !dbg ![[DEBUG_LOC_VAL:[0-9]+]]
+; CHECK: %val = call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) %group.ptr, i1 true, i1 true, i1 false, i1 false), !dbg ![[DEBUG_LOC_VAL:[0-9]+]]
 define i32 @objectsize_group_to_flat_i32(ptr addrspace(3) %group.ptr) #0 !dbg !16 {
   %cast = addrspacecast ptr addrspace(3) %group.ptr to ptr, !dbg !17
-  %val = call i32 @llvm.objectsize.i32.p0(ptr %cast, i1 true, i1 false, i1 false), !dbg !18
+  %val = call i32 @llvm.objectsize.i32.p0(ptr %cast, i1 true, i1 true, i1 false, i1 false), !dbg !18
   ret i32 %val, !dbg !19
 }
 
@@ -66,7 +66,7 @@ entry:
   ret float %arrayidx.load, !dbg !45
 }
 
-declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg) #1
+declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg) #1
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg) #2
 declare ptr @llvm.ptrmask.p0.i64(ptr, i64) #3
 declare i1 @llvm.amdgcn.is.shared(ptr nocapture) #4

--- a/llvm/test/Transforms/InferAddressSpaces/AMDGPU/intrinsics.ll
+++ b/llvm/test/Transforms/InferAddressSpaces/AMDGPU/intrinsics.ll
@@ -1,23 +1,23 @@
 ; RUN: opt -S -mtriple=amdgcn-amd-amdhsa -passes=infer-address-spaces %s | FileCheck %s
 
 ; CHECK-LABEL: @objectsize_group_to_flat_i32(
-; CHECK: %val = call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) %group.ptr, i1 true, i1 false, i1 false)
+; CHECK: %val = call i32 @llvm.objectsize.i32.p3(ptr addrspace(3) %group.ptr, i1 true, i1 true, i1 false, i1 false)
 define i32 @objectsize_group_to_flat_i32(ptr addrspace(3) %group.ptr) #0 {
   %cast = addrspacecast ptr addrspace(3) %group.ptr to ptr
-  %val = call i32 @llvm.objectsize.i32.p0(ptr %cast, i1 true, i1 false, i1 false)
+  %val = call i32 @llvm.objectsize.i32.p0(ptr %cast, i1 true, i1 true, i1 false, i1 false)
   ret i32 %val
 }
 
 ; CHECK-LABEL: @objectsize_global_to_flat_i64(
-; CHECK: %val = call i64 @llvm.objectsize.i64.p3(ptr addrspace(3) %global.ptr, i1 true, i1 false, i1 false)
+; CHECK: %val = call i64 @llvm.objectsize.i64.p3(ptr addrspace(3) %global.ptr, i1 true, i1 true, i1 false, i1 false)
 define i64 @objectsize_global_to_flat_i64(ptr addrspace(3) %global.ptr) #0 {
   %cast = addrspacecast ptr addrspace(3) %global.ptr to ptr
-  %val = call i64 @llvm.objectsize.i64.p0(ptr %cast, i1 true, i1 false, i1 false)
+  %val = call i64 @llvm.objectsize.i64.p0(ptr %cast, i1 true, i1 true, i1 false, i1 false)
   ret i64 %val
 }
 
-declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1) #1
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1) #1
+declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1, i1) #1
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }

--- a/llvm/test/Transforms/InferAlignment/propagate-assume.ll
+++ b/llvm/test/Transforms/InferAlignment/propagate-assume.ll
@@ -193,7 +193,7 @@ define void @complex_backpropagate(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    [[LOAD_A:%.*]] = load i32, ptr [[A]], align 32
 ; CHECK-NEXT:    [[LOAD_B:%.*]] = load i32, ptr [[B]], align 4
 ; CHECK-NEXT:    store i32 [[LOAD_B]], ptr [[A]], align 32
-; CHECK-NEXT:    [[OBJ_SIZE:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[C]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[OBJ_SIZE:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[C]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i64 [[OBJ_SIZE]], ptr [[ALLOCA]], align 8
 ; CHECK-NEXT:    [[PTRINT:%.*]] = ptrtoint ptr [[A]] to i64
 ; CHECK-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], 31
@@ -225,7 +225,7 @@ define void @complex_backpropagate_bundle(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    [[LOAD_A:%.*]] = load i32, ptr [[A]], align 32
 ; CHECK-NEXT:    [[LOAD_B:%.*]] = load i32, ptr [[B]], align 4
 ; CHECK-NEXT:    store i32 [[LOAD_B]], ptr [[A]], align 32
-; CHECK-NEXT:    [[OBJ_SIZE:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[C]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[OBJ_SIZE:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[C]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i64 [[OBJ_SIZE]], ptr [[ALLOCA]], align 8
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i32 32) ]
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/Inline/call-intrinsic-objectsize.ll
+++ b/llvm/test/Transforms/Inline/call-intrinsic-objectsize.ll
@@ -4,12 +4,12 @@
 @numa_nodes_parsed = external constant %struct.nodemask_t, align 8
 
 declare void @foo()
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg)
 
 ; Test that we inline @callee into @caller.
 define i64 @caller() {
 ; CHECK-LABEL: @caller(
-; CHECK-NEXT:    [[TMP1:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr @numa_nodes_parsed, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr @numa_nodes_parsed, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp uge i64 [[TMP1]], 128
 ; CHECK-NEXT:    br i1 [[TMP2]], label %[[CALLEE_EXIT:.*]], label %[[HANDLER_TYPE_MISMATCH94_I:.*]]
 ; CHECK:       [[HANDLER_TYPE_MISMATCH94_I]]:
@@ -31,7 +31,7 @@ define i64 @caller() {
 ; Do not change the linkage of @callee; that will give it a severe discount in
 ; cost (LastCallToStaticBonus).
 define i64 @callee() {
-  %1 = tail call i64 @llvm.objectsize.i64.p0(ptr @numa_nodes_parsed, i1 false, i1 false, i1 false)
+  %1 = tail call i64 @llvm.objectsize.i64.p0(ptr @numa_nodes_parsed, i1 true, i1 false, i1 false, i1 false)
   %2 = icmp uge i64 %1, 128
   br i1 %2, label %cont95, label %handler.type_mismatch94
 

--- a/llvm/test/Transforms/InstCombine/allocsize.ll
+++ b/llvm/test/Transforms/InstCombine/allocsize.ll
@@ -47,7 +47,7 @@ define void @test_malloc_fails(ptr %p, ptr %r, i32 %n) {
 ; CHECK-SAME: ptr [[P:%.*]], ptr [[R:%.*]], i32 [[N:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @my_malloc(ptr null, i32 [[N]])
 ; CHECK-NEXT:    store ptr [[TMP1]], ptr [[P]], align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP1]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP1]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i64 [[TMP2]], ptr [[R]], align 8
 ; CHECK-NEXT:    ret void
 ;
@@ -64,11 +64,11 @@ define void @test_calloc_fails(ptr %p, ptr %r, i32 %n) {
 ; CHECK-SAME: ptr [[P:%.*]], ptr [[R:%.*]], i32 [[N:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @my_calloc(ptr null, ptr null, i32 [[N]], i32 5)
 ; CHECK-NEXT:    store ptr [[TMP1]], ptr [[P]], align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP1]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP1]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i64 [[TMP2]], ptr [[R]], align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call ptr @my_calloc(ptr null, ptr null, i32 100, i32 [[N]])
 ; CHECK-NEXT:    store ptr [[TMP3]], ptr [[P]], align 8
-; CHECK-NEXT:    [[TMP4:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP3]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP4:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[TMP3]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i64 [[TMP4]], ptr [[R]], align 8
 ; CHECK-NEXT:    ret void
 ;
@@ -127,14 +127,14 @@ define void @test_overflow(ptr %p, ptr %r) {
 ; CHECK-SAME: ptr [[P:%.*]], ptr [[R:%.*]]) {
 ; CHECK-NEXT:    [[BIG_MALLOC:%.*]] = call dereferenceable_or_null(4294967298) ptr @my_calloc(ptr null, ptr null, i32 -2147483647, i32 2)
 ; CHECK-NEXT:    store ptr [[BIG_MALLOC]], ptr [[P]], align 8
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr [[BIG_MALLOC]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr [[BIG_MALLOC]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i32 [[TMP1]], ptr [[R]], align 4
 ; CHECK-NEXT:    [[BIG_LITTLE_MALLOC:%.*]] = call dereferenceable_or_null(508) ptr @my_tiny_calloc(ptr null, ptr null, i8 127, i8 4)
 ; CHECK-NEXT:    store ptr [[BIG_LITTLE_MALLOC]], ptr [[P]], align 8
 ; CHECK-NEXT:    store i32 508, ptr [[R]], align 4
 ; CHECK-NEXT:    [[BIG_MALLOC_I64:%.*]] = call dereferenceable_or_null(8589934592) ptr @my_malloc_i64(ptr null, i64 8589934592)
 ; CHECK-NEXT:    store ptr [[BIG_MALLOC_I64]], ptr [[P]], align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr [[BIG_MALLOC_I64]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr [[BIG_MALLOC_I64]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i32 [[TMP2]], ptr [[R]], align 4
 ; CHECK-NEXT:    store i64 8589934592, ptr [[R]], align 8
 ; CHECK-NEXT:    [[VARIED_CALLOC:%.*]] = call dereferenceable_or_null(5000) ptr @my_varied_calloc(ptr null, ptr null, i32 1000, i8 5)

--- a/llvm/test/Transforms/InstCombine/builtin-dynamic-object-size.ll
+++ b/llvm/test/Transforms/InstCombine/builtin-dynamic-object-size.ll
@@ -15,7 +15,7 @@ define i64 @weird_identity_but_ok(i64 %sz) {
 ;
 entry:
   %call = tail call ptr @malloc(i64 %sz)
-  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %call, i1 false, i1 true, i1 true)
+  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %call, i1 true, i1 false, i1 true, i1 true)
   tail call void @free(ptr %call)
   ret i64 %calc_size
 }
@@ -46,7 +46,7 @@ second_label:
 
 join_label:
   %joined = phi ptr [ %first_call, %first_label ], [ %second_call, %second_label ]
-  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %joined, i1 false, i1 true, i1 true)
+  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %joined, i1 true, i1 false, i1 true, i1 true)
   ret i64 %calc_size
 }
 
@@ -60,18 +60,18 @@ define i64 @internal_pointer(i64 %sz) {
 entry:
   %ptr = call ptr @malloc(i64 %sz)
   %ptr2 = getelementptr inbounds i8, ptr %ptr, i32 2
-  %calc_size = call i64 @llvm.objectsize.i64.p0(ptr %ptr2, i1 false, i1 true, i1 true)
+  %calc_size = call i64 @llvm.objectsize.i64.p0(ptr %ptr2, i1 true, i1 false, i1 true, i1 true)
   ret i64 %calc_size
 }
 
 define i64 @uses_nullptr_no_fold() {
 ; CHECK-LABEL: define i64 @uses_nullptr_no_fold() {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RES:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr null, i1 false, i1 true, i1 true)
+; CHECK-NEXT:    [[RES:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr null, i1 true, i1 false, i1 true, i1 true)
 ; CHECK-NEXT:    ret i64 [[RES]]
 ;
 entry:
-  %res = call i64 @llvm.objectsize.i64.p0(ptr null, i1 false, i1 true, i1 true)
+  %res = call i64 @llvm.objectsize.i64.p0(ptr null, i1 true, i1 false, i1 true, i1 true)
   ret i64 %res
 }
 
@@ -82,7 +82,7 @@ define i64 @uses_nullptr_fold() {
 ;
 entry:
   ; NOTE: the third parameter to this call is false, unlike above.
-  %res = call i64 @llvm.objectsize.i64.p0(ptr null, i1 false, i1 false, i1 true)
+  %res = call i64 @llvm.objectsize.i64.p0(ptr null, i1 true, i1 false, i1 false, i1 true)
   ret i64 %res
 }
 
@@ -98,7 +98,7 @@ define void @f() {
 ; CHECK-NEXT:    br i1 [[TOBOOL4]], label [[FOR_END:%.*]], label [[FOR_BODY:%.*]]
 ; CHECK:       for.body:
 ; CHECK-NEXT:    [[DP_05:%.*]] = phi ptr [ [[ADD_PTR:%.*]], [[FOR_BODY]] ], [ @d, [[ENTRY:%.*]] ]
-; CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr [[DP_05]], i1 false, i1 true, i1 true)
+; CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr [[DP_05]], i1 true, i1 false, i1 true, i1 true)
 ; CHECK-NEXT:    [[CONV:%.*]] = trunc i64 [[TMP0]] to i32
 ; CHECK-NEXT:    tail call void @bury(i32 [[CONV]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @c, align 4
@@ -118,7 +118,7 @@ entry:
 
 for.body:                                         ; preds = %entry, %for.body
   %dp.05 = phi ptr [ %add.ptr, %for.body ], [ @d, %entry ]
-  %0 = tail call i64 @llvm.objectsize.i64.p0(ptr %dp.05, i1 false, i1 true, i1 true)
+  %0 = tail call i64 @llvm.objectsize.i64.p0(ptr %dp.05, i1 true, i1 false, i1 true, i1 true)
   %conv = trunc i64 %0 to i32
   tail call void @bury(i32 %conv) #3
   %1 = load i32, ptr @c, align 4
@@ -153,7 +153,7 @@ define void @bdos_cmpm1(i64 %alloc) {
 ;
 entry:
   %obj = call ptr @malloc(i64 %alloc)
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 0, i1 0, i1 1)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 1, i1 0, i1 0, i1 1)
   %cmp.not = icmp eq i64 %objsize, -1
   br i1 %cmp.not, label %if.else, label %if.then
 
@@ -189,7 +189,7 @@ define void @bdos_cmpm1_expr(i64 %alloc, i64 %part) {
 entry:
   %sz = udiv i64 %alloc, %part
   %obj = call ptr @malloc(i64 %sz)
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 0, i1 0, i1 1)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 1, i1 0, i1 0, i1 1)
   %cmp.not = icmp eq i64 %objsize, -1
   br i1 %cmp.not, label %if.else, label %if.then
 
@@ -220,7 +220,7 @@ entry:
   %gep = getelementptr i8, ptr addrspace(7) @p7, i32 1
   %as = addrspacecast ptr addrspace(7) %gep to ptr
   %select = select i1 %c, ptr %p0, ptr %as
-  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %select, i1 false, i1 true, i1 true)
+  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %select, i1 true, i1 false, i1 true, i1 true)
   ret i64 %calc_size
 }
 
@@ -234,7 +234,7 @@ define i64 @constexpr_as_cast(i1 %c) {
 entry:
   %p0 = tail call ptr @malloc(i64 64)
   %select = select i1 %c, ptr %p0, ptr addrspacecast (ptr addrspace(7) getelementptr (i8, ptr addrspace(7) @p7, i32 1) to ptr)
-  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %select, i1 false, i1 true, i1 true)
+  %calc_size = tail call i64 @llvm.objectsize.i64.p0(ptr %select, i1 true, i1 false, i1 true, i1 true)
   ret i64 %calc_size
 }
 
@@ -249,7 +249,7 @@ declare ptr @get_unknown_buffer()
 declare void @free(ptr nocapture) nounwind allockind("free") "alloc-family"="malloc"
 
 ; Function Attrs: nounwind readnone speculatable
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 
 declare void @fortified_chk(ptr, i64)
 

--- a/llvm/test/Transforms/InstCombine/builtin-object-size-custom-dl.ll
+++ b/llvm/test/Transforms/InstCombine/builtin-object-size-custom-dl.ll
@@ -6,7 +6,7 @@ define i64 @objsize1_custom_idx(i64 %sz) {
 entry:
   %ptr = call ptr @malloc(i64 %sz)
   %ptr2 = getelementptr inbounds i8, ptr %ptr, i32 2
-  %calc_size = call i64 @llvm.objectsize.i64.p0(ptr %ptr2, i1 false, i1 true, i1 true)
+  %calc_size = call i64 @llvm.objectsize.i64.p0(ptr %ptr2, i1 true, i1 false, i1 true, i1 true)
   ret i64 %calc_size
 }
 
@@ -17,7 +17,7 @@ entry:
   %var = alloca %struct.V, align 4
   call void @llvm.lifetime.start.p0(i64 28, ptr %var) #3
   %arrayidx = getelementptr inbounds [10 x i8], ptr %var, i64 0, i64 1
-  %0 = call i64 @llvm.objectsize.i64.p0(ptr %arrayidx, i1 false, i1 false, i1 false)
+  %0 = call i64 @llvm.objectsize.i64.p0(ptr %arrayidx, i1 true, i1 false, i1 false, i1 false)
   %conv = trunc i64 %0 to i32
   call void @llvm.lifetime.end.p0(i64 28, ptr %var) #3
   ret i32 %conv
@@ -27,4 +27,4 @@ entry:
 declare void @llvm.lifetime.start.p0(i64, ptr nocapture) #1
 declare void @llvm.lifetime.end.p0(i64, ptr nocapture) #1
 declare ptr @malloc(i64)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)

--- a/llvm/test/Transforms/InstCombine/builtin-object-size-strdup-family.ll
+++ b/llvm/test/Transforms/InstCombine/builtin-object-size-strdup-family.ll
@@ -6,7 +6,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 declare dso_local noalias noundef ptr @malloc(i64 noundef) local_unnamed_addr
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg)
 declare noalias ptr @strdup(ptr);
 declare noalias ptr @__strdup(ptr);
 declare noalias ptr @strndup(ptr, i64);
@@ -19,7 +19,7 @@ define dso_local i64 @check_strdup(i32 noundef %n) local_unnamed_addr {
 ; CHECK-NEXT:    ret i64 11
 ;
   %ptr = call noalias ptr @strdup(ptr noundef @str)
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -28,7 +28,7 @@ define dso_local i64 @check_dunder_strdup(i32 noundef %n) local_unnamed_addr {
 ; CHECK-NEXT:    ret i64 11
 ;
   %ptr = call noalias ptr @__strdup(ptr noundef @str)
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -37,7 +37,7 @@ define dso_local i64 @check_strndup(i32 noundef %n) local_unnamed_addr {
 ; CHECK-NEXT:    ret i64 5
 ;
   %ptr = call noalias ptr @strndup(ptr noundef @str, i64 4)
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -46,6 +46,6 @@ define dso_local i64 @check_dunder_strndup(i32 noundef %n) local_unnamed_addr {
 ; CHECK-NEXT:    ret i64 5
 ;
   %ptr = call noalias ptr @__strndup(ptr noundef @str, i64 4)
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %ptr, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }

--- a/llvm/test/Transforms/InstCombine/invoke.ll
+++ b/llvm/test/Transforms/InstCombine/invoke.ll
@@ -55,7 +55,7 @@ entry:
           to label %invoke.cont unwind label %lpad
 
 invoke.cont:
-; CHECK: call i64 @llvm.objectsize.i64.p0(ptr %call, i1 false, i1 false, i1 false)
+; CHECK: call i64 @llvm.objectsize.i64.p0(ptr %call, i1 true, i1 false, i1 false, i1 false)
   %0 = tail call i64 @llvm.objectsize.i64(ptr %call, i1 false)
   ret i64 %0
 

--- a/llvm/test/Transforms/InstCombine/memset_chk-1.ll
+++ b/llvm/test/Transforms/InstCombine/memset_chk-1.ll
@@ -91,7 +91,7 @@ define i32 @test_rauw(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CALL49:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[A:%.*]])
 ; CHECK-NEXT:    [[ADD180:%.*]] = add i64 [[CALL49]], 1
-; CHECK-NEXT:    [[YO107:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[B:%.*]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[YO107:%.*]] = call i64 @llvm.objectsize.i64.p0(ptr [[B:%.*]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[CALL50:%.*]] = call ptr @__memmove_chk(ptr [[B]], ptr [[A]], i64 [[ADD180]], i64 [[YO107]])
 ; CHECK-NEXT:    [[STRLEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[B]])
 ; CHECK-NEXT:    [[STRCHR1:%.*]] = getelementptr inbounds i8, ptr [[B]], i64 [[STRLEN]]
@@ -106,7 +106,7 @@ define i32 @test_rauw(ptr %a, ptr %b, ptr %c) {
 entry:
   %call49 = call i64 @strlen(ptr %a)
   %add180 = add i64 %call49, 1
-  %yo107 = call i64 @llvm.objectsize.i64.p0(ptr %b, i1 false, i1 false, i1 false)
+  %yo107 = call i64 @llvm.objectsize.i64.p0(ptr %b, i1 true, i1 false, i1 false, i1 false)
   %call50 = call ptr @__memmove_chk(ptr %b, ptr %a, i64 %add180, i64 %yo107)
   %call51i = call ptr @strrchr(ptr %b, i32 0)
   %d = load ptr, ptr %c, align 8
@@ -121,7 +121,7 @@ entry:
 declare ptr @__memmove_chk(ptr, ptr, i64, i64)
 declare ptr @strrchr(ptr, i32)
 declare i64 @strlen(ptr nocapture)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1)
 
 declare ptr @__memset_chk(ptr, i32, i64, i64)
 
@@ -134,7 +134,7 @@ define ptr @pr25892(i64 %size) #0 {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[CALL]], null
 ; CHECK-NEXT:    br i1 [[CMP]], label [[CLEANUP:%.*]], label [[IF_END:%.*]]
 ; CHECK:       if.end:
-; CHECK-NEXT:    [[CALL2:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr nonnull [[CALL]], i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[CALL2:%.*]] = tail call i64 @llvm.objectsize.i64.p0(ptr nonnull [[CALL]], i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[CALL3:%.*]] = tail call ptr @__memset_chk(ptr nonnull [[CALL]], i32 0, i64 [[SIZE]], i64 [[CALL2]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label [[CLEANUP]]
 ; CHECK:       cleanup:
@@ -146,7 +146,7 @@ entry:
   %cmp = icmp eq ptr %call, null
   br i1 %cmp, label %cleanup, label %if.end
 if.end:
-  %call2 = tail call i64 @llvm.objectsize.i64.p0(ptr nonnull %call, i1 false, i1 false, i1 false)
+  %call2 = tail call i64 @llvm.objectsize.i64.p0(ptr nonnull %call, i1 true, i1 false, i1 false, i1 false)
   %call3 = tail call ptr @__memset_chk(ptr nonnull %call, i32 0, i64 %size, i64 %call2) #1
   br label %cleanup
 cleanup:

--- a/llvm/test/Transforms/InstCombine/objsize.ll
+++ b/llvm/test/Transforms/InstCombine/objsize.ll
@@ -10,7 +10,7 @@ define i32 @foo() nounwind {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:    ret i32 60
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -27,7 +27,7 @@ define ptr @bar() nounwind {
 ;
 entry:
   %retval = alloca ptr
-  %0 = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %0 = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %cmp = icmp ne i32 %0, -1
   br i1 %cmp, label %cond.true, label %cond.false
 
@@ -44,7 +44,7 @@ define i32 @f() nounwind {
 ; CHECK-LABEL: @f(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr ([60 x i8], ptr @a, i32 1, i32 0), i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr ([60 x i8], ptr @a, i32 1, i32 0), i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -52,11 +52,11 @@ define i32 @f() nounwind {
 
 define i1 @baz() nounwind {
 ; CHECK-LABEL: @baz(
-; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.objectsize.i32.p0(ptr @window, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.objectsize.i32.p0(ptr @window, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i32 [[TMP1]], -1
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr @window, i1 false, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr @window, i1 true, i1 false, i1 false, i1 false)
   %2 = icmp eq i32 %1, -1
   ret i1 %2
 }
@@ -64,7 +64,7 @@ define i1 @baz() nounwind {
 define void @test1(ptr %q, i32 %x) nounwind noinline {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr getelementptr inbounds ([0 x i8], ptr @window, i32 0, i32 10), i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr getelementptr inbounds ([0 x i8], ptr @window, i32 0, i32 10), i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], -1
 ; CHECK-NEXT:    br i1 [[TMP1]], label %"47", label %"46"
 ; CHECK:       "46":
@@ -73,7 +73,7 @@ define void @test1(ptr %q, i32 %x) nounwind noinline {
 ; CHECK-NEXT:    unreachable
 ;
 entry:
-  %0 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr inbounds ([0 x i8], ptr @window, i32 0, i32 10), i1 false, i1 false, i1 false) ; <i64> [#uses=1]
+  %0 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr inbounds ([0 x i8], ptr @window, i32 0, i32 10), i1 true, i1 false, i1 false, i1 false) ; <i64> [#uses=1]
   %1 = icmp eq i32 %0, -1                         ; <i1> [#uses=1]
   br i1 %1, label %"47", label %"46"
 
@@ -90,7 +90,7 @@ define i32 @test2() nounwind {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:    ret i32 34
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr (i8, ptr @.str5, i32 2), i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr getelementptr (i8, ptr @.str5, i32 2), i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -99,9 +99,9 @@ define i32 @test2() nounwind {
 
 declare ptr @__memcpy_chk(ptr, ptr, i32, i32) nounwind
 
-declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1) nounwind readonly
+declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1, i1) nounwind readonly
 
-declare i32 @llvm.objectsize.i32.p1(ptr addrspace(1), i1, i1, i1) nounwind readonly
+declare i32 @llvm.objectsize.i32.p1(ptr addrspace(1), i1, i1, i1, i1) nounwind readonly
 
 declare ptr @__inline_memcpy_chk(ptr, ptr, i32) nounwind inlinehint
 
@@ -120,7 +120,7 @@ entry:
 
 bb11:
   %0 = getelementptr inbounds float, ptr getelementptr inbounds ([480 x float], ptr @array, i32 0, i32 128), i32 -127 ; <ptr> [#uses=1]
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr %0, i1 false, i1 false, i1 false) ; <i32> [#uses=1]
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr %0, i1 true, i1 false, i1 false, i1 false) ; <i32> [#uses=1]
   %2 = call ptr @__memcpy_chk(ptr %ptr1, ptr %ptr2, i32 512, i32 %1) nounwind ; <ptr> [#uses=0]
   unreachable
 
@@ -144,7 +144,7 @@ define i32 @test4(ptr %esc) nounwind ssp {
 ;
 entry:
   %0 = alloca %struct.data, align 8
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr %0, i1 false, i1 false, i1 false) nounwind
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr %0, i1 true, i1 false, i1 false, i1 false) nounwind
   %2 = call ptr @__memset_chk(ptr %0, i32 0, i32 1824, i32 %1) nounwind
   store ptr %0, ptr %esc
   ret i32 0
@@ -163,7 +163,7 @@ define ptr @test5(i32 %n) nounwind ssp {
 ;
 entry:
   %0 = tail call noalias ptr @malloc(i32 20) nounwind
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %0, i1 false, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %0, i1 true, i1 false, i1 false, i1 false)
   %2 = load ptr, ptr @s, align 8
   %3 = tail call ptr @__memcpy_chk(ptr %0, ptr %2, i32 10, i32 %1) nounwind
   ret ptr %0
@@ -179,7 +179,7 @@ define void @test6(i32 %n) nounwind ssp {
 ;
 entry:
   %0 = tail call noalias ptr @malloc(i32 20) nounwind
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %0, i1 false, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %0, i1 true, i1 false, i1 false, i1 false)
   %2 = load ptr, ptr @s, align 8
   %3 = tail call ptr @__memcpy_chk(ptr %0, ptr %2, i32 30, i32 %1) nounwind
   ret void
@@ -198,7 +198,7 @@ define i32 @test7(ptr %esc) {
   %alloc = call noalias ptr @malloc(i32 48) nounwind
   store ptr %alloc, ptr %esc
   %gep = getelementptr inbounds i8, ptr %alloc, i32 16
-  %objsize = call i32 @llvm.objectsize.i32.p0(ptr %gep, i1 false, i1 false, i1 false) nounwind readonly
+  %objsize = call i32 @llvm.objectsize.i32.p0(ptr %gep, i1 true, i1 false, i1 false, i1 false) nounwind readonly
   ret i32 %objsize
 }
 
@@ -213,7 +213,7 @@ define i32 @test8(ptr %esc) {
   %alloc = call noalias ptr @calloc(i32 5, i32 7) nounwind
   store ptr %alloc, ptr %esc
   %gep = getelementptr inbounds i8, ptr %alloc, i32 5
-  %objsize = call i32 @llvm.objectsize.i32.p0(ptr %gep, i1 false, i1 false, i1 false) nounwind readonly
+  %objsize = call i32 @llvm.objectsize.i32.p0(ptr %gep, i1 true, i1 false, i1 false, i1 false) nounwind readonly
   ret i32 %objsize
 }
 
@@ -228,7 +228,7 @@ define i32 @test9(ptr %esc) {
 ;
   %call = tail call ptr @strdup(ptr @.str) nounwind
   store ptr %call, ptr %esc, align 8
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -240,7 +240,7 @@ define i32 @test10(ptr %esc) {
 ;
   %call = tail call ptr @strndup(ptr @.str, i32 3) nounwind
   store ptr %call, ptr %esc, align 8
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -252,7 +252,7 @@ define i32 @test11(ptr %esc) {
 ;
   %call = tail call ptr @strndup(ptr @.str, i32 7) nounwind
   store ptr %call, ptr %esc, align 8
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -264,7 +264,7 @@ define i32 @test12(ptr %esc) {
 ;
   %call = tail call ptr @strndup(ptr @.str, i32 8) nounwind
   store ptr %call, ptr %esc, align 8
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -276,7 +276,7 @@ define i32 @test13(ptr %esc) {
 ;
   %call = tail call ptr @strndup(ptr @.str, i32 57) nounwind
   store ptr %call, ptr %esc, align 8
-  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 false, i1 false)
+  %1 = tail call i32 @llvm.objectsize.i32.p0(ptr %call, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -286,7 +286,7 @@ define i32 @test18() {
 ; CHECK-LABEL: @test18(
 ; CHECK-NEXT:    ret i32 60
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr @globalalias, i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr @globalalias, i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -294,10 +294,10 @@ define i32 @test18() {
 
 define i32 @test19() {
 ; CHECK-LABEL: @test19(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @globalalias2, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @globalalias2, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr @globalalias2, i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr @globalalias2, i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -305,7 +305,7 @@ define i32 @test20() {
 ; CHECK-LABEL: @test20(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 false, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 false, i1 false, i1 false)
   ret i32 %1
 }
 
@@ -313,65 +313,65 @@ define i32 @test21() {
 ; CHECK-LABEL: @test21(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 false, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 true, i1 false, i1 false)
   ret i32 %1
 }
 
 define i32 @test22() {
 ; CHECK-LABEL: @test22(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr null, i1 false, i1 true, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 false, i1 true, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 false, i1 true, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 false, i1 true, i1 false)
   ret i32 %1
 }
 
 define i32 @test23() {
 ; CHECK-LABEL: @test23(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 true, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 true, i1 true, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 true, i1 false)
+  %1 = call i32 @llvm.objectsize.i32.p0(ptr null, i1 true, i1 true, i1 true, i1 false)
   ret i32 %1
 }
 
 ; 1 is an arbitrary non-zero address space.
 define i32 @test24() {
 ; CHECK-LABEL: @test24(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 false,
+  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 false,
   i1 false, i1 false)
   ret i32 %1
 }
 
 define i32 @test25() {
 ; CHECK-LABEL: @test25(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 false, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 true, i1 false, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true,
+  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 true,
   i1 false, i1 false)
   ret i32 %1
 }
 
 define i32 @test26() {
 ; CHECK-LABEL: @test26(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 false, i1 true, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 false, i1 true, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 false,
+  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 false,
   i1 true, i1 false)
   ret i32 %1
 }
 
 define i32 @test27() {
 ; CHECK-LABEL: @test27(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 true, i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 true, i1 true, i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
-  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true,
+  %1 = call i32 @llvm.objectsize.i32.p1(ptr addrspace(1) null, i1 true, i1 true,
   i1 true, i1 false)
   ret i32 %1
 }

--- a/llvm/test/Transforms/InstCombine/stpcpy_chk-1.ll
+++ b/llvm/test/Transforms/InstCombine/stpcpy_chk-1.ll
@@ -78,12 +78,12 @@ define ptr @test_simplify4_tail() {
 
 define ptr @test_simplify5() {
 ; CHECK-LABEL: @test_simplify5(
-; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @__memcpy_chk(ptr nonnull @a, ptr nonnull @.str, i32 12, i32 [[LEN]])
 ; CHECK-NEXT:    ret ptr getelementptr inbounds ([60 x i8], ptr @a, i32 0, i32 11)
 ;
 
-  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %ret = call ptr @__stpcpy_chk(ptr @a, ptr @.str, i32 %len)
   ret ptr %ret
 }
@@ -97,7 +97,7 @@ define ptr @test_simplify6() {
 ; CHECK-NEXT:    ret ptr [[RET]]
 ;
 
-  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %ret = call ptr @__stpcpy_chk(ptr @a, ptr @a, i32 %len)
   ret ptr %ret
 }
@@ -127,4 +127,4 @@ define ptr @test_no_simplify1() {
 }
 
 declare ptr @__stpcpy_chk(ptr, ptr, i32) nounwind
-declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1) nounwind readonly
+declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1, i1) nounwind readonly

--- a/llvm/test/Transforms/InstCombine/strcpy_chk-1.ll
+++ b/llvm/test/Transforms/InstCombine/strcpy_chk-1.ll
@@ -78,12 +78,12 @@ define ptr @test_simplify4_tail() {
 
 define ptr @test_simplify5() {
 ; CHECK-LABEL: @test_simplify5(
-; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[RET:%.*]] = call ptr @__memcpy_chk(ptr nonnull @a, ptr nonnull @.str, i32 12, i32 [[LEN]])
 ; CHECK-NEXT:    ret ptr [[RET]]
 ;
 
-  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %ret = call ptr @__strcpy_chk(ptr @a, ptr @.str, i32 %len)
   ret ptr %ret
 }
@@ -92,12 +92,12 @@ define ptr @test_simplify5() {
 
 define ptr @test_simplify6() {
 ; CHECK-LABEL: @test_simplify6(
-; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[LEN:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    [[RET:%.*]] = call ptr @__strcpy_chk(ptr nonnull @a, ptr nonnull @a, i32 [[LEN]])
 ; CHECK-NEXT:    ret ptr [[RET]]
 ;
 
-  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 false, i1 false, i1 false)
+  %len = call i32 @llvm.objectsize.i32.p0(ptr @a, i1 true, i1 false, i1 false, i1 false)
   %ret = call ptr @__strcpy_chk(ptr @a, ptr @a, i32 %len)
   ret ptr %ret
 }
@@ -136,4 +136,4 @@ define ptr @test_no_simplify2(ptr %dst, ptr %src, i32 %a) {
 }
 
 declare ptr @__strcpy_chk(ptr, ptr, i32) nounwind
-declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1) nounwind readonly
+declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1, i1) nounwind readonly

--- a/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-load.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-load.ll
@@ -4,7 +4,7 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg)
 
 
 define dso_local i64 @check_store_load(i1 %cond) local_unnamed_addr {
@@ -37,7 +37,7 @@ if.end:
 
 return:
   %held = load ptr, ptr %holder
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %held, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %held, i1 true, i1 false, i1 true, i1 false)
   ret i64 %objsize
 
 }

--- a/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-phi.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-phi.ll
@@ -6,7 +6,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 declare dso_local noalias noundef ptr @malloc(i64 noundef) local_unnamed_addr allocsize(0)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg)
 
 @buffer = dso_local global [4 x i8] zeroinitializer, align 1
 
@@ -32,7 +32,7 @@ if.else:
 
 if.end:
   %p = phi ptr [ %malloced, %if.else ], [ @buffer, %entry ]
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -58,7 +58,7 @@ if.else:
 
 if.end:
   %p = phi ptr [ %malloced, %if.else ], [ @buffer, %entry ]
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 true, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -86,7 +86,7 @@ if.else:
 
 if.end:
   %p = phi ptr [ %offseted, %if.else ], [ %buffer, %entry ]
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 false, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 false, i1 true, i1 false)
   ret i64 %size
 }
 
@@ -114,6 +114,6 @@ if.else:
 
 if.end:
   %p = phi ptr [ %offseted, %if.else ], [ %buffer, %entry ]
-  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 true, i1 false)
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %p, i1 true, i1 true, i1 true, i1 false)
   ret i64 %size
 }

--- a/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-posix-memalign.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/builtin-object-size-posix-memalign.ll
@@ -5,7 +5,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 declare dso_local i32 @posix_memalign(ptr noundef, i64 noundef, i64 noundef)
-declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg)
 
 ; Check posix_memalign call with proper handlig of return value
 define dso_local i64 @check_posix_memalign(i32 noundef %n) local_unnamed_addr {
@@ -29,7 +29,7 @@ entry:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:
@@ -63,7 +63,7 @@ entry:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:
@@ -91,7 +91,7 @@ entry:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:
@@ -113,7 +113,7 @@ entry:
   %obj = alloca ptr
   %call = call i32 @posix_memalign(ptr noundef %obj, i64 noundef 8, i64 noundef 10)
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   ret i64 %objsize
 }
 
@@ -142,7 +142,7 @@ entry:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:
@@ -173,7 +173,7 @@ entry:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:
@@ -209,7 +209,7 @@ cond.true:
 
 cond.false:
   %val = load ptr, ptr %obj
-  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 false, i1 true, i1 false)
+  %objsize = call i64 @llvm.objectsize.i64.p0(ptr %val, i1 true, i1 false, i1 true, i1 false)
   br label %exit
 
 exit:

--- a/llvm/test/Transforms/LowerConstantIntrinsics/constant-intrinsics.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/constant-intrinsics.ll
@@ -19,7 +19,7 @@ declare i1 @llvm.is.constant.sl_i32i32s({i32, i32} %a) nounwind readnone
 declare i1 @llvm.is.constant.a2i64([2 x i64] %a) nounwind readnone
 declare i1 @llvm.is.constant.p0(ptr %a) nounwind readnone
 
-declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1) nounwind readnone
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1, i1) nounwind readnone
 
 declare i32 @subfun_1()
 declare i32 @subfun_2()
@@ -45,7 +45,7 @@ define i1 @test_objectsize(ptr %obj) nounwind {
 ;; CHECK-NOT:      llvm.objectsize
 ;; CHECK-NOT:      llvm.is.constant
 ;; CHECK:          ret i1 true
-  %os = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 false, i1 false, i1 false)
+  %os = call i64 @llvm.objectsize.i64.p0(ptr %obj, i1 true, i1 false, i1 false, i1 false)
   %os1 = add i64 %os, 1
   %v = call i1 @llvm.is.constant.i64(i64 %os1)
   ret i1 %v

--- a/llvm/test/Transforms/LowerConstantIntrinsics/crash-on-large-allocas.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/crash-on-large-allocas.ll
@@ -8,9 +8,9 @@ target datalayout = "p:16:16"
 ; CHECK-LABEL: @alloca_overflow_is_unknown(
 define i16 @alloca_overflow_is_unknown() {
   %i = alloca i8, i32 65537
-  %j = call i16 @llvm.objectsize.i16.p0(ptr %i, i1 false, i1 false, i1 false)
+  %j = call i16 @llvm.objectsize.i16.p0(ptr %i, i1 true, i1 false, i1 false, i1 false)
   ; CHECK: ret i16 -1
   ret i16 %j
 }
 
-declare i16 @llvm.objectsize.i16.p0(ptr, i1, i1, i1)
+declare i16 @llvm.objectsize.i16.p0(ptr, i1, i1, i1, i1)

--- a/llvm/test/Transforms/LowerConstantIntrinsics/objectsize_basic.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/objectsize_basic.ll
@@ -4,8 +4,9 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-apple-darwin10.0.0"
 
-declare i64 @llvm.objectsize.i64(ptr, i1, i1, i1) nounwind readonly
-declare i64 @llvm.objectsize.i64.p1(ptr addrspace(1), i1, i1, i1) nounwind readonly
+declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1, i1)
+declare i64 @llvm.objectsize.i64(ptr, i1, i1, i1, i1) nounwind readonly
+declare i64 @llvm.objectsize.i64.p1(ptr addrspace(1), i1, i1, i1, i1) nounwind readonly
 declare void @llvm.trap() nounwind
 
 ; objectsize should fold to a constant, which causes the branch to fold to an
@@ -18,7 +19,7 @@ define i32 @test1(ptr %ptr) nounwind ssp noredzone align 2 {
 ; CHECK-NEXT:    ret i32 4
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 false, i1 false, i1 false)
+  %0 = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 false, i1 false, i1 false)
   %1 = icmp ugt i64 %0, 3
   br i1 %1, label %T, label %trap
 
@@ -37,7 +38,7 @@ define i64 @test_objectsize_null_flag(ptr %ptr) {
 ; CHECK-NEXT:    ret i64 -1
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64(ptr null, i1 false, i1 true, i1 false)
+  %0 = tail call i64 @llvm.objectsize.i64(ptr null, i1 true, i1 false, i1 true, i1 false)
   ret i64 %0
 }
 
@@ -47,7 +48,7 @@ define i64 @test_objectsize_null_flag_min(ptr %ptr) {
 ; CHECK-NEXT:    ret i64 0
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64(ptr null, i1 true, i1 true, i1 false)
+  %0 = tail call i64 @llvm.objectsize.i64(ptr null, i1 true, i1 true, i1 true, i1 false)
   ret i64 %0
 }
 
@@ -59,7 +60,7 @@ define i64 @test_objectsize_null_flag_noas0() {
 ; CHECK-NEXT:    ret i64 -1
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 false,
+  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true, i1 false,
   i1 true, i1 false)
   ret i64 %0
 }
@@ -70,7 +71,7 @@ define i64 @test_objectsize_null_flag_min_noas0() {
 ; CHECK-NEXT:    ret i64 0
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true,
+  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true, i1 true,
   i1 true, i1 false)
   ret i64 %0
 }
@@ -81,7 +82,7 @@ define i64 @test_objectsize_null_known_flag_noas0() {
 ; CHECK-NEXT:    ret i64 -1
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 false,
+  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true, i1 false,
   i1 false, i1 false)
   ret i64 %0
 }
@@ -92,7 +93,7 @@ define i64 @test_objectsize_null_known_flag_min_noas0() {
 ; CHECK-NEXT:    ret i64 0
 ;
 entry:
-  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true,
+  %0 = tail call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) null, i1 true, i1 true,
   i1 false, i1 false)
   ret i64 %0
 }
@@ -101,7 +102,7 @@ define i64 @test_objectsize_byval_arg(ptr byval([42 x i8]) %ptr) {
 ; CHECK-LABEL: @test_objectsize_byval_arg(
 ; CHECK-NEXT:    ret i64 42
 ;
-  %size = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 false, i1 false)
+  %size = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 true, i1 false, i1 false)
   ret i64 %size
 }
 
@@ -109,7 +110,7 @@ define i64 @test_objectsize_byref_arg(ptr byref([42 x i8]) %ptr) {
 ; CHECK-LABEL: @test_objectsize_byref_arg(
 ; CHECK-NEXT:    ret i64 42
 ;
-  %size = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 false, i1 false)
+  %size = tail call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 true, i1 false, i1 false)
   ret i64 %size
 }
 
@@ -131,7 +132,7 @@ define i64 @vla_pointer_size_mismatch(i42 %x) {
 ;
   %A = alloca i8, i42 %x, align 1
   %G1 = getelementptr i8, ptr %A, i8 17
-  %objsize = call i64 @llvm.objectsize.i64(ptr %G1, i1 false, i1 true, i1 true)
+  %objsize = call i64 @llvm.objectsize.i64(ptr %G1, i1 true, i1 false, i1 true, i1 true)
   ret i64 %objsize
 }
 
@@ -143,7 +144,7 @@ define i64 @test_objectsize_malloc() {
 ; CHECK-NEXT:    ret i64 16
 ;
   %ptr = call ptr @malloc(i64 16)
-  %objsize = call i64 @llvm.objectsize.i64(ptr %ptr, i1 false, i1 true, i1 true)
+  %objsize = call i64 @llvm.objectsize.i64(ptr %ptr, i1 true, i1 false, i1 true, i1 true)
   ret i64 %objsize
 }
 
@@ -153,7 +154,7 @@ define i32 @promote_with_objectsize_min_false() {
 ; CHECK-LABEL: @promote_with_objectsize_min_false(
 ; CHECK-NEXT:    ret i32 -1
 ;
-  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_weak, i1 false, i1 false, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_weak, i1 true, i1 false, i1 false, i1 false)
   ret i32 %size
 }
 
@@ -161,7 +162,7 @@ define i32 @promote_with_objectsize_min_true() {
 ; CHECK-LABEL: @promote_with_objectsize_min_true(
 ; CHECK-NEXT:    ret i32 8
 ;
-  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_weak, i1 true, i1 false, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_weak, i1 true, i1 true, i1 false, i1 false)
   ret i32 %size
 }
 
@@ -171,7 +172,7 @@ define i32 @promote_with_objectsize_nullunknown_false() {
 ; CHECK-LABEL: @promote_with_objectsize_nullunknown_false(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_extern, i1 true, i1 false, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_extern, i1 true, i1 true, i1 false, i1 false)
   ret i32 %size
 }
 
@@ -179,8 +180,6 @@ define i32 @promote_with_objectsize_nullunknown_true() {
 ; CHECK-LABEL: @promote_with_objectsize_nullunknown_true(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_extern, i1 true, i1 true, i1 false)
+  %size = call i32 @llvm.objectsize.i32.p0(ptr @gv_extern, i1 true, i1 true, i1 true, i1 false)
   ret i32 %size
 }
-
-declare i32 @llvm.objectsize.i32.p0(ptr, i1, i1, i1)

--- a/llvm/test/Transforms/LowerConstantIntrinsics/stale-worklist-phi.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/stale-worklist-phi.ll
@@ -15,7 +15,7 @@
 
 define fastcc void @foo(ptr %p) unnamed_addr {
 entry:
-  %0 = tail call i32 @llvm.objectsize.i32.p0(ptr %p, i1 false, i1 false, i1 false) #2
+  %0 = tail call i32 @llvm.objectsize.i32.p0(ptr %p, i1 true, i1 false, i1 false, i1 false) #2
   %1 = icmp ne i32 %0, 0
   %.not1.i = icmp eq i32 %0, 0
   br label %for.cond
@@ -41,7 +41,7 @@ cont4.i:                                          ; preds = %cont2.i
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg) #1
+declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg) #1
 
 attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #2 = { nounwind }

--- a/llvm/test/Transforms/SCCP/issue59602-assume-like-call-users.ll
+++ b/llvm/test/Transforms/SCCP/issue59602-assume-like-call-users.ll
@@ -18,11 +18,11 @@ define i32 @call_assume_self_user() {
 ; users have a concrete value"
 define internal i32 @assume_self_user() {
 ; CHECK-LABEL: define {{[^@]+}}@assume_self_user() {
-; CHECK-NEXT:    [[OBJSIZE:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @assume_self_user, i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[OBJSIZE:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr @assume_self_user, i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i32 [[OBJSIZE]], ptr @extern, align 4
 ; CHECK-NEXT:    ret i32 undef
 ;
-  %objsize = call i32 @llvm.objectsize.i32.p0(ptr @assume_self_user, i1 false, i1 false, i1 false)
+  %objsize = call i32 @llvm.objectsize.i32.p0(ptr @assume_self_user, i1 true, i1 false, i1 false, i1 false)
   store i32 %objsize, ptr @extern
   ret i32 0
 }
@@ -48,15 +48,15 @@ define i32 @callsite_with_returned() {
 define internal i32 @constexpr_self_user(i32 %arg0) addrspace(1) {
 ; CHECK-LABEL: define {{[^@]+}}@constexpr_self_user
 ; CHECK-SAME: (i32 [[ARG0:%.*]]) addrspace(1) {
-; CHECK-NEXT:    [[OBJSIZE:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr addrspacecast (ptr addrspace(1) @constexpr_self_user to ptr), i1 false, i1 false, i1 false)
+; CHECK-NEXT:    [[OBJSIZE:%.*]] = call i32 @llvm.objectsize.i32.p0(ptr addrspacecast (ptr addrspace(1) @constexpr_self_user to ptr), i1 true, i1 false, i1 false, i1 false)
 ; CHECK-NEXT:    store i32 [[OBJSIZE]], ptr @extern, align 4
 ; CHECK-NEXT:    ret i32 undef
 ;
-  %objsize = call i32 @llvm.objectsize.i32.p0(ptr addrspacecast (ptr addrspace(1) @constexpr_self_user to ptr), i1 false, i1 false, i1 false)
+  %objsize = call i32 @llvm.objectsize.i32.p0(ptr addrspacecast (ptr addrspace(1) @constexpr_self_user to ptr), i1 true, i1 false, i1 false, i1 false)
   store i32 %objsize, ptr @extern
   ret i32 %arg0
 }
 
-declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg) #0
+declare i32 @llvm.objectsize.i32.p0(ptr, i1 immarg, i1 immarg, i1 immarg, i1 immarg) #0
 
 attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
The second argument of __builtin_dynamic_object_size controls whether it
returns the size of the whole object or the closest surrounding object.
For this struct:
    
      struct s {
        int  foo;
        char bar[2][40];
        int  baz;
        int  qux;
      };
    
      int main(int argc, char **argv) {
        struct s f;
    
      #define report(x) fprintf(stderr, #x ": %zu\n", x)
    
        argc = 1;
        report(__builtin_dynamic_object_size(f.bar[argc], 0));
        report(__builtin_dynamic_object_size(f.bar[argc], 1));
        return 0;
      }
    
should return:
    
      __builtin_dynamic_object_size(f.bar[argc], 0): 48
      __builtin_dynamic_object_size(f.bar[argc], 1): 40
    
determined by the least significant bit of the TYPE.
    
Add a new parameter to the llvm.objectsize intrinsic to control which
size it should return.
