### PR TITLE
[Clang][AArch64] Define __USER_LABEL_PREFIX__ to # for ARM64EC

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1462,10 +1462,12 @@ WindowsARM64TargetInfo::WindowsARM64TargetInfo(const llvm::Triple &Triple,
 }
 
 void WindowsARM64TargetInfo::setDataLayout() {
-  resetDataLayout(Triple.isOSBinFormatMachO()
-                      ? "e-m:o-i64:64-i128:128-n32:64-S128"
-                      : "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128",
-                  Triple.isOSBinFormatMachO() ? "_" : "");
+  if (Triple.isOSBinFormatMachO()) {
+    resetDataLayout("e-m:o-i64:64-i128:128-n32:64-S128", "_");
+  } else {
+    resetDataLayout("e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128",
+                    Triple.isWindowsArm64EC() ? "#" : "");
+  }
 }
 
 TargetInfo::BuiltinVaListKind


### PR DESCRIPTION
This is required so that the linker knows that any symbols defined in assembly code are ARM64EC rather than X86_64.

CC: @cjacek 