### PR TITLE
[RISCV] Re-format RISCVFeatures.td so it doesn't look like AssemblerPredicate is an operand to Predicate.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -115,7 +115,7 @@ def FeatureStdExtZicfilp
                        "'Zicfilp' (Landing pad)">;
 def HasStdExtZicfilp : Predicate<"Subtarget->hasStdExtZicfilp()">,
                        AssemblerPredicate<(all_of FeatureStdExtZicfilp),
-                                         "'Zicfilp' (Landing pad)">;
+                                          "'Zicfilp' (Landing pad)">;
 
 def FeatureStdExtZicfiss
     : SubtargetFeature<"experimental-zicfiss", "HasStdExtZicfiss", "true",

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -16,8 +16,8 @@ def FeatureStdExtI
     : SubtargetFeature<"i", "HasStdExtI", "true",
                        "'I' (Base Integer Instruction Set)">;
 def HasStdExtI : Predicate<"Subtarget->hasStdExtI()">,
-                           AssemblerPredicate<(all_of FeatureStdExtI),
-                           "'I' (Base Integer Instruction Set)">;
+                 AssemblerPredicate<(all_of FeatureStdExtI),
+                                    "'I' (Base Integer Instruction Set)">;
 def FeatureStdExtZic64b
     : SubtargetFeature<"zic64b", "HasStdExtZic64b", "true",
                        "'Zic64b' (Cache Block Size Is 64 Bytes)">;
@@ -26,22 +26,22 @@ def FeatureStdExtZicbom
     : SubtargetFeature<"zicbom", "HasStdExtZicbom", "true",
                        "'Zicbom' (Cache-Block Management Instructions)">;
 def HasStdExtZicbom : Predicate<"Subtarget->hasStdExtZicbom()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZicbom),
-                                "'Zicbom' (Cache-Block Management Instructions)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZicbom),
+                          "'Zicbom' (Cache-Block Management Instructions)">;
 
 def FeatureStdExtZicbop
     : SubtargetFeature<"zicbop", "HasStdExtZicbop", "true",
                        "'Zicbop' (Cache-Block Prefetch Instructions)">;
 def HasStdExtZicbop : Predicate<"Subtarget->hasStdExtZicbop()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZicbop),
-                                "'Zicbop' (Cache-Block Prefetch Instructions)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZicbop),
+                          "'Zicbop' (Cache-Block Prefetch Instructions)">;
 
 def FeatureStdExtZicboz
     : SubtargetFeature<"zicboz", "HasStdExtZicboz", "true",
                        "'Zicboz' (Cache-Block Zero Instructions)">;
 def HasStdExtZicboz : Predicate<"Subtarget->hasStdExtZicboz()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZicboz),
-                                "'Zicboz' (Cache-Block Zero Instructions)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZicboz),
+                          "'Zicboz' (Cache-Block Zero Instructions)">;
 
 def FeatureStdExtZiccamoa
     : SubtargetFeature<"ziccamoa", "HasStdExtZiccamoa", "true",
@@ -63,8 +63,8 @@ def FeatureStdExtZicsr
     : SubtargetFeature<"zicsr", "HasStdExtZicsr", "true",
                        "'zicsr' (CSRs)">;
 def HasStdExtZicsr : Predicate<"Subtarget->hasStdExtZicsr()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZicsr),
-                                "'Zicsr' (CSRs)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZicsr),
+                                        "'Zicsr' (CSRs)">;
 
 def FeatureStdExtZicntr
     : SubtargetFeature<"zicntr", "HasStdExtZicntr", "true",
@@ -75,29 +75,29 @@ def FeatureStdExtZicond
     : SubtargetFeature<"experimental-zicond", "HasStdExtZicond", "true",
                        "'Zicond' (Integer Conditional Operations)">;
 def HasStdExtZicond : Predicate<"Subtarget->hasStdExtZicond()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZicond),
-                                "'Zicond' (Integer Conditional Operations)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZicond),
+                          "'Zicond' (Integer Conditional Operations)">;
 
 def FeatureStdExtZifencei
     : SubtargetFeature<"zifencei", "HasStdExtZifencei", "true",
                        "'Zifencei' (fence.i)">;
 def HasStdExtZifencei : Predicate<"Subtarget->hasStdExtZifencei()">,
-                                   AssemblerPredicate<(all_of FeatureStdExtZifencei),
-                                   "'Zifencei' (fence.i)">;
+                        AssemblerPredicate<(all_of FeatureStdExtZifencei),
+                                           "'Zifencei' (fence.i)">;
 
 def FeatureStdExtZihintpause
     : SubtargetFeature<"zihintpause", "HasStdExtZihintpause", "true",
                        "'Zihintpause' (Pause Hint)">;
 def HasStdExtZihintpause : Predicate<"Subtarget->hasStdExtZihintpause()">,
-                                     AssemblerPredicate<(all_of FeatureStdExtZihintpause),
-                                     "'Zihintpause' (Pause Hint)">;
+                           AssemblerPredicate<(all_of FeatureStdExtZihintpause),
+                                              "'Zihintpause' (Pause Hint)">;
 
 def FeatureStdExtZihintntl
     : SubtargetFeature<"zihintntl", "HasStdExtZihintntl", "true",
                        "'Zihintntl' (Non-Temporal Locality Hints)">;
 def HasStdExtZihintntl : Predicate<"Subtarget->hasStdExtZihintntl()">,
-                                    AssemblerPredicate<(all_of FeatureStdExtZihintntl),
-                                    "'Zihintntl' (Non-Temporal Locality Hints)">;
+                         AssemblerPredicate<(all_of FeatureStdExtZihintntl),
+                             "'Zihintntl' (Non-Temporal Locality Hints)">;
 
 def FeatureStdExtZihpm
     : SubtargetFeature<"zihpm", "HasStdExtZihpm", "true",
@@ -107,23 +107,23 @@ def FeatureStdExtZihpm
 def FeatureStdExtZimop : SubtargetFeature<"experimental-zimop", "HasStdExtZimop", "true",
                                           "'Zimop' (May-Be-Operations)">;
 def HasStdExtZimop : Predicate<"Subtarget->hasStdExtZimop()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZimop),
-                               "'Zimop' (May-Be-Operations)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZimop),
+                                        "'Zimop' (May-Be-Operations)">;
 
 def FeatureStdExtZicfilp
     : SubtargetFeature<"experimental-zicfilp", "HasStdExtZicfilp", "true",
                        "'Zicfilp' (Landing pad)">;
 def HasStdExtZicfilp : Predicate<"Subtarget->hasStdExtZicfilp()">,
-                                 AssemblerPredicate<(all_of FeatureStdExtZicfilp),
-                                 "'Zicfilp' (Landing pad)">;
+                       AssemblerPredicate<(all_of FeatureStdExtZicfilp),
+                                         "'Zicfilp' (Landing pad)">;
 
 def FeatureStdExtZicfiss
     : SubtargetFeature<"experimental-zicfiss", "HasStdExtZicfiss", "true",
                        "'Zicfiss' (Shadow stack)",
                        [FeatureStdExtZicsr, FeatureStdExtZimop]>;
 def HasStdExtZicfiss : Predicate<"Subtarget->hasStdExtZicfiss()">,
