### PR TITLE
[RISCV] Re-order riscv-target-features.c to put non-experimental extensions together.

### DIFF
--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -19,6 +19,8 @@
 // CHECK-NOT: __riscv_m {{.*$}}
 // CHECK-NOT: __riscv_mul {{.*$}}
 // CHECK-NOT: __riscv_muldiv {{.*$}}
+// CHECK-NOT: __riscv_smaia {{.*$}}
+// CHECK-NOT: __riscv_ssaia {{.*$}}
 // CHECK-NOT: __riscv_svinval {{.*$}}
 // CHECK-NOT: __riscv_svnapot {{.*$}}
 // CHECK-NOT: __riscv_svpbmt {{.*$}}
@@ -70,6 +72,7 @@
 // CHECK-NOT: __riscv_zcmp {{.*$}}
 // CHECK-NOT: __riscv_zcmt {{.*$}}
 // CHECK-NOT: __riscv_zdinx {{.*$}}
+// CHECK-NOT: __riscv_zfa {{.*$}}
 // CHECK-NOT: __riscv_zfh {{.*$}}
 // CHECK-NOT: __riscv_zfhmin {{.*$}}
 // CHECK-NOT: __riscv_zfinx {{.*$}}
@@ -100,12 +103,27 @@
 // CHECK-NOT: __riscv_zksh {{.*$}}
 // CHECK-NOT: __riscv_zkt {{.*$}}
 // CHECK-NOT: __riscv_zmmul {{.*$}}
+// CHECK-NOT: __riscv_zvbb {{.*$}}
+// CHECK-NOT: __riscv_zvbc {{.*$}}
 // CHECK-NOT: __riscv_zve32f {{.*$}}
 // CHECK-NOT: __riscv_zve32x {{.*$}}
 // CHECK-NOT: __riscv_zve64d {{.*$}}
 // CHECK-NOT: __riscv_zve64f {{.*$}}
 // CHECK-NOT: __riscv_zve64x {{.*$}}
 // CHECK-NOT: __riscv_zvfh {{.*$}}
+// CHECK-NOT: __riscv_zvkg {{.*$}}
+// CHECK-NOT: __riscv_zvkn {{.*$}}
+// CHECK-NOT: __riscv_zvknc {{.*$}}
+// CHECK-NOT: __riscv_zvkned {{.*$}}
+// CHECK-NOT: __riscv_zvkng {{.*$}}
+// CHECK-NOT: __riscv_zvknha {{.*$}}
+// CHECK-NOT: __riscv_zvknhb {{.*$}}
+// CHECK-NOT: __riscv_zvks {{.*$}}
+// CHECK-NOT: __riscv_zvksc {{.*$}}
+// CHECK-NOT: __riscv_zvksed {{.*$}}
+// CHECK-NOT: __riscv_zvksg {{.*$}}
+// CHECK-NOT: __riscv_zvksh {{.*$}}
+// CHECK-NOT: __riscv_zvkt {{.*$}}
 // CHECK-NOT: __riscv_zvl32b {{.*$}}
 // CHECK-NOT: __riscv_zvl64b {{.*$}}
 // CHECK-NOT: __riscv_zvl128b {{.*$}}
@@ -121,34 +139,16 @@
 
 // Experimental extensions
 
-// CHECK-NOT: __riscv_smaia {{.*$}}
-// CHECK-NOT: __riscv_ssaia {{.*$}}
 // CHECK-NOT: __riscv_zacas {{.*$}}
-// CHECK-NOT: __riscv_zfa {{.*$}}
+// CHECK-NOT: __riscv_zcmop {{.*$}}
 // CHECK-NOT: __riscv_zfbfmin {{.*$}}
 // CHECK-NOT: __riscv_zicfilp {{.*$}}
 // CHECK-NOT: __riscv_zicfiss {{.*$}}
 // CHECK-NOT: __riscv_zicond {{.*$}}
 // CHECK-NOT: __riscv_zimop {{.*$}}
-// CHECK-NOT: __riscv_zcmop {{.*$}}
 // CHECK-NOT: __riscv_ztso {{.*$}}
