### PR TITLE
[libc] remove getauxval from arm32 entrypoint list

### DIFF
--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -95,9 +95,6 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # sys/prctl.h entrypoints
     libc.src.sys.prctl.prctl
-
-    # sys/auxv.h entrypoints
-    libc.src.sys.auxv.getauxval
 )
 
 set(TARGET_LIBM_ENTRYPOINTS


### PR DESCRIPTION
`getauxval` depends on `open/read/close` which are not built on arm32. Remove `getauxval` for now.