-                                 AssemblerPredicate<(all_of FeatureStdExtZicfiss),
-                                 "'Zicfiss' (Shadow stack)">;
+                       AssemblerPredicate<(all_of FeatureStdExtZicfiss),
+                                          "'Zicfiss' (Shadow stack)">;
 def NoHasStdExtZicfiss : Predicate<"!Subtarget->hasStdExtZicfiss()">;
 
 // Multiply Extensions
@@ -132,8 +132,8 @@ def FeatureStdExtM
     : SubtargetFeature<"m", "HasStdExtM", "true",
                        "'M' (Integer Multiplication and Division)">;
 def HasStdExtM : Predicate<"Subtarget->hasStdExtM()">,
-                           AssemblerPredicate<(all_of FeatureStdExtM),
-                           "'M' (Integer Multiplication and Division)">;
+                 AssemblerPredicate<(all_of FeatureStdExtM),
+                     "'M' (Integer Multiplication and Division)">;
 
 def FeatureStdExtZmmul
     : SubtargetFeature<"zmmul", "HasStdExtZmmul", "true",
@@ -141,9 +141,9 @@ def FeatureStdExtZmmul
 
 def HasStdExtMOrZmmul
     : Predicate<"Subtarget->hasStdExtM() || Subtarget->hasStdExtZmmul()">,
-                AssemblerPredicate<(any_of FeatureStdExtM, FeatureStdExtZmmul),
-                                   "'M' (Integer Multiplication and Division) or "
-                                   "'Zmmul' (Integer Multiplication)">;
+      AssemblerPredicate<(any_of FeatureStdExtM, FeatureStdExtZmmul),
+                         "'M' (Integer Multiplication and Division) or "
+                         "'Zmmul' (Integer Multiplication)">;
 
 // Atomic Extensions
 
@@ -151,15 +151,15 @@ def FeatureStdExtA
     : SubtargetFeature<"a", "HasStdExtA", "true",
                        "'A' (Atomic Instructions)">;
 def HasStdExtA : Predicate<"Subtarget->hasStdExtA()">,
-                           AssemblerPredicate<(all_of FeatureStdExtA),
-                           "'A' (Atomic Instructions)">;
+                 AssemblerPredicate<(all_of FeatureStdExtA),
+                                    "'A' (Atomic Instructions)">;
 
 def FeatureStdExtZtso
     : SubtargetFeature<"experimental-ztso", "HasStdExtZtso", "true",
                        "'Ztso' (Memory Model - Total Store Order)">;
 def HasStdExtZtso : Predicate<"Subtarget->hasStdExtZtso()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZtso),
-                              "'Ztso' (Memory Model - Total Store Order)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZtso),
+                        "'Ztso' (Memory Model - Total Store Order)">;
 def NotHasStdExtZtso : Predicate<"!Subtarget->hasStdExtZtso()">;
 
 def FeatureStdExtZa64rs : SubtargetFeature<"za64rs", "HasStdExtZa64rs", "true",
@@ -172,15 +172,15 @@ def FeatureStdExtZacas
     : SubtargetFeature<"experimental-zacas", "HasStdExtZacas", "true",
                        "'Zacas' (Atomic Compare-And-Swap Instructions)">;
 def HasStdExtZacas : Predicate<"Subtarget->hasStdExtZacas()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZacas),
-                               "'Zacas' (Atomic Compare-And-Swap Instructions)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZacas),
+                         "'Zacas' (Atomic Compare-And-Swap Instructions)">;
 def NoStdExtZacas : Predicate<"!Subtarget->hasStdExtZacas()">;
 
 def FeatureStdExtZawrs : SubtargetFeature<"zawrs", "HasStdExtZawrs", "true",
                                           "'Zawrs' (Wait on Reservation Set)">;
 def HasStdExtZawrs : Predicate<"Subtarget->hasStdExtZawrs()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZawrs),
-                               "'Zawrs' (Wait on Reservation Set)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZawrs),
+                                        "'Zawrs' (Wait on Reservation Set)">;
 
 // Floating Point Extensions
 
@@ -189,41 +189,41 @@ def FeatureStdExtF
                        "'F' (Single-Precision Floating-Point)",
                        [FeatureStdExtZicsr]>;
 def HasStdExtF : Predicate<"Subtarget->hasStdExtF()">,
-                           AssemblerPredicate<(all_of FeatureStdExtF),
-                           "'F' (Single-Precision Floating-Point)">;
+                 AssemblerPredicate<(all_of FeatureStdExtF),
+                                    "'F' (Single-Precision Floating-Point)">;
 
 def FeatureStdExtD
     : SubtargetFeature<"d", "HasStdExtD", "true",
                        "'D' (Double-Precision Floating-Point)",
                        [FeatureStdExtF]>;
 def HasStdExtD : Predicate<"Subtarget->hasStdExtD()">,
-                           AssemblerPredicate<(all_of FeatureStdExtD),
-                           "'D' (Double-Precision Floating-Point)">;
+                 AssemblerPredicate<(all_of FeatureStdExtD),
+                                    "'D' (Double-Precision Floating-Point)">;
 
 def FeatureStdExtH
     : SubtargetFeature<"h", "HasStdExtH", "true",
                        "'H' (Hypervisor)">;
 
 def HasStdExtH : Predicate<"Subtarget->hasStdExtH()">,
-                           AssemblerPredicate<(all_of FeatureStdExtH),
-                           "'H' (Hypervisor)">;
+                 AssemblerPredicate<(all_of FeatureStdExtH),
+                                    "'H' (Hypervisor)">;
 
 def FeatureStdExtZfhmin
     : SubtargetFeature<"zfhmin", "HasStdExtZfhmin", "true",
                        "'Zfhmin' (Half-Precision Floating-Point Minimal)",
                        [FeatureStdExtF]>;
 def HasStdExtZfhmin : Predicate<"Subtarget->hasStdExtZfhmin()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZfhmin),
-                             "'Zfh' (Half-Precision Floating-Point) or "
-                             "'Zfhmin' (Half-Precision Floating-Point Minimal)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZfhmin),
+                          "'Zfh' (Half-Precision Floating-Point) or "
+                          "'Zfhmin' (Half-Precision Floating-Point Minimal)">;
 
 def FeatureStdExtZfh
     : SubtargetFeature<"zfh", "HasStdExtZfh", "true",
                        "'Zfh' (Half-Precision Floating-Point)",
                        [FeatureStdExtZfhmin]>;
 def HasStdExtZfh : Predicate<"Subtarget->hasStdExtZfh()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZfh),
-                             "'Zfh' (Half-Precision Floating-Point)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZfh),
+                       "'Zfh' (Half-Precision Floating-Point)">;
 def NoStdExtZfh : Predicate<"!Subtarget->hasStdExtZfh()">;
 
 def FeatureStdExtZfbfmin
@@ -231,14 +231,14 @@ def FeatureStdExtZfbfmin
                        "'Zfbfmin' (Scalar BF16 Converts)",
                        [FeatureStdExtF]>;
 def HasStdExtZfbfmin : Predicate<"Subtarget->hasStdExtZfbfmin()">,
-                                 AssemblerPredicate<(all_of FeatureStdExtZfbfmin),
-                                 "'Zfbfmin' (Scalar BF16 Converts)">;
+                       AssemblerPredicate<(all_of FeatureStdExtZfbfmin),
+                                          "'Zfbfmin' (Scalar BF16 Converts)">;
 
 def HasHalfFPLoadStoreMove
     : Predicate<"Subtarget->hasHalfFPLoadStoreMove()">,
