### PR TITLE
[clang-tidy] Ignore user-defined literals in google-runtime-int

### DIFF
--- a/clang-tools-extra/clang-tidy/google/IntegerTypesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/IntegerTypesCheck.cpp
@@ -56,11 +56,14 @@ void IntegerTypesCheck::registerMatchers(MatchFinder *Finder) {
   // http://google.github.io/styleguide/cppguide.html#64-bit_Portability
   // "Where possible, avoid passing arguments of types specified by
   // bitwidth typedefs to printf-based APIs."
-  Finder->addMatcher(typeLoc(loc(isInteger()),
-                             unless(hasAncestor(callExpr(
-                                 callee(functionDecl(hasAttr(attr::Format)))))))
-                         .bind("tl"),
-                     this);
+  Finder->addMatcher(
+      typeLoc(loc(isInteger()),
+              unless(anyOf(hasAncestor(callExpr(
+                               callee(functionDecl(hasAttr(attr::Format))))),
+                           hasParent(parmVarDecl(hasAncestor(functionDecl(
+                               matchesName("operator\"\".*$"))))))))
+          .bind("tl"),
+      this);
   IdentTable = std::make_unique<IdentifierTable>(getLangOpts());
 }
 

--- a/clang-tools-extra/clang-tidy/google/IntegerTypesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/IntegerTypesCheck.cpp
@@ -36,6 +36,12 @@ static Token getTokenAtLoc(SourceLocation Loc,
   return Tok;
 }
 
+namespace {
+AST_MATCHER(FunctionDecl, isUserDefineLiteral) {
+  return Node.getLiteralIdentifier() != nullptr;
+}
+} // namespace
+
 namespace tidy::google::runtime {
 
 IntegerTypesCheck::IntegerTypesCheck(StringRef Name, ClangTidyContext *Context)
@@ -60,8 +66,8 @@ void IntegerTypesCheck::registerMatchers(MatchFinder *Finder) {
       typeLoc(loc(isInteger()),
               unless(anyOf(hasAncestor(callExpr(
                                callee(functionDecl(hasAttr(attr::Format))))),
-                           hasParent(parmVarDecl(hasAncestor(functionDecl(
-                               matchesName("operator\"\".*$"))))))))
+                           hasParent(parmVarDecl(hasAncestor(
+                               functionDecl(isUserDefineLiteral())))))))
           .bind("tl"),
       this);
   IdentTable = std::make_unique<IdentifierTable>(getLangOpts());

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -374,6 +374,9 @@ Changes in existing checks
   <clang-tidy/checks/google/readability-casting>` check to ignore constructor
   calls disguised as functional casts.
 
+- Improved :doc:`google-runtime-int` check to ignore
+  false positives on user defined-literals.
+
 - Improved :doc:`llvm-namespace-comment
   <clang-tidy/checks/llvm/namespace-comment>` check to provide fixes for
   ``inline`` namespaces in the same format as :program:`clang-format`.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -374,8 +374,8 @@ Changes in existing checks
   <clang-tidy/checks/google/readability-casting>` check to ignore constructor
   calls disguised as functional casts.
 
-- Improved :doc:`google-runtime-int` check to ignore
-  false positives on user defined-literals.
+- Improved :doc:`google-runtime-int <clang-tidy/checks/google/runtime-int>`
+  check to ignore false positives on user defined-literals.
 
 - Improved :doc:`llvm-namespace-comment
   <clang-tidy/checks/llvm/namespace-comment>` check to provide fixes for

--- a/clang-tools-extra/test/clang-tidy/checkers/google/runtime-int.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/runtime-int.cpp
@@ -59,11 +59,13 @@ void qux() {
 // CHECK-MESSAGES: [[@LINE-1]]:3: warning: consider replacing 'short' with 'int16'
 }
 
-// FIXME: This shouldn't warn, as UD-literal operators require one of a handful
-// of types as an argument.
 struct some_value {};
-constexpr some_value operator"" _some_literal(unsigned long long int i);
-// CHECK-MESSAGES: [[@LINE-1]]:47: warning: consider replacing 'unsigned long long'
+constexpr some_value operator"" _some_literal(unsigned long long int i)
+{
+  short j;
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: consider replacing 'short' with 'int16'
+  return some_value();
+}
 
 struct A { A& operator=(const A&); };
 class B { A a[0]; };


### PR DESCRIPTION
User-defined literals do not accept u?intXX(_t)? variables. So the check should not emit a warning.

Fixes #54546 #25214