### PR TITLE
[libc++][NFC] Add additional tests for begin/end of std::ranges::take_view

### DIFF
--- a/libcxx/test/std/ranges/range.adaptors/range.take/begin.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/begin.pass.cpp
@@ -11,11 +11,10 @@
 // constexpr auto begin() requires (!simple-view<V>);
 // constexpr auto begin() const requires range<const V>;
 
-#include <ranges>
 #include <cassert>
+#include <ranges>
 #include <utility>
 
-#include "__ranges/concepts.h"
 #include "test_macros.h"
 #include "test_iterators.h"
 #include "test_range.h"
@@ -29,100 +28,101 @@ struct NonCommonSimpleView : std::ranges::view_base {
 static_assert(std::ranges::sized_range<NonCommonSimpleView>);
 static_assert(!std::ranges::sized_range<const NonCommonSimpleView>);
 
+using CommonInputIterPtrConstInt        = common_input_iterator<const int*>;
+using CountedCommonInputIterPtrConstInt = std::counted_iterator<CommonInputIterPtrConstInt>;
+
 constexpr bool test() {
   int buffer[8] = {1, 2, 3, 4, 5, 6, 7, 8};
 
   // simple-view<V> && sized_range<V> && random_access_range<V>
   {
-    static_assert(simple_view<SizedRandomAccessView>);
-    static_assert(std::ranges::sized_range<SizedRandomAccessView>);
-    static_assert(std::ranges::random_access_range<SizedRandomAccessView>);
+    using ViewTested = SizedRandomAccessView;
+    static_assert(simple_view<ViewTested>);
+    static_assert(std::ranges::sized_range<ViewTested>);
+    static_assert(std::ranges::random_access_range<ViewTested>);
 
-    std::ranges::take_view<SizedRandomAccessView> tv(SizedRandomAccessView(buffer), 4);
-    assert(tv.begin() == SizedRandomAccessView(buffer).begin());
+    std::ranges::take_view<ViewTested> tv(ViewTested(buffer), 4);
+    assert(tv.begin() == ViewTested(buffer).begin());
     ASSERT_SAME_TYPE(decltype(tv.begin()), RandomAccessIter);
-  }
 
-  {
-    const std::ranges::take_view<SizedRandomAccessView> tv(SizedRandomAccessView(buffer), 4);
-    assert(tv.begin() == SizedRandomAccessView(buffer).begin());
-    ASSERT_SAME_TYPE(decltype(tv.begin()), RandomAccessIter);
+    const std::ranges::take_view<ViewTested> ctv(ViewTested(buffer), 4);
+    assert(ctv.begin() == ViewTested(buffer).begin());
+    ASSERT_SAME_TYPE(decltype(ctv.begin()), RandomAccessIter);
   }
 
   // simple-view<V> && sized_range<V> && !random_access_range<V>
   {
-    static_assert(simple_view<SizedForwardView>);
-    static_assert(std::ranges::sized_range<SizedForwardView>);
-    static_assert(!std::ranges::random_access_range<SizedForwardView>);
+    using ViewTested = SizedForwardView;
+    static_assert(simple_view<ViewTested>);
+    static_assert(std::ranges::sized_range<ViewTested>);
+    static_assert(!std::ranges::random_access_range<ViewTested>);
 
-    std::ranges::take_view<SizedForwardView> tv(SizedForwardView{buffer}, 16);        // underlying size is 8
+    std::ranges::take_view<ViewTested> tv(ViewTested{buffer}, 16);                    // underlying size is 8
     assert(tv.begin() == std::counted_iterator<ForwardIter>(ForwardIter(buffer), 8)); // expect min(8, 16)
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<ForwardIter>);
-  }
 
-  {
-    const std::ranges::take_view<SizedForwardView> tv(SizedForwardView{buffer}, 4);
-    assert(tv.begin() == std::counted_iterator<ForwardIter>(ForwardIter(buffer), 4));
-    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<ForwardIter>);
+    const std::ranges::take_view<ViewTested> ctv(ViewTested{buffer}, 4);
+    assert(ctv.begin() == std::counted_iterator<ForwardIter>(ForwardIter(buffer), 4));
+    ASSERT_SAME_TYPE(decltype(ctv.begin()), std::counted_iterator<ForwardIter>);
   }
 
   // simple-view<V> && !sized_range<V>
   {
-    static_assert(simple_view<MoveOnlyView>);
-    static_assert(simple_view<MoveOnlyView>);
-    std::ranges::take_view<MoveOnlyView> tv(MoveOnlyView{buffer}, 4);
+    using ViewTested = MoveOnlyView;
+    static_assert(simple_view<ViewTested>);
+    std::ranges::take_view<ViewTested> tv(ViewTested{buffer}, 4);
     assert(tv.begin() == std::counted_iterator<int*>(buffer, 4));
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
-  }
 