-                AssemblerPredicate<(any_of FeatureStdExtZfh, FeatureStdExtZfhmin,
-                                    FeatureStdExtZfbfmin),
-                                    "'Zfh' (Half-Precision Floating-Point) or "
+      AssemblerPredicate<(any_of FeatureStdExtZfh, FeatureStdExtZfhmin,
+                                 FeatureStdExtZfbfmin),
+                         "'Zfh' (Half-Precision Floating-Point) or "
                                     "'Zfhmin' (Half-Precision Floating-Point Minimal) or "
                                     "'Zfbfmin' (Scalar BF16 Converts)">;
 
@@ -247,41 +247,41 @@ def FeatureStdExtZfa
                        "'Zfa' (Additional Floating-Point)",
                        [FeatureStdExtF]>;
 def HasStdExtZfa : Predicate<"Subtarget->hasStdExtZfa()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZfa),
-                             "'Zfa' (Additional Floating-Point)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZfa),
+                                      "'Zfa' (Additional Floating-Point)">;
 
 def FeatureStdExtZfinx
     : SubtargetFeature<"zfinx", "HasStdExtZfinx", "true",
                        "'Zfinx' (Float in Integer)",
                        [FeatureStdExtZicsr]>;
 def HasStdExtZfinx : Predicate<"Subtarget->hasStdExtZfinx()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZfinx),
-                               "'Zfinx' (Float in Integer)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZfinx),
+                                        "'Zfinx' (Float in Integer)">;
 
 def FeatureStdExtZdinx
     : SubtargetFeature<"zdinx", "HasStdExtZdinx", "true",
                        "'Zdinx' (Double in Integer)",
                        [FeatureStdExtZfinx]>;
 def HasStdExtZdinx : Predicate<"Subtarget->hasStdExtZdinx()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZdinx),
-                               "'Zdinx' (Double in Integer)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZdinx),
+                                        "'Zdinx' (Double in Integer)">;
 
 def FeatureStdExtZhinxmin
     : SubtargetFeature<"zhinxmin", "HasStdExtZhinxmin", "true",
                        "'Zhinxmin' (Half Float in Integer Minimal)",
                        [FeatureStdExtZfinx]>;
 def HasStdExtZhinxmin : Predicate<"Subtarget->hasStdExtZhinxmin()">,
-                                  AssemblerPredicate<(all_of FeatureStdExtZhinxmin),
-                                  "'Zhinx' (Half Float in Integer) or "
-                                  "'Zhinxmin' (Half Float in Integer Minimal)">;
+                        AssemblerPredicate<(all_of FeatureStdExtZhinxmin),
+                            "'Zhinx' (Half Float in Integer) or "
+                            "'Zhinxmin' (Half Float in Integer Minimal)">;
 
 def FeatureStdExtZhinx
     : SubtargetFeature<"zhinx", "HasStdExtZhinx", "true",
                        "'Zhinx' (Half Float in Integer)",
                        [FeatureStdExtZhinxmin]>;
 def HasStdExtZhinx : Predicate<"Subtarget->hasStdExtZhinx()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZhinx),
-                               "'Zhinx' (Half Float in Integer)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZhinx),
+                                        "'Zhinx' (Half Float in Integer)">;
 def NoStdExtZhinx : Predicate<"!Subtarget->hasStdExtZhinx()">;
 
 // Compressed Extensions
@@ -290,15 +290,15 @@ def FeatureStdExtC
     : SubtargetFeature<"c", "HasStdExtC", "true",
                        "'C' (Compressed Instructions)">;
 def HasStdExtC : Predicate<"Subtarget->hasStdExtC()">,
-                           AssemblerPredicate<(all_of FeatureStdExtC),
-                           "'C' (Compressed Instructions)">;
+                 AssemblerPredicate<(all_of FeatureStdExtC),
+                                    "'C' (Compressed Instructions)">;
 
 def FeatureNoRVCHints
     : SubtargetFeature<"no-rvc-hints", "EnableRVCHintInstrs", "false",
                        "Disable RVC Hint Instructions.">;
 def HasRVCHints : Predicate<"Subtarget->enableRVCHintInstrs()">,
                   AssemblerPredicate<(all_of(not FeatureNoRVCHints)),
-                                      "RVC Hint Instructions">;
+                                     "RVC Hint Instructions">;
 
 def FeatureStdExtZca
     : SubtargetFeature<"zca", "HasStdExtZca", "true",
@@ -307,18 +307,18 @@ def FeatureStdExtZca
 
 def HasStdExtCOrZca
     : Predicate<"Subtarget->hasStdExtCOrZca()">,
-                AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZca),
-                                   "'C' (Compressed Instructions) or "
-                                   "'Zca' (part of the C extension, excluding "
-                                   "compressed floating point loads/stores)">;
+      AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZca),
+                         "'C' (Compressed Instructions) or "
+                         "'Zca' (part of the C extension, excluding "
+                         "compressed floating point loads/stores)">;
 
 def FeatureStdExtZcb
     : SubtargetFeature<"zcb", "HasStdExtZcb", "true",
                        "'Zcb' (Compressed basic bit manipulation instructions)",
                        [FeatureStdExtZca]>;
 def HasStdExtZcb : Predicate<"Subtarget->hasStdExtZcb()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZcb),
-                             "'Zcb' (Compressed basic bit manipulation instructions)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZcb),
+                       "'Zcb' (Compressed basic bit manipulation instructions)">;
 
 def FeatureStdExtZcd
     : SubtargetFeature<"zcd", "HasStdExtZcd", "true",
@@ -327,9 +327,9 @@ def FeatureStdExtZcd
 
 def HasStdExtCOrZcd
     : Predicate<"Subtarget->hasStdExtC() || Subtarget->hasStdExtZcd()">,
-                AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcd),
-                                   "'C' (Compressed Instructions) or "
-                                   "'Zcd' (Compressed Double-Precision Floating-Point Instructions)">;
+      AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcd),
+                         "'C' (Compressed Instructions) or "
+                         "'Zcd' (Compressed Double-Precision Floating-Point Instructions)">;
 
 def FeatureStdExtZcf
     : SubtargetFeature<"zcf", "HasStdExtZcf", "true",
@@ -341,8 +341,8 @@ def FeatureStdExtZcmp
                        "'Zcmp' (sequenced instuctions for code-size reduction)",
                        [FeatureStdExtZca]>;
 def HasStdExtZcmp : Predicate<"Subtarget->hasStdExtZcmp() && !Subtarget->hasStdExtC()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZcmp),
-                               "'Zcmp' (sequenced instuctions for code-size reduction)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZcmp),
+                        "'Zcmp' (sequenced instuctions for code-size reduction)">;
 
 def FeatureStdExtZcmt
     : SubtargetFeature<"zcmt", "HasStdExtZcmt", "true",
@@ -361,17 +361,17 @@ def FeatureStdExtZce
 def HasStdExtCOrZcfOrZce
     : Predicate<"Subtarget->hasStdExtC() || Subtarget->hasStdExtZcf() "
                 "Subtarget->hasStdExtZce()">,