-// CHECK-NOT: __riscv_zvbb {{.*$}}
-// CHECK-NOT: __riscv_zvbc {{.*$}}
 // CHECK-NOT: __riscv_zvfbfmin {{.*$}}
 // CHECK-NOT: __riscv_zvfbfwma {{.*$}}
-// CHECK-NOT: __riscv_zvkg {{.*$}}
-// CHECK-NOT: __riscv_zvkn {{.*$}}
-// CHECK-NOT: __riscv_zvknc {{.*$}}
-// CHECK-NOT: __riscv_zvkned {{.*$}}
-// CHECK-NOT: __riscv_zvkng {{.*$}}
-// CHECK-NOT: __riscv_zvknha {{.*$}}
-// CHECK-NOT: __riscv_zvknhb {{.*$}}
-// CHECK-NOT: __riscv_zvks {{.*$}}
-// CHECK-NOT: __riscv_zvksc {{.*$}}
-// CHECK-NOT: __riscv_zvksed {{.*$}}
-// CHECK-NOT: __riscv_zvksg {{.*$}}
-// CHECK-NOT: __riscv_zvksh {{.*$}}
-// CHECK-NOT: __riscv_zvkt {{.*$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN: -march=rv32ia -x c -E -dM %s \
@@ -1092,31 +1092,21 @@
 // RUN: -o - | FileCheck --check-prefix=CHECK-ZVL65536b %s
 // CHECK-ZVL65536b: __riscv_v_min_vlen 65536
 
-// Experimental extensions
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
+// RUN: %clang --target=riscv32 \
 // RUN: -march=rv32ismaia1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-SMAIA-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
+// RUN: %clang --target=riscv64 \
 // RUN: -march=rv64ismaia1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-SMAIA-EXT %s
 // CHECK-SMAIA-EXT: __riscv_smaia  1000000{{$}}
 
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
+// RUN: %clang --target=riscv32 \
 // RUN: -march=rv32issaia1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-SSAIA-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
+// RUN: %clang --target=riscv64 \
 // RUN: -march=rv64issaia1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-SSAIA-EXT %s
 // CHECK-SSAIA-EXT: __riscv_ssaia  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zacas1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZACAS-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zacas1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZACAS-EXT %s
-// CHECK-ZACAS-EXT: __riscv_zacas 1000000{{$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN: -march=rv32izfa -x c -E -dM %s \
@@ -1125,6 +1115,188 @@
 // RUN: -march=rv64izfa -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-ZFA-EXT %s
 // CHECK-ZFA-EXT: __riscv_zfa 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvbb1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBB-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvbb1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBB-EXT %s
