### PR TITLE
[llvm-rc] Support ARM64EC resource generation

### DIFF
--- a/llvm/test/tools/llvm-rc/windres-prefix.test
+++ b/llvm/test/tools/llvm-rc/windres-prefix.test
@@ -5,14 +5,22 @@
 ; Check that a triple prefix on the executable gets picked up as target triple.
 
 ; RUN: ln -fs llvm-windres %t/aarch64-w64-mingw32-windres
+; RUN: ln -fs llvm-windres %t/arm64ec-w64-mingw32-windres
 ; RUN: %t/aarch64-w64-mingw32-windres -### %p/Inputs/empty.rc %t.res | FileCheck %s --check-prefix=CHECK-PREPROC
+; RUN: %t/arm64ec-w64-mingw32-windres -### %p/Inputs/empty.rc %t.res | FileCheck %s --check-prefix=CHECK-PREPROC-EC
 ; CHECK-PREPROC: "clang" "--driver-mode=gcc" "-target" "aarch64-w64-mingw32"
+; CHECK-PREPROC-EC: "clang" "--driver-mode=gcc" "-target" "arm64ec-w64-mingw32"
 
 ; Check that the triple prefix also affects the output object file type.
 
 ; RUN: %t/aarch64-w64-mingw32-windres --no-preprocess %p/Inputs/tag-stringtable-basic.rc %t.o
+; RUN: %t/arm64ec-w64-mingw32-windres --no-preprocess %p/Inputs/tag-stringtable-basic.rc %t-ec.o
 ; RUN: llvm-readobj --coff-resources %t.o | FileCheck %s --check-prefix=CHECK-OBJ
+; RUN: llvm-readobj --coff-resources %t-ec.o | FileCheck %s --check-prefix=CHECK-OBJ-EC
 
 ; CHECK-OBJ: Format: COFF-ARM64
 ; CHECK-OBJ: Resources [
 ; CHECK-OBJ:   Total Number of Resources:
+; CHECK-OBJ-EC: Format: COFF-ARM64EC
+; CHECK-OBJ-EC: Resources [
+; CHECK-OBJ-EC:   Total Number of Resources:

--- a/llvm/tools/llvm-rc/llvm-rc.cpp
+++ b/llvm/tools/llvm-rc/llvm-rc.cpp
@@ -710,7 +710,10 @@ void doCvtres(std::string Src, std::string Dest, std::string TargetTriple) {
     MachineType = COFF::IMAGE_FILE_MACHINE_ARMNT;
     break;
   case Triple::aarch64:
-    MachineType = COFF::IMAGE_FILE_MACHINE_ARM64;
+    if (T.isWindowsArm64EC())
+      MachineType = COFF::IMAGE_FILE_MACHINE_ARM64EC;
+    else
+      MachineType = COFF::IMAGE_FILE_MACHINE_ARM64;
     break;
   default:
     fatalError("Unsupported architecture in target '" + Twine(TargetTriple) +


### PR DESCRIPTION
This is already supported in llvm-cvtres, so only a small change is needed.

CC: @cjacek 