### PR TITLE
[X86][CodeGen] Fix crash when commute operands of Instruction for code size

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -2328,9 +2328,9 @@ MachineInstr *X86InstrInfo::commuteInstructionImpl(MachineInstr &MI, bool NewMI,
     if (MI.getParent()->getParent()->getFunction().hasOptSize()) {
       unsigned Mask = (Opc == X86::BLENDPDrri || Opc == X86::VBLENDPDrri) ? 0x03: 0x0F;
       if ((MI.getOperand(3).getImm() ^ Mask) == 1) {
-#define FROM_TO(A, B)                                                          \
-  case X86::A:                                                                 \
-    Opc = X86::B;                                                              \
+#define FROM_TO(FROM, TO)                                                      \
+  case X86::FROM:                                                              \
+    Opc = X86::TO;                                                             \
     break;
         switch (Opc) {
         default:

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -2327,29 +2327,30 @@ MachineInstr *X86InstrInfo::commuteInstructionImpl(MachineInstr &MI, bool NewMI,
     // If we're optimizing for size, try to use MOVSD/MOVSS.
     if (MI.getParent()->getParent()->getFunction().hasOptSize()) {
       unsigned Mask;
+      unsigned NewOpc;
       switch (Opc) {
       default:
         llvm_unreachable("Unreachable!");
       case X86::BLENDPDrri:
-        Opc = X86::MOVSDrr;
+        NewOpc = X86::MOVSDrr;
         Mask = 0x03;
         break;
       case X86::BLENDPSrri:
-        Opc = X86::MOVSSrr;
+        NewOpc = X86::MOVSSrr;
         Mask = 0x0F;
         break;
       case X86::VBLENDPDrri:
-        Opc = X86::VMOVSDrr;
+        NewOpc = X86::VMOVSDrr;
         Mask = 0x03;
         break;
       case X86::VBLENDPSrri:
-        Opc = X86::VMOVSSrr;
+        NewOpc = X86::VMOVSSrr;
         Mask = 0x0F;
         break;
       }
       if ((MI.getOperand(3).getImm() ^ Mask) == 1) {
         WorkingMI = CloneIfNew(MI);
-        WorkingMI->setDesc(get(Opc));
+        WorkingMI->setDesc(get(NewOpc));
         WorkingMI->removeOperand(3);
         break;
       }

--- a/llvm/test/CodeGen/X86/commute-blend-avx2.ll
+++ b/llvm/test/CodeGen/X86/commute-blend-avx2.ll
@@ -88,3 +88,12 @@ define <4 x double> @commute_fold_vblendpd_256(<4 x double> %a, ptr %b) #0 {
   ret <4 x double> %2
 }
 declare <4 x double> @llvm.x86.avx.blend.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
+
+define <4 x float> @commute_vblendpd_128_for_code_size(<4 x float> %a, <4 x float> %b) optsize {
+; CHECK-LABEL: commute_vblendpd_128_for_code_size:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vblendps {{.*#+}} xmm0 = xmm1[0],xmm0[1],xmm1[2,3]
+; CHECK-NEXT:    retq
+  %r = shufflevector <4 x float> %b, <4 x float> %a, <4 x i32> <i32 0, i32 5, i32 2, i32 3>
+  ret <4 x float> %r
+}


### PR DESCRIPTION
Reported in 134fcc62786d31ab73439201dce2d73808d1785a

Incorrect opcode is used  b/c there is a `[[fallthrough]]` at line 2386.
