### PR TITLE
[CodeGen] Add standard traits for LiveInterval::SingleLinkedListIterator

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveInterval.h
+++ b/llvm/include/llvm/CodeGen/LiveInterval.h
@@ -731,6 +731,12 @@ namespace llvm {
       T *P;
 
     public:
+      using difference_type = ptrdiff_t;
+      using value_type = T;
+      using pointer = T *;
+      using reference = T &;
+      using iterator_category = std::forward_iterator_tag;
+
       SingleLinkedListIterator(T *P) : P(P) {}
 
       SingleLinkedListIterator<T> &operator++() {


### PR DESCRIPTION
For example this will allow LiveInterval::subranges() to be used in
any_of/all_of/none_of.
