### PR TITLE
[RemoveDIs][DebugInfo] Enable creation of DPVAssigns, update outstanding AT tests

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -74,9 +74,6 @@ void BasicBlock::convertToNewDbgValues() {
   for (Instruction &I : make_early_inc_range(InstList)) {
     assert(!I.DbgMarker && "DbgMarker already set on old-format instrs?");
     if (DbgVariableIntrinsic *DVI = dyn_cast<DbgVariableIntrinsic>(&I)) {
-      if (isa<DbgAssignIntrinsic>(DVI))
-        continue;
-
       // Convert this dbg.value to a DPValue.
       DPValue *Value = new DPValue(DVI);
       DPVals.push_back(Value);

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1816,8 +1816,12 @@ void at::RAUW(DIAssignID *Old, DIAssignID *New) {
 
 void at::deleteAll(Function *F) {
   SmallVector<DbgAssignIntrinsic *, 12> ToDelete;
+  SmallVector<DPValue *, 12> DPToDelete;
   for (BasicBlock &BB : *F) {
     for (Instruction &I : BB) {
+      for (auto &DPV : I.getDbgValueRange())
+        if (DPV.isDbgAssign())
+          DPToDelete.push_back(&DPV);
       if (auto *DAI = dyn_cast<DbgAssignIntrinsic>(&I))
         ToDelete.push_back(DAI);
       else
@@ -1826,6 +1830,8 @@ void at::deleteAll(Function *F) {
   }
   for (auto *DAI : ToDelete)
     DAI->eraseFromParent();
+  for (auto *DPV : DPToDelete)
+    DPV->eraseFromParent();
 }
 
 /// Get the FragmentInfo for the variable if it exists, otherwise return a
@@ -2056,9 +2062,9 @@ std::optional<AssignmentInfo> at::getAssignmentInfo(const DataLayout &DL,
 }
 
 /// Returns nullptr if the assignment shouldn't be attributed to this variable.
-static CallInst *emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
-                               Instruction &StoreLikeInst,
-                               const VarRecord &VarRec, DIBuilder &DIB) {
+static void emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
+                          Instruction &StoreLikeInst, const VarRecord &VarRec,
+                          DIBuilder &DIB) {
   auto *ID = StoreLikeInst.getMetadata(LLVMContext::MD_DIAssignID);
   assert(ID && "Store instruction must have DIAssignID metadata");
   (void)ID;
@@ -2082,7 +2088,7 @@ static CallInst *emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
 
     // Discard stores to bits outside this variable.
     if (FragStartBit >= FragEndBit)
-      return nullptr;
+      return;
 
     StoreToWholeVariable = FragStartBit <= VarStartBit && FragEndBit >= *Size;
   }
@@ -2097,8 +2103,17 @@ static CallInst *emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
   }
   DIExpression *AddrExpr =
       DIExpression::get(StoreLikeInst.getContext(), std::nullopt);
-  return DIB.insertDbgAssign(&StoreLikeInst, Val, VarRec.Var, Expr, Dest,
-                             AddrExpr, VarRec.DL);
+  if (StoreLikeInst.getParent()->IsNewDbgInfoFormat) {
+    auto *Assign = DPValue::createLinkedDPVAssign(
+        &StoreLikeInst, Val, VarRec.Var, Expr, Dest, AddrExpr, VarRec.DL);
+    (void)Assign;
+    LLVM_DEBUG(if (Assign) errs() << " > INSERT: " << *Assign << "\n");
+    return;
+  }
+  auto *Assign = DIB.insertDbgAssign(&StoreLikeInst, Val, VarRec.Var, Expr,
+                                     Dest, AddrExpr, VarRec.DL);
+  (void)Assign;
+  LLVM_DEBUG(if (Assign) errs() << " > INSERT: " << *Assign << "\n");
 }
 
 #undef DEBUG_TYPE // Silence redefinition warning (from ConstantsContext.h).
@@ -2185,12 +2200,8 @@ void at::trackAssignments(Function::iterator Start, Function::iterator End,
         I.setMetadata(LLVMContext::MD_DIAssignID, ID);
       }
 
-      for (const VarRecord &R : LocalIt->second) {
-        auto *Assign =
-            emitDbgAssign(*Info, ValueComponent, DestComponent, I, R, DIB);
-        (void)Assign;
-        LLVM_DEBUG(if (Assign) errs() << " > INSERT: " << *Assign << "\n");
-      }
+      for (const VarRecord &R : LocalIt->second)
+        emitDbgAssign(*Info, ValueComponent, DestComponent, I, R, DIB);
     }
   }
 }
