### PR TITLE
[DebugInfo][RemoveDIs] Handle DPValues in SelectOptimize

### DIFF
--- a/llvm/lib/CodeGen/SelectOptimize.cpp
+++ b/llvm/lib/CodeGen/SelectOptimize.cpp
@@ -491,6 +491,21 @@ void SelectOptimizeImpl::convertProfitableSIGroups(SelectGroups &ProfSIGroups) {
       DI->moveBeforePreserving(&*EndBlock->getFirstInsertionPt());
     }
 
+    // Duplicate implementation for DPValues, the non-instruction debug-info
+    // record. Helper lambda for moving DPValues to the end block.
+    auto TransferDPValues = [&](Instruction &I) {
+      for (auto &DPValue : llvm::make_early_inc_range(I.getDbgValueRange())) {
+        DPValue.removeFromParent();
+        EndBlock->insertDPValueBefore(&DPValue, EndBlock->getFirstInsertionPt());
+      }
+    };
+
+    // Iterate over all instructions in between SI and LastSI, not including
+    // SI itself. These are all the variable assignments that happen "in the
+    // middle" of the select group.
+    auto R = make_range(std::next(SI->getIterator()), std::next(LastSI->getIterator()));
+    llvm::for_each(R, TransferDPValues);
+
     // These are the new basic blocks for the conditional branch.
     // At least one will become an actual new basic block.
     BasicBlock *TrueBlock = nullptr, *FalseBlock = nullptr;

--- a/llvm/lib/CodeGen/SelectOptimize.cpp
+++ b/llvm/lib/CodeGen/SelectOptimize.cpp
@@ -496,14 +496,16 @@ void SelectOptimizeImpl::convertProfitableSIGroups(SelectGroups &ProfSIGroups) {
     auto TransferDPValues = [&](Instruction &I) {
       for (auto &DPValue : llvm::make_early_inc_range(I.getDbgValueRange())) {
         DPValue.removeFromParent();
-        EndBlock->insertDPValueBefore(&DPValue, EndBlock->getFirstInsertionPt());
+        EndBlock->insertDPValueBefore(&DPValue,
+                                      EndBlock->getFirstInsertionPt());
       }
     };
 
     // Iterate over all instructions in between SI and LastSI, not including
     // SI itself. These are all the variable assignments that happen "in the
     // middle" of the select group.
-    auto R = make_range(std::next(SI->getIterator()), std::next(LastSI->getIterator()));
+    auto R = make_range(std::next(SI->getIterator()),
+                        std::next(LastSI->getIterator()));
     llvm::for_each(R, TransferDPValues);
 
     // These are the new basic blocks for the conditional branch.

--- a/llvm/test/CodeGen/X86/select-optimize.ll
+++ b/llvm/test/CodeGen/X86/select-optimize.ll
@@ -2,6 +2,9 @@
 ; RUN: opt -mtriple=x86_64-unknown-unknown -select-optimize -S < %s | FileCheck %s
 ; RUN: opt -mtriple=x86_64-unknown-unknown -passes='require<profile-summary>,function(select-optimize)' -S < %s | FileCheck %s
 
+; RUN: opt -mtriple=x86_64-unknown-unknown -select-optimize -S < %s --try-experimental-debuginfo-iterators | FileCheck %s
+; RUN: opt -mtriple=x86_64-unknown-unknown -passes='require<profile-summary>,function(select-optimize)' -S < %s --try-experimental-debuginfo-iterators | FileCheck %s
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test base heuristic 1:
 ;; highly-biased selects assumed to be highly predictable, converted to branches


### PR DESCRIPTION
When there are debug intrinsics in-between groups of select instructions, select-optimise sinks them into the "end" block. This needs to be replicated for DPValues, the non-instruction variable assignment object. Implement that and add a RUN line to a test that was sensitive to this to ensure it gets tested.

(The exact range of instructions being transformed here is a little fiddly, hence I've gone with a helper lambda).