### PR TITLE
[flang][driver] deprecate manual usage of -lFortran_main

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -427,6 +427,8 @@ def warn_drv_clang_unsupported : Warning<
   "the clang compiler does not support '%0'">;
 def warn_drv_deprecated_arg : Warning<
   "argument '%0' is deprecated, use '%1' instead">, InGroup<Deprecated>;
+def warn_drv_deprecated_custom : Warning<
+  "argument '%0' is deprecated, %1">, InGroup<Deprecated>;
 def warn_drv_assuming_mfloat_abi_is : Warning<
   "unknown platform, assuming -mfloat-abi=%0">;
 def warn_drv_unsupported_float_abi_by_lib : Warning<

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1193,6 +1193,16 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
     return;
   }
 
+  const Driver &D = TC.getDriver();
+  const char *LinkFlag = "-lFortran_main";
+
+  // warn if -lFortran_main was already specified
+  for (const char *arg : CmdArgs) {
+    if (strncmp(arg, LinkFlag, strlen(LinkFlag)) == 0)
+      D.Diag(diag::warn_drv_deprecated_custom)
+          << LinkFlag << "see the flang driver documentation for correct usage";
+  }
+
   // 2. GNU and similar
   // The --whole-archive option needs to be part of the link line to make
   // sure that the main() function from Fortran_main.a is pulled in by the
@@ -1201,12 +1211,12 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
   if (!isWholeArchivePresent(Args) && !TC.getTriple().isMacOSX() &&
       !TC.getTriple().isOSAIX()) {
     CmdArgs.push_back("--whole-archive");
-    CmdArgs.push_back("-lFortran_main");
+    CmdArgs.push_back(LinkFlag);
     CmdArgs.push_back("--no-whole-archive");
     return;
   }
 
-  CmdArgs.push_back("-lFortran_main");
+  CmdArgs.push_back(LinkFlag);
 }
 
 /// Add Fortran runtime libs

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1193,17 +1193,19 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
     return;
   }
 
+  // 2. GNU and similar
   const Driver &D = TC.getDriver();
-  const char *LinkFlag = "-lFortran_main";
+  const char *FortranMainLinkFlag = "-lFortran_main";
 
-  // warn if -lFortran_main was already specified
+  // Warn if the user added `-lFortran_main` - this library is an implementation
+  // detail of Flang and should be handled automaticaly by the driver.
   for (const char *arg : CmdArgs) {
-    if (strncmp(arg, LinkFlag, strlen(LinkFlag)) == 0)
+    if (strncmp(arg, FortranMainLinkFlag, strlen(FortranMainLinkFlag)) == 0)
       D.Diag(diag::warn_drv_deprecated_custom)
-          << LinkFlag << "see the flang driver documentation for correct usage";
+          << FortranMainLinkFlag
+          << "see the Flang driver documentation for correct usage";
   }
 
-  // 2. GNU and similar
   // The --whole-archive option needs to be part of the link line to make
   // sure that the main() function from Fortran_main.a is pulled in by the
   // linker. However, it shouldn't be used if it's already active.
@@ -1211,12 +1213,12 @@ static void addFortranMain(const ToolChain &TC, const ArgList &Args,
   if (!isWholeArchivePresent(Args) && !TC.getTriple().isMacOSX() &&
       !TC.getTriple().isOSAIX()) {
     CmdArgs.push_back("--whole-archive");
-    CmdArgs.push_back(LinkFlag);
+    CmdArgs.push_back(FortranMainLinkFlag);
     CmdArgs.push_back("--no-whole-archive");
     return;
   }
 
-  CmdArgs.push_back(LinkFlag);
+  CmdArgs.push_back(FortranMainLinkFlag);
 }
 
 /// Add Fortran runtime libs

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -56,4 +56,4 @@
 ! MSVC-SAME: "[[object_file]]"
 
 ! Check that we warn when using -lFortran_main
-! DEPRECATED: warning: argument '-lFortran_main' is deprecated, see the flang driver documentation for correct usage [-Wdeprecated]
+! DEPRECATED: warning: argument '-lFortran_main' is deprecated, see the Flang driver documentation for correct usage [-Wdeprecated]

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -11,6 +11,7 @@
 ! RUN: %flang -### --target=x86_64-unknown-dragonfly %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX
 ! RUN: %flang -### --target=x86_64-unknown-haiku %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,HAIKU
 ! RUN: %flang -### --target=x86_64-windows-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MINGW
+! RUN: %flang -### --target=aarch64-unknown-linux-gnu %S/Inputs/hello.f90 -lFortran_main 2>&1 | FileCheck %s --check-prefixes=DEPRECATED
 
 ! NOTE: Clang's driver library, clangDriver, usually adds 'oldnames' on Windows,
 !       but it is not needed when compiling Fortran code and they might bring in
@@ -53,3 +54,6 @@
 ! MSVC-LABEL: link
 ! MSVC-SAME: /subsystem:console
 ! MSVC-SAME: "[[object_file]]"
+
+! Check that we warn when using -lFortran_main
+! DEPRECATED: warning: argument '-lFortran_main' is deprecated, see the flang driver documentation for correct usage [-Wdeprecated]


### PR DESCRIPTION
Intended to warn users of the 18.x release not to do this.

A better solution should be found for the 19.x release. See discussion in https://github.com/llvm/llvm-project/pull/78152.

Unfortunately there is no warning on Windows currently. I am rushing to get this landed before 19.x branches.