### PR TITLE
[clang][Parser] Fix crash of clang when trying to convert a cast to a nullptr casted to an array of non-constant size to a reference (#78841).

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -1718,6 +1718,12 @@ namespace {
         Designator.setInvalid();
         return;
       }
+      if (!Base) {
+        // Can not perform cast if there is no underlying type.
+        Info.CCEDiag(E, diag::err_cast_selector_expr);
+        Designator.setInvalid();
+        return;
+      }
       if (checkSubobject(Info, E, CSK_ArrayToPointer)) {
         assert(getType(Base)->isPointerType() || getType(Base)->isArrayType());
         Designator.FirstEntryIsAnUnsizedArray = true;


### PR DESCRIPTION
This situation is undefined behavior, and should not lead to a compiler crash. Thus, the problematic cast is only executed on non-null pointers.

Fixes the crash in #78841.