### PR TITLE
[libc] Fix type warning on gcc in float to str

### DIFF
--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -503,7 +503,7 @@ public:
 
       cpp::UInt<MID_INT_SIZE> val;
 
-      const uint32_t pos_exp = idx * IDX_SIZE;
+      const uint32_t pos_exp = static_cast<uint32_t>(idx * IDX_SIZE);
 
 #if defined(LIBC_COPT_FLOAT_TO_STR_USE_DYADIC_FLOAT)
       // ----------------------- DYADIC FLOAT CALC MODE ------------------------


### PR DESCRIPTION
Minor cast warning that was missed in previous patch. Fixed with
explicit cast.

