### PR TITLE
[clangd] Add support to rename Objective-C selectors

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -844,14 +844,15 @@ void ClangdLSPServer::onWorkspaceSymbol(
 }
 
 void ClangdLSPServer::onPrepareRename(const TextDocumentPositionParams &Params,
-                                      Callback<std::optional<Range>> Reply) {
+                                      Callback<PrepareRenameResult> Reply) {
   Server->prepareRename(
       Params.textDocument.uri.file(), Params.position, /*NewName*/ std::nullopt,
       Opts.Rename,
       [Reply = std::move(Reply)](llvm::Expected<RenameResult> Result) mutable {
         if (!Result)
           return Reply(Result.takeError());
-        return Reply(std::move(Result->Target));
+        PrepareRenameResult PrepareResult{Result->Target, Result->OldName};
+        return Reply(std::move(PrepareResult));
       });
 }
 

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -134,7 +134,7 @@ private:
   void onWorkspaceSymbol(const WorkspaceSymbolParams &,
                          Callback<std::vector<SymbolInformation>>);
   void onPrepareRename(const TextDocumentPositionParams &,
-                       Callback<std::optional<Range>>);
+                       Callback<PrepareRenameResult>);
   void onRename(const RenameParams &, Callback<WorkspaceEdit>);
   void onHover(const TextDocumentPositionParams &,
                Callback<std::optional<Hover>>);

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -578,8 +578,7 @@ void ClangdServer::prepareRename(PathRef File, Position Pos,
     // prepareRename is latency-sensitive: we don't query the index, as we
     // only need main-file references
     auto Results =
-        clangd::rename({Pos, NewName.value_or("__clangd_rename_placeholder"),
-                        InpAST->AST, File, /*FS=*/nullptr,
+        clangd::rename({Pos, NewName, InpAST->AST, File, /*FS=*/nullptr,
                         /*Index=*/nullptr, RenameOpts});
     if (!Results) {
       // LSP says to return null on failure, but that will result in a generic

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -905,6 +905,10 @@ llvm::json::Value toJSON(const DocumentSymbol &S) {
   return std::move(Result);
 }
 
+llvm::json::Value toJSON(const PrepareRenameResult &R) {
+  return llvm::json::Object{{"range", R.range}, {"placeholder", R.placeholder}};
+}
+
 llvm::json::Value toJSON(const WorkspaceEdit &WE) {
   llvm::json::Object Result;
   if (WE.changes) {

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1004,6 +1004,17 @@ struct CodeActionParams {
 };
 bool fromJSON(const llvm::json::Value &, CodeActionParams &, llvm::json::Path);
 
+struct PrepareRenameResult {
+  /// The range of the string to rename.
+  Range range;
+  /// A placeholder text of the string content to be renamed.
+  ///
+  /// This is useful to populate the rename field with an Objective-C selector
+  /// name (eg. `performAction:with:`) when renaming Objective-C methods.
+  std::string placeholder;
+};
+llvm::json::Value toJSON(const PrepareRenameResult &WE);
+
 /// The edit should either provide changes or documentChanges. If the client
 /// can handle versioned document edits and if documentChanges are present,
 /// the latter are preferred over changes.

--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -625,16 +625,16 @@ llvm::StringMap<unsigned> collectIdentifiers(llvm::StringRef Content,
   return Identifiers;
 }
 
-std::vector<Range> collectIdentifierRanges(llvm::StringRef Identifier,
-                                           llvm::StringRef Content,
-                                           const LangOptions &LangOpts) {
+std::vector<Range>
+collectIdentifierRanges(llvm::StringRef Identifier,
+                        const syntax::UnexpandedTokenBuffer &Tokens) {
   std::vector<Range> Ranges;
-  lex(Content, LangOpts,
-      [&](const syntax::Token &Tok, const SourceManager &SM) {
-        if (Tok.kind() != tok::identifier || Tok.text(SM) != Identifier)
-          return;
-        Ranges.push_back(halfOpenToRange(SM, Tok.range(SM).toCharRange(SM)));
-      });
+  const SourceManager &SM = Tokens.sourceManager();
+  for (const syntax::Token &Tok : Tokens.tokens()) {
+    if (Tok.kind() != tok::identifier || Tok.text(SM) != Identifier)
+      continue;
+    Ranges.push_back(halfOpenToRange(SM, Tok.range(SM).toCharRange(SM)));
+  }
   return Ranges;
 }
 

--- a/clang-tools-extra/clangd/SourceCode.h
+++ b/clang-tools-extra/clangd/SourceCode.h
@@ -217,9 +217,9 @@ llvm::StringMap<unsigned> collectIdentifiers(llvm::StringRef Content,
                                              const format::FormatStyle &Style);
 
 /// Collects all ranges of the given identifier in the source code.
-std::vector<Range> collectIdentifierRanges(llvm::StringRef Identifier,
-                                           llvm::StringRef Content,
-                                           const LangOptions &LangOpts);
+std::vector<Range>
+collectIdentifierRanges(llvm::StringRef Identifier,
+                        const syntax::UnexpandedTokenBuffer &Tokens);
 
 /// Collects words from the source code.
 /// Unlike collectIdentifiers:

--- a/clang-tools-extra/clangd/refactor/Rename.h
+++ b/clang-tools-extra/clangd/refactor/Rename.h
@@ -35,8 +35,12 @@ struct RenameOptions {
 };
 
 struct RenameInputs {
-  Position Pos; // the position triggering the rename
-  llvm::StringRef NewName;
+  /// The position triggering the rename
+  Position Pos;
+
+  /// The new name to give to the symbol or `nullopt` to perform a fake rename
+  /// that checks if rename is possible.
+  std::optional<llvm::StringRef> NewName;
 
   ParsedAST &AST;
   llvm::StringRef MainFilePath;
@@ -52,12 +56,14 @@ struct RenameInputs {
 };
 
 struct RenameResult {
-  // The range of the symbol that the user can attempt to rename.
+  /// The range of the symbol that the user can attempt to rename.
   Range Target;
-  // Rename occurrences for the current main file.
+  /// The current name of the declaration at the cursor.
+  std::string OldName;
+  /// Rename occurrences for the current main file.
   std::vector<Range> LocalChanges;
-  // Complete edits for the rename, including LocalChanges.
-  // If the full set of changes is unknown, this field is empty.
+  /// Complete edits for the rename, including LocalChanges.
+  /// If the full set of changes is unknown, this field is empty.
   FileEdits GlobalChanges;
 };
 

--- a/clang-tools-extra/clangd/refactor/Rename.h
+++ b/clang-tools-extra/clangd/refactor/Rename.h
@@ -75,7 +75,7 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs);
 /// Generates rename edits that replaces all given occurrences with the
 /// `NewName`.
 ///
-/// `OldName` is and `Tokens` are used to to find the argument labels of
+/// `OldName` and `Tokens` are used to to find the argument labels of
 /// Objective-C selectors.
 ///
 /// Exposed for testing only.

--- a/clang-tools-extra/clangd/test/rename.test
+++ b/clang-tools-extra/clangd/test/rename.test
@@ -10,6 +10,8 @@
 #      CHECK:  "id": 1,
 # CHECK-NEXT:  "jsonrpc": "2.0",
 # CHECK-NEXT:  "result": {
+# CHECK-NEXT:    "placeholder": "foo",
+# CHECK-NEXT:    "range": {
 # CHECK-NEXT:      "end": {
 # CHECK-NEXT:        "character": 7,
 # CHECK-NEXT:        "line": 0
@@ -18,6 +20,7 @@
 # CHECK-NEXT:        "character": 4,
 # CHECK-NEXT:        "line": 0
 # CHECK-NEXT:      }
+# CHECK-NEXT:    }
 # CHECK-NEXT:  }
 ---
 {"jsonrpc":"2.0","id":2,"method":"textDocument/prepareRename","params":{"textDocument":{"uri":"test:///foo.cpp"},"position":{"line":0,"character":2}}}

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -1535,7 +1535,6 @@ TEST(RenameTest, PrepareRenameObjC) {
   for (Position Point : Input.points()) {
     auto Results = runPrepareRename(Server, Path, Point,
                                     /*NewName=*/std::nullopt, {});
-    // Verify that for multi-file rename, we only return main-file occurrences.
     ASSERT_TRUE(bool(Results)) << Results.takeError();
     ASSERT_EQ(Results->OldName, "performAction:with:");
   }
@@ -1947,8 +1946,7 @@ TEST(CrossFileRenameTests, WithUpToDateIndex) {
 TEST(CrossFileRenameTests, ObjC) {
   MockCompilationDatabase CDB;
   CDB.ExtraClangFlags = {"-xobjective-c"};
-  // rename is runnning on all "^" points in FooH, and "[[]]" ranges are the
-  // expected rename occurrences.
+  // rename is runnning on all "^" points in FooH.
   struct Case {
     llvm::StringRef FooH;
     llvm::StringRef FooM;

--- a/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
@@ -772,8 +772,8 @@ o foo2;
   )cpp");
   LangOptions LangOpts;
   LangOpts.CPlusPlus = true;
-  EXPECT_EQ(Code.ranges(),
-            collectIdentifierRanges("Foo", Code.code(), LangOpts));
+  syntax::UnexpandedTokenBuffer Tokens(Code.code(), LangOpts);
+  EXPECT_EQ(Code.ranges(), collectIdentifierRanges("Foo", Tokens));
 }
 
 TEST(SourceCodeTests, isHeaderFile) {

--- a/clang/include/clang/Tooling/Refactoring/Rename/RenamingAction.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/RenamingAction.h
@@ -132,10 +132,10 @@ enum class ObjCSymbolSelectorKind {
   Unknown
 };
 
-llvm::Expected<SmallVector<SourceLocation>> findObjCSymbolSelectorPieces(
+llvm::Error findObjCSymbolSelectorPieces(
     ArrayRef<syntax::Token> Tokens, const SourceManager &SrcMgr,
     SourceLocation RenameLoc, const SymbolName &OldName,
-    ObjCSymbolSelectorKind Kind);
+    ObjCSymbolSelectorKind Kind, SmallVectorImpl<SourceLocation> &Result);
 
 } // end namespace tooling
 } // end namespace clang

--- a/clang/include/clang/Tooling/Refactoring/Rename/RenamingAction.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/RenamingAction.h
@@ -19,6 +19,7 @@
 #include "clang/Tooling/Refactoring/RefactoringActionRules.h"
 #include "clang/Tooling/Refactoring/RefactoringOptions.h"
 #include "clang/Tooling/Refactoring/Rename/SymbolOccurrences.h"
+#include "clang/Tooling/Syntax/Tokens.h"
 #include "llvm/Support/Error.h"
 
 namespace clang {
@@ -115,6 +116,26 @@ private:
   /// A file path to replacements map.
   std::map<std::string, tooling::Replacements> &FileToReplaces;
 };
+
+enum class ObjCSymbolSelectorKind {
+  /// The rename location is an Objective-C method call, eg. `[self add: 1]`.
+  MessageSend,
+
+  /// The rename location is an Objective-C method definition, eg.
+  /// ` - (void)add:(int)theValue`
+  MethodDecl,
+
+  /// It is unknown if the renamed location is a method call or declaration.
+  ///
+  /// The selector kind is being used to improve error recovery, passing unknown
+  /// does not lead to correctness issues.
+  Unknown
+};
+
+llvm::Expected<SmallVector<SourceLocation>> findObjCSymbolSelectorPieces(
+    ArrayRef<syntax::Token> Tokens, const SourceManager &SrcMgr,
+    SourceLocation RenameLoc, const SymbolName &OldName,
+    ObjCSymbolSelectorKind Kind);
 
 } // end namespace tooling
 } // end namespace clang

--- a/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLING_REFACTORING_RENAME_SYMBOLNAME_H
 #define LLVM_CLANG_TOOLING_REFACTORING_RENAME_SYMBOLNAME_H
 
+#include "clang/AST/DeclarationName.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -36,6 +37,8 @@ public:
   /// Create a new \c SymbolName with the specified pieces.
   explicit SymbolName(ArrayRef<StringRef> NamePieces);
 
+  explicit SymbolName(const DeclarationName &Name);
+
   /// Creates a \c SymbolName from the given string representation.
   ///
   /// For Objective-C symbol names, this splits a selector into multiple pieces
@@ -45,7 +48,25 @@ public:
 
   ArrayRef<std::string> getNamePieces() const { return NamePieces; }
 
+  /// If this symbol consists of a single piece return it, otherwise return
+  /// `None`.
+  ///
+  /// Only symbols in Objective-C can consist of multiple pieces, so this
+  /// function always returns a value for non-Objective-C symbols.
+  std::optional<std::string> getSinglePiece() const;
+
+  /// Returns a human-readable version of this symbol name.
+  ///
+  /// If the symbol consists of multiple pieces (aka. it is an Objective-C
+  /// selector/method name), the pieces are separated by `:`, otherwise just an
+  /// identifier name.
+  std::string getAsString() const;
+
   void print(raw_ostream &OS) const;
+
+  bool operator==(const SymbolName &Other) const {
+    return NamePieces == Other.NamePieces;
+  }
 };
 
 } // end namespace tooling

--- a/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
@@ -36,6 +36,7 @@ class SymbolName {
 public:
   /// Create a new \c SymbolName with the specified pieces.
   explicit SymbolName(ArrayRef<StringRef> NamePieces);
+  explicit SymbolName(ArrayRef<std::string> NamePieces);
 
   explicit SymbolName(const DeclarationName &Name);
 

--- a/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
@@ -15,6 +15,9 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace clang {
+
+class LangOptions;
+
 namespace tooling {
 
 /// A name of a symbol.
@@ -27,19 +30,22 @@ namespace tooling {
 /// //       ^~ string 0 ~~~~~         ^~ string 1 ~~~~~
 /// \endcode
 class SymbolName {
+  llvm::SmallVector<std::string, 1> NamePieces;
+
 public:
-  explicit SymbolName(StringRef Name) {
-    // While empty symbol names are valid (Objective-C selectors can have empty
-    // name pieces), occurrences Objective-C selectors are created using an
-    // array of strings instead of just one string.
-    assert(!Name.empty() && "Invalid symbol name!");
-    this->Name.push_back(Name.str());
-  }
+  /// Create a new \c SymbolName with the specified pieces.
+  explicit SymbolName(ArrayRef<StringRef> NamePieces);
 
-  ArrayRef<std::string> getNamePieces() const { return Name; }
+  /// Creates a \c SymbolName from the given string representation.
+  ///
+  /// For Objective-C symbol names, this splits a selector into multiple pieces
+  /// on `:`. For all other languages the name is used as the symbol name.
+  SymbolName(StringRef Name, bool IsObjectiveCSelector);
+  SymbolName(StringRef Name, const LangOptions &LangOpts);
 
-private:
-  llvm::SmallVector<std::string, 1> Name;
+  ArrayRef<std::string> getNamePieces() const { return NamePieces; }
+
+  void print(raw_ostream &OS) const;
 };
 
 } // end namespace tooling

--- a/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
+++ b/clang/include/clang/Tooling/Refactoring/Rename/SymbolName.h
@@ -34,6 +34,8 @@ class SymbolName {
   llvm::SmallVector<std::string, 1> NamePieces;
 
 public:
+  SymbolName();
+
   /// Create a new \c SymbolName with the specified pieces.
   explicit SymbolName(ArrayRef<StringRef> NamePieces);
   explicit SymbolName(ArrayRef<std::string> NamePieces);

--- a/clang/include/clang/Tooling/Syntax/Tokens.h
+++ b/clang/include/clang/Tooling/Syntax/Tokens.h
@@ -145,6 +145,20 @@ private:
 /// For debugging purposes. Equivalent to a call to Token::str().
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Token &T);
 
+/// A list of tokens as lexed from the input file, without expanding
+/// preprocessor macros.
+class UnexpandedTokenBuffer {
+  std::string Code;
+  std::vector<syntax::Token> Tokens;
+  std::unique_ptr<SourceManagerForFile> SrcMgr;
+
+public:
+  UnexpandedTokenBuffer(StringRef Code, const LangOptions &LangOpts);
+
+  ArrayRef<syntax::Token> tokens() const { return Tokens; }
+  const SourceManager &sourceManager() const { return SrcMgr->get(); }
+};
+
 /// A list of tokens obtained by preprocessing a text buffer and operations to
 /// map between the expanded and spelled tokens, i.e. TokenBuffer has
 /// information about two token streams:

--- a/clang/include/clang/Tooling/Syntax/Tokens.h
+++ b/clang/include/clang/Tooling/Syntax/Tokens.h
@@ -148,7 +148,6 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Token &T);
 /// A list of tokens as lexed from the input file, without expanding
 /// preprocessor macros.
 class UnexpandedTokenBuffer {
-  std::string Code;
   std::vector<syntax::Token> Tokens;
   std::unique_ptr<SourceManagerForFile> SrcMgr;
 

--- a/clang/lib/Tooling/Refactoring/CMakeLists.txt
+++ b/clang/lib/Tooling/Refactoring/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(clangToolingRefactoring
   Rename/USRFinder.cpp
   Rename/USRFindingAction.cpp
   Rename/USRLocFinder.cpp
+  SymbolName.cpp
 
   LINK_LIBS
   clangAST

--- a/clang/lib/Tooling/Refactoring/CMakeLists.txt
+++ b/clang/lib/Tooling/Refactoring/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangToolingRefactoring
   clangLex
   clangRewrite
   clangToolingCore
+  clangToolingSyntax
 
   DEPENDS
   omp_gen

--- a/clang/lib/Tooling/Refactoring/Rename/RenamingAction.cpp
+++ b/clang/lib/Tooling/Refactoring/Rename/RenamingAction.cpp
@@ -82,7 +82,7 @@ RenameOccurrences::createSourceReplacements(RefactoringRuleContext &Context) {
   if (!Occurrences)
     return Occurrences.takeError();
   // FIXME: Verify that the new name is valid.
-  SymbolName Name(NewName);
+  SymbolName Name(NewName, /*IsObjectiveCSelector=*/false);
   return createRenameReplacements(
       *Occurrences, Context.getASTContext().getSourceManager(), Name);
 }
@@ -219,7 +219,7 @@ public:
     }
     // FIXME: Support multi-piece names.
     // FIXME: better error handling (propagate error out).
-    SymbolName NewNameRef(NewName);
+    SymbolName NewNameRef(NewName, /*IsObjectiveCSelector=*/false);
     Expected<std::vector<AtomicChange>> Change =
         createRenameReplacements(Occurrences, SourceMgr, NewNameRef);
     if (!Change) {

--- a/clang/lib/Tooling/Refactoring/Rename/RenamingAction.cpp
+++ b/clang/lib/Tooling/Refactoring/Rename/RenamingAction.cpp
@@ -275,5 +275,99 @@ std::unique_ptr<ASTConsumer> QualifiedRenamingAction::newASTConsumer() {
   return std::make_unique<USRSymbolRenamer>(NewNames, USRList, FileToReplaces);
 }
 
+static bool isMatchingSelectorName(const syntax::Token &Tok,
+                                   const syntax::Token &Next,
+                                   StringRef NamePiece,
+                                   const SourceManager &SrcMgr) {
+  if (NamePiece.empty())
+    return Tok.kind() == tok::colon;
+  return (Tok.kind() == tok::identifier || Tok.kind() == tok::raw_identifier) &&
+         Next.kind() == tok::colon && Tok.text(SrcMgr) == NamePiece;
+}
+
+llvm::Expected<SmallVector<SourceLocation>>
+findObjCSymbolSelectorPieces(ArrayRef<syntax::Token> AllTokens,
+                             const SourceManager &SM, SourceLocation RenameLoc,
+                             const SymbolName &OldName,
+                             ObjCSymbolSelectorKind Kind) {
+  ArrayRef<syntax::Token> Tokens =
+      AllTokens.drop_while([RenameLoc](syntax::Token Tok) -> bool {
+        return Tok.location() != RenameLoc;
+      });
+  assert(!Tokens.empty() && "no tokens");
+  assert(OldName.getNamePieces()[0].empty() ||
+         Tokens[0].text(SM) == OldName.getNamePieces()[0]);
+  assert(OldName.getNamePieces().size() > 1);
+  SmallVector<SourceLocation> Result;
+
+  Result.push_back(Tokens[0].location());
+
+  // We have to track square brackets, parens and braces as we want to skip the
+  // tokens inside them. This ensures that we don't use identical selector
+  // pieces in inner message sends, blocks, lambdas and @selector expressions.
+  unsigned SquareCount = 0;
+  unsigned ParenCount = 0;
+  unsigned BraceCount = 0;
+
+  // Start looking for the next selector piece.
+  unsigned Last = Tokens.size() - 1;
+  // Skip the ':' or any other token after the first selector piece token.
+  for (unsigned Index = OldName.getNamePieces()[0].empty() ? 1 : 2;
+       Index < Last; ++Index) {
+    const auto &Tok = Tokens[Index];
+
+    bool NoScoping = SquareCount == 0 && BraceCount == 0 && ParenCount == 0;
+    if (NoScoping &&
+        isMatchingSelectorName(Tok, Tokens[Index + 1],
+                               OldName.getNamePieces()[Result.size()], SM)) {
+      if (!OldName.getNamePieces()[Result.size()].empty()) {
+        // Skip the ':' after the name. This ensures that it won't match a
+        // follow-up selector piece with an empty name.
+        ++Index;
+      }
+      Result.push_back(Tok.location());
+      // All the selector pieces have been found.
+      if (Result.size() == OldName.getNamePieces().size())
+        return Result;
+    } else if (Tok.kind() == tok::r_square) {
+      // Stop scanning at the end of the message send.
+      // Also account for spurious ']' in blocks or lambdas.
+      if (Kind == ObjCSymbolSelectorKind::MessageSend && !SquareCount &&
+          !BraceCount)
+        break;
+      if (SquareCount)
+        --SquareCount;
+    } else if (Tok.kind() == tok::l_square)
+      ++SquareCount;
+    else if (Tok.kind() == tok::l_paren)
+      ++ParenCount;
+    else if (Tok.kind() == tok::r_paren) {
+      if (!ParenCount)
+        break;
+      --ParenCount;
+    } else if (Tok.kind() == tok::l_brace) {
+      // Stop scanning at the start of the of the method's body.
+      // Also account for any spurious blocks inside argument parameter types
+      // or parameter attributes.
+      if (Kind == ObjCSymbolSelectorKind::MethodDecl && !BraceCount &&
+          !ParenCount)
+        break;
+      ++BraceCount;
+    } else if (Tok.kind() == tok::r_brace) {
+      if (!BraceCount)
+        break;
+      --BraceCount;
+    }
+    // Stop scanning at the end of the method's declaration.
+    if (Kind == ObjCSymbolSelectorKind::MethodDecl && NoScoping &&
+        (Tok.kind() == tok::semi || Tok.kind() == tok::minus ||
+         Tok.kind() == tok::plus))
+      break;
+  }
+  return llvm::make_error<llvm::StringError>(
+      "failed to find all selector pieces in the source code",
+      inconvertibleErrorCode());
+}
+
 } // end namespace tooling
 } // end namespace clang

--- a/clang/lib/Tooling/Refactoring/Rename/USRLocFinder.cpp
+++ b/clang/lib/Tooling/Refactoring/Rename/USRLocFinder.cpp
@@ -60,8 +60,8 @@ public:
                                    const ASTContext &Context)
       : RecursiveSymbolVisitor(Context.getSourceManager(),
                                Context.getLangOpts()),
-        USRSet(USRs.begin(), USRs.end()), PrevName(PrevName), Context(Context) {
-  }
+        USRSet(USRs.begin(), USRs.end()),
+        PrevName(PrevName, /*IsObjectiveCSelector=*/false), Context(Context) {}
 
   bool visitSymbolOccurrence(const NamedDecl *ND,
                              ArrayRef<SourceRange> NameRanges) {

--- a/clang/lib/Tooling/Refactoring/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactoring/SymbolName.cpp
@@ -13,6 +13,11 @@
 namespace clang {
 namespace tooling {
 
+SymbolName::SymbolName(const DeclarationName &DeclName)
+    : SymbolName(DeclName.getAsString(),
+                 /*IsObjectiveCSelector=*/DeclName.getNameKind() ==
+                     DeclarationName::NameKind::ObjCMultiArgSelector) {}
+
 SymbolName::SymbolName(StringRef Name, const LangOptions &LangOpts)
     : SymbolName(Name, LangOpts.ObjC) {}
 
@@ -32,6 +37,21 @@ SymbolName::SymbolName(StringRef Name, bool IsObjectiveCSelector) {
 SymbolName::SymbolName(ArrayRef<StringRef> NamePieces) {
   for (const auto &Piece : NamePieces)
     this->NamePieces.push_back(Piece.str());
+}
+
+std::optional<std::string> SymbolName::getSinglePiece() const {
+  if (getNamePieces().size() == 1) {
+    return NamePieces.front();
+  } else {
+    return std::nullopt;
+  }
+}
+
+std::string SymbolName::getAsString() const {
+  std::string Result;
+  llvm::raw_string_ostream OS(Result);
+  this->print(OS);
+  return Result;
 }
 
 void SymbolName::print(raw_ostream &OS) const {

--- a/clang/lib/Tooling/Refactoring/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactoring/SymbolName.cpp
@@ -1,0 +1,46 @@
+//===--- SymbolName.cpp - Clang refactoring library -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Tooling/Refactoring/Rename/SymbolName.h"
+#include "clang/Basic/LangOptions.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace clang {
+namespace tooling {
+
+SymbolName::SymbolName(StringRef Name, const LangOptions &LangOpts)
+    : SymbolName(Name, LangOpts.ObjC) {}
+
+SymbolName::SymbolName(StringRef Name, bool IsObjectiveCSelector) {
+  if (!IsObjectiveCSelector) {
+    NamePieces.push_back(Name.str());
+    return;
+  }
+  // Decompose an Objective-C selector name into multiple strings.
+  do {
+    auto StringAndName = Name.split(':');
+    NamePieces.push_back(StringAndName.first.str());
+    Name = StringAndName.second;
+  } while (!Name.empty());
+}
+
+SymbolName::SymbolName(ArrayRef<StringRef> NamePieces) {
+  for (const auto &Piece : NamePieces)
+    this->NamePieces.push_back(Piece.str());
+}
+
+void SymbolName::print(raw_ostream &OS) const {
+  for (size_t I = 0, E = NamePieces.size(); I != E; ++I) {
+    if (I != 0)
+      OS << ':';
+    OS << NamePieces[I];
+  }
+}
+
+} // end namespace tooling
+} // end namespace clang

--- a/clang/lib/Tooling/Refactoring/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactoring/SymbolName.cpp
@@ -41,6 +41,11 @@ SymbolName::SymbolName(ArrayRef<StringRef> NamePieces) {
     this->NamePieces.push_back(Piece.str());
 }
 
+SymbolName::SymbolName(ArrayRef<std::string> NamePieces) {
+  for (const auto &Piece : NamePieces)
+    this->NamePieces.push_back(Piece);
+}
+
 std::optional<std::string> SymbolName::getSinglePiece() const {
   if (getNamePieces().size() == 1) {
     return NamePieces.front();

--- a/clang/lib/Tooling/Refactoring/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactoring/SymbolName.cpp
@@ -16,7 +16,9 @@ namespace tooling {
 SymbolName::SymbolName(const DeclarationName &DeclName)
     : SymbolName(DeclName.getAsString(),
                  /*IsObjectiveCSelector=*/DeclName.getNameKind() ==
-                     DeclarationName::NameKind::ObjCMultiArgSelector) {}
+                         DeclarationName::NameKind::ObjCMultiArgSelector ||
+                     DeclName.getNameKind() ==
+                         DeclarationName::NameKind::ObjCOneArgSelector) {}
 
 SymbolName::SymbolName(StringRef Name, const LangOptions &LangOpts)
     : SymbolName(Name, LangOpts.ObjC) {}

--- a/clang/lib/Tooling/Refactoring/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactoring/SymbolName.cpp
@@ -13,6 +13,8 @@
 namespace clang {
 namespace tooling {
 
+SymbolName::SymbolName() : NamePieces({}) {}
+
 SymbolName::SymbolName(const DeclarationName &DeclName)
     : SymbolName(DeclName.getAsString(),
                  /*IsObjectiveCSelector=*/DeclName.getNameKind() ==
@@ -49,9 +51,8 @@ SymbolName::SymbolName(ArrayRef<std::string> NamePieces) {
 std::optional<std::string> SymbolName::getSinglePiece() const {
   if (getNamePieces().size() == 1) {
     return NamePieces.front();
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 std::string SymbolName::getAsString() const {
@@ -62,11 +63,7 @@ std::string SymbolName::getAsString() const {
 }
 
 void SymbolName::print(raw_ostream &OS) const {
-  for (size_t I = 0, E = NamePieces.size(); I != E; ++I) {
-    if (I != 0)
-      OS << ':';
-    OS << NamePieces[I];
-  }
+  llvm::interleave(NamePieces, OS, ":");
 }
 
 } // end namespace tooling

--- a/clang/lib/Tooling/Syntax/Tokens.cpp
+++ b/clang/lib/Tooling/Syntax/Tokens.cpp
@@ -225,6 +225,17 @@ llvm::StringRef FileRange::text(const SourceManager &SM) const {
   return Text.substr(Begin, length());
 }
 
+UnexpandedTokenBuffer::UnexpandedTokenBuffer(StringRef Code,
+                                             const LangOptions &LangOpts) {
+  // InMemoryFileAdapter crashes unless the buffer is null terminated, so ensure
+  // the string is null-terminated.
+  this->Code = Code.str();
+  SrcMgr =
+      std::make_unique<SourceManagerForFile>("mock_file_name.cpp", this->Code);
+  Tokens = syntax::tokenize(sourceManager().getMainFileID(), sourceManager(),
+                            LangOpts);
+}
+
 void TokenBuffer::indexExpandedTokens() {
   // No-op if the index is already created.
   if (!ExpandedTokIndex.empty())

--- a/clang/lib/Tooling/Syntax/Tokens.cpp
+++ b/clang/lib/Tooling/Syntax/Tokens.cpp
@@ -227,11 +227,7 @@ llvm::StringRef FileRange::text(const SourceManager &SM) const {
 
 UnexpandedTokenBuffer::UnexpandedTokenBuffer(StringRef Code,
                                              const LangOptions &LangOpts) {
-  // InMemoryFileAdapter crashes unless the buffer is null terminated, so ensure
-  // the string is null-terminated.
-  this->Code = Code.str();
-  SrcMgr =
-      std::make_unique<SourceManagerForFile>("mock_file_name.cpp", this->Code);
+  SrcMgr = std::make_unique<SourceManagerForFile>("mock_file_name.cpp", Code);
   Tokens = syntax::tokenize(sourceManager().getMainFileID(), sourceManager(),
                             LangOpts);
 }

--- a/clang/tools/clang-refactor/CMakeLists.txt
+++ b/clang/tools/clang-refactor/CMakeLists.txt
@@ -20,4 +20,5 @@ clang_target_link_libraries(clang-refactor
   clangTooling
   clangToolingCore
   clangToolingRefactoring
+  clangToolingSyntax
   )

--- a/clang/tools/clang-rename/CMakeLists.txt
+++ b/clang/tools/clang-rename/CMakeLists.txt
@@ -16,6 +16,7 @@ clang_target_link_libraries(clang-rename
   clangTooling
   clangToolingCore
   clangToolingRefactoring
+  clangToolingSyntax
   )
 
 install(FILES clang-rename.py

--- a/clang/tools/libclang/CMakeLists.txt
+++ b/clang/tools/libclang/CMakeLists.txt
@@ -69,6 +69,7 @@ set(LIBS
   clangSema
   clangSerialization
   clangTooling
+  clangToolingSyntax
 )
 
 if (CLANG_ENABLE_ARCMT)

--- a/clang/unittests/Tooling/RefactoringActionRulesTest.cpp
+++ b/clang/unittests/Tooling/RefactoringActionRulesTest.cpp
@@ -211,9 +211,9 @@ TEST_F(RefactoringActionRulesTest, ReturnSymbolOccurrences) {
     Expected<SymbolOccurrences>
     findSymbolOccurrences(RefactoringRuleContext &) override {
       SymbolOccurrences Occurrences;
-      Occurrences.push_back(SymbolOccurrence(SymbolName("test"),
-                                             SymbolOccurrence::MatchingSymbol,
-                                             Selection.getBegin()));
+      Occurrences.push_back(SymbolOccurrence(
+          SymbolName("test", /*IsObjectiveCSelector=*/false),
+          SymbolOccurrence::MatchingSymbol, Selection.getBegin()));
       return std::move(Occurrences);
     }
   };


### PR DESCRIPTION
This adds support to rename Objective-C method declarations and calls to clangd.