### PR TITLE
[ASan][ADT] Don't scribble with ASan

### DIFF
--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -35,6 +35,7 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLForwardCompat.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemAlloc.h"
 #include "llvm/Support/type_traits.h"
 #include <cstring>
@@ -317,7 +318,7 @@ protected:
     // Clear the old callback and inline flag to get back to as-if-null.
     RHS.CallbackAndInlineFlag = {};
 
-#if !defined(NDEBUG) && !defined(LLVM_ADDRESS_SANITIZER_BUILD)
+#if !defined(NDEBUG) && !LLVM_ADDRESS_SANITIZER_BUILD
     // In debug builds without ASan, we also scribble across the rest of the
     // storage. AddressSanitizer (ASAN) disables scribbling to prevent
     // overwriting poisoned objects (e.g., annotated short strings).

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -317,8 +317,7 @@ protected:
     // Clear the old callback and inline flag to get back to as-if-null.
     RHS.CallbackAndInlineFlag = {};
 
-#if !defined(NDEBUG) &&                                                        \
-    !(defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__))
+#if !defined(NDEBUG) && !defined(LLVM_ADDRESS_SANITIZER_BUILD)
     // In debug builds without ASan, we also scribble across the rest of the
     // storage. AddressSanitizer (ASAN) disables scribbling to prevent
     // overwriting poisoned objects (e.g., annotated short strings).

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -320,7 +320,7 @@ protected:
 
 #if !defined(NDEBUG) && !LLVM_ADDRESS_SANITIZER_BUILD
     // In debug builds without ASan, we also scribble across the rest of the
-    // storage. AddressSanitizer (ASAN) disables scribbling to prevent
+    // storage. Scribbling under AddressSanitizer (ASan) is disabled to prevent
     // overwriting poisoned objects (e.g., annotated short strings).
     memset(RHS.getInlineStorage(), 0xAD, InlineStorageSize);
 #endif

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -317,8 +317,10 @@ protected:
     // Clear the old callback and inline flag to get back to as-if-null.
     RHS.CallbackAndInlineFlag = {};
 
-#ifndef NDEBUG
-    // In debug builds, we also scribble across the rest of the storage.
+#if !defined(NDEBUG) && !(defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__))
+    // In debug builds without ASan, we also scribble across the rest of the storage.
+    // AddressSanitizer (ASAN) disables scribbling to prevent overwriting poisoned objects
+    // (e.g., annotated short strings).
     memset(RHS.getInlineStorage(), 0xAD, InlineStorageSize);
 #endif
   }

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -317,10 +317,11 @@ protected:
     // Clear the old callback and inline flag to get back to as-if-null.
     RHS.CallbackAndInlineFlag = {};
 
-#if !defined(NDEBUG) && !(defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__))
-    // In debug builds without ASan, we also scribble across the rest of the storage.
-    // AddressSanitizer (ASAN) disables scribbling to prevent overwriting poisoned objects
-    // (e.g., annotated short strings).
+#if !defined(NDEBUG) &&                                                        \
+    !(defined(ADDRESS_SANITIZER) || defined(__SANITIZE_ADDRESS__))
+    // In debug builds without ASan, we also scribble across the rest of the
+    // storage. AddressSanitizer (ASAN) disables scribbling to prevent
+    // overwriting poisoned objects (e.g., annotated short strings).
     memset(RHS.getInlineStorage(), 0xAD, InlineStorageSize);
 #endif
   }


### PR DESCRIPTION
AddressSanitizer (ASAN) disables scribbling to prevent overwriting poisoned objects.
Needed by https://github.com/llvm/llvm-project/pull/79049