### PR TITLE
[test] Avoid libc dep in Update warn-unsafe-buffer-usage-warning-data…

### DIFF
--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-warning-data-invocation.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-warning-data-invocation.cpp
@@ -7,13 +7,14 @@
 // RUN: %clang_cc1 -std=c++20 -fblocks -include %s %s 2>&1 | FileCheck --allow-empty %s
 // CHECK-NOT: [-Wunsafe-buffer-usage]
 
-#include <stdint.h>
 #ifndef INCLUDED
 #define INCLUDED
 #pragma clang system_header
 
 // no spanification warnings for system headers
 #else
+
+typedef __INTPTR_TYPE__ intptr_t;
 
 namespace std {
   class type_info;


### PR DESCRIPTION
Avoid libc dep in warn-unsafe-buffer-usage-warning-data-invocation.

To keep the test hermetic. This is in line with other existing declarations in the file that avoid includes.