### PR TITLE
[RISCV] Teach RISCVMergeBaseOffset to handle inline asm

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -782,6 +782,10 @@ public:
   void ChangeToGA(const GlobalValue *GV, int64_t Offset,
                   unsigned TargetFlags = 0);
 
+  /// ChangeToBA - Replace this operand with a new block address operand.
+  void ChangeToBA(const BlockAddress *BA, int64_t Offset,
+                  unsigned TargetFlags = 0);
+
   /// ChangeToMCSymbol - Replace this operand with a new MC symbol operand.
   void ChangeToMCSymbol(MCSymbol *Sym, unsigned TargetFlags = 0);
 

--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -206,6 +206,19 @@ void MachineOperand::ChangeToGA(const GlobalValue *GV, int64_t Offset,
   setTargetFlags(TargetFlags);
 }
 
+void MachineOperand::ChangeToBA(const BlockAddress *BA, int64_t Offset,
+                                unsigned TargetFlags) {
+  assert((!isReg() || !isTied()) &&
+         "Cannot change a tied operand into a block address");
+
+  removeRegFromUses();
+
+  OpKind = MO_BlockAddress;
+  Contents.OffsetedInfo.Val.BA = BA;
+  setOffset(Offset);
+  setTargetFlags(TargetFlags);
+}
+
 void MachineOperand::ChangeToMCSymbol(MCSymbol *Sym, unsigned TargetFlags) {
   assert((!isReg() || !isTied()) &&
          "Cannot change a tied operand into an MCSymbol");

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -323,7 +323,8 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
   // RISCVDAGToDAGISel::SelectInlineAsmMemoryOperand).
   if (!AddrReg.isReg())
     return true;
-  if (!Offset.isImm() && !Offset.isGlobal() && !Offset.isBlockAddress())
+  if (!Offset.isImm() && !Offset.isGlobal() && !Offset.isBlockAddress() &&
+      !Offset.isMCSymbol())
     return true;
 
   MCOperand MCO;
@@ -332,7 +333,7 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
 
   if (Offset.isImm())
     OS << MCO.getImm();
-  else if (Offset.isGlobal() || Offset.isBlockAddress())
+  else if (Offset.isGlobal() || Offset.isBlockAddress() || Offset.isMCSymbol())
     OS << *MCO.getExpr();
   OS << "(" << RISCVInstPrinter::getRegisterName(AddrReg.getReg()) << ")";
   return false;

--- a/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
+++ b/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
@@ -125,9 +125,8 @@ define void @constraint_m_with_global_1() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi0:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -135,9 +134,8 @@ define void @constraint_m_with_global_1() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi0:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) @eg)
@@ -147,39 +145,35 @@ define void @constraint_m_with_global_1() nounwind {
 define void @constraint_m_with_global_2() nounwind {
 ; RV32I-LABEL: constraint_m_with_global_2:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lui a0, %hi(eg)
-; RV32I-NEXT:    addi a0, a0, %lo(eg)
+; RV32I-NEXT:    lui a0, %hi(eg+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 4(a0)
+; RV32I-NEXT:    sw zero, %lo(eg+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_m_with_global_2:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    lui a0, %hi(eg)
-; RV64I-NEXT:    addi a0, a0, %lo(eg)
+; RV64I-NEXT:    lui a0, %hi(eg+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 4(a0)
+; RV64I-NEXT:    sw zero, %lo(eg+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
 ; RV32I-MEDIUM-LABEL: constraint_m_with_global_2:
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi1:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi1)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
 ; RV64I-MEDIUM-LABEL: constraint_m_with_global_2:
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi1:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi1)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 1))
@@ -190,18 +184,16 @@ define void @constraint_m_with_global_3() nounwind {
 ; RV32I-LABEL: constraint_m_with_global_3:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a0, %hi(eg+8000)
-; RV32I-NEXT:    addi a0, a0, %lo(eg+8000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 0(a0)
+; RV32I-NEXT:    sw zero, %lo(eg+8000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_m_with_global_3:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    lui a0, %hi(eg+8000)
-; RV64I-NEXT:    addi a0, a0, %lo(eg+8000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 0(a0)
+; RV64I-NEXT:    sw zero, %lo(eg+8000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -209,9 +201,8 @@ define void @constraint_m_with_global_3() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi2:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi2)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -219,9 +210,8 @@ define void @constraint_m_with_global_3() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi2:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi2)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 2000))
@@ -271,19 +261,17 @@ define void @constraint_m_with_extern_weak_global_1() nounwind {
 define void @constraint_m_with_extern_weak_global_2() nounwind {
 ; RV32I-LABEL: constraint_m_with_extern_weak_global_2:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lui a0, %hi(ewg)
-; RV32I-NEXT:    addi a0, a0, %lo(ewg)
+; RV32I-NEXT:    lui a0, %hi(ewg+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 4(a0)
+; RV32I-NEXT:    sw zero, %lo(ewg+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_m_with_extern_weak_global_2:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    lui a0, %hi(ewg)
-; RV64I-NEXT:    addi a0, a0, %lo(ewg)
+; RV64I-NEXT:    lui a0, %hi(ewg+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 4(a0)
+; RV64I-NEXT:    sw zero, %lo(ewg+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -314,18 +302,16 @@ define void @constraint_m_with_extern_weak_global_3() nounwind {
 ; RV32I-LABEL: constraint_m_with_extern_weak_global_3:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a0, %hi(ewg+8000)
-; RV32I-NEXT:    addi a0, a0, %lo(ewg+8000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 0(a0)
+; RV32I-NEXT:    sw zero, %lo(ewg+8000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_m_with_extern_weak_global_3:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    lui a0, %hi(ewg+8000)
-; RV64I-NEXT:    addi a0, a0, %lo(ewg+8000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 0(a0)
+; RV64I-NEXT:    sw zero, %lo(ewg+8000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -385,9 +371,8 @@ define void @constraint_m_with_local_1() nounwind {
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi6:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -397,9 +382,8 @@ define void @constraint_m_with_local_1() nounwind {
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi6:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:
@@ -415,10 +399,9 @@ define void @constraint_m_with_local_2() nounwind {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:  .Ltmp1: # Block address taken
 ; RV32I-NEXT:  # %bb.1: # %label
-; RV32I-NEXT:    lui a0, %hi(.Ltmp1)
-; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp1)
+; RV32I-NEXT:    lui a0, %hi(.Ltmp1+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    lw zero, 4(a0)
+; RV32I-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
@@ -426,10 +409,9 @@ define void @constraint_m_with_local_2() nounwind {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:  .Ltmp1: # Block address taken
 ; RV64I-NEXT:  # %bb.1: # %label
-; RV64I-NEXT:    lui a0, %hi(.Ltmp1)
-; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp1)
+; RV64I-NEXT:    lui a0, %hi(.Ltmp1+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    lw zero, 4(a0)
+; RV64I-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -438,10 +420,9 @@ define void @constraint_m_with_local_2() nounwind {
 ; RV32I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi7:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -450,10 +431,9 @@ define void @constraint_m_with_local_2() nounwind {
 ; RV64I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi7:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:
@@ -469,10 +449,9 @@ define void @constraint_m_with_local_3() nounwind {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:  .Ltmp2: # Block address taken
 ; RV32I-NEXT:  # %bb.1: # %label
-; RV32I-NEXT:    lui a0, %hi(.Ltmp2)
-; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp2)
+; RV32I-NEXT:    lui a0, %hi(.Ltmp2+2000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    lw zero, 2000(a0)
+; RV32I-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
@@ -480,10 +459,9 @@ define void @constraint_m_with_local_3() nounwind {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:  .Ltmp2: # Block address taken
 ; RV64I-NEXT:  # %bb.1: # %label
-; RV64I-NEXT:    lui a0, %hi(.Ltmp2)
-; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp2)
+; RV64I-NEXT:    lui a0, %hi(.Ltmp2+2000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    lw zero, 2000(a0)
+; RV64I-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -492,10 +470,9 @@ define void @constraint_m_with_local_3() nounwind {
 ; RV32I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi8:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi8)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -504,10 +481,9 @@ define void @constraint_m_with_local_3() nounwind {
 ; RV64I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi8:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi8)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:
@@ -539,9 +515,8 @@ define void @constraint_m_with_multi_operands() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi9:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi9)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0); sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0); sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -549,9 +524,8 @@ define void @constraint_m_with_multi_operands() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi9:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi9)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0); sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0); sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0; sw zero, $1", "=*m,=*m"(ptr elementtype(i32) @eg, ptr elementtype(i32) @eg)
@@ -585,12 +559,11 @@ define void @constraint_m_with_multi_asm() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi10:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -598,12 +571,11 @@ define void @constraint_m_with_multi_asm() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi10:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) @eg)
@@ -646,9 +618,8 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM:       # %bb.0: # %entry
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi11:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi11)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB14_2
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1); sw zero, %pcrel_lo(.Lpcrel_hi11)(a1); beqz a0, .LBB14_2
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NEXT:    li a0, 0
@@ -663,9 +634,8 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM:       # %bb.0: # %entry
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi11:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi11)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB14_2
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1); sw zero, %pcrel_lo(.Lpcrel_hi11)(a1); beqz a0, .LBB14_2
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NEXT:    li a0, 0
@@ -728,13 +698,12 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM:       # %bb.0: # %entry
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi12:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi12)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1); beqz a0, .LBB15_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1); beqz a0, .LBB15_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NEXT:    li a0, 0
@@ -749,13 +718,12 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM:       # %bb.0: # %entry
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi12:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi12)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1); beqz a0, .LBB15_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1); beqz a0, .LBB15_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NEXT:    li a0, 0
@@ -892,9 +860,8 @@ define void @constraint_o_with_global_1() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi13:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi13)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -902,9 +869,8 @@ define void @constraint_o_with_global_1() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi13:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi13)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) @eg)
@@ -914,39 +880,35 @@ define void @constraint_o_with_global_1() nounwind {
 define void @constraint_o_with_global_2() nounwind {
 ; RV32I-LABEL: constraint_o_with_global_2:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lui a0, %hi(eg)
-; RV32I-NEXT:    addi a0, a0, %lo(eg)
+; RV32I-NEXT:    lui a0, %hi(eg+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 4(a0)
+; RV32I-NEXT:    sw zero, %lo(eg+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_o_with_global_2:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    lui a0, %hi(eg)
-; RV64I-NEXT:    addi a0, a0, %lo(eg)
+; RV64I-NEXT:    lui a0, %hi(eg+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 4(a0)
+; RV64I-NEXT:    sw zero, %lo(eg+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_global_2:
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi14:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi14)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_global_2:
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi14:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi14)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 1))
@@ -957,18 +919,16 @@ define void @constraint_o_with_global_3() nounwind {
 ; RV32I-LABEL: constraint_o_with_global_3:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a0, %hi(eg+8000)
-; RV32I-NEXT:    addi a0, a0, %lo(eg+8000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 0(a0)
+; RV32I-NEXT:    sw zero, %lo(eg+8000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_o_with_global_3:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    lui a0, %hi(eg+8000)
-; RV64I-NEXT:    addi a0, a0, %lo(eg+8000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 0(a0)
+; RV64I-NEXT:    sw zero, %lo(eg+8000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -976,9 +936,8 @@ define void @constraint_o_with_global_3() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi15:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi15)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -986,9 +945,8 @@ define void @constraint_o_with_global_3() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi15:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi15)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 2000))
@@ -1038,19 +996,17 @@ define void @constraint_o_with_extern_weak_global_1() nounwind {
 define void @constraint_o_with_extern_weak_global_2() nounwind {
 ; RV32I-LABEL: constraint_o_with_extern_weak_global_2:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lui a0, %hi(ewg)
-; RV32I-NEXT:    addi a0, a0, %lo(ewg)
+; RV32I-NEXT:    lui a0, %hi(ewg+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 4(a0)
+; RV32I-NEXT:    sw zero, %lo(ewg+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_o_with_extern_weak_global_2:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    lui a0, %hi(ewg)
-; RV64I-NEXT:    addi a0, a0, %lo(ewg)
+; RV64I-NEXT:    lui a0, %hi(ewg+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 4(a0)
+; RV64I-NEXT:    sw zero, %lo(ewg+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -1081,18 +1037,16 @@ define void @constraint_o_with_extern_weak_global_3() nounwind {
 ; RV32I-LABEL: constraint_o_with_extern_weak_global_3:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a0, %hi(ewg+8000)
-; RV32I-NEXT:    addi a0, a0, %lo(ewg+8000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, 0(a0)
+; RV32I-NEXT:    sw zero, %lo(ewg+8000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: constraint_o_with_extern_weak_global_3:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    lui a0, %hi(ewg+8000)
-; RV64I-NEXT:    addi a0, a0, %lo(ewg+8000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, 0(a0)
+; RV64I-NEXT:    sw zero, %lo(ewg+8000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -1146,9 +1100,8 @@ define void @constraint_o_with_multi_operands() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi19:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi19)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0) \n sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0) \n sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -1156,9 +1109,8 @@ define void @constraint_o_with_multi_operands() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi19:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi19)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0) \n sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0) \n sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0 \n sw zero, $1", "=*o,=*o"(ptr elementtype(i32) @eg, ptr elementtype(i32) @eg)
@@ -1192,12 +1144,11 @@ define void @constraint_o_with_multi_asm() nounwind {
 ; RV32I-MEDIUM:       # %bb.0:
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi20:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi20)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -1205,12 +1156,11 @@ define void @constraint_o_with_multi_asm() nounwind {
 ; RV64I-MEDIUM:       # %bb.0:
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi20:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi20)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) @eg)
@@ -1253,9 +1203,8 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM:       # %bb.0: # %entry
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi21:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi21)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB27_2
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1); sw zero, %pcrel_lo(.Lpcrel_hi21)(a1); beqz a0, .LBB27_2
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NEXT:    li a0, 0
@@ -1270,9 +1219,8 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM:       # %bb.0: # %entry
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi21:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi21)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB27_2
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1); sw zero, %pcrel_lo(.Lpcrel_hi21)(a1); beqz a0, .LBB27_2
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NEXT:    li a0, 0
@@ -1335,13 +1283,12 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM:       # %bb.0: # %entry
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi22:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi22)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi22)(a1); beqz a0, .LBB28_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi22)(a1); beqz a0, .LBB28_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NEXT:    li a0, 0
@@ -1356,13 +1303,12 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM:       # %bb.0: # %entry
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi22:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi22)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi22)(a1); beqz a0, .LBB28_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi22)(a1); beqz a0, .LBB28_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NEXT:    li a0, 0
@@ -1412,9 +1358,8 @@ define void @constraint_o_with_local_1() nounwind {
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi23:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi23)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -1424,9 +1369,8 @@ define void @constraint_o_with_local_1() nounwind {
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi23:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi23)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:
@@ -1442,10 +1386,9 @@ define void @constraint_o_with_local_2() nounwind {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:  .Ltmp4: # Block address taken
 ; RV32I-NEXT:  # %bb.1: # %label
-; RV32I-NEXT:    lui a0, %hi(.Ltmp4)
-; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp4)
+; RV32I-NEXT:    lui a0, %hi(.Ltmp4+4)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    lw zero, 4(a0)
+; RV32I-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
@@ -1453,10 +1396,9 @@ define void @constraint_o_with_local_2() nounwind {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:  .Ltmp4: # Block address taken
 ; RV64I-NEXT:  # %bb.1: # %label
-; RV64I-NEXT:    lui a0, %hi(.Ltmp4)
-; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp4)
+; RV64I-NEXT:    lui a0, %hi(.Ltmp4+4)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    lw zero, 4(a0)
+; RV64I-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -1465,10 +1407,9 @@ define void @constraint_o_with_local_2() nounwind {
 ; RV32I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi24:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi24)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -1477,10 +1418,9 @@ define void @constraint_o_with_local_2() nounwind {
 ; RV64I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi24:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi24)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:
