### PR TITLE
[libc++] Remove a duplicated definition of _LIBCPP_NOINLINE

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1235,12 +1235,6 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 #    define _LIBCPP_CONSTINIT
 #  endif
 
-#  if __has_attribute(__noinline__)
-#    define _LIBCPP_NOINLINE __attribute__((__noinline__))
-#  else
-#    define _LIBCPP_NOINLINE
-#  endif
-
 #  if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)
 // The CUDA SDK contains an unfortunate definition for the __noinline__ macro,
 // which breaks the regular __attribute__((__noinline__)) syntax. Therefore,


### PR DESCRIPTION
I failed to delete the old definition as a part of https://github.com/llvm/llvm-project/pull/73838.