-                AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcf,
-                                           FeatureStdExtZce),
-                                   "'C' (Compressed Instructions) or "
-                                   "'Zcf' (Compressed Single-Precision Floating-Point Instructions)">;
+      AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcf,
+                                 FeatureStdExtZce),
+                         "'C' (Compressed Instructions) or "
+                         "'Zcf' (Compressed Single-Precision Floating-Point Instructions)">;
 
 def FeatureStdExtZcmop : SubtargetFeature<"experimental-zcmop", "HasStdExtZcmop", "true",
                                           "'Zcmop' (Compressed May-Be-Operations)",
                                           [FeatureStdExtZca]>;
 def HasStdExtZcmop : Predicate<"Subtarget->hasStdExtZcmop()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZcmop),
-                               "'Zcmop' (Compressed May-Be-Operations)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZcmop),
+                         "'Zcmop' (Compressed May-Be-Operations)">;
 
 // Bitmanip Extensions
 
@@ -379,30 +379,30 @@ def FeatureStdExtZba
     : SubtargetFeature<"zba", "HasStdExtZba", "true",
                        "'Zba' (Address Generation Instructions)">;
 def HasStdExtZba : Predicate<"Subtarget->hasStdExtZba()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZba),
-                             "'Zba' (Address Generation Instructions)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZba),
+                                      "'Zba' (Address Generation Instructions)">;
 def NotHasStdExtZba : Predicate<"!Subtarget->hasStdExtZba()">;
 
 def FeatureStdExtZbb
     : SubtargetFeature<"zbb", "HasStdExtZbb", "true",
                        "'Zbb' (Basic Bit-Manipulation)">;
 def HasStdExtZbb : Predicate<"Subtarget->hasStdExtZbb()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZbb),
-                             "'Zbb' (Basic Bit-Manipulation)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZbb),
+                                      "'Zbb' (Basic Bit-Manipulation)">;
 
 def FeatureStdExtZbc
     : SubtargetFeature<"zbc", "HasStdExtZbc", "true",
                        "'Zbc' (Carry-Less Multiplication)">;
 def HasStdExtZbc : Predicate<"Subtarget->hasStdExtZbc()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZbc),
-                             "'Zbc' (Carry-Less Multiplication)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZbc),
+                                      "'Zbc' (Carry-Less Multiplication)">;
 
 def FeatureStdExtZbs
     : SubtargetFeature<"zbs", "HasStdExtZbs", "true",
                        "'Zbs' (Single-Bit Instructions)">;
 def HasStdExtZbs : Predicate<"Subtarget->hasStdExtZbs()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZbs),
-                             "'Zbs' (Single-Bit Instructions)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZbs),
+                                      "'Zbs' (Single-Bit Instructions)">;
 
 // Bitmanip Extensions for Cryptography Extensions
 
@@ -410,21 +410,21 @@ def FeatureStdExtZbkb
     : SubtargetFeature<"zbkb", "HasStdExtZbkb", "true",
                        "'Zbkb' (Bitmanip instructions for Cryptography)">;
 def HasStdExtZbkb : Predicate<"Subtarget->hasStdExtZbkb()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZbkb),
-                             "'Zbkb' (Bitmanip instructions for Cryptography)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZbkb),
+                        "'Zbkb' (Bitmanip instructions for Cryptography)">;
 
 def FeatureStdExtZbkx
     : SubtargetFeature<"zbkx", "HasStdExtZbkx", "true",
                        "'Zbkx' (Crossbar permutation instructions)">;
 def HasStdExtZbkx : Predicate<"Subtarget->hasStdExtZbkx()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZbkx),
-                             "'Zbkx' (Crossbar permutation instructions)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZbkx),
+                        "'Zbkx' (Crossbar permutation instructions)">;
 
 def HasStdExtZbbOrZbkb
     : Predicate<"Subtarget->hasStdExtZbb() || Subtarget->hasStdExtZbkb()">,
-                AssemblerPredicate<(any_of FeatureStdExtZbb, FeatureStdExtZbkb),
-                                   "'Zbb' (Basic Bit-Manipulation) or "
-                                   "'Zbkb' (Bitmanip instructions for Cryptography)">;
+      AssemblerPredicate<(any_of FeatureStdExtZbb, FeatureStdExtZbkb),
+                         "'Zbb' (Basic Bit-Manipulation) or "
+                         "'Zbkb' (Bitmanip instructions for Cryptography)">;
 
 // The Carry-less multiply subextension for cryptography is a subset of basic
 // carry-less multiply subextension. The former should be enabled if the latter
@@ -435,15 +435,15 @@ def FeatureStdExtZbkc
                        "Cryptography)">;
 def HasStdExtZbkc
     : Predicate<"Subtarget->hasStdExtZbkc()">,
-                AssemblerPredicate<(all_of FeatureStdExtZbkc),
-                "'Zbkc' (Carry-less multiply instructions for Cryptography)">;
+      AssemblerPredicate<(all_of FeatureStdExtZbkc),
+          "'Zbkc' (Carry-less multiply instructions for Cryptography)">;
 
 def HasStdExtZbcOrZbkc
     : Predicate<"Subtarget->hasStdExtZbc() || Subtarget->hasStdExtZbkc()">,
-                AssemblerPredicate<(any_of FeatureStdExtZbc, FeatureStdExtZbkc),
-                                   "'Zbc' (Carry-Less Multiplication) or "
-                                   "'Zbkc' (Carry-less multiply instructions "
-                                   "for Cryptography)">;
+      AssemblerPredicate<(any_of FeatureStdExtZbc, FeatureStdExtZbkc),
+                         "'Zbc' (Carry-Less Multiplication) or "
+                         "'Zbkc' (Carry-less multiply instructions "
+                         "for Cryptography)">;
 
 // Cryptography Extensions
 
@@ -451,52 +451,51 @@ def FeatureStdExtZknd
     : SubtargetFeature<"zknd", "HasStdExtZknd", "true",
                        "'Zknd' (NIST Suite: AES Decryption)">;
 def HasStdExtZknd : Predicate<"Subtarget->hasStdExtZknd()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZknd),
-                              "'Zknd' (NIST Suite: AES Decryption)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZknd),
+                                       "'Zknd' (NIST Suite: AES Decryption)">;
 
 def FeatureStdExtZkne
     : SubtargetFeature<"zkne", "HasStdExtZkne", "true",
                        "'Zkne' (NIST Suite: AES Encryption)">;
 def HasStdExtZkne : Predicate<"Subtarget->hasStdExtZkne()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZkne),
-                              "'Zkne' (NIST Suite: AES Encryption)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZkne),
+                                       "'Zkne' (NIST Suite: AES Encryption)">;
 
 // Some instructions belong to both Zknd and Zkne subextensions.
 // They should be enabled if either has been specified.
 def HasStdExtZkndOrZkne
     : Predicate<"Subtarget->hasStdExtZknd() || Subtarget->hasStdExtZkne()">,
