### PR TITLE
[workflows] Drop the intermediate /branch comment for release workflow

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     if: >-
       (github.repository == 'llvm/llvm-project') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
@@ -56,38 +57,6 @@ jobs:
           ./llvm/utils/git/github-automation.py --token ${{ github.token }} setup-llvmbot-git
 
       - name: Backport Commits
-        run: |
-          printf "%s" "$COMMENT_BODY" |
-          ./llvm/utils/git/github-automation.py \
-          --repo "$GITHUB_REPOSITORY" \
-          --token ${{ github.token }} \
-          release-workflow \
-          --branch-repo-token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
-          --issue-number ${{ github.event.issue.number }} \
-          auto
-
-  create-pull-request:
-    name: Create Pull Request
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    if: >-
-      (github.repository == 'llvm/llvm-project') &&
-      !startswith(github.event.comment.body, '<!--IGNORE-->') &&
-      contains(github.event.comment.body, '/branch ')
-
-    steps:
-      - name: Fetch LLVM sources
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Environment
-        run: |
-          pip install -r ./llvm/utils/git/requirements.txt
-
-      - name: Create Pull Request
         run: |
           printf "%s" "$COMMENT_BODY" |
           ./llvm/utils/git/github-automation.py \

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -374,8 +374,6 @@ apply cleanly, then a comment with a link to the failing job will be added to
 the issue.  If the commit(s) do apply cleanly, then a pull request will
 be created with the specified commits.
 
-::
-
 If a commit you want to backport does not apply cleanly, you may resolve
 the conflicts locally and then create a pull request against the release
 branch.  Just make sure to add the release milestone to the pull request.

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -360,8 +360,8 @@ Releases
 Backporting Fixes to the Release Branches
 -----------------------------------------
 You can use special comments on issues to make backport requests for the
-release branches.  This is done by making a comment containing one of the
-following commands on any issue that has been added to one of the "X.Y.Z Release"
+release branches.  This is done by making a comment containing the following
+command on any issue that has been added to one of the "X.Y.Z Release"
 milestones.
 
 ::
@@ -376,8 +376,6 @@ be created with the specified commits.
 
 ::
 
-  /branch <owner>/<repo>/<branch>
-
-This command will create a pull request against the latest release branch using
-the <branch> from the <owner>/<repo> repository.  <branch> cannot contain any
-forward slash '/' characters.
+If a commit you want to backport does not apply cleanly, you may resolve
+the conflicts locally and then create a pull request against the release
+branch.  Just make sure to add the release milestone to the pull request.

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -309,6 +309,10 @@ class ReleaseWorkflow:
         return self._issue_number
 
     @property
+    def branch_repo_owner(self) -> str:
+        return self.branch_repo_name.split('/')[0]
+
+    @property
     def branch_repo_name(self) -> str:
         return self._branch_repo_name
 
@@ -394,7 +398,7 @@ class ReleaseWorkflow:
         action_url = self.action_url
         if action_url:
             message += action_url + "\n\n"
-        message += "Please manually backport the fix and push it to your github fork.  Once this is done, please add a comment like this:\n\n`/branch <user>/<repo>/<branch>`"
+        message += "Please manually backport the fix and push it to your github fork.  Once this is done, please create a [pull request](https://github.com/llvm/llvm-project/compare)"
         issue = self.issue
         comment = issue.create_comment(message)
         issue.add_to_labels(self.CHERRY_PICK_FAILED_LABEL)
@@ -472,9 +476,8 @@ class ReleaseWorkflow:
         print("Pushing to {} {}".format(push_url, branch_name))
         local_repo.git.push(push_url, "HEAD:{}".format(branch_name), force=True)
 
-        self.issue_notify_branch()
         self.issue_remove_cherry_pick_failed_label()
-        return True
+        return self.create_pull_request(self.branch_repo_owner, self.repo_name, branch_name)
 
     def check_if_pull_request_exists(
         self, repo: github.Repository.Repository, head: str
@@ -551,14 +554,6 @@ class ReleaseWorkflow:
                 arg_list = args.split()
                 commits = list(map(lambda a: extract_commit_hash(a), arg_list))
                 return self.create_branch(commits)
-
-            if command == "branch":
-                m = re.match("([^/]+)/([^/]+)/(.+)", args)
-                if m:
-                    owner = m.group(1)
-                    repo = m.group(2)
-                    branch = m.group(3)
-                    return self.create_pull_request(owner, repo, branch)
 
         print("Do not understand input:")
         print(sys.stdin.readlines())

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -310,7 +310,7 @@ class ReleaseWorkflow:
 
     @property
     def branch_repo_owner(self) -> str:
-        return self.branch_repo_name.split('/')[0]
+        return self.branch_repo_name.split("/")[0]
 
     @property
     def branch_repo_name(self) -> str:
@@ -477,7 +477,9 @@ class ReleaseWorkflow:
         local_repo.git.push(push_url, "HEAD:{}".format(branch_name), force=True)
 
         self.issue_remove_cherry_pick_failed_label()
-        return self.create_pull_request(self.branch_repo_owner, self.repo_name, branch_name)
+        return self.create_pull_request(
+            self.branch_repo_owner, self.repo_name, branch_name
+        )
 
     def check_if_pull_request_exists(
         self, repo: github.Repository.Repository, head: str


### PR DESCRIPTION
We used to support a /branch comment to specify a branch with commits to backport to the release branch.  However, now that we can use pull requests this is not needed.

This also simplifies the process, because now the cherry-pick job can create the pull request directly instead of having it split across two separate jobs.