### PR TITLE
[clangd] Attempt to fix https://github.com/clangd/clangd/issues/1536

### DIFF
--- a/clang-tools-extra/clangd/test/fixits-codeaction-documentchanges.test
+++ b/clang-tools-extra/clangd/test/fixits-codeaction-documentchanges.test
@@ -87,6 +87,7 @@
 # CHECK-NEXT:          }
 # CHECK-NEXT:        ]
 # CHECK-NEXT:      },
+# CHECK-NEXT:      "isPreferred": true,
 # CHECK-NEXT:      "kind": "quickfix",
 # CHECK-NEXT:      "title": "place parentheses around the assignment to silence this warning"
 # CHECK-NEXT:    },
@@ -134,6 +135,7 @@
 # CHECK-NEXT:          }
 # CHECK-NEXT:        ]
 # CHECK-NEXT:      },
+# CHECK-NEXT:      "isPreferred": true,
 # CHECK-NEXT:      "kind": "quickfix",
 # CHECK-NEXT:      "title": "use '==' to turn this assignment into an equality comparison"
 # CHECK-NEXT:    }

--- a/clang-tools-extra/clangd/test/fixits-codeaction.test
+++ b/clang-tools-extra/clangd/test/fixits-codeaction.test
@@ -81,6 +81,7 @@
 # CHECK-NEXT:          ]
 # CHECK-NEXT:        }
 # CHECK-NEXT:      },
+# CHECK-NEXT:      "isPreferred": true,
 # CHECK-NEXT:      "kind": "quickfix",
 # CHECK-NEXT:      "title": "place parentheses around the assignment to silence this warning"
 # CHECK-NEXT:    },
@@ -122,6 +123,7 @@
 # CHECK-NEXT:          ]
 # CHECK-NEXT:        }
 # CHECK-NEXT:      },
+# CHECK-NEXT:      "isPreferred": true,
 # CHECK-NEXT:      "kind": "quickfix",
 # CHECK-NEXT:      "title": "use '==' to turn this assignment into an equality comparison"
 # CHECK-NEXT:    }


### PR DESCRIPTION
This PR attempts to fix [1536.](https://github.com/clangd/clangd/issues/1536). See in the unit tests, when all quick fixes are of the same `code`, `isPreferred` will be true. However, this doesn't seem to change the behavior in vscode:

![image](https://github.com/llvm/llvm-project/assets/49597791/1d8236c3-3e43-4260-b655-d33d6cac6e42)
