### PR TITLE
[IR] Add support for metadata attachments for Function Arguments

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -319,7 +319,7 @@ added in the future:
     not be used lightly but only for specific situations such as an
     alternative to the *register pinning* performance technique often
     used when implementing functional programming languages. At the
-    moment only X86, AArch64, and RISCV support this convention. The 
+    moment only X86, AArch64, and RISCV support this convention. The
     following limitations exist:
 
     -  On *X86-32* only up to 4 bit type parameters are supported. No
@@ -643,10 +643,10 @@ implementation defined, the optimizer can't do the latter.  The former is
 challenging as many commonly expected properties, such as
 ``ptrtoint(v)-ptrtoint(v) == 0``, don't hold for non-integral types.
 Similar restrictions apply to intrinsics that might examine the pointer bits,
-such as :ref:`llvm.ptrmask<int_ptrmask>`. 
+such as :ref:`llvm.ptrmask<int_ptrmask>`.
 
 The alignment information provided by the frontend for a non-integral pointer
-(typically using attributes or metadata) must be valid for every possible 
+(typically using attributes or metadata) must be valid for every possible
 representation of the pointer.
 
 .. _globalvars:
@@ -824,7 +824,8 @@ an optional :ref:`calling convention <callingconv>`,
 an optional ``unnamed_addr`` attribute, a return type, an optional
 :ref:`parameter attribute <paramattrs>` for the return type, a function
 name, a (possibly empty) argument list (each with optional :ref:`parameter
-attributes <paramattrs>`), optional :ref:`function attributes <fnattrs>`,
+attributes <paramattrs>` and an optional list of attached :ref:`metadata <metadata>`),
+optional :ref:`function attributes <fnattrs>`,
 an optional address space, an optional section, an optional partition,
 an optional alignment, an optional :ref:`comdat <langref_comdats>`,
 an optional :ref:`garbage collector name <gc>`, an optional :ref:`prefix <prefixdata>`,
@@ -848,7 +849,7 @@ argument is of the following form:
 
 Syntax::
 
-   <type> [parameter Attrs] [name]
+   <type> [parameter Attrs] (!name !N)* [name]
 
 LLVM function declarations consist of the "``declare``" keyword, an
 optional :ref:`linkage type <linkage>`, an optional :ref:`visibility style

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -285,6 +285,8 @@ namespace llvm {
     };
     bool parseEnumAttribute(Attribute::AttrKind Attr, AttrBuilder &B,
                             bool InAttrGroup);
+    bool parseOptionalParamMetadata(
+        SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs);
     bool parseOptionalParamOrReturnAttrs(AttrBuilder &B, bool IsParam);
     bool parseOptionalParamAttrs(AttrBuilder &B) {
       return parseOptionalParamOrReturnAttrs(B, true);
@@ -607,8 +609,10 @@ namespace llvm {
       Type *Ty;
       AttributeSet Attrs;
       std::string Name;
-      ArgInfo(LocTy L, Type *ty, AttributeSet Attr, const std::string &N)
-          : Loc(L), Ty(ty), Attrs(Attr), Name(N) {}
+      SmallVector<std::pair<unsigned, MDNode *>, 8> MDs;
+      ArgInfo(LocTy L, Type *ty, AttributeSet Attr, const std::string &N,
+              const SmallVector<std::pair<unsigned, MDNode *>, 8> &mds)
+          : Loc(L), Ty(ty), Attrs(Attr), Name(N), MDs(mds) {}
     };
     bool parseArgumentList(SmallVectorImpl<ArgInfo> &ArgList,
                            SmallVectorImpl<unsigned> &UnnamedArgNums,

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -369,6 +369,7 @@ enum MetadataCodes {
   METADATA_GENERIC_SUBRANGE = 45, // [distinct, count, lo, up, stride]
   METADATA_ARG_LIST = 46,         // [n x [type num, value num]]
   METADATA_ASSIGN_ID = 47,        // [distinct, ...]
+  METADATA_PARAM_ATTACHMENT = 48, // [ [valueid ,] [valueid, [n x [id, mdnode]]]
 };
 
 // The constants block (CONSTANTS_BLOCK_ID) describes emission for each

--- a/llvm/include/llvm/IR/Argument.h
+++ b/llvm/include/llvm/IR/Argument.h
@@ -177,6 +177,14 @@ public:
   static bool classof(const Value *V) {
     return V->getValueID() == ArgumentVal;
   }
+
+  using Value::addMetadata;
+  using Value::clearMetadata;
+  using Value::eraseMetadata;
+  using Value::getAllMetadata;
+  using Value::getMetadata;
+  using Value::hasMetadata;
+  using Value::setMetadata;
 };
 
 } // End llvm namespace

