### PR TITLE
[JITLink][AArch32] Implement R_ARM_PREL31 and process .ARM.exidx sections

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -41,6 +41,8 @@ enum EdgeKind_aarch32 : Edge::Kind {
   /// Absolute 32-bit value relocation
   Data_Pointer32,
 
+  Data_PRel31,
+
   /// Create GOT entry and store offset
   Data_RequestGOTAndTransformToDelta32,
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -41,6 +41,7 @@ enum EdgeKind_aarch32 : Edge::Kind {
   /// Absolute 32-bit value relocation
   Data_Pointer32,
 
+  /// Relative 31-bit value relocation that preserves the most-significant bit
   Data_PRel31,
 
   /// Create GOT entry and store offset

--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -397,6 +397,11 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySections() {
                                   orc::ExecutorAddr(Sec.sh_addr),
                                   Sec.sh_addralign, 0);
 
+    if (Sec.sh_type == ELF::SHT_ARM_EXIDX) {
+      // Add live symbol to avoid dead-stripping for .ARM.exidx sections
+      G->addAnonymousSymbol(*B, orc::ExecutorAddrDiff(), orc::ExecutorAddrDiff(), false, true);
+    }
+
     setGraphBlock(SecIndex, B);
   }
 

--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -399,7 +399,8 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySections() {
 
     if (Sec.sh_type == ELF::SHT_ARM_EXIDX) {
       // Add live symbol to avoid dead-stripping for .ARM.exidx sections
-      G->addAnonymousSymbol(*B, orc::ExecutorAddrDiff(), orc::ExecutorAddrDiff(), false, true);
+      G->addAnonymousSymbol(*B, orc::ExecutorAddrDiff(),
+                            orc::ExecutorAddrDiff(), false, true);
     }
 
     setGraphBlock(SecIndex, B);

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -397,6 +397,8 @@ Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
   case Data_Pointer32:
   case Data_RequestGOTAndTransformToDelta32:
     return SignExtend64<32>(support::endian::read32(FixupPtr, Endian));
+  case Data_PRel31:
+    return SignExtend64<31>(support::endian::read32(FixupPtr, Endian));
   default:
     return make_error<JITLinkError>(
         "In graph " + G.getName() + ", section " + B.getSection().getName() +
@@ -471,9 +473,8 @@ Error applyFixupData(LinkGraph &G, Block &B, const Edge &E) {
   Symbol &TargetSymbol = E.getTarget();
   uint64_t TargetAddress = TargetSymbol.getAddress().getValue();
 
-  // Regular data relocations have size 4, alignment 1 and write the full 32-bit
-  // result to the place; no need for overflow checking. There are three
-  // exceptions: R_ARM_ABS8, R_ARM_ABS16, R_ARM_PREL31
+  // Data relocations have alignment 1, size 4 (except R_ARM_ABS8 and
+  // R_ARM_ABS16) and write the full 32-bit result (except R_ARM_PREL31).
   switch (Kind) {
   case Data_Delta32: {
     int64_t Value = TargetAddress - FixupAddress + Addend;
@@ -493,6 +494,19 @@ Error applyFixupData(LinkGraph &G, Block &B, const Edge &E) {
       endian::write32le(FixupPtr, Value);
     else
       endian::write32be(FixupPtr, Value);
+    return Error::success();
+  }
+  case Data_PRel31: {
+    int64_t Value = TargetAddress - FixupAddress + Addend;
+    if (!isInt<31>(Value))
+      return makeTargetOutOfRangeError(G, B, E);
+    if (LLVM_LIKELY(G.getEndianness() == endianness::little)) {
+      uint32_t MSB = endian::read32le(FixupPtr) & 0x80000000;
+      endian::write32le(FixupPtr, MSB | (Value & ~0x80000000));
+    } else {
+      uint32_t MSB = endian::read32be(FixupPtr) & 0x80000000;
+      endian::write32be(FixupPtr, MSB | (Value & ~0x80000000));
+    }
     return Error::success();
   }
   case Data_RequestGOTAndTransformToDelta32:
@@ -755,6 +769,7 @@ const char *getEdgeKindName(Edge::Kind K) {
   switch (K) {
     KIND_NAME_CASE(Data_Delta32)
     KIND_NAME_CASE(Data_Pointer32)
+    KIND_NAME_CASE(Data_PRel31)
     KIND_NAME_CASE(Data_RequestGOTAndTransformToDelta32)
     KIND_NAME_CASE(Arm_Call)
     KIND_NAME_CASE(Arm_Jump24)

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_data.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_data.s
@@ -64,7 +64,7 @@ got_prel_offset:
 	.size	got_prel_offset, .-got_prel_offset
 	.size	got_prel, .-got_prel
 
-# EH personality routine
+# EH personality routine in .ARM.exidx
 # CHECK-TYPE: {{[0-9a-f]+}} R_ARM_NONE __aeabi_unwind_cpp_pr0
 	.globl __aeabi_unwind_cpp_pr0
 	.type __aeabi_unwind_cpp_pr0,%function
@@ -72,8 +72,19 @@ got_prel_offset:
 __aeabi_unwind_cpp_pr0:
 	bx lr
 
-# Generate reference to EH personality (right now we ignore the resulting
-# R_ARM_PREL31 relocation since it's in .ARM.exidx)
+# CHECK-TYPE: {{[0-9a-f]+}} R_ARM_PREL31 .text
+#
+# An .ARM.exidx table entry is 8-bytes in size, made up of 2 4-byte entries.
+# First word contains offset to function for this entry:
+# jitlink-check: (*{4}section_addr(out.o, .ARM.exidx))[31:0] = prel31 - section_addr(out.o, .ARM.exidx)
+#
+# Most-significant bit in second word denotes inline entry when set (and
+# relocation to .ARM.extab otherwise). Inline entry with compact model index 0:
+#   0x9b      vsp = r11
+#   0x84 0x80 pop {r11, r14}
+#
+# jitlink-check: *{4}(section_addr(out.o, .ARM.exidx) + 4) = 0x809b8480
+#
 	.globl  prel31
 	.type   prel31,%function
 	.align  2
@@ -85,8 +96,8 @@ prel31:
 	mov     r11, sp
 	pop     {r11, lr}
 	mov     pc, lr
-	.size   prel31,.-prel31
 	.fnend
+	.size   prel31,.-prel31
 
 # This test is executable with any 4-byte external target:
 #  > echo "unsigned target = 42;" | clang -target armv7-linux-gnueabihf -o target.o -c -xc -
@@ -98,5 +109,6 @@ prel31:
 main:
 	push	{lr}
 	bl	got_prel
+	bl	prel31
 	pop	{pc}
 	.size   main, .-main


### PR DESCRIPTION
`R_ARM_PREL31` is a 31-bits relative data relocation where the most-significant bit is preserved. It's used primarily in `.ARM.exidx` sections, which we skipped processing until now, because we didn't support the relocation type. This was implemented in RuntimeDyld with https://reviews.llvm.org/D25069 and I implemented it in a similar way in JITLink in order to reach feature parity.