### PR TITLE
[LoopIdiomRecognizer] Implement CRC recognition

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -2999,6 +2999,7 @@ public:
     }
 
     void print(raw_ostream &OS) {
+#ifndef NDEBUG
       switch (_Type) {
       case BitType::ONE:
         OS << "1";
@@ -3016,6 +3017,7 @@ public:
         _RHS->print(OS);
         break;
       }
+#endif
     }
   };
   using PValueBits = std::shared_ptr<ValueBits>;
@@ -3153,6 +3155,7 @@ public:
   }
 
   virtual void print(raw_ostream &OS) {
+#ifndef NDEBUG
     assert(Size != 0);
     OS << "[";
     Bits[Size - 1].print(OS);
@@ -3161,6 +3164,7 @@ public:
       Bits[i].print(OS);
     }
     OS << "]\n";
+#endif
   }
 };
 
@@ -3218,9 +3222,11 @@ public:
   ICmpInst *getPredicate() { return _Predicate; }
 
   virtual void print(raw_ostream &OS) override {
+#ifndef NDEBUG
     OS << "Predicate: " << *_Predicate << "\nIf True:\n"
        << *_IfTrue << "If False:\n"
        << *_IfFalse;
+#endif
   }
 };
 

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -2955,7 +2955,7 @@ public:
         _RHS = new ValueBit(*VB._RHS);
       }
     }
-    ValueBit& operator=(const ValueBit &VB) {
+    ValueBit &operator=(const ValueBit &VB) {
       _Type = VB._Type;
       if (_Type == BitType::REF)
         _BitRef = VB._BitRef;
@@ -3272,8 +3272,8 @@ symbolicallyExecute(BasicBlock *BB,
         }
       }
       assert(IncomingBlock);
-      ValueMap.insert({&I,
-          getOrCreateValueBits(PHI->getIncomingValueForBlock(IncomingBlock))});
+      ValueMap.insert({&I, getOrCreateValueBits(
+                               PHI->getIncomingValueForBlock(IncomingBlock))});
     } break;
     case Instruction::Shl: {
       ConstantInt *CI = getConstantOperand(&I, 1);
@@ -3320,8 +3320,8 @@ symbolicallyExecute(BasicBlock *BB,
       }
       auto IfTrue = getOrCreateValueBits(Select->getTrueValue());
       auto IfFalse = getOrCreateValueBits(Select->getFalseValue());
-      ValueMap.insert({&I,
-          std::make_shared<PredicatedValueBits>(Cond, IfTrue, IfFalse)});
+      ValueMap.insert(
+          {&I, std::make_shared<PredicatedValueBits>(Cond, IfTrue, IfFalse)});
     } break;
     default:
       // If this instruction is not recognized, then just continue. This is
