### PR TITLE
[Flang][OpenMP] Use simdloop operation only for omp simd pragma

### DIFF
--- a/flang/test/Lower/OpenMP/FIR/if-clause.f90
+++ b/flang/test/Lower/OpenMP/FIR/if-clause.f90
@@ -28,7 +28,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! DO SIMD
   ! ----------------------------------------------------------------------------
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp do simd
@@ -36,15 +36,13 @@ program main
   end do
   !$omp end do simd
 
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp do simd if(.true.)
   do i = 1, 10
   end do
   !$omp end do simd
 
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -103,7 +101,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp parallel do simd
@@ -113,8 +111,7 @@ program main
 
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -122,8 +119,7 @@ program main
   
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do
@@ -131,7 +127,7 @@ program main
   
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp parallel do simd if(parallel: .true.)
@@ -142,8 +138,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -306,7 +301,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp target parallel do simd
@@ -318,8 +313,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -329,8 +323,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(target: .true.) if(parallel: .false.) &
   !$omp&                        if(simd: .true.)
   do i = 1, 10
@@ -342,7 +335,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp target parallel do simd if(target: .true.)
@@ -355,8 +348,7 @@ program main
   ! CHECK-SAME: {
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do

--- a/flang/test/Lower/OpenMP/FIR/loop-combined.f90
+++ b/flang/test/Lower/OpenMP/FIR/loop-combined.f90
@@ -23,7 +23,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! DO SIMD
   ! ----------------------------------------------------------------------------
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp do simd
   do i = 1, 10
   end do
@@ -33,7 +33,7 @@ program main
   ! PARALLEL DO SIMD
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.parallel
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp parallel do simd
   do i = 1, 10
   end do
@@ -54,7 +54,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.target
   ! CHECK: omp.parallel
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp target parallel do simd
   do i = 1, 10
   end do

--- a/flang/test/Lower/OpenMP/Todo/omp-do-simd-aligned.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-do-simd-aligned.f90
@@ -1,0 +1,16 @@
+! This test checks lowering of OpenMP do simd aligned() pragma
+
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+subroutine testDoSimdAligned(int_array)
+        use iso_c_binding
+        type(c_ptr) :: int_array
+!CHECK: not yet implemented: Unhandled clause ALIGNED in DO SIMD construct
+!$omp do simd aligned(int_array)
+        do index_ = 1, 10
+          call c_test_call(int_array)
+        end do
+!$omp end do simd
+
+end subroutine testDoSimdAligned
+

--- a/flang/test/Lower/OpenMP/Todo/omp-do-simd-linear.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-do-simd-linear.f90
@@ -1,0 +1,14 @@
+! This test checks lowering of OpenMP do simd linear() pragma
+
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+subroutine testDoSimdLinear(int_array)
+        integer :: int_array(*)
+!CHECK: not yet implemented: Unhandled clause LINEAR in DO SIMD construct
+!$omp do simd linear(int_array)
+        do index_ = 1, 10
+        end do
+!$omp end do simd
+
+end subroutine testDoSimdLinear
+

--- a/flang/test/Lower/OpenMP/Todo/omp-do-simd-safelen.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-do-simd-safelen.f90
@@ -1,0 +1,14 @@
+! This test checks lowering of OpenMP do simd safelen() pragma
+
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+subroutine testDoSimdSafelen(int_array)
+        integer :: int_array(*)
+!CHECK: not yet implemented: Unhandled clause SAFELEN in DO SIMD construct
+!$omp do simd safelen(4)
+        do index_ = 1, 10
+        end do
+!$omp end do simd
+
+end subroutine testDoSimdSafelen
+

--- a/flang/test/Lower/OpenMP/Todo/omp-do-simd-simdlen.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-do-simd-simdlen.f90
@@ -1,0 +1,14 @@
+! This test checks lowering of OpenMP do simd simdlen() pragma
+
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+subroutine testDoSimdSimdlen(int_array)
+        integer :: int_array(*)
+!CHECK: not yet implemented: Unhandled clause SIMDLEN in DO SIMD construct
+!$omp do simd simdlen(4)
+        do index_ = 1, 10
+        end do
+!$omp end do simd
+
+end subroutine testDoSimdSimdlen
+

--- a/flang/test/Lower/OpenMP/if-clause.f90
+++ b/flang/test/Lower/OpenMP/if-clause.f90
@@ -28,7 +28,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! DO SIMD
   ! ----------------------------------------------------------------------------
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp do simd
@@ -36,15 +36,13 @@ program main
   end do
   !$omp end do simd
 
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp do simd if(.true.)
   do i = 1, 10
   end do
   !$omp end do simd
 
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -103,7 +101,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp parallel do simd
@@ -113,8 +111,7 @@ program main
 
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -122,8 +119,7 @@ program main
   
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do
@@ -131,7 +127,7 @@ program main
   
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp parallel do simd if(parallel: .true.)
@@ -142,8 +138,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp parallel do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -306,7 +301,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp target parallel do simd
@@ -318,8 +313,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -329,8 +323,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(target: .true.) if(parallel: .false.) &
   !$omp&                        if(simd: .true.)
   do i = 1, 10
@@ -342,7 +335,7 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
-  ! CHECK:      omp.simdloop
+  ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
   !$omp target parallel do simd if(target: .true.)
@@ -355,8 +348,7 @@ program main
   ! CHECK-SAME: {
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
-  ! CHECK:      omp.simdloop
-  ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
   !$omp target parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do

--- a/flang/test/Lower/OpenMP/loop-combined.f90
+++ b/flang/test/Lower/OpenMP/loop-combined.f90
@@ -23,7 +23,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! DO SIMD
   ! ----------------------------------------------------------------------------
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp do simd
   do i = 1, 10
   end do
@@ -33,7 +33,7 @@ program main
   ! PARALLEL DO SIMD
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.parallel
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp parallel do simd
   do i = 1, 10
   end do
@@ -54,7 +54,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.target
   ! CHECK: omp.parallel
-  ! CHECK: omp.simdloop
+  ! CHECK: omp.wsloop
   !$omp target parallel do simd
   do i = 1, 10
   end do


### PR DESCRIPTION
OpenMP standard differentiates between omp simd (2.9.3.1) and omp do/for simd (2.9.3.2 for OpenMP 5.0 standard) pragmas. The first one describes the loop which needs to be vectorized. The second pragma describes the loop which needs to be workshared between existing threads. Each thread can use SIMD instructions to execute its chunk of the loop.

That's why we need to model
```
!$omp simd
  do-loop
```
as `omp.simdloop` operation and add compiler hints for vectorization.

The worksharing loop:
!$omp do simd
  do-loop
should be represented as worksharing loop (`omp.wsloop`).

Currently Flang denotes both type of OpenMP pragmas by `omp.simdloop` operation. In consequence we cannot differentiate between: 
```
!$omp parallel simd
   do-loop
```
and
```
!$omp parallel do simd
   do-loop
 ```
The second loop should be workshared between multiple threads. The first one describes the loop which needs to be redundantly executed by multiple threads. Current Flang implementation does not perform worksharing for `!$omp do simd` pragma and generates valid code only for first case.

@skatrak will propose detailed MLIR representation of `!$omp do simd` pragma