### PR TITLE
[lldb][NFCI] Change BreakpointIDList::FindBreakpointID to BreakpointIDList::Contains

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointID.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointID.h
@@ -26,6 +26,10 @@ public:
 
   virtual ~BreakpointID();
 
+  bool operator==(BreakpointID rhs) const {
+    return m_break_id == rhs.m_break_id && m_location_id == rhs.m_location_id;
+  }
+
   lldb::break_id_t GetBreakpointID() const { return m_break_id; }
 
   lldb::break_id_t GetLocationID() const { return m_location_id; }

--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -42,8 +42,7 @@ public:
 
   bool AddBreakpointID(BreakpointID bp_id);
 
-  // TODO: This should take a const BreakpointID.
-  bool FindBreakpointID(BreakpointID &bp_id, size_t *position) const;
+  bool Contains(BreakpointID bp_id) const;
 
   // Returns a pair consisting of the beginning and end of a breakpoint
   // ID range expression.  If the input string is not a valid specification,

--- a/lldb/source/Breakpoint/BreakpointIDList.cpp
+++ b/lldb/source/Breakpoint/BreakpointIDList.cpp
@@ -15,6 +15,8 @@
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/StreamString.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -48,18 +50,8 @@ bool BreakpointIDList::AddBreakpointID(BreakpointID bp_id) {
                // return true.
 }
 
-bool BreakpointIDList::FindBreakpointID(BreakpointID &bp_id,
-                                        size_t *position) const {
-  for (size_t i = 0; i < m_breakpoint_ids.size(); ++i) {
-    BreakpointID tmp_id = m_breakpoint_ids[i];
-    if (tmp_id.GetBreakpointID() == bp_id.GetBreakpointID() &&
-        tmp_id.GetLocationID() == bp_id.GetLocationID()) {
-      *position = i;
-      return true;
-    }
-  }
-
-  return false;
+bool BreakpointIDList::Contains(BreakpointID bp_id) const {
+  return llvm::is_contained(m_breakpoint_ids, bp_id);
 }
 
 //  This function takes OLD_ARGS, which is usually the result of breaking the

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -1485,9 +1485,8 @@ protected:
       for (auto breakpoint_sp : breakpoints.Breakpoints()) {
         if (!breakpoint_sp->IsEnabled() && breakpoint_sp->AllowDelete()) {
           BreakpointID bp_id(breakpoint_sp->GetID());
-          size_t pos = 0;
-          if (!excluded_bp_ids.FindBreakpointID(bp_id, &pos))
-            valid_bp_ids.AddBreakpointID(breakpoint_sp->GetID());
+          if (!excluded_bp_ids.Contains(bp_id))
+            valid_bp_ids.AddBreakpointID(bp_id);
         }
       }
       if (valid_bp_ids.GetSize() == 0) {

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -646,9 +646,7 @@ protected:
           for (size_t loc_idx = 0; loc_idx < num_locations; loc_idx++) {
             BreakpointLocationSP loc_sp = bp_sp->GetLocationAtIndex(loc_idx);
             tmp_id.SetBreakpointLocationID(loc_idx);
-            size_t position = 0;
-            if (!with_locs.FindBreakpointID(tmp_id, &position)
-                && loc_sp->IsEnabled()) {
+            if (!with_locs.Contains(tmp_id) && loc_sp->IsEnabled()) {
               locs_disabled.push_back(tmp_id);
               loc_sp->SetEnabled(false);
             }


### PR DESCRIPTION
`FindBreakpointID` take a BreakpointID and a pointer to a size_t (so you can get position information). It returns a bool to indicate whether the id was found in the list or not.

There are 2 callers of this currently and neither one actually uses the position information, so I removed it. After that, I renamed it to Contains to more accurately reflect the intent. Additionally, I changed the argument type from a reference to a value (because BreakpointID is just a wrapper around 2 integers, copies are cheap).