### PR TITLE
[AIX] Support per global code model.

### DIFF
--- a/llvm/include/llvm/MC/MCSymbolXCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolXCOFF.h
@@ -78,7 +78,7 @@ public:
 
   CodeModel getPerSymbolCodeModel() const {
     assert(hasPerSymbolCodeModel() &&
-           "Requested codemodel for symbol with out one");
+           "Requested code model for symbol without one");
     return *PerSymbolCodeModel;
   }
 

--- a/llvm/include/llvm/MC/MCSymbolXCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolXCOFF.h
@@ -26,6 +26,8 @@ public:
 
   static bool classof(const MCSymbol *S) { return S->isXCOFF(); }
 
+  enum CodeModel : uint8_t { CM_Small, CM_Large };
+
   static StringRef getUnqualifiedName(StringRef Name) {
     if (Name.back() == ']') {
       StringRef Lhs, Rhs;
@@ -72,8 +74,22 @@ public:
 
   void setEHInfo() const { modifyFlags(SF_EHInfo, SF_EHInfo); }
 
+  bool hasPerSymbolCodeModel() const { return PerSymbolCodeModel.has_value(); }
+
+  CodeModel getPerSymbolCodeModel() const {
+    assert(hasPerSymbolCodeModel() &&
+           "Requested codemodel for symbol with out one");
+    return *PerSymbolCodeModel;
+  }
+
+  void setPerSymbolCodeModel(MCSymbolXCOFF::CodeModel Model) {
+    PerSymbolCodeModel = Model;
+  }
+
 private:
   std::optional<XCOFF::StorageClass> StorageClass;
+  std::optional<CodeModel> PerSymbolCodeModel;
+
   MCSectionXCOFF *RepresentedCsect = nullptr;
   XCOFF::VisibilityType VisibilityType = XCOFF::SYM_V_UNSPECIFIED;
   StringRef SymbolTableName;

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2691,8 +2691,8 @@ MCSection *TargetLoweringObjectFileXCOFF::getSectionForTOCEntry(
       return XCOFF::XMC_TC;
 
     // Use large code model toc entries for ehinfo symbols as they are
-    // never refrenced directly. The runtime loads their TOC entries
-    // address from the trace-back table.
+    // never refrenced directly. The runtime loads their TOC entry
+    // addresses from the trace-back table.
     if (XSym->isEHInfo())
       return XCOFF::XMC_TE;
 

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2682,11 +2682,10 @@ MCSection *TargetLoweringObjectFileXCOFF::getSectionForTOCEntry(
     const MCSymbol *Sym, const TargetMachine &TM) const {
   const XCOFF::StorageMappingClass SMC = [](const MCSymbol *Sym,
                                             const TargetMachine &TM) {
-
     const MCSymbolXCOFF *XSym = cast<MCSymbolXCOFF>(Sym);
 
-    // The "_$TLSML" symbol for TLS local-dynamic mode requires XMC_TC, otherwise
-    // the AIX assembler will complain.
+    // The "_$TLSML" symbol for TLS local-dynamic mode requires XMC_TC,
+    // otherwise the AIX assembler will complain.
     if (XSym->getSymbolTableName() == "_$TLSML")
       return XCOFF::XMC_TC;
 

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2690,7 +2690,7 @@ MCSection *TargetLoweringObjectFileXCOFF::getSectionForTOCEntry(
       return XCOFF::XMC_TC;
 
     // Use large code model toc entries for ehinfo symbols as they are
-    // never refrenced directly. The runtime loads their TOC entry
+    // never referenced directly. The runtime loads their TOC entry
     // addresses from the trace-back table.
     if (XSym->isEHInfo())
       return XCOFF::XMC_TE;

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -477,9 +477,10 @@ static void collectTOCStats(PPCAsmPrinter::TOCEntryType Type) {
 static CodeModel::Model getCodeModel(const PPCSubtarget &S,
                                      const TargetMachine &TM,
                                      const MachineOperand &MO) {
-  assert(S.isAIXABI() && "ELF per global code model not supported yet");
-
   CodeModel::Model ModuleModel = TM.getCodeModel();
+  // Per global code model is only support on AIX.
+  if (!S.isAIXABI())
+    return ModuleModel;
 
   // If the operand is not a global address then there is no
   // global variable to carry an attribute.
@@ -493,7 +494,7 @@ static CodeModel::Model getCodeModel(const PPCSubtarget &S,
     return ModuleModel;
 
   std::optional<CodeModel::Model> MaybeCodeModel =
-      dyn_cast<GlobalVariable>(GV)->getCodeModel();
+      cast<GlobalVariable>(GV)->getCodeModel();
   if (MaybeCodeModel)
     return *MaybeCodeModel;
 

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -478,7 +478,7 @@ static CodeModel::Model getCodeModel(const PPCSubtarget &S,
                                      const TargetMachine &TM,
                                      const MachineOperand &MO) {
   CodeModel::Model ModuleModel = TM.getCodeModel();
-  // Per global code model is only support on AIX.
+  // Per global code model is only supported on AIX.
   if (!S.isAIXABI())
     return ModuleModel;
 
@@ -502,7 +502,7 @@ static CodeModel::Model getCodeModel(const PPCSubtarget &S,
 }
 
 static std::optional<CodeModel::Model>
-hasPerGlobalCodeModel(const GlobalValue *GV) {
+getPerGlobalCodeModel(const GlobalValue *GV) {
   // Symbols that aren't global variables cannot have the attribute.
   if (!isa<GlobalVariable>(GV))
     return std::nullopt;
@@ -3044,7 +3044,7 @@ bool PPCAIXAsmPrinter::doInitialization(Module &M) {
 
     setCsectAlignment(&G);
     std::optional<CodeModel::Model> OptionalCodeModel =
-        hasPerGlobalCodeModel(&G);
+        getPerGlobalCodeModel(&G);
     if (OptionalCodeModel)
       setOptionalCodeModel(cast<MCSymbolXCOFF>(getSymbol(&G)),
                            *OptionalCodeModel);

--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -541,11 +541,7 @@ static CodeModel::Model getCodeModel(const PPCSubtarget &Subtarget,
   if (!isa<GlobalAddressSDNode>(Operand))
     return ModuleModel;
 
-  GlobalAddressSDNode *GA = cast<GlobalAddressSDNode>(Operand);
-  if (!GA)
-    return ModuleModel;
-
-  const GlobalValue *GV = GA->getGlobal();
+  const GlobalValue *GV = cast<GlobalAddressSDNode>(Operand)->getGlobal();
   if (!GV || !isa<GlobalVariable>(GV))
     return ModuleModel;
 

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
@@ -189,6 +189,15 @@ bool PPCSubtarget::isGVIndirectSymbol(const GlobalValue *GV) const {
   // Large code model always uses the TOC even for local symbols.
   if (TM.getCodeModel() == CodeModel::Large)
     return true;
+
+  // AIX may have a per global code model attribute.
+  if (isAIXABI() && isa<GlobalVariable>(GV)) {
+    const GlobalVariable *GVar = cast<GlobalVariable>(GV);
+    std::optional<CodeModel::Model> OptionalCM = GVar->getCodeModel();
+    if (OptionalCM && *OptionalCM == CodeModel::Large)
+      return true;
+  }
+
   if (TM.shouldAssumeDSOLocal(GV))
     return false;
   return true;

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
@@ -186,10 +186,10 @@ bool PPCSubtarget::enableSubRegLiveness() const {
 }
 
 bool PPCSubtarget::isGVIndirectSymbol(const GlobalValue *GV) const {
-  if (isAIXABI() && isa<GlobalVariable>(GV)) {
-    // On AIX the only symbols that aren't indirect are toc-data.
-    if (cast<GlobalVariable>(GV)->hasAttribute("toc-data"))
-      return false;
+  if (isAIXABI()) {
+    if (const GlobalVariable *GVar = dyn_cast<GlobalVariable>(GV))
+      // On AIX the only symbols that aren't indirect are toc-data.
+      return !GVar->hasAttribute("toc-data");
 
     return true;
   }

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
@@ -186,17 +186,17 @@ bool PPCSubtarget::enableSubRegLiveness() const {
 }
 
 bool PPCSubtarget::isGVIndirectSymbol(const GlobalValue *GV) const {
+  if (isAIXABI() && isa<GlobalVariable>(GV)) {
+    // On AIX the only symbols that aren't indirect are toc-data.
+    if (cast<GlobalVariable>(GV)->hasAttribute("toc-data"))
+      return false;
+
+    return true;
+  }
+
   // Large code model always uses the TOC even for local symbols.
   if (TM.getCodeModel() == CodeModel::Large)
     return true;
-
-  // AIX may have a per global code model attribute.
-  if (isAIXABI() && isa<GlobalVariable>(GV)) {
-    const GlobalVariable *GVar = cast<GlobalVariable>(GV);
-    std::optional<CodeModel::Model> OptionalCM = GVar->getCodeModel();
-    if (OptionalCM && *OptionalCM == CodeModel::Large)
-      return true;
-  }
 
   if (TM.shouldAssumeDSOLocal(GV))
     return false;

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.h
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.h
@@ -245,6 +245,10 @@ public:
   /// True if the GV will be accessed via an indirect symbol.
   bool isGVIndirectSymbol(const GlobalValue *GV) const;
 
+  /// Calculates the effective code model for argument GV.
+  CodeModel::Model getCodeModel(const TargetMachine &TM,
+                                const GlobalValue *GV) const;
+
   /// True if the ABI is descriptor based.
   bool usesFunctionDescriptors() const {
     // Both 32-bit and 64-bit AIX are descriptor based. For ELF only the 64-bit

--- a/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
@@ -17,6 +17,14 @@
 @e = external dso_local global i32, align 4
 @f = dso_local global i32 2748, align 4
 
+@large_aliasee = global i32 10, code_model "large", align 4
+@small_aliasee = global i32 171, code_model "small", align 4
+@normal_aliasee = global i32 2748, align 4
+
+@al = alias i32, ptr @large_aliasee
+@as = alias i32, ptr @small_aliasee
+@an = alias i32, ptr @normal_aliasee
+
 define i32 @A() local_unnamed_addr {
 entry:
   %0 = load i32, ptr @a, align 4
@@ -120,6 +128,23 @@ entry:
 ; CHECK64: ld 3, L..C[[TL_D]]@l([[HI]])
 ; CHECK:   blr
 
+define i32 @G() {
+   %tmp = load i32, ptr @al
+   ret i32 %tmp
+}
+; CHECK:   addis [[HI:[0-9]+]], L..C[[TL_AL:[0-9]+]]@u(2)
+; CHECK32: lwz [[ADDR:[0-9]+]], L..C[[TL_AL]]@l([[HI]])
+; CHECK64: ld  [[ADDR:[0-9]+]], L..C[[TL_AL]]@l([[HI]])
+; CHECK:   lwz 3, 0([[ADDR]])
+
+define i32 @H() {
+   %tmp = load i32, ptr @as
+   ret i32 %tmp
+}
+; CHECK32: lwz [[ADDR:[0-9]+]], L..C[[TL_AS:[0-9]+]](2)
+; CHECK64: ld [[ADDR:[0-9]+]], L..C[[TL_AS:[0-9]+]](2)
+; CHECK:   lwz 3, 0([[ADDR]])
+
 ;; Check TOC entires have correct storage mapping class
 ; CHECK:         L..C[[TL_A]]:
 ; CHECK:           .tc a[TC],a[UA]
@@ -135,3 +160,7 @@ entry:
 ; CHECK:         L..C[[TL_F]]:
 ; CHECK-SMALL:     .tc f[TC],f[RW]
 ; CHECK-LARGE:     .tc f[TE],f[RW]
+; CHECK:         L..C[[TL_AL]]:
+; CHECK:           .tc al[TE],al
+; CHECK:         L..C[[TL_AS]]:
+; CHECK:           .tc as[TC],as

--- a/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
@@ -1,20 +1,21 @@
 ; RUN: llc --verify-machineinstrs -mtriple powerpc-ibm-aix --code-model=small < \
-; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32 %s
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32,CHECK-SMALL,CHECK-SMALL32 %s
 
 ; RUN: llc --verify-machineinstrs -mtriple powerpc-ibm-aix --code-model=large < \
-; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32 %s
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32,CHECK-LARGE,CHECK-LARGE32 %s
 
 ; RUN: llc --verify-machineinstrs -mtriple powerpc64-ibm-aix --code-model=small < \
-; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64 %s
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64,CHECK-SMALL,CHECK-SMALL64 %s
 
 ; RUN: llc --verify-machineinstrs -mtriple powerpc64-ibm-aix --code-model=large < \
-; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64 %s
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64,CHECK-LARGE,CHECK-LARGE64 %s
 
 @a = external dso_local global i32, code_model "small", align 4
 @b = external dso_local global i32, code_model "large", align 4
 @c = dso_local global i32 55, code_model "small", align 4
 @d = dso_local global i32 41, code_model "large", align 4
-
+@e = external dso_local global i32, align 4
+@f = dso_local global i32 2748, align 4
 
 define i32 @A() local_unnamed_addr {
 entry:
@@ -58,6 +59,32 @@ entry:
 ; CHECK: lwz 3, 0([[ADDR]])
 ; CHECK: blr
 
+define i32 @E() {
+entry:
+  %0 = load i32, ptr @e, align 4
+  ret i32 %0
+}
+; CHECK-LARGE: addis [[HI:[0-9]+]], L..C[[TL_E:[0-9]+]]@u(2)
+; CHECK-LARGE32: lwz [[SCRATCH:[0-9]+]], L..C[[TL_E]]@l([[HI]])
+; CHECK-SMALL32: lwz [[SCRATCH:[0-9]+]], L..C[[TL_E:[0-9]+]](2)
+; CHECK-LARGE64: ld  [[SCRATCH:[0-9]+]], L..C[[TL_E]]@l([[HI]])
+; CHECK-SMALL64: ld  [[SCRATCH:[0-9]+]], L..C[[TL_E:[0-9]+]](2)
+; CHECK: lwz 3, 0([[SCRATCH]])
+; CHECK: blr
+
+define i32 @F() {
+entry:
+  %0 = load i32, ptr @f, align 4
+  ret i32 %0
+}
+; CHECK-LARGE: addis [[HI:[0-9]+]], L..C[[TL_F:[0-9]+]]@u(2)
+; CHECK-LARGE32: lwz [[SCRATCH:[0-9]+]], L..C[[TL_F]]@l([[HI]])
+; CHECK-SMALL32: lwz [[SCRATCH:[0-9]+]], L..C[[TL_F:[0-9]+]](2)
+; CHECK-LARGE64: ld [[SCRATCH:[0-9]+]], L..C[[TL_F]]@l([[HI]])
+; CHECK-SMALL64: ld  [[SCRATCH:[0-9]+]], L..C[[TL_F:[0-9]+]](2)
+; CHECK: lwz 3, 0([[SCRATCH]])
+; CHECK: blr
+
 define noundef nonnull ptr @addr_a() local_unnamed_addr {
 entry:
   ret ptr @a
@@ -94,11 +121,17 @@ entry:
 ; CHECK:   blr
 
 ;; Check TOC entires have correct storage mapping class
-; CHECK:  L..C[[TL_A]]:
-; CHECK:  .tc a[TC],a[UA]
-; CHECK:  L..C[[TL_B]]:
-; CHECK:  .tc b[TE],b[UA]
-; CHECK:  L..C[[TL_C]]:
-; CHECK:  .tc c[TC],c[RW]
-; CHECK:  L..C[[TL_D]]:
-; CHECK:  .tc d[TE],d[RW]
+; CHECK:         L..C[[TL_A]]:
+; CHECK:           .tc a[TC],a[UA]
+; CHECK:         L..C[[TL_B]]:
+; CHECK:           .tc b[TE],b[UA]
+; CHECK:         L..C[[TL_C]]:
+; CHECK:           .tc c[TC],c[RW]
+; CHECK:         L..C[[TL_D]]:
+; CHECK:           .tc d[TE],d[RW]
+; CHECK:         L..C[[TL_E]]:
+; CHECK-SMALL:     .tc e[TC],e[UA]
+; CHECK-LARGE:     .tc e[TE],e[UA]
+; CHECK:         L..C[[TL_F]]:
+; CHECK-SMALL:     .tc f[TC],f[RW]
+; CHECK-LARGE:     .tc f[TE],f[RW]

--- a/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-codemodel-attr.ll
@@ -1,0 +1,104 @@
+; RUN: llc --verify-machineinstrs -mtriple powerpc-ibm-aix --code-model=small < \
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32 %s
+
+; RUN: llc --verify-machineinstrs -mtriple powerpc-ibm-aix --code-model=large < \
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK32 %s
+
+; RUN: llc --verify-machineinstrs -mtriple powerpc64-ibm-aix --code-model=small < \
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64 %s
+
+; RUN: llc --verify-machineinstrs -mtriple powerpc64-ibm-aix --code-model=large < \
+; RUN: %s | FileCheck --check-prefixes=CHECK,CHECK64 %s
+
+@a = external dso_local global i32, code_model "small", align 4
+@b = external dso_local global i32, code_model "large", align 4
+@c = dso_local global i32 55, code_model "small", align 4
+@d = dso_local global i32 41, code_model "large", align 4
+
+
+define i32 @A() local_unnamed_addr {
+entry:
+  %0 = load i32, ptr @a, align 4
+  ret i32 %0
+}
+; CHECK32:  lwz [[SCRATCH:[0-9]+]], L..C[[TL_A:[0-9]+]](2)                         # @a
+; CHECK64:  ld [[SCRATCH:[0-9]+]], L..C[[TL_A:[0-9]+]](2)                         # @a
+; CHECK:    lwz 3, 0([[SCRATCH]])
+; CHECK:    blr
+
+define i32 @B() local_unnamed_addr {
+entry:
+  %0 = load i32, ptr @b, align 4
+  ret i32 %0
+}
+; CHECK:   addis [[HI:[0-9]+]], L..C[[TL_B:[0-9]+]]@u(2)
+; CHECK32: lwz [[ADDR:[0-9]+]], L..C[[TL_B]]@l([[HI]])
+; CHECK64: ld [[ADDR:[0-9]+]], L..C[[TL_B]]@l([[HI]])
+; CHECK:   lwz 3, 0([[ADDR]])
+; CHECK:   blr
+
+define i32 @C() local_unnamed_addr {
+entry:
+  %0 = load i32, ptr @c, align 4
+  ret i32 %0
+}
+; CHECK32:  lwz [[SCRATCH:[0-9]+]], L..C[[TL_C:[0-9]+]](2)                         # @c
+; CHECK64:  ld [[SCRATCH:[0-9]+]], L..C[[TL_C:[0-9]+]](2)                         # @c
+; CHECK:    lwz 3, 0([[SCRATCH]])
+; CHECK:    blr
+
+define i32 @D() local_unnamed_addr {
+entry:
+  %0 = load i32, ptr @d, align 4
+  ret i32 %0
+}
+; CHECK: addis [[HI:[0-9]+]], L..C[[TL_D:[0-9]+]]@u(2)
+; CHECK32: lwz [[ADDR:[0-9]+]], L..C[[TL_D]]@l([[HI]])
+; CHECK64: ld [[ADDR:[0-9]+]], L..C[[TL_D]]@l([[HI]])
+; CHECK: lwz 3, 0([[ADDR]])
+; CHECK: blr
+
+define noundef nonnull ptr @addr_a() local_unnamed_addr {
+entry:
+  ret ptr @a
+}
+; CHECK32:  lwz 3, L..C[[TL_A]](2)                         # @a
+; CHECK64:  ld 3, L..C[[TL_A]](2)                         # @a
+; CHECK:    blr
+
+define noundef nonnull ptr @addr_b() local_unnamed_addr {
+entry:
+  ret ptr @b
+}
+; CHECK:    addis [[HI:[0-9]+]], L..C[[TL_B]]@u(2)
+; CHECK32:  lwz 3, L..C[[TL_B]]@l([[HI]])
+; CHECK64:  ld 3, L..C[[TL_B]]@l([[HI]])
+; CHECK:    blr
+
+
+define noundef nonnull ptr @addr_c() local_unnamed_addr {
+entry:
+  ret ptr @c
+}
+; CHECK32:  lwz 3, L..C[[TL_C]](2)                         # @c
+; CHECK64:  ld 3, L..C[[TL_C]](2)                         # @c
+; CHECK:    blr
+
+define noundef nonnull ptr @addr_d() local_unnamed_addr {
+entry:
+  ret ptr @d
+}
+; CHECK:   addis [[HI:[0-9]+]], L..C[[TL_D]]@u(2)
+; CHECK32: lwz 3, L..C[[TL_D]]@l([[HI]])
+; CHECK64: ld 3, L..C[[TL_D]]@l([[HI]])
+; CHECK:   blr
+
+;; Check TOC entires have correct storage mapping class
+; CHECK:  L..C[[TL_A]]:
+; CHECK:  .tc a[TC],a[UA]
+; CHECK:  L..C[[TL_B]]:
+; CHECK:  .tc b[TE],b[UA]
+; CHECK:  L..C[[TL_C]]:
+; CHECK:  .tc c[TC],c[RW]
+; CHECK:  L..C[[TL_D]]:
+; CHECK:  .tc d[TE],d[RW]


### PR DESCRIPTION
Exploit the per global code model attribute on AIX. On AIX we need to update both the code sequence used to access the global (either 1 or 2 instructions for small and large code model respectively) and the storage mapping class that we emit the toc entry.