### PR TITLE
[libc] force GCC limits.h to not include_next limits.h

### DIFF
--- a/libc/src/__support/CPP/limits.h
+++ b/libc/src/__support/CPP/limits.h
@@ -13,7 +13,24 @@
 #include "src/__support/CPP/type_traits/is_signed.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 
+// Coax GCC to NOT attempt to include_next limits.h from glibc. llvmlibc should
+// include this file rather than <limits.h> directy for this reason.
+#ifndef __clang__
+#define _LIBC_LIMITS_H_
+#endif
 #include <limits.h> // CHAR_BIT
+
+// GCC's limits.h only defines these for __STDC_VERSION__ >= 199901L, i.e. not
+// C++.
+#ifndef LLONG_MAX
+#define LLONG_MAX __LONG_LONG_MAX__
+#endif
+#ifndef LLONG_MIN
+#define LLONG_MIN (-LONG_MAX - 1LL)
+#endif
+#ifndef ULLONG_MAX
+#define ULLONG_MAX (~0ULL)
+#endif
 
 namespace LIBC_NAMESPACE {
 namespace cpp {

--- a/libc/src/__support/FPUtil/ManipulationFunctions.h
+++ b/libc/src/__support/FPUtil/ManipulationFunctions.h
@@ -14,12 +14,12 @@
 #include "NormalFloat.h"
 
 #include "src/__support/CPP/bit.h"
+#include "src/__support/CPP/limits.h" // INT_MAX, INT_MIN
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 
-#include <limits.h>
 #include <math.h>
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/__support/math_extras.h
+++ b/libc/src/__support/math_extras.h
@@ -10,11 +10,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_EXTRAS_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_EXTRAS_H
 
+#include "src/__support/CPP/limits.h"        // CHAR_BIT
 #include "src/__support/CPP/type_traits.h"   // is_unsigned_v
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"     // LIBC_HAS_BUILTIN
-
-#include <limits.h> // CHAR_BIT
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/str_to_integer.h
+++ b/libc/src/__support/str_to_integer.h
@@ -15,7 +15,6 @@
 #include "src/__support/ctype_utils.h"
 #include "src/__support/str_to_num_result.h"
 #include "src/errno/libc_errno.h" // For ERANGE
-#include <limits.h>
 
 namespace LIBC_NAMESPACE {
 namespace internal {

--- a/libc/src/__support/threads/linux/callonce.cpp
+++ b/libc/src/__support/threads/linux/callonce.cpp
@@ -9,10 +9,10 @@
 #include "futex_word.h"
 
 #include "src/__support/CPP/atomic.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/OSUtil/syscall.h" // For syscall functions.
 #include "src/__support/threads/callonce.h"
 
-#include <limits.h>
 #include <linux/futex.h>
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/src/__support/threads/linux/callonce.cpp
+++ b/libc/src/__support/threads/linux/callonce.cpp
@@ -9,7 +9,7 @@
 #include "futex_word.h"
 
 #include "src/__support/CPP/atomic.h"
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h"     // For INT_MAX.
 #include "src/__support/OSUtil/syscall.h" // For syscall functions.
 #include "src/__support/threads/callonce.h"
 

--- a/libc/src/threads/CMakeLists.txt
+++ b/libc/src/threads/CMakeLists.txt
@@ -10,6 +10,7 @@ add_entrypoint_object(
     call_once.h
   DEPENDS
     libc.include.threads
+    libc.src.__support.CPP.limits
     libc.src.__support.threads.callonce
 )
 

--- a/libc/src/threads/linux/call_once.cpp
+++ b/libc/src/threads/linux/call_once.cpp
@@ -9,7 +9,7 @@
 #include "Futex.h"
 
 #include "src/__support/CPP/atomic.h"
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h"     // For INT_MAX.
 #include "src/__support/OSUtil/syscall.h" // For syscall functions.
 #include "src/__support/common.h"
 #include "src/threads/call_once.h"

--- a/libc/src/threads/linux/call_once.cpp
+++ b/libc/src/threads/linux/call_once.cpp
@@ -9,12 +9,12 @@
 #include "Futex.h"
 
 #include "src/__support/CPP/atomic.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/OSUtil/syscall.h" // For syscall functions.
 #include "src/__support/common.h"
 #include "src/threads/call_once.h"
 #include "src/threads/linux/Futex.h"
 
-#include <limits.h>
 #include <linux/futex.h>
 #include <sys/syscall.h> // For syscall numbers.
 #include <threads.h>     // For call_once related type definition.

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -10,6 +10,7 @@ add_object_library(
     time_utils.h
   DEPENDS
     libc.include.time
+    libc.src.__support.CPP.limits
     libc.src.errno.errno
 )
 
@@ -76,6 +77,7 @@ add_entrypoint_object(
   DEPENDS
     .time_utils
     libc.include.time
+    libc.src.__support.CPP.limits
     libc.src.errno.errno
 )
 

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -77,7 +77,6 @@ add_entrypoint_object(
   DEPENDS
     .time_utils
     libc.include.time
-    libc.src.__support.CPP.limits
     libc.src.errno.errno
 )
 

--- a/libc/src/time/mktime.cpp
+++ b/libc/src/time/mktime.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/mktime.h"
-#include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
 #include "src/time/time_utils.h"
 

--- a/libc/src/time/mktime.cpp
+++ b/libc/src/time/mktime.cpp
@@ -7,10 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/mktime.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
 #include "src/time/time_utils.h"
-
-#include <limits.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/time/time_utils.cpp
+++ b/libc/src/time/time_utils.cpp
@@ -7,9 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/time_utils.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
-
-#include <limits.h>
 
 namespace LIBC_NAMESPACE {
 namespace time_utils {

--- a/libc/src/time/time_utils.cpp
+++ b/libc/src/time/time_utils.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/time_utils.h"
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX, INT_MIN
 #include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE {

--- a/libc/test/src/math/ILogbTest.h
+++ b/libc/test/src/math/ILogbTest.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/math/ILogbTest.h
+++ b/libc/test/src/math/ILogbTest.h
@@ -9,12 +9,11 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "test/UnitTest/Test.h"
 #include <math.h>
-
-#include <limits.h>
 
 class LlvmLibcILogbTest : public LIBC_NAMESPACE::testing::Test {
 public:

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/NormalFloat.h"
 #include "test/UnitTest/FPMatcher.h"

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/NormalFloat.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 

--- a/libc/test/src/math/smoke/ILogbTest.h
+++ b/libc/test/src/math/smoke/ILogbTest.h
@@ -9,12 +9,11 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_ILOGBTEST_H
 
+#include "src/__support/CPP/limits.h" // INT_MAX
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "test/UnitTest/Test.h"
 #include <math.h>
-
-#include <limits.h>
 
 class LlvmLibcILogbTest : public LIBC_NAMESPACE::testing::Test {
 public:

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 #define LLVM_LIBC_TEST_SRC_MATH_LDEXPTEST_H
 
+#include "src/__support/CPP/limits.h" // INT_MAX
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/NormalFloat.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 

--- a/libc/test/src/stdlib/AtoiTest.h
+++ b/libc/test/src/stdlib/AtoiTest.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX, INT_MIN, LLONG_MAX, LLONG_MIN
 #include "src/__support/CPP/type_traits.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/stdlib/AtoiTest.h
+++ b/libc/test/src/stdlib/AtoiTest.h
@@ -6,10 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
 #include "test/UnitTest/Test.h"
-
-#include <limits.h>
 
 using LIBC_NAMESPACE::cpp::is_same_v;
 

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -7,7 +7,6 @@ add_libc_test(
   SRCS
     atof_test.cpp
   DEPENDS
-    libc.src.__support.CPP.limits
     libc.src.errno.errno
     libc.src.stdlib.atof
 )
@@ -63,7 +62,6 @@ if(NOT LIBC_GPU_TARGET_ARCHITECTURE_IS_NVPTX)
     SRCS
       strtod_test.cpp
     DEPENDS
-      libc.src.__support.CPP.limits
       libc.src.__support.FPUtil.fenv_impl
       libc.src.errno.errno
       libc.src.stdlib.strtod
@@ -77,7 +75,6 @@ add_fp_unittest(
   SRCS
     strtof_test.cpp
   DEPENDS
-    libc.src.__support.CPP.limits
     libc.src.__support.FPUtil.fenv_impl
     libc.src.errno.errno
     libc.src.stdlib.strtof
@@ -137,7 +134,6 @@ if(NOT LIBC_GPU_TARGET_ARCHITECTURE_IS_NVPTX)
     SRCS
       strtold_test.cpp
     DEPENDS
-      libc.src.__support.CPP.limits
       libc.src.__support.uint128
       libc.src.errno.errno
       libc.src.stdlib.strtold

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -7,6 +7,7 @@ add_libc_test(
   SRCS
     atof_test.cpp
   DEPENDS
+    libc.src.__support.CPP.limits
     libc.src.errno.errno
     libc.src.stdlib.atof
 )
@@ -62,9 +63,10 @@ if(NOT LIBC_GPU_TARGET_ARCHITECTURE_IS_NVPTX)
     SRCS
       strtod_test.cpp
     DEPENDS
+      libc.src.__support.CPP.limits
+      libc.src.__support.FPUtil.fenv_impl
       libc.src.errno.errno
       libc.src.stdlib.strtod
-      libc.src.__support.FPUtil.fenv_impl
   )
 endif()
 
@@ -75,9 +77,10 @@ add_fp_unittest(
   SRCS
     strtof_test.cpp
   DEPENDS
+    libc.src.__support.CPP.limits
+    libc.src.__support.FPUtil.fenv_impl
     libc.src.errno.errno
     libc.src.stdlib.strtof
-    libc.src.__support.FPUtil.fenv_impl
 )
 
 add_header_library(
@@ -134,8 +137,9 @@ if(NOT LIBC_GPU_TARGET_ARCHITECTURE_IS_NVPTX)
     SRCS
       strtold_test.cpp
     DEPENDS
-      libc.src.errno.errno
+      libc.src.__support.CPP.limits
       libc.src.__support.uint128
+      libc.src.errno.errno
       libc.src.stdlib.strtold
   )
 endif()

--- a/libc/test/src/stdlib/StrtolTest.h
+++ b/libc/test/src/stdlib/StrtolTest.h
@@ -12,7 +12,6 @@
 #include "src/errno/libc_errno.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <stddef.h>
 
 using LIBC_NAMESPACE::cpp::is_signed_v;

--- a/libc/test/src/stdlib/atof_test.cpp
+++ b/libc/test/src/stdlib/atof_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/atof.h"
@@ -13,7 +14,6 @@
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <stddef.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/libc/test/src/stdlib/atof_test.cpp
+++ b/libc/test/src/stdlib/atof_test.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/atof.h"

--- a/libc/test/src/stdlib/strtod_test.cpp
+++ b/libc/test/src/stdlib/strtod_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/strtod.h"
@@ -14,7 +15,6 @@
 #include "test/UnitTest/RoundingModeUtils.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <stddef.h>
 
 using LIBC_NAMESPACE::fputil::testing::ForceRoundingModeTest;

--- a/libc/test/src/stdlib/strtod_test.cpp
+++ b/libc/test/src/stdlib/strtod_test.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/strtod.h"

--- a/libc/test/src/stdlib/strtof_test.cpp
+++ b/libc/test/src/stdlib/strtof_test.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/strtof.h"

--- a/libc/test/src/stdlib/strtof_test.cpp
+++ b/libc/test/src/stdlib/strtof_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdlib/strtof.h"
@@ -14,7 +15,6 @@
 #include "test/UnitTest/RoundingModeUtils.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <stddef.h>
 
 using LIBC_NAMESPACE::fputil::testing::ForceRoundingModeTest;

--- a/libc/test/src/stdlib/strtold_test.cpp
+++ b/libc/test/src/stdlib/strtold_test.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/UInt128.h"
 #include "src/errno/libc_errno.h"

--- a/libc/test/src/stdlib/strtold_test.cpp
+++ b/libc/test/src/stdlib/strtold_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/UInt128.h"
 #include "src/errno/libc_errno.h"
@@ -13,7 +14,6 @@
 
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <stddef.h>
 
 #if defined(LIBC_LONG_DOUBLE_IS_FLOAT64)

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -71,6 +71,7 @@ add_libc_unittest(
     TmMatcher.h
   DEPENDS
     libc.src.time.gmtime
+    libc.src.__support.CPP.limits
 )
 
 add_libc_unittest(
@@ -98,6 +99,7 @@ add_libc_unittest(
     20
   DEPENDS
     libc.src.time.mktime
+    libc.src.__support.CPP.limits
 )
 
 # Sleeping is not supported on older NVPTX architectures.
@@ -136,6 +138,7 @@ add_libc_test(
     clock_test.cpp
   DEPENDS
     libc.include.time
-    libc.src.time.clock
+    libc.src.__support.CPP.limits
     libc.src.errno.errno
+    libc.src.time.clock
 )

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -70,8 +70,8 @@ add_libc_unittest(
   HDRS
     TmMatcher.h
   DEPENDS
-    libc.src.time.gmtime
     libc.src.__support.CPP.limits
+    libc.src.time.gmtime
 )
 
 add_libc_unittest(
@@ -98,8 +98,8 @@ add_libc_unittest(
   CXX_STANDARD
     20
   DEPENDS
-    libc.src.time.mktime
     libc.src.__support.CPP.limits
+    libc.src.time.mktime
 )
 
 # Sleeping is not supported on older NVPTX architectures.
@@ -126,8 +126,9 @@ add_libc_unittest(
     time_test.cpp
   DEPENDS
     libc.include.time
-    libc.src.time.time
+    libc.src.__support.CPP.limits
     libc.src.errno.errno
+    libc.src.time.time
 )
 
 add_libc_test(

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -139,7 +139,6 @@ add_libc_test(
     clock_test.cpp
   DEPENDS
     libc.include.time
-    libc.src.__support.CPP.limits
     libc.src.errno.errno
     libc.src.time.clock
 )

--- a/libc/test/src/time/clock_test.cpp
+++ b/libc/test/src/time/clock_test.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/time/clock.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <time.h>
 
 TEST(LlvmLibcClockTest, SmokeTest) {

--- a/libc/test/src/time/clock_test.cpp
+++ b/libc/test/src/time/clock_test.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
 #include "src/time/clock.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -6,14 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/errno/libc_errno.h"
 #include "src/time/gmtime.h"
 #include "src/time/time_utils.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmMatcher.h"
-
-#include <limits.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX, INT_MIN
 #include "src/errno/libc_errno.h"
 #include "src/time/gmtime.h"
 #include "src/time/time_utils.h"

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -6,14 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/time/mktime.h"
 #include "src/time/time_utils.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmHelper.h"
 #include "test/src/time/TmMatcher.h"
-
-#include <limits.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/limits.h" // INT_MAX
 #include "src/time/mktime.h"
 #include "src/time/time_utils.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"

--- a/libc/test/src/time/time_test.cpp
+++ b/libc/test/src/time/time_test.cpp
@@ -9,7 +9,6 @@
 #include "src/time/time_func.h"
 #include "test/UnitTest/Test.h"
 
-#include <limits.h>
 #include <time.h>
 
 TEST(LlvmLibcTimeTest, SmokeTest) {


### PR DESCRIPTION
Who defines what the width and thus the min/max values for a given integer
type? We'd like to rely on the compiler's resource dir's definitions, but GCC's
limits.h can end up using include_next to include limits.h from GLIBC.

This results in build failures with GCC due to __GLIBC_USE being undefined (a
feature detection macro defined only relevant to glibc). We'd like to avoid
the compiler pulling in the libc's headers (unless there's some critical reason
why, which we don't have today AFAIK). GCC's limits.h will avoid this circular
includes if _LIBC_LIMITS_H_ is defined.

GCC's limits.h only defines LLONG_MAX, LLONG_MIN, and ULLONG_MAX if
__STDC_VERSION__ is defined and >= 199901L, i.e. not for C++, so provide those
definitions ourselves.

Due to this, we should never be including <limits.h> in libc/ (other than in
CPP/limits.h). Sources and tests should be including
"libc/src/__support/CPP/limits.h" in place of <limits.h>.
