### PR TITLE
[Format] Fix detection of languages when reading from stdin

### DIFF
--- a/clang/test/Format/dump-config-objc-stdin.m
+++ b/clang/test/Format/dump-config-objc-stdin.m
@@ -1,0 +1,5 @@
+// RUN: clang-format -dump-config - < %s | FileCheck %s
+
+// CHECK: Language: ObjC
+@interface Foo
+@end

--- a/clang/unittests/Format/FormatTestObjC.cpp
+++ b/clang/unittests/Format/FormatTestObjC.cpp
@@ -31,6 +31,14 @@ protected:
   _verifyIncompleteFormat(__FILE__, __LINE__, __VA_ARGS__)
 #define verifyFormat(...) _verifyFormat(__FILE__, __LINE__, __VA_ARGS__)
 
+TEST(FormatTestObjCStyle, DetectsObjCInStdin) {
+  auto Style = getStyle("LLVM", "<stdin>", "none",
+                        "@interface\n"
+                        "- (id)init;");
+  ASSERT_TRUE((bool)Style);
+  EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
+}
+
 TEST(FormatTestObjCStyle, DetectsObjCInHeaders) {
   auto Style = getStyle("LLVM", "a.h", "none",
                         "@interface\n"


### PR DESCRIPTION
The code cleanup in #74794 accidentally broke detection of languages by reading file content from stdin, e.g. via `clang-format -dump-config - < /path/to/filename`.

This PR adds unit and integration tests to reproduce the issue and adds a fix.

Fixes: #79023 
