### PR TITLE
[VFABI] fix vfabi-demangler-fuzzer.cpp

### DIFF
--- a/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
+++ b/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/VFABIDemangler.h"
+#include "llvm/Support/SourceMgr.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/77513 which broke the fuzzer, which is currently failing the OSS-Fuzz build with:

```
[233/242] Building CXX object tools/vfabi-demangle-fuzzer/CMakeFiles/vfabi-demangler-fuzzer.dir/vfabi-demangler-fuzzer.cpp.o[K
Step #3 - "compile-honggfuzz-address-x86_64": [31mFAILED: [0mtools/vfabi-demangle-fuzzer/CMakeFiles/vfabi-demangler-fuzzer.dir/vfabi-demangler-fuzzer.cpp.o 
Step #3 - "compile-honggfuzz-address-x86_64": /usr/local/bin/clang++ -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/src/build/tools/vfabi-demangle-fuzzer -I/src/llvm-project/llvm/tools/vfabi-demangle-fuzzer -I/src/build/include -I/src/llvm-project/llvm/include -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize-coverage=trace-pc-guard,indirect-calls,trace-cmp -stdlib=libc++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -std=c++17 -MD -MT tools/vfabi-demangle-fuzzer/CMakeFiles/vfabi-demangler-fuzzer.dir/vfabi-demangler-fuzzer.cpp.o -MF tools/vfabi-demangle-fuzzer/CMakeFiles/vfabi-demangler-fuzzer.dir/vfabi-demangler-fuzzer.cpp.o.d -o tools/vfabi-demangle-fuzzer/CMakeFiles/vfabi-demangler-fuzzer.dir/vfabi-demangler-fuzzer.cpp.o -c /src/llvm-project/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
Step #3 - "compile-honggfuzz-address-x86_64": [1m/src/llvm-project/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp:20:16: [0m[0;1;31merror: [0m[1mvariable has incomplete type 'llvm::SMDiagnostic'[0m
Step #3 - "compile-honggfuzz-address-x86_64":   SMDiagnostic Err;
Step #3 - "compile-honggfuzz-address-x86_64": [0;1;32m               ^
Step #3 - "compile-honggfuzz-address-x86_64": [0m[1m/src/llvm-project/llvm/include/llvm/AsmParser/Parser.h:29:7: [0m[0;1;30mnote: [0mforward declaration of 'llvm::SMDiagnostic'[0m
Step #3 - "compile-honggfuzz-address-x86_64": class SMDiagnostic;
Step #3 - "compile-honggfuzz-address-x86_64": [0;1;32m      ^
Step #3 - "compile-honggfuzz-address-x86_64": [0m[1m/src/llvm-project/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp:33:44: [0m[0;1;31merror: [0m[1mmember access into incomplete type 'llvm::Module'[0m
Step #3 - "compile-honggfuzz-address-x86_64":         FunctionType::get(Type::getVoidTy(M->getContext()), false);
Step #3 - "compile-honggfuzz-address-x86_64": [0;1;32m                                           ^
Step #3 - "compile-honggfuzz-address-x86_64": [0m[1m/src/llvm-project/llvm/include/llvm/AsmParser/Parser.h:26:7: [0m[0;1;30mnote: [0mforward declaration of 'llvm::Module'[0m
Step #3 - "compile-honggfuzz-address-x86_64": class Module;
Step #3 - "compile-honggfuzz-address-x86_64": [0;1;32m      ^
Step #3 - "compile-honggfuzz-address-x86_64": [0m2 errors generated.
Step #3 - "compile-honggfuzz-address-x86_64":
```