### PR TITLE
new-prs-labeler: Add `clang-tools-extra` labeling

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -308,6 +308,9 @@ clang-tidy:
   - clang-tools-extra/docs/clang-tidy/**
   - clang-tools-extra/test/clang-tidy/**
 
+clang-tools-extra:
+  - clang-tools-extra/**
+
 tools:llvm-mca:
   - llvm/tools/llvm-mca/**
   - llvm/include/llvm/MCA/**


### PR DESCRIPTION
There is no automatic labeling for the Extra Clang Tools, except Clang-Tidy and ClangD.
