### PR TITLE
[MLGO] Add pytype test

### DIFF
--- a/llvm/utils/mlgo-utils/tests/lit.local.cfg
+++ b/llvm/utils/mlgo-utils/tests/lit.local.cfg
@@ -4,3 +4,11 @@ import sys
 # the entire project has been bumped to 3.8.
 if sys.version_info > (3,8):
     config.available_features.add("python-38")
+
+# TODO(boomanaiden154): Remove this flag once we enable type checking in the
+# precommit CI.
+try:
+    import pytype
+    config.available_features.add("has-pytype")
+except:
+    pass

--- a/llvm/utils/mlgo-utils/tests/pytype.test
+++ b/llvm/utils/mlgo-utils/tests/pytype.test
@@ -1,0 +1,4 @@
+# REQUIRES: system-linux, has-pytype
+
+# RUN: pytype %S/../mlgo
+# RUN: pytype %S/../tests


### PR DESCRIPTION
This patch adds a pytype test to the mlgo-utils lit test suite to prevent regressions in typing while we wait to setup precommit CI for this specific project.

This is somewhat hacky, but is a temporary fix and will be pulled out soonish. It also should only impact the ML buildbots as they are the only ones that should have `pytype` installed.