### PR TITLE
[memref] Support dense resources for memref-to-llvm

### DIFF
--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -503,17 +503,18 @@ struct GlobalMemrefOpLowering
     Attribute initialValue = nullptr;
     if (!global.isExternal() && !global.isUninitialized()) {
       Attribute initialAttr = *global.getInitialValue();
-      if (auto resourceAttr = llvm::dyn_cast<DenseResourceElementsAttr>(initialAttr)) {
+      if (auto resourceAttr =
+              llvm::dyn_cast<DenseResourceElementsAttr>(initialAttr)) {
         auto blob = resourceAttr.getRawHandle().getBlob();
         initialAttr = DenseElementsAttr::getFromRawBuffer(
-          resourceAttr.getType(), blob->getData());
-      } 
+            resourceAttr.getType(), blob->getData());
+      }
 
       if (auto elementsAttr = llvm::cast<ElementsAttr>(initialAttr)) {
         initialValue = elementsAttr;
 
-        // For scalar memrefs, the global variable created is of the element type,
-        // so unpack the elements attribute to extract the value.
+        // For scalar memrefs, the global variable created is of the element
+        // type, so unpack the elements attribute to extract the value.
         if (type.getRank() == 0)
           initialValue = elementsAttr.getSplatValue<Attribute>();
       }

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -505,7 +505,8 @@ struct GlobalMemrefOpLowering
       Attribute initialAttr = *global.getInitialValue();
       if (auto resourceAttr = llvm::dyn_cast<DenseResourceElementsAttr>(initialAttr)) {
         auto blob = resourceAttr.getRawHandle().getBlob();
-        initialAttr = DenseElementsAttr::get(resourceAttr.getType(), blob->getData());
+        initialAttr = DenseElementsAttr::getFromRawBuffer(
+          resourceAttr.getType(), blob->getData());
       } 
 
       if (auto elementsAttr = llvm::cast<ElementsAttr>(initialAttr)) {

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -331,14 +331,17 @@ memref.global "private" @gv4 : memref<f32> = dense<1.0> {alignment = 64}
 // -----
 
 module {
-  // CHECK: llvm.mlir.global private constant @__constant_xf32(1.41421354 : f32) {addr_space = 0 : i32} : f32
-  memref.global "private" constant @__constant_xf32 : memref<f32> = dense_resource<NAME>
+  // CHECK: llvm.mlir.global private constant @__constant_xf32_0(1.41421354 : f32) {addr_space = 0 : i32} : f32
+  memref.global "private" constant @__constant_xf32_0 : memref<f32> = dense_resource<NAME0>
+  // CHECK: llvm.mlir.global private constant @__constant_xf32_1(dense<[5.000000e-01, 2.500000e-01]> : tensor<2xf32>) {addr_space = 0 : i32} : !llvm.array<2 x f32>
+  memref.global "private" constant @__constant_xf32_1 : memref<2xf32> = dense_resource<NAME1>
 }
 
 {-#
   dialect_resources: {
     builtin: {
-      NAME: "0x08000000F304B53F"
+      NAME0: "0x08000000F304B53F",
+      NAME1: "0x080000000000003F0000803E"
     }
   }
 #-}

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -330,6 +330,21 @@ memref.global "private" @gv4 : memref<f32> = dense<1.0> {alignment = 64}
 
 // -----
 
+module {
+  // CHECK: llvm.mlir.global private constant @__constant_xf32(1.41421354 : f32) {addr_space = 0 : i32} : f32
+  memref.global "private" constant @__constant_xf32 : memref<f32> = dense_resource<NAME>
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      NAME: "0x08000000F304B53F"
+    }
+  }
+#-}
+
+// -----
+
 // Expand shapes need to be expanded outside of the memref-to-llvm pass.
 // CHECK-LABEL: func @expand_shape_static(
 // CHECK-SAME:         %[[ARG:.*]]: memref<{{.*}}>)


### PR DESCRIPTION
Memref to llvm did not handle the DenseResourceElementsAttr. Reworked
the lowering so that it converts to a valid LLVM type.