### PR TITLE
[libc][NFC] use builder pattern for ErrnoSetterMatcher

### DIFF
--- a/libc/test/UnitTest/ErrnoSetterMatcher.h
+++ b/libc/test/UnitTest/ErrnoSetterMatcher.h
@@ -161,10 +161,22 @@ static internal::ErrnoSetterMatcher<RetT> Fails(int ExpectedErrno,
                                             EQ(ExpectedErrno));
 }
 
+template <typename RetT = int> class ErrnoSetterMatcherBuilder {
+public:
+  template <typename T> using Cmp = internal::Comparator<T>;
+  ErrnoSetterMatcherBuilder(Cmp<RetT> cmp) : return_cmp(cmp) {}
+
+  internal::ErrnoSetterMatcher<RetT> with_errno(Cmp<int> cmp) {
+    return internal::ErrnoSetterMatcher<RetT>(return_cmp, cmp);
+  }
+
+private:
+  Cmp<RetT> return_cmp;
+};
+
 template <typename RetT>
-static internal::ErrnoSetterMatcher<RetT>
-returns(internal::Comparator<RetT> cmp) {
-  return internal::ErrnoSetterMatcher<RetT>(cmp);
+static ErrnoSetterMatcherBuilder<RetT> returns(internal::Comparator<RetT> cmp) {
+  return ErrnoSetterMatcherBuilder<RetT>(cmp);
 }
 
 } // namespace ErrnoSetterMatcher


### PR DESCRIPTION
ErrnoSetterMatcher::returns can be misleading as it does not initialize the errno. This is made worse as later on there is a switch statement on the errno comparator using __builtin_unreachable(). This patch make ErrnoSetterMatcher::returns give back a builder that is nomially different from ErrnoSetterMatcher.