### PR TITLE
[SafeStack] Fix logic checking for incompatible llvm.gcroot intrinsics

### DIFF
--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -400,6 +400,10 @@ void SafeStack::findInsts(Function &F,
         Returns.push_back(CI);
       else
         Returns.push_back(RI);
+    } else if (auto II = dyn_cast<IntrinsicInst>(&I)) {
+      if (II->getIntrinsicID() == Intrinsic::gcroot)
+        report_fatal_error(
+            "gcroot intrinsic not compatible with safestack attribute");
     } else if (auto CI = dyn_cast<CallInst>(&I)) {
       // setjmps require stack restore.
       if (CI->getCalledFunction() && CI->canReturnTwice())
@@ -407,10 +411,6 @@ void SafeStack::findInsts(Function &F,
     } else if (auto LP = dyn_cast<LandingPadInst>(&I)) {
       // Exception landing pads require stack restore.
       StackRestorePoints.push_back(LP);
-    } else if (auto II = dyn_cast<IntrinsicInst>(&I)) {
-      if (II->getIntrinsicID() == Intrinsic::gcroot)
-        report_fatal_error(
-            "gcroot intrinsic not compatible with safestack attribute");
     }
   }
   for (Argument &Arg : F.args()) {

--- a/llvm/test/Transforms/SafeStack/X86/gcroot.ll
+++ b/llvm/test/Transforms/SafeStack/X86/gcroot.ll
@@ -1,0 +1,15 @@
+; RUN: not --crash opt -safe-stack -S -mtriple=i386-pc-linux-gnu < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not --crash opt -safe-stack -S -mtriple=x86_64-pc-linux-gnu < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not --crash opt -passes=safe-stack -S -mtriple=i386-pc-linux-gnu < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not --crash opt -passes=safe-stack -S -mtriple=x86_64-pc-linux-gnu < %s -o /dev/null 2>&1 | FileCheck %s
+
+define void @foo()  nounwind uwtable safestack gc "shadow-stack" {
+  %1 = alloca ptr, align 4
+  call void @bar(ptr %1)
+  ; CHECK: LLVM ERROR: gcroot intrinsic not compatible with safestack attribute
+  call void @llvm.gcroot(ptr %1, ptr null)
+  ret void
+}
+
+declare void @bar(ptr)
+declare void @llvm.gcroot(ptr, ptr)


### PR DESCRIPTION
This patch fixes a logic bug that prevented SafeStack from detecting and reporting llvm.gcroot intrinsics, which are not compatible with SafeStack.