+// CHECK-ZVBB-EXT: __riscv_zvbb  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvbc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBC-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvbc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBC-EXT %s
+// CHECK-ZVBC-EXT: __riscv_zvbc  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvkg1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKG-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvkg1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKG-EXT %s
+// CHECK-ZVKG-EXT: __riscv_zvkg  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvkn1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKN-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvkn1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKN-EXT %s
+// CHECK-ZVKN-EXT: __riscv_zvkn 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKN %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKN %s
+// CHECK-COMBINE-INTO-ZVKN: __riscv_zvkn 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvknc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNC-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvknc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNC-EXT %s
+// CHECK-ZVKNC-EXT: __riscv_zvknc 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvbc1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNC %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvbc1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNC %s
+// CHECK-COMBINE-INTO-ZVKNC: __riscv_zvkn 1000000{{$}}
+// CHECK-COMBINE-INTO-ZVKNC: __riscv_zvknc 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvkned1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNED-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvkned1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNED-EXT %s
+// CHECK-ZVKNED-EXT: __riscv_zvkned 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvkng1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNG-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvkng1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNG-EXT %s
+// CHECK-ZVKNG-EXT: __riscv_zvkng 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvkg1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNG %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvkg1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNG %s
+// CHECK-COMBINE-INTO-ZVKNG: __riscv_zvkn 1000000{{$}}
+// CHECK-COMBINE-INTO-ZVKNG: __riscv_zvkng 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvknha1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHA-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvknha1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHA-EXT %s
+// CHECK-ZVKNHA-EXT: __riscv_zvknha 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvknhb1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHB-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvknhb1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHB-EXT %s
+// CHECK-ZVKNHB-EXT: __riscv_zvknhb  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvks1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKS-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvks1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKS-EXT %s
+// CHECK-ZVKS-EXT: __riscv_zvks 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKS %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKS %s
+// CHECK-COMBINE-INTO-ZVKS: __riscv_zvks 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvksc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSC-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvksc1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSC-EXT %s
+// CHECK-ZVKSC-EXT: __riscv_zvksc 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvbc1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSC %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvbc1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSC %s
+// CHECK-COMBINE-INTO-ZVKSC: __riscv_zvks 1000000{{$}}
+// CHECK-COMBINE-INTO-ZVKSC: __riscv_zvksc 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvksed1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSED-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvksed1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSED-EXT %s
+// CHECK-ZVKSED-EXT: __riscv_zvksed  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve64x_zvksg1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSG-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve64x_zvksg1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSG-EXT %s
+// CHECK-ZVKSG-EXT: __riscv_zvksg 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32iv_zvbb1p0_zvkg1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSG %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64iv_zvbb1p0_zvkg1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSG %s
+// CHECK-COMBINE-INTO-ZVKSG: __riscv_zvks 1000000{{$}}
+// CHECK-COMBINE-INTO-ZVKSG: __riscv_zvksg 1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvksh1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSH-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvksh1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSH-EXT %s
+// CHECK-ZVKSH-EXT: __riscv_zvksh  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN: -march=rv32i_zve32x_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKT-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN: -march=rv64i_zve32x_zvkt1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKT-EXT %s
+// CHECK-ZVKT-EXT: __riscv_zvkt 1000000{{$}}
+
+// Experimental extensions
+
+// RUN: %clang --target=riscv32 -menable-experimental-extensions \
+// RUN: -march=rv32i_zacas1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZACAS-EXT %s
+// RUN: %clang --target=riscv64 -menable-experimental-extensions \
+// RUN: -march=rv64i_zacas1p0 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZACAS-EXT %s
+// CHECK-ZACAS-EXT: __riscv_zacas 1000000{{$}}
 
 // RUN: %clang --target=riscv32 -menable-experimental-extensions \
 // RUN: -march=rv32izfbfmin1p0 -x c -E -dM %s \
@@ -1175,22 +1347,6 @@
 // CHECK-ZTSO-EXT: __riscv_ztso 1000{{$}}
 
 // RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvbb1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBB-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvbb1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBB-EXT %s
-// CHECK-ZVBB-EXT: __riscv_zvbb  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvbc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBC-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvbc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVBC-EXT %s
-// CHECK-ZVBC-EXT: __riscv_zvbc  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
 // RUN: -march=rv32ifzvfbfmin1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-ZVFBFMIN-EXT %s
 // RUN: %clang --target=riscv64 -menable-experimental-extensions \
