### PR TITLE
[clang] Make sure the same UsingType is searched and inserted

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -4729,13 +4729,12 @@ public:
   bool typeMatchesDecl() const { return !UsingBits.hasTypeDifferentFromDecl; }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, Found, typeMatchesDecl() ? QualType() : getUnderlyingType());
+    Profile(ID, Found, getUnderlyingType());
   }
   static void Profile(llvm::FoldingSetNodeID &ID, const UsingShadowDecl *Found,
                       QualType Underlying) {
     ID.AddPointer(Found);
-    if (!Underlying.isNull())
-      Underlying.Profile(ID);
+    Underlying.Profile(ID);
   }
   static bool classof(const Type *T) { return T->getTypeClass() == Using; }
 };

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4672,12 +4672,6 @@ QualType ASTContext::getTypedefType(const TypedefNameDecl *Decl,
 QualType ASTContext::getUsingType(const UsingShadowDecl *Found,
                                   QualType Underlying) const {
   llvm::FoldingSetNodeID ID;
-  UsingType::Profile(ID, Found, Underlying);
-
-  void *InsertPos = nullptr;
-  if (UsingType *T = UsingTypes.FindNodeOrInsertPos(ID, InsertPos))
-    return QualType(T, 0);
-
   const Type *TypeForDecl =
       cast<TypeDecl>(Found->getTargetDecl())->getTypeForDecl();
 
@@ -4687,6 +4681,13 @@ QualType ASTContext::getUsingType(const UsingShadowDecl *Found,
 
   if (Underlying.getTypePtr() == TypeForDecl)
     Underlying = QualType();
+  UsingType::Profile(ID, Found, Underlying);
+
+  void *InsertPos = nullptr;
+  if (UsingType *T = UsingTypes.FindNodeOrInsertPos(ID, InsertPos)) {
+    return QualType(T, 0);
+  }
+
   void *Mem =
       Allocate(UsingType::totalSizeToAlloc<QualType>(!Underlying.isNull()),
                alignof(UsingType));

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4672,6 +4672,12 @@ QualType ASTContext::getTypedefType(const TypedefNameDecl *Decl,
 QualType ASTContext::getUsingType(const UsingShadowDecl *Found,
                                   QualType Underlying) const {
   llvm::FoldingSetNodeID ID;
+  UsingType::Profile(ID, Found, Underlying);
+
+  void *InsertPos = nullptr;
+  if (UsingType *T = UsingTypes.FindNodeOrInsertPos(ID, InsertPos))
+    return QualType(T, 0);
+
   const Type *TypeForDecl =
       cast<TypeDecl>(Found->getTargetDecl())->getTypeForDecl();
 
@@ -4681,13 +4687,6 @@ QualType ASTContext::getUsingType(const UsingShadowDecl *Found,
 
   if (Underlying.getTypePtr() == TypeForDecl)
     Underlying = QualType();
-  UsingType::Profile(ID, Found, Underlying);
-
-  void *InsertPos = nullptr;
-  if (UsingType *T = UsingTypes.FindNodeOrInsertPos(ID, InsertPos)) {
-    return QualType(T, 0);
-  }
-
   void *Mem =
       Allocate(UsingType::totalSizeToAlloc<QualType>(!Underlying.isNull()),
                alignof(UsingType));

--- a/clang/test/AST/ast-dump-using.cpp
+++ b/clang/test/AST/ast-dump-using.cpp
@@ -12,7 +12,13 @@ using a::S;
 typedef S f; // to dump the introduced type
 // CHECK:      TypedefDecl
 // CHECK-NEXT: `-ElaboratedType {{.*}} 'S' sugar
-// CHECK-NEXT:   `-UsingType {{.*}} 'a::S' sugar
-// CHECK-NEXT:     |-UsingShadow {{.*}} 'S'
+// CHECK-NEXT:   `-UsingType [[TYPE_ADDR:.*]] 'a::S' sugar
+// CHECK-NEXT:     |-UsingShadow [[SHADOW_ADDR:.*]] 'S'
+// CHECK-NEXT:     `-RecordType {{.*}} 'a::S'
+typedef S e; // check the same UsingType is reused.
+// CHECK:      TypedefDecl
+// CHECK-NEXT: `-ElaboratedType {{.*}} 'S' sugar
+// CHECK-NEXT:   `-UsingType [[TYPE_ADDR]] 'a::S' sugar
+// CHECK-NEXT:     |-UsingShadow [[SHADOW_ADDR]] 'S'
 // CHECK-NEXT:     `-RecordType {{.*}} 'a::S'
 }


### PR DESCRIPTION
When creating a new UsingType, the underlying type may change if it is a declaration. This creates an inconsistency between the type searched and type created. Update member and non-member Profile functions so that they return the same ID.