### PR TITLE
[lldb][NFCI] Remove Broadcaster::BroadcastEvent overload with EventData param

### DIFF
--- a/lldb/include/lldb/Utility/Broadcaster.h
+++ b/lldb/include/lldb/Utility/Broadcaster.h
@@ -172,11 +172,6 @@ public:
     m_broadcaster_sp->BroadcastEventIfUnique(event_sp);
   }
 
-  void BroadcastEvent(uint32_t event_type,
-                      const lldb::EventDataSP &event_data_sp) {
-    m_broadcaster_sp->BroadcastEvent(event_type, event_data_sp);
-  }
-
   void BroadcastEvent(uint32_t event_type) {
     m_broadcaster_sp->BroadcastEvent(event_type);
   }
@@ -347,9 +342,6 @@ protected:
     void BroadcastEventIfUnique(lldb::EventSP &event_sp);
 
     void BroadcastEvent(uint32_t event_type);
-
-    void BroadcastEvent(uint32_t event_type,
-                        const lldb::EventDataSP &event_data_sp);
 
     void BroadcastEventIfUnique(uint32_t event_type,
                                 EventData *event_data = nullptr);

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -984,8 +984,10 @@ void Breakpoint::SendBreakpointChangedEvent(
           Target::eBroadcastBitBreakpointChanged)) {
     std::shared_ptr<BreakpointEventData> data =
         std::make_shared<BreakpointEventData>(eventKind, shared_from_this());
+    auto event_sp =
+        std::make_shared<Event>(Target::eBroadcastBitBreakpointChanged, data);
 
-    GetTarget().BroadcastEvent(Target::eBroadcastBitBreakpointChanged, data);
+    GetTarget().BroadcastEvent(event_sp);
   }
 }
 
@@ -995,9 +997,12 @@ void Breakpoint::SendBreakpointChangedEvent(
     return;
 
   if (!m_being_created && !IsInternal() &&
-      GetTarget().EventTypeHasListeners(Target::eBroadcastBitBreakpointChanged))
-    GetTarget().BroadcastEvent(Target::eBroadcastBitBreakpointChanged,
-                               breakpoint_data_sp);
+      GetTarget().EventTypeHasListeners(
+          Target::eBroadcastBitBreakpointChanged)) {
+    auto event_sp = std::make_shared<Event>(
+        Target::eBroadcastBitBreakpointChanged, breakpoint_data_sp);
+    GetTarget().BroadcastEvent(event_sp);
+  }
 }
 
 const char *Breakpoint::BreakpointEventTypeAsCString(BreakpointEventType type) {

--- a/lldb/source/Breakpoint/BreakpointList.cpp
+++ b/lldb/source/Breakpoint/BreakpointList.cpp
@@ -20,8 +20,9 @@ static void NotifyChange(const BreakpointSP &bp, BreakpointEventType event) {
   if (target.EventTypeHasListeners(Target::eBroadcastBitBreakpointChanged)) {
     auto event_data_sp =
         std::make_shared<Breakpoint::BreakpointEventData>(event, bp);
-    target.BroadcastEvent(Target::eBroadcastBitBreakpointChanged,
-                          event_data_sp);
+    auto event_sp = std::make_shared<Event>(
+        Target::eBroadcastBitBreakpointChanged, event_data_sp);
+    target.BroadcastEvent(event_sp);
   }
 }
 

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -652,8 +652,9 @@ void BreakpointLocation::SendBreakpointLocationChangedEvent(
     auto data_sp = std::make_shared<Breakpoint::BreakpointEventData>(
         eventKind, m_owner.shared_from_this());
     data_sp->GetBreakpointLocationCollection().Add(shared_from_this());
-    m_owner.GetTarget().BroadcastEvent(Target::eBroadcastBitBreakpointChanged,
-                                       data_sp);
+    auto event_sp = std::make_shared<Event>(
+        Target::eBroadcastBitBreakpointChanged, data_sp);
+    m_owner.GetTarget().BroadcastEvent(event_sp);
   }
 }
 

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -466,7 +466,9 @@ void Watchpoint::SendWatchpointChangedEvent(
                               Target::eBroadcastBitWatchpointChanged)) {
     auto data_sp =
         std::make_shared<WatchpointEventData>(eventKind, shared_from_this());
-    GetTarget().BroadcastEvent(Target::eBroadcastBitWatchpointChanged, data_sp);
+    auto event_sp = std::make_shared<Event>(
+        Target::eBroadcastBitWatchpointChanged, data_sp);
+    GetTarget().BroadcastEvent(event_sp);
   }
 }
 