@@ -1496,10 +1436,9 @@ define void @constraint_o_with_local_3() nounwind {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:  .Ltmp5: # Block address taken
 ; RV32I-NEXT:  # %bb.1: # %label
-; RV32I-NEXT:    lui a0, %hi(.Ltmp5)
-; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp5)
+; RV32I-NEXT:    lui a0, %hi(.Ltmp5+2000)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    lw zero, 2000(a0)
+; RV32I-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:    ret
 ;
@@ -1507,10 +1446,9 @@ define void @constraint_o_with_local_3() nounwind {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:  .Ltmp5: # Block address taken
 ; RV64I-NEXT:  # %bb.1: # %label
-; RV64I-NEXT:    lui a0, %hi(.Ltmp5)
-; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp5)
+; RV64I-NEXT:    lui a0, %hi(.Ltmp5+2000)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    lw zero, 2000(a0)
+; RV64I-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
@@ -1519,10 +1457,9 @@ define void @constraint_o_with_local_3() nounwind {
 ; RV32I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi25:
-; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi25)
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi25)(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:    ret
 ;
@@ -1531,10 +1468,9 @@ define void @constraint_o_with_local_3() nounwind {
 ; RV64I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi25:
-; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi25)
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi25)(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:    ret
 entry:


### PR DESCRIPTION
For inline asm with memory operands, we can merge the offset into
the second operand of memory constraint operands.

Differential Revision: https://reviews.llvm.org/D158062
