### PR TITLE
[MemProf][NFC] Rename DefaultShadowGranularity to DefaultMemGranulari…

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -59,7 +59,7 @@ extern cl::opt<bool> NoPGOWarnMismatchComdatWeak;
 constexpr int LLVM_MEM_PROFILER_VERSION = 1;
 
 // Size of memory mapped to a single shadow location.
-constexpr uint64_t DefaultShadowGranularity = 64;
+constexpr uint64_t DefaultMemGranularity = 64;
 
 // Scale from granularity down to shadow size.
 constexpr uint64_t DefaultShadowScale = 3;
@@ -120,7 +120,7 @@ static cl::opt<int> ClMappingScale("memprof-mapping-scale",
 static cl::opt<int>
     ClMappingGranularity("memprof-mapping-granularity",
                          cl::desc("granularity of memprof shadow mapping"),
-                         cl::Hidden, cl::init(DefaultShadowGranularity));
+                         cl::Hidden, cl::init(DefaultMemGranularity));
 
 static cl::opt<bool> ClStack("memprof-instrument-stack",
                              cl::desc("Instrument scalar stack variables"),


### PR DESCRIPTION
…ty in instrumentation code, be consistent with runtime

In runtime code, the size of memory block mapped to a single shadow location is called MEM_GRANULARITY.
In instrumentation code, the size of memory block mapped to a single shadow location is called DefaultShadowGranularity.
Actually, the SHADOW_GRANULARITY is 8 (1 << SHADOW_SCALE), and the MEM_GRANULARITY is 64.
The wording of DefaultShadowGranularity in instrumentation code is a bit misleading, this patch renames DefaultShadowGranularity to DefaultMemGranularity, be consistent with runtime.