### PR TITLE
Added settings for DEBUGINFOD cache location and timeout

### DIFF
--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -11,6 +11,8 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Interpreter/OptionValueString.h"
 #include "lldb/Utility/Args.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 #include "llvm/Debuginfod/Debuginfod.h"
 #include "llvm/Debuginfod/HTTPClient.h"
@@ -173,9 +175,13 @@ GetFileForModule(const ModuleSpec &module_spec,
       cache_key, url_path, cache_path, debuginfod_urls, timeout);
   if (result)
     return FileSpec(*result);
-  // An error here should be logged as a failure in the Debuginfod library,
-  // just consume it here.
-  consumeError(result.takeError());
+
+  Log *log = GetLog(LLDBLog::Symbols);
+  auto err_message = llvm::toString(result.takeError());
+  LLDB_LOGV(log,
+            "[Debuginfod] Failed to download symbol artifact {0} "
+            "with error {1}",
+            url_path, err_message);
   return {};
 }
 

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -175,8 +175,7 @@ GetFileForModule(const ModuleSpec &module_spec,
   Log *log = GetLog(LLDBLog::Symbols);
   auto err_message = llvm::toString(result.takeError());
   LLDB_LOGV(log,
-            "[Debuginfod] Failed to download symbol artifact {0} "
-            "with error {1}",
+            "Debuginfod failed to download symbol artifact {0} with error {1}",
             url_path, err_message);
   return {};
 }

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -155,22 +155,22 @@ GetFileForModule(const ModuleSpec &module_spec,
   // Grab LLDB's Debuginfod overrides from the
   // plugin.symbol-locator.debuginfod.* settings.
   PluginProperties &plugin_props = GetGlobalPluginProperties();
-  llvm::Expected<llvm::StringRef> CacheDirectoryPathOrErr =
+  llvm::Expected<llvm::StringRef> cache_path_or_err =
       plugin_props.GetCachePath();
   // A cache location is *required*.
-  if (!CacheDirectoryPathOrErr)
+  if (!cache_path_or_err)
     return {};
-  llvm::StringRef CacheDirectoryPath = *CacheDirectoryPathOrErr;
-  llvm::SmallVector<llvm::StringRef> DebuginfodUrls =
+  llvm::StringRef cache_path = *cache_path_or_err;
+  llvm::SmallVector<llvm::StringRef> debuginfod_urls =
       llvm::getDefaultDebuginfodUrls();
-  std::chrono::milliseconds Timeout = plugin_props.GetTimeout();
+  std::chrono::milliseconds timeout = plugin_props.GetTimeout();
 
   // We're ready to ask the Debuginfod library to find our file.
   llvm::object::BuildID build_id(module_uuid.GetBytes());
-  std::string UrlPath = UrlBuilder(build_id);
-  std::string CacheKey = llvm::getDebuginfodCacheKey(UrlPath);
+  std::string url_path = UrlBuilder(build_id);
+  std::string cache_key = llvm::getDebuginfodCacheKey(url_path);
   llvm::Expected<std::string> result = llvm::getCachedOrDownloadArtifact(
-      CacheKey, UrlPath, CacheDirectoryPath, DebuginfodUrls, Timeout);
+      cache_key, url_path, cache_path, debuginfod_urls, timeout);
   if (result)
     return FileSpec(*result);
   // An error here should be logged as a failure in the Debuginfod library,

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -142,10 +142,9 @@ SymbolLocator *SymbolLocatorDebuginfod::CreateInstance() {
   return new SymbolLocatorDebuginfod();
 }
 
