### PR TITLE
Add support for builtin_verbose_trap

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3501,13 +3501,13 @@ The debugging information would look as if it were produced for the following co
 .. code-block:: c++
 
     __attribute__((always_inline))
-    inline void "__llvm_verbose_trap$check null$Argument must not be null!"() {
+    inline void "__trap_msg$check null$Argument must not be null!"() {
       __builtin_trap();
     }
 
     void foo(int* p) {
       if (p == nullptr)
-        "__llvm_verbose_trap$check null$Argument must not be null!"();
+        "__trap_msg$check null$Argument must not be null!"();
     }
 
 However, the generated code would not actually contain a call to the artificial

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3501,13 +3501,13 @@ The debugging information would look as if it were produced for the following co
 .. code-block:: c++
 
     __attribute__((always_inline))
-    inline void "__trap_msg$check null$Argument must not be null!"() {
+    inline void "__clang_trap_msg$check null$Argument must not be null!"() {
       __builtin_trap();
     }
 
     void foo(int* p) {
       if (p == nullptr)
-        "__trap_msg$check null$Argument must not be null!"();
+        "__clang_trap_msg$check null$Argument must not be null!"();
     }
 
 However, the generated code would not actually contain a call to the artificial

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3501,13 +3501,13 @@ The debugging information would look as if it were produced for the following co
 .. code-block:: c++
 
     __attribute__((always_inline))
-    inline void "__llvm_verbose_trap:check null:Argument must not be null!"() {
+    inline void "__llvm_verbose_trap$check null$Argument must not be null!"() {
       __builtin_trap();
     }
 
     void foo(int* p) {
       if (p == nullptr)
-        "__llvm_verbose_trap:check null:Argument must not be null!"();
+        "__llvm_verbose_trap$check null$Argument must not be null!"();
     }
 
 However, the generated code would not actually contain a call to the artificial

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3518,6 +3518,9 @@ users need to enable debug information to enable this feature. A call to this
 builtin is equivalent to a call to ``__builtin_trap`` if debug information isn't
 enabled.
 
+The optimizer can merge calls to trap with different messages, which degrades
+the debugging experience.
+
 ``__builtin_allow_runtime_check``
 ---------------------------------
 
@@ -3565,6 +3568,7 @@ guarded check. It's unused now. It will enable kind-specific lowering in future.
 E.g. a higher hotness cutoff can be used for more expensive kind of check.
 
 Query for this feature with ``__has_builtin(__builtin_allow_runtime_check)``.
+
 ``__builtin_nondeterministic_value``
 ------------------------------------
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3510,8 +3510,8 @@ The debugging information would look as if it were produced for the following co
         "__llvm_verbose_trap: Argument must not be null!"();
     }
 
-However, the LLVM IR would not actually contain a call to the artificial
-function — it only exists in the debug metadata.
+However, the generated code would not actually contain a call to the artificial
+function — it only exists in the debugging information.
 
 Query for this feature with ``__has_builtin(__builtin_verbose_trap)``. Note that
 users need to enable debug information to enable this feature. A call to this

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3483,9 +3483,9 @@ debugger is attached or in a symbolicated crash log.
 **Description**
 
 ``__builtin_verbose_trap`` is lowered to the ` ``llvm.trap`` <https://llvm.org/docs/LangRef.html#llvm-trap-intrinsic>`_ builtin.
-Additionally, clang emits debug metadata that represents an artificial inline
-frame whose name encodes the string passed to the builtin, prefixed by a "magic"
-prefix.
+Additionally, clang emits debugging information that represents an artificial
+inline frame whose name encodes the string passed to the builtin, prefixed by a
+"magic" prefix.
 
 For example, consider the following code:
 
@@ -3493,27 +3493,30 @@ For example, consider the following code:
 
     void foo(int* p) {
       if (p == nullptr)
-        __builtin_verbose_trap("Argument_must_not_be_null");
+        __builtin_verbose_trap("Argument must not be null!");
     }
 
-The debug metadata would look as if it were produced for the following code:
+The debugging information would look as if it were produced for the following code:
 
 .. code-block:: c++
 
     __attribute__((always_inline))
-    inline void "__llvm_verbose_trap: Argument_must_not_be_null"() {
+    inline void "__llvm_verbose_trap: Argument must not be null!"() {
       __builtin_trap();
     }
 
     void foo(int* p) {
       if (p == nullptr)
-        "__llvm_verbose_trap: Argument_must_not_be_null"();
+        "__llvm_verbose_trap: Argument must not be null!"();
     }
 
 However, the LLVM IR would not actually contain a call to the artificial
 function — it only exists in the debug metadata.
 
-Query for this feature with ``__has_builtin(__builtin_verbose_trap)``.
+Query for this feature with ``__has_builtin(__builtin_verbose_trap)``. Note that
+users need to enable debug information to enable this feature. A call to this
+builtin is equivalent to a call to ``__builtin_trap`` if debug information isn't
+enabled.
 
 ``__builtin_allow_runtime_check``
 ---------------------------------

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3478,14 +3478,14 @@ debugger is attached or in a symbolicated crash log.
 
 .. code-block:: c++
 
-    __builtin_verbose_trap(const char *reason)
+    __builtin_verbose_trap(const char *category, const char *reason)
 
 **Description**
 
 ``__builtin_verbose_trap`` is lowered to the ` ``llvm.trap`` <https://llvm.org/docs/LangRef.html#llvm-trap-intrinsic>`_ builtin.
 Additionally, clang emits debugging information that represents an artificial
-inline frame whose name encodes the string passed to the builtin, prefixed by a
-"magic" prefix.
+inline frame whose name encodes the category and reason strings passed to the builtin,
+prefixed by a "magic" prefix.
 
 For example, consider the following code:
 
@@ -3493,7 +3493,7 @@ For example, consider the following code:
 
     void foo(int* p) {
       if (p == nullptr)
-        __builtin_verbose_trap("Argument must not be null!");
+        __builtin_verbose_trap("check null", "Argument must not be null!");
     }
 
 The debugging information would look as if it were produced for the following code:
@@ -3501,13 +3501,13 @@ The debugging information would look as if it were produced for the following co
 .. code-block:: c++
 
     __attribute__((always_inline))
-    inline void "__llvm_verbose_trap: Argument must not be null!"() {
+    inline void "__llvm_verbose_trap:check null:Argument must not be null!"() {
       __builtin_trap();
     }
 
     void foo(int* p) {
       if (p == nullptr)
-        "__llvm_verbose_trap: Argument must not be null!"();
+        "__llvm_verbose_trap:check null:Argument must not be null!"();
     }
 
 However, the generated code would not actually contain a call to the artificial

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -787,6 +787,11 @@ public:
                                  const Expr *PtrExpression, ASTContext &Ctx,
                                  EvalResult &Status) const;
 
+  /// If the current Expr can be evaluated to a pointer to a null-terminated
+  /// constant string, return the constant string (without the terminating null)
+  /// in Result. Return true if it succeeds.
+  bool tryEvaluateString(std::string &Result, ASTContext &Ctx) const;
+
   /// Enumeration used to describe the kind of Null pointer constant
   /// returned from \c isNullPointerConstant().
   enum NullPointerConstantKind {

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -788,9 +788,9 @@ public:
                                  EvalResult &Status) const;
 
   /// If the current Expr can be evaluated to a pointer to a null-terminated
-  /// constant string, return the constant string (without the terminating null)
-  /// in Result. Return true if it succeeds.
-  bool tryEvaluateString(std::string &Result, ASTContext &Ctx) const;
+  /// constant string, return the constant string (without the terminating
+  /// null).
+  std::optional<std::string> tryEvaluateString(ASTContext &Ctx) const;
 
   /// Enumeration used to describe the kind of Null pointer constant
   /// returned from \c isNullPointerConstant().

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -1152,6 +1152,12 @@ def Trap : Builtin {
   let Prototype = "void()";
 }
 
+def VerboseTrap : Builtin {
+  let Spellings = ["__builtin_verbose_trap"];
+  let Attributes = [NoThrow, NoReturn];
+  let Prototype = "void(char const*)";
+}
+
 def Debugtrap : Builtin {
   let Spellings = ["__builtin_debugtrap"];
   let Attributes = [NoThrow];

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -1155,7 +1155,7 @@ def Trap : Builtin {
 def VerboseTrap : Builtin {
   let Spellings = ["__builtin_verbose_trap"];
   let Attributes = [NoThrow, NoReturn];
-  let Prototype = "void(char const*)";
+  let Prototype = "void(char const*, char const*)";
 }
 
 def Debugtrap : Builtin {

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8876,7 +8876,7 @@ def err_expected_callable_argument : Error<
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
-  "argument to __builtin_verbose_trap must be a pointer to a constant string">;
+  "argument to __builtin_verbose_trap must %select{be a pointer to a constant string|not contain $}0">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8875,6 +8875,8 @@ def err_expected_callable_argument : Error<
   "expected a callable expression as %ordinal0 argument to %1, found %2">;
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
+def err_builtin_verbose_trap_arg : Error<
+  "argument to __builtin_verbose_trap must be a non-empty string literal">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8876,8 +8876,7 @@ def err_expected_callable_argument : Error<
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
-  "argument to __builtin_verbose_trap must be a pointer to a non-empty constant "
-  "string">;
+  "argument to __builtin_verbose_trap must be a pointer to a constant string">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8876,7 +8876,8 @@ def err_expected_callable_argument : Error<
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
-  "argument to __builtin_verbose_trap must be a non-empty string literal">;
+  "argument to __builtin_verbose_trap must be a pointer to a non-empty constant "
+  "string">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -27,6 +27,9 @@ namespace llvm {
   }
 }
 
+// Prefix for __builtin_verbose_trap.
+#define CLANG_VERBOSE_TRAP_PREFIX "__llvm_verbose_trap"
+
 namespace clang {
   class CodeGenOptions;
   class CoverageSourceInfo;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -27,8 +27,8 @@ namespace llvm {
   }
 }
 
-// Prefix for __builtin_verbose_trap.
-#define CLANG_VERBOSE_TRAP_PREFIX "__llvm_verbose_trap"
+// Prefix of the name of the artificial inline frame.
+#define CLANG_TRAP_PREFIX "__trap_msg"
 
 namespace clang {
   class CodeGenOptions;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -29,7 +29,7 @@ namespace llvm {
 }
 
 // Prefix of the name of the artificial inline frame.
-inline constexpr llvm::StringRef CLANG_TRAP_PREFIX = "__clang_trap_msg";
+inline constexpr llvm::StringRef ClangTrapPrefix = "__clang_trap_msg";
 
 namespace clang {
   class CodeGenOptions;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -28,7 +28,7 @@ namespace llvm {
 }
 
 // Prefix of the name of the artificial inline frame.
-#define CLANG_TRAP_PREFIX "__trap_msg"
+#define CLANG_TRAP_PREFIX "__clang_trap_msg"
 
 namespace clang {
   class CodeGenOptions;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -15,6 +15,7 @@
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace llvm {
   class Constant;
@@ -28,7 +29,7 @@ namespace llvm {
 }
 
 // Prefix of the name of the artificial inline frame.
-#define CLANG_TRAP_PREFIX "__clang_trap_msg"
+inline constexpr llvm::StringRef CLANG_TRAP_PREFIX = "__clang_trap_msg";
 
 namespace clang {
   class CodeGenOptions;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16844,12 +16844,15 @@ static bool EvaluateBuiltinStrLen(const Expr *E, uint64_t &Result,
   }
 }
 
-bool Expr::tryEvaluateString(std::string &StringResult, ASTContext &Ctx) const {
+std::optional<std::string> Expr::tryEvaluateString(ASTContext &Ctx) const {
   Expr::EvalStatus Status;
   EvalInfo Info(Ctx, Status, EvalInfo::EM_ConstantFold);
   uint64_t Result;
+  std::string StringResult;
 
-  return EvaluateBuiltinStrLen(this, Result, Info, &StringResult);
+  if (EvaluateBuiltinStrLen(this, Result, Info, &StringResult))
+    return StringResult;
+  return {};
 }
 
 bool Expr::EvaluateCharRangeAsString(std::string &Result,

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -1884,7 +1884,8 @@ static bool EvaluateAtomic(const Expr *E, const LValue *This, APValue &Result,
                            EvalInfo &Info);
 static bool EvaluateAsRValue(EvalInfo &Info, const Expr *E, APValue &Result);
 static bool EvaluateBuiltinStrLen(const Expr *E, uint64_t &Result,
-                                  EvalInfo &Info);
+                                  EvalInfo &Info,
+                                  std::string *StringResult = nullptr);
 
 /// Evaluate an integer or fixed point expression into an APResult.
 static bool EvaluateFixedPointOrInteger(const Expr *E, APFixedPoint &Result,
@@ -16792,7 +16793,7 @@ bool Expr::tryEvaluateObjectSize(uint64_t &Result, ASTContext &Ctx,
 }
 
 static bool EvaluateBuiltinStrLen(const Expr *E, uint64_t &Result,
-                                  EvalInfo &Info) {
+                                  EvalInfo &Info, std::string *StringResult) {
   if (!E->getType()->hasPointerRepresentation() || !E->isPRValue())
     return false;
 
@@ -16819,6 +16820,8 @@ static bool EvaluateBuiltinStrLen(const Expr *E, uint64_t &Result,
         Str = Str.substr(0, Pos);
 
       Result = Str.size();
+      if (StringResult)
+        *StringResult = Str;
       return true;
     }
 
@@ -16834,10 +16837,19 @@ static bool EvaluateBuiltinStrLen(const Expr *E, uint64_t &Result,
     if (!Char.getInt()) {
       Result = Strlen;
       return true;
-    }
+    } else if (StringResult)
+      StringResult->push_back(Char.getInt().getExtValue());
     if (!HandleLValueArrayAdjustment(Info, E, String, CharTy, 1))
       return false;
   }
+}
+
+bool Expr::tryEvaluateString(std::string &StringResult, ASTContext &Ctx) const {
+  Expr::EvalStatus Status;
+  EvalInfo Info(Ctx, Status, EvalInfo::EM_ConstantFold);
+  uint64_t Result;
+
+  return EvaluateBuiltinStrLen(this, Result, Info, &StringResult);
 }
 
 bool Expr::EvaluateCharRangeAsString(std::string &Result,

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3589,10 +3589,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_verbose_trap: {
     llvm::DILocation *TrapLocation = Builder.getCurrentDebugLocation();
     if (getDebugInfo()) {
-      std::string Str;
-      E->getArg(0)->tryEvaluateString(Str, getContext());
-      TrapLocation =
-          getDebugInfo()->CreateTrapFailureMessageFor(TrapLocation, Str);
+      TrapLocation = getDebugInfo()->CreateTrapFailureMessageFor(
+          TrapLocation, *E->getArg(0)->tryEvaluateString(getContext()));
     }
     ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
     EmitTrapCall(Intrinsic::trap);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3586,6 +3586,18 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_trap:
     EmitTrapCall(Intrinsic::trap);
     return RValue::get(nullptr);
+  case Builtin::BI__builtin_verbose_trap: {
+    llvm::DILocation *TrapLocation = Builder.getCurrentDebugLocation();
+    if (getDebugInfo()) {
+      std::string Str;
+      E->getArg(0)->tryEvaluateString(Str, getContext());
+      TrapLocation = getDebugInfo()->CreateTrapFailureMessageFor(
+          TrapLocation, "__llvm_verbose_trap", Str);
+    }
+    ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
+    EmitTrapCall(Intrinsic::trap);
+    return RValue::get(nullptr);
+  }
   case Builtin::BI__debugbreak:
     EmitTrapCall(Intrinsic::debugtrap);
     return RValue::get(nullptr);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3591,8 +3591,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     if (getDebugInfo()) {
       std::string Str;
       E->getArg(0)->tryEvaluateString(Str, getContext());
-      TrapLocation = getDebugInfo()->CreateTrapFailureMessageFor(
-          TrapLocation, "__llvm_verbose_trap", Str);
+      TrapLocation =
+          getDebugInfo()->CreateTrapFailureMessageFor(TrapLocation, Str);
     }
     ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
     EmitTrapCall(Intrinsic::trap);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3593,6 +3593,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
           TrapLocation, *E->getArg(0)->tryEvaluateString(getContext()));
     }
     ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
+    // Currently no attempt is made to prevent traps from being merged.
     EmitTrapCall(Intrinsic::trap);
     return RValue::get(nullptr);
   }

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3590,7 +3590,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm::DILocation *TrapLocation = Builder.getCurrentDebugLocation();
     if (getDebugInfo()) {
       TrapLocation = getDebugInfo()->CreateTrapFailureMessageFor(
-          TrapLocation, *E->getArg(0)->tryEvaluateString(getContext()));
+          TrapLocation, *E->getArg(0)->tryEvaluateString(getContext()),
+          *E->getArg(1)->tryEvaluateString(getContext()));
     }
     ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
     // Currently no attempt is made to prevent traps from being merged.

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3515,7 +3515,7 @@ llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
     llvm::DebugLoc TrapLocation, StringRef Category, StringRef FailureMsg) {
   // Create a debug location from `TrapLocation` that adds an artificial inline
   // frame.
-  const char *Prefix = CLANG_VERBOSE_TRAP_PREFIX;
+  const char *Prefix = CLANG_TRAP_PREFIX;
   SmallString<64> FuncName(Prefix);
 
   FuncName += "$";

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3515,7 +3515,7 @@ llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
     llvm::DebugLoc TrapLocation, StringRef Category, StringRef FailureMsg) {
   // Create a debug location from `TrapLocation` that adds an artificial inline
   // frame.
-  SmallString<64> FuncName(CLANG_TRAP_PREFIX);
+  SmallString<64> FuncName(ClangTrapPrefix);
 
   FuncName += "$";
   FuncName += Category;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3515,8 +3515,7 @@ llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
     llvm::DebugLoc TrapLocation, StringRef Category, StringRef FailureMsg) {
   // Create a debug location from `TrapLocation` that adds an artificial inline
   // frame.
-  const char *Prefix = CLANG_TRAP_PREFIX;
-  SmallString<64> FuncName(Prefix);
+  SmallString<64> FuncName(CLANG_TRAP_PREFIX);
 
   FuncName += "$";
   FuncName += Category;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -32,6 +32,7 @@
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Version.h"
+#include "clang/CodeGen/ModuleBuilder.h"
 #include "clang/Frontend/FrontendOptions.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/ModuleMap.h"
@@ -3515,7 +3516,7 @@ CGDebugInfo::CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
                                          StringRef FailureMsg) {
   // Create a debug location from `TrapLocation` that adds an artificial inline
   // frame.
-  const char *Prefix = "__llvm_verbose_trap";
+  const char *Prefix = CLANG_VERBOSE_TRAP_PREFIX;
   SmallString<64> FuncName(Prefix);
   if (!FailureMsg.empty()) {
     FuncName += ": ";

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3511,17 +3511,17 @@ llvm::DIMacroFile *CGDebugInfo::CreateTempMacroFile(llvm::DIMacroFile *Parent,
   return DBuilder.createTempMacroFile(Parent, Line, FName);
 }
 
-llvm::DILocation *
-CGDebugInfo::CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
-                                         StringRef FailureMsg) {
+llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
+    llvm::DebugLoc TrapLocation, StringRef Category, StringRef FailureMsg) {
   // Create a debug location from `TrapLocation` that adds an artificial inline
   // frame.
   const char *Prefix = CLANG_VERBOSE_TRAP_PREFIX;
   SmallString<64> FuncName(Prefix);
-  if (!FailureMsg.empty()) {
-    FuncName += ": ";
-    FuncName += FailureMsg;
-  }
+
+  FuncName += ":";
+  FuncName += Category;
+  FuncName += ":";
+  FuncName += FailureMsg;
 
   llvm::DISubprogram *TrapSP =
       createInlinedTrapSubprogram(FuncName, TrapLocation->getFile());

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3518,9 +3518,9 @@ llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
   const char *Prefix = CLANG_VERBOSE_TRAP_PREFIX;
   SmallString<64> FuncName(Prefix);
 
-  FuncName += ":";
+  FuncName += "$";
   FuncName += Category;
-  FuncName += ":";
+  FuncName += "$";
   FuncName += FailureMsg;
 
   llvm::DISubprogram *TrapSP =

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1692,6 +1692,27 @@ llvm::DIType *CGDebugInfo::createFieldType(
                                    offsetInBits, flags, debugType, Annotations);
 }
 
+llvm::DISubprogram *
+CGDebugInfo::getFakeFuncSubprogram(const std::string &FakeFuncName) {
+  llvm::DISubprogram *&SP = FakeFuncMap[FakeFuncName];
+
+  if (!SP) {
+    auto FileScope = TheCU->getFile();
+    llvm::DISubroutineType *DIFnTy = DBuilder.createSubroutineType(nullptr);
+    // Note: We use `FileScope` rather than `TheCU` as the scope because that's
+    // what LLVM's inliner seems to do.
+    SP = DBuilder.createFunction(
+        /*Scope=*/FileScope, /*Name=*/FakeFuncName, /*LinkageName=*/StringRef(),
+        /*File=*/FileScope, /*LineNo=*/0, /*Ty=*/DIFnTy,
+        /*ScopeLine=*/0,
+        /*Flags=*/llvm::DINode::FlagArtificial,
+        /*SPFlags=*/llvm::DISubprogram::SPFlagDefinition,
+        /*TParams=*/nullptr, /*ThrownTypes=*/nullptr, /*Annotations=*/nullptr);
+  }
+
+  return SP;
+}
+
 void CGDebugInfo::CollectRecordLambdaFields(
     const CXXRecordDecl *CXXDecl, SmallVectorImpl<llvm::Metadata *> &elements,
     llvm::DIType *RecordTy) {
@@ -3486,6 +3507,27 @@ llvm::DIMacroFile *CGDebugInfo::CreateTempMacroFile(llvm::DIMacroFile *Parent,
   llvm::DIFile *FName = getOrCreateFile(FileLoc);
   unsigned Line = LineLoc.isInvalid() ? 0 : getLineNumber(LineLoc);
   return DBuilder.createTempMacroFile(Parent, Line, FName);
+}
+
+llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
+    llvm::DebugLoc TrapLocation, StringRef Prefix, StringRef FailureMsg) {
+  // Create debug info that describes a fake function whose name is the failure
+  // message.
+  std::string FuncName(Prefix);
+  if (!FailureMsg.empty()) {
+    // A space in the function name identifies this as not being a real function
+    // because it's not a valid symbol name.
+    FuncName += ": ";
+    FuncName += FailureMsg;
+  }
+
+  assert(FuncName.size() > 0);
+  assert(FuncName.find(' ') != std::string::npos &&
+         "Fake function name must contain a space");
+
+  llvm::DISubprogram *TrapSP = getFakeFuncSubprogram(FuncName);
+  return llvm::DILocation::get(CGM.getLLVMContext(), /*Line=*/0, /*Column=*/0,
+                               /*Scope=*/TrapSP, /*InlinedAt=*/TrapLocation);
 }
 
 static QualType UnwrapTypeForDebugInfo(QualType T, const ASTContext &C) {

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1693,7 +1693,7 @@ llvm::DIType *CGDebugInfo::createFieldType(
 }
 
 llvm::DISubprogram *
-CGDebugInfo::createInlinedTrapSubprogram(const std::string &FuncName) {
+CGDebugInfo::createInlinedTrapSubprogram(StringRef FuncName) {
   llvm::DISubprogram *&SP = InlinedTrapFuncMap[FuncName];
 
   if (!SP) {
@@ -3509,14 +3509,13 @@ llvm::DIMacroFile *CGDebugInfo::CreateTempMacroFile(llvm::DIMacroFile *Parent,
   return DBuilder.createTempMacroFile(Parent, Line, FName);
 }
 
-llvm::DILocation *CGDebugInfo::CreateTrapFailureMessageFor(
-    llvm::DebugLoc TrapLocation, StringRef Prefix, StringRef FailureMsg) {
-  assert((!FailureMsg.empty() || Prefix.find(' ') != std::string::npos) &&
-         "Prefix must contain a space when FailureMsg is empty");
-
-  // Create debug info that describes an inlined function whose name is the
-  // failure message.
-  std::string FuncName(Prefix);
+llvm::DILocation *
+CGDebugInfo::CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
+                                         StringRef FailureMsg) {
+  // Create a debug location from `TrapLocation` that adds an artificial inline
+  // frame.
+  const char *Prefix = "__llvm_verbose_trap";
+  SmallString<64> FuncName(Prefix);
   if (!FailureMsg.empty()) {
     // A space in the function name identifies this as not being a real function
     // because it's not a valid symbol name.

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1693,14 +1693,12 @@ llvm::DIType *CGDebugInfo::createFieldType(
 }
 
 llvm::DISubprogram *
-CGDebugInfo::createInlinedTrapSubprogram(StringRef FuncName) {
+CGDebugInfo::createInlinedTrapSubprogram(StringRef FuncName,
+                                         llvm::DIFile *FileScope) {
   llvm::DISubprogram *&SP = InlinedTrapFuncMap[FuncName];
 
   if (!SP) {
-    auto FileScope = TheCU->getFile();
     llvm::DISubroutineType *DIFnTy = DBuilder.createSubroutineType(nullptr);
-    // Note: We use `FileScope` rather than `TheCU` as the scope because that's
-    // what LLVM's inliner seems to do.
     SP = DBuilder.createFunction(
         /*Scope=*/FileScope, /*Name=*/FuncName, /*LinkageName=*/StringRef(),
         /*File=*/FileScope, /*LineNo=*/0, /*Ty=*/DIFnTy,
@@ -3523,7 +3521,8 @@ CGDebugInfo::CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
     FuncName += FailureMsg;
   }
 
-  llvm::DISubprogram *TrapSP = createInlinedTrapSubprogram(FuncName);
+  llvm::DISubprogram *TrapSP =
+      createInlinedTrapSubprogram(FuncName, TrapLocation->getFile());
   return llvm::DILocation::get(CGM.getLLVMContext(), /*Line=*/0, /*Column=*/0,
                                /*Scope=*/TrapSP, /*InlinedAt=*/TrapLocation);
 }

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1695,6 +1695,9 @@ llvm::DIType *CGDebugInfo::createFieldType(
 llvm::DISubprogram *
 CGDebugInfo::createInlinedTrapSubprogram(StringRef FuncName,
                                          llvm::DIFile *FileScope) {
+  // We are caching the subprogram because we don't want to duplicate
+  // subprograms with the same message. Note that `SPFlagDefinition` prevents
+  // subprograms from being uniqued.
   llvm::DISubprogram *&SP = InlinedTrapFuncMap[FuncName];
 
   if (!SP) {
@@ -3515,8 +3518,6 @@ CGDebugInfo::CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
   const char *Prefix = "__llvm_verbose_trap";
   SmallString<64> FuncName(Prefix);
   if (!FailureMsg.empty()) {
-    // A space in the function name identifies this as not being a real function
-    // because it's not a valid symbol name.
     FuncName += ": ";
     FuncName += FailureMsg;
   }

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -352,8 +352,8 @@ class CGDebugInfo {
   /// __builtin_verbose_trap to subprograms.
   llvm::StringMap<llvm::DISubprogram *> InlinedTrapFuncMap;
 
-  // A function that returns the subprogram corresponding to the artificial
-  // inlined function for traps.
+  /// A function that returns the subprogram corresponding to the artificial
+  /// inlined function for traps.
   llvm::DISubprogram *createInlinedTrapSubprogram(StringRef FuncName,
                                                   llvm::DIFile *FileScope);
 

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -29,7 +29,9 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/Allocator.h"
+#include <map>
 #include <optional>
+#include <string>
 
 namespace llvm {
 class MDNode;

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -348,8 +348,8 @@ class CGDebugInfo {
       const FieldDecl *BitFieldDecl, const llvm::DIDerivedType *BitFieldDI,
       llvm::ArrayRef<llvm::Metadata *> PreviousFieldsDI, const RecordDecl *RD);
 
-  // A cache that maps artificial inlined function names used for
-  // __builtin_verbose_trap to subprograms.
+  /// A cache that maps artificial inlined function names used for
+  /// __builtin_verbose_trap to subprograms.
   llvm::StringMap<llvm::DISubprogram *> InlinedTrapFuncMap;
 
   // A function that returns the subprogram corresponding to the artificial
@@ -613,15 +613,15 @@ public:
     return CoroutineParameterMappings;
   }
 
-  // Create a debug location from `TrapLocation` that adds an artificial inline
-  // frame where the frame name is
-  //
-  // * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
-  // * `<Prefix>` if `<FailureMsg>` is empty.
-  //
-  // Currently `<Prefix>` is always "__llvm_verbose_trap".
-  //
-  // This is used to store failure reasons for traps.
+  /// Create a debug location from `TrapLocation` that adds an artificial inline
+  /// frame where the frame name is
+  ///
+  /// * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
+  /// * `<Prefix>` if `<FailureMsg>` is empty.
+  ///
+  /// Currently `<Prefix>` is always "__llvm_verbose_trap".
+  ///
+  /// This is used to store failure reasons for traps.
   llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
                                                 StringRef FailureMsg);
 

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -346,6 +346,14 @@ class CGDebugInfo {
       const FieldDecl *BitFieldDecl, const llvm::DIDerivedType *BitFieldDI,
       llvm::ArrayRef<llvm::Metadata *> PreviousFieldsDI, const RecordDecl *RD);
 
+  // A cache that maps fake function names used for __builtin_verbose_trap to
+  // subprograms.
+  std::map<std::string, llvm::DISubprogram *> FakeFuncMap;
+
+  // A function that returns the subprogram corresponding to the fake function
+  // name.
+  llvm::DISubprogram *getFakeFuncSubprogram(const std::string &FakeFuncName);
+
   /// Helpers for collecting fields of a record.
   /// @{
   void CollectRecordLambdaFields(const CXXRecordDecl *CXXDecl,
@@ -601,6 +609,18 @@ public:
   ParamDecl2StmtTy &getCoroutineParameterMappings() {
     return CoroutineParameterMappings;
   }
+
+  // Create a debug location from `TrapLocation` that adds a fake
+  // inline frame where the frame name is
+  //
+  // * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
+  // * `<Prefix>` if `<FailureMsg>` is empty. Note `<Prefix>` must
+  //   contain a space.
+  //
+  // This is used to store failure reasons for traps.
+  llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
+                                                StringRef Prefix,
+                                                StringRef FailureMsg);
 
 private:
   /// Emit call to llvm.dbg.declare for a variable declaration.

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -350,11 +350,11 @@ class CGDebugInfo {
 
   // A cache that maps artificial inlined function names used for
   // __builtin_verbose_trap to subprograms.
-  std::map<std::string, llvm::DISubprogram *> InlinedTrapFuncMap;
+  llvm::StringMap<llvm::DISubprogram *> InlinedTrapFuncMap;
 
   // A function that returns the subprogram corresponding to the artificial
   // inlined function for traps.
-  llvm::DISubprogram *createInlinedTrapSubprogram(const std::string &FuncName);
+  llvm::DISubprogram *createInlinedTrapSubprogram(StringRef FuncName);
 
   /// Helpers for collecting fields of a record.
   /// @{
@@ -619,9 +619,10 @@ public:
   // * `<Prefix>` if `<FailureMsg>` is empty. Note `<Prefix>` must
   //   contain a space.
   //
+  // Currently `<Prefix>` is always "__llvm_verbose_trap".
+  //
   // This is used to store failure reasons for traps.
   llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
-                                                StringRef Prefix,
                                                 StringRef FailureMsg);
 
 private:

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -617,8 +617,7 @@ public:
   // frame where the frame name is
   //
   // * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
-  // * `<Prefix>` if `<FailureMsg>` is empty. Note `<Prefix>` must
-  //   contain a space.
+  // * `<Prefix>` if `<FailureMsg>` is empty.
   //
   // Currently `<Prefix>` is always "__llvm_verbose_trap".
   //

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -346,13 +346,13 @@ class CGDebugInfo {
       const FieldDecl *BitFieldDecl, const llvm::DIDerivedType *BitFieldDI,
       llvm::ArrayRef<llvm::Metadata *> PreviousFieldsDI, const RecordDecl *RD);
 
-  // A cache that maps fake function names used for __builtin_verbose_trap to
-  // subprograms.
-  std::map<std::string, llvm::DISubprogram *> FakeFuncMap;
+  // A cache that maps artificial inlined function names used for
+  // __builtin_verbose_trap to subprograms.
+  std::map<std::string, llvm::DISubprogram *> InlinedTrapFuncMap;
 
-  // A function that returns the subprogram corresponding to the fake function
-  // name.
-  llvm::DISubprogram *getFakeFuncSubprogram(const std::string &FakeFuncName);
+  // A function that returns the subprogram corresponding to the artificial
+  // inlined function for traps.
+  llvm::DISubprogram *createInlinedTrapSubprogram(const std::string &FuncName);
 
   /// Helpers for collecting fields of a record.
   /// @{
@@ -610,8 +610,8 @@ public:
     return CoroutineParameterMappings;
   }
 
-  // Create a debug location from `TrapLocation` that adds a fake
-  // inline frame where the frame name is
+  // Create a debug location from `TrapLocation` that adds an artificial inline
+  // frame where the frame name is
   //
   // * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
   // * `<Prefix>` if `<FailureMsg>` is empty. Note `<Prefix>` must

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -354,7 +354,8 @@ class CGDebugInfo {
 
   // A function that returns the subprogram corresponding to the artificial
   // inlined function for traps.
-  llvm::DISubprogram *createInlinedTrapSubprogram(StringRef FuncName);
+  llvm::DISubprogram *createInlinedTrapSubprogram(StringRef FuncName,
+                                                  llvm::DIFile *FileScope);
 
   /// Helpers for collecting fields of a record.
   /// @{

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -348,8 +348,7 @@ class CGDebugInfo {
       const FieldDecl *BitFieldDecl, const llvm::DIDerivedType *BitFieldDI,
       llvm::ArrayRef<llvm::Metadata *> PreviousFieldsDI, const RecordDecl *RD);
 
-  /// A cache that maps artificial inlined function names used for
-  /// __builtin_verbose_trap to subprograms.
+  /// A cache that maps names of artificial inlined functions to subprograms.
   llvm::StringMap<llvm::DISubprogram *> InlinedTrapFuncMap;
 
   /// A function that returns the subprogram corresponding to the artificial
@@ -618,7 +617,7 @@ public:
   ///
   /// * `<Prefix>:<Category>:<FailureMsg>`
   ///
-  /// `<Prefix>` is "__llvm_verbose_trap".
+  /// `<Prefix>` is "__trap_msg".
   ///
   /// This is used to store failure reasons for traps.
   llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -617,7 +617,7 @@ public:
   ///
   /// * `<Prefix>:<Category>:<FailureMsg>`
   ///
-  /// `<Prefix>` is "__trap_msg".
+  /// `<Prefix>` is "__clang_trap_msg".
   ///
   /// This is used to store failure reasons for traps.
   llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -616,13 +616,13 @@ public:
   /// Create a debug location from `TrapLocation` that adds an artificial inline
   /// frame where the frame name is
   ///
-  /// * `<Prefix>: <FailureMsg>` if `<FailureMsg>` is not empty.
-  /// * `<Prefix>` if `<FailureMsg>` is empty.
+  /// * `<Prefix>:<Category>:<FailureMsg>`
   ///
-  /// Currently `<Prefix>` is always "__llvm_verbose_trap".
+  /// `<Prefix>` is "__llvm_verbose_trap".
   ///
   /// This is used to store failure reasons for traps.
   llvm::DILocation *CreateTrapFailureMessageFor(llvm::DebugLoc TrapLocation,
+                                                StringRef Category,
                                                 StringRef FailureMsg);
 
 private:

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -180,8 +180,7 @@ static bool checkBuiltinVerboseTrap(CallExpr *Call, Sema &S) {
 
   // FIXME: Add more checks and reject strings that can't be handled by
   // debuggers.
-  std::string Result;
-  if (!Arg->tryEvaluateString(Result, S.Context)) {
+  if (!Arg->tryEvaluateString(S.Context).has_value()) {
     S.Diag(Arg->getBeginLoc(), diag::err_builtin_verbose_trap_arg)
         << Arg->getSourceRange();
     return false;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -181,7 +181,7 @@ static bool checkBuiltinVerboseTrap(CallExpr *Call, Sema &S) {
   // FIXME: Add more checks and reject strings that can't be handled by
   // debuggers.
   std::string Result;
-  if (!Arg->tryEvaluateString(Result, S.Context) || Result.empty()) {
+  if (!Arg->tryEvaluateString(Result, S.Context)) {
     S.Diag(Arg->getBeginLoc(), diag::err_builtin_verbose_trap_arg)
         << Arg->getSourceRange();
     return false;

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -std=c++20 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
+
+// CHECK-LABEL: define void @_Z2f0v()
+// CHECK: call void @llvm.trap(), !dbg ![[LOC17:.*]]
+
+// CHECK-LABEL: define void @_Z2f1v()
+// CHECK: call void @llvm.trap(), !dbg ![[LOC23:.*]]
+// CHECK: call void @llvm.trap(), !dbg ![[LOC25:.*]]
+
+// CHECK-LABEL: define void @_Z2f3v()
+// CHECK: call void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
+
+// CHECK-LABEL: define internal void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
+// CHECK: call void @llvm.trap(), !dbg ![[LOC36:.*]]
+
+// CHECK: ![[FILESCOPE:.*]] = !DIFile(filename:
+// CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
+// CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap: Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[LOC20]] = !DILocation(line: 34, column: 3, scope: ![[SUBPROG14]])
+// CHECK: ![[SUBPROG22:.*]] = distinct !DISubprogram(name: "f1", linkageName: "_Z2f1v",
+// CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
+// CHECK: ![[LOC24]] = !DILocation(line: 38, column: 3, scope: ![[SUBPROG22]])
+// CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap: hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[LOC27]] = !DILocation(line: 39, column: 3, scope: ![[SUBPROG22]])
+// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<&constMsg[0]>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
+// CHECK: ![[LOC36]] = !DILocation(line: 0, scope: ![[SUBPROG26]], inlinedAt: ![[LOC37:.*]])
+// CHECK: ![[LOC37]] = !DILocation(line: 44, column: 3, scope: ![[SUBPROG32]])
+
+char const constMsg[] = "hello";
+
+void f0() {
+  __builtin_verbose_trap("Argument_must_not_be_null");
+}
+
+void f1() {
+  __builtin_verbose_trap("Argument_must_not_be_null");
+  __builtin_verbose_trap("hello");
+}
+
+template <const char * const str>
+void f2() {
+  __builtin_verbose_trap(str);
+}
+
+void f3() {
+  f2<constMsg>();
+}

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -13,7 +13,7 @@
 // CHECK-LABEL: define internal void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
 // CHECK: call void @llvm.trap(), !dbg ![[LOC36:.*]]
 
-// CHECK: ![[FILESCOPE:.*]] = !DIFile(filename:
+// CHECK: ![[FILESCOPE:.*]] = !DIFile(filename: "{{.*}}debug-info-verbose-trap.cpp"
 // CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
 // CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
 // CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap: Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -std=c++20 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
 
 // CHECK-LABEL: define void @_Z2f0v()
 // CHECK: call void @llvm.trap(), !dbg ![[LOC17:.*]]

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -40,7 +40,7 @@ void f1() {
   __builtin_verbose_trap("hello");
 }
 
-// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<&constMsg[0]>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
+// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<constMsg>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
 // CHECK: ![[LOC36]] = !DILocation(line: 0, scope: ![[SUBPROG26]], inlinedAt: ![[LOC37:.*]])
 // CHECK: ![[LOC37]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG32]])
 template <const char * const str>

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -3,6 +3,8 @@
 // CHECK-LABEL: define void @_Z2f0v()
 // CHECK: call void @llvm.trap(), !dbg ![[LOC17:.*]]
 
+// CHECK: declare void @llvm.trap() #[[ATTR1:.*]]
+
 // CHECK-LABEL: define void @_Z2f1v()
 // CHECK: call void @llvm.trap(), !dbg ![[LOC23:.*]]
 // CHECK: call void @llvm.trap(), !dbg ![[LOC25:.*]]
@@ -13,32 +15,34 @@
 // CHECK-LABEL: define internal void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
 // CHECK: call void @llvm.trap(), !dbg ![[LOC36:.*]]
 
+// CHECK: attributes #[[ATTR1]] = { cold {{.*}}}
+
 // CHECK: ![[FILESCOPE:.*]] = !DIFile(filename: "{{.*}}debug-info-verbose-trap.cpp"
-// CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
-// CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
-// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap: Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
-// CHECK: ![[LOC20]] = !DILocation(line: 34, column: 3, scope: ![[SUBPROG14]])
-// CHECK: ![[SUBPROG22:.*]] = distinct !DISubprogram(name: "f1", linkageName: "_Z2f1v",
-// CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
-// CHECK: ![[LOC24]] = !DILocation(line: 38, column: 3, scope: ![[SUBPROG22]])
-// CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
-// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap: hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
-// CHECK: ![[LOC27]] = !DILocation(line: 39, column: 3, scope: ![[SUBPROG22]])
-// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<&constMsg[0]>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
-// CHECK: ![[LOC36]] = !DILocation(line: 0, scope: ![[SUBPROG26]], inlinedAt: ![[LOC37:.*]])
-// CHECK: ![[LOC37]] = !DILocation(line: 44, column: 3, scope: ![[SUBPROG32]])
 
 char const constMsg[] = "hello";
 
+// CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
+// CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap: Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[LOC20]] = !DILocation(line: [[@LINE+2]], column: 3, scope: ![[SUBPROG14]])
 void f0() {
   __builtin_verbose_trap("Argument_must_not_be_null");
 }
 
+// CHECK: ![[SUBPROG22:.*]] = distinct !DISubprogram(name: "f1", linkageName: "_Z2f1v",
+// CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
+// CHECK: ![[LOC24]] = !DILocation(line: [[@LINE+5]], column: 3, scope: ![[SUBPROG22]])
+// CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap: hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[LOC27]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG22]])
 void f1() {
   __builtin_verbose_trap("Argument_must_not_be_null");
   __builtin_verbose_trap("hello");
 }
 
+// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<&constMsg[0]>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
+// CHECK: ![[LOC36]] = !DILocation(line: 0, scope: ![[SUBPROG26]], inlinedAt: ![[LOC37:.*]])
+// CHECK: ![[LOC37]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG32]])
 template <const char * const str>
 void f2() {
   __builtin_verbose_trap(str);

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -24,7 +24,7 @@ char const constMsg[] = "hello";
 
 // CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
 // CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
-// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap$category1$Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__trap_msg$category1$Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC20]] = !DILocation(line: [[@LINE+2]], column: 3, scope: ![[SUBPROG14]])
 void f0() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");
@@ -34,7 +34,7 @@ void f0() {
 // CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
 // CHECK: ![[LOC24]] = !DILocation(line: [[@LINE+5]], column: 3, scope: ![[SUBPROG22]])
 // CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
-// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap$category2$hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__trap_msg$category2$hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC27]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG22]])
 void f1() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -24,7 +24,7 @@ char const constMsg[] = "hello";
 
 // CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
 // CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
-// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__trap_msg$category1$Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__clang_trap_msg$category1$Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC20]] = !DILocation(line: [[@LINE+2]], column: 3, scope: ![[SUBPROG14]])
 void f0() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");
@@ -34,7 +34,7 @@ void f0() {
 // CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
 // CHECK: ![[LOC24]] = !DILocation(line: [[@LINE+5]], column: 3, scope: ![[SUBPROG22]])
 // CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
-// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__trap_msg$category2$hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__clang_trap_msg$category2$hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC27]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG22]])
 void f1() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -10,44 +10,45 @@
 // CHECK: call void @llvm.trap(), !dbg ![[LOC25:.*]]
 
 // CHECK-LABEL: define void @_Z2f3v()
-// CHECK: call void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
+// CHECK: call void @_Z2f2IXadsoKcL_ZL8constCatEEEXadsoS0_L_ZL8constMsgEEEEvv()
 
-// CHECK-LABEL: define internal void @_Z2f2IXadsoKcL_ZL8constMsgEEEEvv()
+// CHECK-LABEL: define internal void @_Z2f2IXadsoKcL_ZL8constCatEEEXadsoS0_L_ZL8constMsgEEEEvv
 // CHECK: call void @llvm.trap(), !dbg ![[LOC36:.*]]
 
 // CHECK: attributes #[[ATTR1]] = { cold {{.*}}}
 
 // CHECK: ![[FILESCOPE:.*]] = !DIFile(filename: "{{.*}}debug-info-verbose-trap.cpp"
 
+char const constCat[] = "category2";
 char const constMsg[] = "hello";
 
 // CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
 // CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
-// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap: Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap:category1:Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC20]] = !DILocation(line: [[@LINE+2]], column: 3, scope: ![[SUBPROG14]])
 void f0() {
-  __builtin_verbose_trap("Argument_must_not_be_null");
+  __builtin_verbose_trap("category1", "Argument_must_not_be_null");
 }
 
 // CHECK: ![[SUBPROG22:.*]] = distinct !DISubprogram(name: "f1", linkageName: "_Z2f1v",
 // CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
 // CHECK: ![[LOC24]] = !DILocation(line: [[@LINE+5]], column: 3, scope: ![[SUBPROG22]])
 // CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
-// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap: hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap:category2:hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC27]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG22]])
 void f1() {
-  __builtin_verbose_trap("Argument_must_not_be_null");
-  __builtin_verbose_trap("hello");
+  __builtin_verbose_trap("category1", "Argument_must_not_be_null");
+  __builtin_verbose_trap("category2", "hello");
 }
 
-// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<constMsg>", linkageName: "_Z2f2IXadsoKcL_ZL8constMsgEEEEvv",
+// CHECK: ![[SUBPROG32:.*]] = distinct !DISubprogram(name: "f2<constCat, constMsg>", linkageName: "_Z2f2IXadsoKcL_ZL8constCatEEEXadsoS0_L_ZL8constMsgEEEEvv",
 // CHECK: ![[LOC36]] = !DILocation(line: 0, scope: ![[SUBPROG26]], inlinedAt: ![[LOC37:.*]])
 // CHECK: ![[LOC37]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG32]])
-template <const char * const str>
+template <const char * const category, const char * const reason>
 void f2() {
-  __builtin_verbose_trap(str);
+  __builtin_verbose_trap(category, reason);
 }
 
 void f3() {
-  f2<constMsg>();
+  f2<constCat, constMsg>();
 }

--- a/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
+++ b/clang/test/CodeGenCXX/debug-info-verbose-trap.cpp
@@ -24,7 +24,7 @@ char const constMsg[] = "hello";
 
 // CHECK: ![[SUBPROG14:.*]] = distinct !DISubprogram(name: "f0", linkageName: "_Z2f0v",
 // CHECK: ![[LOC17]] = !DILocation(line: 0, scope: ![[SUBPROG18:.*]], inlinedAt: ![[LOC20:.*]])
-// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap:category1:Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG18]] = distinct !DISubprogram(name: "__llvm_verbose_trap$category1$Argument_must_not_be_null", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC20]] = !DILocation(line: [[@LINE+2]], column: 3, scope: ![[SUBPROG14]])
 void f0() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");
@@ -34,7 +34,7 @@ void f0() {
 // CHECK: ![[LOC23]] = !DILocation(line: 0, scope: ![[SUBPROG18]], inlinedAt: ![[LOC24:.*]])
 // CHECK: ![[LOC24]] = !DILocation(line: [[@LINE+5]], column: 3, scope: ![[SUBPROG22]])
 // CHECK: ![[LOC25]] = !DILocation(line: 0, scope: ![[SUBPROG26:.*]], inlinedAt: ![[LOC27:.*]])
-// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap:category2:hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
+// CHECK: ![[SUBPROG26]] = distinct !DISubprogram(name: "__llvm_verbose_trap$category2$hello", scope: ![[FILESCOPE]], file: ![[FILESCOPE]], type: !{{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !{{.*}})
 // CHECK: ![[LOC27]] = !DILocation(line: [[@LINE+3]], column: 3, scope: ![[SUBPROG22]])
 void f1() {
   __builtin_verbose_trap("category1", "Argument_must_not_be_null");

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -fcxx-exceptions -verify %s
+
+#if !__has_builtin(__builtin_verbose_trap)
+#error
+#endif
+
+constexpr char const* constMsg1 = "hello";
+char const* const constMsg2 = "hello";
+char const constMsg3[] = "hello";
+
+template <const char * const str>
+void f(const char * arg) {
+  __builtin_verbose_trap("Argument_must_not_be_null");
+  __builtin_verbose_trap("hello" "world");
+  __builtin_verbose_trap(constMsg1);
+  __builtin_verbose_trap(constMsg2);
+  __builtin_verbose_trap(""); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(); // expected-error {{too few arguments}}
+  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with}}
+  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(str);
+  __builtin_verbose_trap(u8"hello");
+}
+
+void test() {
+  f<constMsg3>(nullptr);
+}

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -14,11 +14,11 @@ void f(const char * arg) {
   __builtin_verbose_trap("hello" "world");
   __builtin_verbose_trap(constMsg1);
   __builtin_verbose_trap(constMsg2);
-  __builtin_verbose_trap(""); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
-  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
   __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with}}
-  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a non-empty string literal}}
+  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
   __builtin_verbose_trap(str);
   __builtin_verbose_trap(u8"hello");
 }

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -19,7 +19,7 @@ void f(const char * arg) {
   __builtin_verbose_trap("");
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
   __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
-  __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with}}
+  __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
   __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
   __builtin_verbose_trap(str);
   __builtin_verbose_trap(u8"hello");

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++11 -fsyntax-only -fcxx-exceptions -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -fcxx-exceptions -verify %s
 
 #if !__has_builtin(__builtin_verbose_trap)
 #error
@@ -15,13 +16,18 @@ void f(const char * arg) {
   __builtin_verbose_trap("hello" "world");
   __builtin_verbose_trap(constMsg1);
   __builtin_verbose_trap(constMsg2);
-  __builtin_verbose_trap(""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
+  __builtin_verbose_trap("");
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
-  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
+  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
   __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with}}
-  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a non-empty constant string}}
+  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
   __builtin_verbose_trap(str);
   __builtin_verbose_trap(u8"hello");
+#if __cplusplus >= 202002L
+  // FIXME: Accept c++20 u8 string literals.
+  // expected-error@-3 {{cannot initialize a parameter of type 'const char *' with an lvalue of type 'const char8_t[6]'}}
+#endif
+  __builtin_verbose_trap("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
 }
 
 void test() {

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -10,6 +10,7 @@ char const constMsg3[] = "hello";
 
 template <const char * const str>
 void f(const char * arg) {
+  __builtin_verbose_trap("Arbitrary string literals can be used!");
   __builtin_verbose_trap("Argument_must_not_be_null");
   __builtin_verbose_trap("hello" "world");
   __builtin_verbose_trap(constMsg1);

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -27,6 +27,7 @@ void f(const char * arg) {
   __builtin_verbose_trap("", 0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
   __builtin_verbose_trap(1, ""); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
   __builtin_verbose_trap(arg, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  __builtin_verbose_trap("cat$1", "hel$lo"); // expected-error 2 {{argument to __builtin_verbose_trap must not contain $}}
   __builtin_verbose_trap(category, reason);
   __builtin_verbose_trap(u8"cat1", u8"hello");
 #if __cplusplus >= 202002L

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -5,31 +5,42 @@
 #error
 #endif
 
+constexpr char const* constCat1 = "cat";
+char const* const constCat2 = "cat";
+char const constCat3[] = "cat";
+
 constexpr char const* constMsg1 = "hello";
 char const* const constMsg2 = "hello";
 char const constMsg3[] = "hello";
 
-template <const char * const str>
+template <const char * const category, const char * const reason>
 void f(const char * arg) {
-  __builtin_verbose_trap("Arbitrary string literals can be used!");
-  __builtin_verbose_trap("Argument_must_not_be_null");
-  __builtin_verbose_trap("hello" "world");
-  __builtin_verbose_trap(constMsg1);
-  __builtin_verbose_trap(constMsg2);
-  __builtin_verbose_trap("");
+  __builtin_verbose_trap("cat1", "Arbitrary string literals can be used!");
+  __builtin_verbose_trap(" cat1 ", "Argument_must_not_be_null");
+  __builtin_verbose_trap("cat" "egory1", "hello" "world");
+  __builtin_verbose_trap(constCat1, constMsg1);
+  __builtin_verbose_trap(constCat2, constMsg2);
+  __builtin_verbose_trap("", "");
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
-  __builtin_verbose_trap(0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
-  __builtin_verbose_trap(1); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
-  __builtin_verbose_trap(arg); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
-  __builtin_verbose_trap(str);
-  __builtin_verbose_trap(u8"hello");
+  __builtin_verbose_trap(""); // expected-error {{too few arguments}}
+  __builtin_verbose_trap("", "", ""); // expected-error {{too many arguments}}
+  __builtin_verbose_trap("", 0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  __builtin_verbose_trap(1, ""); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
+  __builtin_verbose_trap(arg, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  __builtin_verbose_trap(category, reason);
+  __builtin_verbose_trap(u8"cat1", u8"hello");
 #if __cplusplus >= 202002L
   // FIXME: Accept c++20 u8 string literals.
-  // expected-error@-3 {{cannot initialize a parameter of type 'const char *' with an lvalue of type 'const char8_t[6]'}}
+  // expected-error@-3 {{cannot initialize a parameter of type 'const char *' with an lvalue of type 'const char8_t[5]'}}
 #endif
-  __builtin_verbose_trap("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+  __builtin_verbose_trap("", "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+}
+
+template <const char * const category>
+void f2() {
+  __builtin_verbose_trap(category, 1); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
 }
 
 void test() {
-  f<constMsg3>(nullptr);
+  f<constCat3, constMsg3>(nullptr);
 }


### PR DESCRIPTION
The builtin causes the program to stop its execution abnormally and shows a human-readable description of the reason for the termination when a debugger is attached or in a symbolicated crash log.

The motivation for the builtin is explained in the following RFC:

https://discourse.llvm.org/t/rfc-adding-builtin-verbose-trap-string-literal/75845

clang's CodeGen lowers the builtin to `llvm.trap` and emits debugging information that represents an artificial
inline frame whose name encodes the category and reason strings passed to the builtin.