-  {
-    const std::ranges::take_view<MoveOnlyView> tv(MoveOnlyView{buffer}, 4);
-    assert(tv.begin() == std::counted_iterator<int*>(buffer, 4));
-    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
+    const std::ranges::take_view<ViewTested> ctv(ViewTested{buffer}, 4);
+    assert(ctv.begin() == std::counted_iterator<int*>(buffer, 4));
+    ASSERT_SAME_TYPE(decltype(ctv.begin()), std::counted_iterator<int*>);
   }
 
   // simple-view<V> && sized_range<V> && !sized_range<const V>
   {
-    static_assert(simple_view<NonCommonSimpleView>);
-    static_assert(std::ranges::sized_range<NonCommonSimpleView>);
-    static_assert(!std::ranges::sized_range<const NonCommonSimpleView>);
+    using ViewTested = NonCommonSimpleView;
+    static_assert(simple_view<ViewTested>);
+    static_assert(std::ranges::sized_range<ViewTested>);
+    static_assert(!std::ranges::sized_range<const ViewTested>);
 
-    std::ranges::take_view<NonCommonSimpleView> tv{};
+    std::ranges::take_view<ViewTested> tv{};
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
     ASSERT_SAME_TYPE(decltype(std::as_const(tv).begin()), std::counted_iterator<int*>);
   }
 
-  // non simple-view<V> && !sized_range<V>
+  //  !simple-view<V> && !sized_range<V>
   {
-    static_assert(!simple_view<NonSimpleNonSizedView>);
-    static_assert(!std::ranges::sized_range<NonSimpleNonSizedView>);
+    using ViewTested = NonSimpleNonSizedView;
+    static_assert(!simple_view<ViewTested>);
+    static_assert(!std::ranges::sized_range<ViewTested>);
 
-    std::ranges::take_view<NonSimpleNonSizedView> tv{NonSimpleNonSizedView{buffer, buffer + 2}, 4};
+    std::ranges::take_view<ViewTested> tv{ViewTested{buffer, buffer + 2}, 4};
     // The count for the counted iterator is the count of the take_view (i.e., 4)
-    assert(tv.begin() ==
-           std::counted_iterator<common_input_iterator<const int*>>(common_input_iterator<const int*>(buffer), 4));
-    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<common_input_iterator<const int*>>);
+    assert(tv.begin() == CountedCommonInputIterPtrConstInt(CommonInputIterPtrConstInt(buffer), 4));
+    ASSERT_SAME_TYPE(decltype(tv.begin()), CountedCommonInputIterPtrConstInt);
   }
 
-  // non simple-view<V> && sized_range<V>
+  // !simple-view<V> && sized_range<V>
   {
-    static_assert(!simple_view<NonSimpleSizedView>);
-    static_assert(std::ranges::sized_range<NonSimpleSizedView>);
+    using ViewTested = NonSimpleSizedView;
+    static_assert(!simple_view<ViewTested>);
+    static_assert(std::ranges::sized_range<ViewTested>);
 
-    std::ranges::take_view<NonSimpleSizedView> tv{NonSimpleSizedView{buffer, buffer + 2}, 4};
+    std::ranges::take_view<ViewTested> tv{ViewTested{buffer, buffer + 2}, 4};
     // The count for the counted iterator is the min(2, 4) (i.e., 2).
-    assert(tv.begin() ==
-           std::counted_iterator<common_input_iterator<const int*>>(common_input_iterator<const int*>(buffer), 2));
-    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<common_input_iterator<const int*>>);
+    assert(tv.begin() == CountedCommonInputIterPtrConstInt(CommonInputIterPtrConstInt(buffer), 2));
+    ASSERT_SAME_TYPE(decltype(tv.begin()), CountedCommonInputIterPtrConstInt);
   }
 
