### PR TITLE
[LLD] [COFF] Fix crashes for cfguard with undefined weak symbols

### DIFF
--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1802,6 +1802,8 @@ void Writer::createSEHTable() {
 // symbol's offset into that Chunk.
 static void addSymbolToRVASet(SymbolRVASet &rvaSet, Defined *s) {
   Chunk *c = s->getChunk();
+  if (!c)
+    return;
   if (auto *sc = dyn_cast<SectionChunk>(c))
     c = sc->repl; // Look through ICF replacement.
   uint32_t off = s->getRVA() - (c ? c->getRVA() : 0);

--- a/lld/test/COFF/cfguard-weak-undef.s
+++ b/lld/test/COFF/cfguard-weak-undef.s
@@ -1,0 +1,27 @@
+# REQUIRES: x86
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj -o %t.obj %s
+# RUN: lld-link %t.obj /out:%t.exe /entry:entry /subsystem:console /guard:cf
+
+	.def	@feat.00;
+	.scl	3;
+	.type	0;
+	.endef
+	.globl	@feat.00
+.set @feat.00, 2048
+
+	.globl	entry
+entry:
+	retq
+
+	.data
+	.globl	funcs
+funcs:
+	.quad	weakfunc
+
+	.section	.gfids$y,"dr"
+	.symidx	weakfunc
+	.section	.giats$y,"dr"
+	.section	.gljmp$y,"dr"
+	.weak	weakfunc
+	.addrsig
+	.addrsig_sym weakfunc


### PR DESCRIPTION
When marking symbols as having their address taken, we can have the sitaution where we have the address taken of a weak symbol. If there's no strong definition of the symbol, the symbol ends up as an absolute symbol with the value null. In those cases, we don't have any Chunk. Skip such symbols from the cfguard tables.

This fixes https://github.com/llvm/llvm-project/issues/78619.