@@ -1206,161 +1362,15 @@
 // RUN: -o - | FileCheck --check-prefix=CHECK-ZVFBFWMA-EXT %s
 // CHECK-ZVFBFWMA-EXT: __riscv_zvfbfwma 1000000{{$}}
 
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvkg1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKG-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvkg1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKG-EXT %s
-// CHECK-ZVKG-EXT: __riscv_zvkg  1000000{{$}}
+// RUN: %clang -target riscv32 -menable-experimental-extensions \
+// RUN: -march=rv32izicfiss0p4 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZICFISS-EXT %s
+// RUN: %clang -target riscv64 -menable-experimental-extensions \
+// RUN: -march=rv64izicfiss0p4 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-ZICFISS-EXT %s
+// CHECK-ZICFISS-EXT: __riscv_zicfiss 4000{{$}}
 
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvkn1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKN-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvkn1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKN-EXT %s
-// CHECK-ZVKN-EXT: __riscv_zvkn 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKN %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKN %s
-// CHECK-COMBINE-INTO-ZVKN: __riscv_zvkn 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvknc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNC-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvknc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNC-EXT %s
-// CHECK-ZVKNC-EXT: __riscv_zvknc 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvbc1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNC %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvbc1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNC %s
-// CHECK-COMBINE-INTO-ZVKNC: __riscv_zvkn 1000000{{$}}
-// CHECK-COMBINE-INTO-ZVKNC: __riscv_zvknc 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvkned1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNED-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvkned1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNED-EXT %s
-// CHECK-ZVKNED-EXT: __riscv_zvkned 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvkng1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNG-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvkng1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNG-EXT %s
-// CHECK-ZVKNG-EXT: __riscv_zvkng 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvkg1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNG %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvkg1p0_zvkned1p0_zvknhb1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKNG %s
-// CHECK-COMBINE-INTO-ZVKNG: __riscv_zvkn 1000000{{$}}
-// CHECK-COMBINE-INTO-ZVKNG: __riscv_zvkng 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvknha1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHA-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvknha1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHA-EXT %s
-// CHECK-ZVKNHA-EXT: __riscv_zvknha 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvknhb1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHB-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvknhb1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKNHB-EXT %s
-// CHECK-ZVKNHB-EXT: __riscv_zvknhb  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvks1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKS-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvks1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKS-EXT %s
-// CHECK-ZVKS-EXT: __riscv_zvks 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKS %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKS %s
-// CHECK-COMBINE-INTO-ZVKS: __riscv_zvks 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvksc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSC-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvksc1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSC-EXT %s
-// CHECK-ZVKSC-EXT: __riscv_zvksc 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvbc1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSC %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvbc1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSC %s
-// CHECK-COMBINE-INTO-ZVKSC: __riscv_zvks 1000000{{$}}
-// CHECK-COMBINE-INTO-ZVKSC: __riscv_zvksc 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvksed1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSED-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvksed1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSED-EXT %s
-// CHECK-ZVKSED-EXT: __riscv_zvksed  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve64x_zvksg1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSG-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve64x_zvksg1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSG-EXT %s
-// CHECK-ZVKSG-EXT: __riscv_zvksg 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32iv_zvbb1p0_zvkg1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSG %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64iv_zvbb1p0_zvkg1p0_zvksed1p0_zvksh1p0_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-COMBINE-INTO-ZVKSG %s
-// CHECK-COMBINE-INTO-ZVKSG: __riscv_zvks 1000000{{$}}
-// CHECK-COMBINE-INTO-ZVKSG: __riscv_zvksg 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvksh1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSH-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvksh1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKSH-EXT %s
-// CHECK-ZVKSH-EXT: __riscv_zvksh  1000000{{$}}
-
-// RUN: %clang --target=riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32i_zve32x_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKT-EXT %s
-// RUN: %clang --target=riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64i_zve32x_zvkt1p0 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZVKT-EXT %s
-// CHECK-ZVKT-EXT: __riscv_zvkt 1000000{{$}}
+// Misaligned
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu -march=rv32i -x c -E -dM %s \
 // RUN: -o - | FileCheck %s --check-prefix=CHECK-MISALIGNED-AVOID
@@ -1373,11 +1383,3 @@
 // RUN: %clang --target=riscv64-unknown-linux-gnu -march=rv64i -E -dM %s \
 // RUN:   -munaligned-access -o - | FileCheck %s --check-prefix=CHECK-MISALIGNED-FAST
 // CHECK-MISALIGNED-FAST: __riscv_misaligned_fast 1
-
-// RUN: %clang -target riscv32 -menable-experimental-extensions \
-// RUN: -march=rv32izicfiss0p4 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZICFISS-EXT %s
-// RUN: %clang -target riscv64 -menable-experimental-extensions \
-// RUN: -march=rv64izicfiss0p4 -x c -E -dM %s \
-// RUN: -o - | FileCheck --check-prefix=CHECK-ZICFISS-EXT %s
-// CHECK-ZICFISS-EXT: __riscv_zicfiss 4000{{$}}


### PR DESCRIPTION
Drop -menable-experimenta-extensions where it isn't needed.

This file has sections for non-experimental and experimental extensions, but we keep forgetting to move things when we change the extension status.