### PR TITLE
[Clang] Fix build with GCC 14 on ARM

### DIFF
--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -260,7 +260,7 @@ inline bool doesKeywordAttributeTakeArgs(tok::TokenKind Kind) {
   switch (Kind) {
   default:
     return false;
-#define KEYWORD_ATTRIBUTE(NAME, HASARG)                                        \
+#define KEYWORD_ATTRIBUTE(NAME, HASARG, ...)                                   \
   case tok::kw_##NAME:                                                         \
     return HASARG;
 #include "clang/Basic/RegularKeywordAttrInfo.inc"

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -760,8 +760,9 @@ KEYWORD(__builtin_available              , KEYALL)
 KEYWORD(__builtin_sycl_unique_stable_name, KEYSYCL)
 
 // Keywords defined by Attr.td.
+// The "EMPTY ## X" is used to prevent early macro-expansion of the keyword.
 #ifndef KEYWORD_ATTRIBUTE
-#define KEYWORD_ATTRIBUTE(X, ...) KEYWORD(X, KEYALL)
+#define KEYWORD_ATTRIBUTE(X, HASARG, EMPTY) KEYWORD(EMPTY ## X, KEYALL)
 #endif
 #include "clang/Basic/RegularKeywordAttrInfo.inc"
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3589,7 +3589,7 @@ void EmitClangRegularKeywordAttributeInfo(RecordKeeper &Records,
 
       OS << "KEYWORD_ATTRIBUTE("
          << S.getSpellingRecord().getValueAsString("Name") << ", "
-         << (HasArgs ? "true" : "false") << ")\n";
+         << (HasArgs ? "true" : "false") << ", )\n";
     }
   OS << "#undef KEYWORD_ATTRIBUTE\n";
 }


### PR DESCRIPTION
GCC 14 defines `__arm_streaming` as a macro expanding to `[[arm::streaming]]`. Due to the nested macro use, this gets expanded prior to concatenation.

It doesn't look like C++ has a really clean way to prevent macro expansion. The best I have found is to use `EMPTY ## X` where `EMPTY` is an empty macro argument, so this is the hack I'm implementing here.

Fixes https://github.com/llvm/llvm-project/issues/78691.