### PR TITLE
Updating the XFail on PowerPC to debug mode for layout_stride/assert.conversion.pass.cpp

### DIFF
--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: libcpp-hardening-mode=none
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
-// XFAIL: target=powerpc{{.*}}le-unknown-linux-gnu
+// XFAIL: libcpp-hardening-mode=debug && target=powerpc{{.*}}le-unknown-linux-gnu
 
 // <mdspan>
 


### PR DESCRIPTION
Adding the debug hardening modes into PowerPC target to check the assertion messages, to fix the PPC rehl [bot](https://lab.llvm.org/buildbot/#/builders/57/builds/32354). This is needed as this [commit](https://github.com/llvm/llvm-project/commit/58780b811c23df3d928d8452ee21c862dde754a2)  changed the assertion to trap in production hardening modes.
