### PR TITLE
[lld][WebAssembly] Fix use of undefined funcs under --warn-unresolved-symbols

### DIFF
--- a/lld/test/wasm/unresolved-symbols.s
+++ b/lld/test/wasm/unresolved-symbols.s
@@ -18,10 +18,15 @@
 # RUN:   FileCheck -check-prefix=ERR1 %s
 
 ## Ignore all should not produce error and should not produce
-# any imports.  It should create a stub function in the place of the missing
-# function symbol.
+## any imports.  It should create a stub function in the place of the missing
+## function symbol.
 # RUN: wasm-ld %t1.o -o %t2.wasm --unresolved-symbols=ignore-all
 # RUN: obj2yaml %t2.wasm | FileCheck -check-prefix=IGNORE %s
+
+## --warn-unresolved-symbols should behave the same
+# RUN: wasm-ld %t1.o -o %t2.wasm --warn-unresolved-symbols
+# RUN: obj2yaml %t2.wasm | FileCheck -check-prefix=IGNORE %s
+
 # IGNORE-NOT: - Type:            IMPORT
 # IGNORE-NOT: - Type:            ELEM
 #
@@ -52,10 +57,10 @@
 # IGNORE-NEXT:      - Index:           3
 # IGNORE-NEXT:        Name:            get_func_addr
 
-## --import-undefined should handle unresolved funtions symbols
-# by importing them but still report errors/warning for missing data symbols.
-# `--allow-undefined` should behave like `--import-undefined` +
-# `--unresolve-symbols=ignore`
+## --import-undefined should handle unresolved functions symbols
+## by importing them but still report errors/warning for missing data symbols.
+## `--allow-undefined` should behave like `--import-undefined` +
+## `--unresolve-symbols=ignore`
 # RUN: wasm-ld %t1.o -o %t3.wasm --import-undefined --unresolved-symbols=ignore-all
 # RUN: obj2yaml %t3.wasm | FileCheck -check-prefix=IMPORT %s
 #      IMPORT:  - Type:            IMPORT

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -54,20 +54,21 @@ static void reportUndefined(Symbol *sym) {
     case UnresolvedPolicy::Ignore:
       LLVM_DEBUG(dbgs() << "ignoring undefined symbol: " + toString(*sym) +
                                "\n");
-      if (!config->importUndefined) {
-        if (auto *f = dyn_cast<UndefinedFunction>(sym)) {
-          if (!f->stubFunction) {
-            f->stubFunction = symtab->createUndefinedStub(*f->getSignature());
-            f->stubFunction->markLive();
-            // Mark the function itself as a stub which prevents it from being
-            // assigned a table entry.
-            f->isStub = true;
-          }
-        }
-      }
       break;
     case UnresolvedPolicy::ImportDynamic:
       break;
+    }
+
+    if (auto *f = dyn_cast<UndefinedFunction>(sym)) {
+      if (!f->stubFunction &&
+          config->unresolvedSymbols != UnresolvedPolicy::ImportDynamic &&
+          !config->importUndefined) {
+        f->stubFunction = symtab->createUndefinedStub(*f->getSignature());
+        f->stubFunction->markLive();
+        // Mark the function itself as a stub which prevents it from being
+        // assigned a table entry.
+        f->isStub = true;
+      }
     }
   }
 }


### PR DESCRIPTION
When undefined functions exist in the final link we need to create
stub functions (otherwise direct calls to those functions could
not be generated).  We were creating those stub when
`--unresolved-symbols=ignore-all` was passed but overlooked the fact
that `--warn-unresolved-symbols` essentially has the same effect (i.e.
undefined function can exist in the final link).

Fixes: #53987