-  // non simple-view<V> && sized_range<V> && random_access_range<V>
+  // !simple-view<V> && sized_range<V> && random_access_range<V>
   {
-    static_assert(!simple_view<NonSimpleSizedRandomView>);
-    static_assert(std::ranges::sized_range<NonSimpleSizedRandomView>);
-    static_assert(std::ranges::random_access_range<NonSimpleSizedRandomView>);
+    using ViewTested = NonSimpleSizedRandomView;
+    static_assert(!simple_view<ViewTested>);
+    static_assert(std::ranges::sized_range<ViewTested>);
+    static_assert(std::ranges::random_access_range<ViewTested>);
 
-    std::ranges::take_view<NonSimpleSizedRandomView> tv{NonSimpleSizedRandomView{buffer, buffer + 2}, 4};
+    std::ranges::take_view<ViewTested> tv{ViewTested{buffer, buffer + 2}, 4};
     assert(tv.begin() == random_access_iterator<const int*>(buffer));
     ASSERT_SAME_TYPE(decltype(tv.begin()), random_access_iterator<const int*>);
   }

--- a/libcxx/test/std/ranges/range.adaptors/range.take/begin.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/begin.pass.cpp
@@ -13,7 +13,9 @@
 
 #include <ranges>
 #include <cassert>
+#include <utility>
 
+#include "__ranges/concepts.h"
 #include "test_macros.h"
 #include "test_iterators.h"
 #include "test_range.h"
@@ -30,8 +32,12 @@ static_assert(!std::ranges::sized_range<const NonCommonSimpleView>);
 constexpr bool test() {
   int buffer[8] = {1, 2, 3, 4, 5, 6, 7, 8};
 
-  // sized_range && random_access_iterator
+  // simple-view<V> && sized_range<V> && random_access_range<V>
   {
+    static_assert(simple_view<SizedRandomAccessView>);
+    static_assert(std::ranges::sized_range<SizedRandomAccessView>);
+    static_assert(std::ranges::random_access_range<SizedRandomAccessView>);
+
     std::ranges::take_view<SizedRandomAccessView> tv(SizedRandomAccessView(buffer), 4);
     assert(tv.begin() == SizedRandomAccessView(buffer).begin());
     ASSERT_SAME_TYPE(decltype(tv.begin()), RandomAccessIter);
@@ -43,10 +49,14 @@ constexpr bool test() {
     ASSERT_SAME_TYPE(decltype(tv.begin()), RandomAccessIter);
   }
 
-  // sized_range && !random_access_iterator
+  // simple-view<V> && sized_range<V> && !random_access_range<V>
   {
-    std::ranges::take_view<SizedForwardView> tv(SizedForwardView{buffer}, 4);
-    assert(tv.begin() == std::counted_iterator<ForwardIter>(ForwardIter(buffer), 4));
+    static_assert(simple_view<SizedForwardView>);
+    static_assert(std::ranges::sized_range<SizedForwardView>);
+    static_assert(!std::ranges::random_access_range<SizedForwardView>);
+
+    std::ranges::take_view<SizedForwardView> tv(SizedForwardView{buffer}, 16);        // underlying size is 8
+    assert(tv.begin() == std::counted_iterator<ForwardIter>(ForwardIter(buffer), 8)); // expect min(8, 16)
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<ForwardIter>);
   }
 
@@ -56,8 +66,10 @@ constexpr bool test() {
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<ForwardIter>);
   }
 
-  // !sized_range
+  // simple-view<V> && !sized_range<V>
   {
+    static_assert(simple_view<MoveOnlyView>);
+    static_assert(simple_view<MoveOnlyView>);
     std::ranges::take_view<MoveOnlyView> tv(MoveOnlyView{buffer}, 4);
     assert(tv.begin() == std::counted_iterator<int*>(buffer, 4));
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
@@ -69,13 +81,51 @@ constexpr bool test() {
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
   }
 
-  // simple-view<V> && sized_range<V> && !size_range<!V>
+  // simple-view<V> && sized_range<V> && !sized_range<const V>
   {
+    static_assert(simple_view<NonCommonSimpleView>);
+    static_assert(std::ranges::sized_range<NonCommonSimpleView>);
+    static_assert(!std::ranges::sized_range<const NonCommonSimpleView>);
+
     std::ranges::take_view<NonCommonSimpleView> tv{};
     ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<int*>);
     ASSERT_SAME_TYPE(decltype(std::as_const(tv).begin()), std::counted_iterator<int*>);
   }
 
