### PR TITLE
[CodeGen] Remove MachinePassKey

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -37,20 +37,13 @@ class MachineFunction;
 
 extern template class AnalysisManager<MachineFunction>;
 
-/// Like \c AnalysisKey, but only for machine passes.
-struct alignas(8) MachinePassKey {};
-
 /// A CRTP mix-in that provides informational APIs needed for machine passes.
 ///
 /// This provides some boilerplate for types that are machine passes. It
 /// automatically mixes in \c PassInfoMixin.
 template <typename DerivedT>
 struct MachinePassInfoMixin : public PassInfoMixin<DerivedT> {
-  static MachinePassKey *ID() {
-    static_assert(std::is_base_of<MachinePassInfoMixin, DerivedT>::value,
-                  "Must pass the derived type as the template argument!");
-    return &DerivedT::Key;
-  }
+  // TODO: Add MachineFunctionProperties support.
 };
 
 /// An AnalysisManager<MachineFunction> that also exposes IR analysis results.

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -94,7 +94,6 @@ namespace llvm {
                           MachineFunctionAnalysisManager &) {                  \
       llvm_unreachable("this api is to make new PM api happy");                \
     }                                                                          \
-    static MachinePassKey Key;                                                 \
   };
 #define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)              \
   struct PASS_NAME : public MachinePassInfoMixin<PASS_NAME> {                  \
@@ -103,7 +102,6 @@ namespace llvm {
                           MachineFunctionAnalysisManager &) {                  \
       return PreservedAnalyses::all();                                         \
     }                                                                          \
-    static MachinePassKey Key;                                                 \
   };
 #define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
   struct PASS_NAME : public AnalysisInfoMixin<PASS_NAME> {                     \
@@ -164,8 +162,6 @@ public:
   }
 
 protected:
-  template <typename PassT> using has_key_t = decltype(PassT::Key);
-
   template <typename PassT>
   using is_module_pass_t = decltype(std::declval<PassT &>().run(
       std::declval<Module &>(), std::declval<ModuleAnalysisManager &>()));
@@ -225,10 +221,6 @@ protected:
         : PM(PM), PB(PB) {}
 
     template <typename PassT> void operator()(PassT &&Pass) {
-      static_assert(
-          is_detected<has_key_t, PassT>::value,
-          "Machine function pass must define a static member variable `Key`.");
-
       if (!PB.runBeforeAdding(PassT::name()))
         return;
 
@@ -238,10 +230,10 @@ protected:
         C(PassT::name());
     }
 
-    template <typename PassT> void insertPass(MachinePassKey *ID, PassT Pass) {
+    template <typename PassT> void insertPass(StringRef PassName, PassT Pass) {
       PB.AfterCallbacks.emplace_back(
-          [this, ID, Pass = std::move(Pass)](MachinePassKey *PassID) {
-            if (PassID == ID)
+          [this, PassName, Pass = std::move(Pass)](StringRef Name) {
+            if (PassName == Name)
               this->PM.addPass(std::move(Pass));
           });
     }

--- a/llvm/lib/Passes/CodeGenPassBuilder.cpp
+++ b/llvm/lib/Passes/CodeGenPassBuilder.cpp
@@ -16,11 +16,6 @@
 using namespace llvm;
 
 namespace llvm {
-#define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  MachinePassKey PASS_NAME::Key;
-#include "llvm/Passes/MachinePassRegistry.def"
-#define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)              \
-  MachinePassKey PASS_NAME::Key;
 #define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
   AnalysisKey PASS_NAME::Key;
 #include "llvm/Passes/MachinePassRegistry.def"

--- a/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
+++ b/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
@@ -248,7 +248,6 @@ public:
     }
 
   public:
-    static MachinePassKey Key;
     PreservedAnalyses run(MachineFunction &IR,
                           MachineFunctionAnalysisManager::Base &AM) {
       return Handle->run(IR, AM);
@@ -278,9 +277,6 @@ struct MockAnalysisHandle : public MockAnalysisHandleBase<MockAnalysisHandle> {
 
   MockAnalysisHandle() { setDefaults(); }
 };
-
-template <typename DerivedT>
-MachinePassKey MockPassHandleBase<DerivedT>::Pass::Key;
 
 template <typename DerivedT>
 AnalysisKey MockAnalysisHandleBase<DerivedT>::Analysis::Key;


### PR DESCRIPTION
We now use PassT::name to distinguish Passes.