### PR TITLE
[flang] Do not leak intrinsics used by ISO_C_BINDING and ISO_FORTRAN_ENV

### DIFF
--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -28,15 +28,8 @@ module iso_c_binding
   ! to be exported by this MODULE.
   private
 
-  public :: c_associated, &
-    c_funloc, &
-    c_funptr, &
-    c_f_pointer, &
-    c_loc, &
-    c_null_funptr, &
-    c_null_ptr, &
-    c_ptr, &
-    c_sizeof, &
+  public :: c_associated, c_funloc, c_funptr, c_f_pointer, c_loc, &
+    c_null_funptr, c_null_ptr, c_ptr, c_sizeof, &
     operator(==), operator(/=)
 
   ! Table 18.2 (in clause 18.3.1)

--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -22,6 +22,8 @@ module iso_c_binding
     c_sizeof => sizeof, &
     operator(==), operator(/=)
 
+  implicit none
+
   ! Do not leak these intrinsics into the USEing code.
   private :: kind
   private :: achar

--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -22,6 +22,10 @@ module iso_c_binding
     c_sizeof => sizeof, &
     operator(==), operator(/=)
 
+  ! Do not leak these intrinsics into the USEing code.
+  private :: kind
+  private :: achar
+
   ! Table 18.2 (in clause 18.3.1)
   ! TODO: Specialize (via macros?) for alternative targets
   integer, parameter :: &

--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -24,19 +24,30 @@ module iso_c_binding
 
   implicit none
 
-  ! Do not leak these intrinsics into the USEing code.
-  private :: kind
-  private :: achar
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  public :: c_associated, &
+    c_funloc, &
+    c_funptr, &
+    c_f_pointer, &
+    c_loc, &
+    c_null_funptr, &
+    c_null_ptr, &
+    c_ptr, &
+    c_sizeof, &
+    operator(==), operator(/=)
 
   ! Table 18.2 (in clause 18.3.1)
   ! TODO: Specialize (via macros?) for alternative targets
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_int8_t = 1, &
     c_int16_t = 2, &
     c_int32_t = 4, &
     c_int64_t = 8, &
     c_int128_t = 16 ! anticipating future addition
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_int = c_int32_t, &
     c_short = c_int16_t, &
     c_long = c_int64_t, &
@@ -46,7 +57,7 @@ module iso_c_binding
     c_intmax_t = c_int128_t, &
     c_intptr_t = c_size_t, &
     c_ptrdiff_t = c_size_t
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_int_least8_t = c_int8_t, &
     c_int_fast8_t = c_int8_t, &
     c_int_least16_t = c_int16_t, &
@@ -58,7 +69,7 @@ module iso_c_binding
     c_int_least128_t = c_int128_t, &
     c_int_fast128_t = c_int128_t
 
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_float = 4, &
     c_double = 8, &
 #if __x86_64__
@@ -67,30 +78,31 @@ module iso_c_binding
     c_long_double = 16
 #endif
 
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_float_complex = c_float, &
     c_double_complex = c_double, &
     c_long_double_complex = c_long_double
 
-  integer, parameter :: c_bool = 1
-  integer, parameter :: c_char = 1
+  integer, parameter, public :: c_bool = 1
+  integer, parameter, public :: c_char = 1
 
   ! C characters with special semantics
-  character(kind=c_char, len=1), parameter :: c_null_char = achar(0)
-  character(kind=c_char, len=1), parameter :: c_alert = achar(7)
-  character(kind=c_char, len=1), parameter :: c_backspace = achar(8)
-  character(kind=c_char, len=1), parameter :: c_form_feed = achar(12)
-  character(kind=c_char, len=1), parameter :: c_new_line = achar(10)
-  character(kind=c_char, len=1), parameter :: c_carriage_return = achar(13)
-  character(kind=c_char, len=1), parameter :: c_horizontal_tab = achar(9)
-  character(kind=c_char, len=1), parameter :: c_vertical_tab =  achar(11)
+  character(kind=c_char, len=1), parameter, public :: c_null_char = achar(0)
+  character(kind=c_char, len=1), parameter, public :: c_alert = achar(7)
+  character(kind=c_char, len=1), parameter, public :: c_backspace = achar(8)
+  character(kind=c_char, len=1), parameter, public :: c_form_feed = achar(12)
+  character(kind=c_char, len=1), parameter, public :: c_new_line = achar(10)
+  character(kind=c_char, len=1), parameter, public :: c_carriage_return = achar(13)
+  character(kind=c_char, len=1), parameter, public :: c_horizontal_tab = achar(9)
+  character(kind=c_char, len=1), parameter, public :: c_vertical_tab =  achar(11)
 
   interface c_f_procpointer
     module procedure c_f_procpointer
   end interface
+  public :: c_f_procpointer
 
   ! gfortran extensions
