### PR TITLE
[libc++] Fix linking for platforms that don't implement std::exception_ptr

### DIFF
--- a/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
+++ b/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
@@ -30,6 +30,12 @@ exception_ptr& exception_ptr::operator=(const exception_ptr& other) noexcept {
   ::abort();
 }
 
+exception_ptr exception_ptr::__from_native_exception_pointer(void *__e) noexcept {
+#warning exception_ptr not yet implemented
+  fprintf(stderr, "exception_ptr not yet implemented\n");
+  ::abort();
+}
+
 nested_exception::nested_exception() noexcept : __ptr_(current_exception()) {}
 
 #if !defined(__GLIBCXX__)


### PR DESCRIPTION
This patch fixes linkage for platforms that don't implement `std::exception_ptr`, as such setup was overlooked in https://github.com/llvm/llvm-project/pull/65534