### PR TITLE
[clang-format] NEVER allow && to be an unary operator.

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2503,6 +2503,9 @@ private:
     if (!PrevToken)
       return true;
 
+    if (Tok.is(tok::ampamp))
+      return false;
+
     // These keywords are deliberately not included here because they may
     // precede only one of unary star/amp and plus/minus but not both.  They are
     // either included in determineStarAmpUsage or determinePlusMinusCaretUsage.

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -309,6 +309,10 @@ TEST_F(TokenAnnotatorTest, UnderstandsUsesOfStarAndAmp) {
   EXPECT_TOKEN(Tokens[6], tok::l_paren, TT_OverloadedOperatorLParen);
   EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_FunctionLBrace);
   EXPECT_TOKEN(Tokens[11], tok::amp, TT_PointerOrReference);
+
+  Tokens = annotate("if (delete && foo) {}");
+  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::ampamp, TT_BinaryOperator);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsUsesOfPlusAndMinus) {


### PR DESCRIPTION
Simply always return false if tok::ampamp is passed into determineUnaryOperatorByUsage.

I've done a fix earlier regarding ampamp becoming an unary operator, this would technically supersede that.

I'm not sure why this hasn't been done before, I don't see any downsides.

Fixes https://github.com/llvm/llvm-project/issues/78789