### PR TITLE
[flang] Accept OPEN(...,CONVERT="SWAP") in semantics

### DIFF
--- a/flang/lib/Semantics/check-io.cpp
+++ b/flang/lib/Semantics/check-io.cpp
@@ -918,7 +918,7 @@ void IoChecker::CheckStringValue(IoSpecKind specKind, const std::string &value,
           // Open values; Close values are {"DELETE", "KEEP"}.
           {"NEW", "OLD", "REPLACE", "SCRATCH", "UNKNOWN"}},
       {IoSpecKind::Carriagecontrol, {"LIST", "FORTRAN", "NONE"}},
-      {IoSpecKind::Convert, {"BIG_ENDIAN", "LITTLE_ENDIAN", "NATIVE"}},
+      {IoSpecKind::Convert, {"BIG_ENDIAN", "LITTLE_ENDIAN", "NATIVE", "SWAP"}},
       {IoSpecKind::Dispose, {"DELETE", "KEEP"}},
   };
   auto upper{Normalize(value)};


### PR DESCRIPTION
The runtime implements CONVERT="SWAP", but semantics doesn't like it.  Add it to the relevant table.

Fixes llvm-test-suite/Fortran/gfortran/regression/record_marker_1.f90, .../unf_io_convert_1.f90, .../unf_io_convert_2.f90, and .../unf_io_convert_3.f90.