### PR TITLE
[clang-repl] Fix PLT offset too large linker error on ARM

### DIFF
--- a/clang/tools/clang-repl/CMakeLists.txt
+++ b/clang/tools/clang-repl/CMakeLists.txt
@@ -22,3 +22,7 @@ clang_target_link_libraries(clang-repl PRIVATE
 if(CLANG_PLUGIN_SUPPORT)
   export_executable_symbols_for_plugins(clang-repl)
 endif()
+
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ARM")
+  target_link_options(clang-repl PRIVATE LINKER:--long-plt)
+endif()

--- a/clang/tools/clang-repl/CMakeLists.txt
+++ b/clang/tools/clang-repl/CMakeLists.txt
@@ -23,6 +23,7 @@ if(CLANG_PLUGIN_SUPPORT)
   export_executable_symbols_for_plugins(clang-repl)
 endif()
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ARM")
+string(TOUPPER ${CMAKE_SYSTEM_PROCESSOR} system_processor)
+if(${system_processor} MATCHES "ARM")
   target_link_options(clang-repl PRIVATE LINKER:--long-plt)
 endif()


### PR DESCRIPTION
I cross-compile clang-repl with GCC-10 on Ubuntu 20.04 and get this error when linking with gold: PLT offset too large, try linking with --long-plt