### PR TITLE
[lldb] [NFC] Remove unused WatchpointResource::SetID method

### DIFF
--- a/lldb/include/lldb/Breakpoint/WatchpointResource.h
+++ b/lldb/include/lldb/Breakpoint/WatchpointResource.h
@@ -121,14 +121,6 @@ public:
   ///    A copy of the Watchpoints which own this resource.
   WatchpointCollection CopyConstituentsList();
 
-  // The ID of the WatchpointResource is set by the WatchpointResourceList
-  // when the Resource has been set in the inferior and is being added
-  // to the List, in an attempt to match the hardware watchpoint register
-  // ordering.  If a Process can correctly identify the hardware watchpoint
-  // register index when it has created the Resource, it may initialize it
-  // before it is inserted in the WatchpointResourceList.
-  void SetID(lldb::wp_resource_id_t);
-
   lldb::wp_resource_id_t GetID() const;
 
   bool Contains(lldb::addr_t addr);

--- a/lldb/source/Breakpoint/WatchpointResource.cpp
+++ b/lldb/source/Breakpoint/WatchpointResource.cpp
@@ -42,8 +42,6 @@ void WatchpointResource::SetType(bool read, bool write) {
 
 wp_resource_id_t WatchpointResource::GetID() const { return m_id; }
 
-void WatchpointResource::SetID(wp_resource_id_t id) { m_id = id; }
-
 bool WatchpointResource::Contains(addr_t addr) {
   if (addr >= m_addr && addr < m_addr + m_size)
     return true;


### PR DESCRIPTION
I originally thought to try to guesstimate the hardware watchpoint index number that a Resource was associated with, but gdb remote serial protocol doesn't give us the hardware register index used so it was only a guess.  I changed my mind and simply use ever-incrementing ID numbers for the WatchpointResources, but forgot to remove the SetID method.