--- a/lldb/source/Breakpoint/WatchpointList.cpp
+++ b/lldb/source/Breakpoint/WatchpointList.cpp
@@ -26,8 +26,9 @@ lldb::watch_id_t WatchpointList::Add(const WatchpointSP &wp_sp, bool notify) {
             Target::eBroadcastBitWatchpointChanged)) {
       auto data_sp = std::make_shared<Watchpoint::WatchpointEventData>(
           eWatchpointEventTypeAdded, wp_sp);
-      wp_sp->GetTarget().BroadcastEvent(Target::eBroadcastBitWatchpointChanged,
-                                        data_sp);
+      auto event_sp = std::make_shared<Event>(
+          Target::eBroadcastBitWatchpointChanged, data_sp);
+      wp_sp->GetTarget().BroadcastEvent(event_sp);
     }
   }
   return wp_sp->GetID();
@@ -176,8 +177,9 @@ bool WatchpointList::Remove(lldb::watch_id_t watch_id, bool notify) {
               Target::eBroadcastBitWatchpointChanged)) {
         auto data_sp = std::make_shared<Watchpoint::WatchpointEventData>(
             eWatchpointEventTypeRemoved, wp_sp);
-        wp_sp->GetTarget().BroadcastEvent(
+        auto event_sp = std::make_shared<Event>(
             Target::eBroadcastBitWatchpointChanged, data_sp);
+        wp_sp->GetTarget().BroadcastEvent(event_sp);
       }
     }
     m_watchpoints.erase(pos);
@@ -239,8 +241,9 @@ void WatchpointList::RemoveAll(bool notify) {
                 Target::eBroadcastBitBreakpointChanged)) {
           auto data_sp = std::make_shared<Watchpoint::WatchpointEventData>(
               eWatchpointEventTypeRemoved, *pos);
-          (*pos)->GetTarget().BroadcastEvent(
+          auto event_sp = std::make_shared<Event>(
               Target::eBroadcastBitWatchpointChanged, data_sp);
+          (*pos)->GetTarget().BroadcastEvent(event_sp);
         }
       }
     }

--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -202,7 +202,7 @@ bool ThreadedCommunication::StopReadThread(Status *error_ptr) {
 
   m_read_thread_enabled = false;
 
-  BroadcastEvent(eBroadcastBitReadThreadShouldExit, nullptr);
+  BroadcastEvent(eBroadcastBitReadThreadShouldExit);
 
   Status error = m_read_thread.Join(nullptr);
   return error.Success();

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
@@ -296,7 +296,7 @@ bool GDBRemoteClientBase::ShouldStop(const UnixSignals &signals,
 
 void GDBRemoteClientBase::OnRunPacketSent(bool first) {
   if (first)
-    BroadcastEvent(eBroadcastBitRunPacketSent, nullptr);
+    BroadcastEvent(eBroadcastBitRunPacketSent);
 }
 
 ///////////////////////////////////////

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1090,7 +1090,9 @@ Status ProcessGDBRemote::DoAttachToProcessWithID(
           ::snprintf(packet, sizeof(packet), "vAttach;%" PRIx64, attach_pid);
       SetID(attach_pid);
       auto data_sp = std::make_shared<EventDataBytes>(packet, packet_len);
-      m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
+      auto event_sp =
+          std::make_shared<Event>(eBroadcastBitAsyncContinue, data_sp);
+      m_async_broadcaster.BroadcastEvent(event_sp);
     } else
       SetExitStatus(-1, error.AsCString());
   }
@@ -1129,7 +1131,9 @@ Status ProcessGDBRemote::DoAttachToProcessWithName(
 
       auto data_sp = std::make_shared<EventDataBytes>(packet.GetString().data(),
                                                       packet.GetSize());
-      m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
+      auto event_sp =
+          std::make_shared<Event>(eBroadcastBitAsyncContinue, data_sp);
+      m_async_broadcaster.BroadcastEvent(event_sp);
 
     } else
       SetExitStatus(-1, error.AsCString());
@@ -1376,7 +1380,9 @@ Status ProcessGDBRemote::DoResume() {
 
       auto data_sp = std::make_shared<EventDataBytes>(
           continue_packet.GetString().data(), continue_packet.GetSize());
-      m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
+      auto async_continue_event_sp =
+          std::make_shared<Event>(eBroadcastBitAsyncContinue, data_sp);
+      m_async_broadcaster.BroadcastEvent(async_continue_event_sp);
 
       if (!listener_sp->GetEvent(event_sp, std::chrono::seconds(5))) {
         error.SetErrorString("Resume timed out.");

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -3859,7 +3859,7 @@ thread_result_t Process::RunPrivateStateThread(bool is_secondary_thread) {
         // case we should tell it to stop doing that.  Normally, we don't NEED
         // to do that because we will next close the communication to the stub
         // and that will get it to shut down.  But there are remote debugging
-        // cases where relying on that side-effect causes the shutdown to be 
+        // cases where relying on that side-effect causes the shutdown to be
         // flakey, so we should send a positive signal to interrupt the wait.
         Status error = HaltPrivate();
         BroadcastEvent(eBroadcastBitInterrupt);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1706,7 +1706,9 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
     }
     auto data_sp =
         std::make_shared<TargetEventData>(shared_from_this(), module_list);
-    BroadcastEvent(eBroadcastBitModulesLoaded, data_sp);
+    auto event_sp =
+        std::make_shared<Event>(eBroadcastBitModulesLoaded, data_sp);
+    BroadcastEvent(event_sp);
   }
 }
 
@@ -1722,7 +1724,9 @@ void Target::SymbolsDidLoad(ModuleList &module_list) {
     m_internal_breakpoint_list.UpdateBreakpoints(module_list, true, false);
     auto data_sp =
         std::make_shared<TargetEventData>(shared_from_this(), module_list);
-    BroadcastEvent(eBroadcastBitSymbolsLoaded, data_sp);
+    auto event_sp =
+        std::make_shared<Event>(eBroadcastBitSymbolsLoaded, data_sp);
+    BroadcastEvent(event_sp);
   }
 }
 
