### PR TITLE
[mlir][ArmSME] Refine the `EnableArmStreaming` pass

### DIFF
--- a/mlir/include/mlir/Dialect/ArmSME/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/ArmSME/Transforms/Passes.td
@@ -101,10 +101,9 @@ def EnableArmStreaming
                             "The function uses ZA state. The ZA state may "
                             "be used for input and/or output.")
            )}]>,
-    Option<"onlyIfRequiredByOps", "only-if-required-by-ops", "bool",
+    Option<"enableZAConservatively", "enable-za-conservatively", "bool",
            /*default=*/"false",
-           "Only apply the selected streaming/ZA modes if the function "
-           " contains ops that require them.">
+           "Enable ZA iff the function contains ops that require it.">
   ];
   let dependentDialects = ["func::FuncDialect"];
 }

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transfer-read-2d.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transfer-read-2d.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -convert-vector-to-arm-sme -convert-arm-sme-to-scf -allocate-arm-sme-tiles \
-// DEFINE:   -enable-arm-streaming="streaming-mode=streaming-locally za-mode=new-za only-if-required-by-ops" \
+// DEFINE:   -enable-arm-streaming="streaming-mode=streaming-locally za-mode=new-za enable-za-conservatively" \
 // DEFINE:   -convert-arm-sme-to-llvm -cse -canonicalize \
 // DEFINE:   -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transfer-write-2d.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transfer-write-2d.mlir
@@ -2,7 +2,7 @@
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -convert-vector-to-arm-sme -convert-arith-to-arm-sme \
 // DEFINE:   -convert-arm-sme-to-scf -allocate-arm-sme-tiles \
-// DEFINE:   -enable-arm-streaming="streaming-mode=streaming-locally za-mode=new-za only-if-required-by-ops" \
+// DEFINE:   -enable-arm-streaming="streaming-mode=streaming-locally za-mode=new-za enable-za-conservatively" \
 // DEFINE:   -convert-arm-sme-to-llvm -cse -canonicalize \
 // DEFINE:   -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \


### PR DESCRIPTION
Updates the logic in `EnableArmStreaming` pass so that:
  * the streaming mode is always enabled whenever the pass is run -
    the `onlyIfRequiredByOps` flag no longer applies to the streaming
    mode and is effectively removed;
  * new flag, `enableZAConservatively`, controls whether to enable ZA
    unconditionally based on the `zaMode` flag (default) or
    conditionally - only when SME ops are in present.

This change basically limits the previous behaviour to only apply to the
"ZA array" as opposed to the "streaming mode" + "ZA array". This is
required for cases where we do want to enable the streaming mode even
though there are no SME ops.
