### PR TITLE
[libc++] Un-xfail module tests in picolibc tests

### DIFF
--- a/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
@@ -12,6 +12,10 @@
 
 // XFAIL: has-no-cxx-module-support
 
+// picolibc does not provide the required timespec_get function, and the
+// "using-if-exists" mechanism apparently did not work here.
+// XFAIL: LIBCXX-PICOLIBC-FIXME
+
 // Make sure that the compile flags contain the expected elements.
 // The tests only look for the expected components and not the exact flags.
 // Otherwise changing the location of the module would break this test.

--- a/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
@@ -12,6 +12,10 @@
 
 // XFAIL: has-no-cxx-module-support
 
+// picolibc does not provide the required timespec_get function, and the
+// "using-if-exists" mechanism apparently did not work here.
+// XFAIL: LIBCXX-PICOLIBC-FIXME
+
 // Make sure that the compile flags contain the expected elements.
 // The tests only look for the expected components and not the exact flags.
 // Otherwise changing the location of the module would break this test.

--- a/libcxx/test/std/modules/std.compat.pass.cpp
+++ b/libcxx/test/std/modules/std.compat.pass.cpp
@@ -12,6 +12,10 @@
 
 // XFAIL: has-no-cxx-module-support
 
+// picolibc does not provide the required timespec_get function, and the
+// "using-if-exists" mechanism apparently did not work here.
+// XFAIL: LIBCXX-PICOLIBC-FIXME
+
 // A minimal test to validate import works.
 
 // MODULE_DEPENDENCIES: std.compat

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -324,7 +324,6 @@ DEFAULT_FEATURES = [
         # This is not allowed per C11 7.1.2 Standard headers/6
         #  Any declaration of a library function shall have external linkage.
         when=lambda cfg: "__ANDROID__" in compilerMacros(cfg)
-        or "__PICOLIBC__" in compilerMacros(cfg)
         or platform.system().lower().startswith("aix")
         # Avoid building on platforms that don't support modules properly.
         or not hasCompileFlag(cfg, "-Wno-reserved-module-identifier"),


### PR DESCRIPTION
Some of the module tests now pass after picolibc update. https://github.com/llvm/llvm-project/pull/77908

The remaining tests fail and are now set to xfail on picolibc specifically.