@@ -2206,32 +2217,40 @@ bool AssignmentTrackingPass::runOnFunction(Function &F) {
   // storage" is limited to Allocas). We'll use this to find dbg.declares to
   // delete after running `trackAssignments`.
   DenseMap<const AllocaInst *, SmallPtrSet<DbgDeclareInst *, 2>> DbgDeclares;
+  DenseMap<const AllocaInst *, SmallPtrSet<DPValue *, 2>> DPVDeclares;
   // Create another similar map of {storage : variables} that we'll pass to
   // trackAssignments.
   StorageToVarsMap Vars;
+  auto ProcessDeclare = [&](auto *Declare, auto &DeclareList) {
+    // FIXME: trackAssignments doesn't let you specify any modifiers to the
+    // variable (e.g. fragment) or location (e.g. offset), so we have to
+    // leave dbg.declares with non-empty expressions in place.
+    if (Declare->getExpression()->getNumElements() != 0)
+      return;
+    if (!Declare->getAddress())
+      return;
+    if (AllocaInst *Alloca =
+            dyn_cast<AllocaInst>(Declare->getAddress()->stripPointerCasts())) {
+      // FIXME: Skip VLAs for now (let these variables use dbg.declares).
+      if (!Alloca->isStaticAlloca())
+        return;
+      // Similarly, skip scalable vectors (use dbg.declares instead).
+      if (auto Sz = Alloca->getAllocationSize(*DL); Sz && Sz->isScalable())
+        return;
+      DeclareList[Alloca].insert(Declare);
+      Vars[Alloca].insert(VarRecord(Declare));
+    }
+  };
   for (auto &BB : F) {
     for (auto &I : BB) {
+      for (auto &DPV : I.getDbgValueRange()) {
+        if (DPV.isDbgDeclare())
+          ProcessDeclare(&DPV, DPVDeclares);
+      }
       DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(&I);
       if (!DDI)
         continue;
-      // FIXME: trackAssignments doesn't let you specify any modifiers to the
-      // variable (e.g. fragment) or location (e.g. offset), so we have to
-      // leave dbg.declares with non-empty expressions in place.
-      if (DDI->getExpression()->getNumElements() != 0)
-        continue;
-      if (!DDI->getAddress())
-        continue;
-      if (AllocaInst *Alloca =
-              dyn_cast<AllocaInst>(DDI->getAddress()->stripPointerCasts())) {
-        // FIXME: Skip VLAs for now (let these variables use dbg.declares).
-        if (!Alloca->isStaticAlloca())
-          continue;
-        // Similarly, skip scalable vectors (use dbg.declares instead).
-        if (auto Sz = Alloca->getAllocationSize(*DL); Sz && Sz->isScalable())
-          continue;
-        DbgDeclares[Alloca].insert(DDI);
-        Vars[Alloca].insert(VarRecord(DDI));
-      }
+      ProcessDeclare(DDI, DbgDeclares);
     }
   }
 
@@ -2247,35 +2266,30 @@ bool AssignmentTrackingPass::runOnFunction(Function &F) {
   trackAssignments(F.begin(), F.end(), Vars, *DL);
 
   // Delete dbg.declares for variables now tracked with assignment tracking.
-  for (auto &P : DbgDeclares) {
-    const AllocaInst *Alloca = P.first;
-    auto Markers = at::getAssignmentMarkers(Alloca);
-    SmallVector<DPValue *> DPMarkers = at::getDPVAssignmentMarkers(Alloca);
+  auto DeleteSubsumedDeclare = [&](const auto &Markers, auto &Declares) {
     (void)Markers;
-    (void)DPMarkers;
-    for (DbgDeclareInst *DDI : P.second) {
-      // Assert that the alloca that DDI uses is now linked to a dbg.assign
+    for (auto *Declare : Declares) {
+      // Assert that the alloca that Declare uses is now linked to a dbg.assign
       // describing the same variable (i.e. check that this dbg.declare has
       // been replaced by a dbg.assign). Use DebugVariableAggregate to Discard
       // the fragment part because trackAssignments may alter the
       // fragment. e.g. if the alloca is smaller than the variable, then
       // trackAssignments will create an alloca-sized fragment for the
       // dbg.assign.
-      assert(llvm::any_of(Markers,
-                          [DDI](DbgAssignIntrinsic *DAI) {
-                            return DebugVariableAggregate(DAI) ==
-                                   DebugVariableAggregate(DDI);
-                          }) ||
-             llvm::any_of(DPMarkers, [DDI](DPValue *DPV) {
-               return DebugVariableAggregate(DPV) ==
-                      DebugVariableAggregate(DDI);
-             }));
-      // Delete DDI because the variable location is now tracked using
+      assert(llvm::any_of(Markers, [Declare](auto *Assign) {
+        return DebugVariableAggregate(Assign) ==
+               DebugVariableAggregate(Declare);
+      }));
+      // Delete Declare because the variable location is now tracked using
       // assignment tracking.
-      DDI->eraseFromParent();
+      Declare->eraseFromParent();
       Changed = true;
     }
-  }
+  };
+  for (auto &P : DbgDeclares)
+    DeleteSubsumedDeclare(at::getAssignmentMarkers(P.first), P.second);
+  for (auto &P : DPVDeclares)
+    DeleteSubsumedDeclare(at::getDPVAssignmentMarkers(P.first), P.second);
   return Changed;
 }
 

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2247,10 +2247,8 @@ bool AssignmentTrackingPass::runOnFunction(Function &F) {
         if (DPV.isDbgDeclare())
           ProcessDeclare(&DPV, DPVDeclares);
       }
-      DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(&I);
-      if (!DDI)
-        continue;
-      ProcessDeclare(DDI, DbgDeclares);
+      if (DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(&I))
+        ProcessDeclare(DDI, DbgDeclares);
     }
   }
 

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/long-double-x87.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/long-double-x87.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -S -passes=declare-to-assign -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -S -passes=declare-to-assign -o - | FileCheck %s
 
 ;; Generated from this C++:
 ;; long double get();

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/nullptr-declare.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/nullptr-declare.ll
@@ -1,4 +1,5 @@
 ; RUN: opt %s -passes=declare-to-assign -S | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes=declare-to-assign -S | FileCheck %s
 
 ;; Check AssignmentTrackingPass ignores a dbg.declare with an empty metadata
 ;; location operand.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/scalable-vector.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/scalable-vector.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes=declare-to-assign %s -S | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes=declare-to-assign %s -S | FileCheck %s
 
 ;; Check declare-to-assign skips scalable vectors for now. i.e. do not replace
 ;; the dbg.declare with a dbg.assign intrinsic.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/set-flag-only-if-modified.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/set-flag-only-if-modified.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes=declare-to-assign -S %s -o - \
 ; RUN: | FileCheck %s --check-prefix=WITHOUT-INTRINSIC
