### PR TITLE
[SHT_LLVM_BB_ADDR_MAP] Avoids side-effects in addition since order is unspecified.

### DIFF
--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1439,9 +1439,9 @@ void ELFState<ELFT>::writeSectionContent(
       for (const ELFYAML::BBAddrMapEntry::BBEntry &BBE : *E.BBEntries) {
         if (Section.Type == llvm::ELF::SHT_LLVM_BB_ADDR_MAP && E.Version > 1)
           SHeader.sh_size += CBA.writeULEB128(BBE.ID);
-        SHeader.sh_size += CBA.writeULEB128(BBE.AddressOffset) +
-                           CBA.writeULEB128(BBE.Size) +
-                           CBA.writeULEB128(BBE.Metadata);
+        SHeader.sh_size += CBA.writeULEB128(BBE.AddressOffset);
+        SHeader.sh_size += CBA.writeULEB128(BBE.Size);
+        SHeader.sh_size += CBA.writeULEB128(BBE.Metadata);
       }
     }
 
@@ -1469,8 +1469,10 @@ void ELFState<ELFT>::writeSectionContent(
         SHeader.sh_size += CBA.writeULEB128(*PGOBBE.BBFreq);
       if (PGOBBE.Successors) {
         SHeader.sh_size += CBA.writeULEB128(PGOBBE.Successors->size());
-        for (const auto &[ID, BrProb] : *PGOBBE.Successors)
-          SHeader.sh_size += CBA.writeULEB128(ID) + CBA.writeULEB128(BrProb);
+        for (const auto &[ID, BrProb] : *PGOBBE.Successors) {
+          SHeader.sh_size += CBA.writeULEB128(ID);
+          SHeader.sh_size += CBA.writeULEB128(BrProb);
+        }
       }
     }
   }

--- a/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-disassemble-symbolize-operands.yaml
+++ b/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-disassemble-symbolize-operands.yaml
@@ -1,9 +1,6 @@
 ## Test that in the presence of SHT_LLVM_BB_ADDR_MAP sections,
 ## --symbolize-operands can display <BB*> labels.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 ## Executable object file.
 # RUN: yaml2obj --docnum=1 -DFOO_ADDR=0x4000 -DBAR_ADDR=0x5000 %s -o %t1
 # RUN: llvm-objdump %t1 -d --symbolize-operands -M intel --no-show-raw-insn --no-leading-addr | \

--- a/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-symbolize-relocatable.yaml
+++ b/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-symbolize-relocatable.yaml
@@ -2,9 +2,6 @@
 ## --symbolize-operands can display <BB*> labels properly in a relocatable
 ## object file.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 ## Relocatable Object file.
 # RUN: yaml2obj %s -o %t1
 # RUN: llvm-objdump %t1 -d --symbolize-operands -M att --no-show-raw-insn --no-leading-addr | \

--- a/llvm/test/tools/llvm-objdump/X86/elf-pgoanalysismap.yaml
+++ b/llvm/test/tools/llvm-objdump/X86/elf-pgoanalysismap.yaml
@@ -2,9 +2,6 @@
 ## contain PGO data, --symbolize-operands is able to label the basic blocks
 ## correctly.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 ## Check the case where we only have entry counts.
 
 # RUN: yaml2obj --docnum=1 %s -o %t1

--- a/llvm/test/tools/llvm-readobj/ELF/bb-addr-map-relocatable.test
+++ b/llvm/test/tools/llvm-readobj/ELF/bb-addr-map-relocatable.test
@@ -1,9 +1,6 @@
 ## This test checks how we handle the --bb-addr-map option on relocatable
 ## object files.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 # RUN: yaml2obj %s -o %t1.o
 # RUN: llvm-readobj %t1.o --bb-addr-map | FileCheck %s
 

