### PR TITLE
[clang][driver] Add -mtls-dialect option

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -359,6 +359,9 @@ ENUM_CODEGENOPT(VecLib, llvm::driver::VectorLibrary, 3, llvm::driver::VectorLibr
 /// The default TLS model to use.
 ENUM_CODEGENOPT(DefaultTLSModel, TLSModel, 2, GeneralDynamicTLSModel)
 
+/// The default TLS model to use.
+ENUM_CODEGENOPT(DefaultTLSDialect, TLSDialect, 2, TraditionalTLSDialect)
+
 /// Bit size of immediate TLS offsets (0 == use the default).
 VALUE_CODEGENOPT(TLSSize, 8, 0)
 

--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -72,6 +72,11 @@ public:
     LocalExecTLSModel
   };
 
+  enum TLSDialect {
+    TraditionalTLSDialect,
+    TLSDescTLSDialect,
+  };
+
   enum StructReturnConventionKind {
     SRCK_Default,  // No special option was passed.
     SRCK_OnStack,  // Small structs on the stack (-fpcc-struct-return).

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4403,6 +4403,13 @@ def mtls_size_EQ : Joined<["-"], "mtls-size=">, Group<m_Group>,
   HelpText<"Specify bit size of immediate TLS offsets (AArch64 ELF only): "
            "12 (for 4KB) | 24 (for 16MB, default) | 32 (for 4GB) | 48 (for 256TB, needs -mcmodel=large)">,
   MarshallingInfoInt<CodeGenOpts<"TLSSize">>;
+def mtls_dialect_EQ : Joined<["-"], "mtls-dialect=">, Group<m_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Use the given thread-local storage dialect">,
+  Values<"trad,desc">,
+  NormalizedValuesScope<"CodeGenOptions">,
+  NormalizedValues<["TraditionalTLSDialect", "TLSDescTLSDialect"]>,
+  MarshallingInfoEnum<CodeGenOpts<"DefaultTLSDialect">, "TraditionalTLSDialect">;
 def mimplicit_it_EQ : Joined<["-"], "mimplicit-it=">, Group<m_Group>;
 def mdefault_build_attributes : Joined<["-"], "mdefault-build-attributes">, Group<m_Group>;
 def mno_default_build_attributes : Joined<["-"], "mno-default-build-attributes">, Group<m_Group>;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -401,6 +401,8 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
   Options.UniqueBasicBlockSectionNames =
       CodeGenOpts.UniqueBasicBlockSectionNames;
   Options.TLSSize = CodeGenOpts.TLSSize;
+  // TODO: Add correct codegen options in LLVM
+  // Options.TLSDesc = CodeGenOpts.getDefaultTLSDialect();
   Options.EmulatedTLS = CodeGenOpts.EmulatedTLS;
   Options.DebuggerTuning = CodeGenOpts.getDebuggerTuning();
   Options.EmitStackSizeSection = CodeGenOpts.StackSizeSection;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5812,6 +5812,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     Args.AddLastArg(CmdArgs, options::OPT_mtls_size_EQ);
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_mtls_dialect_EQ)) {
+    // mlts-dialect= is ELF only
+    if (!Triple.isOSBinFormatELF())
+      D.Diag(diag::err_drv_unsupported_opt_for_target)
+          << A->getOption().getName() << TripleStr;
+    Args.AddLastArg(CmdArgs, options::OPT_mtls_dialect_EQ);
+  }
+
   // Add the target cpu
   std::string CPU = getCPUName(D, Args, Triple, /*FromAs*/ false);
   if (!CPU.empty()) {

--- a/clang/test/Driver/tls-dialect.c
+++ b/clang/test/Driver/tls-dialect.c
@@ -1,0 +1,15 @@
+/// Options for ELF
+// RUN: %clang -### -target aarch64-linux-gnu -mtls-dialect=trad %s 2>&1 | FileCheck -check-prefix=TRAD %s
+// RUN: %clang -### -target aarch64-linux-gnu -mtls-dialect=desc %s 2>&1 | FileCheck -check-prefix=DESC %s
+
+/// Unsupported target
+// RUN: not %clang -target aarch64-unknown-windows-msvc -mtls-dialect=trad %s 2>&1 | FileCheck -check-prefix=UNSUPPORTED-TARGET %s
+// RUN: not %clang -target aarch64-unknown-windows-msvc -mtls-dialect=desc %s 2>&1 | FileCheck -check-prefix=UNSUPPORTED-TARGET %s
+
+/// Invalid option value
+// RUN: not %clang -target x86_64-linux-gnu -mtls-dialect=foo %s 2>&1 | FileCheck -check-prefix=INVALID-VALUE %s
+
+// TRAD: "-cc1" {{.*}}"-mtls-dialect=trad"
+// DESC: "-cc1" {{.*}}"-mtls-dialect=desc"
+// UNSUPPORTED-TARGET: error: unsupported option
+// INVALID-VALUE: error: invalid value 'foo' in '-mtls-dialect=foo'


### PR DESCRIPTION
GCC an other ELF compilers support -mlts-dialect= options to control the
use of ELF TLS Descriptors as part of the TLS model. This patch only
adds support to the clang driver for the flag. Support for the
EnableTLSDesc code generation option in LLVM is added separately.
