### PR TITLE
[AArch64] Simplify Clang's description of architecture extensions

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -55,24 +55,19 @@ static constexpr Builtin::Info BuiltinInfo[] = {
 };
 
 void AArch64TargetInfo::setArchFeatures() {
+  // FIXME Could we drop this function altogether and migrate everything
+  //       to AArch64TargetParser in LLVM core?
   if (*ArchInfo == llvm::AArch64::ARMV8R) {
-    HasDotProd = true;
     HasDIT = true;
     HasFlagM = true;
-    HasRCPC = true;
     FPU |= NeonMode;
     HasCCPP = true;
-    HasCRC = true;
     HasLSE = true;
-    HasRDM = true;
   } else if (ArchInfo->Version.getMajor() == 8) {
     if (ArchInfo->Version.getMinor() >= 7u) {
       HasWFxT = true;
     }
-    if (ArchInfo->Version.getMinor() >= 6u) {
-      HasBFloat16 = true;
-      HasMatMul = true;
-    }
+    // No special cases for Armv8.6-a
     if (ArchInfo->Version.getMinor() >= 5u) {
       HasAlternativeNZCV = true;
       HasFRInt3264 = true;
@@ -82,30 +77,19 @@ void AArch64TargetInfo::setArchFeatures() {
       HasBTI = true;
     }
     if (ArchInfo->Version.getMinor() >= 4u) {
-      HasDotProd = true;
       HasDIT = true;
       HasFlagM = true;
     }
-    if (ArchInfo->Version.getMinor() >= 3u) {
-      HasRCPC = true;
-      FPU |= NeonMode;
-    }
+    // No special cases for Armv8.3-a
     if (ArchInfo->Version.getMinor() >= 2u) {
       HasCCPP = true;
     }
-    if (ArchInfo->Version.getMinor() >= 1u) {
-      HasCRC = true;
-      HasLSE = true;
-      HasRDM = true;
-    }
+    // No special cases for Armv8.1-a
   } else if (ArchInfo->Version.getMajor() == 9) {
     if (ArchInfo->Version.getMinor() >= 2u) {
       HasWFxT = true;
     }
-    if (ArchInfo->Version.getMinor() >= 1u) {
-      HasBFloat16 = true;
-      HasMatMul = true;
-    }
+    // No special cases for Armv9.1-a
     FPU |= SveMode;
     HasSVE2 = true;
     HasFullFP16 = true;
@@ -115,15 +99,9 @@ void AArch64TargetInfo::setArchFeatures() {
     HasSB = true;
     HasPredRes = true;
     HasBTI = true;
-    HasDotProd = true;
     HasDIT = true;
     HasFlagM = true;
-    HasRCPC = true;
-    FPU |= NeonMode;
     HasCCPP = true;
-    HasCRC = true;
-    HasLSE = true;
-    HasRDM = true;
   }
 }
 
@@ -257,7 +235,6 @@ void AArch64TargetInfo::getTargetDefinesARMV82A(const LangOptions &Opts,
 void AArch64TargetInfo::getTargetDefinesARMV83A(const LangOptions &Opts,
                                                 MacroBuilder &Builder) const {
   Builder.defineMacro("__ARM_FEATURE_COMPLEX", "1");
-  Builder.defineMacro("__ARM_FEATURE_JCVT", "1");
   Builder.defineMacro("__ARM_FEATURE_PAUTH", "1");
   // Also include the Armv8.2 defines
   getTargetDefinesARMV82A(Opts, Builder);
@@ -272,7 +249,6 @@ void AArch64TargetInfo::getTargetDefinesARMV84A(const LangOptions &Opts,
 void AArch64TargetInfo::getTargetDefinesARMV85A(const LangOptions &Opts,
                                                 MacroBuilder &Builder) const {
   Builder.defineMacro("__ARM_FEATURE_FRINT", "1");
-  Builder.defineMacro("__ARM_FEATURE_BTI", "1");
   // Also include the Armv8.4 defines
   getTargetDefinesARMV84A(Opts, Builder);
 }
@@ -472,7 +448,10 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if ((FPU & NeonMode) && HasFullFP16)
     Builder.defineMacro("__ARM_FEATURE_FP16_VECTOR_ARITHMETIC", "1");
   if (HasFullFP16)
-   Builder.defineMacro("__ARM_FEATURE_FP16_SCALAR_ARITHMETIC", "1");
+    Builder.defineMacro("__ARM_FEATURE_FP16_SCALAR_ARITHMETIC", "1");
+
+  if (HasJSCVT)
+    Builder.defineMacro("__ARM_FEATURE_JCVT", "1");
 
   if (HasDotProd)
     Builder.defineMacro("__ARM_FEATURE_DOTPROD", "1");
@@ -529,6 +508,9 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
 
     Builder.defineMacro("__ARM_FEATURE_PAC_DEFAULT", std::to_string(Value));
   }
+
+  if (HasBTI)
+    Builder.defineMacro("__ARM_FEATURE_BTI", "1");
 
   if (Opts.BranchTargetEnforcement)
     Builder.defineMacro("__ARM_FEATURE_BTI_DEFAULT", "1");
@@ -741,7 +723,7 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
 
     if (Feature == "+neon" || Feature == "+fp-armv8")
       FPU |= NeonMode;
-    if (Feature == "+jscvt") {
+    if (Feature == "+jsconv") {
       HasJSCVT = true;
       FPU |= NeonMode;
     }
@@ -860,7 +842,7 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
     }
     if (Feature == "+dit")
       HasDIT = true;
-    if (Feature == "+cccp")
+    if (Feature == "+ccpp")
       HasCCPP = true;
     if (Feature == "+ccdp") {
       HasCCPP = true;

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -60,7 +60,6 @@ void AArch64TargetInfo::setArchFeatures() {
   if (*ArchInfo == llvm::AArch64::ARMV8R) {
     HasDIT = true;
     HasFlagM = true;
-    FPU |= NeonMode;
     HasCCPP = true;
     HasLSE = true;
   } else if (ArchInfo->Version.getMajor() == 8) {

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -634,3 +634,6 @@
 
 // RUN: %clang --target=aarch64 -march=armv8.2-a+rcpc3 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-RCPC3 %s
 // CHECK-RCPC3: __ARM_FEATURE_RCPC 3
+
+// RUN: %clang --target=aarch64 -march=armv8.3-a+nojscvt -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-NOJSCONV %s
+// CHECK-NOJSCONV-NOT: __ARM_FEATURE_JCVT


### PR DESCRIPTION
Core LLVM has AArch64TargetParser.h header describing the mapping from Armv8.x and Armv9.x architecture extensions to the particular list of features that are mandatory for the extension.

Clang partially reimplements this in AArch64TargetInfo::setArchFeatures() function. This patch simplifies setArchFeatures() by dropping obvious cases of duplication, though it seems not all the dependencies are listed in AArch64TargetParser.h yet.

Specifically, this patch drops `HasX = true` statements for the following features:
* v8.1-a: CRC, LSE, RDM
* v8.3-a: RCPC, NeonMode (it is enabled by the base Armv8-a and indirectly by -target-feature +fcma)
* v8.4-a: DOTPROD
* v8.6-a: BF16, MATMUL

In Clang's AArch64TargetInfo::handleTargetFeatures() function, the string literal "+jscvt" is changed to "+jsconv" and "+cccp" to "+ccpp", so the information is conveyed from TargetParser.

Additionally, this patch makes __ARM_FEATURE_BTI and __ARM_FEATURE_JCVT conditional on the particular HasX flags instead of an architecture extension as a whole, as using TargetParser makes it possible to specify the requested architecture like "armv8.5+nojscvt".