### PR TITLE
Revert "[clang-repl] Enable native CPU detection by default (#77491)"

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -148,7 +148,6 @@ IncrementalCompilerBuilder::create(std::vector<const char *> &ClangArgv) {
   // We do C++ by default; append right after argv[0] if no "-x" given
   ClangArgv.insert(ClangArgv.end(), "-Xclang");
   ClangArgv.insert(ClangArgv.end(), "-fincremental-extensions");
-  ClangArgv.insert(ClangArgv.end(), "-mcpu=native");
   ClangArgv.insert(ClangArgv.end(), "-c");
 
   // Put a dummy C++ file on to ensure there's at least one compile job for the


### PR DESCRIPTION
Reverting because `clang-repl -Xcc -mcpu=arm1176jzf-s` isn't overwriting this as I had expected. We need to check whether a specific CPU flag was given by the user first.

Reverts llvm/llvm-project#77491