### PR TITLE
Make two texts static in `ReplayInlineAdvisor`

### DIFF
--- a/llvm/lib/Analysis/ReplayInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/ReplayInlineAdvisor.cpp
@@ -43,8 +43,8 @@ ReplayInlineAdvisor::ReplayInlineAdvisor(
   //   main:3:1.1;
   // We use the callsite string after `at callsite` to replay inlining.
   line_iterator LineIt(*BufferOrErr.get(), /*SkipBlanks=*/true);
-  const std::string PositiveRemark = "' inlined into '";
-  const std::string NegativeRemark = "' will not be inlined into '";
+  static const std::string PositiveRemark = "' inlined into '";
+  static const std::string NegativeRemark = "' will not be inlined into '";
 
   for (; !LineIt.is_at_eof(); ++LineIt) {
     StringRef Line = *LineIt;


### PR DESCRIPTION
Edit after merge: reason of failure below may be incorrect, based on https://github.com/llvm/llvm-project/pull/79522.

---
This commit makes two variables static.
That makes two buildbot tests pass with short string annotations.
I suspect that there may be use after end of life bug and it's fixed by this change, but it requires confirmation.

Short string annotations PR (reverted):
- https://github.com/llvm/llvm-project/pull/79049

Tests fixed with this PR:
```
  LLVM :: Transforms/Inline/cgscc-inline-replay.ll 
  LLVM :: Transforms/SampleProfile/inline-replay.ll
```
Buildbot output: https://lab.llvm.org/buildbot/#/builders/5/builds/40364/steps/9/logs/stdio

This PR does not resolve a problem with `Clang :: SemaCXX/builtins.cpp`, related PR is:
- https://github.com/llvm/llvm-project/pull/79522