### PR TITLE
[NVPTX] improve identifier renaming for PTX

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAssignValidGlobalNames.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAssignValidGlobalNames.cpp
@@ -74,6 +74,8 @@ std::string NVPTXAssignValidGlobalNames::cleanUpName(StringRef Name) {
   std::string ValidName;
   raw_string_ostream ValidNameStream(ValidName);
   for (char C : Name) {
+    // While PTX also allows '%' at the start of identifiers, LLVM will throw a
+    // fatal error for '%' in symbol names in MCSymbol::print. Exclude for now.
     if (isAlnum(C) || C == '_' || C == '$') {
       ValidNameStream << C;
     } else {

--- a/llvm/lib/Target/NVPTX/NVPTXAssignValidGlobalNames.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAssignValidGlobalNames.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "NVPTX.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -73,10 +74,10 @@ std::string NVPTXAssignValidGlobalNames::cleanUpName(StringRef Name) {
   std::string ValidName;
   raw_string_ostream ValidNameStream(ValidName);
   for (char C : Name) {
-    if (C == '.' || C == '@' || C == '<' || C == '>') {
-      ValidNameStream << "_$_";
-    } else {
+    if (isAlnum(C) || C == '_' || C == '$') {
       ValidNameStream << C;
+    } else {
+      ValidNameStream << "_$_";
     }
   }
 

--- a/llvm/test/CodeGen/NVPTX/symbol-naming.ll
+++ b/llvm/test/CodeGen/NVPTX/symbol-naming.ll
@@ -8,11 +8,13 @@
 
 ; CHECK-NOT: .str
 ; CHECK-NOT: <str>
+; CHECK-NOT: another-str
 ; CHECK-NOT: .function.
 
 ; CHECK-DAG: _$_str
 ; CHECK-DAG: _$_str_$_
 ; CHECK-DAG: _$_str1
+; CHECK-DAG: another_$_str
 
 ; CHECK-DAG: _$_function_$_
 ; CHECK-DAG: _$_function_$_2
@@ -24,6 +26,7 @@ target triple = "nvptx64-unknown-unknown"
 @.str = private unnamed_addr constant [13 x i8] c"%d %f %c %d\0A\00", align 1
 @"<str>" = private unnamed_addr constant [13 x i8] c"%d %f %c %d\0A\00", align 1
 @_$_str = private unnamed_addr constant [13 x i8] c"%d %f %c %d\0A\00", align 1
+@another-str = private unnamed_addr constant [13 x i8] c"%d %f %c %d\0A\00", align 1
 
 
 ; Function Attrs: nounwind
@@ -38,7 +41,7 @@ entry:
 define internal void @_$_function_$_() {
 entry:
   %call = call i32 (ptr, ...) @printf(ptr @_$_str)
-  %call2 = call i32 (ptr, ...) @printf(ptr @"<str>")
+  %call2 = call i32 (ptr, ...) @printf(ptr @another-str)
   ret void
 }
 


### PR DESCRIPTION
Update `NVPTXAssignValidGlobalNames` to convert all characters which are illegal in PTX identifiers to `_$_`. ([PTX ISA: 4.4 Identifiers](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#identifiers)).