### PR TITLE
[libc++][modules] Add using_if_exists attribute (#77559)

### DIFF
--- a/libcxx/modules/std.compat/cstdlib.inc
+++ b/libcxx/modules/std.compat/cstdlib.inc
@@ -16,10 +16,10 @@ export {
   // [support.start.term], start and termination
   using ::_Exit;
   using ::abort;
-  using ::at_quick_exit;
+  using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
   using ::atexit;
   using ::exit;
-  using ::quick_exit;
+  using ::quick_exit _LIBCPP_USING_IF_EXISTS;
 
   using ::getenv;
   using ::system;


### PR DESCRIPTION
libc on macOS does not provide at_quick_exit or quick_exit. This allows modules to build on macOS and defer any errors to usage site of these symbols.

Fixes: https://github.com/llvm/llvm-project/issues/77559