### PR TITLE
[libc][NFC] remove TODO about AppProperties

### DIFF
--- a/libc/startup/linux/do_start.cpp
+++ b/libc/startup/linux/do_start.cpp
@@ -37,7 +37,6 @@ extern uintptr_t __fini_array_end[];
 }
 
 namespace LIBC_NAMESPACE {
-// TODO: this symbol will be moved to config.linux.app
 AppProperties app;
 
 using InitCallback = void(int, char **, char **);


### PR DESCRIPTION
```
AppProperties app;
```
is marked as a weak symbol in header now. One can just use `&app != nullptr` to check if `app` is defined. There is no need to define it for overlay mode.