### PR TITLE
 [libc++][test] Use LIBCPP_ASSERT in some `system_category`-related tests

### DIFF
--- a/libcxx/test/std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp
@@ -46,9 +46,9 @@ int main(int, char**)
     assert(e_code2 == e_code2);
     assert(e_code2 != e_code3);
     assert(e_code2 != e_code4);
-    assert(e_code2 == e_condition1);  // ?
+    LIBCPP_ASSERT(e_code2 == e_condition1);
     assert(e_code2 == e_condition2);
-    assert(e_code2 != e_condition3);
+    LIBCPP_ASSERT(e_code2 != e_condition3);
     assert(e_code2 != e_condition4);
 
     assert(e_code3 != e_code1);
@@ -64,15 +64,15 @@ int main(int, char**)
     assert(e_code4 != e_code2);
     assert(e_code4 != e_code3);
     assert(e_code4 == e_code4);
-    assert(e_code4 != e_condition1);
+    LIBCPP_ASSERT(e_code4 != e_condition1);
     assert(e_code4 != e_condition2);
-    assert(e_code4 == e_condition3);  // ?
+    LIBCPP_ASSERT(e_code4 == e_condition3);
     assert(e_code4 == e_condition4);
 
     assert(e_condition1 == e_code1);
-    assert(e_condition1 == e_code2);  // ?
+    LIBCPP_ASSERT(e_condition1 == e_code2);
     assert(e_condition1 != e_code3);
-    assert(e_condition1 != e_code4);
+    LIBCPP_ASSERT(e_condition1 != e_code4);
     assert(e_condition1 == e_condition1);
     assert(e_condition1 != e_condition2);
     assert(e_condition1 != e_condition3);
@@ -88,9 +88,9 @@ int main(int, char**)
     assert(e_condition2 != e_condition4);
 
     assert(e_condition3 != e_code1);
-    assert(e_condition3 != e_code2);
+    LIBCPP_ASSERT(e_condition3 != e_code2);
     assert(e_condition3 == e_code3);
-    assert(e_condition3 == e_code4);  // ?
+    LIBCPP_ASSERT(e_condition3 == e_code4);
     assert(e_condition3 != e_condition1);
     assert(e_condition3 != e_condition2);
     assert(e_condition3 == e_condition3);