+; RUN: opt --try-experimental-debuginfo-iterators -passes=declare-to-assign -S %s -o - \
+; RUN: | FileCheck %s --check-prefix=WITHOUT-INTRINSIC
 
 ; RUN: sed 's/;Uncomment-with-sed//g' < %s \
 ; RUN: | opt -passes=declare-to-assign -S - -o - \

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/structured-bindings.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/structured-bindings.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes=declare-to-assign -S %s -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes=declare-to-assign -S %s -o - | FileCheck %s
 
 ;; Check assignment tracking debug info for structured bindings. FIXME only
 ;; variables at offset 0 in the backing alloca are currently tracked with the

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/var-not-alloca-sized.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/var-not-alloca-sized.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes=declare-to-assign -S %s -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -passes=declare-to-assign -S %s -o - | FileCheck %s
 
 ;; The variable doesn't fill the whole alloca which has a range of different
 ;; sized stores to it, overlapping (or not) the variable in various ways. Check

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/vla.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/vla.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -S %s -passes=declare-to-assign -o - | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators -S %s -passes=declare-to-assign -o - | FileCheck %s
 
 ;; Check declare-to-assign ignores VLA-backed variables (for now).
 ;; From C++ source:

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/instcombine/remove-redundant-dbg.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/instcombine/remove-redundant-dbg.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes=sroa -S %s -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -passes=sroa -S %s -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Check that sroa removes redundant debug intrinsics after it makes a
 ;; change. This has a significant positive impact on peak memory and compiler

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/loop-vectorize/remove-redundant-dbg.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/loop-vectorize/remove-redundant-dbg.ll
@@ -1,5 +1,7 @@
 ; RUN: opt %s -passes=loop-vectorize -force-vector-width=2 -force-vector-interleave=2 -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes=loop-vectorize -force-vector-width=2 -force-vector-interleave=2 -S -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Check that loop-vectorize removes redundant debug intrinsics after it makes
 ;; a change. This has a significant positive impact on peak memory and compiler

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/optnone.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/optnone.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -S %s -o - --passes=declare-to-assign \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -S %s -o - --passes=declare-to-assign \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Assignment tracking doesn't add any value when optimisations are disabled.
 ;; Check it doesn't get applied to functions marked optnone.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/parse-and-verify/roundtrip.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/parse-and-verify/roundtrip.ll
