### PR TITLE
[LLVM][CMake] Add ffi_static target for the FFI static library

### DIFF
--- a/llvm/cmake/modules/FindFFI.cmake
+++ b/llvm/cmake/modules/FindFFI.cmake
@@ -34,7 +34,7 @@ else()
   endif()
 endif()
 
-find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
+find_library(FFI_LIBRARIES NAMES libffi.a ffi PATHS ${FFI_LIBRARY_DIR})
 
 if(FFI_LIBRARIES)
   include(CMakePushCheckState)

--- a/llvm/cmake/modules/FindFFI.cmake
+++ b/llvm/cmake/modules/FindFFI.cmake
@@ -15,6 +15,7 @@
 # FFI_FOUND
 # FFI_INCLUDE_DIRS
 # FFI_LIBRARIES
+# FFI_STATIC_LIBRARIES
 # HAVE_FFI_CALL
 #
 # HAVE_FFI_H or HAVE_FFI_FFI_H is defined depending on the ffi.h include path.
@@ -34,7 +35,8 @@ else()
   endif()
 endif()
 
-find_library(FFI_LIBRARIES NAMES libffi.a ffi PATHS ${FFI_LIBRARY_DIR})
+find_library(FFI_LIBRARIES NAMES ffi PATHS ${FFI_LIBRARY_DIR})
+find_library(FFI_STATIC_LIBRARIES NAMES libffi.a PATHS ${FFI_LIBRARY_DIR})
 
 if(FFI_LIBRARIES)
   include(CMakePushCheckState)
@@ -76,6 +78,7 @@ find_package_handle_standard_args(FFI
                                     ${required_includes}
                                     HAVE_FFI_CALL)
 mark_as_advanced(FFI_LIBRARIES
+                 FFI_STATIC_LIBRARIES
                  FFI_INCLUDE_DIRS
                  HAVE_FFI_CALL
                  FFI_HEADER
@@ -83,11 +86,18 @@ mark_as_advanced(FFI_LIBRARIES
                  HAVE_FFI_FFI_H)
 
 if(FFI_FOUND)
-  if(NOT TARGET FFI::ffi)
+  if(NOT TARGET FFI::ffi AND FFI_LIBRARIES)
     add_library(FFI::ffi UNKNOWN IMPORTED)
     set_target_properties(FFI::ffi PROPERTIES IMPORTED_LOCATION "${FFI_LIBRARIES}")
     if(FFI_INCLUDE_DIRS)
       set_target_properties(FFI::ffi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFI_INCLUDE_DIRS}")
+    endif()
+  endif()
+  if(NOT TARGET FFI::ffi_static AND FFI_STATIC_LIBRARIES)
+    add_library(FFI::ffi_static UNKNOWN IMPORTED)
+    set_target_properties(FFI::ffi_static PROPERTIES IMPORTED_LOCATION "${FFI_STATIC_LIBRARIES}")
+    if(FFI_INCLUDE_DIRS)
+      set_target_properties(FFI::ffi_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFI_INCLUDE_DIRS}")
     endif()
   endif()
 endif()

--- a/openmp/libomptarget/plugins-nextgen/CMakeLists.txt
+++ b/openmp/libomptarget/plugins-nextgen/CMakeLists.txt
@@ -49,11 +49,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "${tmachine}$")
   )
 
   if(LIBOMPTARGET_DEP_LIBFFI_FOUND)
-     libomptarget_say("Building ${tmachine_libname} plugin linked with libffi")
-     target_link_libraries("omptarget.rtl.${tmachine_libname}" PRIVATE
-                           ${FFI_LIBRARIES})
-     target_include_directories("omptarget.rtl.${tmachine_libname}" PRIVATE
-                                ${FFI_INCLUDE_DIRS})
+    libomptarget_say("Building ${tmachine_libname} plugin linked with libffi")
+    if(FFI_STATIC_LIBRARIES)
+      target_link_libraries(
+        "omptarget.rtl.${tmachine_libname}" PRIVATE FFI::ffi_static)
+    else()
+      target_link_libraries(
+        "omptarget.rtl.${tmachine_libname}" PRIVATE FFI::ffi)
+    endif()
   else()
      libomptarget_say("Building ${tmachine_libname} plugie for dlopened libffi")
      target_sources("omptarget.rtl.${tmachine_libname}" PRIVATE


### PR DESCRIPTION
Summary:
This patch is an attempt to make the `find_package(FFI)` support in LLVM
prefer to provide the static library version if present. This is currently
an optional library for building `libffi`, and its presence implies that
it should likely be used. This patch is an attempt to fix some problems
observed with testing programs linked against `libffi` on many different
systems that could have conflicting paths. Linking it statically
prevents this.

This patch adds the `ffi_static` target for this library.
