### PR TITLE
[InstCombine] Remove Store when its Ptr is removable 

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -157,6 +157,9 @@ public:
   Instruction *visitGEPOfGEP(GetElementPtrInst &GEP, GEPOperator *Src);
   Instruction *visitAllocaInst(AllocaInst &AI);
   Instruction *visitAllocSite(Instruction &FI);
+  bool isAllocSiteRemovable(Instruction *AI,
+                            SmallVectorImpl<WeakTrackingVH> &Users,
+                            const TargetLibraryInfo &TLI);
   Instruction *visitFree(CallInst &FI, Value *FreedOp);
   Instruction *visitLoadInst(LoadInst &LI);
   Instruction *visitStoreInst(StoreInst &SI);

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2712,9 +2712,9 @@ static bool isRemovableWrite(CallBase &CB, Value *UsedV,
   return Dest && Dest->Ptr == UsedV;
 }
 
-static bool isAllocSiteRemovable(Instruction *AI,
-                                 SmallVectorImpl<WeakTrackingVH> &Users,
-                                 const TargetLibraryInfo &TLI) {
+bool InstCombinerImpl::isAllocSiteRemovable(
+    Instruction *AI, SmallVectorImpl<WeakTrackingVH> &Users,
+    const TargetLibraryInfo &TLI) {
   SmallVector<Instruction*, 4> Worklist;
   const std::optional<StringRef> Family = getAllocationFamily(AI, &TLI);
   Worklist.push_back(AI);


### PR DESCRIPTION
If the `store` target is OneUse and the user is `AddrSpaceCastInst`, proper processing was not performed. Therefore, when processing `Alloca` in the second process, this storage space was deleted and a problem occurred.

This patch removes the `store` when the store target is OneUse and the user is `AddrSpaceCastInst`.

This is a sample IR a crash occurred. crafted by @arsenm 
```
define void @test(ptr align 8 %arg) {
bb:
  %i = alloca ptr, align 8, addrspace(5)
  %i1 = addrspacecast ptr addrspace(5) %i to ptr
  store ptr %arg, ptr %i1, align 8
  %i2 = load ptr, ptr %i1, align 8
  store ptr %i2, ptr null, align 8
  ret void
}
```

RUN RECORD:

$ bllvm0/bin/clang --version
clang version 18.0.0git (git@github.com:ParkHanbum/llvm-project.git 0633226612a37933ebd41e523bb9383d80b4cf6a)
$ bllvm0/bin/opt --passes=instcombine crash.ll -debug
```
INSTCOMBINE ITERATION #1 on test
ADD:   ret void
ADD:   store ptr %i2, ptr null, align 8
ADD:   %i2 = load ptr, ptr %i1, align 8
ADD:   store ptr %arg, ptr %i1, align 8
ADD:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD:   %i = alloca ptr, align 8, addrspace(5)
IC: Visiting:   %i = alloca ptr, align 8, addrspace(5)
IC: Visiting:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
IC: Visiting:   store ptr %arg, ptr %i1, align 8
IC: Visiting:   %i2 = load ptr, ptr %i1, align 8
IC: Replacing   %i2 = load ptr, ptr %i1, align 8
    with ptr %arg
IC: Mod =   %i2 = load ptr, ptr %i1, align 8
    New =   %i2 = load ptr, ptr %i1, align 8
IC: ERASE   %i2 = load ptr, ptr %i1, align 8
ADD DEFERRED:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD DEFERRED:   store ptr %arg, ptr %i1, align 8
ADD:   store ptr %arg, ptr %i1, align 8
ADD:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
IC: Visiting:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
IC: Visiting:   store ptr %arg, ptr %i1, align 8
IC: Visiting:   store ptr %arg, ptr null, align 8
IC: Mod =   store ptr %arg, ptr null, align 8
    New =   store ptr poison, ptr null, align 8
ADD:   store ptr poison, ptr null, align 8
IC: Visiting:   store ptr poison, ptr null, align 8
IC: Visiting:   ret void


INSTCOMBINE ITERATION #2 on test
ADD:   ret void
ADD:   store ptr poison, ptr null, align 8
ADD:   store ptr %arg, ptr %i1, align 8
ADD:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD:   %i = alloca ptr, align 8, addrspace(5)
IC: Visiting:   %i = alloca ptr, align 8, addrspace(5)
IC: Replacing   %i1 = addrspacecast ptr addrspace(5) %i to ptr
    with ptr poison
IC: ERASE   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD DEFERRED:   %i = alloca ptr, align 8, addrspace(5)
IC: ERASE   store ptr %arg, ptr poison, align 8
IC: ERASE   %i = alloca ptr, align 8, addrspace(5)
IC: Visiting:   store ptr poison, ptr null, align 8
IC: Visiting:   ret void
LLVM ERROR: Instruction Combining did not reach a fixpoint after 1 iterations
```

ANALYZE : 

This problem seems to come from incomplete processing of the `addrspacecast` instruction.
In the first instcombine process, after the load instruction is removed as follows:
```
IC: Replacing   %i2 = load ptr, ptr %i1, align 8
    with ptr %arg
IC: Mod =   %i2 = load ptr, ptr %i1, align 8
    New =   %i2 = load ptr, ptr %i1, align 8
IC: ERASE   %i2 = load ptr, ptr %i1, align 8
ADD DEFERRED:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD DEFERRED:   store ptr %arg, ptr %i1, align 8
ADD:   store ptr %arg, ptr %i1, align 8
ADD:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
IC: Visiting:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
IC: Visiting:   store ptr %arg, ptr %i1, align 8
IC: Visiting:   store ptr %arg, ptr null, align 8
IC: Mod =   store ptr %arg, ptr null, align 8
    New =   store ptr poison, ptr null, align 8
ADD:   store ptr poison, ptr null, align 8
IC: Visiting:   store ptr poison, ptr null, align 8
IC: Visiting:   ret void
```
In the processing the first instruction `alloc` in the second instcombine process, `isAllocSiteRemovable` inside the `visitAllocSite` function is called.
```
ADD:   ret void
ADD:   store ptr poison, ptr null, align 8
ADD:   store ptr %arg, ptr %i1, align 8
ADD:   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD:   %i = alloca ptr, align 8, addrspace(5)
IC: Visiting:   %i = alloca ptr, align 8, addrspace(5)
IC: Replacing   %i1 = addrspacecast ptr addrspace(5) %i to ptr
    with ptr poison
IC: ERASE   %i1 = addrspacecast ptr addrspace(5) %i to ptr
ADD DEFERRED:   %i = alloca ptr, align 8, addrspace(5)
```
In this function, the `addrspacecast` and `store` instructions are removed.

This is the processing that should have occurred when the `load` instruction was removed. However, addrspacecast does not do this.