-  integer, parameter :: &
+  integer, parameter, public :: &
     c_float128 = 16, &
     c_float128_complex = c_float128
 

--- a/flang/module/iso_fortran_env.f90
+++ b/flang/module/iso_fortran_env.f90
@@ -25,29 +25,33 @@ module iso_fortran_env
 
   implicit none
 
-  ! Do not leak these intrinsics into the USEing code.
-  private :: count
-  private :: selected_char_kind
-  private :: selected_int_kind
-  private :: merge
-  private :: digits
-  private :: int
-  private :: selected_real_kind
-  private :: real
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  public :: event_type, &
+    notify_type, &
+    lock_type, &
+    team_type, &
+    atomic_int_kind, &
+    atomic_logical_kind, &
+    compiler_options, &
+    compiler_version
+
 
   ! TODO: Use PACK([x],test) in place of the array constructor idiom
   ! [(x, integer::j=1,COUNT([test]))] below once PACK() can be folded.
 
-  integer, parameter, private :: &
+  integer, parameter :: &
     selectedASCII = selected_char_kind('ASCII'), &
     selectedUCS_2 = selected_char_kind('UCS-2'), &
     selectedUnicode = selected_char_kind('ISO_10646')
-  integer, parameter :: character_kinds(*) = [ &
+  integer, parameter, public :: character_kinds(*) = [ &
     [(selectedASCII, integer :: j=1, count([selectedASCII >= 0]))], &
     [(selectedUCS_2, integer :: j=1, count([selectedUCS_2 >= 0]))], &
     [(selectedUnicode, integer :: j=1, count([selectedUnicode >= 0]))]]
 
-  integer, parameter, private :: &
+  integer, parameter :: &
     selectedInt8 = selected_int_kind(2), &
     selectedInt16 = selected_int_kind(4), &
     selectedInt32 = selected_int_kind(9), &
@@ -63,7 +67,7 @@ module iso_fortran_env
                       selectedInt64 >= 0), &
     safeInt128 = merge(selectedInt128, selected_int_kind(0), &
                        selectedInt128 >= 0)
