### PR TITLE
[include-cleaner] Check emptiness instead of occurences

### DIFF
--- a/clang-tools-extra/include-cleaner/test/tool.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool.cpp
@@ -22,9 +22,17 @@ int x = foo();
 // IGNORE2-NOT: - "foobar.h"
 //     IGNORE2: + "foo.h"
 
+//        RUN: clang-include-cleaner -print=changes %s --ignore-headers= -- -I%S/Inputs/ | FileCheck --allow-empty --check-prefix=IGNORE3 %s
+//    IGNORE3: - "foobar.h"
+//    IGNORE3: + "foo.h"
+
 //        RUN: clang-include-cleaner -print=changes %s --only-headers="foo\.h" -- -I%S/Inputs/ | FileCheck --match-full-lines --allow-empty --check-prefix=ONLY %s
 //   ONLY-NOT: - "foobar.h"
 //       ONLY: + "foo.h"
+
+//        RUN: clang-include-cleaner -print=changes %s --only-headers= -- -I%S/Inputs/ | FileCheck --allow-empty --check-prefix=ONLY2 %s
+//      ONLY2: - "foobar.h"
+//      ONLY2: + "foo.h"
 
 //        RUN: clang-include-cleaner -print %s -- -I%S/Inputs/ | FileCheck --match-full-lines --check-prefix=PRINT %s
 //      PRINT: #include "foo.h"

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -262,9 +262,9 @@ std::function<bool(llvm::StringRef)> headerFilter() {
     return nullptr;
 
   return [OnlyMatches, IgnoreMatches](llvm::StringRef Header) {
-    if (OnlyHeaders.getNumOccurrences() && !OnlyMatches(Header))
+    if (!OnlyHeaders.empty() && !OnlyMatches(Header))
       return true;
-    if (IgnoreHeaders.getNumOccurrences() && IgnoreMatches(Header))
+    if (!IgnoreHeaders.empty() && IgnoreMatches(Header))
       return true;
     return false;
   };


### PR DESCRIPTION
Our internal integration relies on injecting some default values to ignore/keep
lists. That means we can have filters, despite of not having occurences for the
flag.
