### PR TITLE
[ELF] Improve comment of InputSection::file and update getFile. NFC

### DIFF
--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -118,9 +118,9 @@ public:
 
   static bool classof(const SectionBase *s) { return s->kind() != Output; }
 
-  // The file which contains this section. Its dynamic type is always
-  // ObjFile<ELFT>, but in order to avoid ELFT, we use InputFile as
-  // its static type.
+  // The file which contains this section. Its dynamic type is usually
+  // ObjFile<ELFT>, but may be an InputFile of InternalKind (for a synthetic
+  // section).
   InputFile *file;
 
   // Input sections are part of an output section. Special sections
@@ -132,8 +132,9 @@ public:
   // Section index of the relocation section if exists.
   uint32_t relSecIdx = 0;
 
+  // Getter when the dynamic type is ObjFile<ELFT>.
   template <class ELFT> ObjFile<ELFT> *getFile() const {
-    return cast_or_null<ObjFile<ELFT>>(file);
+    return cast<ObjFile<ELFT>>(file);
   }
 
   // Used by --optimize-bb-jumps and RISC-V linker relaxation temporarily to


### PR DESCRIPTION
Clarify a comment after #78944.

All uses of `getFile()` assert `file` is non-null. `getFile` is not used with a
synthetic section. Replace `cast_or_null` with `cast`.
