### PR TITLE
[SystemZ] Require D12 for i128 accesses in isLegalAddressingMode()

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -1067,7 +1067,8 @@ bool SystemZTargetLowering::isLegalAddressingMode(const DataLayout &DL,
   if (!isInt<20>(AM.BaseOffs))
     return false;
 
-  bool RequireD12 = Subtarget.hasVector() && Ty->isVectorTy();
+  bool RequireD12 =
+      Subtarget.hasVector() && (Ty->isVectorTy() || Ty->isIntegerTy(128));
   AddressingMode SupportedAM(!RequireD12, true);
   if (I != nullptr)
     SupportedAM = supportedAddressingMode(I, Subtarget.hasVector());

--- a/llvm/test/CodeGen/SystemZ/loop-01.ll
+++ b/llvm/test/CodeGen/SystemZ/loop-01.ll
@@ -312,3 +312,26 @@ for.inc.i:                                        ; preds = %for.body.i63
   %indvars.iv.next156.i.3 = add nsw i64 %indvars.iv155.i, 4
   br label %for.body.i63
 }
+
+; Test that offsets are in range for i128 memory accesses.
+define void @fun10() {
+; CHECK-Z13-LABEL: fun10:
+; CHECK-Z13: # =>This Inner Loop Header: Depth=1
+; CHECK-Z13-NOT: lay
+entry:
+  %A1 = alloca [3 x [7 x [10 x i128]]], align 8
+  br label %for.body
+
+for.body:                        ; preds = %for.body, %entry
+  %IV = phi i64 [ 0, %entry ], [ %IV.next, %for.body ]
+  %Addr1 = getelementptr inbounds [3 x [7 x [10 x i128]]], ptr %A1, i64 0, i64 %IV, i64 6, i64 6
+  store i128 17174966165894859678, ptr %Addr1, align 8
+  %Addr2 = getelementptr inbounds [3 x [7 x [10 x i128]]], ptr %A1, i64 0, i64 %IV, i64 6, i64 8
+  store i128 17174966165894859678, ptr %Addr2, align 8
+  %IV.next = add nuw nsw i64 %IV, 1
+  %exitcond.not.i.i = icmp eq i64 %IV.next, 3
+  br i1 %exitcond.not.i.i, label %exit, label %for.body
+
+exit:                        ; preds = %for.body
+  unreachable
+}


### PR DESCRIPTION
For targets with vector support handle i128 in vector registers and therefore only have the small displacement available for memory accesses. Update isLegalAddressingMode() to reflect this.
