### PR TITLE
[NFC] Size and element numbers are often swapped when calling calloc

### DIFF
--- a/clang/test/Analysis/malloc.mm
+++ b/clang/test/Analysis/malloc.mm
@@ -116,17 +116,17 @@ void testUseAfterFree() {
 }
 
 void testNoCopy() {
-  char *p = (char *)calloc(sizeof(int), 1);
+  char *p = (char *)calloc(1, sizeof(int));
   CustomData *w = [CustomData somethingNoCopy:p]; // no-warning
 }
 
 void testFreeWhenDone() {
-  char *p = (char *)calloc(sizeof(int), 1);
+  char *p = (char *)calloc(1, sizeof(int));
   CustomData *w = [CustomData something:p freeWhenDone:1]; // no-warning
 }
 
 void testFreeWhenDonePositive() {
-  char *p = (char *)calloc(sizeof(int), 1);
+  char *p = (char *)calloc(1, sizeof(int));
   CustomData *w = [CustomData something:p freeWhenDone:0]; // expected-warning{{leak}}
 }
 

--- a/clang/test/Analysis/uninit-vals.m
+++ b/clang/test/Analysis/uninit-vals.m
@@ -158,7 +158,7 @@ Point makePoint(float x, float y) {
 }
 
 void PR14765_test(void) {
-  Circle *testObj = calloc(sizeof(Circle), 1);
+  Circle *testObj = calloc(1, sizeof(Circle));
 
   clang_analyzer_eval(testObj->size == 0); // expected-warning{{TRUE}}
                                            // expected-note@-1{{TRUE}}
@@ -207,7 +207,7 @@ IntPoint makeIntPoint(int x, int y) {
 }
 
 void PR14765_test_int(void) {
-  IntCircle *testObj = calloc(sizeof(IntCircle), 1);
+  IntCircle *testObj = calloc(1, sizeof(IntCircle));
 
   clang_analyzer_eval(testObj->size == 0); // expected-warning{{TRUE}}
                                            // expected-note@-1{{TRUE}}
@@ -311,7 +311,7 @@ void testLargeStructsNotCopiedPerField(void) {
 }
 
 void testSmallStructInLargerStruct(void) {
-  IntCircle2D *testObj = calloc(sizeof(IntCircle2D), 1);
+  IntCircle2D *testObj = calloc(1, sizeof(IntCircle2D));
 
   clang_analyzer_eval(testObj->size == 0); // expected-warning{{TRUE}}
                                            // expected-note@-1{{TRUE}}

--- a/clang/test/CodeGen/alloc-size.c
+++ b/clang/test/CodeGen/alloc-size.c
@@ -137,7 +137,7 @@ void test5(void) {
   // CHECK: store i32 36
   gi = OBJECT_SIZE_BUILTIN(&data->t[1], 3);
 
-  struct Data *const arr = my_calloc(sizeof(*data), 2);
+  struct Data *const arr = my_calloc(2, sizeof(*data));
   // CHECK: store i32 96
   gi = OBJECT_SIZE_BUILTIN(arr, 0);
   // CHECK: store i32 96
@@ -171,7 +171,7 @@ void test6(void) {
   // CHECK: store i32 11
   gi = OBJECT_SIZE_BUILTIN(data->end, 3);
 
-  struct Data *const arr = my_calloc(sizeof(*arr) + 5, 3);
+  struct Data *const arr = my_calloc(3, sizeof(*arr) + 5);
   // AFAICT, GCC treats malloc and calloc identically. So, we should do the
   // same.
   //

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -335,10 +335,10 @@ static void initFileWriter(ProfDataWriter *This, FILE *File) {
 COMPILER_RT_VISIBILITY ProfBufferIO *
 lprofCreateBufferIOInternal(void *File, uint32_t BufferSz) {
   FreeHook = &free;
-  DynamicBufferIOBuffer = (uint8_t *)calloc(BufferSz, 1);
+  DynamicBufferIOBuffer = (uint8_t *)calloc(1, BufferSz);
   VPBufferSize = BufferSz;
   ProfDataWriter *fileWriter =
-      (ProfDataWriter *)calloc(sizeof(ProfDataWriter), 1);
+      (ProfDataWriter *)calloc(1, sizeof(ProfDataWriter));
   initFileWriter(fileWriter, File);
   ProfBufferIO *IO = lprofCreateBufferIO(fileWriter);
   IO->OwnFileWriter = 1;

--- a/compiler-rt/test/tsan/java_finalizer2.cpp
+++ b/compiler-rt/test/tsan/java_finalizer2.cpp
@@ -51,7 +51,7 @@ void *Ballast(void *p) {
 }
 
 int main() {
-  Heap* heap = (Heap*)calloc(sizeof(Heap), 2) + 1;
+  Heap *heap = (Heap *)calloc(2, sizeof(Heap)) + 1;
   __tsan_java_init((jptr)heap, sizeof(*heap));
   __tsan_java_alloc((jptr)heap, sizeof(*heap));
   // Ballast threads merely make the bug a bit easier to trigger.


### PR DESCRIPTION
gcc-14 will now throw a warning if size and elements are swapped.