### PR TITLE
[analyzer] Unbreak [[clang::suppress]] on checkers without decl-with-issue.

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
@@ -28,7 +28,7 @@ class PathDiagnosticLocation;
 
 class BugSuppression {
 public:
-  BugSuppression(ASTContext &ACtx): ACtx(ACtx) {}
+  BugSuppression(ASTContext &ACtx) : ACtx(ACtx) {}
 
   using DiagnosticIdentifierList = llvm::ArrayRef<llvm::StringRef>;
 

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
@@ -47,9 +47,9 @@ private:
   using CachedRanges =
       llvm::SmallVector<SourceRange, EXPECTED_NUMBER_OF_SUPPRESSIONS>;
 
-  llvm::DenseMap<const Decl *, CachedRanges> CachedSuppressionLocations{};
+  llvm::DenseMap<const Decl *, CachedRanges> CachedSuppressionLocations;
 
-  ASTContext &ACtx;
+  const ASTContext &ACtx;
 };
 
 } // end namespace ento

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
@@ -28,7 +28,7 @@ class PathDiagnosticLocation;
 
 class BugSuppression {
 public:
-  BugSuppression(ASTContext &ACtx) : ACtx(ACtx) {}
+  explicit BugSuppression(const ASTContext &ACtx) : ACtx(ACtx) {}
 
   using DiagnosticIdentifierList = llvm::ArrayRef<llvm::StringRef>;
 

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugSuppression.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 namespace clang {
+class ASTContext;
 class Decl;
 
 namespace ento {
@@ -27,6 +28,8 @@ class PathDiagnosticLocation;
 
 class BugSuppression {
 public:
+  BugSuppression(ASTContext &ACtx): ACtx(ACtx) {}
+
   using DiagnosticIdentifierList = llvm::ArrayRef<llvm::StringRef>;
 
   /// Return true if the given bug report was explicitly suppressed by the user.
@@ -44,7 +47,9 @@ private:
   using CachedRanges =
       llvm::SmallVector<SourceRange, EXPECTED_NUMBER_OF_SUPPRESSIONS>;
 
-  llvm::DenseMap<const Decl *, CachedRanges> CachedSuppressionLocations;
+  llvm::DenseMap<const Decl *, CachedRanges> CachedSuppressionLocations{};
+
+  ASTContext &ACtx;
 };
 
 } // end namespace ento

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2467,8 +2467,8 @@ ProgramStateManager &PathSensitiveBugReporter::getStateManager() const {
   return Eng.getStateManager();
 }
 
-BugReporter::BugReporter(BugReporterData &d)
-    : D(d), UserSuppressions(d.getASTContext()) {}
+BugReporter::BugReporter(BugReporterData &D)
+    : D(D), UserSuppressions(D.getASTContext()) {}
 
 BugReporter::~BugReporter() {
   // Make sure reports are flushed.

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2467,7 +2467,9 @@ ProgramStateManager &PathSensitiveBugReporter::getStateManager() const {
   return Eng.getStateManager();
 }
 
-BugReporter::BugReporter(BugReporterData &d) : D(d) {}
+BugReporter::BugReporter(BugReporterData &d)
+    : D(d), UserSuppressions(d.getASTContext()) {}
+
 BugReporter::~BugReporter() {
   // Make sure reports are flushed.
   assert(StrBugTypes.empty() &&

--- a/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
@@ -138,8 +138,16 @@ bool BugSuppression::isSuppressed(const BugReport &R) {
 bool BugSuppression::isSuppressed(const PathDiagnosticLocation &Location,
                                   const Decl *DeclWithIssue,
                                   DiagnosticIdentifierList Hashtags) {
-  if (!Location.isValid() || DeclWithIssue == nullptr)
+  if (!Location.isValid())
     return false;
+
+  if (!DeclWithIssue) {
+    // FIXME: This defeats the purpose of passing DeclWithIssue to begin with.
+    // If this branch is ever hit, we're re-doing all the work we've already
+    // done as well as perform a lot of work we'll never need.
+    // Gladly, none of our on-by-default checkers currently need it.
+    DeclWithIssue = ACtx.getTranslationUnitDecl();
+  }
 
   // While some warnings are attached to AST nodes (mostly path-sensitive
   // checks), others are simply associated with a plain source location

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -10,6 +10,12 @@ namespace simple {
     consume_refcntbl(provide());
     // expected-warning@-1{{Call argument is uncounted and unsafe}}
   }
+
+  // Test that the checker works with [[clang::suppress]].
+  void foo_suppressed() {
+    [[clang::suppress]]
+    consume_refcntbl(provide()); // no-warning
+  }
 }
 
 namespace multi_arg {

--- a/clang/test/Analysis/copypaste/suspicious-clones.cpp
+++ b/clang/test/Analysis/copypaste/suspicious-clones.cpp
@@ -21,6 +21,30 @@ int maxClone(int x, int y, int z) {
   return z; // expected-warning{{Potential copy-paste error; did you really mean to use 'z' here?}}
 }
 
+// Test that the checker works with [[clang::suppress]].
+int max_suppressed(int a, int b) {
+  log();
+  if (a > b)
+    return a;
+
+  // This [[clang::suppress]] doesn't suppress anything but we need it here
+  // because otherwise the other function won't count as a perfect clone.
+  // FIXME: The checker should probably skip the attribute entirely
+  // when detecting clones. Otherwise warnings will still get suppressed,
+  // but for a completely wrong reason.
+  [[clang::suppress]]
+  return b; // no-note
+}
+
+int maxClone_suppressed(int x, int y, int z) {
+  log();
+  if (x > y)
+    return x;
+  [[clang::suppress]]
+  return z; // no-warning
+}
+
+
 // Tests finding a suspicious clone that references global variables.
 
 struct mutex {


### PR DESCRIPTION
There are currently a few checkers that don't fill in the bug report's "decl-with-issue" field (typically a function in which the bug is found).

The new attribute `[[clang::suppress]]` uses decl-with-issue to reduce the size of the suppression source range map so that it didn't need to do that for the entire translation unit.

I'm already seeing a few problems with this approach so I'll probably redesign it in some point as it looks like a premature optimization. Not only checkers shouldn't be required to pass decl-with-issue (consider clang-tidy checkers that never had such notion), but also it's not necessarily uniquely determined (consider leak suppressions at allocation site).

For now I'm adding a simple stop-gap solution that falls back to building the suppression map for the entire TU whenever decl-with-issue isn't specified. Which won't happen in the default setup because luckily all default checkers do provide decl-with-issue.