### PR TITLE
[RISCV] Don't look for sext in RISCVCodeGenPrepare::visitAnd.

### DIFF
--- a/llvm/test/CodeGen/RISCV/riscv-codegenprepare.ll
+++ b/llvm/test/CodeGen/RISCV/riscv-codegenprepare.ll
@@ -91,3 +91,15 @@ for.body:                                         ; preds = %for.body, %for.body
   %niter.ncmp.1 = icmp eq i64 %niter.next.1, %unroll_iter
   br i1 %niter.ncmp.1, label %for.cond.cleanup.loopexit.unr-lcssa, label %for.body
 }
+
+; TODO: We should not change 4294967295 to -1 here.
+define i64 @bug(i32 %x) {
+; CHECK-LABEL: @bug(
+; CHECK-NEXT:    [[A:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], -1
+; CHECK-NEXT:    ret i64 [[B]]
+;
+  %a = sext i32 %x to i64
+  %b = and i64 %a, 4294967295
+  ret i64 %b
+}

--- a/llvm/test/CodeGen/RISCV/riscv-codegenprepare.ll
+++ b/llvm/test/CodeGen/RISCV/riscv-codegenprepare.ll
@@ -92,11 +92,11 @@ for.body:                                         ; preds = %for.body, %for.body
   br i1 %niter.ncmp.1, label %for.cond.cleanup.loopexit.unr-lcssa, label %for.body
 }
 
-; TODO: We should not change 4294967295 to -1 here.
+; Make sure we do not change 4294967295 to -1 here.
 define i64 @bug(i32 %x) {
 ; CHECK-LABEL: @bug(
 ; CHECK-NEXT:    [[A:%.*]] = sext i32 [[X:%.*]] to i64
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], -1
+; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4294967295
 ; CHECK-NEXT:    ret i64 [[B]]
 ;
   %a = sext i32 %x to i64


### PR DESCRIPTION
We want to know the upper 33 bits of the And Input are zero. SExt
only guarantees they are the same.
    
We originally checked for SExt or ZExt when we were using
isImpliedByDomCondition because a ZExt may have been changed to SExt
before we visited the And.
    
We are no longer using isImpliedByDomCondition so we can only look
for zext with the nneg flag.
    
While here, switch to PatternMatch to simplify the code.
    
Fixes #78783