### PR TITLE
[ASan][JSON] Unpoison memory before its reuse

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -482,7 +482,7 @@ private:
   friend class Object;
 
   template <typename T, typename... U> void create(U &&... V) {
-#if defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__)
+#if defined(LLVM_ADDRESS_SANITIZER_BUILD)
     // Unpoisoning to prevent overwriting poisoned object (e.g., annotated short
     // string). Objects that have had their memory poisoned may cause an ASan
     // error if their memory is reused without calling their destructor.

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -483,9 +483,10 @@ private:
 
   template <typename T, typename... U> void create(U &&... V) {
 #if defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__)
-    // Unpoisoning to prevent overwriting poisoned object (e.g., annotated short string).
-    // Objects that have had their memory poisoned may cause an ASan error if their memory is reused
-    // without calling their destructor. Unpoisoning the memory prevents this error from occurring.
+    // Unpoisoning to prevent overwriting poisoned object (e.g., annotated short
+    // string). Objects that have had their memory poisoned may cause an ASan
+    // error if their memory is reused without calling their destructor.
+    // Unpoisoning the memory prevents this error from occurring.
     __asan_unpoison_memory_region(&Union, sizeof(T));
 #endif
     new (reinterpret_cast<T *>(&Union)) T(std::forward<U>(V)...);

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -488,6 +488,11 @@ private:
     // string). Objects that have had their memory poisoned may cause an ASan
     // error if their memory is reused without calling their destructor.
     // Unpoisoning the memory prevents this error from occurring.
+    // FIXME: This is a temporary solution to prevent buildbots from failing.
+    //  The more appropriate approach would be to call the object's destructor
+    //  to unpoison memory. This would prevent any potential memory leaks (long
+    //  strings). Read for details:
+    //  https://github.com/llvm/llvm-project/pull/79065#discussion_r1462621761
     __asan_unpoison_memory_region(&Union, sizeof(T));
 #endif
     new (reinterpret_cast<T *>(&Union)) T(std::forward<U>(V)...);

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -47,9 +47,9 @@
 #define LLVM_SUPPORT_JSON_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -482,6 +482,12 @@ private:
   friend class Object;
 
   template <typename T, typename... U> void create(U &&... V) {
+#if defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__)
+    // Unpoisoning to prevent overwriting poisoned object (e.g., annotated short string).
+    // Objects that have had their memory poisoned may cause an ASan error if their memory is reused
+    // without calling their destructor. Unpoisoning the memory prevents this error from occurring.
+    __asan_unpoison_memory_region(&Union, sizeof(T));
+#endif
     new (reinterpret_cast<T *>(&Union)) T(std::forward<U>(V)...);
   }
   template <typename T> T &as() const {

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -50,6 +50,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
@@ -482,7 +483,7 @@ private:
   friend class Object;
 
   template <typename T, typename... U> void create(U &&... V) {
-#if defined(LLVM_ADDRESS_SANITIZER_BUILD)
+#if LLVM_ADDRESS_SANITIZER_BUILD
     // Unpoisoning to prevent overwriting poisoned object (e.g., annotated short
     // string). Objects that have had their memory poisoned may cause an ASan
     // error if their memory is reused without calling their destructor.


### PR DESCRIPTION
This commit unpoisons memory before its reuse (with reinterpret_cast).
Required by https://github.com/llvm/llvm-project/pull/79049

Notice that it's a temporary solution to prevent buildbots from failing. Read FIXME text for details.