### PR TITLE
Restore lost nuance in DeveloperPolicy regarding input languages for test cases

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -209,7 +209,11 @@ features added.  Some tips for getting your testcase approved:
   directory. The appropriate sub-directory should be selected (see the
   :doc:`Testing Guide <TestingGuide>` for details).
 
-* Test cases should be written in :doc:`LLVM assembly language <LangRef>`.
+* Test cases should be written in the closest, most directly supported input
+  language for the component being tested. This is usually
+  :doc:`LLVM assembly language <LangRef>` but there are some exceptions such as
+  assembly for MC layer tests, or in some cases a choice is available such
+  LLVM assembly language or MIR for GlobalISel tests.
 
 * Test cases, especially for regressions, should be reduced as much as possible,
   by :doc:`bugpoint <Bugpoint>` or manually. It is unacceptable to place an


### PR DESCRIPTION
While re-reading the various policies for changes I've missed, I noticed that the policy on test cases had been rewritten to be a bit overly restrictive and not accurately reflect the test cases in LLVM today.

Back in 2019 (git: e0ddc731a4ad3, svn: 201619), some references to llvm-gcc were removed from the DeveloperPolicy. One of these removals removed some important nuance along with the example that referenced llvm-gcc. The original text was:
> * Test cases should be written in `LLVM assembly language <LangRef.html>`_ unless the feature or regression being 
> tested requires another language (e.g. the bug being fixed or feature being implemented is in the llvm-gcc C++ front-end, in which case it must be written in C++).

and this was reduced to:
> * Test cases should be written in :doc:`LLVM assembly language <LangRef>`. 

which is a bit too definite and restrictive.

This commit attempts to restore the original intent but with examples that exist in the current LLVM source.