### PR TITLE
[llvm][DebugInfo] Fix c++20 warnings in LVOptions.h

### DIFF
--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
@@ -510,14 +510,14 @@ class LVPatterns final {
   template <typename T, typename U>
   void resolveGenericPatternMatch(T *Element, const U &Requests) {
     assert(Element && "Element must not be nullptr");
-    auto CheckPattern = [=]() -> bool {
+    auto CheckPattern = [this, Element]() -> bool {
       return (Element->isNamed() &&
               (matchGenericPattern(Element->getName()) ||
                matchGenericPattern(Element->getLinkageName()))) ||
              (Element->isTyped() &&
               matchGenericPattern(Element->getTypeName()));
     };
-    auto CheckOffset = [=]() -> bool {
+    auto CheckOffset = [this, Element]() -> bool {
       return matchOffsetPattern(Element->getOffset());
     };
     if ((options().getSelectGenericPattern() && CheckPattern()) ||
@@ -530,12 +530,12 @@ class LVPatterns final {
   template <typename U>
   void resolveGenericPatternMatch(LVLine *Line, const U &Requests) {
     assert(Line && "Line must not be nullptr");
-    auto CheckPattern = [=]() -> bool {
+    auto CheckPattern = [this, Line]() -> bool {
       return matchGenericPattern(Line->lineNumberAsStringStripped()) ||
              matchGenericPattern(Line->getName()) ||
              matchGenericPattern(Line->getPathname());
     };
-    auto CheckOffset = [=]() -> bool {
+    auto CheckOffset = [this, Line]() -> bool {
       return matchOffsetPattern(Line->getAddress());
     };
     if ((options().getSelectGenericPattern() && CheckPattern()) ||


### PR DESCRIPTION
Compiling with -DCMAKE_CXX_STANDARD=20 produces 228 warnings from this file due to:
```
LVOptions.h:515:16: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
```

So I've changed these to explicitly list the captures, including `this`.

As llvm requires at least c++17, I think we could use `[=, *this]` instead. However when I did so I got a lot of errors about const. So on balance, explicitly listing the captures seems better than adding some kind of const cast to each one.

These and other warnings can be seen on the c++20 buildbot https://lab.llvm.org/buildbot/#/builders/249.