### PR TITLE
 [Clang][Parser] Fix crash of clang when trying to convert a cast to …

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9272,10 +9272,17 @@ bool PointerExprEvaluator::VisitCastExpr(const CastExpr *E) {
     }
     // The result is a pointer to the first element of the array.
     auto *AT = Info.Ctx.getAsArrayType(SubExpr->getType());
-    if (auto *CAT = dyn_cast<ConstantArrayType>(AT))
+    if (auto *CAT = dyn_cast<ConstantArrayType>(AT)) {
       Result.addArray(Info, E, CAT);
-    else
-      Result.addUnsizedArray(Info, E, AT->getElementType());
+    }
+    else {
+      if (Result.checkNullPointer(Info, E, CSK_ArrayToPointer)) {
+        // Only add unsized array if there actually is a pointer.
+        return false;        
+      } else {
+        Result.addUnsizedArray(Info, E, AT->getElementType());
+      }
+    }
     return true;
   }
 


### PR DESCRIPTION
…a nullptr casted to an array of non-constant size to a reference (#76634).

This situation is undefined behavior, and should not lead to a compiler crash. Thus, the problematic cast is only executed on non-null pointers.

Fixes one reason for a crash in #76634.