### PR TITLE
[libc][NFC] mark hashtable as resizable

### DIFF
--- a/libc/src/__support/HashTable/table.h
+++ b/libc/src/__support/HashTable/table.h
@@ -1,4 +1,4 @@
-//===-- Fix-sized Monotonic HashTable ---------------------------*- C++ -*-===//
+//===-- Resizable Monotonic HashTable ---------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
It is not fix-sized anymore.