+  // non simple-view<V> && !sized_range<V>
+  {
+    static_assert(!simple_view<NonSimpleNonSizedView>);
+    static_assert(!std::ranges::sized_range<NonSimpleNonSizedView>);
+
+    std::ranges::take_view<NonSimpleNonSizedView> tv{NonSimpleNonSizedView{buffer, buffer + 2}, 4};
+    // The count for the counted iterator is the count of the take_view (i.e., 4)
+    assert(tv.begin() ==
+           std::counted_iterator<common_input_iterator<const int*>>(common_input_iterator<const int*>(buffer), 4));
+    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<common_input_iterator<const int*>>);
+  }
+
+  // non simple-view<V> && sized_range<V>
+  {
+    static_assert(!simple_view<NonSimpleSizedView>);
+    static_assert(std::ranges::sized_range<NonSimpleSizedView>);
+
+    std::ranges::take_view<NonSimpleSizedView> tv{NonSimpleSizedView{buffer, buffer + 2}, 4};
+    // The count for the counted iterator is the min(2, 4) (i.e., 2).
+    assert(tv.begin() ==
+           std::counted_iterator<common_input_iterator<const int*>>(common_input_iterator<const int*>(buffer), 2));
+    ASSERT_SAME_TYPE(decltype(tv.begin()), std::counted_iterator<common_input_iterator<const int*>>);
+  }
+
+  // non simple-view<V> && sized_range<V> && random_access_range<V>
+  {
+    static_assert(!simple_view<NonSimpleSizedRandomView>);
+    static_assert(std::ranges::sized_range<NonSimpleSizedRandomView>);
+    static_assert(std::ranges::random_access_range<NonSimpleSizedRandomView>);
+
+    std::ranges::take_view<NonSimpleSizedRandomView> tv{NonSimpleSizedRandomView{buffer, buffer + 2}, 4};
+    assert(tv.begin() == random_access_iterator<const int*>(buffer));
+    ASSERT_SAME_TYPE(decltype(tv.begin()), random_access_iterator<const int*>);
+  }
   return true;
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.take/end.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/end.pass.cpp
@@ -69,24 +69,17 @@ constexpr bool test() {
     assert(tv.end() == std::ranges::next(tv.begin(), 8));
   }
 
-  // Check that (non-)simple, non-sized views have different types for their end() member function.
   {
-    // These assertions must be true in order to trigger the different paths through the end member function
-    // that will return values with different types:
-    static_assert(!simple_view<NonSimpleViewNonSized>);
-    static_assert(!std::ranges::sized_range<NonSimpleViewNonSized>);
-    static_assert(simple_view<SimpleViewNonSized>);
-    static_assert(std::ranges::range<const SimpleViewNonSized>);
-    static_assert(!std::ranges::sized_range<const SimpleViewNonSized>);
-
-    std::ranges::take_view<NonSimpleViewNonSized> tvns(NonSimpleViewNonSized{buffer, buffer + 8}, 0);
-    std::ranges::take_view<SimpleViewNonSized> tvs(SimpleViewNonSized{buffer, buffer + 8}, 0);
-
     // __iterator<false> has base with type std::ranges::sentinel_t<NonSimpleViewNonSized>; adding a const qualifier
     // would change the equality.
+    std::ranges::take_view<NonSimpleViewNonSized> tvns(NonSimpleViewNonSized{buffer, buffer + 8}, 0);
     static_assert(!std::is_same_v<decltype(tvns.end().base()), std::ranges::sentinel_t<const NonSimpleViewNonSized>>);
+  }
+
+  {
     // __iterator<true> has base with type std::ranges::sentinel_t<const NonSimpleViewNonSized>; adding a const qualifier
     // would not change the equality.
+    std::ranges::take_view<SimpleViewNonSized> tvs(SimpleViewNonSized{buffer, buffer + 8}, 0);
     static_assert(std::is_same_v<decltype(tvs.end().base()), std::ranges::sentinel_t<const SimpleViewNonSized>>);
   }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.take/end.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/end.pass.cpp
