### PR TITLE
[flang] Fix module file generation when generic shadows derived type

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -183,6 +183,13 @@ static void HarvestInitializerSymbols(
       if (symbol->scope()) {
         HarvestInitializerSymbols(set, *symbol->scope());
       }
+    } else if (const auto &generic{symbol->detailsIf<GenericDetails>()};
+               generic && generic->derivedType()) {
+      const Symbol &dtSym{*generic->derivedType()};
+      CHECK(dtSym.has<DerivedTypeDetails>());
+      if (dtSym.scope()) {
+        HarvestInitializerSymbols(set, *dtSym.scope());
+      }
     } else if (IsNamedConstant(*symbol) || scope.IsDerivedType()) {
       if (const auto *object{symbol->detailsIf<ObjectEntityDetails>()}) {
         if (object->init()) {

--- a/flang/test/Semantics/modfile62.f90
+++ b/flang/test/Semantics/modfile62.f90
@@ -1,0 +1,31 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+module m
+  use iso_c_binding, only: c_ptr, c_null_ptr
+  type foo
+    type(c_ptr) :: p = c_null_ptr
+  end type
+  interface foo ! same name as derived type
+    procedure f
+  end interface
+ contains
+  type(foo) function f()
+  end
+end
+
+!Expect: m.mod
+!module m
+!use,intrinsic::__fortran_builtins,only:__builtin_c_ptr
+!use,intrinsic::iso_c_binding,only:c_ptr
+!use,intrinsic::iso_c_binding,only:c_null_ptr
+!private::__builtin_c_ptr
+!type::foo
+!type(c_ptr)::p=__builtin_c_ptr(__address=0_8)
+!end type
+!interface foo
+!procedure::f
+!end interface
+!contains
+!function f()
+!type(foo)::f
+!end
+!end


### PR DESCRIPTION
Fortran allows the name of a generic interface to be the same as the name of a derived type or specific procedure.  When this happens, it causes the code in module file generation to miss the symbol of a derived type when scanning for symbols in initialization expressions that need to be imported.  Fix.