### PR TITLE
Fix tblgen properties printing

### DIFF
--- a/mlir/test/IR/properties.mlir
+++ b/mlir/test/IR/properties.mlir
@@ -2,31 +2,31 @@
 // # RUN: mlir-opt %s -mlir-print-op-generic -split-input-file  | mlir-opt -mlir-print-op-generic | FileCheck %s --check-prefix=GENERIC
 
 // CHECK:   test.with_properties
-// CHECK-SAME: <{a = 32 : i64, array = array<i64: 1, 2, 3, 4>, b = "foo"}>
+// CHECK-SAME: <{a = 32 : i64, array = array<i64: 1, 2, 3, 4>, b = "foo"}>{{$}}
 // GENERIC:   "test.with_properties"()
 // GENERIC-SAME: <{a = 32 : i64, array = array<i64: 1, 2, 3, 4>, b = "foo"}> : () -> ()
 test.with_properties <{a = 32 : i64, array = array<i64: 1, 2, 3, 4>, b = "foo"}>
 
 // CHECK:   test.with_nice_properties
-// CHECK-SAME:    "foo bar" is -3
+// CHECK-SAME:    "foo bar" is -3{{$}}
 // GENERIC: "test.with_nice_properties"()
 // GENERIC-SAME:  <{prop = {label = "foo bar", value = -3 : i32}}> : () -> ()
 test.with_nice_properties "foo bar" is -3
 
 // CHECK:   test.with_wrapped_properties
-// CHECK-SAME:    "content for properties"
+// CHECK-SAME:    <{prop = "content for properties"}>{{$}}
 // GENERIC: "test.with_wrapped_properties"()
 // GENERIC-SAME:  <{prop = "content for properties"}> : () -> ()
 test.with_wrapped_properties <{prop = "content for properties"}>
 
 // CHECK: test.using_property_in_custom
-// CHECK-SAME: [1, 4, 20]
+// CHECK-SAME: [1, 4, 20]{{$}}
 // GENERIC: "test.using_property_in_custom"()
 // GENERIC-SAME: prop = array<i64: 1, 4, 20>
 test.using_property_in_custom [1, 4, 20]
 
 // CHECK: test.using_property_ref_in_custom
-// CHECK-SAME: 1 + 4 = 5
+// CHECK-SAME: 1 + 4 = 5{{$}}
 // GENERIC: "test.using_property_ref_in_custom"()
 // GENERIC-SAME: <{
 // GENERIC-SAME: first = 1

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -366,6 +366,9 @@ struct OperationFormat {
   /// Indicate whether attribute are stored in properties.
   bool useProperties;
 
+  /// Indicate whether prop-dict is used in the format
+  bool hasPropDict;
+
   /// The Operation class name
   StringRef opCppClassName;
 
@@ -1810,9 +1813,14 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
       body << "  }\n";
     }
   }
-  body << "  _odsPrinter.printOptionalAttrDict"
-       << (withKeyword ? "WithKeyword" : "")
-       << "((*this)->getAttrs(), elidedAttrs);\n";
+  if (fmt.hasPropDict)
+    body << "  _odsPrinter.printOptionalAttrDict"
+         << (withKeyword ? "WithKeyword" : "")
+         << "(llvm::to_vector((*this)->getDiscardableAttrs()), elidedAttrs);\n";
+  else
+    body << "  _odsPrinter.printOptionalAttrDict"
+         << (withKeyword ? "WithKeyword" : "")
+         << "((*this)->getAttrs(), elidedAttrs);\n";
 }
 
 /// Generate the printer for a literal value. `shouldEmitSpace` is true if a
@@ -2560,6 +2568,9 @@ LogicalResult OpFormatParser::verify(SMLoc loc,
 
   // Collect the set of used attributes in the format.
   fmt.usedAttributes = seenAttrs.takeVector();
+
+  // Set whether prop-dict is used in the format
+  fmt.hasPropDict = hasPropDict;
   return success();
 }
 


### PR DESCRIPTION
This is to fix the bug reported in https://discourse.llvm.org/t/whats-the-recommended-way-to-use-prop-dict/75921

When `prop-dict` is used in the assembly format, `attr-dict` should print discardable attributes only.