### PR TITLE
[flang] Handle -S assemble only flag in flang-to-external-fc

### DIFF
--- a/flang/tools/f18/flang-to-external-fc.in
+++ b/flang/tools/f18/flang-to-external-fc.in
@@ -108,6 +108,10 @@ parse_args()
           COMPILE_ONLY="True"
         fi
 
+        if [[ $1 == "-S" ]]; then
+          COMPILE_ONLY="True"
+        fi
+
         if [[ $1 == "-E" ]]; then
           PREPROCESS_ONLY="True"
         fi


### PR DESCRIPTION
Flang was recently updated on Compiler Explorer and by default it's in assemble only mode, you have to enable linking and executing.

This means that the default output for flang-to-external-fc is nothing, as it doesn't know what `-S` means. You'd have to know to enable the link to binary option to see any output.

Handle `-S` so that users of Compiler Explorer don't have to wonder why the "compiler" is broken.