### PR TITLE
[libc][riscv] Check if we have F or D extension before using them

### DIFF
--- a/libc/src/__support/FPUtil/riscv/FMA.h
+++ b/libc/src/__support/FPUtil/riscv/FMA.h
@@ -26,6 +26,7 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
+#if defined(__riscv_flen)
 template <typename T>
 LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, float>, T> fma(T x, T y, T z) {
   float result;
@@ -35,6 +36,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, float>, T> fma(T x, T y, T z) {
   return result;
 }
 
+#if __riscv_flen == 64
 template <typename T>
 LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, double>, T> fma(T x, T y, T z) {
   double result;
@@ -43,6 +45,8 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, double>, T> fma(T x, T y, T z) {
                   : "f"(x), "f"(y), "f"(z));
   return result;
 }
+#endif // __riscv_flen == 64
+#endif // defined(__riscv_flen)
 
 } // namespace fputil
 } // namespace LIBC_NAMESPACE

--- a/libc/src/__support/FPUtil/riscv/FMA.h
+++ b/libc/src/__support/FPUtil/riscv/FMA.h
@@ -26,7 +26,7 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
-#if defined(__riscv_flen)
+#ifdef __riscv_flen
 template <typename T>
 LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, float>, T> fma(T x, T y, T z) {
   float result;
@@ -36,7 +36,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, float>, T> fma(T x, T y, T z) {
   return result;
 }
 
-#if __riscv_flen == 64
+#if __riscv_flen >= 64
 template <typename T>
 LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, double>, T> fma(T x, T y, T z) {
   double result;
@@ -45,8 +45,8 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_same_v<T, double>, T> fma(T x, T y, T z) {
                   : "f"(x), "f"(y), "f"(z));
   return result;
 }
-#endif // __riscv_flen == 64
-#endif // defined(__riscv_flen)
+#endif // __riscv_flen >= 64
+#endif // __riscv_flen
 
 } // namespace fputil
 } // namespace LIBC_NAMESPACE

--- a/libc/src/__support/FPUtil/riscv/sqrt.h
+++ b/libc/src/__support/FPUtil/riscv/sqrt.h
@@ -21,21 +21,21 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
-#if defined(__riscv_flen)
+#ifdef __riscv_flen
 template <> LIBC_INLINE float sqrt<float>(float x) {
   float result;
   __asm__ __volatile__("fsqrt.s %0, %1\n\t" : "=f"(result) : "f"(x));
   return result;
 }
 
-#if __riscv_flen == 64
+#if __riscv_flen >= 64
 template <> LIBC_INLINE double sqrt<double>(double x) {
   double result;
   __asm__ __volatile__("fsqrt.d %0, %1\n\t" : "=f"(result) : "f"(x));
   return result;
 }
-#endif // __riscv_flen == 64
-#endif // defined(__riscv_flen)
+#endif // __riscv_flen >= 64
+#endif // __riscv_flen
 
 } // namespace fputil
 } // namespace LIBC_NAMESPACE

--- a/libc/src/__support/FPUtil/riscv/sqrt.h
+++ b/libc/src/__support/FPUtil/riscv/sqrt.h
@@ -21,17 +21,21 @@
 namespace LIBC_NAMESPACE {
 namespace fputil {
 
+#if defined(__riscv_flen)
 template <> LIBC_INLINE float sqrt<float>(float x) {
   float result;
   __asm__ __volatile__("fsqrt.s %0, %1\n\t" : "=f"(result) : "f"(x));
   return result;
 }
 
+#if __riscv_flen == 64
 template <> LIBC_INLINE double sqrt<double>(double x) {
   double result;
   __asm__ __volatile__("fsqrt.d %0, %1\n\t" : "=f"(result) : "f"(x));
   return result;
 }
+#endif // __riscv_flen == 64
+#endif // defined(__riscv_flen)
 
 } // namespace fputil
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
We shouldn't be using instructions that require F or D extensions unconditionally before checking if those instructions are available.