### PR TITLE
[polly][ScheduleOptimizer] Use IslMaxOperationsGuard helper instead of explicit restoration

### DIFF
--- a/polly/test/ScheduleOptimizer/schedule_computeout.ll
+++ b/polly/test/ScheduleOptimizer/schedule_computeout.ll
@@ -1,8 +1,8 @@
-; RUN: opt %loadPolly -S -polly-optree -polly-delicm  -polly-opt-isl -polly-schedule-computeout=100000 -debug-only="polly-opt-isl" < %s 2>&1 | FileCheck %s
+; RUN: opt %loadPolly -S -polly-optree -polly-delicm  -polly-opt-isl -polly-schedule-computeout=10000 -debug-only="polly-opt-isl" < %s 2>&1 | FileCheck %s
 ; REQUIRES: asserts
 
 ; Bailout if the computations of schedule compute exceeds the max scheduling quota.
-; Max compute out is initialized to 300000, Here it is set to 100000 for test purpose.
+; Max compute out is initialized to 300000, Here it is set to 10000 for test purpose.
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 target triple = "aarch64-unknown-linux-gnu"


### PR DESCRIPTION
To fix long compile time issue of Schedule optimizer, patch #77280 sets the upper cap on max ISL operations. In case of bailing out when ISL quota is hit, error handling behavior was restored manually. This commit replaces the restoration code with IslMaxOperationsGuard helper and also removes redundant early return.