-  integer, parameter :: &
+  integer, parameter, public :: &
     int8 = merge(selectedInt8, merge(-2, -1, selectedInt8 >= 0), &
                  digits(int(0,kind=safeInt8)) == 7), &
     int16 = merge(selectedInt16, merge(-2, -1, selectedInt16 >= 0), &
@@ -75,7 +79,7 @@ module iso_fortran_env
     int128 = merge(selectedInt128, merge(-2, -1, selectedInt128 >= 0), &
                    digits(int(0,kind=safeInt128)) == 127)
 
-  integer, parameter :: integer_kinds(*) = [ &
+  integer, parameter, public :: integer_kinds(*) = [ &
     selected_int_kind(0), &
     ((selected_int_kind(k), &
       integer :: j=1, count([selected_int_kind(k) >= 0 .and. &
@@ -83,15 +87,15 @@ module iso_fortran_env
                                selected_int_kind(k-1)])), &
      integer :: k=1, 39)]
 
-  integer, parameter :: &
+  integer, parameter, public :: &
     logical8 = int8, logical16 = int16, logical32 = int32, logical64 = int64
-  integer, parameter :: logical_kinds(*) = [ &
+  integer, parameter, public :: logical_kinds(*) = [ &
     [(logical8, integer :: j=1, count([logical8 >= 0]))], &
     [(logical16, integer :: j=1, count([logical16 >= 0]))], &
     [(logical32, integer :: j=1, count([logical32 >= 0]))], &
     [(logical64, integer :: j=1, count([logical64 >= 0]))]]
 
-  integer, parameter, private :: &
+  integer, parameter :: &
     selectedReal16 = selected_real_kind(3, 4), &      ! IEEE half
     selectedBfloat16 = selected_real_kind(2, 37), &   ! truncated IEEE single
     selectedReal32 = selected_real_kind(6, 37), &     ! IEEE single
@@ -113,7 +117,7 @@ module iso_fortran_env
                          selectedReal64x2 >= 0), &
     safeReal128 = merge(selectedReal128, selected_real_kind(0,0), &
                         selectedReal128 >= 0)
-  integer, parameter :: &
+  integer, parameter, public :: &
     real16 = merge(selectedReal16, merge(-2, -1, selectedReal16 >= 0), &
                    digits(real(0,kind=safeReal16)) == 11), &
     bfloat16 = merge(selectedBfloat16, merge(-2, -1, selectedBfloat16 >= 0), &
@@ -129,7 +133,7 @@ module iso_fortran_env
     real128 = merge(selectedReal128, merge(-2, -1, selectedReal128 >= 0), &
                     digits(real(0,kind=safeReal128)) == 113)
 
-  integer, parameter :: real_kinds(*) = [ &
+  integer, parameter, public :: real_kinds(*) = [ &
     [(real16, integer :: j=1, count([real16 >= 0]))], &
     [(bfloat16, integer :: j=1, count([bfloat16 >= 0]))], &
     [(real32, integer :: j=1, count([real32 >= 0]))], &
@@ -138,27 +142,27 @@ module iso_fortran_env
     [(real64x2, integer :: j=1, count([real64x2 >= 0]))], &
     [(real128, integer :: j=1, count([real128 >= 0]))]]
 
-  integer, parameter :: current_team = -1, initial_team = -2, parent_team = -3
+  integer, parameter, public :: current_team = -1, initial_team = -2, parent_team = -3
 
-  integer, parameter :: output_unit = FORTRAN_DEFAULT_OUTPUT_UNIT
-  integer, parameter :: input_unit = FORTRAN_DEFAULT_INPUT_UNIT
-  integer, parameter :: error_unit = FORTRAN_ERROR_UNIT
-  integer, parameter :: iostat_end = FORTRAN_RUNTIME_IOSTAT_END
-  integer, parameter :: iostat_eor = FORTRAN_RUNTIME_IOSTAT_EOR
-  integer, parameter :: iostat_inquire_internal_unit = &
+  integer, parameter, public :: output_unit = FORTRAN_DEFAULT_OUTPUT_UNIT
+  integer, parameter, public :: input_unit = FORTRAN_DEFAULT_INPUT_UNIT
+  integer, parameter, public :: error_unit = FORTRAN_ERROR_UNIT
+  integer, parameter, public :: iostat_end = FORTRAN_RUNTIME_IOSTAT_END
+  integer, parameter, public :: iostat_eor = FORTRAN_RUNTIME_IOSTAT_EOR
+  integer, parameter, public :: iostat_inquire_internal_unit = &
                           FORTRAN_RUNTIME_IOSTAT_INQUIRE_INTERNAL_UNIT
 
-  integer, parameter :: character_storage_size = 8
-  integer, parameter :: file_storage_size = 8
-  integer, parameter :: numeric_storage_size = 32
+  integer, parameter, public :: character_storage_size = 8
+  integer, parameter, public :: file_storage_size = 8
+  integer, parameter, public :: numeric_storage_size = 32
 
-  integer, parameter :: stat_failed_image = FORTRAN_RUNTIME_STAT_FAILED_IMAGE
-  integer, parameter :: stat_locked = FORTRAN_RUNTIME_STAT_LOCKED
-  integer, parameter :: &
+  integer, parameter, public :: stat_failed_image = FORTRAN_RUNTIME_STAT_FAILED_IMAGE
+  integer, parameter, public :: stat_locked = FORTRAN_RUNTIME_STAT_LOCKED
+  integer, parameter, public :: &
     stat_locked_other_image = FORTRAN_RUNTIME_STAT_LOCKED_OTHER_IMAGE
-  integer, parameter :: stat_stopped_image = FORTRAN_RUNTIME_STAT_STOPPED_IMAGE
-  integer, parameter :: stat_unlocked = FORTRAN_RUNTIME_STAT_UNLOCKED
-  integer, parameter :: &
+  integer, parameter, public :: stat_stopped_image = FORTRAN_RUNTIME_STAT_STOPPED_IMAGE
+  integer, parameter, public :: stat_unlocked = FORTRAN_RUNTIME_STAT_UNLOCKED
+  integer, parameter, public :: &
     stat_unlocked_failed_image = FORTRAN_RUNTIME_STAT_UNLOCKED_FAILED_IMAGE
 
 end module iso_fortran_env

--- a/flang/module/iso_fortran_env.f90
+++ b/flang/module/iso_fortran_env.f90
@@ -24,7 +24,16 @@ module iso_fortran_env
     compiler_version => __builtin_compiler_version
 
   implicit none
-  private count
+
+  ! Do not leak these intrinsics into the USEing code.
+  private :: count
+  private :: selected_char_kind
+  private :: selected_int_kind
+  private :: merge
+  private :: digits
+  private :: int
+  private :: selected_real_kind
+  private :: real
 
   ! TODO: Use PACK([x],test) in place of the array constructor idiom
   ! [(x, integer::j=1,COUNT([test]))] below once PACK() can be folded.

--- a/flang/module/iso_fortran_env.f90
+++ b/flang/module/iso_fortran_env.f90
@@ -29,13 +29,8 @@ module iso_fortran_env
   ! to be exported by this MODULE.
   private
 
-  public :: event_type, &
-    notify_type, &
-    lock_type, &
-    team_type, &
-    atomic_int_kind, &
-    atomic_logical_kind, &
-    compiler_options, &
+  public :: event_type, notify_type, lock_type, team_type, &
+    atomic_int_kind, atomic_logical_kind, compiler_options, &
     compiler_version
 
 


### PR DESCRIPTION
This resolves bug #78953.  Intrinsics used by the MODULE definition are being declared PRIVATE, so that they do not leak into the namespace of the code that USEs the modules.