### PR TITLE
[flang][runtime] Fix integer overflow check for FORMATs

### DIFF
--- a/flang/runtime/format-implementation.h
+++ b/flang/runtime/format-implementation.h
@@ -85,8 +85,9 @@ int FormatControl<CONTEXT>::GetIntField(
     ch = PeekNext();
   }
   while (ch >= '0' && ch <= '9') {
-    if (result >
-        std::numeric_limits<int>::max() / 10 - (static_cast<int>(ch) - '0')) {
+    constexpr int tenth{std::numeric_limits<int>::max() / 10};
+    if (result > tenth ||
+        ch - '0' > std::numeric_limits<int>::max() - 10 * result) {
       handler.SignalError(
           IostatErrorInFormat, "FORMAT integer field out of range");
       if (hadError) {


### PR DESCRIPTION
The code that parses repeat counts, field widths, &c. from FORMAT strings has an incorrect overflow check, so the maximum integer value is not accepted.  Fix.

Fixes https://github.com/llvm/llvm-project/issues/79255.