### PR TITLE
[dsymutil] Add --linker parallel to more tests.

### DIFF
--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -465,7 +465,7 @@ DWARFLinker::getVariableRelocAdjustment(AddressesMap &RelocMgr,
       if (std::optional<int64_t> RelocAdjustment =
               RelocMgr.getExprOpAddressRelocAdjustment(
                   *U, Op, AttrOffset + CurExprOffset,
-                  AttrOffset + Op.getEndOffset()))
+                  AttrOffset + Op.getEndOffset(), Options.Verbose))
         return std::make_pair(HasLocationAddress, *RelocAdjustment);
     } break;
     case dwarf::DW_OP_constx:
@@ -478,7 +478,8 @@ DWARFLinker::getVariableRelocAdjustment(AddressesMap &RelocMgr,
         if (std::optional<int64_t> RelocAdjustment =
                 RelocMgr.getExprOpAddressRelocAdjustment(
                     *U, Op, *AddressOffset,
-                    *AddressOffset + DIE.getDwarfUnit()->getAddressByteSize()))
+                    *AddressOffset + DIE.getDwarfUnit()->getAddressByteSize(),
+                    Options.Verbose))
           return std::make_pair(HasLocationAddress, *RelocAdjustment);
       }
     } break;
@@ -552,7 +553,7 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
 
   assert(LowPc && "low_pc attribute is not an address.");
   std::optional<int64_t> RelocAdjustment =