--- a/llvm/test/tools/llvm-readobj/ELF/bb-addr-map.test
+++ b/llvm/test/tools/llvm-readobj/ELF/bb-addr-map.test
@@ -1,8 +1,5 @@
 ## This test checks how we handle the --bb-addr-map option.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 ## Check 64-bit:
 # RUN: yaml2obj --docnum=1 %s -DBITS=64 -DADDR=0x999999999 -o %t1.x64.o
 # RUN: llvm-readobj %t1.x64.o --bb-addr-map 2>&1 | FileCheck %s -DADDR=0x999999999 -DFILE=%t1.x64.o --check-prefix=CHECK

--- a/llvm/test/tools/obj2yaml/ELF/bb-addr-map.yaml
+++ b/llvm/test/tools/obj2yaml/ELF/bb-addr-map.yaml
@@ -1,8 +1,5 @@
 ## Check how obj2yaml produces YAML .llvm_bb_addr_map descriptions.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 ## Check that obj2yaml uses the "Entries" tag to describe an .llvm_bb_addr_map section.
 
 # RUN: yaml2obj --docnum=1 %s -o %t1

--- a/llvm/test/tools/yaml2obj/ELF/bb-addr-map.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/bb-addr-map.yaml
@@ -1,8 +1,5 @@
 ## Check how yaml2obj produces .llvm_bb_addr_map sections.
 
-## Fails on windows (https://github.com/llvm/llvm-project/issues/60013).
-# UNSUPPORTED: system-windows
-
 # RUN: yaml2obj --docnum=1 %s -o %t1
 # RUN: llvm-readobj --sections --section-data %t1 | FileCheck %s
 

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -21,13 +21,6 @@
 using namespace llvm;
 using namespace llvm::object;
 
-// Used to skip LLVM_BB_ADDR_MAP tests on windows platforms due to
-// https://github.com/llvm/llvm-project/issues/60013.
-bool IsHostWindows() {
-  Triple Host(Triple::normalize(sys::getProcessTriple()));
-  return Host.isOSWindows();
-}
-
 namespace {
 
 // A struct to initialize a buffer to represent an ELF object file.
@@ -508,8 +501,6 @@ Sections:
 
 // Tests for error paths of the ELFFile::decodeBBAddrMap API.
 TEST(ELFObjectFileTest, InvalidDecodeBBAddrMap) {
-  if (IsHostWindows())
-    GTEST_SKIP();
   StringRef CommonYamlString(R"(
 --- !ELF
 FileHeader:
@@ -656,8 +647,6 @@ Sections:
 
 // Test for the ELFObjectFile::readBBAddrMap API.
 TEST(ELFObjectFileTest, ReadBBAddrMap) {
-  if (IsHostWindows())
-    GTEST_SKIP();
   StringRef CommonYamlString(R"(
 --- !ELF
 FileHeader:
@@ -816,8 +805,6 @@ Sections:
 // Tests for error paths of the ELFFile::decodeBBAddrMap with PGOAnalysisMap
 // API.
 TEST(ELFObjectFileTest, InvalidDecodePGOAnalysisMap) {
-  if (IsHostWindows())
-    GTEST_SKIP();
   StringRef CommonYamlString(R"(
 --- !ELF
 FileHeader:
@@ -948,8 +935,6 @@ Sections:
 
 // Test for the ELFObjectFile::readBBAddrMap API with PGOAnalysisMap.
 TEST(ELFObjectFileTest, ReadPGOAnalysisMap) {
-  if (IsHostWindows())
-    GTEST_SKIP();
   StringRef CommonYamlString(R"(
 --- !ELF
 FileHeader:


### PR DESCRIPTION
Turns out the problem with https://github.com/llvm/llvm-project/issues/60013 is due to the fact that order of operation is unspecified in C++: https://en.cppreference.com/w/cpp/language/eval_order. A small example of where this manifests with MSVC can be seen here https://ooo.godbolt.org/z/bxqKeqzqn.

This patch does the following:
* Removes the addition operations where we sequence more than one side-effect based expression.
* Removes test guards to now run on Windows