@@ -1731,7 +1735,9 @@ void Target::ModulesDidUnload(ModuleList &module_list, bool delete_locations) {
     UnloadModuleSections(module_list);
     auto data_sp =
         std::make_shared<TargetEventData>(shared_from_this(), module_list);
-    BroadcastEvent(eBroadcastBitModulesUnloaded, data_sp);
+    auto event_sp =
+        std::make_shared<Event>(eBroadcastBitModulesUnloaded, data_sp);
+    BroadcastEvent(event_sp);
     m_breakpoint_list.UpdateBreakpoints(module_list, false, delete_locations);
     m_internal_breakpoint_list.UpdateBreakpoints(module_list, false,
                                                  delete_locations);

--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -458,7 +458,7 @@ uint32_t TargetList::SendAsyncInterrupt(lldb::pid_t pid) {
   } else {
     // We don't have a valid pid to broadcast to, so broadcast to the target
     // list's async broadcaster...
-    BroadcastEvent(Process::eBroadcastBitInterrupt, nullptr);
+    BroadcastEvent(Process::eBroadcastBitInterrupt);
   }
 
   return num_async_interrupts_sent;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -256,7 +256,9 @@ void Thread::BroadcastSelectedFrameChange(StackID &new_frame_id) {
   if (EventTypeHasListeners(eBroadcastBitSelectedFrameChanged)) {
     auto data_sp =
         std::make_shared<ThreadEventData>(shared_from_this(), new_frame_id);
-    BroadcastEvent(eBroadcastBitSelectedFrameChanged, data_sp);
+    auto event_sp =
+        std::make_shared<Event>(eBroadcastBitSelectedFrameChanged, data_sp);
+    BroadcastEvent(event_sp);
   }
 }
 
@@ -1511,7 +1513,9 @@ Status Thread::ReturnFromFrame(lldb::StackFrameSP frame_sp,
         thread->ClearStackFrames();
         if (broadcast && EventTypeHasListeners(eBroadcastBitStackChanged)) {
           auto data_sp = std::make_shared<ThreadEventData>(shared_from_this());
-          BroadcastEvent(eBroadcastBitStackChanged, data_sp);
+          auto event_sp =
+              std::make_shared<Event>(eBroadcastBitStackChanged, data_sp);
+          BroadcastEvent(event_sp);
         }
       } else {
         return_error.SetErrorString("Could not reset register values.");

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -729,8 +729,9 @@ void ThreadList::NotifySelectedThreadChanged(lldb::tid_t tid) {
           Thread::eBroadcastBitThreadSelected)) {
     auto data_sp =
         std::make_shared<Thread::ThreadEventData>(selected_thread_sp);
-    selected_thread_sp->BroadcastEvent(Thread::eBroadcastBitThreadSelected,
-                                       data_sp);
+    auto event_sp =
+        std::make_shared<Event>(Thread::eBroadcastBitThreadSelected, data_sp);
+    selected_thread_sp->BroadcastEvent(event_sp);
   }
 }
 

--- a/lldb/source/Utility/Broadcaster.cpp
+++ b/lldb/source/Utility/Broadcaster.cpp
@@ -305,12 +305,6 @@ void Broadcaster::BroadcasterImpl::BroadcastEvent(uint32_t event_type) {
   PrivateBroadcastEvent(event_sp, false);
 }
 
