### PR TITLE
[MLIR][AMDGPU] Switch to code object version 5

### DIFF
--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -238,7 +238,7 @@ void SerializeGPUModuleBase::addControlVariables(
   addControlVariable("__oclc_wavefrontsize64", wave64);
 
   llvm::Type *i32Ty = llvm::Type::getInt32Ty(module.getContext());
-  int abi = 400;
+  int abi = 500;
   abiVer.getAsInteger(0, abi);
   llvm::GlobalVariable *abiVersion = new llvm::GlobalVariable(
       module, i32Ty, true, llvm::GlobalValue::LinkageTypes::LinkOnceODRLinkage,


### PR DESCRIPTION
As AMDGPU backend has moved to cov5 as default, mlir should also switch to it.