### PR TITLE
[AArch64] FP/SIMD is not mandatory for v8-R

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -81,7 +81,8 @@ def FeatureFMV : SubtargetFeature<"fmv", "HasFMV", "true",
   "Enable Function Multi Versioning support.">;
 
 def FeatureRDM : SubtargetFeature<"rdm", "HasRDM", "true",
-  "Enable ARMv8.1 Rounding Double Multiply Add/Subtract instructions (FEAT_RDM)">;
+  "Enable ARMv8.1 Rounding Double Multiply Add/Subtract instructions (FEAT_RDM)",
+  [FeatureNEON]>;
 
 def FeaturePAN : SubtargetFeature<
     "pan", "HasPAN", "true",
@@ -321,7 +322,7 @@ def FeatureUseRSqrt : SubtargetFeature<
 
 def FeatureDotProd : SubtargetFeature<
     "dotprod", "HasDotProd", "true",
-    "Enable dot product support (FEAT_DotProd)">;
+    "Enable dot product support (FEAT_DotProd)", [FeatureNEON]>;
 
 def FeaturePAuth : SubtargetFeature<
     "pauth", "HasPAuth", "true",
@@ -708,15 +709,14 @@ def HasV9_5aOps : SubtargetFeature<
 def HasV8_0rOps : SubtargetFeature<
   "v8r", "HasV8_0rOps", "true", "Support ARM v8r instructions",
   [//v8.1
-  FeatureCRC, FeaturePAN, FeatureRDM, FeatureLSE, FeatureCONTEXTIDREL2,
+  FeatureCRC, FeaturePAN, FeatureLSE, FeatureCONTEXTIDREL2,
   //v8.2
   FeatureRAS, FeaturePsUAO, FeatureCCPP, FeaturePAN_RWV,
   //v8.3
-  FeatureComplxNum, FeatureCCIDX, FeatureJS,
-  FeaturePAuth, FeatureRCPC,
+  FeatureCCIDX, FeaturePAuth, FeatureRCPC,
   //v8.4
-  FeatureDotProd, FeatureTRACEV8_4, FeatureTLB_RMI,
-  FeatureFlagM, FeatureDIT, FeatureSEL2, FeatureRCPC_IMMO,
+  FeatureTRACEV8_4, FeatureTLB_RMI, FeatureFlagM, FeatureDIT, FeatureSEL2,
+  FeatureRCPC_IMMO,
   // Not mandatory in v8.0-R, but included here on the grounds that it
   // only enables names of system registers
   FeatureSpecRestrict
@@ -1420,7 +1420,8 @@ def ProcessorFeatures {
                                  FeaturePerfMon, FeatureSPE, FeatureSPE_EEF];
   list<SubtargetFeature> R82  = [HasV8_0rOps, FeaturePerfMon, FeatureFullFP16,
                                  FeatureFP16FML, FeatureSSBS, FeaturePredRes,
-                                 FeatureSB];
+                                 FeatureSB, FeatureRDM, FeatureDotProd,
+                                 FeatureComplxNum, FeatureJS];
   list<SubtargetFeature> X1   = [HasV8_2aOps, FeatureCrypto, FeatureFPARMv8,
                                  FeatureNEON, FeatureRCPC, FeaturePerfMon,
                                  FeatureSPE, FeatureFullFP16, FeatureDotProd,

--- a/llvm/test/MC/AArch64/armv8.1a-rdma.s
+++ b/llvm/test/MC/AArch64/armv8.1a-rdma.s
@@ -1,6 +1,6 @@
 // RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8.1a -show-encoding < %s 2> %t | FileCheck %s
 // RUN: FileCheck --check-prefix=CHECK-ERROR < %t %s
-// RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r -show-encoding < %s 2> %t | FileCheck %s
+// RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r,+rdm -show-encoding < %s 2> %t | FileCheck %s
 // RUN: FileCheck --check-prefix=CHECK-ERROR < %t %s
   .text
 

--- a/llvm/test/MC/AArch64/armv8.2a-dotprod-errors.s
+++ b/llvm/test/MC/AArch64/armv8.2a-dotprod-errors.s
@@ -1,6 +1,6 @@
 // RUN: not llvm-mc -triple aarch64 -mattr=+dotprod -show-encoding < %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-ERROR < %t %s
-// RUN: not llvm-mc -triple aarch64 -mattr=+v8r -show-encoding < %s 2> %t
+// RUN: not llvm-mc -triple aarch64 -mattr=+v8r,+dotprod -show-encoding < %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-ERROR < %t %s
 
 udot v0.2s, v1.8b, v2.4b[4]

--- a/llvm/test/MC/AArch64/armv8.2a-dotprod.s
+++ b/llvm/test/MC/AArch64/armv8.2a-dotprod.s
@@ -12,13 +12,13 @@
 // RUN: llvm-mc -triple aarch64 -mcpu=neoverse-n2 -show-encoding < %s| FileCheck %s --check-prefix=CHECK-DOTPROD
 // RUN: llvm-mc -triple aarch64 -mcpu=tsv110 -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
 // RUN: llvm-mc -triple aarch64 -mcpu=cortex-r82 -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
-// RUN: llvm-mc -triple aarch64 -mattr=+v8r -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
+// RUN: llvm-mc -triple aarch64 -mattr=+v8r,+dotprod -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
 // RUN: llvm-mc -triple aarch64 -mcpu=ampere1 -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
 // RUN: llvm-mc -triple aarch64 -mcpu=ampere1a -show-encoding < %s | FileCheck %s --check-prefix=CHECK-DOTPROD
 
 // RUN: not llvm-mc -triple aarch64 -mattr=+v8.2a -show-encoding < %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NO-DOTPROD < %t %s
-// RUN: not llvm-mc -triple aarch64 -mattr=+v8r,-dotprod -show-encoding < %s 2> %t
+// RUN: not llvm-mc -triple aarch64 -mattr=+v8r -show-encoding < %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NO-DOTPROD < %t %s
 // RUN: not llvm-mc -triple aarch64 -mcpu=cortex-r82 -mattr=-dotprod -show-encoding < %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NO-DOTPROD < %t %s

--- a/llvm/test/MC/AArch64/armv8r-sysreg.s
+++ b/llvm/test/MC/AArch64/armv8r-sysreg.s
@@ -1,4 +1,7 @@
 // RUN: llvm-mc -triple aarch64 -show-encoding -mattr=+v8r -o - %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64 -show-encoding -mattr=+v8r,-fp-armv8,-rdm,-dotprod,-complxnum,-jsconv -o - %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64 -show-encoding -mcpu=cortex-r82 -o - %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64 -show-encoding -mcpu=cortex-r82 -mattr=-fp-armv8,-rdm,-dotprod,-complxnum,-jsconv -o - %s | FileCheck %s
 .text
 mrs x0, VSCTLR_EL2
 mrs x0, MPUIR_EL1

--- a/llvm/test/MC/Disassembler/AArch64/armv8.3a-complex.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv8.3a-complex.txt
@@ -1,7 +1,7 @@
 # RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8.3a,-fullfp16 --disassemble < %s 2>%t | FileCheck %s --check-prefix=CHECK
 # RUN: FileCheck %s < %t --check-prefix=NO-FP16
 # RUN:     llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8.3a,+fullfp16 --disassemble < %s 2>%t | FileCheck %s --check-prefix=CHECK --check-prefix=FP16
-# RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r --disassemble < %s 2>%t | FileCheck %s --check-prefix=CHECK
+# RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r,+complxnum --disassemble < %s 2>%t | FileCheck %s --check-prefix=CHECK
 # RUN: FileCheck %s < %t --check-prefix=NO-FP16
 # RUN: not llvm-mc -triple aarch64-none-linux-gnu -mattr=-v8.3a,+fullfp16 --disassemble < %s 2>&1 | FileCheck %s --check-prefix=NO-V83A
 

--- a/llvm/test/MC/Disassembler/AArch64/armv8.3a-js.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv8.3a-js.txt
@@ -1,4 +1,4 @@
 # RUN: llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8.3a --disassemble < %s | FileCheck %s
-# RUN: llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r --disassemble < %s | FileCheck %s
+# RUN: llvm-mc -triple aarch64-none-linux-gnu -mattr=+v8r,+jsconv --disassemble < %s | FileCheck %s
 # CHECK: fjcvtzs w0, d0
 [0x00,0x00,0x7e,0x1e]


### PR DESCRIPTION
The FP/SIMD instructions are optional for v8-R, so they should not be marked as a dependency of HasV8_0rOps. This had the effect of disabling some v8R-specific system registers when any of these features was disabled.

I've moved these features to be enabled by default for Cortex-R82 (currently the only v8-R AArch64 core), matching the previous behavior, and clang's default.

Based on a patch by Simi Pallipurath <simi.pallipurath@arm.com>