### PR TITLE
[clang][analyzer] Improve modeling of 'execv' and 'execvp' in StdLibraryFunctionsChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -3002,7 +3002,7 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
         "execv",
         Signature(ArgTypes{ConstCharPtrTy, CharPtrConstPtr}, RetType{IntTy}),
         Summary(NoEvalCall)
-            .Case(ReturnsMinusOne, ErrnoIrrelevant)
+            .Case(ReturnsMinusOne, ErrnoNEZeroIrrelevant)
             .ArgConstraint(NotNull(ArgNo(0))));
 
     // int execvp(const char *file, char *const argv[]);
@@ -3010,7 +3010,7 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
         "execvp",
         Signature(ArgTypes{ConstCharPtrTy, CharPtrConstPtr}, RetType{IntTy}),
         Summary(NoEvalCall)
-            .Case(ReturnsMinusOne, ErrnoIrrelevant)
+            .Case(ReturnsMinusOne, ErrnoNEZeroIrrelevant)
             .ArgConstraint(NotNull(ArgNo(0))));
 
     // int getopt(int argc, char * const argv[], const char *optstring);

--- a/clang/test/Analysis/errno-stdlibraryfunctions.c
+++ b/clang/test/Analysis/errno-stdlibraryfunctions.c
@@ -89,3 +89,17 @@ void errno_getcwd(char *Buf, size_t Sz) {
     if (errno) {}                      // expected-warning{{An undefined value may be read from 'errno'}}
   }
 }
+
+void errno_execv(char *Path, char * Argv[]) {
+  int Ret = execv(Path, Argv);
+  clang_analyzer_eval(Ret == -1);  // expected-warning{{TRUE}}
+  clang_analyzer_eval(errno != 0); // expected-warning{{TRUE}}
+  if (errno) {}                    // no warning
+}
+
+void errno_execvp(char *File, char * Argv[]) {
+  int Ret = execvp(File, Argv);
+  clang_analyzer_eval(Ret == -1);  // expected-warning{{TRUE}}
+  clang_analyzer_eval(errno != 0); // expected-warning{{TRUE}}
+  if (errno) {}                    // no warning
+}


### PR DESCRIPTION
These functions always return -1 and set 'errno'.