### PR TITLE
[libc] remove extra -Werror

### DIFF
--- a/libc/src/signal/linux/CMakeLists.txt
+++ b/libc/src/signal/linux/CMakeLists.txt
@@ -41,7 +41,6 @@ add_object_library(
     -fomit-frame-pointer
     -O3
     -Wframe-larger-than=0
-    -Werror
     -Wno-attributes
     # asan creates asan.module_ctor which uses stack space, causing warnings.
     -fno-sanitize=address


### PR DESCRIPTION
-Werror is now a global default as of
commit c52b467875e2 ("Reapply "[libc] build with -Werror (#73966)" (#74506)")
