### PR TITLE
[PowerPC] Diagnose invalid combination with Altivec, VSX and soft-float

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -442,19 +442,44 @@ void PPCTargetInfo::getTargetDefines(const LangOptions &Opts,
   //   _CALL_DARWIN
 }
 
-// Handle explicit options being passed to the compiler here: if we've
-// explicitly turned off vsx and turned on any of:
-// - power8-vector
-// - direct-move
-// - float128
-// - power9-vector
-// - paired-vector-memops
-// - mma
-// - power10-vector
+// Handle explicit options being passed to the compiler here:
+// - if we've explicitly turned off vsx and turned on any of:
+//   - power8-vector
+//   - direct-move
+//   - float128
+//   - power9-vector
+//   - paired-vector-memops
+//   - mma
+//   - power10-vector
+// - if we've explicitly turned on vsx and turned off altivec.
+// - if we've explicitly turned on soft-float and altivec.
 // then go ahead and error since the customer has expressed an incompatible
 // set of options.
 static bool ppcUserFeaturesCheck(DiagnosticsEngine &Diags,
                                  const std::vector<std::string> &FeaturesVec) {
+  // Cannot allow soft-float with Altivec.
+  if (llvm::is_contained(FeaturesVec, "-hard-float") &&
+      llvm::is_contained(FeaturesVec, "+altivec")) {
+    Diags.Report(diag::err_opt_not_valid_with_opt) << "-msoft-float"
+                                                   << "-maltivec";
+    return false;
+  }
+
+  // Cannot allow soft-float with VSX.
+  if (llvm::is_contained(FeaturesVec, "-hard-float") &&
+      llvm::is_contained(FeaturesVec, "+vsx")) {
+    Diags.Report(diag::err_opt_not_valid_with_opt) << "-msoft-float"
+                                                   << "-mvsx";
+    return false;
+  }
+
+  // Cannot allow VSX with no Altivec.
+  if (llvm::is_contained(FeaturesVec, "+vsx") &&
+      llvm::is_contained(FeaturesVec, "-altivec")) {
+    Diags.Report(diag::err_opt_not_valid_with_opt) << "-mvsx"
+                                                   << "-mno-altivec";
+    return false;
+  }
 
   // vsx was not explicitly turned off.
   if (!llvm::is_contained(FeaturesVec, "-vsx"))

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -452,7 +452,7 @@ void PPCTargetInfo::getTargetDefines(const LangOptions &Opts,
 //   - mma
 //   - power10-vector
 // - if we've explicitly turned on vsx and turned off altivec.
-// - if we've explicitly turned on soft-float and altivec.
+// - if we've explicitly turned off hard-float and turned on altivec.
 // then go ahead and error since the customer has expressed an incompatible
 // set of options.
 static bool ppcUserFeaturesCheck(DiagnosticsEngine &Diags,

--- a/clang/test/CodeGen/PowerPC/attr-target-ppc.c
+++ b/clang/test/CodeGen/PowerPC/attr-target-ppc.c
@@ -3,5 +3,5 @@
 long __attribute__((target("power8-vector,no-vsx"))) foo (void) { return 0; }  // expected-error {{option '-mpower8-vector' cannot be specified with '-mno-vsx'}}
 long __attribute__((target("no-altivec,vsx"))) foo2(void) { return 0; }        // expected-error {{option '-mvsx' cannot be specified with '-mno-altivec'}}
 long __attribute__((target("no-hard-float,altivec"))) foo3(void) { return 0; } // expected-error {{option '-msoft-float' cannot be specified with '-maltivec'}}
-long __attribute__((target("no-hard-float,vsx"))) foo3(void) { return 0; } // expected-error {{option '-msoft-float' cannot be specified with '-mvsx'}}
+long __attribute__((target("no-hard-float,vsx"))) foo4(void) { return 0; } // expected-error {{option '-msoft-float' cannot be specified with '-mvsx'}}
 

--- a/clang/test/CodeGen/PowerPC/attr-target-ppc.c
+++ b/clang/test/CodeGen/PowerPC/attr-target-ppc.c
@@ -1,4 +1,7 @@
 // RUN: not %clang_cc1 -triple powerpc64le-linux-gnu -emit-llvm %s -o -
 
 long __attribute__((target("power8-vector,no-vsx"))) foo (void) { return 0; }  // expected-error {{option '-mpower8-vector' cannot be specified with '-mno-vsx'}}
+long __attribute__((target("no-altivec,vsx"))) foo2(void) { return 0; }        // expected-error {{option '-mvsx' cannot be specified with '-mno-altivec'}}
+long __attribute__((target("no-hard-float,altivec"))) foo3(void) { return 0; } // expected-error {{option '-msoft-float' cannot be specified with '-maltivec'}}
+long __attribute__((target("no-hard-float,vsx"))) foo3(void) { return 0; } // expected-error {{option '-msoft-float' cannot be specified with '-mvsx'}}
 

--- a/clang/test/Driver/ppc-dependent-options.cpp
+++ b/clang/test/Driver/ppc-dependent-options.cpp
@@ -78,6 +78,18 @@
 // RUN: -mcpu=power10 -std=c++11 -mno-vsx -mpower10-vector %s 2>&1 | \
 // RUN: FileCheck %s -check-prefix=CHECK-NVSX-P10V
 
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -mvsx -mno-altivec %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-NALTI-VSX
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -maltivec %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-ALTI
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mvsx %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-VSX
+
 #ifdef __VSX__
 static_assert(false, "VSX enabled");
 #endif
@@ -114,3 +126,6 @@ static_assert(false, "Neither enabled");
 // CHECK-NVSX-MMA: error: option '-mmma' cannot be specified with '-mno-vsx'
 // CHECK-NVSX: Neither enabled
 // CHECK-VSX: VSX enabled
+// CHECK-NALTI-VSX: error: option '-mvsx' cannot be specified with '-mno-altivec'
+// CHECK-SOFTFLT-ALTI: error: option '-msoft-float' cannot be specified with '-maltivec'
+// CHECK-SOFTFLT-VSX: error: option '-msoft-float' cannot be specified with '-mvsx'


### PR DESCRIPTION
Moved from https://reviews.llvm.org/D126302

The current behaviour with these three options is quite undesirable:
-mno-altivec -mvsx allows VSX to override no Altivec, thereby turning on both
-msoft-float -maltivec causes a crash if an actual Altivec instruction is required because soft float turns of Altivec
-msoft-float -mvsx is also accepted with both Altivec and VSX turned off (potentially causing crashes as above)

This patch diagnoses these impossible combinations in the driver so the user does not end up with surprises in terms of their options being ignored or silently overridden.

Fixes https://github.com/llvm/llvm-project/issues/55556