### PR TITLE
[Coverage] Const-ize `MCDCRecordProcessor` stuff

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -587,8 +587,9 @@ public:
   /// Return an MCDC record that indicates executed test vectors and condition
   /// pairs.
   Expected<MCDCRecord>
-  evaluateMCDCRegion(CounterMappingRegion Region, BitVector Bitmap,
-                     ArrayRef<CounterMappingRegion> Branches);
+  evaluateMCDCRegion(const CounterMappingRegion &Region,
+                     const BitVector &Bitmap,
+                     ArrayRef<const CounterMappingRegion *> Branches);
 
   unsigned getMaxCounterID(const Counter &C) const;
 };


### PR DESCRIPTION
The life of `MCDCRecordProcessor`'s instance is short. It may accept `const` objects to process.

On the other hand, the life of `MCDCBranches` is shorter than `Record`. It may be rewritten with reference, rather than copying.