### PR TITLE
[FatLTO] output of -ffat-lto-objects -S should be assembly.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4764,10 +4764,11 @@ Action *Driver::ConstructPhaseAction(
   case phases::Backend: {
     if (isUsingLTO() && TargetDeviceOffloadKind == Action::OFK_None) {
       types::ID Output;
-      if (Args.hasArg(options::OPT_S))
+      if (Args.hasArg(options::OPT_ffat_lto_objects))
+        Output = Args.hasArg(options::OPT_emit_llvm) ? types::TY_LTO_IR
+                                                     : types::TY_PP_Asm;
+      else if (Args.hasArg(options::OPT_S))
         Output = types::TY_LTO_IR;
-      else if (Args.hasArg(options::OPT_ffat_lto_objects))
-        Output = types::TY_PP_Asm;
       else
         Output = types::TY_LTO_BC;
       return C.MakeAction<BackendJobAction>(Input, Output);

--- a/clang/test/Driver/fat-lto-objects.c
+++ b/clang/test/Driver/fat-lto-objects.c
@@ -12,13 +12,26 @@
 // CHECK-CC-S-NOT: -emit-llvm
 // CHECK-CC-S-NOT: -ffat-lto-objects
 
-/// When LTO is enabled, we expect LLVM IR output and -ffat-lto-objects to be passed to cc1.
+/// When fat LTO is enabled with -S, we expect asm output and -ffat-lto-objects to be passed to cc1.
 // RUN: %clang --target=x86_64-unknown-linux-gnu -flto -ffat-lto-objects -### %s -S 2>&1 | FileCheck %s -check-prefix=CHECK-CC-S-LTO
-// RUN: %clang --target=x86_64-unknown-linux-gnu -flto -ffat-lto-objects -### %s -S -emit-llvm 2>&1 | FileCheck %s -check-prefix=CHECK-CC-S-LTO
 // CHECK-CC-S-LTO: -cc1
 // CHECK-CC-S-LTO-SAME: -funified-lto
-// CHECK-CC-S-LTO-SAME: -emit-llvm
+// CHECK-CC-S-NOT: -emit-llvm
 // CHECK-CC-S-LTO-SAME: -ffat-lto-objects
+
+/// When fat LTO is enabled with -S and -emit-llvm, we expect IR output and -ffat-lto-objects to be passed to cc1.
+// RUN: %clang --target=x86_64-unknown-linux-gnu -flto -ffat-lto-objects -### %s -S -emit-llvm 2>&1 | FileCheck %s -check-prefix=CHECK-CC-S-EL-LTO
+// CHECK-CC-S-EL-LTO: -cc1
+// CHECK-CC-S-EL-LTO-SAME: -funified-lto
+// CHECK-CC-S-EL-LTO-SAME: -emit-llvm
+// CHECK-CC-S-EL-LTO-SAME: -ffat-lto-objects
+
+/// When fat LTO is enabled wihtout -S we expect native object output and -ffat-lto-object to be passed to cc1.
+// RUN: %clang --target=x86_64-unknown-linux-gnu -flto -ffat-lto-objects -### %s -c 2>&1 | FileCheck %s -check-prefix=CHECK-CC-C-LTO
+// CHECK-CC-C-LTO: -cc1
+// CHECK-CC-C-LTO: -funified-lto
+// CHECK-CC-C-LTO: -emit-obj
+// CHECK-CC-C-LTO: -ffat-lto-objects
 
 /// Make sure we don't have a warning for -ffat-lto-objects being unused
 // RUN: %clang --target=x86_64-unknown-linux-gnu -ffat-lto-objects -fdriver-only -Werror -v %s -c 2>&1 | FileCheck %s -check-prefix=CHECK-CC-NOLTO


### PR DESCRIPTION
Fat lto with -c compiles to an object file with the IR embedded in a section of the object, the combination of fat-lto with -S should then produce an assembly file equivalent of that. The IR output can still be genreated by using both -S and -emit-llvm.