### PR TITLE
[BOLT][DWARF] Add option to specify DW_AT_comp_dir

### DIFF
--- a/bolt/test/X86/dwarf4-override-comp-dir.test
+++ b/bolt/test/X86/dwarf4-override-comp-dir.test
@@ -1,0 +1,17 @@
+; REQUIRES: system-linux
+
+; RUN: rm -rf %t
+; RUN: mkdir %t
+; RUN: cd %t
+; RUN: mkdir temp
+; RUN: llvm-mc -dwarf-version=4 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf4-df-basic.s \
+; RUN: -split-dwarf-file=main.dwo -o main.o
+; RUN: %clang %cflags -gdwarf-4 -gsplit-dwarf=split main.o -o main.exe
+; RUN: cd temp
+; RUN: llvm-bolt ../main.exe -o ../main.exe.bolt --update-debug-sections -v 1 --comp-dir-override=%t
+; RUN: cd ..
+; RUN: ls -lat | FileCheck %s -check-prefix=BOLT-CHECK
+
+;; Tests that BOLT processes .dwo files with --comp-dir-override.
+
+; BOLT-CHECK: main.dwo.dwo

--- a/bolt/test/X86/dwarf5-override-comp-dir.test
+++ b/bolt/test/X86/dwarf5-override-comp-dir.test
@@ -1,0 +1,17 @@
+; REQUIRES: system-linux
+
+; RUN: rm -rf %t
+; RUN: mkdir %t
+; RUN: cd %t
+; RUN: mkdir temp
+; RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-df-input-lowpc-ranges-main.s \
+; RUN: -split-dwarf-file=main.dwo -o main.o
+; RUN: %clang %cflags -gdwarf-5 -gsplit-dwarf=split main.o -o main.exe
+; RUN: cd temp
+; RUN: llvm-bolt ../main.exe -o ../main.exe.bolt --update-debug-sections -v 1 --comp-dir-override=%t
+; RUN: cd ..
+; RUN: ls -lat | FileCheck %s -check-prefix=BOLT-CHECK
+
+;; Tests that BOLT processes .dwo files with --comp-dir-override.
+
+; BOLT-CHECK: main.dwo.dwo


### PR DESCRIPTION
Added an --comp-dir-override option that overrides DW_AT_comp_dir in the unit die. This allows for llvm-bolt to be invoked from any category and still find .dwo files.