### PR TITLE
[AMDGPU] Do not bother adding reserved registers to liveins

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -6890,11 +6890,9 @@ bool AMDGPULegalizerInfo::legalizeWaveID(MachineInstr &MI,
     return false;
   LLT S32 = LLT::scalar(32);
   Register DstReg = MI.getOperand(0).getReg();
-  Register TTMP8 =
-      getFunctionLiveInPhysReg(B.getMF(), B.getTII(), AMDGPU::TTMP8,
-                               AMDGPU::SReg_32RegClass, B.getDebugLoc(), S32);
   auto LSB = B.buildConstant(S32, 25);
   auto Width = B.buildConstant(S32, 5);
+  auto TTMP8 = B.buildCopy(S32, Register(AMDGPU::TTMP8));
   B.buildUbfx(DstReg, TTMP8, LSB, Width);
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -6890,9 +6890,9 @@ bool AMDGPULegalizerInfo::legalizeWaveID(MachineInstr &MI,
     return false;
   LLT S32 = LLT::scalar(32);
   Register DstReg = MI.getOperand(0).getReg();
+  auto TTMP8 = B.buildCopy(S32, Register(AMDGPU::TTMP8));
   auto LSB = B.buildConstant(S32, 25);
   auto Width = B.buildConstant(S32, 5);
-  auto TTMP8 = B.buildCopy(S32, Register(AMDGPU::TTMP8));
   B.buildUbfx(DstReg, TTMP8, LSB, Width);
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -7927,8 +7927,7 @@ SDValue SITargetLowering::lowerWaveID(SelectionDAG &DAG, SDValue Op) const {
     return {};
   SDLoc SL(Op);
   MVT VT = MVT::i32;
-  SDValue TTMP8 = CreateLiveInRegister(DAG, &AMDGPU::SReg_32RegClass,
-                                       AMDGPU::TTMP8, VT, SL);
+  SDValue TTMP8 = DAG.getCopyFromReg(DAG.getEntryNode(), SL, AMDGPU::TTMP8, VT);
   return DAG.getNode(AMDGPUISD::BFE_U32, SL, VT, TTMP8,
                      DAG.getConstant(25, SL, VT), DAG.getConstant(5, SL, VT));
 }


### PR DESCRIPTION
Tweak the implementation of llvm.amdgcn.wave.id to not add TTMP8 to the
function liveins.
