### PR TITLE
[clang-apply-replacements] Add support for the `.yml` file extension

### DIFF
--- a/clang-tools-extra/clang-apply-replacements/lib/Tooling/ApplyReplacements.cpp
+++ b/clang-tools-extra/clang-apply-replacements/lib/Tooling/ApplyReplacements.cpp
@@ -23,11 +23,14 @@
 #include "clang/Tooling/DiagnosticsYaml.h"
 #include "clang/Tooling/ReplacementsYaml.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include <array>
 #include <optional>
 
 using namespace llvm;
@@ -39,6 +42,9 @@ namespace clang {
 namespace replace {
 
 namespace detail {
+
+static constexpr std::array<StringRef, 2> AllowedExtensions = {".yaml", ".yml"};
+
 template <typename TranslationUnits>
 static std::error_code collectReplacementsFromDirectory(
     const llvm::StringRef Directory, TranslationUnits &TUs,
@@ -56,7 +62,7 @@ static std::error_code collectReplacementsFromDirectory(
       continue;
     }
 
-    if (extension(I->path()) != ".yaml")
+    if (!is_contained(AllowedExtensions, extension(I->path())))
       continue;
 
     TUFiles.push_back(I->path());

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/basic.h
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/basic.h
@@ -1,0 +1,32 @@
+#ifndef BASIC_H
+#define BASIC_H
+
+
+class Parent {
+public:
+  virtual void func() {}
+};
+
+class Derived : public Parent {
+public:
+  virtual void func() {}
+  // CHECK: virtual void func() override {}
+};
+
+extern void ext(int (&)[5], const Parent &);
+
+void func(int t) {
+  int ints[5];
+  for (unsigned i = 0; i < 5; ++i) {
+    int &e = ints[i];
+    e = t;
+    // CHECK: for (auto & elem : ints) {
+    // CHECK-NEXT: elem = t;
+  }
+
+  Derived d;
+
+  ext(ints, d);
+}
+
+#endif // BASIC_H

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/file1.yml
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/file1.yml
@@ -1,0 +1,26 @@
+---
+MainSourceFile:     source1.cpp
+Diagnostics:
+  - DiagnosticName: test-basic
+    DiagnosticMessage:
+      Message: Fix
+      FilePath: $(path)/basic.h
+      FileOffset: 242
+      Replacements:
+        - FilePath:        $(path)/basic.h
+          Offset:          242
+          Length:          26
+          ReplacementText: 'auto & elem : ints'
+        - FilePath:        $(path)/basic.h
+          Offset:          276
+          Length:          22
+          ReplacementText: ''
+        - FilePath:        $(path)/basic.h
+          Offset:          298
+          Length:          1
+          ReplacementText: elem
+        - FilePath:        $(path)/../yml-basic/basic.h
+          Offset:          148
+          Length:          0
+          ReplacementText: 'override '
+...

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/file2.yml
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/yml-basic/file2.yml
@@ -1,0 +1,14 @@
+---
+MainSourceFile:     source2.cpp
+Diagnostics:
+  - DiagnosticName: test-basic
+    DiagnosticMessage:
+      Message: Fix
+      FilePath: $(path)/basic.h
+      FileOffset: 148
+      Replacements:
+        - FilePath:        $(path)/../yml-basic/basic.h
+          Offset:          298
+          Length:          1
+          ReplacementText: elem
+...

--- a/clang-tools-extra/test/clang-apply-replacements/yml-basic.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/yml-basic.cpp
@@ -1,0 +1,17 @@
+// RUN: mkdir -p %T/Inputs/yml-basic
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %T/Inputs/yml-basic/basic.h
+// RUN: sed "s#\$(path)#%/T/Inputs/yml-basic#" %S/Inputs/yml-basic/file1.yml > %T/Inputs/yml-basic/file1.yml
+// RUN: sed "s#\$(path)#%/T/Inputs/yml-basic#" %S/Inputs/yml-basic/file2.yml > %T/Inputs/yml-basic/file2.yml
+// RUN: clang-apply-replacements %T/Inputs/yml-basic
+// RUN: FileCheck -input-file=%T/Inputs/yml-basic/basic.h %S/Inputs/yml-basic/basic.h
+//
+// Check that the yml files are *not* deleted after running clang-apply-replacements without remove-change-desc-files.
+// RUN: ls -1 %T/Inputs/yml-basic | FileCheck %s --check-prefix=YML
+//
+// Check that the yml files *are* deleted after running clang-apply-replacements with remove-change-desc-files.
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %T/Inputs/yml-basic/basic.h
+// RUN: clang-apply-replacements -remove-change-desc-files %T/Inputs/yml-basic
+// RUN: ls -1 %T/Inputs/yml-basic | FileCheck %s --check-prefix=NO_YML
+//
+// YML: {{^file.\.yml$}}
+// NO_YML-NOT: {{^file.\.yml$}}


### PR DESCRIPTION
The `.yml` file extension is a valid extension for the YAML files, but it was not previously supported by the Clang Apply Replacements tool. This commit adds support for processing `.yml` files. Without this change, running the tool on a folder containing `.yml` files generated by clang-tidy would have no effect.
