### PR TITLE
[analyzer] Avoid a crash in a debug printout function

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -3272,10 +3272,10 @@ void RangeConstraintManager::printValue(raw_ostream &Out, ProgramStateRef State,
   const RangeSet RS = getRange(State, Sym);
   if (RS.isEmpty()) {
     Out << "<empty rangeset>";
-  } else {
-    Out << RS.getBitWidth() << (RS.isUnsigned() ? "u:" : "s:");
-    RS.dump(Out);
+    return;
   }
+  Out << RS.getBitWidth() << (RS.isUnsigned() ? "u:" : "s:");
+  RS.dump(Out);
 }
 
 static std::string toString(const SymbolRef &Sym) {

--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -3270,8 +3270,12 @@ void RangeConstraintManager::printJson(raw_ostream &Out, ProgramStateRef State,
 void RangeConstraintManager::printValue(raw_ostream &Out, ProgramStateRef State,
                                         SymbolRef Sym) {
   const RangeSet RS = getRange(State, Sym);
-  Out << RS.getBitWidth() << (RS.isUnsigned() ? "u:" : "s:");
-  RS.dump(Out);
+  if (RS.isEmpty()) {
+    Out << "<empty rangeset>";
+  } else {
+    Out << RS.getBitWidth() << (RS.isUnsigned() ? "u:" : "s:");
+    RS.dump(Out);
+  }
 }
 
 static std::string toString(const SymbolRef &Sym) {


### PR DESCRIPTION
Previously the function `RangeConstraintManager::printValue()` crashed when it encountered an empty rangeset (because `RangeSet::getBitwidth()` and `RangeSet::isUnsigned()` assert that the rangeset is not empty). This commit adds a special case that avoids this behavior.

As `printValue()` is only used by the checker debug.ExprInspection (and during manual debugging), the impacts of this commit are very limited.