### PR TITLE
[clang-repl] Typo within InterpreterTest.cpp

### DIFF
--- a/clang/unittests/Interpreter/InterpreterTest.cpp
+++ b/clang/unittests/Interpreter/InterpreterTest.cpp
@@ -256,7 +256,8 @@ static Value AllocateObject(TypeDecl *TD, Interpreter &Interp) {
   // cantFail(Interp.ParseAndExecute("new " + Name + "()", &Addr));
 
   // The lifetime of the temporary is extended by the clang::Value.
-  cantFail(Interp.ParseAndExecute(Name + "()", &Addr));
+  cantFail(Interp.ParseAndExecute(Name + "();", &Addr));
+  Addr.setKind(Value::Kind::K_PtrOrObj);
   return Addr;
 }
 


### PR DESCRIPTION
Recent changes to InterpreterTest.cpp (https://github.com/llvm/llvm-project/pull/76218) introduced typos within code passed to a Parse() function. This causes some tests to fail, namely IncrementalProcessing.InstantiateTemplate. 
