### PR TITLE
[Clang][NFC] Optimize isAsciiIdentifierContinue

### DIFF
--- a/clang/include/clang/Basic/CharInfo.h
+++ b/clang/include/clang/Basic/CharInfo.h
@@ -59,7 +59,6 @@ LLVM_READONLY inline bool isAsciiIdentifierStart(unsigned char c,
   return AllowDollar && c == '$';
 }
 
-
 LLVM_READONLY inline bool isAsciiIdentifierContinue(unsigned char c) {
   // Precomputed CHAR_UPPER|CHAR_LOWER|CHAR_DIGIT|CHAR_UNDER
   static constexpr unsigned char IDContinue[256] = {

--- a/clang/include/clang/Basic/CharInfo.h
+++ b/clang/include/clang/Basic/CharInfo.h
@@ -59,12 +59,29 @@ LLVM_READONLY inline bool isAsciiIdentifierStart(unsigned char c,
   return AllowDollar && c == '$';
 }
 
+
+LLVM_READONLY inline bool isAsciiIdentifierContinue(unsigned char c) {
+  // Precomputed CHAR_UPPER|CHAR_LOWER|CHAR_DIGIT|CHAR_UNDER
+  static constexpr unsigned char IDContinue[256] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1,
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  return IDContinue[c];
+}
+
 /// Returns true if this is a body character of a C identifier,
 /// which is [a-zA-Z0-9_].
 LLVM_READONLY inline bool isAsciiIdentifierContinue(unsigned char c,
-                                                    bool AllowDollar = false) {
-  using namespace charinfo;
-  if (InfoTable[c] & (CHAR_UPPER|CHAR_LOWER|CHAR_DIGIT|CHAR_UNDER))
+                                                    bool AllowDollar) {
+  if (isAsciiIdentifierContinue(c))
     return true;
   return AllowDollar && c == '$';
 }


### PR DESCRIPTION
Precompute the isAsciiIdentifierContinue table which is on the hot path.

https://llvm-compile-time-tracker.com/compare.php?from=30da0f5a359ab4a684c5fdf0f4dbed20bae10f99&to=cb0e48db2b8193d2ee59c2a6e998317cb220d513&stat=instructions:u