### PR TITLE
[TableGen] Support type aliases via new keyword deftype

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -59,6 +59,8 @@ Changes to building LLVM
 Changes to TableGen
 -------------------
 
+- We can define type aliases via new keyword ``deftype``.
+
 Changes to Interprocedural Optimizations
 ----------------------------------------
 

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -1227,8 +1227,8 @@ statements that follow the definition.
 The identifier on the left of the ``=`` is defined to be a type name
 whose actual type is given by the type expression on the right of the ``=``.
 
-Currently, only primitive types are supported and ``deftype`` statements can
-only appear at the top level.
+Currently, only primitive types and type aliases are supported to be the source
+type and `deftype` statements can only appear at the top level.
 
 ``defvar`` --- define a variable
 --------------------------------

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -570,8 +570,8 @@ files.
 .. productionlist::
    TableGenFile: (`Statement` | `IncludeDirective`
             :| `PreprocessorDirective`)*
-   Statement: `Assert` | `Class` | `Def` | `Defm` | `Defset` | `Defvar`
-            :| `Dump`  | `Foreach` | `If` | `Let` | `MultiClass`
+   Statement: `Assert` | `Class` | `Def` | `Defm` | `Defset` | `Deftype`
+            :| `Defvar` | `Dump`  | `Foreach` | `If` | `Let` | `MultiClass`
 
 The following sections describe each of these top-level statements.
 
@@ -931,7 +931,8 @@ template that expands into multiple records.
              : `ParentClassList`
              : "{" `MultiClassStatement`+ "}"
    MultiClassID: `TokIdentifier`
-   MultiClassStatement: `Assert` | `Def` | `Defm` | `Defvar` | `Foreach` | `If` | `Let`
+   MultiClassStatement: `Assert` | `Def` | `Defm` | `Deftype` | `Defvar`
+                      :| `Foreach` | `If` | `Let`
 
 As with regular classes, the multiclass has a name and can accept template
 arguments. A multiclass can inherit from other multiclasses, which causes
@@ -1215,6 +1216,17 @@ set.
 Anonymous records created inside initialization expressions using the
 ``ClassID<...>`` syntax are not collected in the set.
 
+``deftype`` --- define a type
+--------------------------------
+
+A ``deftype`` statement defines a type. Its value can be used
+throughout the statements that follow the definition.
+
+.. productionlist::
+   Deftype: "deftype" `TokIdentifier` "=" `Value` ";"
+
+The identifier on the left of the ``=`` is defined to be a type name
+whose actual type is given by the type expression on the right of the ``=``.
 
 ``defvar`` --- define a variable
 --------------------------------

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -931,8 +931,7 @@ template that expands into multiple records.
              : `ParentClassList`
              : "{" `MultiClassStatement`+ "}"
    MultiClassID: `TokIdentifier`
-   MultiClassStatement: `Assert` | `Def` | `Defm` | `Deftype` | `Defvar`
-                      :| `Foreach` | `If` | `Let`
+   MultiClassStatement: `Assert` | `Def` | `Defm` | `Defvar` | `Foreach` | `If` | `Let`
 
 As with regular classes, the multiclass has a name and can accept template
 arguments. A multiclass can inherit from other multiclasses, which causes
@@ -1219,14 +1218,17 @@ Anonymous records created inside initialization expressions using the
 ``deftype`` --- define a type
 --------------------------------
 
-A ``deftype`` statement defines a type. Its value can be used
-throughout the statements that follow the definition.
+A ``deftype`` statement defines a type. The type can be used throughout the
+statements that follow the definition.
 
 .. productionlist::
-   Deftype: "deftype" `TokIdentifier` "=" `Value` ";"
+   Deftype: "deftype" `TokIdentifier` "=" `Type` ";"
 
 The identifier on the left of the ``=`` is defined to be a type name
 whose actual type is given by the type expression on the right of the ``=``.
