### PR TITLE
[libc++] Add "using-if-exists" to timespec_get in modules

### DIFF
--- a/libcxx/modules/std.compat/ctime.inc
+++ b/libcxx/modules/std.compat/ctime.inc
@@ -24,5 +24,5 @@ export {
   using ::mktime;
   using ::strftime;
   using ::time;
-  using ::timespec_get;
+  using ::timespec_get _LIBCPP_USING_IF_EXISTS;
 } // export

--- a/libcxx/modules/std/ctime.inc
+++ b/libcxx/modules/std/ctime.inc
@@ -24,5 +24,5 @@ export namespace std {
   using std::mktime;
   using std::strftime;
   using std::time;
-  using std::timespec_get;
+  using std::timespec_get _LIBCPP_USING_IF_EXISTS;
 } // namespace std

--- a/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std-and-std.compat-module.sh.cpp
@@ -12,10 +12,6 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// picolibc does not provide the required timespec_get function, and the
-// "using-if-exists" mechanism apparently did not work here.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // Make sure that the compile flags contain the expected elements.
 // The tests only look for the expected components and not the exact flags.
 // Otherwise changing the location of the module would break this test.

--- a/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
+++ b/libcxx/test/libcxx/selftest/modules/std.compat-module.sh.cpp
@@ -12,10 +12,6 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// picolibc does not provide the required timespec_get function, and the
-// "using-if-exists" mechanism apparently did not work here.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // Make sure that the compile flags contain the expected elements.
 // The tests only look for the expected components and not the exact flags.
 // Otherwise changing the location of the module would break this test.

--- a/libcxx/test/std/modules/std.compat.pass.cpp
+++ b/libcxx/test/std/modules/std.compat.pass.cpp
@@ -12,10 +12,6 @@
 
 // XFAIL: has-no-cxx-module-support
 
-// picolibc does not provide the required timespec_get function, and the
-// "using-if-exists" mechanism apparently did not work here.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // A minimal test to validate import works.
 
 // MODULE_DEPENDENCIES: std.compat


### PR DESCRIPTION
Picolibc does not provide timespec_get function. Adding "using-if-exists" attribute fixes the modules.

This is a follow up patch for https://github.com/llvm/llvm-project/pull/78580