### PR TITLE
[llvm-objdump,SHT_LLVM_BB_ADDR_MAP,NFC] Use auto && instead of const auto & to allow moving from BBAddrMap objects.

### DIFF
--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1705,7 +1705,7 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
         reportWarning(toString(BBAddrMapsOrErr.takeError()), Obj.getFileName());
         return;
       }
-      for (const auto &[FunctionBBAddrMap, FunctionPGOAnalysis] :
+      for (auto &&[FunctionBBAddrMap, FunctionPGOAnalysis] :
            zip_equal(*std::move(BBAddrMapsOrErr), std::move(PGOAnalyses))) {
         uint64_t Addr = FunctionBBAddrMap.Addr;
         AddrToBBAddrMap.emplace(Addr, std::move(FunctionBBAddrMap));


### PR DESCRIPTION
std::move on `const auto &` references is essentially a noop. Changing to `auto &&` to actually allow moving.