### PR TITLE
[openmp][flang][offloading] Do not use fixed device IDs in checks

### DIFF
--- a/openmp/libomptarget/test/offloading/fortran/target_map_common_block1.f90
+++ b/openmp/libomptarget/test/offloading/fortran/target_map_common_block1.f90
@@ -20,9 +20,9 @@ program main
     devices(2) = omp_get_device_num()
   !$omp end target
   print *, "var1 after target = ", var1
-  print *, "devices: ", devices
+  print *, "devices are different? ", (devices(1) /= devices(2))
 end program
 
 ! CHECK: var1 before target =  10
 ! CHECK: var1 after target =  20
-! CHECK: devices:  1 0
+! CHECK: devices are different? T


### PR DESCRIPTION
Fixes a small issues in an offloading test where the test dependec on the host and device being assigned certains numeric IDs. This however is not stable and fails in situations where any of the devices is assigned an ID different from the expected value. The fix just checks that offloading succeeded by making sure the IDs are different.

The test was failing locally for me.