### PR TITLE
[Clang] Update feature test macros for Clang 18

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -185,7 +185,8 @@ C++20 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 - Implemented `P1907R1 <https://wg21.link/P1907R1>` which extends allowed non-type template argument
   kinds with e.g. floating point values and pointers and references to subobjects.
-  This feature is still experimental. Accordingly, `__cpp_nontype_template_args` was not updated.
+  This feature is still experimental. Accordingly, ``__cpp_nontype_template_args`` was not updated.
+  However, its support can be tested with ``__has_extension(cxx_generalized_nttp)``.
 
 C++23 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
@@ -194,6 +195,7 @@ C++23 Feature Support
   `CWG2653 <https://wg21.link/CWG2653>`_, `CWG2687 <https://wg21.link/CWG2687>`_). Because the
   support for this feature is still experimental, the feature test macro ``__cpp_explicit_this_parameter``
   was not set in this version.
+  However, its support can be tested with ``__has_extension(cxx_explicit_this_parameter)``.
 
 - Added a separate warning to warn the use of attributes on lambdas as a C++23 extension
   in previous language versions: ``-Wc++23-lambda-attributes``.
@@ -1024,6 +1026,8 @@ Bug Fixes to C++ Support
 
 - Remove recorded `#pragma once` state for headers included in named modules.
   Fixes (`#77995 <https://github.com/llvm/llvm-project/issues/77995>`_)
+
+- Set the ``__cpp_auto_cast`` feature test macro in C++23 mode.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -269,6 +269,10 @@ EXTENSION(cxx_fixed_enum, true)
 EXTENSION(cxx_binary_literals, true)
 EXTENSION(cxx_init_captures, LangOpts.CPlusPlus11)
 EXTENSION(cxx_variable_templates, LangOpts.CPlusPlus)
+//C++20
+EXTENSION(cxx_generalized_nttp, LangOpts.CPlusPlus20)
+//C++23
+EXTENSION(cxx_explicit_this_parameter, LangOpts.CPlusPlus23)
 // Miscellaneous language extensions
 EXTENSION(overloadable_unmarked, true)
 EXTENSION(pragma_clang_attribute_namespaces, true)

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -728,6 +728,7 @@ static void InitializeCPlusPlusFeatureTestMacros(const LangOptions &LangOpts,
     Builder.defineMacro("__cpp_size_t_suffix", "202011L");
     Builder.defineMacro("__cpp_if_consteval", "202106L");
     Builder.defineMacro("__cpp_multidimensional_subscript", "202211L");
+    Builder.defineMacro("__cpp_auto_cast", "202110L");
   }
 
   // We provide those C++23 features as extensions in earlier language modes, so

--- a/clang/test/Lexer/cxx-features.cpp
+++ b/clang/test/Lexer/cxx-features.cpp
@@ -40,6 +40,11 @@
 
 // --- C++23 features ---
 
+#if check(auto_cast, 0, 0, 0, 0, 0, 202110, 202110)
+#error "wrong value for __cpp_auto_cast"
+#endif
+
+
 #if check(implicit_move, 0, 0, 0, 0, 0, 202011, 202011)
 #error "wrong value for __cpp_implicit_move"
 #endif

--- a/clang/test/Lexer/has_extension_cxx.cpp
+++ b/clang/test/Lexer/has_extension_cxx.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -std=c++98 -E %s -o - | FileCheck %s
 // RUN: %clang_cc1 -std=c++11 -E %s -o - | FileCheck %s --check-prefix=CHECK11
+// RUN: %clang_cc1 -std=c++20 -E %s -o - | FileCheck %s --check-prefix=CHECK20
+// RUN: %clang_cc1 -std=c++23 -E %s -o - | FileCheck %s --check-prefix=CHECK23
 
 // CHECK: c_static_assert
 #if __has_extension(c_static_assert)
@@ -75,4 +77,18 @@ int has_variable_templates();
 // CHECK11: has_init_captures
 #if __has_extension(cxx_init_captures)
 int has_init_captures();
+#endif
+
+
+// CHECK11-NOT: has_generalized_nttp
+// CHECK20: has_generalized_nttp
+#if __has_extension(cxx_generalized_nttp)
+int has_generalized_nttp();
+#endif
+
+
+// CHECK20-NOT: has_explicit_this_parameter
+// CHECK23: has_explicit_this_parameter
+#if __has_extension(cxx_explicit_this_parameter)
+int has_explicit_this_parameter();
 #endif


### PR DESCRIPTION
* Set `__cpp_auto_cast`, as per https://github.com/cplusplus/CWG/issues/281
* Support `__has_extension(cxx_generalized_nttp)` in C++20 as the feature isn't stable enough for a feature test macro
* Support `__has_extension(cxx_explicit_this_parameter)` in c++23 as the feature isn't stable enough for a feature test macro