### PR TITLE
[cmake] Enable color diagnostics

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,6 +1,7 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 
 cmake_minimum_required(VERSION 3.20.0)
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 set(LLVM_COMMON_CMAKE_UTILS ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 include(${LLVM_COMMON_CMAKE_UTILS}/Modules/CMakePolicy.cmake


### PR DESCRIPTION
Apparently _this_ is the way to do this now (additionally to passing `-fcolor-diagnosics`?).

See https://cmake.org/cmake/help/latest/envvar/CMAKE_COLOR_DIAGNOSTICS.html.

Result:
![Screenshot from 2024-01-25 08-59-24](https://github.com/llvm/llvm-project/assets/49720664/73a67ec8-7349-4d90-a36d-f9810eef3f7b)

Nice. Colors!