@@ -1,6 +1,9 @@
 ; RUN: opt %s -passes=verify   \
 ; RUN: | opt -passes=verify -S \
 ; RUN: | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators %s -passes=verify   \
+; RUN: | opt -passes=verify -S \
+; RUN: | FileCheck %s
 
 ;; Roundtrip test (text -> bitcode -> text) for DIAssignID metadata and
 ;; llvm.dbg.assign intrinsics.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/remove-redundant.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/remove-redundant.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes=redundant-dbg-inst-elim -S %s -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -passes=redundant-dbg-inst-elim -S %s -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Hand-written. Test how RemoveRedundantDbgInstrs interacts with dbg.assign
 ;; intrinsics. FileCehck directives are inline.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/slp-vectorizer/merge-scalars.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/slp-vectorizer/merge-scalars.ll
@@ -60,6 +60,7 @@ entry:
   %arrayidx10 = getelementptr inbounds [4 x float], ptr %quad, i64 0, i64 3, !dbg !58
   store float %add9, ptr %arrayidx10, align 4, !dbg !59, !DIAssignID !60
   call void @llvm.dbg.assign(metadata float %add9, metadata !16, metadata !DIExpression(DW_OP_LLVM_fragment, 96, 32), metadata !60, metadata ptr %arrayidx10, metadata !DIExpression()), !dbg !23
+  call void @llvm.dbg.value(metadata float %add9, metadata !16, metadata !DIExpression(DW_OP_LLVM_fragment, 96, 32)), !dbg !23
   %call11 = call float @_Z3extPf(ptr nonnull %arrayidx), !dbg !61
   ret void, !dbg !62
 }
@@ -69,6 +70,7 @@ declare !dbg !63 dso_local float @_Z3getv() local_unnamed_addr #2
 declare !dbg !66 dso_local float @_Z3extPf(ptr) local_unnamed_addr #2
 declare void @llvm.lifetime.end.p0i8(i64 immarg, ptr nocapture) #1
 declare void @llvm.dbg.assign(metadata, metadata, metadata, metadata, metadata, metadata) #3
+declare void @llvm.dbg.value(metadata, metadata, metadata)
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5, !1000}

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/slp-vectorizer/merge-scalars.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/slp-vectorizer/merge-scalars.ll
@@ -60,7 +60,6 @@ entry:
   %arrayidx10 = getelementptr inbounds [4 x float], ptr %quad, i64 0, i64 3, !dbg !58
   store float %add9, ptr %arrayidx10, align 4, !dbg !59, !DIAssignID !60
   call void @llvm.dbg.assign(metadata float %add9, metadata !16, metadata !DIExpression(DW_OP_LLVM_fragment, 96, 32), metadata !60, metadata ptr %arrayidx10, metadata !DIExpression()), !dbg !23
-  call void @llvm.dbg.value(metadata float %add9, metadata !16, metadata !DIExpression(DW_OP_LLVM_fragment, 96, 32)), !dbg !23
   %call11 = call float @_Z3extPf(ptr nonnull %arrayidx), !dbg !61
   ret void, !dbg !62
 }
