### PR TITLE
[AArch64] Use DAG->isAddLike in add_and_or_is_add

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -899,7 +899,7 @@ def add_and_or_is_add : PatFrags<(ops node:$lhs, node:$rhs),
                          [(add node:$lhs, node:$rhs), (or node:$lhs, node:$rhs)],[{
    if (N->getOpcode() == ISD::ADD)
      return true;
-   return CurDAG->haveNoCommonBitsSet(N->getOperand(0), N->getOperand(1));
+   return CurDAG->isADDLike(SDValue(N,0));
 }]> {
   let GISelPredicateCode = [{
      // Only handle G_ADD for now. FIXME. build capability to compute whether

--- a/llvm/test/CodeGen/AArch64/arm64-csel.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-csel.ll
@@ -500,9 +500,8 @@ entry:
 define i64 @selor64_disjoint(i64 %num, i64 %x) {
 ; CHECK-LABEL: selor64_disjoint:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    orr x8, x0, #0x1
 ; CHECK-NEXT:    cmp x1, #0
-; CHECK-NEXT:    csel x0, x8, x0, ne
+; CHECK-NEXT:    cinc x0, x0, ne
 ; CHECK-NEXT:    ret
 entry:
   %tobool.not = icmp ne i64 %x, 0

--- a/llvm/test/CodeGen/AArch64/shift-accumulate.ll
+++ b/llvm/test/CodeGen/AArch64/shift-accumulate.ll
@@ -178,8 +178,7 @@ define <2 x i64> @usra_with_movi_v2i64(<16 x i8> %0, <16 x i8> %1) {
 define <4 x i16> @usra_v4i16_disjointor(<4 x i16> %a) {
 ; CHECK-LABEL: usra_v4i16_disjointor:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ushr v1.4h, v0.4h, #7
-; CHECK-NEXT:    orr v0.8b, v1.8b, v0.8b
+; CHECK-NEXT:    usra v0.4h, v0.4h, #7
 ; CHECK-NEXT:    ret
   %s = lshr <4 x i16> %a, <i16 7, i16 7, i16 7, i16 7>
   %o = or disjoint <4 x i16> %s, %a

--- a/llvm/test/CodeGen/AArch64/shift-accumulate.ll
+++ b/llvm/test/CodeGen/AArch64/shift-accumulate.ll
@@ -174,3 +174,14 @@ define <2 x i64> @usra_with_movi_v2i64(<16 x i8> %0, <16 x i8> %1) {
   %7 = or <2 x i64> %6, %5
   ret <2 x i64> %7
 }
+
+define <4 x i16> @usra_v4i16_disjointor(<4 x i16> %a) {
+; CHECK-LABEL: usra_v4i16_disjointor:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ushr v1.4h, v0.4h, #7
+; CHECK-NEXT:    orr v0.8b, v1.8b, v0.8b
+; CHECK-NEXT:    ret
+  %s = lshr <4 x i16> %a, <i16 7, i16 7, i16 7, i16 7>
+  %o = or disjoint <4 x i16> %s, %a
+  ret <4 x i16> %o
+}


### PR DESCRIPTION
This allows it to work with disjoint or's as well as computing the known bits.
