### PR TITLE
[clang] Document the type_visibility attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3220,7 +3220,7 @@ def TypeVisibility : InheritableAttr {
   let Args = [EnumArgument<"Visibility", "VisibilityType",
                            ["default", "hidden", "internal", "protected"],
                            ["Default", "Hidden", "Hidden", "Protected"]>];
-  let Subjects = SubjectList<[Tag, ObjCInterface, Namespace], ErrorDiag>;
+  // let Subjects = SubjectList<[Tag, ObjCInterface, Namespace], ErrorDiag>;
   let Documentation = [TypeVisibilityDocs];
 }
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3220,8 +3220,8 @@ def TypeVisibility : InheritableAttr {
   let Args = [EnumArgument<"Visibility", "VisibilityType",
                            ["default", "hidden", "internal", "protected"],
                            ["Default", "Hidden", "Hidden", "Protected"]>];
-//  let Subjects = [Tag, ObjCInterface, Namespace];
-  let Documentation = [Undocumented];
+  let Subjects = SubjectList<[Tag, ObjCInterface, Namespace], ErrorDiag>;
+  let Documentation = [TypeVisibilityDocs];
 }
 
 def VecReturn : InheritableAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5573,7 +5573,7 @@ This attribute can only be applied to types and namespaces.
 If both ``visibility`` and ``type_visibility`` are applied to a type or a namespace, the
 visibility specified with the ``type_visibility`` attribute overrides the visibility
 provided with the regular ``visibility`` attribute.
-  }]
+  }];
 }
 
 def RenderScriptKernelAttributeDocs : Documentation {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5560,7 +5560,7 @@ See :doc:`LTOVisibility`.
 def TypeVisibilityDocs : Documentation {
   let Category = DocCatType;
   let Content = [{
-The ``type_visibility`` attribute allows the ELF visibility of a type and its vague
+The ``type_visibility`` attribute allows the visibility of a type and its vague
 linkage objects (vtable, typeinfo, typeinfo name) to be controlled separately from
 the visibility of functions and data members of the type.
 
@@ -5569,6 +5569,10 @@ of a type while still keeping hidden visibility on its member functions and stat
 members.
 
 This attribute can only be applied to types and namespaces.
+
+If both ``visibility`` and ``type_visibility`` are applied to a type or a namespace, the
+visibility specified with the ``type_visibility`` attribute overrides the visibility
+provided with the regular ``visibility`` attribute.
   }]
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5557,6 +5557,21 @@ See :doc:`LTOVisibility`.
   }];
 }
 
+def TypeVisibilityDocs : Documentation {
+  let Category = DocCatType;
+  let Content = [{
+The ``type_visibility`` attribute allows the ELF visibility of a type and its vague
+linkage objects (vtable, typeinfo, typeinfo name) to be controlled separately from
+the visibility of functions and data members of the type.
+
+For example, this can be used to give default visibility to the typeinfo and the vtable
+of a type while still keeping hidden visibility on its member functions and static data
+members.
+
+This attribute can only be applied to types and namespaces.
+  }]
+}
+
 def RenderScriptKernelAttributeDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{


### PR DESCRIPTION
I was looking for the documentation of that attribute, and the best I could find was a Stackoverflow answer or the commit message that originally introduced the attribute. I figured I might as well document what I find to save everyone time in the future.