### PR TITLE
[libc] add missing header dependencies for sched objects

### DIFF
--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -52,6 +52,8 @@ add_entrypoint_object(
     ../sched_setparam.h
   DEPENDS
     libc.include.sys_syscall
+    libc.include.time
+    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -64,6 +66,8 @@ add_entrypoint_object(
     ../sched_getparam.h
   DEPENDS
     libc.include.sys_syscall
+    libc.include.time
+    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -76,6 +80,8 @@ add_entrypoint_object(
     ../sched_setscheduler.h
   DEPENDS
     libc.include.sys_syscall
+    libc.include.time
+    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -87,6 +93,7 @@ add_entrypoint_object(
   HDRS
     ../sched_getscheduler.h
   DEPENDS
+    libc.include.sched
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -124,6 +131,7 @@ add_entrypoint_object(
     ../sched_rr_get_interval.h
   DEPENDS
     libc.include.sys_syscall
+    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/spawn/linux/CMakeLists.txt
+++ b/libc/src/spawn/linux/CMakeLists.txt
@@ -8,6 +8,7 @@ add_entrypoint_object(
     libc.include.fcntl
     libc.include.spawn
     libc.include.sys_syscall
+    libc.include.signal
     libc.src.__support.CPP.optional
     libc.src.__support.OSUtil.osutil
     libc.src.spawn.file_actions


### PR DESCRIPTION
This patch fixes full build problems in https://github.com/llvm/llvm-project/issues/78721 (the header problem).
The `libc.a` target can be built now.

As a separate issue, `check-libc` is failing because undefined symbols from `libunwind`, which I do not actually know the reason yet. I will be looking into it.