-      RelocMgr.getSubprogramRelocAdjustment(DIE);
+      RelocMgr.getSubprogramRelocAdjustment(DIE, Options.Verbose);
   if (!RelocAdjustment)
     return Flags;
 

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1372,7 +1372,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
     // Get relocation adjustment value for the current function.
     FuncAddressAdjustment =
         getContaingFile().Addresses->getSubprogramRelocAdjustment(
-            getDIE(InputDieEntry));
+            getDIE(InputDieEntry), false);
   } else if (InputDieEntry->getTag() == dwarf::DW_TAG_label) {
     // Get relocation adjustment value for the current label.
     std::optional<uint64_t> lowPC =
@@ -1386,7 +1386,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
     // Get relocation adjustment value for the current variable.
     std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
         getContaingFile().Addresses->getVariableRelocAdjustment(
-            getDIE(InputDieEntry));
+            getDIE(InputDieEntry), false);
 
     HasLocationExpressionAddress = LocExprAddrAndRelocAdjustment.first;
     if (LocExprAddrAndRelocAdjustment.first &&

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -131,7 +131,8 @@ Error DWARFLinkerImpl::link() {
     }
 
     if (GlobalData.getOptions().Verbose) {
-      outs() << "OBJECT: " << Context->InputDWARFFile.FileName << "\n";
+      outs() << "DEBUG MAP OBJECT: " << Context->InputDWARFFile.FileName
+             << "\n";
 
       for (const std::unique_ptr<DWARFUnit> &OrigCU :
            Context->InputDWARFFile.Dwarf->compile_units()) {

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -741,7 +741,7 @@ bool DependencyTracker::isLiveVariableEntry(const UnitEntryPairTy &Entry,
       // enclosing function, unless requested explicitly.
       std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
           Entry.CU->getContaingFile().Addresses->getVariableRelocAdjustment(
-              DIE);
+              DIE, Entry.CU->getGlobalData().getOptions().Verbose);
 
       if (LocExprAddrAndRelocAdjustment.first)
         Info.setHasAnAddress();
@@ -784,7 +784,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
     RelocAdjustment =
         Entry.CU->getContaingFile().Addresses->getSubprogramRelocAdjustment(
-            DIE);
+            DIE, Entry.CU->getGlobalData().getOptions().Verbose);
     if (!RelocAdjustment)
       return false;
 

--- a/llvm/test/tools/dsymutil/absolute_symbol.test
+++ b/llvm/test/tools/dsymutil/absolute_symbol.test
@@ -1,5 +1,7 @@
 RUN: dsymutil -dump-debug-map -oso-prepend-path %p %p/Inputs/absolute_sym.macho.i386 | FileCheck %s
 
+RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path %p %p/Inputs/absolute_sym.macho.i386 | FileCheck %s
+
 The tested object file has been created by the dummy Objective-C code:
 @interface Foo
 @end

--- a/llvm/test/tools/dsymutil/arch-option.test
+++ b/llvm/test/tools/dsymutil/arch-option.test
@@ -11,6 +11,17 @@ RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib 
 RUN: not dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm42 2>&1 | FileCheck %s -check-prefix=BADARCH
 RUN: not dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch i386 2>&1 | FileCheck %s -check-prefix=EMPTY
 
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch all | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch='*' | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 | FileCheck %s -check-prefixes=ARM64,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm | FileCheck %s -check-prefixes=ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch armv7 | FileCheck %s -check-prefixes=ARMV7,CHECK
+RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 -arch armv7s | FileCheck %s -check-prefixes=ARM64,ARMV7S,CHECK
+RUN: not dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm42 2>&1 | FileCheck %s -check-prefix=BADARCH
+RUN: not dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch i386 2>&1 | FileCheck %s -check-prefix=EMPTY
+
+
 
 ARMV7: ---
 ARMV7-NOT: ...

--- a/llvm/test/tools/dsymutil/archive-timestamp.test
+++ b/llvm/test/tools/dsymutil/archive-timestamp.test
@@ -1,5 +1,7 @@
 # RUN: dsymutil -no-output -oso-prepend-path=%p -y %s 2>&1 | FileCheck -DMSG=%errc_ENOENT %s
 
+# RUN: dsymutil --linker parallel -no-output -oso-prepend-path=%p -y %s 2>&1 | FileCheck -DMSG=%errc_ENOENT %s
+
 # This is the archive member part of basic-archive.macho.x86_64 debug map with corrupted timestamps.
 
 # CHECK: warning: {{.*}}libbasic.a(basic2.macho.x86_64.o): [[MSG]]

--- a/llvm/test/tools/dsymutil/basic-linking.test
+++ b/llvm/test/tools/dsymutil/basic-linking.test
@@ -6,6 +6,11 @@ RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/ba
 RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/two-level-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-TWO
 RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -build-variant-suffix=_debug -D WrongPath -D %p/Inputs %p/Inputs/variant-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-VARIANT
 
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefix=CHECK-ARCHIVE
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 %p/Inputs/basic-lto.macho.x86_64 %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefixes=CHECK,CHECK-LTO,CHECK-ARCHIVE
+
 This test check the basic Dwarf linking process through the debug dumps.
 
 ================================= Simple link ================================

--- a/llvm/test/tools/dsymutil/debug-map-parsing.test
+++ b/llvm/test/tools/dsymutil/debug-map-parsing.test
@@ -4,6 +4,13 @@ RUN: dsymutil -verbose -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-arch
 RUN: dsymutil -dump-debug-map %p/Inputs/basic.macho.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NOT-FOUND
 RUN: not dsymutil -dump-debug-map %p/Inputs/inexistant 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NO-EXECUTABLE
 
+RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
+RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
+RUN: dsymutil --linker parallel -verbose -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-ARCHIVE
+RUN: dsymutil --linker parallel -dump-debug-map %p/Inputs/basic.macho.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NOT-FOUND
+RUN: not dsymutil --linker parallel -dump-debug-map %p/Inputs/inexistant 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NO-EXECUTABLE
+
+
 
 Check that We can parse the debug map of the basic executable.
 

--- a/llvm/test/tools/dsymutil/dump-symtab.test
+++ b/llvm/test/tools/dsymutil/dump-symtab.test
@@ -1,6 +1,9 @@
 RUN: dsymutil -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=ALL,I386 %s
 RUN: dsymutil -arch i386 -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=I386,ONE %s
 
+RUN: dsymutil --linker parallel -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=ALL,I386 %s
+RUN: dsymutil --linker parallel -arch i386 -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=I386,ONE %s
+
 
 ALL:  ----------------------------------------------------------------------
 ALL-NEXT:  Symbol table for: '{{.*}}fat-test.dylib' (x86_64)

--- a/llvm/test/tools/dsymutil/fat-binary-output.test
+++ b/llvm/test/tools/dsymutil/fat-binary-output.test
@@ -1,5 +1,7 @@
 RUN: dsymutil -f -verbose -no-output %p/Inputs/fat-test.dylib -oso-prepend-path %p | FileCheck %s
 
+RUN: dsymutil --linker parallel -f -verbose -no-output %p/Inputs/fat-test.dylib -oso-prepend-path %p | FileCheck %s
+
 This test doesn't produce any filesytstem output, we just look at the verbose
 log output.
 

--- a/llvm/test/tools/dsymutil/fat-header.test
+++ b/llvm/test/tools/dsymutil/fat-header.test
@@ -3,7 +3,13 @@ REQUIRES: system-darwin,arm-registered-target,aarch64-registered-target
 RUN: dsymutil -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat32.dSYM
 RUN: llvm-objdump -m --universal-headers %t.fat32.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT32
 
+RUN: dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat32.dSYM
+RUN: llvm-objdump -m --universal-headers %t.fat32.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT32
+
 RUN: dsymutil -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat64.dSYM -fat64
+RUN: llvm-objdump -m --universal-headers %t.fat64.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT64
+
+RUN: dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat64.dSYM -fat64
 RUN: llvm-objdump -m --universal-headers %t.fat64.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT64
 
 FAT32: fat_magic FAT_MAGIC

--- a/llvm/test/tools/dsymutil/yaml-object-address-rewrite.test
+++ b/llvm/test/tools/dsymutil/yaml-object-address-rewrite.test
@@ -1,5 +1,7 @@
 # RUN: dsymutil -dump-debug-map -oso-prepend-path=%p -y %s | FileCheck %s
 #
+# RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p -y %s | FileCheck %s
+#
 # The YAML debug map bellow is the one from basic-archive.macho.x86_64 with
 # the object addresses set to zero. Check that the YAML import is able to
 # rewrite these addresses to the right values.

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -192,18 +192,20 @@ private:
 
     /// Checks that there is a relocation in the \p Relocs array against a
     /// debug map entry between \p StartOffset and \p NextOffset.
+    /// Print debug output if \p Verbose is set.
     ///
     /// \returns relocation value if relocation exist, otherwise std::nullopt.
     std::optional<int64_t>
     hasValidRelocationAt(const std::vector<ValidReloc> &Relocs,
-                         uint64_t StartOffset, uint64_t EndOffset);
+                         uint64_t StartOffset, uint64_t EndOffset,
+                         bool Verbose);
 
     std::optional<int64_t> getExprOpAddressRelocAdjustment(
         DWARFUnit &U, const DWARFExpression::Operation &Op,
-        uint64_t StartOffset, uint64_t EndOffset) override;
+        uint64_t StartOffset, uint64_t EndOffset, bool Verbose) override;
 
