### PR TITLE
[mlgo] bazel rules for mlgo-utils

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4958,6 +4958,36 @@ py_binary(
     srcs = ["utils/lit/lit.py"] + glob(["utils/lit/lit/**/*.py"]),
 )
 
+py_binary(
+    name = "extract_ir",
+    srcs = [
+        "utils/mlgo-utils/mlgo/__init__.py",
+        "utils/mlgo-utils/mlgo/corpus/extract_ir.py",
+        "utils/mlgo-utils/mlgo/corpus/extract_ir_lib.py"
+    ],
+    imports = ["utils/mlgo-utils"]
+)
+
+py_binary(
+    name = "combine_training_corpus",
+    srcs = [
+        "utils/mlgo-utils/mlgo/__init__.py",
+        "utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py",
+        "utils/mlgo-utils/mlgo/corpus/combine_training_corpus_lib.py"
+    ],
+    imports = ["utils/mlgo-utils"]
+)
+
+py_binary(
+    name = "make_corpus",
+    srcs = [
+        "utils/mlgo-utils/mlgo/__init__.py",
+        "utils/mlgo-utils/mlgo/corpus/make_corpus.py",
+        "utils/mlgo-utils/mlgo/corpus/make_corpus_lib.py"
+    ],
+    imports = ["utils/mlgo-utils"]
+)
+
 cc_library(
     name = "TestingADT",
     testonly = True,


### PR DESCRIPTION
Akin the `py_binary` rules for `lit`, these are scoped to binaries, rather than exposing the library - binary split. The latter is available to the package (pip package) users.

Tested:

```
cd utils/bazel
bazel build @llvm-project//llvm:extract_ir
bazel-bin/external/llvm-project/llvm/extract_ir --help
```
...and observed expected output (rather than import not found errors)

(Same for the other 2 targets).