### PR TITLE
[libc++][hardening] XFAIL tests with HWASAN

### DIFF
--- a/libcxx/test/libcxx/assertions/modes/enabling_assertions_enables_extensive_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/enabling_assertions_enables_extensive_mode.pass.cpp
@@ -16,7 +16,7 @@
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // HWASAN replaces TRAP with abort or error exit code.
-// XFAIL: libcpp-hardening-mode=fast && hwasan
+// XFAIL: hwasan
 // Note that GCC doesn't support `-Wno-macro-redefined`.
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_ENABLE_ASSERTIONS=1
 

--- a/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_extensive_mode.pass.cpp
@@ -14,7 +14,7 @@
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // HWASAN replaces TRAP with abort or error exit code.
-// XFAIL: libcpp-hardening-mode=fast && hwasan
+// XFAIL: hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
 
 #include <cassert>

--- a/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
+++ b/libcxx/test/libcxx/assertions/modes/override_with_fast_mode.pass.cpp
@@ -14,7 +14,7 @@
 // debug mode).
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // HWASAN replaces TRAP with abort or error exit code.
-// XFAIL: libcpp-hardening-mode=fast && hwasan
+// XFAIL: hwasan
 // ADDITIONAL_COMPILE_FLAGS: -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 
 #include <cassert>


### PR DESCRIPTION
Follow up to #78862

These tests control hardening mode with ADDITIONAL_COMPILE_FLAGS, and
always set modes which use on TRAP. So we don't need to check
libcpp-hardening-mode=fast, and they must always fail with the current
HWASAN implementation.