-+ static std::optional<FileSpec> +
-    GetFileForModule(
-        const ModuleSpec &module_spec,
-        std::function<std::string(llvm::object::BuildID)> UrlBuilder) {
+static std::optional<FileSpec>
+GetFileForModule(const ModuleSpec &module_spec,
+                 std::function<std::string(llvm::object::BuildID)> UrlBuilder) {
   const UUID &module_uuid = module_spec.GetUUID();
   // Don't bother if we don't have a valid UUID, Debuginfod isn't available,
   // or if the 'symbols.enable-external-lookup' setting is false

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -147,16 +147,17 @@ GetFileForModule(const ModuleSpec &module_spec,
                  std::function<std::string(llvm::object::BuildID)> UrlBuilder) {
   const UUID &module_uuid = module_spec.GetUUID();
   // Don't bother if we don't have a valid UUID, Debuginfod isn't available,
-  // or if the 'symbols.enable-external-lookup' setting is false
+  // or if the 'symbols.enable-external-lookup' setting is false.
   if (!module_uuid.IsValid() || !llvm::canUseDebuginfod() ||
       !ModuleList::GetGlobalModuleListProperties().GetEnableExternalLookup())
     return {};
 
-  // Grab the settings values we need
+  // Grab LLDB's Debuginfod overrides from the
+  // plugin.symbol-locator.debuginfod.* settings.
   PluginProperties &plugin_props = GetGlobalPluginProperties();
   llvm::Expected<llvm::StringRef> CacheDirectoryPathOrErr =
       plugin_props.GetCachePath();
-  // A cache location is *required*
+  // A cache location is *required*.
   if (!CacheDirectoryPathOrErr)
     return {};
   llvm::StringRef CacheDirectoryPath = *CacheDirectoryPathOrErr;
@@ -164,7 +165,7 @@ GetFileForModule(const ModuleSpec &module_spec,
       llvm::getDefaultDebuginfodUrls();
   std::chrono::milliseconds Timeout = plugin_props.GetTimeout();
 
-  // We're ready to ask the Debuginfod library to find our file
+  // We're ready to ask the Debuginfod library to find our file.
   llvm::object::BuildID build_id(module_uuid.GetBytes());
   std::string UrlPath = UrlBuilder(build_id);
   std::string CacheKey = llvm::getDebuginfodCacheKey(UrlPath);
@@ -173,7 +174,7 @@ GetFileForModule(const ModuleSpec &module_spec,
   if (result)
     return FileSpec(*result);
   // An error here should be logged as a failure in the Debuginfod library,
-  // just consume it here
+  // just consume it here.
   consumeError(result.takeError());
   return {};
 }

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
@@ -1,7 +1,13 @@
 include "../../../../include/lldb/Core/PropertiesBase.td"
 
 let Definition = "symbollocatordebuginfod" in {
-  def ServerURLs : Property<"server_urls", "Array">,
+  def ServerURLs : Property<"server-urls", "Array">,
     ElementType<"String">,
     Desc<"An ordered list of Debuginfod server URLs to query for symbols. This defaults to the contents of the DEBUGINFOD_URLS environment variable.">;
+  def SymbolCachePath: Property<"cache-path", "String">,
+    DefaultStringValue<"">,
+    Desc<"The path where symbol files should be cached. This defaults to LLDB's system cache location.">;
+  def Timeout : Property<"timeout", "UInt64">,
+    DefaultUnsignedValue<0>,
+    Desc<"Timeout (in seconds) for requests made to a DEBUGINFOD server. A value of zero defaults to DEBUGINFOD_TIMEOUT environment variable (or 90 seconds).">;
 }

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
@@ -9,5 +9,5 @@ let Definition = "symbollocatordebuginfod" in {
     Desc<"The path where symbol files should be cached. This defaults to LLDB's system cache location.">;
   def Timeout : Property<"timeout", "UInt64">,
     DefaultUnsignedValue<0>,
-    Desc<"Timeout (in seconds) for requests made to a DEBUGINFOD server. A value of zero defaults to DEBUGINFOD_TIMEOUT environment variable (or 90 seconds).">;
+    Desc<"Timeout (in seconds) for requests made to a DEBUGINFOD server. A value of zero means we use the debuginfod default timeout: DEBUGINFOD_TIMEOUT if the environment variable is set and 90 seconds otherwise.">;
 }

--- a/llvm/include/llvm/Debuginfod/Debuginfod.h
+++ b/llvm/include/llvm/Debuginfod/Debuginfod.h
@@ -46,7 +46,7 @@ bool canUseDebuginfod();
 /// environment variable.
 SmallVector<StringRef> getDefaultDebuginfodUrls();
 
-/// Creates the cache-key for a given Debuginfod UrlPath
+/// Returns the cache key for a given debuginfod URL path.
 std::string getDebuginfodCacheKey(StringRef UrlPath);
 
 /// Sets the list of debuginfod server URLs to query. This overrides the
@@ -61,7 +61,8 @@ Expected<std::string> getDefaultDebuginfodCacheDirectory();
 /// DEBUGINFOD_TIMEOUT environment variable, default is 90 seconds (90000 ms).
 std::chrono::milliseconds getDefaultDebuginfodTimeout();
 
-/// Get the full UrlPath for a source request of a given BuildID and file path.
+/// Get the full URL path for a source request of a given BuildID and file
+/// path.
 std::string getDebuginfodSourceUrlPath(object::BuildIDRef ID,
                                        StringRef SourceFilePath);
 
@@ -70,14 +71,14 @@ std::string getDebuginfodSourceUrlPath(object::BuildIDRef ID,
 Expected<std::string> getCachedOrDownloadSource(object::BuildIDRef ID,
                                                 StringRef SourceFilePath);
 
-/// Get the full UrlPath for an Executable request of a given BuildID.
+/// Get the full URL path for an executable request of a given BuildID.
 std::string getDebuginfodExecutableUrlPath(object::BuildIDRef ID);
 
 /// Fetches an executable by searching the default local cache directory and
 /// server URLs.
 Expected<std::string> getCachedOrDownloadExecutable(object::BuildIDRef ID);
 
-/// Get the full UrlPath for a debug binary request of a given BuildID.
+/// Get the full URL path for a debug binary request of a given BuildID.
 std::string getDebuginfodDebuginfoUrlPath(object::BuildIDRef ID);
 
 /// Fetches a debug binary by searching the default local cache directory and

--- a/llvm/include/llvm/Debuginfod/Debuginfod.h
+++ b/llvm/include/llvm/Debuginfod/Debuginfod.h
@@ -46,6 +46,9 @@ bool canUseDebuginfod();
 /// environment variable.
 SmallVector<StringRef> getDefaultDebuginfodUrls();
 
+/// Creates the cache-key for a given Debuginfod UrlPath
+std::string getDebuginfodCacheKey(StringRef UrlPath);
+
 /// Sets the list of debuginfod server URLs to query. This overrides the
 /// environment variable DEBUGINFOD_URLS.
 void setDefaultDebuginfodUrls(const SmallVector<StringRef> &URLs);
@@ -58,14 +61,24 @@ Expected<std::string> getDefaultDebuginfodCacheDirectory();
 /// DEBUGINFOD_TIMEOUT environment variable, default is 90 seconds (90000 ms).
 std::chrono::milliseconds getDefaultDebuginfodTimeout();
 
+/// Get the full UrlPath for a source request of a given BuildID and file path.
+std::string getDebuginfodSourceUrlPath(object::BuildIDRef ID,
+                                       StringRef SourceFilePath);
+
 /// Fetches a specified source file by searching the default local cache
 /// directory and server URLs.
 Expected<std::string> getCachedOrDownloadSource(object::BuildIDRef ID,
                                                 StringRef SourceFilePath);
 
+/// Get the full UrlPath for an Executable request of a given BuildID.
+std::string getDebuginfodExecutableUrlPath(object::BuildIDRef ID);
+
 /// Fetches an executable by searching the default local cache directory and
 /// server URLs.
 Expected<std::string> getCachedOrDownloadExecutable(object::BuildIDRef ID);
+
+/// Get the full UrlPath for a debug binary request of a given BuildID.
+std::string getDebuginfodDebuginfoUrlPath(object::BuildIDRef ID);
 
 /// Fetches a debug binary by searching the default local cache directory and
 /// server URLs.

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -158,6 +158,7 @@ Expected<std::string> getCachedOrDownloadDebuginfo(BuildIDRef ID) {
   std::string UrlPath = getDebuginfodDebuginfoUrlPath(ID);
   return getCachedOrDownloadArtifact(getDebuginfodCacheKey(UrlPath), UrlPath);
 }
+
 // General fetching function.
 Expected<std::string> getCachedOrDownloadArtifact(StringRef UniqueKey,
                                                   StringRef UrlPath) {

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -72,7 +72,7 @@ SmallVector<StringRef> getDefaultDebuginfodUrls() {
   std::shared_lock<llvm::sys::RWMutex> ReadGuard(UrlsMutex);
   if (!DebuginfodUrls) {
     // Only read from the environment variable if the user hasn't already
-    // set the value
+    // set the value.
     ReadGuard.unlock();
     std::unique_lock<llvm::sys::RWMutex> WriteGuard(UrlsMutex);
     DebuginfodUrls = SmallVector<StringRef>();
@@ -86,7 +86,7 @@ SmallVector<StringRef> getDefaultDebuginfodUrls() {
   return DebuginfodUrls.value();
 }
 
-// Set the default debuginfod URL list, override the environment variable
+// Set the default debuginfod URL list, override the environment variable.
 void setDefaultDebuginfodUrls(const SmallVector<StringRef> &URLs) {
   std::unique_lock<llvm::sys::RWMutex> WriteGuard(UrlsMutex);
   DebuginfodUrls = URLs;


### PR DESCRIPTION
I've been working on more/better configuration for improving DEBUGINFOD support. This is the first (and easiest) slice of the work.

I've added `timeout` and `cache-path` settings that can override the DEBUGINFOD library defaults (and environment variables.) I also renamed the `plugin.symbol-locator.debuginfod.server_urls` setting to `server-urls` to be more consistent with the rest of LLDB's settings (the underscore switch is switched to a hyphen)

I've got a few tests that validate the cache-path setting (as a side-effect), but they've exposed a few bugs that I'll be putting up a separate PR for (which will include the tests).