--- a/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
+++ b/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
@@ -398,8 +398,13 @@ ValueEnumerator::ValueEnumerator(const Module &M,
 
   // Enumerate types used by function bodies and argument lists.
   for (const Function &F : M) {
-    for (const Argument &A : F.args())
+    for (const Argument &A : F.args()) {
       EnumerateType(A.getType());
+      MDs.clear();
+      A.getAllMetadata(MDs);
+      for (const auto &I : MDs)
+        EnumerateMetadata(F.isDeclaration() ? nullptr : &F, I.second);
+    }
 
     // Enumerate metadata attached to this function.
     MDs.clear();

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1477,7 +1477,8 @@ void Value::getAllMetadata(
 }
 
 void Value::setMetadata(unsigned KindID, MDNode *Node) {
-  assert(isa<Instruction>(this) || isa<GlobalObject>(this));
+  assert(isa<Instruction>(this) || isa<GlobalObject>(this) ||
+         isa<Argument>(this));
 
   // Handle the case when we're adding/updating metadata on a value.
   if (Node) {
@@ -1511,7 +1512,8 @@ void Value::setMetadata(StringRef Kind, MDNode *Node) {
 }
 
 void Value::addMetadata(unsigned KindID, MDNode &MD) {
-  assert(isa<Instruction>(this) || isa<GlobalObject>(this));
+  assert(isa<Instruction>(this) || isa<GlobalObject>(this) ||
+         isa<Argument>(this));
   if (!HasMetadata)
     HasMetadata = true;
   getContext().pImpl->ValueMetadata[this].insert(KindID, MD);

--- a/llvm/test/Assembler/metadata-decl.ll
+++ b/llvm/test/Assembler/metadata-decl.ll
@@ -1,11 +1,19 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
 ; RUN: llvm-as < %s | llvm-dis -materialize-metadata | FileCheck %s
 
-; CHECK: @foo = external global i32, !foo !0
+; CHECK: @foo = external global i32, !foo [[M0:![0-9]+]]
 @foo = external global i32, !foo !0
 
-; CHECK: declare !bar !1 void @bar()
+; CHECK: declare !bar [[M1:![0-9]+]] void @bar()
 declare !bar !1 void @bar()
+
+; CHECK: declare void @test1(i32 noundef !foo [[M0]] !bar [[M1]], i32 !range [[M2:![0-9]+]])
+declare void @test1(i32 noundef !foo !0 !bar !1, i32 !range !2)
+
+; CHECK: [[M0]] = distinct !{}
+; CHECK: [[M1]] = distinct !{}
+; CHECK: [[M2]] = !{i32 1, i32 0}
 
 !0 = distinct !{}
 !1 = distinct !{}
+!2 = !{ i32 1, i32 0 }

--- a/llvm/test/Assembler/metadata.ll
+++ b/llvm/test/Assembler/metadata.ll
@@ -26,6 +26,11 @@ define void @test3() !bar !3 {
   unreachable, !bar !4
 }
 
+; CHECK: define void @test4(i32 noundef !foo [[M2]] !baz [[M5:![0-9]+]] %a, i32 !range [[M6:![0-9]+]] %b)
+define void @test4(i32 noundef !foo !2 !baz !8 %a, i32 !range !9 %b) {
+  unreachable
+}
+
 ; CHECK-LABEL: define void @test_attachment_name() {
 ; CHECK:   unreachable, !\342abc [[M4]]
 define void @test_attachment_name() {
@@ -38,6 +43,8 @@ define void @test_attachment_name() {
 ; CHECK: [[M0]] = !DILocation
 ; CHECK: [[M1]] = distinct !DISubprogram
 ; CHECK: [[M4]] = distinct !{}
+; CHECK: [[M5]] = distinct !{}
+; CHECK: [[M6]] = !{i32 1, i32 0}
 
 !llvm.module.flags = !{!7}
 !llvm.dbg.cu = !{!5}
@@ -52,6 +59,8 @@ define void @test_attachment_name() {
                              splitDebugFilename: "abc.debug", emissionKind: 2)
 !6 = !DIFile(filename: "path/to/file", directory: "/path/to/dir")
 !7 = !{i32 2, !"Debug Info Version", i32 3}
+!8 = distinct !{}
+!9 = !{ i32 1, i32 0 }
 
 declare void @llvm.dbg.func.start(metadata) nounwind readnone
 


### PR DESCRIPTION
This patch adds an IR, assembly and bitcode representation for metadata attachments for Function Arguments.

Have been noticed multiple times in rust that it is not possible to add range metadata to Function Arguments so this is the first part to support that. 

cc https://github.com/rust-lang/rust/issues/50156
cc https://github.com/llvm/llvm-project/issues/76628

First time contributor to llvm so not sure about the process to add reviewers or if there needs to be some RFC or something like that.