### PR TITLE
[llvm-reduce][DebugInfo] Support reducing non-instruction debug-info

### DIFF
--- a/llvm/test/tools/llvm-reduce/remove-dp-values.ll
+++ b/llvm/test/tools/llvm-reduce/remove-dp-values.ll
@@ -1,0 +1,51 @@
+; RUN: llvm-reduce --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t --try-experimental-debuginfo-iterators
+; RUN: FileCheck --check-prefixes=CHECK-FINAL --input-file=%t %s --implicit-check-not=dbg.value
+
+; Test that we can, in RemoveDIs mode / DPValues mode (where variable location
+; information isn't an instruction), remove one variable location assignment
+; but not another.
+
+; CHECK-INTERESTINGNESS:     call void @llvm.dbg.value(metadata i32 %added,
+
+; CHECK-FINAL:     declare void @llvm.dbg.value(metadata,
+; CHECK-FINAL:     %added = add
+; CHECK-FINAL-NEXT: call void @llvm.dbg.value(metadata i32 %added,
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+define i32 @main() !dbg !7 {
+entry:
+  %uninteresting1 = alloca i32, align 4
+  %interesting = alloca i32, align 4
+  %uninteresting2 = alloca i32, align 4
+  store i32 0, ptr %uninteresting1, align 4
+  store i32 0, ptr %interesting, align 4
+  %0 = load i32, ptr %interesting, align 4
+  %added = add nsw i32 %0, 1
+  tail call void @llvm.dbg.value(metadata i32 %added, metadata !13, metadata !DIExpression()), !dbg !14
+  store i32 %added, ptr %interesting, align 4
+  %alsoloaded = load i32, ptr %interesting, align 4
+  tail call void @llvm.dbg.value(metadata i32 %alsoloaded, metadata !13, metadata !DIExpression()), !dbg !14
+  store i32 %alsoloaded, ptr %uninteresting2, align 4
+  ret i32 0
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "/tmp/a.c", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"uwtable", i32 1}
+!6 = !{i32 7, !"frame-pointer", i32 2}
+!7 = distinct !DISubprogram(name: "main", scope: !8, file: !8, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !12)
+!8 = !DIFile(filename: "/tmp/a.c", directory: "")
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!12 = !{}
+!13 = !DILocalVariable(name: "a", scope: !7, file: !8, line: 2, type: !11)
+!14 = !DILocation(line: 2, column: 7, scope: !7)
+

--- a/llvm/tools/llvm-reduce/CMakeLists.txt
+++ b/llvm/tools/llvm-reduce/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_tool(llvm-reduce
   deltas/ReduceAttributes.cpp
   deltas/ReduceBasicBlocks.cpp
   deltas/ReduceDIMetadata.cpp
+  deltas/ReduceDPValues.cpp
   deltas/ReduceFunctionBodies.cpp
   deltas/ReduceFunctions.cpp
   deltas/ReduceGlobalObjects.cpp

--- a/llvm/tools/llvm-reduce/DeltaManager.cpp
+++ b/llvm/tools/llvm-reduce/DeltaManager.cpp
@@ -20,6 +20,7 @@
 #include "deltas/ReduceAttributes.h"
 #include "deltas/ReduceBasicBlocks.h"
 #include "deltas/ReduceDIMetadata.h"
+#include "deltas/ReduceDPValues.h"
 #include "deltas/ReduceFunctionBodies.h"
 #include "deltas/ReduceFunctions.h"
 #include "deltas/ReduceGlobalObjects.h"
@@ -89,6 +90,7 @@ static cl::list<std::string>
     DELTA_PASS("global-initializers", reduceGlobalsInitializersDeltaPass)      \
     DELTA_PASS("global-variables", reduceGlobalsDeltaPass)                     \
     DELTA_PASS("di-metadata", reduceDIMetadataDeltaPass)                       \
+    DELTA_PASS("dpvalues", reduceDPValuesDeltaPass)                            \
     DELTA_PASS("metadata", reduceMetadataDeltaPass)                            \
     DELTA_PASS("named-metadata", reduceNamedMetadataDeltaPass)                 \
     DELTA_PASS("arguments", reduceArgumentsDeltaPass)                          \

--- a/llvm/tools/llvm-reduce/DeltaManager.cpp
+++ b/llvm/tools/llvm-reduce/DeltaManager.cpp
@@ -79,9 +79,11 @@ static cl::list<std::string>
     DELTA_PASS("aliases", reduceAliasesDeltaPass)                              \
     DELTA_PASS("ifuncs", reduceIFuncsDeltaPass)                                \
     DELTA_PASS("simplify-conditionals-true", reduceConditionalsTrueDeltaPass)  \
-    DELTA_PASS("simplify-conditionals-false", reduceConditionalsFalseDeltaPass)\
+    DELTA_PASS("simplify-conditionals-false",                                  \
+               reduceConditionalsFalseDeltaPass)                               \
     DELTA_PASS("invokes", reduceInvokesDeltaPass)                              \
-    DELTA_PASS("unreachable-basic-blocks", reduceUnreachableBasicBlocksDeltaPass) \
+    DELTA_PASS("unreachable-basic-blocks",                                     \
+               reduceUnreachableBasicBlocksDeltaPass)                          \
     DELTA_PASS("basic-blocks", reduceBasicBlocksDeltaPass)                     \
     DELTA_PASS("simplify-cfg", reduceUsingSimplifyCFGDeltaPass)                \
     DELTA_PASS("function-data", reduceFunctionDataDeltaPass)                   \

--- a/llvm/tools/llvm-reduce/deltas/ReduceDPValues.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDPValues.cpp
@@ -1,0 +1,40 @@
+//===- ReduceInstructions.cpp - Specialized Delta Pass ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a function which calls the Generic Delta pass in order
+// to reduce uninteresting DPValues from defined functions.
+//
+// DPValues store variable-location debug-info and are attached to instructions.
+// This information used to be represented by intrinsics such as dbg.value, and
+// would naturally get reduced by llvm-reduce like any other instruction. As
+// DPValues get stored elsewhere, they need to be enumerated and eliminated like
+// any other data structure in LLVM.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ReduceDPValues.h"
+#include "Utils.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace llvm;
+
+static void extractDPValuesFromModule(Oracle &O, ReducerWorkItem &WorkItem) {
+  Module &M = WorkItem.getModule();
+
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB)
+        for (DPValue &DPV : llvm::make_early_inc_range(I.getDbgValueRange()))
+          if (!O.shouldKeep())
+            DPV.eraseFromParent();
+}
+
+void llvm::reduceDPValuesDeltaPass(TestRunner &Test) {
+  runDeltaPass(Test, extractDPValuesFromModule, "Reducing DPValues");
+}
+

--- a/llvm/tools/llvm-reduce/deltas/ReduceDPValues.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDPValues.cpp
@@ -1,4 +1,4 @@
-//===- ReduceInstructions.cpp - Specialized Delta Pass ---------------------===//
+//===- ReduceDPValues.cpp - Specialized Delta Pass ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -37,4 +37,3 @@ static void extractDPValuesFromModule(Oracle &O, ReducerWorkItem &WorkItem) {
 void llvm::reduceDPValuesDeltaPass(TestRunner &Test) {
   runDeltaPass(Test, extractDPValuesFromModule, "Reducing DPValues");
 }
-

--- a/llvm/tools/llvm-reduce/deltas/ReduceDPValues.h
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDPValues.h
@@ -1,0 +1,25 @@
+//===- ReduceDPValues.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a function which calls the Generic Delta pass in order
+// to reduce uninteresting DPValues from defined functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_REDUCE_DELTAS_REDUCEDPVALUES_H
+#define LLVM_TOOLS_LLVM_REDUCE_DELTAS_REDUCEDPVALUES_H
+
+#include "Delta.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DebugProgramInstruction.h"
+
+namespace llvm {
+void reduceDPValuesDeltaPass(TestRunner &Test);
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-reduce/llvm-reduce.cpp
+++ b/llvm/tools/llvm-reduce/llvm-reduce.cpp
@@ -101,9 +101,9 @@ static cl::opt<int>
                       cl::init(5), cl::cat(LLVMReduceOptions));
 
 static cl::opt<bool> TryUseNewDbgInfoFormat(
-      "try-experimental-debuginfo-iterators",
-      cl::desc("Enable debuginfo iterator positions, if they're built in"),
-      cl::init(false));
+    "try-experimental-debuginfo-iterators",
+    cl::desc("Enable debuginfo iterator positions, if they're built in"),
+    cl::init(false));
 
 extern cl::opt<bool> UseNewDbgInfoFormat;
 

--- a/llvm/tools/llvm-reduce/llvm-reduce.cpp
+++ b/llvm/tools/llvm-reduce/llvm-reduce.cpp
@@ -100,6 +100,13 @@ static cl::opt<int>
                                "of delta passes (default=5)"),
                       cl::init(5), cl::cat(LLVMReduceOptions));
 
+static cl::opt<bool> TryUseNewDbgInfoFormat(
+      "try-experimental-debuginfo-iterators",
+      cl::desc("Enable debuginfo iterator positions, if they're built in"),
+      cl::init(false));
+
+extern cl::opt<bool> UseNewDbgInfoFormat;
+
 static codegen::RegisterCodeGenFlags CGF;
 
 /// Turn off crash debugging features
@@ -142,6 +149,17 @@ int main(int Argc, char **Argv) {
 
   cl::HideUnrelatedOptions({&LLVMReduceOptions, &getColorCategory()});
   cl::ParseCommandLineOptions(Argc, Argv, "LLVM automatic testcase reducer.\n");
+
+  // RemoveDIs debug-info transition: tests may request that we /try/ to use the
+  // new debug-info format, if it's built in.
+#ifdef EXPERIMENTAL_DEBUGINFO_ITERATORS
+  if (TryUseNewDbgInfoFormat) {
+    // If LLVM was built with support for this, turn the new debug-info format
+    // on.
+    UseNewDbgInfoFormat = true;
+  }
+#endif
+  (void)TryUseNewDbgInfoFormat;
 
   if (Argc == 1) {
     cl::PrintHelpMessage();


### PR DESCRIPTION
LLVM will shortly be able to represent variable locations without encoding information into intrinsics -- they'll be stored as DPValue objects instead. We'll still need to be able to llvm-reduce these variable location assignments just like we can with intrinsics today, thus, here's an llvm-reduce pass that enumerates and reduces the DPValue objects.

The test for this is paradoxically written with dbg.value intrinsics: this is because we're changing all the core parts of LLVM to support this first, with the textual IR format coming last. Until that arrives, testing the llvm-reduce'ing of DPValues needs the added test using intrinsics. We should be able to drop the variable assignment using %alsoloaded using this method. As with the other llvm-reduce tests, I've got one set of check lines for making the reduction happen as desired, and the other set to check the final output.