### PR TITLE
[AIX][TLS] Disallow the use of -maix-small-local-exec-tls and -fno-data-sections

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -671,14 +671,6 @@ bool PPCTargetInfo::initFeatureMap(
     return false;
   }
 
-  if (llvm::is_contained(FeaturesVec, "+aix-small-local-exec-tls")) {
-    if (!getTriple().isOSAIX() || !getTriple().isArch64Bit()) {
-      Diags.Report(diag::err_opt_not_valid_on_target)
-         << "-maix-small-local-exec-tls";
-      return false;
-    }
-  }
-
   return TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);
 }
 

--- a/clang/lib/Driver/ToolChains/Arch/PPC.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/PPC.cpp
@@ -122,6 +122,25 @@ void ppc::getPPCTargetFeatures(const Driver &D, const llvm::Triple &Triple,
   ppc::ReadGOTPtrMode ReadGOT = ppc::getPPCReadGOTPtrMode(D, Triple, Args);
   if (ReadGOT == ppc::ReadGOTPtrMode::SecurePlt)
     Features.push_back("+secure-plt");
+
+  bool UseSeparateSections = isUseSeparateSections(Triple);
+  bool HasDefaultDataSections = Triple.isOSBinFormatXCOFF();
+  if (Args.hasArg(options::OPT_maix_small_local_exec_tls)) {
+    if (!Triple.isOSAIX() || !Triple.isArch64Bit())
+      D.Diag(diag::err_opt_not_valid_on_target) << "-maix-small-local-exec-tls";
+
+    // The -maix-small-local-exec-tls option should only be used with
+    // -fdata-sections, as having data sections turned off with this option
+    // is not ideal for performance. Moreover, the small-local-exec-tls region
+    // is a limited resource, and should not be used for variables that may
+    // be replaced.
+    if (!Args.hasFlag(options::OPT_fdata_sections,
+                      options::OPT_fno_data_sections,
+                      UseSeparateSections || HasDefaultDataSections))
+      D.Diag(diag::err_drv_argument_only_allowed_with)
+          << "-maix-small-local-exec-tls"
+          << "-fdata-sections";
+  }
 }
 
 ppc::ReadGOTPtrMode ppc::getPPCReadGOTPtrMode(const Driver &D, const llvm::Triple &Triple,

--- a/clang/test/Driver/aix-small-local-exec-tls.c
+++ b/clang/test/Driver/aix-small-local-exec-tls.c
@@ -12,6 +12,12 @@
 // RUN:    -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK-UNSUPPORTED-LINUX %s
 // RUN: not %clang -target powerpc64-unknown-linux-gnu -maix-small-local-exec-tls \
 // RUN:    -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK-UNSUPPORTED-LINUX %s
+// RUN: not %clang -target powerpc64-unknown-aix -maix-small-local-exec-tls \
+// RUN:    -fsyntax-only -fno-data-sections %s 2>&1 | \
+// RUN:    FileCheck --check-prefix=CHECK-UNSUPPORTED-NO-DATASEC %s
+// RUN: not %clang -target powerpc64-unknown-linux-gnu -maix-small-local-exec-tls \
+// RUN:    -fsyntax-only -fno-data-sections %s 2>&1 | \
+// RUN:    FileCheck --check-prefix=CHECK-UNSUPPORTED-NO-DATASEC %s
 
 int test(void) {
   return 0;
@@ -23,6 +29,7 @@ int test(void) {
 
 // CHECK-UNSUPPORTED-AIX32: option '-maix-small-local-exec-tls' cannot be specified on this target
 // CHECK-UNSUPPORTED-LINUX: option '-maix-small-local-exec-tls' cannot be specified on this target
+// CHECK-UNSUPPORTED-NO-DATASEC: invalid argument '-maix-small-local-exec-tls' only allowed with '-fdata-sections'
 
 // CHECK-AIX_SMALL_LOCALEXEC_TLS: test() #0 {
 // CHECK-AIX_SMALL_LOCALEXEC_TLS: attributes #0 = {

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.cpp
@@ -124,10 +124,23 @@ void PPCSubtarget::initSubtargetFeatures(StringRef CPU, StringRef TuneCPU,
   // Determine endianness.
   IsLittleEndian = TM.isLittleEndian();
 
-  if (HasAIXSmallLocalExecTLS && (!TargetTriple.isOSAIX() || !IsPPC64))
-    report_fatal_error(
-      "The aix-small-local-exec-tls attribute is only supported on AIX in "
-      "64-bit mode.\n", false);
+  if (HasAIXSmallLocalExecTLS) {
+    if (!TargetTriple.isOSAIX() || !IsPPC64)
+      report_fatal_error(
+          "The aix-small-local-exec-tls attribute is only supported on AIX in "
+          "64-bit mode.\n",
+          false);
+    // The aix-small-local-exec-tls attribute should only be used with
+    // -data-sections, as having data sections turned off with this option
+    // is not ideal for performance. Moreover, the small-local-exec-tls region
+    // is a limited resource, and should not be used for variables that may
+    // be replaced.
+    if (!TM.getDataSections())
+      report_fatal_error(
+          "The aix-small-local-exec-tls attribute can only be specified with "
+          "-data-sections.\n",
+          false);
+  }
 }
 
 bool PPCSubtarget::enableMachineScheduler() const { return true; }

--- a/llvm/test/CodeGen/PowerPC/check-aix-small-local-exec-tls-opt-IRattribute.ll
+++ b/llvm/test/CodeGen/PowerPC/check-aix-small-local-exec-tls-opt-IRattribute.ll
@@ -6,7 +6,7 @@
 ; RUN:   < %s 2>&1 | FileCheck %s --check-prefix=CHECK-NOT-SUPPORTED
 ; RUN: not llc -mtriple powerpc64-ibm-aix-xcoff -ppc-asm-full-reg-names \
 ; RUN:   -data-sections=false < %s 2>&1 | \
-; RUN: FileCheck %s --check-prefix=CHECK-NOT-SUPPORTED-NO-DATASEC
+; RUN: FileCheck %s --check-prefix=CHECK-UNSUPPORTED-NO-DATASEC
 
 define dso_local signext i32 @testWithIRAttr() #0 {
 entry:
@@ -17,7 +17,7 @@ entry:
 
 ; Check that the aix-small-local-exec-tls attribute is only supported when
 ; data sections are enabled.
-; CHECK-NOT-SUPPORTED-NO-DATASEC: The aix-small-local-exec-tls attribute can only be specified with -data-sections.
+; CHECK-UNSUPPORTED-NO-DATASEC: The aix-small-local-exec-tls attribute can only be specified with -data-sections.
 
 ; Make sure that the test was actually compiled successfully after using the
 ; aix-small-local-exec-tls attribute.

--- a/llvm/test/CodeGen/PowerPC/check-aix-small-local-exec-tls-opt-IRattribute.ll
+++ b/llvm/test/CodeGen/PowerPC/check-aix-small-local-exec-tls-opt-IRattribute.ll
@@ -4,6 +4,9 @@
 ; RUN:   < %s 2>&1 | FileCheck %s --check-prefix=CHECK-NOT-SUPPORTED
 ; RUN: not llc -mtriple powerpc64le-unknown-linux-gnu -ppc-asm-full-reg-names \
 ; RUN:   < %s 2>&1 | FileCheck %s --check-prefix=CHECK-NOT-SUPPORTED
+; RUN: not llc -mtriple powerpc64-ibm-aix-xcoff -ppc-asm-full-reg-names \
+; RUN:   -data-sections=false < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=CHECK-NOT-SUPPORTED-NO-DATASEC
 
 define dso_local signext i32 @testWithIRAttr() #0 {
 entry:
@@ -11,6 +14,10 @@ entry:
 }
 ; Check that the aix-small-local-exec-tls attribute is not supported on Linux and AIX (32-bit).
 ; CHECK-NOT-SUPPORTED: The aix-small-local-exec-tls attribute is only supported on AIX in 64-bit mode.
+
+; Check that the aix-small-local-exec-tls attribute is only supported when
+; data sections are enabled.
+; CHECK-NOT-SUPPORTED-NO-DATASEC: The aix-small-local-exec-tls attribute can only be specified with -data-sections.
 
 ; Make sure that the test was actually compiled successfully after using the
 ; aix-small-local-exec-tls attribute.


### PR DESCRIPTION


This patch disallows the use of the -maix-small-local-exec-tls and -fno-data-sections options within clang, and also disallows the use of the aix-small-local-exec-tls attribute with the -data-sections=false option in llc.

This is because having data sections off when using the aix-small-local-exec-tls feature is not ideal for performance. As the small-local-exec-tls region is a limited resource, this space should not used for variables that may be replaced.

Note, that on AIX, data sections is turned on by default, so this patch makes it so that a diagnostic is emitted when users explicitly turn off data sections while using the aix-small-local-exec-tls feature.