### PR TITLE
[lldb][NFCI] Remove unused method BreakpointIDList::AddBreakpointID(const char *)

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -42,8 +42,6 @@ public:
 
   bool AddBreakpointID(BreakpointID bp_id);
 
-  bool AddBreakpointID(const char *bp_id);
-
   // TODO: This should take a const BreakpointID.
   bool FindBreakpointID(BreakpointID &bp_id, size_t *position) const;
 

--- a/lldb/source/Breakpoint/BreakpointIDList.cpp
+++ b/lldb/source/Breakpoint/BreakpointIDList.cpp
@@ -48,15 +48,6 @@ bool BreakpointIDList::AddBreakpointID(BreakpointID bp_id) {
                // return true.
 }
 
-bool BreakpointIDList::AddBreakpointID(const char *bp_id_str) {
-  auto bp_id = BreakpointID::ParseCanonicalReference(bp_id_str);
-  if (!bp_id)
-    return false;
-
-  m_breakpoint_ids.push_back(*bp_id);
-  return true;
-}
-
 bool BreakpointIDList::FindBreakpointID(BreakpointID &bp_id,
                                         size_t *position) const {
   for (size_t i = 0; i < m_breakpoint_ids.size(); ++i) {


### PR DESCRIPTION
This overload is completely unused.