-                AssemblerPredicate<(any_of FeatureStdExtZknd, FeatureStdExtZkne),
-                                   "'Zknd' (NIST Suite: AES Decryption) or "
-                                   "'Zkne' (NIST Suite: AES Encryption)">;
+      AssemblerPredicate<(any_of FeatureStdExtZknd, FeatureStdExtZkne),
+                         "'Zknd' (NIST Suite: AES Decryption) or "
+                         "'Zkne' (NIST Suite: AES Encryption)">;
 
 def FeatureStdExtZknh
     : SubtargetFeature<"zknh", "HasStdExtZknh", "true",
                        "'Zknh' (NIST Suite: Hash Function Instructions)">;
 def HasStdExtZknh : Predicate<"Subtarget->hasStdExtZknh()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZknh),
-                             "'Zknh' (NIST Suite: Hash Function Instructions)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZknh),
+                        "'Zknh' (NIST Suite: Hash Function Instructions)">;
 
 def FeatureStdExtZksed
     : SubtargetFeature<"zksed", "HasStdExtZksed", "true",
                        "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)">;
 def HasStdExtZksed : Predicate<"Subtarget->hasStdExtZksed()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZksed),
-                             "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZksed),
+                         "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)">;
 
 def FeatureStdExtZksh
     : SubtargetFeature<"zksh", "HasStdExtZksh", "true",
                        "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)">;
 def HasStdExtZksh : Predicate<"Subtarget->hasStdExtZksh()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZksh),
-                              "'Zksh' (ShangMi Suite: SM3 Hash Function "
-                              "Instructions)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZksh),
+                        "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)">;
 
 def FeatureStdExtZkr
     : SubtargetFeature<"zkr", "HasStdExtZkr", "true",
                        "'Zkr' (Entropy Source Extension)">;
 def HasStdExtZkr : Predicate<"Subtarget->hasStdExtZkr()">,
-                             AssemblerPredicate<(all_of FeatureStdExtZkr),
-                             "'Zkr' (Entropy Source Extension)">;
+                   AssemblerPredicate<(all_of FeatureStdExtZkr),
+                                      "'Zkr' (Entropy Source Extension)">;
 
 def FeatureStdExtZkn
     : SubtargetFeature<"zkn", "HasStdExtZkn", "true",
@@ -581,16 +580,16 @@ def FeatureStdExtZvfbfmin
                        "'Zvbfmin' (Vector BF16 Converts)",
                        [FeatureStdExtZve32f]>;
 def HasStdExtZvfbfmin : Predicate<"Subtarget->hasStdExtZvfbfmin()">,
-                                  AssemblerPredicate<(all_of FeatureStdExtZvfbfmin),
-                                  "'Zvfbfmin' (Vector BF16 Converts)">;
+                        AssemblerPredicate<(all_of FeatureStdExtZvfbfmin),
+                            "'Zvfbfmin' (Vector BF16 Converts)">;
 
 def FeatureStdExtZvfbfwma
     : SubtargetFeature<"experimental-zvfbfwma", "HasStdExtZvfbfwma", "true",
                        "'Zvfbfwma' (Vector BF16 widening mul-add)",
                        [FeatureStdExtZvfbfmin, FeatureStdExtZfbfmin]>;
 def HasStdExtZvfbfwma : Predicate<"Subtarget->hasStdExtZvfbfwma()">,
-                                  AssemblerPredicate<(all_of FeatureStdExtZvfbfwma),
-                                  "'Zvfbfwma' (Vector BF16 widening mul-add)">;
+                        AssemblerPredicate<(all_of FeatureStdExtZvfbfwma),
+                            "'Zvfbfwma' (Vector BF16 widening mul-add)">;
 
 def FeatureStdExtZvfhmin
     : SubtargetFeature<"zvfhmin", "HasStdExtZvfhmin", "true",
@@ -604,9 +603,9 @@ def FeatureStdExtZvfh
 
 def HasStdExtZfhOrZvfh
     : Predicate<"Subtarget->hasStdExtZfh() || Subtarget->hasStdExtZvfh()">,
-                AssemblerPredicate<(any_of FeatureStdExtZfh, FeatureStdExtZvfh),
-                                   "'Zfh' (Half-Precision Floating-Point) or "
-                                   "'Zvfh' (Vector Half-Precision Floating-Point)">;
+      AssemblerPredicate<(any_of FeatureStdExtZfh, FeatureStdExtZvfh),
+                         "'Zfh' (Half-Precision Floating-Point) or "
+                         "'Zvfh' (Vector Half-Precision Floating-Point)">;
 
 // Vector Cryptography and Bitmanip Extensions
 
@@ -614,70 +613,70 @@ def FeatureStdExtZvkb
     : SubtargetFeature<"zvkb", "HasStdExtZvkb", "true",
                        "'Zvkb' (Vector Bit-manipulation used in Cryptography)">;
 def HasStdExtZvkb : Predicate<"Subtarget->hasStdExtZvkb()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZvkb),
-                              "'Zvkb' (Vector Bit-manipulation used in Cryptography)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZvkb),
+                        "'Zvkb' (Vector Bit-manipulation used in Cryptography)">;
 
 def FeatureStdExtZvbb
     : SubtargetFeature<"zvbb", "HasStdExtZvbb", "true",
                        "'Zvbb' (Vector basic bit-manipulation instructions)",
                        [FeatureStdExtZvkb]>;
 def HasStdExtZvbb : Predicate<"Subtarget->hasStdExtZvbb()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZvbb),
-                              "'Zvbb' (Vector basic bit-manipulation instructions)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZvbb),
+                        "'Zvbb' (Vector basic bit-manipulation instructions)">;
 
 def FeatureStdExtZvbc
     : SubtargetFeature<"zvbc", "HasStdExtZvbc", "true",
                        "'Zvbc' (Vector Carryless Multiplication)">;
 def HasStdExtZvbc : Predicate<"Subtarget->hasStdExtZvbc()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZvbc),
-                              "'Zvbc' (Vector Carryless Multiplication)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZvbc),
+                        "'Zvbc' (Vector Carryless Multiplication)">;
 
 def FeatureStdExtZvkg
     : SubtargetFeature<"zvkg", "HasStdExtZvkg", "true",
                        "'Zvkg' (Vector GCM instructions for Cryptography)">;
 def HasStdExtZvkg : Predicate<"Subtarget->hasStdExtZvkg()">,
-                              AssemblerPredicate<(all_of FeatureStdExtZvkg),
-                              "'Zvkg' (Vector GCM instructions for Cryptography)">;
+                    AssemblerPredicate<(all_of FeatureStdExtZvkg),
+                        "'Zvkg' (Vector GCM instructions for Cryptography)">;
 
 def FeatureStdExtZvkned
     : SubtargetFeature<"zvkned", "HasStdExtZvkned", "true",
                        "'Zvkned' (Vector AES Encryption & Decryption (Single Round))">;
 def HasStdExtZvkned : Predicate<"Subtarget->hasStdExtZvkned()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZvkned),
-                                "'Zvkned' (Vector AES Encryption & Decryption (Single Round))">;
+                      AssemblerPredicate<(all_of FeatureStdExtZvkned),
+                          "'Zvkned' (Vector AES Encryption & Decryption (Single Round))">;
 
 def FeatureStdExtZvknha
     : SubtargetFeature<"zvknha", "HasStdExtZvknha", "true",
                        "'Zvknha' (Vector SHA-2 (SHA-256 only))">;
 def HasStdExtZvknha : Predicate<"Subtarget->hasStdExtZvknha()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZvknha),
