### PR TITLE
[ELF] Rename LazyObject to LazySymbol. NFC

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1739,7 +1739,7 @@ void BitcodeFile::parseLazy() {
   for (auto [i, irSym] : llvm::enumerate(obj->symbols()))
     if (!irSym.isUndefined()) {
       auto *sym = symtab.insert(saver().save(irSym.getName()));
-      sym->resolve(LazyObject{*this});
+      sym->resolve(LazySymbol{*this});
       symbols[i] = sym;
     }
 }
@@ -1821,7 +1821,7 @@ template <class ELFT> void ObjFile<ELFT>::parseLazy() {
     if (eSyms[i].st_shndx == SHN_UNDEF)
       continue;
     symbols[i] = symtab.insert(CHECK(eSyms[i].getName(stringTable), this));
-    symbols[i]->resolve(LazyObject{*this});
+    symbols[i]->resolve(LazySymbol{*this});
     if (!lazy)
       break;
   }

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -40,7 +40,7 @@ LLVM_ATTRIBUTE_UNUSED static inline void assertSymbols() {
   AssertSymbol<CommonSymbol>();
   AssertSymbol<Undefined>();
   AssertSymbol<SharedSymbol>();
-  AssertSymbol<LazyObject>();
+  AssertSymbol<LazySymbol>();
 }
 
 // Returns a symbol for an error message.
@@ -146,7 +146,7 @@ static uint64_t getSymVA(const Symbol &sym, int64_t addend) {
   case Symbol::SharedKind:
   case Symbol::UndefinedKind:
     return 0;
-  case Symbol::LazyObjectKind:
+  case Symbol::LazySymbolKind:
     llvm_unreachable("lazy symbol reached writer");
   case Symbol::CommonKind:
     llvm_unreachable("common symbol reached writer");
@@ -623,7 +623,7 @@ void Symbol::resolve(const Defined &other) {
     other.overwrite(*this);
 }
 
-void Symbol::resolve(const LazyObject &other) {
+void Symbol::resolve(const LazySymbol &other) {
   if (isPlaceholder()) {
     other.overwrite(*this);
     return;

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -146,7 +146,7 @@ static uint64_t getSymVA(const Symbol &sym, int64_t addend) {
   case Symbol::SharedKind:
   case Symbol::UndefinedKind:
     return 0;
-  case Symbol::LazySymbolKind:
+  case Symbol::LazyKind:
     llvm_unreachable("lazy symbol reached writer");
   case Symbol::CommonKind:
     llvm_unreachable("common symbol reached writer");

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -37,7 +37,7 @@ class InputSectionBase;
 class SharedSymbol;
 class Symbol;
 class Undefined;
-class LazyObject;
+class LazySymbol;
 class InputFile;
 
 void printTraceSymbol(const Symbol &sym, StringRef name);
@@ -76,7 +76,7 @@ public:
     CommonKind,
     SharedKind,
     UndefinedKind,
-    LazyObjectKind,
+    LazySymbolKind,
   };
 
   Kind kind() const { return static_cast<Kind>(symbolKind); }
@@ -181,7 +181,7 @@ public:
 
   bool isLocal() const { return binding == llvm::ELF::STB_LOCAL; }
 
-  bool isLazy() const { return symbolKind == LazyObjectKind; }
+  bool isLazy() const { return symbolKind == LazySymbolKind; }
 
   // True if this is an undefined weak symbol. This only works once
   // all input files have been added.
@@ -237,7 +237,7 @@ public:
   void resolve(const Undefined &other);
   void resolve(const CommonSymbol &other);
   void resolve(const Defined &other);
-  void resolve(const LazyObject &other);
+  void resolve(const LazySymbol &other);
   void resolve(const SharedSymbol &other);
 
   // If this is a lazy symbol, extract an input file and add the symbol
@@ -471,7 +471,7 @@ public:
   uint32_t alignment;
 };
 
-// LazyObject symbols represent symbols in object files between --start-lib and
+// LazySymbol symbols represent symbols in object files between --start-lib and
 // --end-lib options. LLD also handles traditional archives as if all the files
 // in the archive are surrounded by --start-lib and --end-lib.
 //
@@ -480,14 +480,14 @@ public:
 // and the lazy. We represent that with a lazy symbol with a weak binding. This
 // means that code looking for undefined symbols normally also has to take lazy
 // symbols into consideration.
-class LazyObject : public Symbol {
+class LazySymbol : public Symbol {
 public:
-  LazyObject(InputFile &file)
-      : Symbol(LazyObjectKind, &file, {}, llvm::ELF::STB_GLOBAL,
+  LazySymbol(InputFile &file)
+      : Symbol(LazySymbolKind, &file, {}, llvm::ELF::STB_GLOBAL,
                llvm::ELF::STV_DEFAULT, llvm::ELF::STT_NOTYPE) {}
-  void overwrite(Symbol &sym) const { Symbol::overwrite(sym, LazyObjectKind); }
+  void overwrite(Symbol &sym) const { Symbol::overwrite(sym, LazySymbolKind); }
 
-  static bool classof(const Symbol *s) { return s->kind() == LazyObjectKind; }
+  static bool classof(const Symbol *s) { return s->kind() == LazySymbolKind; }
 };
 
 // Some linker-generated symbols need to be created as
@@ -541,7 +541,7 @@ union SymbolUnion {
   alignas(CommonSymbol) char b[sizeof(CommonSymbol)];
   alignas(Undefined) char c[sizeof(Undefined)];
   alignas(SharedSymbol) char d[sizeof(SharedSymbol)];
-  alignas(LazyObject) char e[sizeof(LazyObject)];
+  alignas(LazySymbol) char e[sizeof(LazySymbol)];
 };
 
 template <typename... T> Defined *makeDefined(T &&...args) {

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -76,7 +76,7 @@ public:
     CommonKind,
     SharedKind,
     UndefinedKind,
-    LazySymbolKind,
+    LazyKind,
   };
 
   Kind kind() const { return static_cast<Kind>(symbolKind); }
@@ -181,7 +181,7 @@ public:
 
   bool isLocal() const { return binding == llvm::ELF::STB_LOCAL; }
 
-  bool isLazy() const { return symbolKind == LazySymbolKind; }
+  bool isLazy() const { return symbolKind == LazyKind; }
 
   // True if this is an undefined weak symbol. This only works once
   // all input files have been added.
@@ -483,11 +483,11 @@ public:
 class LazySymbol : public Symbol {
 public:
   LazySymbol(InputFile &file)
-      : Symbol(LazySymbolKind, &file, {}, llvm::ELF::STB_GLOBAL,
+      : Symbol(LazyKind, &file, {}, llvm::ELF::STB_GLOBAL,
                llvm::ELF::STV_DEFAULT, llvm::ELF::STT_NOTYPE) {}
-  void overwrite(Symbol &sym) const { Symbol::overwrite(sym, LazySymbolKind); }
+  void overwrite(Symbol &sym) const { Symbol::overwrite(sym, LazyKind); }
 
-  static bool classof(const Symbol *s) { return s->kind() == LazySymbolKind; }
+  static bool classof(const Symbol *s) { return s->kind() == LazyKind; }
 };
 
 // Some linker-generated symbols need to be created as


### PR DESCRIPTION
LazySymbol (used by wasm port) is a more accurate name (the struct is
not about an object). However, the ELF port calls this LazyObject likely
because we used to have LazyArchive (removed by
https://reviews.llvm.org/D119074), and LazyObject has a similar naming
convention (LazyObjectSymbol would be better, but it is too long).
