### PR TITLE
[libc++] Make __start___lcxx_override/__stop___lcxx_override weak

### DIFF
--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -95,8 +95,8 @@ _LIBCPP_END_NAMESPACE_STD
 // variables with those names corresponding to the start and the end of the section.
 //
 // See https://stackoverflow.com/questions/16552710/how-do-you-get-the-start-and-end-addresses-of-a-custom-elf-section
-extern char __start___lcxx_override;
-extern char __stop___lcxx_override;
+_LIBCPP_WEAK extern char __start___lcxx_override;
+_LIBCPP_WEAK extern char __stop___lcxx_override;
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Ret, class... _Args>


### PR DESCRIPTION
After #69498, when `_LIBCPP_MAKE_OVERRIDABLE_FUNCTION_DETECTABLE`
functions are absent (possibly after ld --gc-sections), there will no
output section `__lcxx_override`. The linker will report an error like

```
ld: error: undefined symbol: __start___lcxx_override
>>> referenced by overridable_function.h:108 (libcxx/src/include/overridable_function.h:108)
```

Fix this by making the references weak.
