### PR TITLE
[MemProf] Add missing header to list of installed headers.

### DIFF
--- a/compiler-rt/include/CMakeLists.txt
+++ b/compiler-rt/include/CMakeLists.txt
@@ -25,6 +25,12 @@ if (COMPILER_RT_BUILD_MEMPROF)
     sanitizer/memprof_interface.h
     profile/MemProfData.inc
     )
+  if (NOT COMPILER_RT_BUILD_SANITIZERS)
+    set(MEMPROF_HEADERS
+      sanitizer/allocator_interface.h
+      sanitizer/common_interface_defs.h
+      )
+  endif()
 endif(COMPILER_RT_BUILD_MEMPROF)
 
 if (COMPILER_RT_BUILD_XRAY)
@@ -90,6 +96,12 @@ if (COMPILER_RT_BUILD_MEMPROF)
     COMPONENT compiler-rt-headers
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     DESTINATION ${COMPILER_RT_INSTALL_INCLUDE_DIR}/sanitizer)
+  if (NOT COMPILER_RT_BUILD_SANITIZERS)
+    install(FILES sanitizer/allocator_interface.h sanitizer/common_interface_defs.h
+      COMPONENT compiler-rt-headers
+      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+      DESTINATION ${COMPILER_RT_INSTALL_INCLUDE_DIR}/sanitizer)
+  endif()
 endif(COMPILER_RT_BUILD_MEMPROF)
 # Install xray headers.
 install(FILES ${XRAY_HEADERS}


### PR DESCRIPTION
There were buildbot failures when running memprof tests: 
Failed Tests (12):
  MemProfiler-x86_64-linux :: TestCases/interface_test.cpp
  MemProfiler-x86_64-linux :: TestCases/log_path_test.cpp
  MemProfiler-x86_64-linux :: TestCases/memprof_merge_mib.cpp
  MemProfiler-x86_64-linux :: TestCases/memprof_profile_dump.cpp
  MemProfiler-x86_64-linux :: TestCases/profile_reset.cpp
  MemProfiler-x86_64-linux :: TestCases/unaligned_loads_and_stores.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/interface_test.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/log_path_test.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/memprof_merge_mib.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/memprof_profile_dump.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/profile_reset.cpp
  MemProfiler-x86_64-linux-dynamic :: TestCases/unaligned_loads_and_stores.cpp

See
- https://lab.llvm.org/buildbot/#/builders/258/builds/8852
- https://lab.llvm.org/buildbot/#/builders/258/builds/12876

I suspect the failure is because when build with
-DLLVM_ENABLE_RUNTIMES=compiler-rt -DCOMPILER_RT_BUILD_SANITIZERS=OFF,
the headers sanitizer/allocator_interface.h and sanitizer/common_interface_defs.h
are not copied to the build tree, and not installed.
But in the failed memprof tests,
sanitizer/allocator_interface.h or sanitizer/memprof_interface.h is included.

This patch adds sanitizer/allocator_interface.h and sanitizer/memprof_interface.h to memprof headers if COMPILER_RT_BUILD_SANITIZERS is false.