--- a/libcxx/test/std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp
@@ -22,88 +22,87 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    std::error_code e_code1(5, std::generic_category());
-    std::error_code e_code2(5, std::system_category());
-    std::error_code e_code3(6, std::generic_category());
-    std::error_code e_code4(6, std::system_category());
-    std::error_condition e_condition1(5, std::generic_category());
-    std::error_condition e_condition2(5, std::system_category());
-    std::error_condition e_condition3(6, std::generic_category());
-    std::error_condition e_condition4(6, std::system_category());
+int main(int, char**) {
+  std::error_code e_code1(5, std::generic_category());
+  std::error_code e_code2(5, std::system_category());
+  std::error_code e_code3(6, std::generic_category());
+  std::error_code e_code4(6, std::system_category());
+  std::error_condition e_condition1(5, std::generic_category());
+  std::error_condition e_condition2(5, std::system_category());
+  std::error_condition e_condition3(6, std::generic_category());
+  std::error_condition e_condition4(6, std::system_category());
 
-    assert(e_code1 == e_code1);
-    assert(e_code1 != e_code2);
-    assert(e_code1 != e_code3);
-    assert(e_code1 != e_code4);
-    assert(e_code1 == e_condition1);
-    assert(e_code1 != e_condition2);
-    assert(e_code1 != e_condition3);
-    assert(e_code1 != e_condition4);
+  assert(e_code1 == e_code1);
+  assert(e_code1 != e_code2);
+  assert(e_code1 != e_code3);
+  assert(e_code1 != e_code4);
+  assert(e_code1 == e_condition1);
+  assert(e_code1 != e_condition2);
+  assert(e_code1 != e_condition3);
+  assert(e_code1 != e_condition4);
 
-    assert(e_code2 != e_code1);
-    assert(e_code2 == e_code2);
-    assert(e_code2 != e_code3);
-    assert(e_code2 != e_code4);
-    LIBCPP_ASSERT(e_code2 == e_condition1);
-    assert(e_code2 == e_condition2);
-    LIBCPP_ASSERT(e_code2 != e_condition3);
-    assert(e_code2 != e_condition4);
+  assert(e_code2 != e_code1);
+  assert(e_code2 == e_code2);
+  assert(e_code2 != e_code3);
+  assert(e_code2 != e_code4);
+  LIBCPP_ASSERT(e_code2 == e_condition1);
+  assert(e_code2 == e_condition2);
+  LIBCPP_ASSERT(e_code2 != e_condition3);
+  assert(e_code2 != e_condition4);
 
-    assert(e_code3 != e_code1);
-    assert(e_code3 != e_code2);
-    assert(e_code3 == e_code3);
-    assert(e_code3 != e_code4);
-    assert(e_code3 != e_condition1);
-    assert(e_code3 != e_condition2);
-    assert(e_code3 == e_condition3);
-    assert(e_code3 != e_condition4);
+  assert(e_code3 != e_code1);
+  assert(e_code3 != e_code2);
+  assert(e_code3 == e_code3);
+  assert(e_code3 != e_code4);
+  assert(e_code3 != e_condition1);
+  assert(e_code3 != e_condition2);
+  assert(e_code3 == e_condition3);
+  assert(e_code3 != e_condition4);
 
-    assert(e_code4 != e_code1);
-    assert(e_code4 != e_code2);
-    assert(e_code4 != e_code3);
-    assert(e_code4 == e_code4);
-    LIBCPP_ASSERT(e_code4 != e_condition1);
-    assert(e_code4 != e_condition2);
-    LIBCPP_ASSERT(e_code4 == e_condition3);
-    assert(e_code4 == e_condition4);
+  assert(e_code4 != e_code1);
+  assert(e_code4 != e_code2);
+  assert(e_code4 != e_code3);
+  assert(e_code4 == e_code4);
+  LIBCPP_ASSERT(e_code4 != e_condition1);
+  assert(e_code4 != e_condition2);
+  LIBCPP_ASSERT(e_code4 == e_condition3);
+  assert(e_code4 == e_condition4);
 
-    assert(e_condition1 == e_code1);
-    LIBCPP_ASSERT(e_condition1 == e_code2);
-    assert(e_condition1 != e_code3);
-    LIBCPP_ASSERT(e_condition1 != e_code4);
-    assert(e_condition1 == e_condition1);
-    assert(e_condition1 != e_condition2);
-    assert(e_condition1 != e_condition3);
-    assert(e_condition1 != e_condition4);
+  assert(e_condition1 == e_code1);
+  LIBCPP_ASSERT(e_condition1 == e_code2);
+  assert(e_condition1 != e_code3);
+  LIBCPP_ASSERT(e_condition1 != e_code4);
+  assert(e_condition1 == e_condition1);
+  assert(e_condition1 != e_condition2);
+  assert(e_condition1 != e_condition3);
+  assert(e_condition1 != e_condition4);
 
-    assert(e_condition2 != e_code1);
-    assert(e_condition2 == e_code2);
-    assert(e_condition2 != e_code3);
-    assert(e_condition2 != e_code4);
-    assert(e_condition2 != e_condition1);
-    assert(e_condition2 == e_condition2);
-    assert(e_condition2 != e_condition3);
-    assert(e_condition2 != e_condition4);
+  assert(e_condition2 != e_code1);
+  assert(e_condition2 == e_code2);
+  assert(e_condition2 != e_code3);
+  assert(e_condition2 != e_code4);
+  assert(e_condition2 != e_condition1);
+  assert(e_condition2 == e_condition2);
+  assert(e_condition2 != e_condition3);
+  assert(e_condition2 != e_condition4);
 
-    assert(e_condition3 != e_code1);
-    LIBCPP_ASSERT(e_condition3 != e_code2);
-    assert(e_condition3 == e_code3);
-    LIBCPP_ASSERT(e_condition3 == e_code4);
-    assert(e_condition3 != e_condition1);
-    assert(e_condition3 != e_condition2);
-    assert(e_condition3 == e_condition3);
-    assert(e_condition3 != e_condition4);
+  assert(e_condition3 != e_code1);
+  LIBCPP_ASSERT(e_condition3 != e_code2);
+  assert(e_condition3 == e_code3);
+  LIBCPP_ASSERT(e_condition3 == e_code4);
+  assert(e_condition3 != e_condition1);
+  assert(e_condition3 != e_condition2);
+  assert(e_condition3 == e_condition3);
+  assert(e_condition3 != e_condition4);
 
-    assert(e_condition4 != e_code1);
-    assert(e_condition4 != e_code2);
-    assert(e_condition4 != e_code3);
-    assert(e_condition4 == e_code4);
-    assert(e_condition4 != e_condition1);
-    assert(e_condition4 != e_condition2);
-    assert(e_condition4 != e_condition3);
-    assert(e_condition4 == e_condition4);
+  assert(e_condition4 != e_code1);
+  assert(e_condition4 != e_code2);
+  assert(e_condition4 != e_code3);
+  assert(e_condition4 == e_code4);
+  assert(e_condition4 != e_condition1);
+  assert(e_condition4 != e_condition2);
+  assert(e_condition4 != e_condition3);
+  assert(e_condition4 == e_condition4);
 
   return 0;
 }

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     assert(!m1.empty());
     assert(!m2.empty());
     assert(!m3.empty());
