### PR TITLE
[PGO] Remove calls to `__llvm_orderfile_dump()` in `instrprof-api.c` test

### DIFF
--- a/compiler-rt/test/profile/instrprof-api.c
+++ b/compiler-rt/test/profile/instrprof-api.c
@@ -1,6 +1,3 @@
-// UNSUPPORTED: target={{.*windows.*}}
-// __llvm_orderfile_dump() is not supported on Windows.
-
 // Testing profile generate.
 // RUN: %clang_profgen %s -S -emit-llvm -o - | FileCheck %s --check-prefix=PROFGEN
 // RUN: %clang_pgogen %s -S -emit-llvm -o - | FileCheck %s --check-prefix=PROFGEN
@@ -38,12 +35,8 @@ int main() {
     return 2;
   // PROFGEN: %{{.*}} = call {{(signext )*}}i32 @__llvm_profile_dump()
   // PROFUSE-NOT: %{{.*}} = call {{(signext )*}}i32 @__llvm_profile_dump()
-  __llvm_orderfile_dump();
-  // PROFGEN: %{{.*}} = call {{(signext )*}}i32 @__llvm_orderfile_dump()
-  // PROFUSE-NOT: %{{.*}} = call {{(signext )*}}i32 @__llvm_orderfile_dump()
   return z + bar() - 11;
 }
 
 // PROFUSE-NOT: declare void @__llvm_profile_set_filename(ptr noundef)
 // PROFUSE-NOT: declare signext i32 @__llvm_profile_dump()
-// PROFUSE-NOT: declare signext i32 @__llvm_orderfile_dump()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/78285 added a test which calls `__llvm_orderfile_dump()`, a functionality that is not supported on many platforms. This PR removes the call to `__llvm_orderfile_dump()` to avoid it failing on unsupported platforms, and turn on the test for Windows, so we test the rest of the API that are supported.