### PR TITLE
[lldb][NFCI] Constrain EventDataBytes creation

### DIFF
--- a/lldb/include/lldb/Utility/Event.h
+++ b/lldb/include/lldb/Utility/Event.h
@@ -60,11 +60,7 @@ public:
   // Constructors
   EventDataBytes();
 
-  EventDataBytes(const char *cstr);
-
   EventDataBytes(llvm::StringRef str);
-
-  EventDataBytes(const void *src, size_t src_len);
 
   ~EventDataBytes() override;
 
@@ -76,12 +72,6 @@ public:
   const void *GetBytes() const;
 
   size_t GetByteSize() const;
-
-  void SetBytes(const void *src, size_t src_len);
-
-  void SwapBytes(std::string &new_bytes);
-
-  void SetBytesFromCString(const char *cstr);
 
   // Static functions
   static const EventDataBytes *GetEventDataFromEvent(const Event *event_ptr);

--- a/lldb/source/API/SBEvent.cpp
+++ b/lldb/source/API/SBEvent.cpp
@@ -24,7 +24,8 @@ using namespace lldb_private;
 SBEvent::SBEvent() { LLDB_INSTRUMENT_VA(this); }
 
 SBEvent::SBEvent(uint32_t event_type, const char *cstr, uint32_t cstr_len)
-    : m_event_sp(new Event(event_type, new EventDataBytes(cstr, cstr_len))),
+    : m_event_sp(new Event(
+          event_type, new EventDataBytes(llvm::StringRef(cstr, cstr_len)))),
       m_opaque_ptr(m_event_sp.get()) {
   LLDB_INSTRUMENT_VA(this, event_type, cstr, cstr_len);
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1089,7 +1089,8 @@ Status ProcessGDBRemote::DoAttachToProcessWithID(
       const int packet_len =
           ::snprintf(packet, sizeof(packet), "vAttach;%" PRIx64, attach_pid);
       SetID(attach_pid);
-      auto data_sp = std::make_shared<EventDataBytes>(packet, packet_len);
+      auto data_sp =
+          std::make_shared<EventDataBytes>(llvm::StringRef(packet, packet_len));
       m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
     } else
       SetExitStatus(-1, error.AsCString());
@@ -1127,8 +1128,7 @@ Status ProcessGDBRemote::DoAttachToProcessWithName(
                                endian::InlHostByteOrder(),
                                endian::InlHostByteOrder());
 
-      auto data_sp = std::make_shared<EventDataBytes>(packet.GetString().data(),
-                                                      packet.GetSize());
+      auto data_sp = std::make_shared<EventDataBytes>(packet.GetString());
       m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
 
     } else
@@ -1374,8 +1374,8 @@ Status ProcessGDBRemote::DoResume() {
         return error;
       }
 
-      auto data_sp = std::make_shared<EventDataBytes>(
-          continue_packet.GetString().data(), continue_packet.GetSize());
+      auto data_sp =
+          std::make_shared<EventDataBytes>(continue_packet.GetString());
       m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
 
       if (!listener_sp->GetEvent(event_sp, std::chrono::seconds(5))) {

--- a/lldb/source/Utility/Event.cpp
+++ b/lldb/source/Utility/Event.cpp
@@ -111,17 +111,7 @@ void EventData::Dump(Stream *s) const { s->PutCString("Generic Event Data"); }
 
 EventDataBytes::EventDataBytes() : m_bytes() {}
 
-EventDataBytes::EventDataBytes(const char *cstr) : m_bytes() {
-  SetBytesFromCString(cstr);
-}
-
-EventDataBytes::EventDataBytes(llvm::StringRef str) : m_bytes() {
-  SetBytes(str.data(), str.size());
-}
-
-EventDataBytes::EventDataBytes(const void *src, size_t src_len) : m_bytes() {
-  SetBytes(src, src_len);
-}
+EventDataBytes::EventDataBytes(llvm::StringRef str) : m_bytes(str.str()) {}
 
 EventDataBytes::~EventDataBytes() = default;
 
@@ -147,20 +137,6 @@ const void *EventDataBytes::GetBytes() const {
 
 size_t EventDataBytes::GetByteSize() const { return m_bytes.size(); }
 
-void EventDataBytes::SetBytes(const void *src, size_t src_len) {
-  if (src != nullptr && src_len > 0)
-    m_bytes.assign(static_cast<const char *>(src), src_len);
-  else
-    m_bytes.clear();
-}
-
-void EventDataBytes::SetBytesFromCString(const char *cstr) {
-  if (cstr != nullptr && cstr[0])
-    m_bytes.assign(cstr);
-  else
-    m_bytes.clear();
-}
-
 const void *EventDataBytes::GetBytesFromEvent(const Event *event_ptr) {
   const EventDataBytes *e = GetEventDataFromEvent(event_ptr);
   if (e != nullptr)
@@ -184,10 +160,6 @@ EventDataBytes::GetEventDataFromEvent(const Event *event_ptr) {
       return static_cast<const EventDataBytes *>(event_data);
   }
   return nullptr;
-}
-
-void EventDataBytes::SwapBytes(std::string &new_bytes) {
-  m_bytes.swap(new_bytes);
 }
 
 llvm::StringRef EventDataReceipt::GetFlavorString() {


### PR DESCRIPTION
There are 3 ways to create an EventDataBytes object: (const char *), (llvm::StringRef), and (const void *, size_t len). All of these cases can be handled under `llvm::StringRef`. Additionally, this allows us to remove the otherwise unused `SetBytes`, `SwapBytes`, and `SetBytesFromCString` methods.