### PR TITLE
[IR] Use SmallDenseSet (NFC)

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -1167,9 +1167,7 @@ void Instruction::copyMetadata(const Instruction &SrcInst,
   if (!SrcInst.hasMetadata())
     return;
 
-  DenseSet<unsigned> WLS;
-  for (unsigned M : WL)
-    WLS.insert(M);
+  SmallDenseSet<unsigned, 4> WLS(WL.begin(), WL.end());
 
   // Otherwise, enumerate and copy over metadata from the old instruction to the
   // new one.


### PR DESCRIPTION
The use of SmallDenseSet saves 0.39% of heap allocations during the
compilation of a large preprocessed file, namely X86ISelLowering.cpp,
for the X86 target.  During the experiment, WL.size() was 2 or less
99.9% of the time.  The inline size of 4 should accommodate up to 2
entries at the 3/4 occupancy rate.
