### PR TITLE
Extend life of variables in `DiagComparison` in `ExprConstant`

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -13300,6 +13300,9 @@ EvaluateComparisonBinaryOperator(EvalInfo &Info, const BinaryOperator *E,
         // We should investigate why buildbots were failing with ASan short
         // string annotations turned on. Related PR:
         // https://github.com/llvm/llvm-project/pull/79049
+        // If making those variables static didn't fix the problem,
+        // please confirm that https://github.com/llvm/llvm-project/pull/79489
+        // fixed the real issue.
         LHS = LHSValue.toString(Info.Ctx, E->getLHS()->getType());
         RHS = RHSValue.toString(Info.Ctx, E->getRHS()->getType());
         Info.FFDiag(E, DiagID)


### PR DESCRIPTION
This commit makes two variables static extending their life span. This patch is designed to address the issue of buildbots failing when AddressSanitizer's (ASan) short string annotations are enabled. It's esentially same as:
- https://github.com/llvm/llvm-project/pull/79489

~~however, it's less likely to solve the real problem as those strings change (aren't `const`). I suspect that there may be use after end of life bug (in StringRef), but it requires confirmation. In that case, one alternative solution, which unfortunately results in memory leaks, is to always allocate new strings instead of overwriting existing (static) ones. This approach would prevent potential data corruption, but I don't suggest it in this PR.~~

This patch makes `Clang :: SemaCXX/builtins.cpp` test pass with short string annotations (ASan). With https://github.com/llvm/llvm-project/pull/79489 it fixes known problems with buildbots, while running with short string annotations. However, the potential issue still requires more investigation therefore FIXME comment is added in that patch.

Short string annotations PR (reverted):
- https://github.com/llvm/llvm-project/pull/79049

Buildbots (failure) output:
- https://lab.llvm.org/buildbot/#/builders/5/builds/40364/steps/9/logs/stdio

While buildbots should not fail with proposed changes, we still should investigate why buildbots were failing with ASan short string annotations turned on. StringRef objects (made from those strings) ~~can potentially change their contents unexpectedly or even (potentially) use of freed memory may happen. That interpretation is only my educated guess, I still didn't understand exactly why those buildbots are failing.~~

Edit: I crossed parts of original description which are no longer likely based on discussion below. Reasoning in https://github.com/llvm/llvm-project/pull/79489 could be wrong and may be related to the same underlying issue as here.