### PR TITLE
[OpenMPIRBuilder] NFC: Improve description of IsTargetDevice and IsGPU

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -83,11 +83,20 @@ BasicBlock *splitBBWithSuffix(IRBuilderBase &Builder, bool CreateBranch,
 /// are ones that are not dependent on the configuration.
 class OpenMPIRBuilderConfig {
 public:
-  /// Flag for specifying if the compilation is done for embedded device code
-  /// or host code.
+  /// Flag to define whether to generate code for the role of the OpenMP host
+  /// (if set to false) or device (if set to true) in an offloading context. It
+  /// is set when the -fopenmp-is-target-device compiler frontend option is
+  /// specified.
   std::optional<bool> IsTargetDevice;
 
-  /// Flag for specifying if the compilation is done for an accelerator.
+  /// Flag for specifying if the compilation is done for an accelerator. It is
+  /// set according to the architecture of the target triple and currently only
+  /// true when targeting AMDGPU or NVPTX. Today, these targets can only perform
+  /// the role of an OpenMP target device, so `IsTargetDevice` must also be true
+  /// if `IsGPU` is true. This restriction might be lifted if an accelerator-
+  /// like target with the ability to work as the OpenMP host is added, or if
+  /// the capabilities of the currently supported GPU architectures are
+  /// expanded.
   std::optional<bool> IsGPU;
 
   // Flag for specifying if offloading is mandatory.


### PR DESCRIPTION
This patch tries to better explain the differences between the `IsTargetDevice` and `IsGPU` flags of the `OpenMPIRBuilderConfig`.