@@ -72,8 +72,8 @@ constexpr bool test() {
   {
     // __iterator<false> has base with type std::ranges::sentinel_t<NonSimpleViewNonSized>; adding a const qualifier
     // would change the equality.
-    std::ranges::take_view<NonSimpleViewNonSized> tvns(NonSimpleViewNonSized{buffer, buffer + 8}, 0);
-    static_assert(!std::is_same_v<decltype(tvns.end().base()), std::ranges::sentinel_t<const NonSimpleViewNonSized>>);
+    std::ranges::take_view<NonSimpleNonSizedView> tvns(NonSimpleNonSizedView{buffer, buffer + 8}, 0);
+    static_assert(!std::is_same_v<decltype(tvns.end().base()), std::ranges::sentinel_t<const NonSimpleNonSizedView>>);
   }
 
   {

--- a/libcxx/test/std/ranges/range.adaptors/range.take/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/types.h
@@ -65,4 +65,37 @@ private:
   int* end_;
 };
 
+template <bool Simple>
+struct InputView : std::ranges::view_base {
+  constexpr explicit InputView(int* b, int* e) : begin_(b), end_(e) {}
+
+  constexpr common_input_iterator<int*> begin() const { return common_input_iterator<int*>(begin_); }
+  constexpr common_input_iterator<int*> end() const { return common_input_iterator<int*>(end_); }
+
+  constexpr common_input_iterator<const int*> begin()
+    requires(!Simple)
+  {
+    return common_input_iterator<const int*>(begin_);
+  }
+  constexpr common_input_iterator<const int*> end()
+    requires(!Simple)
+  {
+    return common_input_iterator<const int*>(end_);
+  }
+
+private:
+  int* begin_;
+  int* end_;
+};
+
+using NonSimpleViewNonSized = InputView<false>;
+static_assert(std::ranges::view<NonSimpleViewNonSized>);
+static_assert(!simple_view<NonSimpleViewNonSized>);
+static_assert(!std::ranges::sized_range<NonSimpleViewNonSized>);
+
+using SimpleViewNonSized = InputView<true>;
+static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
+static_assert(std::ranges::view<SimpleViewNonSized>);
+static_assert(simple_view<SimpleViewNonSized>);
+
 #endif // TEST_STD_RANGES_RANGE_ADAPTORS_RANGE_TAKE_TYPES_H

--- a/libcxx/test/std/ranges/range.adaptors/range.take/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/types.h
@@ -94,22 +94,22 @@ private:
   int* end_;
 };
 
-using NonSimpleNonSizedView = CommonInputView<common_input_iterator, false, false>;
+using NonSimpleNonSizedView = CommonInputView<common_input_iterator, /*Simple=*/false, /*Sized=*/false>;
 static_assert(std::ranges::view<NonSimpleNonSizedView>);
 static_assert(!simple_view<NonSimpleNonSizedView>);
 static_assert(!std::ranges::sized_range<NonSimpleNonSizedView>);
 
-using SimpleViewNonSized = CommonInputView<common_input_iterator, true, false>;
+using SimpleViewNonSized = CommonInputView<common_input_iterator, /*Simple=*/true, /*Sized=*/false>;
 static_assert(std::ranges::view<SimpleViewNonSized>);
 static_assert(simple_view<SimpleViewNonSized>);
 static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
 
-using NonSimpleSizedView = CommonInputView<common_input_iterator, false, true>;
+using NonSimpleSizedView = CommonInputView<common_input_iterator, /*Simple=*/false, /*Sized=*/true>;
 static_assert(std::ranges::view<NonSimpleSizedView>);
 static_assert(!simple_view<NonSimpleSizedView>);
 static_assert(std::ranges::sized_range<NonSimpleSizedView>);
 
-using NonSimpleSizedRandomView = CommonInputView<random_access_iterator, false, true>;
+using NonSimpleSizedRandomView = CommonInputView<random_access_iterator, /*Simple=*/false, /*Sized=*/true>;
 static_assert(std::ranges::view<NonSimpleSizedRandomView>);
 static_assert(!simple_view<NonSimpleSizedRandomView>);
 static_assert(std::ranges::sized_range<NonSimpleSizedRandomView>);

