### PR TITLE
[lld][WebAssembly] Move input vectors from symtab to ctx. NFC

### DIFF
--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -23,6 +23,13 @@ enum class CodeGenOptLevel;
 namespace lld::wasm {
 
 class InputFile;
+class StubFile;
+class ObjFile;
+class SharedFile;
+class BitcodeFile;
+class InputTable;
+class InputGlobal;
+class InputFunction;
 class Symbol;
 
 // For --unresolved-symbols.
@@ -108,6 +115,14 @@ extern Configuration *config;
 
 // The Ctx object hold all other (non-configuration) global state.
 struct Ctx {
+  llvm::SmallVector<ObjFile *, 0> objectFiles;
+  llvm::SmallVector<StubFile *, 0> stubFiles;
+  llvm::SmallVector<SharedFile *, 0> sharedFiles;
+  llvm::SmallVector<BitcodeFile *, 0> bitcodeFiles;
+  llvm::SmallVector<InputFunction *, 0> syntheticFunctions;
+  llvm::SmallVector<InputGlobal *, 0> syntheticGlobals;
+  llvm::SmallVector<InputTable *, 0> syntheticTables;
+
   // True if we are creating position-independent code.
   bool isPic;
 

--- a/lld/wasm/MapFile.cpp
+++ b/lld/wasm/MapFile.cpp
@@ -51,7 +51,7 @@ static void writeHeader(raw_ostream &os, int64_t vma, uint64_t lma,
 // Returns a list of all symbols that we want to print out.
 static std::vector<Symbol *> getSymbols() {
   std::vector<Symbol *> v;
-  for (InputFile *file : symtab->objectFiles)
+  for (InputFile *file : ctx.objectFiles)
     for (Symbol *b : file->getSymbols())
       if (auto *dr = dyn_cast<Symbol>(b))
         if ((!isa<SectionSymbol>(dr)) && dr->isLive() &&

--- a/lld/wasm/MarkLive.cpp
+++ b/lld/wasm/MarkLive.cpp
@@ -97,7 +97,7 @@ void MarkLive::run() {
     enqueue(WasmSym::callDtors);
 
   // Enqueue constructors in objects explicitly live from the command-line.
-  for (const ObjFile *obj : symtab->objectFiles)
+  for (const ObjFile *obj : ctx.objectFiles)
     if (obj->isLive())
       enqueueInitFunctions(obj);
 
@@ -151,7 +151,7 @@ void markLive() {
 
   // Report garbage-collected sections.
   if (config->printGcSections) {
-    for (const ObjFile *obj : symtab->objectFiles) {
+    for (const ObjFile *obj : ctx.objectFiles) {
       for (InputChunk *c : obj->functions)
         if (!c->live)
           message("removing unused section " + toString(c));
@@ -168,13 +168,13 @@ void markLive() {
         if (!t->live)
           message("removing unused section " + toString(t));
     }
-    for (InputChunk *c : symtab->syntheticFunctions)
+    for (InputChunk *c : ctx.syntheticFunctions)
       if (!c->live)
         message("removing unused section " + toString(c));
-    for (InputGlobal *g : symtab->syntheticGlobals)
+    for (InputGlobal *g : ctx.syntheticGlobals)
       if (!g->live)
         message("removing unused section " + toString(g));
-    for (InputTable *t : symtab->syntheticTables)
+    for (InputTable *t : ctx.syntheticTables)
       if (!t->live)
         message("removing unused section " + toString(t));
   }
@@ -192,7 +192,7 @@ bool MarkLive::isCallCtorsLive() {
 
   // If there are any init functions, mark `__wasm_call_ctors` live so that
   // it can call them.
-  for (const ObjFile *file : symtab->objectFiles) {
+  for (const ObjFile *file : ctx.objectFiles) {
     const WasmLinkingData &l = file->getWasmObj()->linkingData();
     for (const WasmInitFunc &f : l.InitFunctions) {
       auto *sym = file->getFunctionSymbol(f.Symbol);

--- a/lld/wasm/SymbolTable.h
+++ b/lld/wasm/SymbolTable.h
@@ -101,14 +101,6 @@ public:
   void handleWeakUndefines();
   DefinedFunction *createUndefinedStub(const WasmSignature &sig);
 
-  std::vector<ObjFile *> objectFiles;
-  std::vector<StubFile *> stubFiles;
-  std::vector<SharedFile *> sharedFiles;
-  std::vector<BitcodeFile *> bitcodeFiles;
-  std::vector<InputFunction *> syntheticFunctions;
-  std::vector<InputGlobal *> syntheticGlobals;
-  std::vector<InputTable *> syntheticTables;
-
 private:
   std::pair<Symbol *, bool> insert(StringRef name, const InputFile *file);
   std::pair<Symbol *, bool> insertName(StringRef name);

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -57,7 +57,7 @@ public:
 bool DylinkSection::isNeeded() const {
   return ctx.isPic ||
          config->unresolvedSymbols == UnresolvedPolicy::ImportDynamic ||
-         !symtab->sharedFiles.empty();
+         !ctx.sharedFiles.empty();
 }
 
 void DylinkSection::writeBody() {
@@ -72,10 +72,10 @@ void DylinkSection::writeBody() {
     sub.writeTo(os);
   }
 
-  if (symtab->sharedFiles.size()) {
+  if (ctx.sharedFiles.size()) {
     SubSection sub(WASM_DYLINK_NEEDED);
-    writeUleb128(sub.os, symtab->sharedFiles.size(), "Needed");
-    for (auto *so : symtab->sharedFiles)
+    writeUleb128(sub.os, ctx.sharedFiles.size(), "Needed");
+    for (auto *so : ctx.sharedFiles)
       writeStr(sub.os, llvm::sys::path::filename(so->getName()), "so name");
     sub.writeTo(os);
   }


### PR DESCRIPTION
Also convert from std::vector to SmallVector.

This matches the ELF linker where these were moved into the ctx object in 9a572164d592e and converted to SmallVector in ba948c5a9c524b.