### PR TITLE
[libc] Redo the install targets

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -348,19 +348,6 @@ foreach(entrypoint IN LISTS TARGET_LLVMLIBC_ENTRYPOINTS)
   list(APPEND TARGET_ENTRYPOINT_NAME_LIST ${entrypoint_name})
 endforeach()
 
-set(LIBC_INSTALL_DEPENDS)
-if(LLVM_LIBC_FULL_BUILD)
-  set(LIBC_INSTALL_DEPENDS "install-libc-static-archives;install-libc-headers")
-  if(NOT LIBC_TARGET_OS_IS_BAREMETAL)
-    # For now we will disable libc-startup installation for baremetal. The
-    # correct way to do it would be to make a hookable startup for baremetal
-    # and install it as part of the libc installation.
-    list(APPEND LIBC_INSTALL_DEPENDS "libc-startup")
-  endif()
-else()
-  set(LIBC_INSTALL_DEPENDS install-libc-static-archives)
-endif()
-
 add_subdirectory(include)
 add_subdirectory(config)
 add_subdirectory(src)
@@ -388,18 +375,3 @@ endif()
 if (LIBC_INCLUDE_DOCS)
   add_subdirectory(docs)
 endif()
-
-
-if(LLVM_LIBC_FULL_BUILD)
-  add_llvm_install_targets(
-    install-libc-headers
-    DEPENDS libc-headers
-    COMPONENT libc-headers
-  )
-endif()
-
-add_llvm_install_targets(
-  install-libc
-  DEPENDS ${LIBC_INSTALL_DEPENDS}
-  COMPONENT libc
-)

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -606,3 +606,13 @@ foreach(target IN LISTS all_install_header_targets)
             COMPONENT libc-headers)
   endif()
 endforeach()
+
+if(LLVM_LIBC_FULL_BUILD)
+  add_custom_target(install-libc-headers
+                    DEPENDS libc-headers
+                    COMMAND "${CMAKE_COMMAND}"
+                            -DCMAKE_INSTALL_COMPONENT=libc-headers
+                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+  # Stripping is a no-op for headers
+  add_custom_target(install-libc-headers-stripped DEPENDS install-libc-headers)
+endif()

--- a/libc/lib/CMakeLists.txt
+++ b/libc/lib/CMakeLists.txt
@@ -33,6 +33,9 @@ foreach(archive IN ZIP_LISTS
     PROPERTIES
       ARCHIVE_OUTPUT_NAME ${archive_0}
   )
+  if(LLVM_LIBC_FULL_BUILD)
+    target_link_libraries(${archive_1} PUBLIC libc-headers)
+  endif()
   list(APPEND added_archive_targets ${archive_1})
 endforeach()
 
@@ -48,11 +51,32 @@ endif()
 install(
   TARGETS ${added_archive_targets}
   ARCHIVE DESTINATION ${LIBC_INSTALL_LIBRARY_DIR}
-  COMPONENT libc-static-archives
+  COMPONENT libc
 )
 
-add_llvm_install_targets(
-  install-libc-static-archives
-  DEPENDS ${added_archive_targets}
-  COMPONENT libc-static-archives
-)
+if(NOT LIBC_TARGET_OS_IS_BAREMETAL)
+  # For now we will disable libc-startup installation for baremetal. The
+  # correct way to do it would be to make a hookable startup for baremetal
+  # and install it as part of the libc installation.
+  set(startup_target "libc-startup")
+endif()
+
+if(LLVM_LIBC_FULL_BUILD)
+  set(header_install_target install-libc-headers)
+endif()
+
+add_custom_target(install-libc
+                  DEPENDS ${added_archive_targets}
+                          ${startup_target}
+                          ${header_install_target}
+                  COMMAND "${CMAKE_COMMAND}"
+                          -DCMAKE_INSTALL_COMPONENT=libc
+                          -P "${LIBCXX_BINARY_DIR}/cmake_install.cmake")
+add_custom_target(install-libc-stripped
+                  DEPENDS ${added_archive_targets}
+                          ${startup_target}
+                          ${header_install_target}
+                  COMMAND "${CMAKE_COMMAND}"
+                          -DCMAKE_INSTALL_COMPONENT=libc
+                          -DCMAKE_INSTALL_DO_STRIP=1
+                          -P "${LIBCXX_BINARY_DIR}/cmake_install.cmake")

--- a/libc/utils/gpu/server/CMakeLists.txt
+++ b/libc/utils/gpu/server/CMakeLists.txt
@@ -14,7 +14,7 @@ target_compile_definitions(llvmlibc_rpc_server PUBLIC
 # Install the server and associated header.
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/rpc_server.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gpu-none-llvm/
-        COMPONENT libc)
+        COMPONENT libc-headers)
 install(TARGETS llvmlibc_rpc_server
         ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
         COMPONENT libc)


### PR DESCRIPTION
Prior to this change, we wouldn't build headers that aren't referenced by other parts of the libc which would result in a build error during installation. To address this, we make the header target a dependency of the libc archive. Additionally, we also redo the install targets, moving the install targets closer to build targets and simplifying the hierarchy and generally matching what we do for other runtimes.