### PR TITLE
[Propeller] Make BBID containing information about MBB's size to detect ir drift

### DIFF
--- a/llvm/lib/CodeGen/BasicBlockSections.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSections.cpp
@@ -310,7 +310,14 @@ bool BasicBlockSections::runOnMachineFunction(MachineFunction &MF) {
             .getClusterInfoForFunction(MF.getName());
     if (!HasProfile)
       return false;
+    DenseSet<UniqueBBID> FuncUniqueBBID;
+    for (auto &MBB : MF) {
+      FuncUniqueBBID.insert(MBB.getBBID().value());
+    }
     for (auto &BBClusterInfo : ClusterInfo) {
+      if (!FuncUniqueBBID.count(BBClusterInfo.BBID)) {
+        return false;
+      }
       FuncClusterInfo.try_emplace(BBClusterInfo.BBID, BBClusterInfo);
     }
   }

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -468,7 +468,11 @@ MachineFunction::CreateMachineBasicBlock(const BasicBlock *BB,
   // blocks.
   if (Target.getBBSectionsType() == BasicBlockSection::Labels ||
       Target.getBBSectionsType() == BasicBlockSection::List)
-    MBB->setBBID(BBID.has_value() ? *BBID : UniqueBBID{NextBBID++, 0});
+    MBB->setBBID(BBID.has_value()
+                     ? *BBID
+                     : UniqueBBID{((NextBBID++ & 0x0000ffff) << 32) |
+                                      (MBB->size() & 0x0000ffff),
+                                  0});
   return MBB;
 }
 


### PR DESCRIPTION
Now Propeller only detect code drift when using pgo together. This patch aims to make BBID containing information about MBB's size to detect ir drift.