-                                "'Zvknha' (Vector SHA-2 (SHA-256 only))">;
+                      AssemblerPredicate<(all_of FeatureStdExtZvknha),
+                          "'Zvknha' (Vector SHA-2 (SHA-256 only))">;
 
 def FeatureStdExtZvknhb
     : SubtargetFeature<"zvknhb", "HasStdExtZvknhb", "true",
                        "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))",
                        [FeatureStdExtZve64x]>;
 def HasStdExtZvknhb : Predicate<"Subtarget->hasStdExtZvknhb()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZvknhb),
-                                "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))">;
+                      AssemblerPredicate<(all_of FeatureStdExtZvknhb),
+                          "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))">;
 
 def HasStdExtZvknhaOrZvknhb : Predicate<"Subtarget->hasStdExtZvknha() || Subtarget->hasStdExtZvknhb()">,
-                                        AssemblerPredicate<(any_of FeatureStdExtZvknha, FeatureStdExtZvknhb),
-                                        "'Zvknha' or 'Zvknhb' (Vector SHA-2)">;
+                              AssemblerPredicate<(any_of FeatureStdExtZvknha, FeatureStdExtZvknhb),
+                                  "'Zvknha' or 'Zvknhb' (Vector SHA-2)">;
 
 def FeatureStdExtZvksed
     : SubtargetFeature<"zvksed", "HasStdExtZvksed", "true",
                        "'Zvksed' (SM4 Block Cipher Instructions)">;
 def HasStdExtZvksed : Predicate<"Subtarget->hasStdExtZvksed()">,
-                                AssemblerPredicate<(all_of FeatureStdExtZvksed),
-                                "'Zvksed' (SM4 Block Cipher Instructions)">;
+                      AssemblerPredicate<(all_of FeatureStdExtZvksed),
+                          "'Zvksed' (SM4 Block Cipher Instructions)">;
 
 def FeatureStdExtZvksh
     : SubtargetFeature<"zvksh", "HasStdExtZvksh", "true",
                        "'Zvksh' (SM3 Hash Function Instructions)">;
 def HasStdExtZvksh : Predicate<"Subtarget->hasStdExtZvksh()">,
-                               AssemblerPredicate<(all_of FeatureStdExtZvksh),
-                               "'Zvksh' (SM3 Hash Function Instructions)">;
+                     AssemblerPredicate<(all_of FeatureStdExtZvksh),
+                         "'Zvksh' (SM3 Hash Function Instructions)">;
 
 def FeatureStdExtZvkt
     : SubtargetFeature<"zvkt", "HasStdExtZvkt", "true",
@@ -767,8 +766,8 @@ def FeatureStdExtSvinval
     : SubtargetFeature<"svinval", "HasStdExtSvinval", "true",
                        "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)">;
 def HasStdExtSvinval : Predicate<"Subtarget->hasStdExtSvinval()">,
-                                AssemblerPredicate<(all_of FeatureStdExtSvinval),
-                                "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)">;
+                       AssemblerPredicate<(all_of FeatureStdExtSvinval),
+                           "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)">;
 
 def FeatureStdExtSvnapot
     : SubtargetFeature<"svnapot", "HasStdExtSvnapot", "true",
@@ -788,8 +787,8 @@ def FeatureVendorXVentanaCondOps
     : SubtargetFeature<"xventanacondops", "HasVendorXVentanaCondOps", "true",
                        "'XVentanaCondOps' (Ventana Conditional Ops)">;
 def HasVendorXVentanaCondOps : Predicate<"Subtarget->hasVendorXVentanaCondOps()">,
-                                AssemblerPredicate<(all_of FeatureVendorXVentanaCondOps),
-                                "'XVentanaCondOps' (Ventana Conditional Ops)">;
+                               AssemblerPredicate<(all_of FeatureVendorXVentanaCondOps),
+                                   "'XVentanaCondOps' (Ventana Conditional Ops)">;
 
 // T-Head Extensions
 
@@ -797,80 +796,80 @@ def FeatureVendorXTHeadBa
     : SubtargetFeature<"xtheadba", "HasVendorXTHeadBa", "true",
                        "'xtheadba' (T-Head address calculation instructions)">;
 def HasVendorXTHeadBa : Predicate<"Subtarget->hasVendorXTHeadBa()">,
-                                  AssemblerPredicate<(all_of FeatureVendorXTHeadBa),
-                                  "'xtheadba' (T-Head address calculation instructions)">;
+                        AssemblerPredicate<(all_of FeatureVendorXTHeadBa),
+                            "'xtheadba' (T-Head address calculation instructions)">;
 
 def FeatureVendorXTHeadBb
     : SubtargetFeature<"xtheadbb", "HasVendorXTHeadBb", "true",
                        "'xtheadbb' (T-Head basic bit-manipulation instructions)">;
 def HasVendorXTHeadBb : Predicate<"Subtarget->hasVendorXTHeadBb()">,
-                                  AssemblerPredicate<(all_of FeatureVendorXTHeadBb),
-                                  "'xtheadbb' (T-Head basic bit-manipulation instructions)">;
+                        AssemblerPredicate<(all_of FeatureVendorXTHeadBb),
+                            "'xtheadbb' (T-Head basic bit-manipulation instructions)">;
 
 def FeatureVendorXTHeadBs
     : SubtargetFeature<"xtheadbs", "HasVendorXTHeadBs", "true",
                        "'xtheadbs' (T-Head single-bit instructions)">;
 def HasVendorXTHeadBs : Predicate<"Subtarget->hasVendorXTHeadBs()">,
-                                  AssemblerPredicate<(all_of FeatureVendorXTHeadBs),
-                                  "'xtheadbs' (T-Head single-bit instructions)">;
+                        AssemblerPredicate<(all_of FeatureVendorXTHeadBs),
+                            "'xtheadbs' (T-Head single-bit instructions)">;
 
 def FeatureVendorXTHeadCondMov
     : SubtargetFeature<"xtheadcondmov", "HasVendorXTHeadCondMov", "true",
                        "'xtheadcondmov' (T-Head conditional move instructions)">;
 def HasVendorXTHeadCondMov : Predicate<"Subtarget->hasVendorXTHeadCondMov()">,
-                                       AssemblerPredicate<(all_of FeatureVendorXTHeadCondMov),
-                                       "'xtheadcondmov' (T-Head conditional move instructions)">;
+                             AssemblerPredicate<(all_of FeatureVendorXTHeadCondMov),
+                                 "'xtheadcondmov' (T-Head conditional move instructions)">;
 
 def FeatureVendorXTHeadCmo
     : SubtargetFeature<"xtheadcmo", "HasVendorXTHeadCmo", "true",
                        "'xtheadcmo' (T-Head cache management instructions)">;
 def HasVendorXTHeadCmo : Predicate<"Subtarget->hasVendorXTHeadCmo()">,
-                                   AssemblerPredicate<(all_of FeatureVendorXTHeadCmo),
-                                   "'xtheadcmo' (T-Head cache management instructions)">;
+                         AssemblerPredicate<(all_of FeatureVendorXTHeadCmo),
+                             "'xtheadcmo' (T-Head cache management instructions)">;
 
 def FeatureVendorXTHeadFMemIdx
     : SubtargetFeature<"xtheadfmemidx", "HasVendorXTHeadFMemIdx", "true",
                        "'xtheadfmemidx' (T-Head FP Indexed Memory Operations)",
                        [FeatureStdExtF]>;
 def HasVendorXTHeadFMemIdx : Predicate<"Subtarget->hasVendorXTHeadFMemIdx()">,
