### PR TITLE
[libc++] Run the nightly libc++ build at 03:00 Eastern for real

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -23,8 +23,8 @@ on:
       - 'cmake/**'
       - '.github/workflows/libcxx-build-and-test.yaml'
   schedule:
-    # Run nightly at 8 AM UTC (or roughly 3 AM eastern)
-    - cron: '0 3 * * *'
+    # Run nightly at 08:00 UTC (aka 00:00 Pacific, aka 03:00 Eastern)
+    - cron: '0 8 * * *'
 
 permissions:
   contents: read # Default everything to read-only


### PR DESCRIPTION
The nightly libc++ build was incorrectly set up to build at 22:00 Eastern when it intended to run at 03:00 Eastern. This patch fixes that.