### PR TITLE
mark std::make_format_args with clang::lifetimebound attribute

### DIFF
--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -64,14 +64,14 @@ using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...>
-make_format_args(_Args&... __args _LIBCPP_LIFETIMEBOUND) {
+make_format_args(_LIBCPP_LIFETIMEBOUND _Args&... __args) {
   return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
 }
 
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<wformat_context, _Args...>
-make_wformat_args(_Args&... __args _LIBCPP_LIFETIMEBOUND) {
+make_wformat_args(_LIBCPP_LIFETIMEBOUND _Args&... __args) {
   return _VSTD::__format_arg_store<wformat_context, _Args...>(__args...);
 }
 #  endif

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -71,7 +71,7 @@ make_format_args(_Args&... __args _LIBCPP_LIFETIMEBOUND) {
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<wformat_context, _Args...>
-make_wformat_args(_Args&... __args) {
+make_wformat_args(_Args&... __args _LIBCPP_LIFETIMEBOUND) {
   return _VSTD::__format_arg_store<wformat_context, _Args...>(__args...);
 }
 #  endif

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -63,7 +63,7 @@ using wformat_args = basic_format_args<wformat_context>;
 #  endif
 
 template <class _Context = format_context, class... _Args>
-_LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args) {
+_LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args [[clang::lifetimebound]]) {
   return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
 }
 

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -63,7 +63,8 @@ using wformat_args = basic_format_args<wformat_context>;
 #  endif
 
 template <class _Context = format_context, class... _Args>
-_LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args [[clang::lifetimebound]]) {
+_LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...>
+make_format_args(_Args&... __args [[clang::lifetimebound]]) {
   return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
 }
 

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -64,7 +64,7 @@ using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...>
-make_format_args(_Args&... __args [[clang::lifetimebound]]) {
+make_format_args(_Args&... __args _LIBCPP_LIFETIMEBOUND) {
   return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
 }
 

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -1,3 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 // Check that format functions are marked [[clang::lifetimebound]] as a conforming extension
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 #include <format>

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Check that format functions are marked [[clang::lifetimebound]] as a conforming extension
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <format>
+
+int j;
+
+auto test_format() {
+    int i = 0;
+    return std::make_format_args(j, i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+}
+
+auto test_wformat() {
+    int i = 0;
+    return std::make_format_args(i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+}

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -21,5 +21,5 @@ auto test_format() {
 
 auto test_wformat() {
     int i = 0;
-    return std::make_format_args(i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+    return std::make_wformat_args(i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -1,19 +1,14 @@
 // Check that format functions are marked [[clang::lifetimebound]] as a conforming extension
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-
 #include <format>
-
 #include "test_macros.h"
-
 int j;
-
 auto test_format() {
   int i = 0;
   return std::make_format_args(
       j, i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }
-
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
 auto test_wformat() {
   int i = 0;

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -15,11 +15,13 @@
 int j;
 
 auto test_format() {
-    int i = 0;
-    return std::make_format_args(j, i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+  int i = 0;
+  return std::make_format_args(
+      j, i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }
 
 auto test_wformat() {
-    int i = 0;
-    return std::make_wformat_args(i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+  int i = 0;
+  return std::make_wformat_args(
+      i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -1,5 +1,4 @@
 // Check that format functions are marked [[clang::lifetimebound]] as a conforming extension
-
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 #include <format>
 #include "test_macros.h"

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -1,11 +1,3 @@
-//===----------------------------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // Check that format functions are marked [[clang::lifetimebound]] as a conforming extension
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17

--- a/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.lifetimebound_extensions.verify.cpp
@@ -12,6 +12,8 @@
 
 #include <format>
 
+#include "test_macros.h"
+
 int j;
 
 auto test_format() {
@@ -20,8 +22,10 @@ auto test_format() {
       j, i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }
 
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
 auto test_wformat() {
   int i = 0;
   return std::make_wformat_args(
       i, j); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
 }
+#endif // TEST_HAS_NO_WIDE_CHARACTERS


### PR DESCRIPTION
Inspired by:

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2905r2.html

[[clang::lifetimebound]] is great, it may be very useful in many places of standard library

how it will work:

https://godbolt.org/z/dqj5eazMn

