### PR TITLE
[lld-macho] Fix for objc_msgSend stubs

### DIFF
--- a/lld/MachO/Arch/ARM64Common.h
+++ b/lld/MachO/Arch/ARM64Common.h
@@ -170,9 +170,10 @@ writeObjCMsgSendStub(uint8_t *buf, const uint32_t objcStubsFastCode[8],
                pageBits(selrefsVA + selectorOffset) - pcPageBits(0));
   encodePageOff12(&buf32[1], d, objcStubsFastCode[1],
                   selrefsVA + selectorOffset);
+  uint64_t gotOffset = msgSendIndex * LP::wordSize;
   encodePage21(&buf32[2], d, objcStubsFastCode[2],
-               pageBits(gotAddr) - pcPageBits(2));
-  encodePage21(&buf32[3], d, objcStubsFastCode[3], msgSendIndex * LP::wordSize);
+               pageBits(gotAddr + gotOffset) - pcPageBits(2));
+  encodePageOff12(&buf32[3], d, objcStubsFastCode[3], gotAddr + gotOffset);
   buf32[4] = objcStubsFastCode[4];
   buf32[5] = objcStubsFastCode[5];
   buf32[6] = objcStubsFastCode[6];

--- a/lld/test/MachO/arm64-objc-stubs-fix.s
+++ b/lld/test/MachO/arm64-objc-stubs-fix.s
@@ -1,0 +1,34 @@
+# REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o %t.o
+# RUN: %lld -arch arm64 -lSystem  -fixup_chains -o %t.out %t.o
+# RUN: llvm-otool -vs __TEXT __objc_stubs %t.out | FileCheck %s --check-prefix=CHECK --check-prefix=FIRST
+
+# Prepend a dummy entry to check if the address for _objc_msgSend is valid.
+# RUN: %lld -arch arm64 -lSystem  -fixup_chains -e _dummy -U _dummy -o %t.out %t.o
+# RUN: llvm-otool -vs __TEXT __objc_stubs %t.out | FileCheck %s --check-prefix=CHECK --check-prefix=SECOND
+
+# CHECK: Contents of (__TEXT,__objc_stubs) section
+
+# CHECK-NEXT: _objc_msgSend$foo:
+# CHECK-NEXT: adrp    x1, 8 ; 0x100008000
+# CHECK-NEXT: ldr     x1, [x1]
+# CHECK-NEXT: adrp    x16, 4 ; 0x100004000
+# FIRST-NEXT: ldr     x16, [x16]
+# SECOND-NEXT:ldr     x16, [x16, #0x8]
+# CHECK-NEXT: br      x16
+# CHECK-NEXT: brk     #0x1
+# CHECK-NEXT: brk     #0x1
+# CHECK-NEXT: brk     #0x1
+
+# CHECK-EMPTY:
+
+.text
+.globl _objc_msgSend
+_objc_msgSend:
+  ret
+
+.globl _main
+_main:
+  bl  _objc_msgSend$foo
+  ret


### PR DESCRIPTION
This commit corrects the address computation for objc_msgSend stubs. Previously, the address computation was incidentally correct due to objc_msgSend often being the first entry in the got section, resulting in a 0 index. This commit ensures accurate address computation regardless of the objc_msgSend stub's position in the got section.