### PR TITLE
[DebugInfo][RemoveDIs] "Final" cleanup for non-instr debug-info

### DIFF
--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -722,8 +722,9 @@ public:
   /// Insert \p BB in the basic block list at \p Position. \Returns an iterator
   /// to the newly inserted BB.
   Function::iterator insert(Function::iterator Position, BasicBlock *BB) {
+    Function::iterator FIt = BasicBlocks.insert(Position, BB);
     BB->setIsNewDbgInfoFormat(IsNewDbgInfoFormat);
-    return BasicBlocks.insert(Position, BB);
+    return FIt;
   }
 
   /// Transfer all blocks from \p FromF to this function at \p ToIt.

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -240,12 +240,12 @@ void BasicBlock::insertInto(Function *NewParent, BasicBlock *InsertBefore) {
   assert(NewParent && "Expected a parent");
   assert(!Parent && "Already has a parent");
 
-  setIsNewDbgInfoFormat(NewParent->IsNewDbgInfoFormat);
-
   if (InsertBefore)
     NewParent->insert(InsertBefore->getIterator(), this);
   else
     NewParent->insert(NewParent->end(), this);
+
+  setIsNewDbgInfoFormat(NewParent->IsNewDbgInfoFormat);
 }
 
 BasicBlock::~BasicBlock() {
@@ -824,9 +824,15 @@ void BasicBlock::spliceDebugInfoEmptyBlock(BasicBlock::iterator Dest,
 
   // There are instructions in this block; if the First iterator was
   // with begin() / getFirstInsertionPt() then the caller intended debug-info
-  // at the start of the block to be transferred.
-  if (!Src->empty() && First == Src->begin() && ReadFromHead)
-    Dest->DbgMarker->absorbDebugValues(*First->DbgMarker, InsertAtHead);
+  // at the start of the block to be transferred. Return otherwise.
+  if (Src->empty() || First != Src->begin() || !ReadFromHead)
+    return;
+
+  // Is there actually anything to transfer?
+  if (!First->hasDbgValues())
+    return;
+
+  createMarker(Dest)->absorbDebugValues(*First->DbgMarker, InsertAtHead);
 
   return;
 }

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -892,6 +892,9 @@ bool llvm::stripNonLineTableDebugInfo(Module &M) {
         // Strip heapallocsite attachments, they point into the DIType system.
         if (I.hasMetadataOtherThanDebugLoc())
           I.setMetadata("heapallocsite", nullptr);
+
+        // Strip any DPValues attached.
+        I.dropDbgValues();
       }
     }
   }

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -146,9 +146,9 @@ void Instruction::insertBefore(BasicBlock &BB,
   bool InsertAtHead = InsertPos.getHeadBit();
   if (!InsertAtHead) {
     DPMarker *SrcMarker = BB.getMarker(InsertPos);
-    if (!SrcMarker)
-      SrcMarker = BB.createMarker(InsertPos);
-    DbgMarker->absorbDebugValues(*SrcMarker, false);
+    // If there's no source marker, InsertPos is very likely end().
+    if (SrcMarker)
+      DbgMarker->absorbDebugValues(*SrcMarker, false);
   }
 
   // If we're inserting a terminator, check if we need to flush out

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2340,7 +2340,7 @@ void llvm::salvageDebugInfoForDbgValues(
       // currently only valid for stack value expressions.
       // Also do not salvage if the resulting DIArgList would contain an
       // unreasonably large number of values.
-      Value *Undef = UndefValue::get(I.getOperand(0)->getType());
+      Value *Undef = PoisonValue::get(I.getOperand(0)->getType());
       DPV->replaceVariableLocationOp(I.getOperand(0), Undef);
     }
     LLVM_DEBUG(dbgs() << "SALVAGE: " << DPV << '\n');

--- a/llvm/test/DebugInfo/salvage-limit-expr-size.ll
+++ b/llvm/test/DebugInfo/salvage-limit-expr-size.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes=dce -S | FileCheck %s
+; RUN: opt %s -passes=dce -S --try-experimental-debuginfo-iterators | FileCheck %s
 
 ;; Tests that a DIExpression will only be salvaged up to a certain length, and
 ;; will produce an undef value if an expression would need to exceed that length.

--- a/llvm/test/Transforms/Util/strip-nonlinetable-debuginfo-localvars.ll
+++ b/llvm/test/Transforms/Util/strip-nonlinetable-debuginfo-localvars.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -S -passes=strip-nonlinetable-debuginfo %s -o - | FileCheck %s
+; RUN: opt -S -passes=strip-nonlinetable-debuginfo %s -o - --try-experimental-debuginfo-iterators | FileCheck %s
 ; CHECK: define void @f() !dbg ![[F:[0-9]+]]
 define void @f() !dbg !4 {
 entry:


### PR DESCRIPTION
Here's a raft of minor fixes for the RemoveDIs project that's replacing dbg.value intrinsics with DPValue objects, all IMO trivial:
 * When inserting functions or blocks and calling setIsNewDbgInfoFormat, do that after setting the Parent pointer, just in case conversion from (or to) dbg.value mode is triggered.
 * When transferring DPValues from an empty range in a splice call, don't transfer if there are no DPValues attached to the source block at all.
 * stripNonLineTableDebugInfo should drop DPValues.
 * In insertBefore, don't try to transfer DPValues if there aren't any.
 * Replace a DIArgList operand with Poison, not Undef, in salvageDebugInfo to match past dbg.value behaviour.

These all cause minor variations in test outputs that we're looking to suppress before turning RemoveDIs on, or some obvious risk of crashing. I've added --try-experimental-debuginfo-iterator runlines to tests that clearly stimulate this -- the deeper modifications aren't easily reachable alas.