--- a/libcxx/test/std/ranges/range.adaptors/range.take/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/types.h
@@ -66,8 +66,8 @@ private:
 };
 
 template <bool Simple>
-struct InputView : std::ranges::view_base {
-  constexpr explicit InputView(int* b, int* e) : begin_(b), end_(e) {}
+struct CommonInputView : std::ranges::view_base {
+  constexpr explicit CommonInputView(int* b, int* e) : begin_(b), end_(e) {}
 
   constexpr common_input_iterator<int*> begin() const { return common_input_iterator<int*>(begin_); }
   constexpr common_input_iterator<int*> end() const { return common_input_iterator<int*>(end_); }
@@ -88,12 +88,12 @@ private:
   int* end_;
 };
 
-using NonSimpleViewNonSized = InputView<false>;
+using NonSimpleViewNonSized = CommonInputView<false>;
 static_assert(std::ranges::view<NonSimpleViewNonSized>);
 static_assert(!simple_view<NonSimpleViewNonSized>);
 static_assert(!std::ranges::sized_range<NonSimpleViewNonSized>);
 
-using SimpleViewNonSized = InputView<true>;
+using SimpleViewNonSized = CommonInputView<true>;
 static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
 static_assert(std::ranges::view<SimpleViewNonSized>);
 static_assert(simple_view<SimpleViewNonSized>);

--- a/libcxx/test/std/ranges/range.adaptors/range.take/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/types.h
@@ -94,8 +94,8 @@ static_assert(!simple_view<NonSimpleViewNonSized>);
 static_assert(!std::ranges::sized_range<NonSimpleViewNonSized>);
 
 using SimpleViewNonSized = CommonInputView<true>;
-static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
 static_assert(std::ranges::view<SimpleViewNonSized>);
 static_assert(simple_view<SimpleViewNonSized>);
+static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
 
 #endif // TEST_STD_RANGES_RANGE_ADAPTORS_RANGE_TAKE_TYPES_H

--- a/libcxx/test/std/ranges/range.adaptors/range.take/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.take/types.h
@@ -65,7 +65,7 @@ private:
   int* end_;
 };
 
-template <template <class ...> typename Iter, bool Simple, bool Sized>
+template <template <class...> typename Iter, bool Simple, bool Sized>
 struct CommonInputView : std::ranges::view_base {
   constexpr explicit CommonInputView(int* b, int* e) : begin_(b), end_(e) {}
 
@@ -94,22 +94,22 @@ private:
   int* end_;
 };
 
-using NonSimpleNonSizedView = CommonInputView<common_input_iterator,false, false>;
+using NonSimpleNonSizedView = CommonInputView<common_input_iterator, false, false>;
 static_assert(std::ranges::view<NonSimpleNonSizedView>);
 static_assert(!simple_view<NonSimpleNonSizedView>);
 static_assert(!std::ranges::sized_range<NonSimpleNonSizedView>);
 
-using SimpleViewNonSized = CommonInputView<common_input_iterator,true, false>;
+using SimpleViewNonSized = CommonInputView<common_input_iterator, true, false>;
 static_assert(std::ranges::view<SimpleViewNonSized>);
 static_assert(simple_view<SimpleViewNonSized>);
 static_assert(!std::ranges::sized_range<SimpleViewNonSized>);
 
-using NonSimpleSizedView = CommonInputView<common_input_iterator,false, true>;
+using NonSimpleSizedView = CommonInputView<common_input_iterator, false, true>;
 static_assert(std::ranges::view<NonSimpleSizedView>);
 static_assert(!simple_view<NonSimpleSizedView>);
 static_assert(std::ranges::sized_range<NonSimpleSizedView>);
 
-using NonSimpleSizedRandomView = CommonInputView<random_access_iterator,false, true>;
+using NonSimpleSizedRandomView = CommonInputView<random_access_iterator, false, true>;
 static_assert(std::ranges::view<NonSimpleSizedRandomView>);
 static_assert(!simple_view<NonSimpleSizedRandomView>);
 static_assert(std::ranges::sized_range<NonSimpleSizedRandomView>);


### PR DESCRIPTION
Add additional tests for `begin`/`end` of `std::ranges::take_view`.

In partial fulfillment of #72406. 