### PR TITLE
[libc++][hardening] XFAIL test in fast mode under HWASAN

### DIFF
--- a/libcxx/test/libcxx/assertions/modes/enabling_assertions_enables_extensive_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/enabling_assertions_enables_extensive_mode.pass.cpp
@@ -15,6 +15,8 @@
 // The ability to set a custom abort message is required to compare the assertion message (which only happens in the
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
+// HWASAN replaces TRAP with abort or error exit code.
+// XFAIL: libcpp-hardening-mode=fast && hwasan
 // Note that GCC doesn't support `-Wno-macro-redefined`.
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_ENABLE_ASSERTIONS=1
 

--- a/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
@@ -13,6 +13,8 @@
 // The ability to set a custom abort message is required to compare the assertion message (which only happens in the
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
+// HWASAN replaces TRAP with abort or error exit code.
+// XFAIL: libcpp-hardening-mode=fast && hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
 
 #include <cassert>

--- a/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
@@ -13,6 +13,8 @@
 // The ability to set a custom abort message is required to compare the assertion message (which only happens in the
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
+// HWASAN replaces TRAP with abort or error exit code.
+// XFAIL: libcpp-hardening-mode=fast && hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 
 #include <cassert>


### PR DESCRIPTION
After #77883 FAST mode uses TRAP, and HWASAN
replaces TRAP with abort or error exit code.

On a quick looks it should be possible to avoid doing
that in HWASAN, but historically this is convention for all
sanitizers. Changing this behavior may existing  users.

Other sanitizers are not affected because they don't
install TRAP handlers by default. But if they do, they also
replace TRAP with abort/exit.