@@ -3456,7 +3456,7 @@ bool LoopIdiomRecognize::recognizeCRC(const SCEV *BECount) {
   // any unexpected loop variant operations happening, e.g. additional select
   // logic or shifts, then this will be captured in the ValueBits.
   std::map<Value *, std::shared_ptr<ValueBits>> ValueMap;
-    
+
   if (!symbolicallyExecute(CurLoop->getHeader(), ValueMap))
     return false;
 
@@ -3487,8 +3487,8 @@ bool LoopIdiomRecognize::recognizeCRC(const SCEV *BECount) {
   // whether this is bit reversed CRC
   ICmpInst *ICmp = CRCOutBitsPred->getPredicate();
   CmpInst::Predicate Pred = ICmp->getPredicate();
-  LLVM_DEBUG(dbgs() << DEBUG_TYPE << " CRCRecognize checking to see if " << *ICmp
-                    << " is checking the "
+  LLVM_DEBUG(dbgs() << DEBUG_TYPE << " CRCRecognize checking to see if "
+                    << *ICmp << " is checking the "
                     << (CRC.BitReversed ? "LSB\n" : "MSB\n"));
 
   // Firstly check the LHS is in our map, and RHS is a constant
@@ -3620,7 +3620,8 @@ bool LoopIdiomRecognize::recognizeCRC(const SCEV *BECount) {
   }
   uint64_t GeneratorPolynomial =
       CRC.BitReversed ? reverseBits(CRC.Polynomial, CRCSize) : CRC.Polynomial;
-  PValueBits Polynomial = std::make_shared<ValueBits>(GeneratorPolynomial, CRCSize);
+  PValueBits Polynomial =
+      std::make_shared<ValueBits>(GeneratorPolynomial, CRCSize);
 
   // Case where the MSB/LSB of the data is 0
   PValueBits IfZero = CRC.BitReversed ? ValueBits::LShr(*CRCValueBits, 1)

--- a/llvm/test/Transforms/LoopIdiom/crc/crc.ll
+++ b/llvm/test/Transforms/LoopIdiom/crc/crc.ll
@@ -4,7 +4,7 @@
 ; CHECK: GeneratorPolynomial: 29
 ; CHECK: CRC Size: 8
 ; CHECK: Reversed: 0
-; CHECK: loop-idiom CRCRegonize: This looks like crc!
+; CHECK: loop-idiom CRCRecognize: This looks like crc!
 define dso_local zeroext i8 @crc8_loop(ptr noundef %data, i32 noundef %length) {
 entry:
   br label %for.cond
@@ -76,7 +76,7 @@ for.end:                                          ; preds = %for.body
 }
 
 ; CRC16 xor outside loop
-; CHECK: loop-idiom CRCRegonize: This looks like crc!
+; CHECK: loop-idiom CRCRecognize: This looks like crc!
 define dso_local zeroext i16 @crc16_xor_outside(i16 %crc, i8 %data) {
 entry:
   %conv2 = zext i8 %data to i16
@@ -103,7 +103,7 @@ for.end:                                          ; preds = %for.body
 ; CRC size 32 xor inside in a byte loop
 ; CHECK: GeneratorPolynomial: 270598144
 ; CHECK: CRC Size: 32
-; CHECK: loop-idiom CRCRegonize: This looks like crc!
+; CHECK: loop-idiom CRCRecognize: This looks like crc!
 define i16 @crc32_reversed(ptr %data_p, i16 %length) {
 entry:
   %cmp = icmp eq i16 %length, 0
@@ -162,7 +162,7 @@ cleanup:                                          ; preds = %entry, %do.end
 ; CHECK: CRC Size: 16
 ; CHECK: Reversed: 0
 ; CHECK: Data Size: 8
-; CHECK: loop-idiom CRCRegonize: This looks like crc!
+; CHECK: loop-idiom CRCRecognize: This looks like crc!
 define signext i16 @crc16(i16 %crcValue, i8 %newByte) {
 entry:
   br label %for.body

--- a/llvm/test/Transforms/LoopIdiom/crc/crc.ll
+++ b/llvm/test/Transforms/LoopIdiom/crc/crc.ll
@@ -1,0 +1,195 @@
+; RUN: opt -passes=loop-idiom < %s -S -debug -recognize-crc 2>&1 | FileCheck %s
+
+; CRC 8 bit, data 8 bit
+; CHECK: GeneratorPolynomial: 29
+; CHECK: CRC Size: 8
+; CHECK: Reversed: 0
+; CHECK: loop-idiom CRCRegonize: This looks like crc!
+define dso_local zeroext i8 @crc8_loop(ptr noundef %data, i32 noundef %length) {
+entry:
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.cond.cleanup7, %entry
+  %crc.0 = phi i8 [ 0, %entry ], [ %crc.1.lcssa, %for.cond.cleanup7 ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc20, %for.cond.cleanup7 ]
+  %cmp = icmp ult i32 %i.0, %length
+  br i1 %cmp, label %for.body, label %for.cond.cleanup
+
+for.cond.cleanup:                                 ; preds = %for.cond
+  %crc.0.lcssa = phi i8 [ %crc.0, %for.cond ]
+  ret i8 %crc.0.lcssa
+
+for.body:                                         ; preds = %for.cond
+  %add.ptr = getelementptr inbounds i8, ptr %data, i32 %i.0
+  %0 = load i8, ptr %add.ptr, align 1
+  %xor29 = xor i8 %0, %crc.0
+  br label %for.body8
+
+for.cond.cleanup7:                                ; preds = %for.body8
+  %crc.1.lcssa = phi i8 [ %crc.2, %for.body8 ]
+  %inc20 = add i32 %i.0, 1
+  br label %for.cond
+
+for.body8:                                        ; preds = %for.body, %for.body8
+  %i3.032 = phi i32 [ 0, %for.body ], [ %inc, %for.body8 ]
+  %crc.131 = phi i8 [ %xor29, %for.body ], [ %crc.2, %for.body8 ]
+  %shl = shl i8 %crc.131, 1
+  %xor14 = xor i8 %shl, 29
+  %cmp10.not30 = icmp slt i8 %crc.131, 0
+  %crc.2 = select i1 %cmp10.not30, i8 %xor14, i8 %shl
+  %inc = add nuw nsw i32 %i3.032, 1
+  %cmp5 = icmp ult i32 %inc, 8
+  br i1 %cmp5, label %for.body8, label %for.cond.cleanup7
+}
+
+; CRC16, 8 bit data
+; CHECK: Input CRC: i16 %crc
+; CHECK: Output CRC:   %crc.addr.2
+; CHECK: GeneratorPolynomial: 32773
+; CHECK: CRC Size: 16
+; CHECK: Reversed: 1
+; CHECK: Data Input: i8 %data
+; CHECK: Data Size: 8
+define i16 @crc16_reversed(i8 %data, i16 %crc) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.036 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %crc.addr.035 = phi i16 [ %crc, %entry ], [ %crc.addr.2, %for.body ]
+  %data.addr.034 = phi i8 [ %data, %entry ], [ %1, %for.body ]
+  %0 = trunc i16 %crc.addr.035 to i8
+  %and33 = xor i8 %0, %data.addr.034
+  %xor = and i8 %and33, 1
+  %1 = lshr i8 %data.addr.034, 1
+  %cmp10.not = icmp eq i8 %xor, 0
+  %2 = lshr i16 %crc.addr.035, 1
+  %3 = xor i16 %2, -24575
+  %crc.addr.2 = select i1 %cmp10.not, i16 %2, i16 %3
+  %inc = add nuw nsw i8 %i.036, 1
+  %cmp = icmp ult i8 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crc.addr.0.lcssa = phi i16 [ %crc.addr.2, %for.body ]
+  ret i16 %crc.addr.0.lcssa
+}
+
+; CRC16 xor outside loop
+; CHECK: loop-idiom CRCRegonize: This looks like crc!
+define dso_local zeroext i16 @crc16_xor_outside(i16 %crc, i8 %data) {
+entry:
+  %conv2 = zext i8 %data to i16
+  %shl = shl nuw i16 %conv2, 8
+  %xor = xor i16 %shl, %crc
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.020 = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %crc.addr.019 = phi i16 [ %xor, %entry ], [ %crc.addr.1, %for.body ]
+  %shl7 = shl i16 %crc.addr.019, 1
+  %xor8 = xor i16 %shl7, 4129
+  %tobool.not18 = icmp slt i16 %crc.addr.019, 0
+  %crc.addr.1 = select i1 %tobool.not18, i16 %xor8, i16 %shl7
+  %inc = add nuw nsw i32 %i.020, 1
+  %cmp = icmp ult i32 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crc.addr.0.lcssa = phi i16 [ %crc.addr.1, %for.body ]
+  ret i16 %crc.addr.0.lcssa
+}
+
+; CRC size 32 xor inside in a byte loop
+; CHECK: GeneratorPolynomial: 270598144
+; CHECK: CRC Size: 32
+; CHECK: loop-idiom CRCRegonize: This looks like crc!
+define i16 @crc32_reversed(ptr %data_p, i16 %length) {
+entry:
+  %cmp = icmp eq i16 %length, 0
+  br i1 %cmp, label %cleanup, label %do.body.preheader
+
+do.body.preheader:                                ; preds = %entry
+  br label %do.body
+
+do.body:                                          ; preds = %do.body.preheader, %do.cond
+  %data_p.addr.0 = phi ptr [ %incdec.ptr, %do.cond ], [ %data_p, %do.body.preheader ]
+  %length.addr.0 = phi i16 [ %dec, %do.cond ], [ %length, %do.body.preheader ]
+  %crc.0 = phi i32 [ %crc.1.lcssa, %do.cond ], [ 65535, %do.body.preheader ]
+  %incdec.ptr = getelementptr inbounds i8, ptr %data_p.addr.0, i64 1
+  %0 = load i8, ptr %data_p.addr.0, align 1
+  %conv3 = zext i8 %0 to i32
+  br label %for.body
+
+for.body:                                         ; preds = %do.body, %for.body
+  %crc.135 = phi i32 [ %crc.0, %do.body ], [ %crc.2, %for.body ]
+  %data.034 = phi i32 [ %conv3, %do.body ], [ %shr13, %for.body ]
+  %i.033 = phi i8 [ 0, %do.body ], [ %inc, %for.body ]
+  %and732 = xor i32 %crc.135, %data.034
+  %xor = and i32 %and732, 1
+  %tobool.not = icmp eq i32 %xor, 0
+  %shr = lshr i32 %crc.135, 1
+  %xor10 = xor i32 %shr, 33800
+  %crc.2 = select i1 %tobool.not, i32 %shr, i32 %xor10
+  %inc = add nuw nsw i8 %i.033, 1
+  %shr13 = lshr i32 %data.034, 1
+  %cmp5 = icmp ult i8 %inc, 8
+  br i1 %cmp5, label %for.body, label %do.cond
+
+do.cond:                                          ; preds = %for.body
+  %crc.1.lcssa = phi i32 [ %crc.2, %for.body ]
+  %dec = add i16 %length.addr.0, -1
+  %tobool14.not = icmp eq i16 %dec, 0
+  br i1 %tobool14.not, label %do.end, label %do.body
+
+do.end:                                           ; preds = %do.cond
+  %crc.1.lcssa.lcssa = phi i32 [ %crc.1.lcssa, %do.cond ]
+  %not15 = xor i32 %crc.1.lcssa.lcssa, -1
+  %shl = shl i32 %not15, 8
+  %shr16 = lshr i32 %not15, 8
+  %and17 = and i32 %shr16, 255
+  %or = add nuw nsw i32 %and17, %shl
+  %conv18 = trunc i32 %or to i16
+  br label %cleanup
+
+cleanup:                                          ; preds = %entry, %do.end
+  %retval.0 = phi i16 [ %conv18, %do.end ], [ 0, %entry ]
+  ret i16 %retval.0
+}
+
+; CRC16 
+; CHECK: GeneratorPolynomial: 258
+; CHECK: CRC Size: 16
+; CHECK: Reversed: 0
+; CHECK: Data Size: 8
+; CHECK: loop-idiom CRCRegonize: This looks like crc!
+define signext i16 @crc16(i16 %crcValue, i8 %newByte) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.017 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %newByte.addr.016 = phi i8 [ %newByte, %entry ], [ %shl7, %for.body ]
+  %crcValue.addr.015 = phi i16 [ %crcValue, %entry ], [ %crcValue.addr.1, %for.body ]
+  %and = lshr i16 %crcValue.addr.015, 8
+  %conv2 = zext i8 %newByte.addr.016 to i16
+  %shr14 = xor i16 %conv2, %and
+  %xor = and i16 %shr14, 128
+  %tobool.not = icmp eq i16 %xor, 0
+  %shl = shl i16 %crcValue.addr.015, 1
+  %xor4 = xor i16 %shl, 258
+  %crcValue.addr.1 = select i1 %tobool.not, i16 %shl, i16 %xor4
+  %shl7 = shl i8 %newByte.addr.016, 1
+  %inc = add nuw nsw i8 %i.017, 1
+  %cmp = icmp ult i8 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crcValue.addr.0.lcssa = phi i16 [ %crcValue.addr.1, %for.body ]
+  ret i16 %crcValue.addr.0.lcssa
+}
+
+; CHECK: @crctable.i16.32773.reversed = private constant [256 x i16] [i16 0, i16 -16191, i16 -15999, i16 320
+; CHECK: @crctable.i16.4129 = private constant [256 x i16] [i16 0, i16 4129, i16 8258, i16 12387, i16 16516
+; CHECK: @crctable.i32.270598144.reversed = private constant [256 x i32] [i32 0, i32 4489, i32 8978, i32 12955
+; CHECK: @crctable.i16.258 = private constant [256 x i16] [i16 0, i16 258, i16 516, i16 774, i16 1032

--- a/llvm/test/Transforms/LoopIdiom/crc/not-crc.ll
+++ b/llvm/test/Transforms/LoopIdiom/crc/not-crc.ll
@@ -1,0 +1,113 @@
+; RUN: opt -passes=loop-idiom < %s -S -debug -recognize-crc 2>&1 | FileCheck %s
+
+; crc16 incorrect xor inside loop
+; CHECK: loop-idiom CRCRegonize: Cannot verify check bit!
+; CHECK: crc[0]^data[0]
+; CHECK: crc[1]^1
+define i16 @crc16_incorrect_xor(i8 %data, i16 %crc) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.036 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %crc.addr.035 = phi i16 [ %crc, %entry ], [ %crc.addr.2, %for.body ]
+  %data.addr.034 = phi i8 [ %data, %entry ], [ %1, %for.body ]
+  %0 = trunc i16 %crc.addr.035 to i8
+  %and33 = xor i8 %0, 25
+  %xor = and i8 %and33, 1
+  %1 = lshr i8 %data.addr.034, 1
+  %cmp10.not = icmp eq i8 %xor, 0
+  %2 = lshr i16 %crc.addr.035, 1
+  %3 = xor i16 %2, -24575
+  %crc.addr.2 = select i1 %cmp10.not, i16 %2, i16 %3
+  %inc = add nuw nsw i8 %i.036, 1
+  %cmp = icmp ult i8 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crc.addr.0.lcssa = phi i16 [ %crc.addr.2, %for.body ]
+  ret i16 %crc.addr.0.lcssa
+}
+
+; Two byte at a time crc not supported
+; CHECK-NOT: loop-idiom CRCRegonize: This looks like crc!
+define i16 @crc16_reversed_data16(i16 %data, i16 %crc) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.036 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %crc.addr.035 = phi i16 [ %crc, %entry ], [ %crc.addr.2, %for.body ]
+  %data.addr.034 = phi i16 [ %data, %entry ], [ %0, %for.body ]
+  %and33 = xor i16 %crc.addr.035, %data.addr.034
+  %xor = and i16 %and33, 1
+  %0 = lshr i16 %data.addr.034, 1
+  %cmp10.not = icmp eq i16 %xor, 0
+  %1 = lshr i16 %crc.addr.035, 1
+  %2 = xor i16 %1, -24575
+  %crc.addr.2 = select i1 %cmp10.not, i16 %1, i16 %2
+  %inc = add nuw nsw i8 %i.036, 1
+  %cmp = icmp ult i8 %inc, 16
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crc.addr.0.lcssa = phi i16 [ %crc.addr.2, %for.body ]
+  ret i16 %crc.addr.0.lcssa
+}
+
+
+; Two shifts per iteration. Check that the ValueBits are correctly mismatched
+; CHECK-NOT: loop-idiom CRCRegonize: This looks like crc!
+define signext i16 @crc16_doubleshift(i16 %crcValue, i8 %newByte) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.017 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %newByte.addr.016 = phi i8 [ %newByte, %entry ], [ %shl7, %for.body ]
+  %crcValue.addr.015 = phi i16 [ %crcValue, %entry ], [ %crcValue.addr.1, %for.body ]
+  %and = lshr i16 %crcValue.addr.015, 8
+  %conv2 = zext i8 %newByte.addr.016 to i16
+  %shr14 = xor i16 %conv2, %and
+  %xor = and i16 %shr14, 128
+  %tobool.not = icmp eq i16 %xor, 0
+  %shlone = shl i16 %crcValue.addr.015, 1
+  %shl = lshr i16 %shlone, 1
+  %xor4 = xor i16 %shl, 258
+  %crcValue.addr.1 = select i1 %tobool.not, i16 %shl, i16 %xor4
+  %shl7 = shl i8 %newByte.addr.016, 1
+  %inc = add nuw nsw i8 %i.017, 1
+  %cmp = icmp ult i8 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crcValue.addr.0.lcssa = phi i16 [ %crcValue.addr.1, %for.body ]
+  ret i16 %crcValue.addr.0.lcssa
+}
+
+; CHECK: loop-idiom CRCRegonize: ICmp RHS is not checking [M/L]SB
+define signext i16 @crc16_not_check_sb(i16 %crcValue, i8 %newByte) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.017 = phi i8 [ 0, %entry ], [ %inc, %for.body ]
+  %newByte.addr.016 = phi i8 [ %newByte, %entry ], [ %shl7, %for.body ]
+  %crcValue.addr.015 = phi i16 [ %crcValue, %entry ], [ %crcValue.addr.1, %for.body ]
+  %and = lshr i16 %crcValue.addr.015, 8
+  %conv2 = zext i8 %newByte.addr.016 to i16
+  %shr14 = xor i16 %conv2, %and
+  %xor = and i16 %shr14, 128
+  %tobool.not = icmp eq i16 %xor, 2
+  %shl = shl i16 %crcValue.addr.015, 1
+  %xor4 = xor i16 %shl, 258
+  %crcValue.addr.1 = select i1 %tobool.not, i16 %shl, i16 %xor4
+  %shl7 = shl i8 %newByte.addr.016, 1
+  %inc = add nuw nsw i8 %i.017, 1
+  %cmp = icmp ult i8 %inc, 8
+  br i1 %cmp, label %for.body, label %for.end
+
+for.end:                                          ; preds = %for.body
+  %crcValue.addr.0.lcssa = phi i16 [ %crcValue.addr.1, %for.body ]
+  ret i16 %crcValue.addr.0.lcssa
+}


### PR DESCRIPTION
Recognizes CRC byte loops and replaces them with a table lookup.

Current limitations:
- Only works on byte loops
	CRC size can be any, but the data is limited to one byte. i.e. a loop with iteration count 8.
- Only works on single-block loops
	most CRC loops would have been flattened to one block with select instructions this far into the pipeline. 

Both limitations were  in effort to reduce complexity, especially for a first patch. The code can be fairly easily extended to overcome these limitations.

Implementation details:
1) Check if the loop looks like CRC and extract some useful information
2) Execute one iteration of the instruction of the loop to see what happens to our output value
4) Ensure the output value is predicated on the value of the M/LSB of our input
4) Construct an expected output value of one iteration of CRC using the extracted information from step one and compare
5) Construct a lookup table and replace the output value with a lookup