### PR TITLE
[libc] Simple __stack_chk_guard implementation

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -19,6 +19,7 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # compiler entrypoints (no corresponding header)
     libc.src.compiler.__stack_chk_fail
+    libc.src.compiler.__stack_chk_guard
 
     # errno.h entrypoints
     libc.src.errno.errno

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -19,6 +19,7 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # compiler entrypoints (no corresponding header)
     libc.src.compiler.__stack_chk_fail
+    libc.src.compiler.__stack_chk_guard
 
     # errno.h entrypoints
     libc.src.errno.errno

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -366,6 +366,7 @@ if(LLVM_LIBC_FULL_BUILD)
   list(APPEND TARGET_LIBC_ENTRYPOINTS
     # compiler entrypoints (no corresponding header)
     libc.src.compiler.__stack_chk_fail
+    libc.src.compiler.__stack_chk_guard
 
     # network.h entrypoints
     libc.src.network.htonl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -235,6 +235,14 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.truncl
 )
 
+if(LLVM_LIBC_FULL_BUILD)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # compiler entrypoints (no corresponding header)
+    libc.src.compiler.__stack_chk_fail
+    libc.src.compiler.__stack_chk_guard
+  )
+endif()
+
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}
   ${TARGET_LIBM_ENTRYPOINTS}

--- a/libc/src/compiler/CMakeLists.txt
+++ b/libc/src/compiler/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
-else()
-  add_subdirectory(generic)
 endif()
+
+add_subdirectory(generic)
 
 if(TARGET libc.src.compiler.${LIBC_TARGET_OS}.__stack_chk_fail)
   set(stack_chk_fail_dep libc.src.compiler.${LIBC_TARGET_OS}.__stack_chk_fail)
@@ -15,4 +15,17 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     ${stack_chk_fail_dep}
+)
+
+if(TARGET libc.src.compiler.${LIBC_TARGET_OS}.__stack_chk_guard)
+  set(stack_chk_guard_dep libc.src.compiler.${LIBC_TARGET_OS}.__stack_chk_guard)
+else()
+  set(stack_chk_guard_dep libc.src.compiler.generic.__stack_chk_guard)
+endif()
+
+add_entrypoint_object(
+  __stack_chk_guard
+  ALIAS
+  DEPENDS
+    ${stack_chk_guard_dep}
 )

--- a/libc/src/compiler/__stack_chk_guard.h
+++ b/libc/src/compiler/__stack_chk_guard.h
@@ -1,0 +1,20 @@
+//===-- Internal header for __stack_chk_guard -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPILER___STACK_CHK_GUARD_H
+#define LLVM_LIBC_SRC_COMPILER___STACK_CHK_GUARD_H
+
+#include <stdint.h>
+
+// The compiler will emit calls implicitly to a non-namespaced version.
+// TODO: can we additionally provide a namespaced alias so that tests can
+// explicitly call the namespaced variant rather than the non-namespaced
+// definition?
+extern "C" uintptr_t __stack_chk_guard;
+
+#endif // LLVM_LIBC_SRC_COMPILER___STACK_CHK_GUARD_H

--- a/libc/src/compiler/baremetal/CMakeLists.txt
+++ b/libc/src/compiler/baremetal/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_entrypoint_object(
+  __stack_chk_guard
+  SRCS
+    __stack_chk_guard.cpp
+  HDRS
+    ../__stack_chk_guard.h
+)

--- a/libc/src/compiler/baremetal/__stack_chk_guard.cpp
+++ b/libc/src/compiler/baremetal/__stack_chk_guard.cpp
@@ -1,0 +1,17 @@
+//===-- Implementation of __stack_chk_guard -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/compiler/__stack_chk_guard.h"
+
+#include <stdint.h>
+
+extern "C" {
+
+uintptr_t __stack_chk_guard = 0x00000aff; // 0, 0, '\n', 255
+
+} // extern "C"

--- a/libc/src/compiler/linux/CMakeLists.txt
+++ b/libc/src/compiler/linux/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_entrypoint_object(
+  __stack_chk_guard
+  SRCS
+    __stack_chk_guard.cpp
+  HDRS
+    ../__stack_chk_guard.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+  COMPILE_OPTIONS
+    -Wno-global-constructors
+)

--- a/libc/src/compiler/linux/__stack_chk_guard.cpp
+++ b/libc/src/compiler/linux/__stack_chk_guard.cpp
@@ -1,0 +1,39 @@
+//===-- Implementation of __stack_chk_guard -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/compiler/__stack_chk_guard.h"
+#include "src/__support/OSUtil/syscall.h"
+#include "src/errno/libc_errno.h"
+
+#include <sys/syscall.h>
+
+extern "C" {
+
+uintptr_t __stack_chk_guard = 0;
+
+} // extern "C"
+
+namespace LIBC_NAMESPACE {
+namespace {
+
+class StackCheckGuard {
+public:
+  StackCheckGuard() {
+    // TODO: Use getauxval(AT_RANDOM) once available.
+    long retval =
+        syscall_impl(SYS_getrandom, reinterpret_cast<long>(&__stack_chk_guard),
+                     sizeof(uintptr_t), 0);
+    if (retval < 0)
+      __stack_chk_guard = 0x00000aff; // 0, 0, '\n', 255
+  }
+};
+
+StackCheckGuard stack_check_guard;
+
+} // anonymous namespace
+} // namespace LIBC_NAMESPACE

--- a/libc/test/src/compiler/CMakeLists.txt
+++ b/libc/test/src/compiler/CMakeLists.txt
@@ -9,6 +9,7 @@ add_libc_unittest(
   DEPENDS
     libc.src.__support.macros.sanitizer
     libc.src.compiler.__stack_chk_fail
+    libc.src.compiler.__stack_chk_guard
     libc.src.string.memset
   COMPILE_OPTIONS
     -fstack-protector-all


### PR DESCRIPTION
This is needed on systems that don't use TLS to store the stack canary.