### PR TITLE
[libc++] FreeBSD CI: Adds `<signal.h>` to `check_assertion.h`

### DIFF
--- a/libcxx/test/support/check_assertion.h
+++ b/libcxx/test/support/check_assertion.h
@@ -24,7 +24,9 @@
 
 #include <unistd.h>
 #include <errno.h>
+#include <signal.h>
 #include <sys/wait.h>
+
 #include "test_macros.h"
 #include "test_allocator.h"
 


### PR DESCRIPTION
...in attempt to fix the FreeBSD CI.

I noticed that suddenly some tests in the latest PRs fail to compile on FreeBSD. This tries to resolved the issue.