-void Broadcaster::BroadcasterImpl::BroadcastEvent(
-    uint32_t event_type, const lldb::EventDataSP &event_data_sp) {
-  auto event_sp = std::make_shared<Event>(event_type, event_data_sp);
-  PrivateBroadcastEvent(event_sp, false);
-}
-
 void Broadcaster::BroadcasterImpl::BroadcastEventIfUnique(
     uint32_t event_type, EventData *event_data) {
   auto event_sp = std::make_shared<Event>(event_type, event_data);

--- a/lldb/unittests/Utility/BroadcasterTest.cpp
+++ b/lldb/unittests/Utility/BroadcasterTest.cpp
@@ -28,7 +28,7 @@ TEST(BroadcasterTest, BroadcastEvent) {
   const uint32_t event_mask1 = 1;
   EXPECT_EQ(event_mask1,
             listener1_sp->StartListeningForEvents(&broadcaster, event_mask1));
-  broadcaster.BroadcastEvent(event_mask1, nullptr);
+  broadcaster.BroadcastEvent(event_mask1);
   EXPECT_TRUE(listener1_sp->GetEvent(event_sp, timeout));
   EXPECT_EQ(event_mask1, event_sp->GetType());
 
@@ -38,12 +38,12 @@ TEST(BroadcasterTest, BroadcastEvent) {
     const uint32_t event_mask2 = 1;
     EXPECT_EQ(event_mask2, listener2_sp->StartListeningForEvents(
                                &broadcaster, event_mask1 | event_mask2));
-    broadcaster.BroadcastEvent(event_mask2, nullptr);
+    broadcaster.BroadcastEvent(event_mask2);
     EXPECT_TRUE(listener2_sp->GetEvent(event_sp, timeout));
     EXPECT_EQ(event_mask2, event_sp->GetType());
 
     // Both listeners should get this event.
-    broadcaster.BroadcastEvent(event_mask1, nullptr);
+    broadcaster.BroadcastEvent(event_mask1);
     EXPECT_TRUE(listener1_sp->GetEvent(event_sp, timeout));
     EXPECT_EQ(event_mask1, event_sp->GetType());
     EXPECT_TRUE(listener2_sp->GetEvent(event_sp, timeout));
@@ -51,7 +51,7 @@ TEST(BroadcasterTest, BroadcastEvent) {
   }
 
   // Now again only one listener should be active.
-  broadcaster.BroadcastEvent(event_mask1, nullptr);
+  broadcaster.BroadcastEvent(event_mask1);
   EXPECT_TRUE(listener1_sp->GetEvent(event_sp, timeout));
   EXPECT_EQ(event_mask1, event_sp->GetType());
 }

--- a/lldb/unittests/Utility/ListenerTest.cpp
+++ b/lldb/unittests/Utility/ListenerTest.cpp
@@ -36,17 +36,17 @@ TEST(ListenerTest, GetEventImmediate) {
       &broadcaster, event_mask, event_sp, timeout));
 
   // Now send events and make sure they get it.
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(listener_sp->GetEvent(event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(listener_sp->GetEventForBroadcaster(nullptr, event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(
       listener_sp->GetEventForBroadcaster(&broadcaster, event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_FALSE(listener_sp->GetEventForBroadcasterWithType(
       &broadcaster, event_mask * 2, event_sp, timeout));
   EXPECT_TRUE(listener_sp->GetEventForBroadcasterWithType(
@@ -73,17 +73,17 @@ TEST(ListenerTest, GetEventWait) {
       &broadcaster, event_mask, event_sp, timeout));
 
   // Now send events and make sure they get it.
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(listener_sp->GetEvent(event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(listener_sp->GetEventForBroadcaster(nullptr, event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_TRUE(
       listener_sp->GetEventForBroadcaster(&broadcaster, event_sp, timeout));
 
-  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask);
   EXPECT_FALSE(listener_sp->GetEventForBroadcasterWithType(
       &broadcaster, event_mask * 2, event_sp, timeout));
   EXPECT_TRUE(listener_sp->GetEventForBroadcasterWithType(
@@ -91,7 +91,7 @@ TEST(ListenerTest, GetEventWait) {
 
   auto delayed_broadcast = [&] {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    broadcaster.BroadcastEvent(event_mask, nullptr);
+    broadcaster.BroadcastEvent(event_mask);
   };
 
   // These should do an infinite wait at return the event our asynchronous


### PR DESCRIPTION
There are 3 variants of BroadcastEvent:
1. Takes an Event
2. Takes an event type
3. Takes an event type and event data.

The latter 2 just create an Event (with the event type, and if available, the event data) and then pass it along to the internal broadcasting logic.

There's no good reason to have all 3 of these, there aren't a lot of different ways to actually create an event object. Forcing callees to create an Event if they want to broadcast an event with event data seems reasonable.