### PR TITLE
[clang][Driver][RISCV] Honor -m[no-]global-merge for RISC-V

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2137,7 +2137,7 @@ void Clang::AddRISCVTargetArgs(const ArgList &Args,
     if (A->getOption().matches(options::OPT_mno_global_merge))
       CmdArgs.push_back("-riscv-enable-global-merge=false");
     else
-      CmdArgs.push_back("-riscv-enable-global-merge=true");
+      CmdArgs.push_back("-riscv-enable-global-merge");
   }
 }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2129,6 +2129,16 @@ void Clang::AddRISCVTargetArgs(const ArgList &Args,
           << A->getSpelling() << Val;
     }
   }
+
+  // Forward the -mglobal-merge option for explicit control over the pass.
+  if (Arg *A = Args.getLastArg(options::OPT_mglobal_merge,
+                               options::OPT_mno_global_merge)) {
+    CmdArgs.push_back("-mllvm");
+    if (A->getOption().matches(options::OPT_mno_global_merge))
+      CmdArgs.push_back("-riscv-enable-global-merge=false");
+    else
+      CmdArgs.push_back("-riscv-enable-global-merge=true");
+  }
 }
 
 void Clang::AddSparcTargetArgs(const ArgList &Args,

--- a/clang/test/Driver/mglobal-merge.c
+++ b/clang/test/Driver/mglobal-merge.c
@@ -36,7 +36,7 @@
 
 // CHECK-GM-ARM: "-mllvm" "-arm-global-merge=true"
 // CHECK-GM-AARCH64: "-mllvm" "-aarch64-enable-global-merge=true"
-// CHECK-GM-RISCV: "-mllvm" "-riscv-enable-global-merge=true"
+// CHECK-GM-RISCV: "-mllvm" "-riscv-enable-global-merge"
 
 // RUN: %clang -target armv7-unknown-unknown -### -fsyntax-only %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NONE < %t %s

--- a/clang/test/Driver/mglobal-merge.c
+++ b/clang/test/Driver/mglobal-merge.c
@@ -6,12 +6,17 @@
 // RUN:   -mno-global-merge
 // RUN: FileCheck --check-prefix=CHECK-NGM-AARCH64 < %t %s
 
+// RUN: %clang -target riscv32-unknown-unknown -### -fsyntax-only %s 2> %t \
+// RUN:   -mno-global-merge
+// RUN: FileCheck --check-prefix=CHECK-NGM-RISCV < %t %s
+
 // RUN: %clang -target x86_64-unknown-unknown -### -fsyntax-only %s 2> %t \
 // RUN:   -mno-global-merge
 // RUN: FileCheck --check-prefix=CHECK-NONE < %t %s
 
 // CHECK-NGM-ARM: "-mllvm" "-arm-global-merge=false"
 // CHECK-NGM-AARCH64: "-mllvm" "-aarch64-enable-global-merge=false"
+// CHECK-NGM-RISCV: "-mllvm" "-riscv-enable-global-merge=false"
 
 // RUN: %clang -target armv7-unknown-unknown -### -fsyntax-only %s 2> %t \
 // RUN:   -mglobal-merge
@@ -21,17 +26,25 @@
 // RUN:   -mglobal-merge
 // RUN: FileCheck --check-prefix=CHECK-GM-AARCH64 < %t %s
 
+// RUN: %clang -target riscv32-unknown-unknown -### -fsyntax-only %s 2> %t \
+// RUN:   -mglobal-merge
+// RUN: FileCheck --check-prefix=CHECK-GM-RISCV < %t %s
+
 // RUN: %clang -target x86_64-unknown-unknown -### -fsyntax-only %s 2> %t \
 // RUN:   -mglobal-merge
 // RUN: FileCheck --check-prefix=CHECK-NONE < %t %s
 
 // CHECK-GM-ARM: "-mllvm" "-arm-global-merge=true"
 // CHECK-GM-AARCH64: "-mllvm" "-aarch64-enable-global-merge=true"
+// CHECK-GM-RISCV: "-mllvm" "-riscv-enable-global-merge=true"
 
 // RUN: %clang -target armv7-unknown-unknown -### -fsyntax-only %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NONE < %t %s
 
 // RUN: %clang -target aarch64-unknown-unknown -### -fsyntax-only %s 2> %t
+// RUN: FileCheck --check-prefix=CHECK-NONE < %t %s
+
+// RUN: %clang -target riscv32-unknown-unknown -### -fsyntax-only %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-NONE < %t %s
 
 // RUN: %clang -target x86_64-unknown-unknown -### -fsyntax-only %s 2> %t


### PR DESCRIPTION
The GlobalMerge pass was enabled for RISC-V in [1] and left off by default. My understanding from [2] is that the concern around enabling the pass by default stemmed primarily from GlobalMerge preventing GP relaxation, which negatively impacted a few benchmarks.

However, as a) this pass provides code size benefits in some cases and b) this shouldn't be a concern for situations where GP relaxation is disabled anyway, we'd like to be able to manually enable/disable this functionality without having to specify -mllvm flags and in a way that is consistent with other targets (Arm/AArch64). So, leave the pass off by default still, but honor the -m[no]-global-merge flag for RISC-V.

[1] https://reviews.llvm.org/D130481
[2] https://reviews.llvm.org/D129178