### PR TITLE
[llvm] Set emulated-tls by default for x86_64-windows-gnu target

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -1030,7 +1030,7 @@ public:
   /// Note: Android API level 29 (10) introduced ELF TLS.
   bool hasDefaultEmulatedTLS() const {
     return (isAndroid() && isAndroidVersionLT(29)) || isOSOpenBSD() ||
-           isWindowsCygwinEnvironment() || isOHOSFamily();
+           isOSCygMing() || isOHOSFamily();
   }
 
   /// True if the target supports both general-dynamic and TLSDESC, and TLSDESC


### PR DESCRIPTION
GCC on Windows uses Emulated TLS by default.
msys2 is doing this patch too. We should just enable this upstream.
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-clang/0004-enable-emutls-for-mingw.patch