-    std::optional<int64_t>
-    getSubprogramRelocAdjustment(const DWARFDie &DIE) override;
+    std::optional<int64_t> getSubprogramRelocAdjustment(const DWARFDie &DIE,
+                                                        bool Verbose) override;
 
     std::optional<StringRef> getLibraryInstallName() override;
 

--- a/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
+++ b/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
@@ -80,8 +80,8 @@ public:
   // should be renamed into has valid address ranges
   bool hasValidRelocs() override { return HasValidAddressRanges; }
 
-  std::optional<int64_t>
-  getSubprogramRelocAdjustment(const DWARFDie &DIE) override {
+  std::optional<int64_t> getSubprogramRelocAdjustment(const DWARFDie &DIE,
+                                                      bool Verbose) override {
     assert((DIE.getTag() == dwarf::DW_TAG_subprogram ||
             DIE.getTag() == dwarf::DW_TAG_label) &&
            "Wrong type of input die");
@@ -101,7 +101,7 @@ public:
   std::optional<int64_t>
   getExprOpAddressRelocAdjustment(DWARFUnit &U,
                                   const DWARFExpression::Operation &Op,
-                                  uint64_t, uint64_t) override {
+                                  uint64_t, uint64_t, bool Verbose) override {
     switch (Op.getCode()) {
     default: {
       assert(false && "Specified operation does not have address operand");


### PR DESCRIPTION
This patch adds check for parallel linker to tests located in the root of test/tools/dsymutil. To pass NoOutput tests it is necessary to add 'Verbose' parameter to the AddressesMap interface (This is necessary to print debug output only once, parallel linker can call to AddressesMap several times for the same address, before this patch such calls would lead to debug output which does not match with debug output of --linker classic).