### PR TITLE
[flang] Silence spurious errors about SAVE

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4817,8 +4817,8 @@ Symbol &DeclarationVisitor::HandleAttributeStmt(
     symbol = &MakeSymbol(name, EntityDetails{});
   }
   if (CheckDuplicatedAttr(name.source, *symbol, attr)) {
+    HandleSaveName(name.source, Attrs{attr});
     SetExplicitAttr(*symbol, attr);
-    symbol->attrs() = HandleSaveName(name.source, symbol->attrs());
   }
   return *symbol;
 }

--- a/flang/test/Semantics/resolve107.f90
+++ b/flang/test/Semantics/resolve107.f90
@@ -9,5 +9,8 @@ subroutine saves
   !CHECK: SAVE attribute was already specified on 'x'
   !CHECK: SAVE attribute was already specified on 'z'
   save x,z
+  save :: p
+  procedure() :: p
+  !CHECK-NOT: SAVE attribute was already specified on 'p'
+  pointer :: p
 end
-


### PR DESCRIPTION
When an attribute specification statement follows a declaration that applies the SAVE attribute to a symbol, name resolution can produce a spurious error message about redundant SAVEs.

Fixes llvm-test-suite/Fortran/gfortran/regression/proc_ptr_9.f90.