### PR TITLE
[lld][ELF] Add `--why-extract` for bitcode libcalls

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2114,8 +2114,11 @@ static void handleUndefinedGlob(StringRef arg) {
 
 static void handleLibcall(StringRef name) {
   Symbol *sym = symtab.find(name);
-  if (sym && sym->isLazy() && isa<BitcodeFile>(sym->file))
+  if (sym && sym->isLazy() && isa<BitcodeFile>(sym->file)) {
+    if (!config->whyExtract.empty())
+      ctx.whyExtractRecords.emplace_back("<libcall>", sym->file, *sym);
     sym->extract();
+  }
 }
 
 static void writeArchiveStats() {

--- a/lld/test/ELF/lto/libcall-archive.ll
+++ b/lld/test/ELF/lto/libcall-archive.ll
@@ -4,10 +4,14 @@
 ; RUN: llvm-as -o %t2.o %S/Inputs/libcall-archive.ll
 ; RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux -o %t3.o %S/Inputs/libcall-archive.s
 ; RUN: llvm-ar rcs %t.a %t2.o %t3.o
-; RUN: ld.lld -o %t %t.o %t.a
+; RUN: ld.lld --why-extract=why.txt -o %t %t.o %t.a
+; RUN: FileCheck %s --input-file=why.txt --check-prefix=CHECK-WHY
 ; RUN: llvm-nm %t | FileCheck %s
 ; RUN: ld.lld -o %t2 %t.o --start-lib %t2.o %t3.o --end-lib
 ; RUN: llvm-nm %t2 | FileCheck %s
+
+; CHECK-WHY: reference extracted symbol
+; CHECK-WHY-NEXT: <libcall> {{.*}}tmp.a({{.*}}tmp2.o) memcpy
 
 ; CHECK-NOT: T __sync_val_compare_and_swap_8
 ; CHECK: T _start


### PR DESCRIPTION
The Wasm linker already records these and its seems useful to do so.