### PR TITLE
[Clang] [NFC] Remove default argument in ASTUnit.h

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -902,7 +902,7 @@ public:
                     SourceManager &SourceMgr, FileManager &FileMgr,
                     SmallVectorImpl<StoredDiagnostic> &StoredDiagnostics,
                     SmallVectorImpl<const llvm::MemoryBuffer *> &OwnedBuffers,
-                    std::unique_ptr<SyntaxOnlyAction> Act = nullptr);
+                    std::unique_ptr<SyntaxOnlyAction> Act);
 
   /// Save this translation unit to a file with the given name.
   ///

--- a/clang/tools/libclang/CIndexCodeCompletion.cpp
+++ b/clang/tools/libclang/CIndexCodeCompletion.cpp
@@ -765,7 +765,8 @@ clang_codeCompleteAt_Impl(CXTranslationUnit TU, const char *complete_filename,
                     IncludeBriefComments, Capture,
                     CXXIdx->getPCHContainerOperations(), *Results->Diag,
                     Results->LangOpts, *Results->SourceMgr, *Results->FileMgr,
-                    Results->Diagnostics, Results->TemporaryBuffers);
+                    Results->Diagnostics, Results->TemporaryBuffers,
+                    /*SyntaxOnlyAction=*/nullptr);
 
   Results->DiagnosticsWrappers.resize(Results->Diagnostics.size());
 


### PR DESCRIPTION
This removes a default argument that is currently broken in C++23 mode due to `std::default_delete` now being `constexpr`. This is a known problem (see #74963, #59966, #69996, and a couple more), fixing which will probably take some time, so this at least makes it possible to compile `ASTUnit.h` in C++23 mode.

Note that we can’t simply include the header that provides the definition of the class causing the problem either, as that would create a circular dependency.