### PR TITLE
[InlineOrder] Fix InlineOrder erase_if implementation

### DIFF
--- a/llvm/lib/Analysis/InlineOrder.cpp
+++ b/llvm/lib/Analysis/InlineOrder.cpp
@@ -262,7 +262,7 @@ public:
 
   void erase_if(function_ref<bool(T)> Pred) override {
     auto PredWrapper = [=](CallBase *CB) -> bool {
-      return Pred(std::make_pair(CB, 0));
+      return Pred(std::make_pair(CB, InlineHistoryMap[CB]));
     };
     llvm::erase_if(Heap, PredWrapper);
     std::make_heap(Heap.begin(), Heap.end(), isLess);


### PR DESCRIPTION
The InlineOrder Heap stores a CallBase ptr and InlineHistoryID pair. When running the `erase_if` method, InlineHistoryID is always returned with 0. Instead, we should be retrieving it from the `InlineHistoryMap` (similar to what is done in the `pop` implementation). 

This change is completely harmless because no one is using InlineHistoryID right now as part of the `erase_if` implementation which is currently only used in the ModuleInliner. 