-                                       AssemblerPredicate<(all_of FeatureVendorXTHeadFMemIdx),
-                                       "'xtheadfmemidx' (T-Head FP Indexed Memory Operations)">;
+                             AssemblerPredicate<(all_of FeatureVendorXTHeadFMemIdx),
+                                 "'xtheadfmemidx' (T-Head FP Indexed Memory Operations)">;
 
 def FeatureVendorXTHeadMac
     : SubtargetFeature<"xtheadmac", "HasVendorXTHeadMac", "true",
                        "'xtheadmac' (T-Head Multiply-Accumulate Instructions)">;
 def HasVendorXTHeadMac : Predicate<"Subtarget->hasVendorXTHeadMac()">,
-                                   AssemblerPredicate<(all_of FeatureVendorXTHeadMac),
-                                   "'xtheadmac' (T-Head Multiply-Accumulate Instructions)">;
+                         AssemblerPredicate<(all_of FeatureVendorXTHeadMac),
+                             "'xtheadmac' (T-Head Multiply-Accumulate Instructions)">;
 
 def FeatureVendorXTHeadMemIdx
     : SubtargetFeature<"xtheadmemidx", "HasVendorXTHeadMemIdx", "true",
                        "'xtheadmemidx' (T-Head Indexed Memory Operations)">;
 def HasVendorXTHeadMemIdx : Predicate<"Subtarget->hasVendorXTHeadMemIdx()">,
-                                      AssemblerPredicate<(all_of FeatureVendorXTHeadMemIdx),
-                                      "'xtheadmemidx' (T-Head Indexed Memory Operations)">;
+                            AssemblerPredicate<(all_of FeatureVendorXTHeadMemIdx),
+                                "'xtheadmemidx' (T-Head Indexed Memory Operations)">;
 
 def FeatureVendorXTHeadMemPair
     : SubtargetFeature<"xtheadmempair", "HasVendorXTHeadMemPair", "true",
                        "'xtheadmempair' (T-Head two-GPR Memory Operations)">;
 def HasVendorXTHeadMemPair : Predicate<"Subtarget->hasVendorXTHeadMemPair()">,
-                                    AssemblerPredicate<(all_of FeatureVendorXTHeadMemPair),
-                                    "'xtheadmempair' (T-Head two-GPR Memory Operations)">;
+                             AssemblerPredicate<(all_of FeatureVendorXTHeadMemPair),
+                                 "'xtheadmempair' (T-Head two-GPR Memory Operations)">;
 
 def FeatureVendorXTHeadSync
     : SubtargetFeature<"xtheadsync", "HasVendorXTHeadSync", "true",
                        "'xtheadsync' (T-Head multicore synchronization instructions)">;
 def HasVendorXTHeadSync : Predicate<"Subtarget->hasVendorXTHeadSync()">,
-                                    AssemblerPredicate<(all_of FeatureVendorXTHeadSync),
-                                    "'xtheadsync' (T-Head multicore synchronization instructions)">;
+                          AssemblerPredicate<(all_of FeatureVendorXTHeadSync),
+                              "'xtheadsync' (T-Head multicore synchronization instructions)">;
 
 def FeatureVendorXTHeadVdot
     : SubtargetFeature<"xtheadvdot", "HasVendorXTHeadVdot", "true",
                        "'xtheadvdot' (T-Head Vector Extensions for Dot)",
                        [FeatureStdExtV]>;
 def HasVendorXTHeadVdot : Predicate<"Subtarget->hasVendorXTHeadVdot()">,
-                                    AssemblerPredicate<(all_of FeatureVendorXTHeadVdot),
-                                    "'xtheadvdot' (T-Head Vector Extensions for Dot)">;
+                          AssemblerPredicate<(all_of FeatureVendorXTHeadVdot),
+                              "'xtheadvdot' (T-Head Vector Extensions for Dot)">;
 
 // SiFive Extensions
 
@@ -879,40 +878,44 @@ def FeatureVendorXSfvcp
                        "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)",
                        [FeatureStdExtZve32x]>;
 def HasVendorXSfvcp : Predicate<"Subtarget->hasVendorXSfvcp()">,
-                                AssemblerPredicate<(all_of FeatureVendorXSfvcp),
-                                "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)">;
+                      AssemblerPredicate<(all_of FeatureVendorXSfvcp),
+                          "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)">;
 
 def FeatureVendorXSfvqmaccdod
     : SubtargetFeature<"xsfvqmaccdod", "HasVendorXSfvqmaccdod", "true",
                        "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))",
                        [FeatureStdExtZve32x]>;
-def HasVendorXSfvqmaccdod : Predicate<"Subtarget->hasVendorXSfvqmaccdod()">,
-                         AssemblerPredicate<(all_of FeatureVendorXSfvqmaccdod),
+def HasVendorXSfvqmaccdod
+    : Predicate<"Subtarget->hasVendorXSfvqmaccdod()">,
+      AssemblerPredicate<(all_of FeatureVendorXSfvqmaccdod),
                          "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))">;
 
 def FeatureVendorXSfvqmaccqoq
     : SubtargetFeature<"xsfvqmaccqoq", "HasVendorXSfvqmaccqoq", "true",
                        "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))",
                        [FeatureStdExtZve32x]>;
-def HasVendorXSfvqmaccqoq : Predicate<"Subtarget->hasVendorXSfvqmaccqoq()">,
-                         AssemblerPredicate<(all_of FeatureVendorXSfvqmaccqoq),
+def HasVendorXSfvqmaccqoq
+    : Predicate<"Subtarget->hasVendorXSfvqmaccqoq()">,
+      AssemblerPredicate<(all_of FeatureVendorXSfvqmaccqoq),
                          "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))">;
 
 def FeatureVendorXSfvfwmaccqqq
     : SubtargetFeature<"xsfvfwmaccqqq", "HasVendorXSfvfwmaccqqq", "true",
                        "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))",
                        [FeatureStdExtZve32f, FeatureStdExtZvfbfmin]>;
-def HasVendorXSfvfwmaccqqq : Predicate<"Subtarget->hasVendorXSfvfwmaccqqq()">,
-                         AssemblerPredicate<(all_of FeatureVendorXSfvfwmaccqqq),
+def HasVendorXSfvfwmaccqqq
+    : Predicate<"Subtarget->hasVendorXSfvfwmaccqqq()">,
+      AssemblerPredicate<(all_of FeatureVendorXSfvfwmaccqqq),
                          "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))">;
 
 def FeatureVendorXSfvfnrclipxfqf
     : SubtargetFeature<"xsfvfnrclipxfqf", "HasVendorXSfvfnrclipxfqf", "true",
                        "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)",
                        [FeatureStdExtZve32f]>;
-def HasVendorXSfvfnrclipxfqf : Predicate<"Subtarget->hasVendorXSfvfnrclipxfqf()">,
-                               AssemblerPredicate<(all_of FeatureVendorXSfvfnrclipxfqf),
-                               "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)">;
+def HasVendorXSfvfnrclipxfqf
+    : Predicate<"Subtarget->hasVendorXSfvfnrclipxfqf()">,
+      AssemblerPredicate<(all_of FeatureVendorXSfvfnrclipxfqf),
+                         "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)">;
 
 // Core-V Extensions
 
