### PR TITLE
[flang] Turn "error" cases into warning for "indistinguishable" specific procedures

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -113,6 +113,13 @@ end
   in F'2023 subclause 19.4 paragraphs 6 & 8 should apply.  Since this
   compiler properly scopes these names, violations of these restrictions
   elicit only portability warnings by default.
+* The rules for pairwise distinguishing the specific procedures of a
+  generic interface are inadequate, as admitted in note C.11.6 of F'2023.
+  Generic interfaces whose specific procedures can be easily proven by
+  hand to be pairwise distinct (i.e., no ambiguous reference is possible)
+  appear in real applications, but are still non-conforming under the
+  incomplete tests in F'2023 15.4.3.4.5.
+  These cases are compiled with optional portability warnings.
 
 ## Extensions, deletions, and legacy features supported by default
 

--- a/flang/include/flang/Common/Fortran-features.h
+++ b/flang/include/flang/Common/Fortran-features.h
@@ -45,7 +45,8 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     MiscSourceExtensions, AllocateToOtherLength, LongNames, IntrinsicAsSpecific,
     BenignNameClash, BenignRedundancy, NullMoldAllocatableComponentValue,
     NopassScalarBase, MiscUseExtensions, ImpliedDoIndexScope,
-    DistinctCommonSizes, OddIndexVariableRestrictions)
+    DistinctCommonSizes, OddIndexVariableRestrictions,
+    IndistinguishableSpecifics)
 
 // Portability and suspicious usage warnings for conforming code
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2644,7 +2644,7 @@ const Symbol &ExpressionAnalyzer::AccessSpecific(
 void ExpressionAnalyzer::EmitGenericResolutionError(
     const Symbol &symbol, bool dueToAmbiguity, bool isSubroutine) {
   Say(dueToAmbiguity
-          ? "One or more actual arguments to the generic procedure '%s' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface"_err_en_US
+          ? "The actual arguments to the generic procedure '%s' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface"_err_en_US
           : semantics::IsGenericDefinedOp(symbol)
           ? "No specific procedure of generic operator '%s' matches the actual arguments"_err_en_US
           : isSubroutine

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -186,9 +186,12 @@ static void HarvestInitializerSymbols(
     } else if (const auto &generic{symbol->detailsIf<GenericDetails>()};
                generic && generic->derivedType()) {
       const Symbol &dtSym{*generic->derivedType()};
-      CHECK(dtSym.has<DerivedTypeDetails>());
-      if (dtSym.scope()) {
-        HarvestInitializerSymbols(set, *dtSym.scope());
+      if (dtSym.has<DerivedTypeDetails>()) {
+        if (dtSym.scope()) {
+          HarvestInitializerSymbols(set, *dtSym.scope());
+        }
+      } else {
+        CHECK(dtSym.has<UseErrorDetails>());
       }
     } else if (IsNamedConstant(*symbol) || scope.IsDerivedType()) {
       if (const auto *object{symbol->detailsIf<ObjectEntityDetails>()}) {

--- a/flang/test/Semantics/generic05.F90
+++ b/flang/test/Semantics/generic05.F90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Check for distinguishability of defined I/O procedures defined within
 ! and outside their types.
 module m1
@@ -6,7 +6,7 @@ module m1
     integer n
    contains
     procedure :: readt1a, readt1b
-    !ERROR: Generic 'read(unformatted)' may not have specific procedures 'readt1a' and 'readt1b' as their interfaces are not distinguishable
+    !PORTABILITY: Generic 'read(unformatted)' should not have specific procedures 'readt1a' and 'readt1b' as their interfaces are not distinguishable by the incomplete rules in the standard
     generic :: read(unformatted) => readt1a, readt1b
   end type
   type t2
@@ -15,7 +15,7 @@ module m1
   type t3
     integer n
   end type
-  !ERROR: Generic 'read(unformatted)' may not have specific procedures 'readt2a' and 'readt2b' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'read(unformatted)' should not have specific procedures 'readt2a' and 'readt2b' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface read(unformatted)
     module procedure :: readt1a, readt2a, readt2b, readt3
   end interface

--- a/flang/test/Semantics/generic07.f90
+++ b/flang/test/Semantics/generic07.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
 module m1
   type :: t1
     sequence
@@ -74,7 +74,7 @@ program test
   interface distinguishable3
     procedure :: s1a, s1b
   end interface
-  !ERROR: Generic 'indistinguishable' may not have specific procedures 's2b' and 's2a' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'indistinguishable' should not have specific procedures 's2b' and 's2a' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface indistinguishable
     procedure :: s2a, s2b
   end interface

--- a/flang/test/Semantics/resolve17.f90
+++ b/flang/test/Semantics/resolve17.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 module m
   integer :: foo
   !Note: PGI, Intel, and GNU allow this; NAG and Sun do not
@@ -96,7 +96,7 @@ contains
   end
 end
 subroutine s6
-  !ERROR: Generic 'g' may not have specific procedures 'sa' and 'sb' as their interfaces are not distinguishable
+  !ERROR: Generic 'g' should not have specific procedures 'sa' and 'sb' as their interfaces are not distinguishable by the incomplete rules in the standard
   use m6a, g => gg
   use m6b, g => gg
 end
@@ -180,7 +180,7 @@ contains
   end
 end module
 subroutine s9
-  !ERROR: USE-associated generic 'g' may not have specific procedures 'g' and 'g' as their interfaces are not distinguishable
+  !PORTABILITY: USE-associated generic 'g' should not have specific procedures 'g' and 'g' as their interfaces are not distinguishable by the incomplete rules in the standard
   use m9a
   use m9b
 end
@@ -197,7 +197,7 @@ contains
 end
 module m10b
   use m10a
-  !ERROR: Generic 'g' may not have specific procedures 's' and 's' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 's' and 's' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     module procedure s
   end interface

--- a/flang/test/Semantics/resolve53.f90
+++ b/flang/test/Semantics/resolve53.f90
@@ -1,9 +1,9 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! 15.4.3.4.5 Restrictions on generic declarations
 ! Specific procedures of generic interfaces must be distinguishable.
 
 module m1
-  !ERROR: Generic 'g' may not have specific procedures 's2' and 's4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 's2' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     procedure s1
     procedure s2
@@ -25,7 +25,7 @@ contains
 end
 
 module m2
-  !ERROR: Generic 'g' may not have specific procedures 'm2s1' and 'm2s2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm2s1' and 'm2s2' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     subroutine m2s1(x)
     end subroutine
@@ -36,7 +36,7 @@ module m2
 end
 
 module m3
-  !ERROR: Generic 'g' may not have specific procedures 'm3f1' and 'm3f2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm3f1' and 'm3f2' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     integer function m3f1()
     end function
@@ -79,7 +79,7 @@ end
 
 module m6
   use m5
-  !ERROR: Generic 'g' may not have specific procedures 'm5s1' and 'm6s4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s1' and 'm6s4' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     subroutine m6s4(x)
     end subroutine
@@ -88,9 +88,9 @@ end
 
 module m7
   use m5
-  !ERROR: Generic 'g' may not have specific procedures 'm5s1' and 'm7s5' as their interfaces are not distinguishable
-  !ERROR: Generic 'g' may not have specific procedures 'm5s2' and 'm7s5' as their interfaces are not distinguishable
-  !ERROR: Generic 'g' may not have specific procedures 'm5s3' and 'm7s5' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s1' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s2' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s3' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     subroutine m7s5(x)
       real x(..)
@@ -100,7 +100,7 @@ end
 
 ! Two procedures that differ only by attributes are not distinguishable
 module m8
-  !ERROR: Generic 'g' may not have specific procedures 'm8s1' and 'm8s2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm8s1' and 'm8s2' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     pure subroutine m8s1(x)
       real, intent(in) :: x
@@ -112,7 +112,7 @@ module m8
 end
 
 module m9
-  !ERROR: Generic 'g' may not have specific procedures 'm9s1' and 'm9s2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm9s1' and 'm9s2' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     subroutine m9s1(x)
       real :: x(10)
@@ -124,7 +124,7 @@ module m9
 end
 
 module m10
-  !ERROR: Generic 'g' may not have specific procedures 'm10s1' and 'm10s2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g' should not have specific procedures 'm10s1' and 'm10s2' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g
     subroutine m10s1(x)
       real :: x(10)
@@ -144,7 +144,7 @@ program m11
       real, allocatable :: x
     end subroutine
   end interface
-  !ERROR: Generic 'g2' may not have specific procedures 'm11s3' and 'm11s4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g2' should not have specific procedures 'm11s3' and 'm11s4' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g2
     subroutine m11s3(x)
       real, pointer, intent(in) :: x
@@ -156,11 +156,11 @@ program m11
 end
 
 module m12
-  !ERROR: Generic 'g1' may not have specific procedures 's1' and 's2' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g1' should not have specific procedures 's1' and 's2' as their interfaces are not distinguishable by the incomplete rules in the standard
   generic :: g1 => s1, s2  ! rank-1 and assumed-rank
-  !ERROR: Generic 'g2' may not have specific procedures 's2' and 's3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g2' should not have specific procedures 's2' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
   generic :: g2 => s2, s3  ! scalar and assumed-rank
-  !ERROR: Generic 'g3' may not have specific procedures 's1' and 's4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g3' should not have specific procedures 's1' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
   generic :: g3 => s1, s4  ! different shape, same rank
 contains
   subroutine s1(x)
@@ -209,7 +209,7 @@ module m14
     module procedure f1
     module procedure f2
   end interface
-  !ERROR: Generic 'OPERATOR(+)' may not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'OPERATOR(+)' should not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface operator(+)
     module procedure f1
     module procedure f3
@@ -218,7 +218,7 @@ module m14
     module procedure f1
     module procedure f2
   end interface
-  !ERROR: Generic 'OPERATOR(.bar.)' may not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'OPERATOR(.bar.)' should not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface operator(.bar.)
     module procedure f1
     module procedure f3
@@ -260,12 +260,12 @@ module m15
     procedure s1
     procedure s2
   end interface
-  !ERROR: Generic 'g2' may not have specific procedures 's1' and 's3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g2' should not have specific procedures 's1' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g2
     procedure s1
     procedure s3
   end interface
-  !ERROR: Generic 'g3' may not have specific procedures 's4' and 's5' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g3' should not have specific procedures 's4' and 's5' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g3
     procedure s4
     procedure s5
@@ -285,17 +285,17 @@ module m15
     procedure s8
     procedure s9
   end interface
-  !ERROR: Generic 'g7' may not have specific procedures 's6' and 's7' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g7' should not have specific procedures 's6' and 's7' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g7
     procedure s6
     procedure s7
   end interface
-  !ERROR: Generic 'g8' may not have specific procedures 's6' and 's8' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g8' should not have specific procedures 's6' and 's8' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g8
     procedure s6
     procedure s8
   end interface
-  !ERROR: Generic 'g9' may not have specific procedures 's7' and 's8' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g9' should not have specific procedures 's7' and 's8' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g9
     procedure s7
     procedure s8
@@ -339,7 +339,7 @@ module m16
     procedure, nopass :: s2
     procedure, nopass :: s3
     generic :: g1 => s1, s2
-    !ERROR: Generic 'g2' may not have specific procedures 's1' and 's3' as their interfaces are not distinguishable
+    !PORTABILITY: Generic 'g2' should not have specific procedures 's1' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
     generic :: g2 => s1, s3
   end type
 contains
@@ -368,7 +368,7 @@ module m17
     procedure s1
     procedure s2
   end interface
-  !ERROR: Generic 'g2' may not have specific procedures 's3' and 's4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g2' should not have specific procedures 's3' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g2
     procedure s3
     procedure s4
@@ -377,17 +377,17 @@ module m17
     procedure s1
     procedure s4
   end interface
-  !ERROR: Generic 'g4' may not have specific procedures 's2' and 's3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g4' should not have specific procedures 's2' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g4
     procedure s2
     procedure s3
   end interface
-  !ERROR: Generic 'g5' may not have specific procedures 's2' and 's5' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g5' should not have specific procedures 's2' and 's5' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g5
     procedure s2
     procedure s5
   end interface
-  !ERROR: Generic 'g6' may not have specific procedures 's2' and 's6' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'g6' should not have specific procedures 's2' and 's6' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface g6
     procedure s2
     procedure s6
@@ -439,7 +439,7 @@ module m19
     module procedure f1
     module procedure f2
   end interface
-  !ERROR: Generic 'OPERATOR(.bar.)' may not have specific procedures 'f2' and 'f3' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'OPERATOR(.bar.)' should not have specific procedures 'f2' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface operator(.bar.)
     module procedure f2
     module procedure f3
@@ -504,3 +504,21 @@ module m21
     class(*), allocatable :: x
   end subroutine
 end module
+
+! Example reduced from pFUnit
+module m22
+  !PORTABILITY: Generic 'generic' should not have specific procedures 'sub1' and 'sub2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  interface generic
+    procedure sub1, sub2
+  end interface
+ contains
+  subroutine sub1(b, c)
+    class(*) b
+    integer, optional :: c
+  end
+  subroutine sub2(a, b, c)
+    real a
+    class(*) b
+    integer, optional :: c
+  end
+end

--- a/flang/test/Semantics/resolve54.f90
+++ b/flang/test/Semantics/resolve54.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
 ! Tests based on examples in C.10.6
 
 ! C.10.6(10)
@@ -55,7 +55,7 @@ end
 ! C.10.6(17)
 ! BAD4(1.0,2,Y=3.0,Z=4) could apply to either procedure
 module m4
-  !ERROR: Generic 'bad4' may not have specific procedures 's4a' and 's4b' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'bad4' should not have specific procedures 's4a' and 's4b' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface BAD4
     subroutine S4A(W, X, Y, Z)
       real :: W, Y
@@ -68,7 +68,7 @@ module m4
   end interface
 end
 module m4b
-  !ERROR: Generic 'bad4' may not have specific procedures 's4b' and 's4a' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'bad4' should not have specific procedures 's4b' and 's4a' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface BAD4
     subroutine S4B(X, W, Z, Y)
       real :: X, Y
@@ -109,7 +109,7 @@ end
 ! type(BOSC) :: A_BOSC
 ! BAD6(A_PEAR,A_BOSC)  ! could be s6a or s6b
 module m6
-  !ERROR: Generic 'bad6' may not have specific procedures 's6a' and 's6b' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'bad6' should not have specific procedures 's6a' and 's6b' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface BAD6
     subroutine S6A(X, Y)
       use FRUITS
@@ -123,7 +123,7 @@ module m6
   end interface
 end
 module m6b
-  !ERROR: Generic 'bad6' may not have specific procedures 's6b' and 's6a' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'bad6' should not have specific procedures 's6b' and 's6a' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface BAD6
     subroutine S6B(X, Y)
       use FRUITS
@@ -170,7 +170,7 @@ end
 ! C.10.6(25)
 ! Invalid generic (according to the rules), despite the fact that it is unambiguous
 module m8
-  !ERROR: Generic 'bad8' may not have specific procedures 's8a' and 's8b' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'bad8' should not have specific procedures 's8a' and 's8b' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface BAD8
     subroutine S8A(X, Y, Z)
       real, optional :: X

--- a/flang/test/Semantics/resolve63.f90
+++ b/flang/test/Semantics/resolve63.f90
@@ -340,7 +340,7 @@ module m8
     call generic(null(), ip) ! ok
     call generic(null(mold=ip), null()) ! ok
     call generic(null(), null(mold=ip)) ! ok
-    !ERROR: One or more actual arguments to the generic procedure 'generic' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface
+    !ERROR: The actual arguments to the generic procedure 'generic' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface
     call generic(null(), null())
   end subroutine
 end
@@ -358,7 +358,7 @@ module m9
   end subroutine
   subroutine test
     external underspecified
-    !ERROR: One or more actual arguments to the generic procedure 'generic' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface
+    !ERROR: The actual arguments to the generic procedure 'generic' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface
     call generic(underspecified)
   end subroutine
 end module

--- a/flang/test/Semantics/resolve65.f90
+++ b/flang/test/Semantics/resolve65.f90
@@ -1,13 +1,13 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Test restrictions on what subprograms can be used for defined assignment.
 
 module m1
   implicit none
   type :: t
   contains
-    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t4' and 't%assign_t5' as their interfaces are not distinguishable
-    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t4' and 't%assign_t6' as their interfaces are not distinguishable
-    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t5' and 't%assign_t6' as their interfaces are not distinguishable
+    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t4' and 't%assign_t5' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t4' and 't%assign_t6' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t5' and 't%assign_t6' as their interfaces are not distinguishable by the incomplete rules in the standard
     !ERROR: Defined assignment procedure 'binding' must be a subroutine
     generic :: assignment(=) => binding
     procedure :: binding => assign_t1
@@ -63,7 +63,7 @@ end
 module m2
   type :: t
   end type
-  !ERROR: Generic 'assignment(=)' may not have specific procedures 's3' and 's4' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 's3' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface assignment(=)
     !ERROR: In defined assignment subroutine 's1', dummy argument 'y' may not be OPTIONAL
     subroutine s1(x, y)

--- a/flang/test/Semantics/resolve96.f90
+++ b/flang/test/Semantics/resolve96.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
 
 ! Check distinguishability for specific procedures of defined operators and
 ! assignment. These are different from names because there a normal generic
@@ -18,7 +18,7 @@ module m1
   end type
   type :: t2
   end type
-  !ERROR: Generic 'OPERATOR(.foo.)' may not have specific procedures 's2' and 't1%p' as their interfaces are not distinguishable
+  !PORTABILITY: Generic 'OPERATOR(.foo.)' should not have specific procedures 's2' and 't1%p' as their interfaces are not distinguishable by the incomplete rules in the standard
   interface operator(.foo.)
     procedure :: s2
   end interface
@@ -39,7 +39,7 @@ module m2
     integer :: n
   contains
     procedure, pass(x1) :: p1 => s1
-    !ERROR: Generic 'assignment(=)' may not have specific procedures 't1%p1' and 't2%p2' as their interfaces are not distinguishable
+    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't1%p1' and 't2%p2' as their interfaces are not distinguishable by the incomplete rules in the standard
     generic :: assignment(=) => p1
   end type
   type :: t2


### PR DESCRIPTION
    When a generic procedure interface, either declared or the result of
    merging two use-associated generics, has two specific procedures
    that are not distinguishable according to the rules in F'2023
    subclause 15.4.3.4.5, emit a portability warning rather than a
    hard error message.  The rules in that subclause are not adequate
    to detect pairs of specific procedures that admit an ambiguous
    reference, as demonstrated by a case that arose in pFUnit.  Further,
    these distinguishability checks, even if sufficient to the task
    of detecting pairs of specifics capable of ambiguous references,
    should only apply to pairs where *every* reference would have to
    be ambiguous -- and this can and is validated at every reference
    anyway.  Last, only XLF enforces these incomplete and needless
    distinguishability rules -- every other compiler seems to just
    check that each procedure reference resolves to exactly one
    specific procedure.
    
    If the standard were to complete lose subclause 15.4.3.4.5 and
    its related note (C.11.6) -- which admits that the rules are
    incomplete! -- and simply require that each generic procedure
    reference resolve unambiguously to exactly one specific, nobody
    would miss them.  This patch changes this compiler to give them
    lip service when requested, but they are now otherwise ignored.