-    assert(m1 == m2);
+    LIBCPP_ASSERT(m1 == m2);
     assert(m1 != m3);
 
   return 0;

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp
@@ -20,18 +20,17 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    const std::error_category& e_cat1 = std::generic_category();
-    const std::error_category& e_cat2 = std::system_category();
-    std::string m1 = e_cat1.message(5);
-    std::string m2 = e_cat2.message(5);
-    std::string m3 = e_cat2.message(6);
-    assert(!m1.empty());
-    assert(!m2.empty());
-    assert(!m3.empty());
-    LIBCPP_ASSERT(m1 == m2);
-    assert(m1 != m3);
+int main(int, char**) {
+  const std::error_category& e_cat1 = std::generic_category();
+  const std::error_category& e_cat2 = std::system_category();
+  std::string m1                    = e_cat1.message(5);
+  std::string m2                    = e_cat2.message(5);
+  std::string m3                    = e_cat2.message(6);
+  assert(!m1.empty());
+  assert(!m2.empty());
+  assert(!m3.empty());
+  LIBCPP_ASSERT(m1 == m2);
+  assert(m1 != m3);
 
   return 0;
 }

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -37,9 +37,12 @@ int main(int, char**) {
     std::error_condition e_cond       = e_cat1.default_error_condition(5);
     LIBCPP_ASSERT(e_cond.value() == 5);
     LIBCPP_ASSERT(e_cond.category() == std::generic_category());
+    assert(e_cat1.equivalent(5, e_cond));
+
     e_cond = e_cat1.default_error_condition(5000);
     LIBCPP_ASSERT(e_cond.value() == 5000);
     LIBCPP_ASSERT(e_cond.category() == std::system_category());
+    assert(e_cat1.equivalent(5000, e_cond));
   }
 
   // Test the result of message(int cond) when given a bad error condition

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -23,47 +23,46 @@
 
 // See https://llvm.org/D65667
 struct StaticInit {
-    const std::error_category* ec;
-    ~StaticInit() {
-        std::string str = ec->name();
-        assert(str == "system") ;
-    }
+  const std::error_category* ec;
+  ~StaticInit() {
+    std::string str = ec->name();
+    assert(str == "system");
+  }
 };
 static StaticInit foo;
 
