### PR TITLE
Remove unnecessary _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1138,7 +1138,7 @@ public:
 #if _LIBCPP_STD_VER >= 23
   basic_string& operator=(nullptr_t) = delete;
 #endif
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string& operator=(value_type __c);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(value_type __c);
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator begin() _NOEXCEPT {
     return __make_iterator(__get_pointer());


### PR DESCRIPTION
This macro is unnecessary with `basic_string& operator=(value_type __c)`.