### PR TITLE
[flang][runtime] Fix namelist substring checking

### DIFF
--- a/flang/runtime/namelist.cpp
+++ b/flang/runtime/namelist.cpp
@@ -313,7 +313,7 @@ static bool HandleSubstring(
         desc.raw().elem_len = 0;
         return true;
       }
-      if (*lower >= 1 || *upper <= chars) {
+      if (*lower >= 1 && *upper <= chars) {
         // Offset the base address & adjust the element byte length
         desc.raw().elem_len = (*upper - *lower + 1) * kind;
         desc.set_base_addr(reinterpret_cast<void *>(


### PR DESCRIPTION
An || operator in namelist substring bounds checking really needs to be an && operator so that the substring is viewed as correct only when both its bounds are valid.

Fixes llvm-test-suite/Fortran/gfortran/regression/namelist_40.f90.