### PR TITLE
Add aligned_alloc to macOS tsan interceptors

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -816,9 +816,14 @@ TSAN_INTERCEPTOR(void*, memalign, uptr align, uptr sz) {
 #define TSAN_MAYBE_INTERCEPT_MEMALIGN
 #endif
 
-#if !SANITIZER_APPLE || defined(__MAC_10_16)
+// aligned_alloc was introduced in macOS 10.15
+// Linking will fail when using an older SDK
+#if !SANITIZER_APPLE || defined(__MAC_10_15)
+// macOS 10.15 is greater than our minimal deployment target.  To ensure we
+// generate a weak reference so the TSan dylib continues to work on older
+// systems, we need to forward declare the intercepted function as "weak
+// imports".
 SANITIZER_WEAK_IMPORT void *aligned_alloc(SIZE_T __alignment, SIZE_T __size);
-
 TSAN_INTERCEPTOR(void*, aligned_alloc, uptr align, uptr sz) {
   if (in_symbolizer())
     return InternalAlloc(sz, nullptr, align);

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -14,6 +14,7 @@
 
 #include "sanitizer_common/sanitizer_atomic.h"
 #include "sanitizer_common/sanitizer_errno.h"
+#include "sanitizer_common/sanitizer_internal_defs.h"
 #include "sanitizer_common/sanitizer_libc.h"
 #include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_platform_limits_netbsd.h"
@@ -816,7 +817,6 @@ TSAN_INTERCEPTOR(void*, memalign, uptr align, uptr sz) {
 #endif
 
 #if !SANITIZER_APPLE || defined(__MAC_10_16)
-# define SANITIZER_WEAK_IMPORT extern "C" __attribute((weak_import))
 SANITIZER_WEAK_IMPORT void *aligned_alloc(SIZE_T __alignment, SIZE_T __size);
 
 TSAN_INTERCEPTOR(void*, aligned_alloc, uptr align, uptr sz) {

--- a/compiler-rt/test/tsan/free_race.c
+++ b/compiler-rt/test/tsan/free_race.c
@@ -1,17 +1,8 @@
-// RUN: %clang_tsan -O1 %s -o %t -undefined dynamic_lookup 
-// RUN: %deflake %run %t | FileCheck %s 
+// RUN: %clang_tsan -O1 %s -o %t
+// RUN: %deflake %run %t | FileCheck %s --check-prefix=CHECK-NOZUPP
+// RUN: %env_tsan_opts=suppressions='%s.supp':print_suppressions=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-SUPP
 
 #include "test.h"
-
-#ifdef __APPLE__
-#include <os/availability.h>
-
-// Allow compilation with pre-aligned-alloc SDKs
-API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0))
-void *aligned_alloc(size_t alignment, size_t size);
-#else
-#include <stdlib.h>
-#endif
 
 int *mem;
 pthread_mutex_t mtx;
@@ -33,13 +24,8 @@ __attribute__((noinline)) void *Thread2(void *x) {
 }
 
 int main() {
-  if (aligned_alloc == NULL) {
-    fprintf(stderr, "Done.\n");
-    return 0;
-  }
-
   barrier_init(&barrier, 2);
-  mem = (int*)aligned_alloc(8, 8);
+  mem = (int*)malloc(100);
   pthread_mutex_init(&mtx, 0);
   pthread_t t;
   pthread_create(&t, NULL, Thread1, NULL);
@@ -49,11 +35,13 @@ int main() {
   return 0;
 }
 
-// CHECK: WARNING: ThreadSanitizer: heap-use-after-free
-// CHECK:   Write of size 4 at {{.*}} by main thread{{.*}}:
-// CHECK:     #0 Thread2
-// CHECK:     #1 main
-// CHECK:   Previous write of size 8 at {{.*}} by thread T1{{.*}}:
-// CHECK:     #0 free
-// CHECK:     #{{(1|2)}} Thread1
-// CHECK: SUMMARY: ThreadSanitizer: heap-use-after-free{{.*}}Thread2
+// CHECK-NOZUPP: WARNING: ThreadSanitizer: heap-use-after-free
+// CHECK-NOZUPP:   Write of size 4 at {{.*}} by main thread{{.*}}:
+// CHECK-NOZUPP:     #0 Thread2
+// CHECK-NOZUPP:     #1 main
+// CHECK-NOZUPP:   Previous write of size 8 at {{.*}} by thread T1{{.*}}:
+// CHECK-NOZUPP:     #0 free
+// CHECK-NOZUPP:     #{{(1|2)}} Thread1
+// CHECK-NOZUPP: SUMMARY: ThreadSanitizer: heap-use-after-free{{.*}}Thread2
+// CHECK-SUPP:   ThreadSanitizer: Matched 1 suppressions
+// CHECK-SUPP:    1 race:^Thread2$

--- a/compiler-rt/test/tsan/free_race.c
+++ b/compiler-rt/test/tsan/free_race.c
@@ -1,8 +1,17 @@
-// RUN: %clang_tsan -O1 %s -o %t
-// RUN: %deflake %run %t | FileCheck %s --check-prefix=CHECK-NOZUPP
-// RUN: %env_tsan_opts=suppressions='%s.supp':print_suppressions=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-SUPP
+// RUN: %clang_tsan -O1 %s -o %t -undefined dynamic_lookup 
+// RUN: %deflake %run %t | FileCheck %s 
 
 #include "test.h"
+
+#ifdef __APPLE__
+#include <os/availability.h>
+
+// Allow compilation with pre-aligned-alloc SDKs
+API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0))
+void *aligned_alloc(size_t alignment, size_t size);
+#else
+#include <stdlib.h>
+#endif
 
 int *mem;
 pthread_mutex_t mtx;
@@ -24,8 +33,13 @@ __attribute__((noinline)) void *Thread2(void *x) {
 }
 
 int main() {
+  if (aligned_alloc == NULL) {
+    fprintf(stderr, "Done.\n");
+    return 0;
+  }
+
   barrier_init(&barrier, 2);
-  mem = (int*)malloc(100);
+  mem = (int*)aligned_alloc(8, 8);
   pthread_mutex_init(&mtx, 0);
   pthread_t t;
   pthread_create(&t, NULL, Thread1, NULL);
@@ -35,13 +49,11 @@ int main() {
   return 0;
 }
 
-// CHECK-NOZUPP: WARNING: ThreadSanitizer: heap-use-after-free
-// CHECK-NOZUPP:   Write of size 4 at {{.*}} by main thread{{.*}}:
-// CHECK-NOZUPP:     #0 Thread2
-// CHECK-NOZUPP:     #1 main
-// CHECK-NOZUPP:   Previous write of size 8 at {{.*}} by thread T1{{.*}}:
-// CHECK-NOZUPP:     #0 free
-// CHECK-NOZUPP:     #{{(1|2)}} Thread1
-// CHECK-NOZUPP: SUMMARY: ThreadSanitizer: heap-use-after-free{{.*}}Thread2
-// CHECK-SUPP:   ThreadSanitizer: Matched 1 suppressions
-// CHECK-SUPP:    1 race:^Thread2$
+// CHECK: WARNING: ThreadSanitizer: heap-use-after-free
+// CHECK:   Write of size 4 at {{.*}} by main thread{{.*}}:
+// CHECK:     #0 Thread2
+// CHECK:     #1 main
+// CHECK:   Previous write of size 8 at {{.*}} by thread T1{{.*}}:
+// CHECK:     #0 free
+// CHECK:     #{{(1|2)}} Thread1
+// CHECK: SUMMARY: ThreadSanitizer: heap-use-after-free{{.*}}Thread2

--- a/compiler-rt/test/tsan/free_race_aligned_alloc.c
+++ b/compiler-rt/test/tsan/free_race_aligned_alloc.c
@@ -1,0 +1,59 @@
+// RUN: %clang_tsan -O1 %s -o %t -undefined dynamic_lookup 
+// RUN: %deflake %run %t | FileCheck %s 
+
+#include "test.h"
+
+#ifdef __APPLE__
+#include <os/availability.h>
+
+// Allow compilation with pre-aligned-alloc SDKs
+API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0))
+void *aligned_alloc(size_t alignment, size_t size);
+#else
+#include <stdlib.h>
+#endif
+
+int *mem;
+pthread_mutex_t mtx;
+
+void *Thread1(void *x) {
+  pthread_mutex_lock(&mtx);
+  free(mem);
+  pthread_mutex_unlock(&mtx);
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+__attribute__((noinline)) void *Thread2(void *x) {
+  barrier_wait(&barrier);
+  pthread_mutex_lock(&mtx);
+  mem[0] = 42;
+  pthread_mutex_unlock(&mtx);
+  return NULL;
+}
+
+int main() {
+  if (aligned_alloc == NULL) {
+    fprintf(stderr, "Done.\n");
+    return 0;
+  }
+
+  barrier_init(&barrier, 2);
+  mem = (int*)aligned_alloc(8, 8);
+  pthread_mutex_init(&mtx, 0);
+  pthread_t t;
+  pthread_create(&t, NULL, Thread1, NULL);
+  Thread2(0);
+  pthread_join(t, NULL);
+  pthread_mutex_destroy(&mtx);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: heap-use-after-free
+// CHECK:   Write of size 4 at {{.*}} by main thread{{.*}}:
+// CHECK:     #0 Thread2
+// CHECK:     #1 main
+// CHECK:   Previous write of size 8 at {{.*}} by thread T1{{.*}}:
+// CHECK:     #0 free
+// CHECK:     #{{(1|2)}} Thread1
+// CHECK: SUMMARY: ThreadSanitizer: heap-use-after-free{{.*}}Thread2

--- a/compiler-rt/test/tsan/free_race_aligned_alloc.c
+++ b/compiler-rt/test/tsan/free_race_aligned_alloc.c
@@ -1,20 +1,19 @@
 // RUN: %clang_tsan -O1 %s -o %t -undefined dynamic_lookup
-// RUN: %deflake %run %t | FileCheck %s 
+// RUN: %deflake %run %t | FileCheck %s
 
 #include "test.h"
 
 #include <stdlib.h>
 
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
-#define HAVE_ALIGNED_ALLOC 1
+#  define HAVE_ALIGNED_ALLOC 1
 #endif
 
-#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                  \
     __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500
-#define HAVE_ALIGNED_ALLOC 0 
+#  define HAVE_ALIGNED_ALLOC 0
 #else
 #endif
-
 
 int *mem;
 pthread_mutex_t mtx;
@@ -39,9 +38,9 @@ int main() {
 
   barrier_init(&barrier, 2);
 #if HAVE_ALIGNED_ALLOC
-  mem = (int*)aligned_alloc(8, 8);
+  mem = (int *)aligned_alloc(8, 8);
 #else
-  mem = (int*)malloc(8);
+  mem = (int *)malloc(8);
 #endif
   pthread_mutex_init(&mtx, 0);
   pthread_t t;

--- a/compiler-rt/test/tsan/free_race_aligned_alloc.c
+++ b/compiler-rt/test/tsan/free_race_aligned_alloc.c
@@ -5,14 +5,18 @@
 
 #include <stdlib.h>
 
-#if defined(__cplusplus) && (__cplusplus >= 201703L)
-#  define HAVE_ALIGNED_ALLOC 1
+#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                  \
+    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101500
+#  define MACOS_VERSION_AT_LEAST_10_15 1
+#else
+#  define MACOS_VERSION_AT_LEAST_10_15 0
 #endif
 
-#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                  \
-    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500
-#  define HAVE_ALIGNED_ALLOC 0
+#if defined(__cplusplus) && (__cplusplus >= 201703L) &&                        \
+    (!defined(__apple__) || MACOS_VERSION_AT_LEAST_10_15)
+#  define HAVE_ALIGNED_ALLOC 1
 #else
+#  define HAVE_ALIGNED_ALLOC 0
 #endif
 
 int *mem;


### PR DESCRIPTION
Directly following on the heels of the suggestion given in #77543 

Following the example in the tsan libdispatch interceptors (https://github.com/llvm/llvm-project/blob/f7669ba3d9443bc95dd63fa25beea13e6265fdc5/compiler-rt/lib/tsan/rtl/tsan_interceptors_libdispatch.cpp#L226-L247)

This PR forward declares `aligned_alloc` on systems that may not have it (like pre-10.15 OSX). There is a unit test provided to ensure this works as intended, which passes for me when I compile both with 

SANITIZER_MIN_OSX_VERSION:STRING=10.10
and 
SANITIZER_MIN_OSX_VERSION:STRING=14.0

This test is almost an exact copy of another tsan test, found [here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/tsan/free_race.c).
