### PR TITLE
[lldb][NFCI] Remove EventData* parameter from BroadcastEventIfUnique

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3216,6 +3216,8 @@ private:
   Status LaunchPrivate(ProcessLaunchInfo &launch_info, lldb::StateType &state,
                        lldb::EventSP &event_sp);
 
+  lldb::EventSP CreateEventFromProcessState(uint32_t event_type);
+
   Process(const Process &) = delete;
   const Process &operator=(const Process &) = delete;
 };

--- a/lldb/include/lldb/Utility/Broadcaster.h
+++ b/lldb/include/lldb/Utility/Broadcaster.h
@@ -181,9 +181,8 @@ public:
     m_broadcaster_sp->BroadcastEvent(event_type);
   }
 
-  void BroadcastEventIfUnique(uint32_t event_type,
-                              EventData *event_data = nullptr) {
-    m_broadcaster_sp->BroadcastEventIfUnique(event_type, event_data);
+  void BroadcastEventIfUnique(uint32_t event_type) {
+    m_broadcaster_sp->BroadcastEventIfUnique(event_type);
   }
 
   void Clear() { m_broadcaster_sp->Clear(); }
@@ -351,8 +350,7 @@ protected:
     void BroadcastEvent(uint32_t event_type,
                         const lldb::EventDataSP &event_data_sp);
 
-    void BroadcastEventIfUnique(uint32_t event_type,
-                                EventData *event_data = nullptr);
+    void BroadcastEventIfUnique(uint32_t event_type);
 
     void Clear();
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4281,25 +4281,31 @@ void Process::CalculateExecutionContext(ExecutionContext &exe_ctx) {
 //    return Host::GetArchSpecForExistingProcess (process_name);
 //}
 
+EventSP Process::CreateEventFromProcessState(uint32_t event_type) {
+  auto event_data_sp =
+      std::make_shared<ProcessEventData>(shared_from_this(), GetState());
+  return std::make_shared<Event>(event_type, event_data_sp);
+}
+
 void Process::AppendSTDOUT(const char *s, size_t len) {
   std::lock_guard<std::recursive_mutex> guard(m_stdio_communication_mutex);
   m_stdout_data.append(s, len);
-  BroadcastEventIfUnique(eBroadcastBitSTDOUT,
-                         new ProcessEventData(shared_from_this(), GetState()));
+  auto event_sp = CreateEventFromProcessState(eBroadcastBitSTDOUT);
+  BroadcastEventIfUnique(event_sp);
 }
 
 void Process::AppendSTDERR(const char *s, size_t len) {
   std::lock_guard<std::recursive_mutex> guard(m_stdio_communication_mutex);
   m_stderr_data.append(s, len);
-  BroadcastEventIfUnique(eBroadcastBitSTDERR,
-                         new ProcessEventData(shared_from_this(), GetState()));
+  auto event_sp = CreateEventFromProcessState(eBroadcastBitSTDERR);
+  BroadcastEventIfUnique(event_sp);
 }
 
 void Process::BroadcastAsyncProfileData(const std::string &one_profile_data) {
   std::lock_guard<std::recursive_mutex> guard(m_profile_data_comm_mutex);
   m_profile_data.push_back(one_profile_data);
-  BroadcastEventIfUnique(eBroadcastBitProfileData,
-                         new ProcessEventData(shared_from_this(), GetState()));
+  auto event_sp = CreateEventFromProcessState(eBroadcastBitProfileData);
+  BroadcastEventIfUnique(event_sp);
 }
 
 void Process::BroadcastStructuredData(const StructuredData::ObjectSP &object_sp,

--- a/lldb/source/Utility/Broadcaster.cpp
+++ b/lldb/source/Utility/Broadcaster.cpp
@@ -311,9 +311,8 @@ void Broadcaster::BroadcasterImpl::BroadcastEvent(
   PrivateBroadcastEvent(event_sp, false);
 }
 
-void Broadcaster::BroadcasterImpl::BroadcastEventIfUnique(
-    uint32_t event_type, EventData *event_data) {
-  auto event_sp = std::make_shared<Event>(event_type, event_data);
+void Broadcaster::BroadcasterImpl::BroadcastEventIfUnique(uint32_t event_type) {
+  auto event_sp = std::make_shared<Event>(event_type, /*data = */ nullptr);
   PrivateBroadcastEvent(event_sp, true);
 }
 


### PR DESCRIPTION
Instead of passing the data to BroadcastEventIfUnique to create an Event object on the behalf of the caller, the caller can create the Event up-front.