-int main(int, char**)
-{
-    {
-        const std::error_category& e_cat1 = std::system_category();
-        std::error_condition e_cond = e_cat1.default_error_condition(5);
-        LIBCPP_ASSERT(e_cond.value() == 5);
-        LIBCPP_ASSERT(e_cond.category() == std::generic_category());
-        e_cond = e_cat1.default_error_condition(5000);
-        LIBCPP_ASSERT(e_cond.value() == 5000);
-        LIBCPP_ASSERT(e_cond.category() == std::system_category());
-    }
+int main(int, char**) {
+  {
+    const std::error_category& e_cat1 = std::system_category();
+    std::error_condition e_cond       = e_cat1.default_error_condition(5);
+    LIBCPP_ASSERT(e_cond.value() == 5);
+    LIBCPP_ASSERT(e_cond.category() == std::generic_category());
+    e_cond = e_cat1.default_error_condition(5000);
+    LIBCPP_ASSERT(e_cond.value() == 5000);
+    LIBCPP_ASSERT(e_cond.category() == std::system_category());
+  }
 
-    // Test the result of message(int cond) when given a bad error condition
-    {
-            errno = E2BIG; // something that message will never generate
-            const std::error_category& e_cat1 = std::system_category();
-            const std::string msg = e_cat1.message(-1);
-            // Exact message format varies by platform.
+  // Test the result of message(int cond) when given a bad error condition
+  {
+    errno                             = E2BIG; // something that message will never generate
+    const std::error_category& e_cat1 = std::system_category();
+    const std::string msg             = e_cat1.message(-1);
+    // Exact message format varies by platform.
 #if defined(_AIX)
-            LIBCPP_ASSERT(msg.rfind("Error -1 occurred", 0) == 0);
+    LIBCPP_ASSERT(msg.rfind("Error -1 occurred", 0) == 0);
 #elif defined(_NEWLIB_VERSION)
-            LIBCPP_ASSERT(msg.empty());
+    LIBCPP_ASSERT(msg.empty());
 #else
-            LIBCPP_ASSERT(msg.rfind("Unknown error", 0) == 0);
+    LIBCPP_ASSERT(msg.rfind("Unknown error", 0) == 0);
 #endif
-            assert(errno == E2BIG);
-    }
+    assert(errno == E2BIG);
+  }
 
-    {
-        foo.ec = &std::system_category();
-        std::string m = foo.ec->name();
-        assert(m == "system");
-    }
+  {
+    foo.ec        = &std::system_category();
+    std::string m = foo.ec->name();
+    assert(m == "system");
+  }
 
-    return 0;
+  return 0;
 }

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -36,11 +36,11 @@ int main(int, char**)
     {
         const std::error_category& e_cat1 = std::system_category();
         std::error_condition e_cond = e_cat1.default_error_condition(5);
-        assert(e_cond.value() == 5);
-        assert(e_cond.category() == std::generic_category());
+        LIBCPP_ASSERT(e_cond.value() == 5);
+        LIBCPP_ASSERT(e_cond.category() == std::generic_category());
         e_cond = e_cat1.default_error_condition(5000);
-        assert(e_cond.value() == 5000);
-        assert(e_cond.category() == std::system_category());
+        LIBCPP_ASSERT(e_cond.value() == 5000);
+        LIBCPP_ASSERT(e_cond.category() == std::system_category());
     }
 
     // Test the result of message(int cond) when given a bad error condition


### PR DESCRIPTION
* `eq_error_code_error_code.pass.cpp`: The comparison between `error_code` and `error_category` internally uses `default_error_condition` to map the `error_code` to its corresponding `error_condition`. When the `error_code`'s `category` is `system_category`, [what constitutes correspondence is unspecified](http://eel.is/c++draft/syserr.errcat.objects#4.sentence-7).
* `message.pass.cpp` assumes that the result of `system_category().message(5)` is equal to `generic_category().message(5)`.
* `system_category.pass.cpp` assumes that `system_category().default_error_condition(5).value() == 5`.

Although libc++'s `system_category` always behave as if the incoming value is a POSIX error code (and thus is very similar to `generic_category`), other implementations do something different on Windows.