### PR TITLE
[clang][dataflow] fix assert in `Environment::getResultObjectLocation`

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -536,6 +536,11 @@ public:
 
       copyRecord(*LocSrc, *LocDst, Env);
       Env.setStorageLocation(*S, *LocDst);
+    } else {
+      // CXXOperatorCallExpr can be prvalues, in which case we must create a
+      // record for them in order for `Environment::getResultObjectLocation()`
+      // to be able to return a value.
+      VisitCallExpr(S);
     }
   }
 

--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -536,12 +536,13 @@ public:
 
       copyRecord(*LocSrc, *LocDst, Env);
       Env.setStorageLocation(*S, *LocDst);
-    } else {
-      // CXXOperatorCallExpr can be prvalues, in which case we must create a
-      // record for them in order for `Environment::getResultObjectLocation()`
-      // to be able to return a value.
-      VisitCallExpr(S);
+      return;
     }
+
+    // CXXOperatorCallExpr can be prvalues. Call `VisitCallExpr`() to create
+    // a `RecordValue` for them so that `Environment::getResultObjectLocation()`
+    // can return a value.
+    VisitCallExpr(S);
   }
 
   void VisitCXXFunctionalCastExpr(const CXXFunctionalCastExpr *S) {


### PR DESCRIPTION
When calling `Environment::getResultObjectLocation` with a CXXOperatorCallExpr that is a prvalue, we just hit an assert because no record was ever created.