### PR TITLE
[flang] fix procedure fir.box_addr identification in boxed-procedure

### DIFF
--- a/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
+++ b/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
@@ -207,8 +207,8 @@ public:
         if (auto addr = mlir::dyn_cast<BoxAddrOp>(op)) {
           mlir::Type ty = addr.getVal().getType();
           mlir::Type resTy = addr.getResult().getType();
-          if (typeConverter.needsConversion(ty) ||
-              ty.isa<mlir::FunctionType>()) {
+          if (llvm::isa<mlir::FunctionType>(ty) ||
+              llvm::isa<fir::BoxProcType>(ty)) {
             // Rewrite all `fir.box_addr` ops on values of type `!fir.boxproc`
             // or function type to be `fir.convert` ops.
             rewriter.setInsertionPoint(addr);

--- a/flang/test/Fir/boxproc-2.fir
+++ b/flang/test/Fir/boxproc-2.fir
@@ -94,3 +94,11 @@ func.func @block_arg_rewrite(%arg0: !fir.ref<!fir.type<t{p:!fir.boxproc<() -> ()
 // CHECK:           fir.call @dosomething(%[[VAL_3]]) : (!fir.ref<!fir.type<tUnboxProc{p:() -> ()}>>) -> ()
 
 func.func private @dosomething(!fir.ref<!fir.type<t{p:!fir.boxproc<() -> ()>}>>)
+
+!t2 = !fir.type<t2{i:!fir.boxproc<() -> ()>}>
+func.func @box_addr_test(%arg0: !fir.box<!t2>) -> !fir.ref<!t2> {
+  %3 = fir.box_addr %arg0 : (!fir.box<!t2>) -> !fir.ref<!t2>
+  return %3 : !fir.ref<!t2>
+}
+// CHECK: func.func @box_addr_test(
+// CHECK:   fir.box_addr %{{.*}} : (!fir.box<!fir.type<t2UnboxProc{i:() -> ()}>>) -> !fir.ref<!fir.type<t2UnboxProc{i:() -> ()}>>


### PR DESCRIPTION
The pass was mistakenly identifying a fir.box_addr on a fir.box/fir.class of a derived type with procedure pointer components as being a fir.box_addr on a procedure.

Simply check if the input type is a fir.box_proc or function type (if input already rewritten) and insert convert only in this case.

This caused "invalid fir.convert" internal error.