### PR TITLE
[libc] Use __SIZEOF_LONG__ to define LONG_WIDTH instead of sizeof(long).

### DIFF
--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -70,8 +70,9 @@
 #elif defined(__WORDSIZE)
 #define LONG_WIDTH __WORDSIZE
 #else
-// Use sizeof(long) * CHAR_BIT as backup. This is needed for clang-13 or before.
-#define LONG_WIDTH (sizeof(long) * CHAR_BIT)
+// Use __SIZEOF_LONG__ * CHAR_BIT as backup.  This is needed for clang-13 or
+// before.
+#define LONG_WIDTH (__SIZEOF_LONG__ * CHAR_BIT)
 #endif // __LONG_WIDTH__
 #endif // LONG_WIDTH
 


### PR DESCRIPTION
The standard requires `limits.h` constants to be used in preprocessors.  So we use `__SIZEOF_LONG__` instead of `sizeof(long)` to define `LONG_WIDTH`.  The macro `__SIZEOF_LONG__` seems to be available on both clang and gcc since at least version 9.