### PR TITLE
[workflows] Use a custom token for creating backport PRs

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -61,7 +61,7 @@ jobs:
           printf "%s" "$COMMENT_BODY" |
           ./llvm/utils/git/github-automation.py \
           --repo "$GITHUB_REPOSITORY" \
-          --token ${{ github.token }} \
+          --token "${{ secrets.RELEASE_WORKFLOW_PR_CREATE }}" \
           release-workflow \
           --branch-repo-token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
           --issue-number ${{ github.event.issue.number }} \


### PR DESCRIPTION
The CI tests don't get triggered if a PR is created by the builtin github token, so we need to use a custom token when creating a PR.