@@ -921,52 +924,56 @@ def FeatureVendorXCVelw
                       "'XCVelw' (CORE-V Event Load Word)">;
 def HasVendorXCVelw
    : Predicate<"Subtarget->hasVendorXCVelw()">,
-              AssemblerPredicate<(any_of FeatureVendorXCVelw),
-              "'XCVelw' (CORE-V Event Load Word)">;
+     AssemblerPredicate<(any_of FeatureVendorXCVelw),
+                        "'XCVelw' (CORE-V Event Load Word)">;
 
 def FeatureVendorXCVbitmanip
     : SubtargetFeature<"xcvbitmanip", "HasVendorXCVbitmanip", "true",
                        "'XCVbitmanip' (CORE-V Bit Manipulation)">;
-def HasVendorXCVbitmanip : Predicate<"Subtarget->hasVendorXCVbitmanip()">,
-                                AssemblerPredicate<(all_of FeatureVendorXCVbitmanip),
-                                "'XCVbitmanip' (CORE-V Bit Manipulation)">;
+def HasVendorXCVbitmanip
+    : Predicate<"Subtarget->hasVendorXCVbitmanip()">,
+      AssemblerPredicate<(all_of FeatureVendorXCVbitmanip),
+                         "'XCVbitmanip' (CORE-V Bit Manipulation)">;
 
 def FeatureVendorXCVmac
     : SubtargetFeature<"xcvmac", "HasVendorXCVmac", "true",
                        "'XCVmac' (CORE-V Multiply-Accumulate)">;
-def HasVendorXCVmac : Predicate<"Subtarget->hasVendorXCVmac()">,
-                                AssemblerPredicate<(all_of FeatureVendorXCVmac),
-                                "'XCVmac' (CORE-V Multiply-Accumulate)">;
+def HasVendorXCVmac
+    : Predicate<"Subtarget->hasVendorXCVmac()">,
+      AssemblerPredicate<(all_of FeatureVendorXCVmac),
+                         "'XCVmac' (CORE-V Multiply-Accumulate)">;
 
 def FeatureVendorXCVmem
     : SubtargetFeature<"xcvmem", "HasVendorXCVmem", "true",
                        "'XCVmem' (CORE-V Post-incrementing Load & Store)">;
 def HasVendorXCVmem
     : Predicate<"Subtarget->hasVendorXCVmem()">,
-               AssemblerPredicate<(any_of FeatureVendorXCVmem),
-               "'XCVmem' (CORE-V Post-incrementing Load & Store)">;
+      AssemblerPredicate<(any_of FeatureVendorXCVmem),
+                         "'XCVmem' (CORE-V Post-incrementing Load & Store)">;
 
 def FeatureVendorXCValu
     : SubtargetFeature<"xcvalu", "HasVendorXCValu", "true",
                        "'XCValu' (CORE-V ALU Operations)">;
-def HasVendorXCValu : Predicate<"Subtarget->hasVendorXCValu()">,
-                                AssemblerPredicate<(all_of FeatureVendorXCValu),
-                                "'XCValu' (CORE-V ALU Operations)">;
+def HasVendorXCValu
+    : Predicate<"Subtarget->hasVendorXCValu()">,
+      AssemblerPredicate<(all_of FeatureVendorXCValu),
+                         "'XCValu' (CORE-V ALU Operations)">;
 
 def FeatureVendorXCVsimd
     : SubtargetFeature<"xcvsimd", "HasVendorXCvsimd", "true",
                        "'XCVsimd' (CORE-V SIMD ALU)">;
 def HasVendorXCVsimd
     : Predicate<"Subtarget->hasVendorXCVsimd()">,
-                AssemblerPredicate<(any_of FeatureVendorXCVsimd),
-                "'XCVsimd' (CORE-V SIMD ALU)">;
+      AssemblerPredicate<(any_of FeatureVendorXCVsimd),
+                         "'XCVsimd' (CORE-V SIMD ALU)">;
 
 def FeatureVendorXCVbi
     : SubtargetFeature<"xcvbi", "HasVendorXCVbi", "true",
                        "'XCVbi' (CORE-V Immediate Branching)">;
-def HasVendorXCVbi : Predicate<"Subtarget->hasVendorXCVbi()">,
-                               AssemblerPredicate<(all_of FeatureVendorXCVbi),
-                               "'XCVbi' (CORE-V Immediate Branching)">;
+def HasVendorXCVbi
+    : Predicate<"Subtarget->hasVendorXCVbi()">,
+      AssemblerPredicate<(all_of FeatureVendorXCVbi),
+                         "'XCVbi' (CORE-V Immediate Branching)">;
 
 //===----------------------------------------------------------------------===//
 // LLVM specific features and extensions
@@ -979,11 +986,11 @@ def Feature32Bit
 def Feature64Bit
     : SubtargetFeature<"64bit", "IsRV64", "true", "Implements RV64">;
 def IsRV64 : Predicate<"Subtarget->is64Bit()">,
-                       AssemblerPredicate<(all_of Feature64Bit),
-                                         "RV64I Base Instruction Set">;
+             AssemblerPredicate<(all_of Feature64Bit),
+                               "RV64I Base Instruction Set">;
 def IsRV32 : Predicate<"!Subtarget->is64Bit()">,
-                       AssemblerPredicate<(all_of (not Feature64Bit)),
-                                          "RV32I Base Instruction Set">;
+             AssemblerPredicate<(all_of (not Feature64Bit)),
+                                "RV32I Base Instruction Set">;
 
 defvar RV32 = DefaultMode;
 def RV64           : HwMode<"+64bit", [IsRV64]>;
@@ -992,7 +999,7 @@ def FeatureRVE
     : SubtargetFeature<"e", "IsRVE", "true",
                        "Implements RV{32,64}E (provides 16 rather than 32 GPRs)">;
 def IsRVE : Predicate<"Subtarget->isRVE()">,
-                        AssemblerPredicate<(all_of FeatureRVE)>;
+            AssemblerPredicate<(all_of FeatureRVE)>;
 
 def FeatureRelax
     : SubtargetFeature<"relax", "EnableLinkerRelax", "true",

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -987,7 +987,7 @@ def Feature64Bit
     : SubtargetFeature<"64bit", "IsRV64", "true", "Implements RV64">;
 def IsRV64 : Predicate<"Subtarget->is64Bit()">,
              AssemblerPredicate<(all_of Feature64Bit),
-                               "RV64I Base Instruction Set">;
+                                "RV64I Base Instruction Set">;
 def IsRV32 : Predicate<"!Subtarget->is64Bit()">,
              AssemblerPredicate<(all_of (not Feature64Bit)),
                                 "RV32I Base Instruction Set">;


### PR DESCRIPTION
AssemblerPredicate was almost always indented to the same column as the first operand to Predicate. But AssemblerPredicate is a separate base class so should have the same indentation as Predicate.

For the string passed to AssemblePredicate, I aligned it to the other arguments on the previous if it fit in 80 columns. Otherwise I indented 4 spaces past the start of AssemblerPredicate.

For some vendor extensions I put the 2 classes on new lines instead of the same line as the def. This gave more room for the strings and was more consistent with other formatting in that portion of the file.