+
+Currently, only primitive types are supported and ``deftype`` statements can
+only appear at the top level.
 
 ``defvar`` --- define a variable
 --------------------------------

--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -360,6 +360,7 @@ tgtok::TokKind TGLexer::LexIdentifier() {
                             .Case("foreach", tgtok::Foreach)
                             .Case("defm", tgtok::Defm)
                             .Case("defset", tgtok::Defset)
+                            .Case("deftype", tgtok::Deftype)
                             .Case("multiclass", tgtok::MultiClass)
                             .Case("field", tgtok::Field)
                             .Case("let", tgtok::Let)

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -97,6 +97,7 @@ enum TokKind {
   Def,
   Defm,
   Defset,
+  Deftype,
   Defvar,
   Dump,
   Foreach,

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3956,7 +3956,8 @@ bool TGParser::ParseClass() {
   if (Lex.getCode() != tgtok::Id)
     return TokError("expected class name after 'class' keyword");
 
-  Record *CurRec = Records.getClass(Lex.getCurStrVal());
+  const std::string &Name = Lex.getCurStrVal();
+  Record *CurRec = Records.getClass(Name);
   if (CurRec) {
     // If the body was previously defined, this is an error.
     if (!CurRec->getValues().empty() ||
@@ -3973,6 +3974,10 @@ bool TGParser::ParseClass() {
     CurRec = NewRec.get();
     Records.addClass(std::move(NewRec));
   }
+
+  if (TypeAliases.count(Name))
+    return TokError("there is already a defined type alias '" + Name + "'");
+
   Lex.Lex(); // eat the name.
 
   // A class definition introduces a new scope.

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -1104,10 +1104,10 @@ RecTy *TGParser::ParseType() {
     Lex.Lex();
     return DagRecTy::get(Records);
   case tgtok::Id: {
-    const std::string TypeName = Lex.getCurStrVal();
-    if (TypeAliases.count(TypeName)) {
+    auto I = TypeAliases.find(Lex.getCurStrVal());
+    if (I != TypeAliases.end()) {
       Lex.Lex();
-      return TypeAliases[TypeName];
+      return I->second;
     }
     if (Record *R = ParseClassID())
       return RecordRecTy::get(R);

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3673,7 +3673,7 @@ bool TGParser::ParseDefset() {
 
 /// ParseDeftype - Parse a defvar statement.
 ///
-///   Deftype ::= DEFTYPE Id '=' Value ';'
+///   Deftype ::= DEFTYPE Id '=' Type ';'
 ///
 bool TGParser::ParseDeftype() {
   assert(Lex.getCode() == tgtok::Deftype);
@@ -3690,9 +3690,15 @@ bool TGParser::ParseDeftype() {
   if (!consume(tgtok::equal))
     return TokError("expected '='");
 
+  SMLoc Loc = Lex.getLoc();
   RecTy *Type = ParseType();
   if (!Type)
     return true;
+
+  if (Type->getRecTyKind() == RecTy::RecordRecTyKind)
+    return Error(Loc, "cannot define type alias for class type '" +
+                          Type->getAsString() + "'");
+
   TypeAliases[TypeName] = Type;
 
   if (!consume(tgtok::semi))

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -1104,7 +1104,7 @@ RecTy *TGParser::ParseType() {
     Lex.Lex();
     return DagRecTy::get(Records);
   case tgtok::Id: {
-    std::string TypeName = Lex.getCurStrVal();
+    const std::string TypeName = Lex.getCurStrVal();
     if (TypeAliases.count(TypeName)) {
       Lex.Lex();
       return TypeAliases[TypeName];
@@ -3682,7 +3682,7 @@ bool TGParser::ParseDeftype() {
   if (Lex.getCode() != tgtok::Id)
     return TokError("expected identifier");
 
-  std::string TypeName = Lex.getCurStrVal();
+  const std::string TypeName = Lex.getCurStrVal();
   if (TypeAliases.count(TypeName) || Records.getClass(TypeName))
     return TokError("type of this name '" + TypeName + "' already exists");
 

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3683,8 +3683,8 @@ bool TGParser::ParseDeftype() {
     return TokError("expected identifier");
 
   std::string TypeName = Lex.getCurStrVal();
-  if (TypeAliases.count(TypeName))
-    return TokError("type of this name already exists");
+  if (TypeAliases.count(TypeName) || Records.getClass(TypeName))
+    return TokError("type of this name '" + TypeName + "' already exists");
 
   Lex.Lex();
   if (!consume(tgtok::equal))

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -143,6 +143,7 @@ class TGParser {
   TGLexer Lex;
   std::vector<SmallVector<LetRecord, 4>> LetStack;
   std::map<std::string, std::unique_ptr<MultiClass>> MultiClasses;
+  std::map<std::string, RecTy *> TypeAliases;
 
   /// Loops - Keep track of any foreach loops we are within.
   ///
@@ -264,6 +265,7 @@ private:  // Parser methods.
   bool ParseDefm(MultiClass *CurMultiClass);
   bool ParseDef(MultiClass *CurMultiClass);
   bool ParseDefset();
+  bool ParseDeftype();
   bool ParseDefvar(Record *CurRec = nullptr);
   bool ParseDump(MultiClass *CurMultiClass, Record *CurRec = nullptr);
   bool ParseForeach(MultiClass *CurMultiClass);

--- a/llvm/test/TableGen/deftype.td
+++ b/llvm/test/TableGen/deftype.td
@@ -2,6 +2,8 @@
 // RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
 // RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
 // RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
+// RUN: not llvm-tblgen -DERROR4 %s 2>&1 | FileCheck --check-prefix=ERROR4 %s
+// RUN: not llvm-tblgen -DERROR5 %s 2>&1 | FileCheck --check-prefix=ERROR5 %s
 
 class Class<int v> {
   int value = v;
@@ -55,4 +57,14 @@ deftype Class = int;
 #ifdef ERROR3
 // ERROR3: [[@LINE+1]]:22: error: cannot define type alias for class type 'Class'
 deftype ClassAlias = Class;
+#endif
+
+#ifdef ERROR4
+// ERROR4: [[@LINE+1]]:7: error: there is already a defined type alias 'Byte'
+class Byte; // incomplete class definition.
+#endif
+
+#ifdef ERROR5
+// ERROR5: [[@LINE+1]]:7: error: there is already a defined type alias 'Byte'
+class Byte {}
 #endif

--- a/llvm/test/TableGen/deftype.td
+++ b/llvm/test/TableGen/deftype.td
@@ -1,26 +1,45 @@
 // RUN: llvm-tblgen %s | FileCheck %s
 // RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
 // RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
+// RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
 
-deftype Byte = bits<8>;
-deftype IntList = list<int>;
-deftype ByteList = list<Byte>;
-class Class<Byte b> {
-  Byte byte = b;
+class Class<int v> {
+  int value = v;
 }
-deftype ClassList = list<Class>;
+
+deftype StringAlias    = string;
+deftype CodeAlias      = code;
+deftype DagAlias       = dag;
+deftype Boolean        = bit;
+deftype Byte           = bits<8>;
+deftype Integer        = int;
+deftype IntList        = list<int>;
+deftype ByteList       = list<Byte>;
+deftype ClassList      = list<Class>;
+// The type can be another type alias.
+deftype ClassListAlias = ClassList;
 
 // CHECK:      def test {
+// CHECK-NEXT:   string str = "string";
+// CHECK-NEXT:   string codeStr = "code";
+// CHECK-NEXT:   dag dagExpr = ("string" "code");
+// CHECK-NEXT:   bit bool = 0;
 // CHECK-NEXT:   bits<8> byte = { 0, 1, 1, 1, 1, 0, 1, 1 };
+// CHECK-NEXT:   int integer = 123;
 // CHECK-NEXT:   list<int> ints = [1, 2, 3];
 // CHECK-NEXT:   list<bits<8>> bytes = [{ 0, 0, 0, 0, 0, 0, 0, 1 }, { 0, 0, 0, 0, 0, 0, 1, 0 }, { 0, 0, 0, 0, 0, 0, 1, 1 }];
 // CHECK-NEXT:   list<Class> defs = [anonymous_0, anonymous_1, anonymous_2];
 // CHECK-NEXT: }
 def test {
-  Byte byte = 123;
-  IntList ints = [1, 2, 3];
-  ByteList bytes = [1, 2, 3];
-  ClassList defs = [Class<1>, Class<2>, Class<3>];
+  StringAlias    str     = "string";
+  CodeAlias      codeStr = "code";
+  DagAlias       dagExpr = (str codeStr);
+  Boolean        bool    = false;
+  Byte           byte    = 123;
+  Integer        integer = 123;
+  IntList        ints    = [1, 2, 3];
+  ByteList       bytes   = [1, 2, 3];
+  ClassListAlias defs    = [Class<1>, Class<2>, Class<3>];
 }
 
 #ifdef ERROR1
@@ -31,4 +50,9 @@ deftype Byte = bits<8>;
 #ifdef ERROR2
 // ERROR2: [[@LINE+1]]:9: error: type of this name 'Class' already exists
 deftype Class = int;
+#endif
+
+#ifdef ERROR3
+// ERROR3: [[@LINE+1]]:22: error: cannot define type alias for class type 'Class'
+deftype ClassAlias = Class;
 #endif

--- a/llvm/test/TableGen/deftype.td
+++ b/llvm/test/TableGen/deftype.td
@@ -1,0 +1,22 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+deftype Byte = bits<8>;
+deftype IntList = list<int>;
+deftype ByteList = list<Byte>;
+class Class<Byte b> {
+  Byte byte = b;
+}
+deftype ClassList = list<Class>;
+
+// CHECK:      def test {
+// CHECK-NEXT:   bits<8> byte = { 0, 1, 1, 1, 1, 0, 1, 1 };
+// CHECK-NEXT:   list<int> ints = [1, 2, 3];
+// CHECK-NEXT:   list<bits<8>> bytes = [{ 0, 0, 0, 0, 0, 0, 0, 1 }, { 0, 0, 0, 0, 0, 0, 1, 0 }, { 0, 0, 0, 0, 0, 0, 1, 1 }];
+// CHECK-NEXT:   list<Class> defs = [anonymous_0, anonymous_1, anonymous_2];
+// CHECK-NEXT: }
+def test {
+  Byte byte = 123;
+  IntList ints = [1, 2, 3];
+  ByteList bytes = [1, 2, 3];
+  ClassList defs = [Class<1>, Class<2>, Class<3>];
+}

--- a/llvm/test/TableGen/deftype.td
+++ b/llvm/test/TableGen/deftype.td
@@ -1,4 +1,6 @@
 // RUN: llvm-tblgen %s | FileCheck %s
+// RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
+// RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
 
 deftype Byte = bits<8>;
 deftype IntList = list<int>;
@@ -20,3 +22,13 @@ def test {
   ByteList bytes = [1, 2, 3];
   ClassList defs = [Class<1>, Class<2>, Class<3>];
 }
+
+#ifdef ERROR1
+// ERROR1: [[@LINE+1]]:9: error: type of this name 'Byte' already exists
+deftype Byte = bits<8>;
+#endif
+
+#ifdef ERROR2
+// ERROR2: [[@LINE+1]]:9: error: type of this name 'Class' already exists
+deftype Class = int;
+#endif


### PR DESCRIPTION
We can use `deftype` (not using `typedef` here to be consistent
with `def`, `defm`, `defset`, `defvar`, etc) to define type aliases.

Currently, only primitive types and type aliases are supported to be
the source type and `deftype` statements can only appear at the top
level.
