### PR TITLE
[nfc][clang] Fix test in new-array-init.cpp

### DIFF
--- a/clang/test/CodeGenCXX/new-array-init.cpp
+++ b/clang/test/CodeGenCXX/new-array-init.cpp
@@ -164,7 +164,7 @@ void string_sufficient_paren() {
   // FIXME: For very large arrays, it would be preferable to emit a small copy and a memset.
   // CHECKCXX20: call void @llvm.memcpy{{.*}}(ptr align {{[0-9]+}} %[[PTR]], ptr align {{[0-9]+}} @[[ABC15]], i32 15,
   // CHECKCXX20-NOT: memset
-  new char[15] { "abc" };
+  new char[15]("abc");
 }
 #endif
 


### PR DESCRIPTION
This test was originally introduced in
https://github.com/llvm/llvm-project/pull/76976, but it incorrectly tests braced-list initialization instead of parenthesized initialization.