### PR TITLE
[TLI] Remove leftover assert in TargetLibraryInfoImpl initialize

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -163,12 +163,6 @@ bool TargetLibraryInfoImpl::isCallingConvCCompatible(Function *F) {
 /// triple gets a sane set of defaults.
 static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
                        ArrayRef<StringLiteral> StandardNames) {
-  // Verify that the StandardNames array is in alphabetical order.
-  assert(
-      llvm::is_sorted(StandardNames,
-                      [](StringRef LHS, StringRef RHS) { return LHS < RHS; }) &&
-      "TargetLibraryInfoImpl function names must be sorted");
-
   // Set IO unlocked variants as unavailable
   // Set them as available per system below
   TLI.setUnavailable(LibFunc_getc_unlocked);


### PR DESCRIPTION
Remove unnecessary assert for a sorted StandardNames after implementation of getLibFunc is changed from binary search to a DenseMap Lookup in commit 7d950f040e3da66ec83f91b58d8c2220483d6335.

The original getLibFunc binary search implementation is in commit c740e3f0d1ca9690100160ed2708d97d3c6562f0