### PR TITLE
[LTO] Reset DiscardValueNames in optimize().

### DIFF
--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -572,6 +572,9 @@ bool LTOCodeGenerator::optimize() {
   if (!this->determineTarget())
     return false;
 
+  // libLTO parses options late, so re-set them here.
+  Context.setDiscardValueNames(LTODiscardValueNames);
+
   auto DiagFileOrErr = lto::setupLLVMOptimizationRemarks(
       Context, RemarksFilename, RemarksPasses, RemarksFormat,
       RemarksWithHotness, RemarksHotnessThreshold);

--- a/llvm/test/tools/lto/discard-value-names.ll
+++ b/llvm/test/tools/lto/discard-value-names.ll
@@ -7,11 +7,10 @@
 
 ; The test requires asserts, as it depends on the default value for
 ; -lto-discard-value-names at the moment.
-; FIXME: -lto-discard-value-names is ignored at the moment.
 
 ; REQUIRES: asserts
 
-; DISCARD: %cmp.i = icmp
+; DISCARD: %{{[0-9]+}} = icmp
 ; DISCARD: %add = add i32
 
 ; KEEP: %cmp.i = icmp


### PR DESCRIPTION
libLTO parses options late, so at the moment the option is ignored. To fix that, 
re-set it in optimize(), as at this point the options have been parsed. When 
LTOCodeGenerator's constructor executes, the options haven't been passed 
by the linker to libLTO yet.

Note that we keep the value name of `%add = add..` because when the module
 is imported, DiscardValueNames is still set to false (the default when building 
with assertions).

I tried to improve this in libLTO, but I am not sure if there's a suitable callback when all options have been set.