### PR TITLE
[VecLib] Fix: Restore DebugFlag state in ReplaceWithVecLibTest

### DIFF
--- a/llvm/unittests/Analysis/ReplaceWithVecLibTest.cpp
+++ b/llvm/unittests/Analysis/ReplaceWithVecLibTest.cpp
@@ -72,9 +72,11 @@ protected:
     PB.registerFunctionAnalyses(FAM);
 
     // Enable debugging and capture std error
+    bool DebugFlagPrev = llvm::DebugFlag;
     llvm::DebugFlag = true;
     testing::internal::CaptureStderr();
     FPM.run(*M->getFunction("foo"), FAM);
+    llvm::DebugFlag = DebugFlagPrev;
     return getLastLine(testing::internal::GetCapturedStderr());
   }
 };


### PR DESCRIPTION
It appears that Google Tests run multiple modules from the same invocation.
As a result setting `llvm::DebugFlag` in this pass kept it on in subsequent passes, which is not the expected behavior.