### PR TITLE
[clang] Use getDefaultArgRange instead of getDefaultArg to retrieve the

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2588,7 +2588,7 @@ private:
       // placeholder to indicate there is a default argument.
       QualType ParamTy = NewDI->getType();
       NewDefArg = new (SemaRef.Context)
-          OpaqueValueExpr(OldParam->getDefaultArg()->getBeginLoc(),
+          OpaqueValueExpr(OldParam->getDefaultArgRange().getBegin(),
                           ParamTy.getNonLValueExprType(SemaRef.Context),
                           ParamTy->isLValueReferenceType()   ? VK_LValue
                           : ParamTy->isRValueReferenceType() ? VK_XValue


### PR DESCRIPTION
source location in` AliasTemplateDeductionGuideTransform`.

I don't have a reproducible testcase, but this should be a safe and non-functional change. We have checked the `hasDefaultArg` before calling `getDefaultArg()`, but `hasDefaultArg` allows unparsed/uninstantiated default arg which is prohibited in `getDefaultArg()`.

Since we're only interested in the source location, we switch to use `getDefaultArgRange()` API.