### PR TITLE
Add necessary permissions to release issue workflow

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -33,6 +33,8 @@ jobs:
   backport-commits:
     name: Backport Commits
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: >-
       (github.repository == 'llvm/llvm-project') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
@@ -66,6 +68,9 @@ jobs:
   create-pull-request:
     name: Create Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     if: >-
       (github.repository == 'llvm/llvm-project') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&


### PR DESCRIPTION
The `/cherry-pick` command needs `issues: write` to post a comment on the issue. The `/branch` command also posts a comment, and also needs `pull-requests: write` to open a PR.

This should fix the failure encountered at https://github.com/llvm/llvm-project/issues/79253#issuecomment-1907850027.