### PR TITLE
[OpenMP][Fix] Require USM capability in force-usm test

### DIFF
--- a/openmp/libomptarget/test/offloading/force-usm.cpp
+++ b/openmp/libomptarget/test/offloading/force-usm.cpp
@@ -6,6 +6,8 @@
 // RUN: env HSA_XNACK=1 LIBOMPTARGET_INFO=32 \
 // RUN:       %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=FORCE-USM
 //
+// REQUIRES: unified_shared_memory
+//
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // clang-format on


### PR DESCRIPTION
This should fix the AMDGPU buildbot breakage from #76571