### PR TITLE
Revert "Fix bazel build past 3fdb431b636975f2062b1931158aa4dfce6a3ff1…

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2132,7 +2132,6 @@ llvm_target_lib_list = [lib for lib in [
             ("-gen-instr-info", "lib/Target/RISCV/RISCVGenInstrInfo.inc"),
             ("-gen-macro-fusion-pred", "lib/Target/RISCV/RISCVGenMacroFusion.inc"),
             ("-gen-emitter", "lib/Target/RISCV/RISCVGenMCCodeEmitter.inc"),
-            ("-gen-macro-fusion-pred", "lib/Target/RISCV/RISCVGenMacroFusion.inc"),
             ("-gen-pseudo-lowering", "lib/Target/RISCV/RISCVGenMCPseudoLowering.inc"),
             ("-gen-register-bank", "lib/Target/RISCV/RISCVGenRegisterBank.inc"),
             ("-gen-register-info", "lib/Target/RISCV/RISCVGenRegisterInfo.inc"),


### PR DESCRIPTION
… (#79599)"

This reverts commit e0e216099505bc5051ba53b2fdb8202cdde5f47e.