### PR TITLE
Revert "[clang] Fix CTAD for aggregates for nested template classes"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -972,9 +972,6 @@ Bug Fixes to C++ Support
   (`#57410 <https://github.com/llvm/llvm-project/issues/57410>`_) and
   (`#76604 <https://github.com/llvm/llvm-project/issues/57410>`_)
 
-- Fixes CTAD for aggregates on nested template classes. Fixes:
-  (`#77599 <https://github.com/llvm/llvm-project/issues/77599>`_)
-
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10718,14 +10718,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     bool HasAnyDeductionGuide = false;
 
     auto SynthesizeAggrGuide = [&](InitListExpr *ListInit) {
-      auto *Pattern = Template;
-      while (Pattern->getInstantiatedFromMemberTemplate()) {
-        if (Pattern->isMemberSpecialization())
-          break;
-        Pattern = Pattern->getInstantiatedFromMemberTemplate();
-      }
-
-      auto *RD = cast<CXXRecordDecl>(Pattern->getTemplatedDecl());
+      auto *RD = cast<CXXRecordDecl>(Template->getTemplatedDecl());
       if (!(RD->getDefinition() && RD->isAggregate()))
         return;
       QualType Ty = Context.getRecordType(RD);

--- a/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
+++ b/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++20 -verify %s
+// expected-no-diagnostics
 
 template<class T> struct S {
     template<class U> struct N {
@@ -57,21 +58,3 @@ template<class X> struct requires_clause {
 requires_clause<int>::B req(1, 2);
 using RC = decltype(req);
 using RC = requires_clause<int>::B<int>;
-
-template<typename X> struct nested_init_list {
-    template<C<X> Y>
-    struct B { // #INIT_LIST_INNER
-        X x;
-        Y y;
-    };
-};
-
-nested_init_list<int>::B nil {1, 2};
-using NIL = decltype(nil);
-using NIL = nested_init_list<int>::B<int>;
-
-// expected-error@+1 {{no viable constructor or deduction guide for deduction of template arguments of 'B'}}
-nested_init_list<int>::B nil_invalid {1, ""};
-// expected-note@#INIT_LIST_INNER {{candidate template ignored: substitution failure [with Y = const char *]: constraints not satisfied for class template 'B' [with Y = const char *]}}
-// expected-note@#INIT_LIST_INNER {{candidate function template not viable: requires 1 argument, but 2 were provided}}
-// expected-note@#INIT_LIST_INNER {{candidate function template not viable: requires 0 arguments, but 2 were provided}}


### PR DESCRIPTION
Reverts llvm/llvm-project#78387

The added tests are failing on several build bots.