### PR TITLE
[AArch64] Use add_and_or_is_add for CSINC

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2672,7 +2672,7 @@ defm CCMP : CondComparison<1, "ccmp", AArch64ccmp>;
 //===----------------------------------------------------------------------===//
 defm CSEL  : CondSelect<0, 0b00, "csel">;
 
-def inc : PatFrag<(ops node:$in), (add node:$in, 1)>;
+def inc : PatFrag<(ops node:$in), (add_and_or_is_add node:$in, 1)>;
 defm CSINC : CondSelectOp<0, 0b01, "csinc", inc>;
 defm CSINV : CondSelectOp<1, 0b00, "csinv", not>;
 defm CSNEG : CondSelectOp<1, 0b01, "csneg", ineg>;
@@ -2715,9 +2715,9 @@ def : Pat<(AArch64csel (i32 -1), GPR32:$fval, (i32 imm:$cc), NZCV),
 def : Pat<(AArch64csel (i64 -1), GPR64:$fval, (i32 imm:$cc), NZCV),
           (CSINVXr GPR64:$fval, XZR, (i32 (inv_cond_XFORM imm:$cc)))>;
 
-def : Pat<(add GPR32:$val, (AArch64csel (i32 0), (i32 1), (i32 imm:$cc), NZCV)),
+def : Pat<(add_and_or_is_add GPR32:$val, (AArch64csel (i32 0), (i32 1), (i32 imm:$cc), NZCV)),
           (CSINCWr GPR32:$val, GPR32:$val, (i32 imm:$cc))>;
-def : Pat<(add GPR64:$val, (zext (AArch64csel (i32 0), (i32 1), (i32 imm:$cc), NZCV))),
+def : Pat<(add_and_or_is_add GPR64:$val, (zext (AArch64csel (i32 0), (i32 1), (i32 imm:$cc), NZCV))),
           (CSINCXr GPR64:$val, GPR64:$val, (i32 imm:$cc))>;
 
 def : Pat<(or (topbitsallzero32:$val), (AArch64csel (i32 0), (i32 1), (i32 imm:$cc), NZCV)),

--- a/llvm/test/CodeGen/AArch64/arm64-csel.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-csel.ll
@@ -423,10 +423,9 @@ entry:
 define i32 @or(i32 %num, i32 %x) {
 ; CHECK-LABEL: or:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmp w1, #0
 ; CHECK-NEXT:    and w8, w0, #0xff00
-; CHECK-NEXT:    cset w9, ne
-; CHECK-NEXT:    orr w0, w8, w9
+; CHECK-NEXT:    cmp w1, #0
+; CHECK-NEXT:    cinc w0, w8, ne
 ; CHECK-NEXT:    ret
 entry:
   %and = and i32 %num, 65280
@@ -439,10 +438,9 @@ entry:
 define i64 @or64(i64 %num, i64 %x) {
 ; CHECK-LABEL: or64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmp x1, #0
 ; CHECK-NEXT:    and x8, x0, #0xff00
-; CHECK-NEXT:    cset w9, ne
-; CHECK-NEXT:    orr x0, x8, x9
+; CHECK-NEXT:    cmp x1, #0
+; CHECK-NEXT:    cinc x0, x8, ne
 ; CHECK-NEXT:    ret
 entry:
   %and = and i64 %num, 65280
@@ -457,8 +455,7 @@ define i32 @selor32(i32 %num, i32 %x) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    and w8, w0, #0xff00
 ; CHECK-NEXT:    cmp w1, #0
-; CHECK-NEXT:    orr w9, w8, #0x1
-; CHECK-NEXT:    csel w0, w9, w8, ne
+; CHECK-NEXT:    cinc w0, w8, ne
 ; CHECK-NEXT:    ret
 entry:
   %and = and i32 %num, 65280
@@ -474,8 +471,7 @@ define i64 @selor64(i64 %num, i64 %x) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    and x8, x0, #0xff00
 ; CHECK-NEXT:    cmp x1, #0
-; CHECK-NEXT:    orr x9, x8, #0x1
-; CHECK-NEXT:    csel x0, x9, x8, ne
+; CHECK-NEXT:    cinc x0, x8, ne
 ; CHECK-NEXT:    ret
 entry:
   %and = and i64 %num, 65280


### PR DESCRIPTION
Adds or add-like-or's of 1 can both be turned into csinc, which can help fold more instructions into a csinc.