### PR TITLE
[TableGen] Fix computeRegUnitLaneMasks for ad hoc aliasing

### DIFF
--- a/llvm/utils/TableGen/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/CodeGenRegisters.cpp
@@ -2144,7 +2144,7 @@ void CodeGenRegBank::computeRegUnitLaneMasks() {
     // Create an initial lane mask for all register units.
     const auto &RegUnits = Register.getRegUnits();
     CodeGenRegister::RegUnitLaneMaskList RegUnitLaneMasks(
-        RegUnits.count(), LaneBitmask::getAll());
+        RegUnits.count(), LaneBitmask::getNone());
     // Iterate through SubRegisters.
     typedef CodeGenRegister::SubRegMap SubRegMap;
     const SubRegMap &SubRegs = Register.getSubRegs();
@@ -2163,7 +2163,7 @@ void CodeGenRegBank::computeRegUnitLaneMasks() {
         unsigned u = 0;
         for (unsigned RU : RegUnits) {
           if (SUI == RU) {
-            RegUnitLaneMasks[u] &= LaneMask;
+            RegUnitLaneMasks[u] |= LaneMask;
             assert(!Found);
             Found = true;
           }
@@ -2172,6 +2172,10 @@ void CodeGenRegBank::computeRegUnitLaneMasks() {
         (void)Found;
         assert(Found);
       }
+    }
+    for (auto &Mask : RegUnitLaneMasks) {
+      if (Mask.none())
+        Mask = LaneBitmask::getAll();
     }
     Register.setRegUnitLaneMasks(RegUnitLaneMasks);
   }


### PR DESCRIPTION
With ad hoc aliasing (using the Aliases field in register definitions)
we can have subregisters with disjoint lane masks that nevertheless
share a regunit. In this case we need to take the union of their
lane masks, not the intersection.

This was inadvertently broken by https://reviews.llvm.org/D157864

Fixes #78942