@@ -70,7 +69,6 @@ declare !dbg !63 dso_local float @_Z3getv() local_unnamed_addr #2
 declare !dbg !66 dso_local float @_Z3extPf(ptr) local_unnamed_addr #2
 declare void @llvm.lifetime.end.p0i8(i64 immarg, ptr nocapture) #1
 declare void @llvm.dbg.assign(metadata, metadata, metadata, metadata, metadata, metadata) #3
-declare void @llvm.dbg.value(metadata, metadata, metadata)
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5, !1000}

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/sroa/remove-redundant-dbg.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/sroa/remove-redundant-dbg.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes=sroa -S %s -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -passes=sroa -S %s -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Check that sroa removes redundant debug intrinsics after it makes a
 ;; change. This has a significant positive impact on peak memory and compiler

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/sroa/user-memcpy.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/sroa/user-memcpy.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes=sroa -S %s -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -passes=sroa -S %s -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; Check that the fragments generated in SROA for a split alloca that has a
 ;; dbg.assign with non-zero-offset fragment are correct.

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/track-assignments.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/track-assignments.ll
@@ -1,5 +1,7 @@
 ; RUN: opt -passes='declare-to-assign,verify' %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
+; RUN: opt --try-experimental-debuginfo-iterators -passes='declare-to-assign,verify' %s -S -o - \
+; RUN: | FileCheck %s --implicit-check-not="call void @llvm.dbg"
 
 ;; This test checks that `trackAssignments` is working correctly by using the
 ;; pass-wrapper `declare-to-assign`. Each function checks some specific

--- a/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-options.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-options.ll
@@ -14,18 +14,28 @@
 ;; Coalescing default + instructino-referencing enabled = enable.
 ; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,ENABLE
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
+; RUN: | FileCheck %s --check-prefixes=CHECK,ENABLE
 
 ;; Coalescing default + instructino-referencing disabled = disable.
 ; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=false \
+; RUN: | FileCheck %s --check-prefixes=CHECK,DISABLE
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=false \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,DISABLE
 
 ;; Coalescing enabled + instructino-referencing disabled = enable.
 ; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=false \
 ; RUN:     -debug-ata-coalesce-frags=true \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,ENABLE
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=false \
+; RUN:     -debug-ata-coalesce-frags=true \
+; RUN: | FileCheck %s --check-prefixes=CHECK,ENABLE
 
 ;; Coalescing disabled + instructino-referencing enabled = disable.
 ; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
+; RUN:     -debug-ata-coalesce-frags=false \
+; RUN: | FileCheck %s --check-prefixes=CHECK,DISABLE
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
 ; RUN:     -debug-ata-coalesce-frags=false \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,DISABLE
 

--- a/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-simple.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-simple.ll
@@ -1,5 +1,7 @@
 ; RUN: llc %s -o - -stop-after=finalize-isel \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel \
+; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Test coalescing of contiguous fragments in adjacent location definitions.
 ;; Further details and check directives inline.

--- a/llvm/test/DebugInfo/assignment-tracking/X86/remove-undef-fragment.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/remove-undef-fragment.ll
@@ -1,5 +1,7 @@
 ; RUN: llc %s -o - -stop-after=finalize-isel \
 ; RUN: | FileCheck %s --implicit-check-not=DBG
+; RUN: llc --try-experimental-debuginfo-iterators %s -o - -stop-after=finalize-isel \
+; RUN: | FileCheck %s --implicit-check-not=DBG
 
 ;; In the IR below, for variable n, we get dbg intrinsics that describe this:
 ;;

--- a/llvm/test/DebugInfo/assignment-tracking/X86/untagged-store-frag.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/untagged-store-frag.ll
@@ -1,5 +1,7 @@
 ; RUN: llc %s -stop-after=finalize-isel -o - \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
+; RUN: llc --try-experimental-debuginfo-iterators %s -stop-after=finalize-isel -o - \
+; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Hand-written to test untagged store handling on a simple case. Here's what
 ;; we're looking at in the IR:


### PR DESCRIPTION
This is the final patch for DPVAssign support, implementing the actual creation of DPVAssigns and allowing them to be converted along with dbg.values and dbg.declares. Numerous tests landed in previous patches will no longer be rotten after this patch lands (previously they would trivially pass due to DPVAssigns not actually being used), and a further batch of tests have been added here that require the changes in this patch before they pass.