### PR TITLE
[llvm][utils] Fix SmallString summary provider

### DIFF
--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -218,12 +218,14 @@ class OptionalSynthProvider:
 
 
 def SmallStringSummaryProvider(valobj, internal_dict):
-    num_elements = valobj.GetNumChildren()
+    # The underlying SmallVector base class is the first child.
+    vector = valobj.GetChildAtIndex(0)
+    num_elements = vector.GetNumChildren()
     res = '"'
-    for i in range(0, num_elements):
-        c = valobj.GetChildAtIndex(i).GetValue()
+    for i in range(num_elements):
+        c = vector.GetChildAtIndex(i)
         if c:
-            res += c.strip("'")
+            res += chr(c.GetValueAsUnsigned())
     res += '"'
     return res
 


### PR DESCRIPTION
Fixes `SmallString` summary provider, which was incorrectly producing the empty string. Initially I thought the strings I was debugging were empty for unknown reasons, but that was not the case.