### PR TITLE
[TextAPI] Rename SymbolKind to EncodeKind

### DIFF
--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1904,10 +1904,10 @@ DylibFile::DylibFile(const InterfaceFile &interface, DylibFile *umbrella,
       continue;
 
     switch (symbol->getKind()) {
-    case SymbolKind::GlobalSymbol:
-    case SymbolKind::ObjectiveCClass:
-    case SymbolKind::ObjectiveCClassEHType:
-    case SymbolKind::ObjectiveCInstanceVariable:
+    case EncodeKind::GlobalSymbol:
+    case EncodeKind::ObjectiveCClass:
+    case EncodeKind::ObjectiveCClassEHType:
+    case EncodeKind::ObjectiveCInstanceVariable:
       normalSymbols.push_back(symbol);
     }
   }
@@ -1915,19 +1915,19 @@ DylibFile::DylibFile(const InterfaceFile &interface, DylibFile *umbrella,
   // TODO(compnerd) filter out symbols based on the target platform
   for (const auto *symbol : normalSymbols) {
     switch (symbol->getKind()) {
-    case SymbolKind::GlobalSymbol:
+    case EncodeKind::GlobalSymbol:
       addSymbol(*symbol, symbol->getName());
       break;
-    case SymbolKind::ObjectiveCClass:
+    case EncodeKind::ObjectiveCClass:
       // XXX ld64 only creates these symbols when -ObjC is passed in. We may
       // want to emulate that.
       addSymbol(*symbol, objc::klass + symbol->getName());
       addSymbol(*symbol, objc::metaclass + symbol->getName());
       break;
-    case SymbolKind::ObjectiveCClassEHType:
+    case EncodeKind::ObjectiveCClassEHType:
       addSymbol(*symbol, objc::ehtype + symbol->getName());
       break;
-    case SymbolKind::ObjectiveCInstanceVariable:
+    case EncodeKind::ObjectiveCInstanceVariable:
       addSymbol(*symbol, objc::ivar + symbol->getName());
       break;
     }

--- a/llvm/include/llvm/TextAPI/InterfaceFile.h
+++ b/llvm/include/llvm/TextAPI/InterfaceFile.h
@@ -351,7 +351,7 @@ public:
   ///
   /// \param Kind The kind of global symbol to record.
   /// \param Name The name of the symbol.
-  std::optional<const Symbol *> getSymbol(SymbolKind Kind,
+  std::optional<const Symbol *> getSymbol(EncodeKind Kind,
                                           StringRef Name) const {
     if (auto *Sym = SymbolsSet->findSymbol(Kind, Name))
       return Sym;
@@ -361,7 +361,7 @@ public:
   /// Add a symbol to the symbols list or extend an existing one.
   template <typename RangeT, typename ElT = std::remove_reference_t<
                                  decltype(*std::begin(std::declval<RangeT>()))>>
-  void addSymbol(SymbolKind Kind, StringRef Name, RangeT &&Targets,
+  void addSymbol(EncodeKind Kind, StringRef Name, RangeT &&Targets,
                  SymbolFlags Flags = SymbolFlags::None) {
     SymbolsSet->addGlobal(Kind, Name, Flags, Targets);
   }
@@ -372,7 +372,7 @@ public:
   /// \param Name The name of the symbol.
   /// \param Targets The list of targets the symbol is defined in.
   /// \param Flags The properties the symbol holds.
-  void addSymbol(SymbolKind Kind, StringRef Name, TargetList &&Targets,
+  void addSymbol(EncodeKind Kind, StringRef Name, TargetList &&Targets,
                  SymbolFlags Flags = SymbolFlags::None) {
     SymbolsSet->addGlobal(Kind, Name, Flags, Targets);
   }
@@ -383,7 +383,7 @@ public:
   /// \param Name The name of the symbol.
   /// \param Target The target the symbol is defined in.
   /// \param Flags The properties the symbol holds.
-  void addSymbol(SymbolKind Kind, StringRef Name, Target &Target,
+  void addSymbol(EncodeKind Kind, StringRef Name, Target &Target,
                  SymbolFlags Flags = SymbolFlags::None) {
     SymbolsSet->addGlobal(Kind, Name, Flags, Target);
   }

--- a/llvm/include/llvm/TextAPI/Symbol.h
+++ b/llvm/include/llvm/TextAPI/Symbol.h
@@ -51,7 +51,8 @@ enum class SymbolFlags : uint8_t {
 
 // clang-format on
 
-enum class SymbolKind : uint8_t {
+/// Mapping of entry types in TextStubs.
+enum class EncodeKind : uint8_t {
   GlobalSymbol,
   ObjectiveCClass,
   ObjectiveCClassEHType,
@@ -81,11 +82,11 @@ typename C::iterator addEntry(C &Container, const Target &Targ) {
 
 class Symbol {
 public:
-  Symbol(SymbolKind Kind, StringRef Name, TargetList Targets, SymbolFlags Flags)
+  Symbol(EncodeKind Kind, StringRef Name, TargetList Targets, SymbolFlags Flags)
       : Name(Name), Targets(std::move(Targets)), Kind(Kind), Flags(Flags) {}
 
   void addTarget(Target InputTarget) { addEntry(Targets, InputTarget); }
-  SymbolKind getKind() const { return Kind; }
+  EncodeKind getKind() const { return Kind; }
   StringRef getName() const { return Name; }
   ArchitectureSet getArchitectures() const {
     return mapToArchitectureSet(Targets);
@@ -156,21 +157,21 @@ public:
 private:
   StringRef Name;
   TargetList Targets;
-  SymbolKind Kind;
+  EncodeKind Kind;
   SymbolFlags Flags;
 };
 
 /// Lightweight struct for passing around symbol information.
 struct SimpleSymbol {
   StringRef Name;
-  SymbolKind Kind;
+  EncodeKind Kind;
 
   bool operator<(const SimpleSymbol &O) const {
     return std::tie(Name, Kind) < std::tie(O.Name, O.Kind);
   }
 };
 
-/// Determine SymbolKind from Flags and parsing Name.
+/// Determine EncodeKind from Flags and parsing Name.
 ///
 /// \param Name The name of symbol.
 /// \param Flags The flags pre-determined for the symbol.

--- a/llvm/include/llvm/TextAPI/SymbolSet.h
+++ b/llvm/include/llvm/TextAPI/SymbolSet.h
@@ -23,19 +23,19 @@
 namespace llvm {
 
 struct SymbolsMapKey {
-  MachO::SymbolKind Kind;
+  MachO::EncodeKind Kind;
   StringRef Name;
 
-  SymbolsMapKey(MachO::SymbolKind Kind, StringRef Name)
+  SymbolsMapKey(MachO::EncodeKind Kind, StringRef Name)
       : Kind(Kind), Name(Name) {}
 };
 template <> struct DenseMapInfo<SymbolsMapKey> {
   static inline SymbolsMapKey getEmptyKey() {
-    return SymbolsMapKey(MachO::SymbolKind::GlobalSymbol, StringRef{});
+    return SymbolsMapKey(MachO::EncodeKind::GlobalSymbol, StringRef{});
   }
 
   static inline SymbolsMapKey getTombstoneKey() {
-    return SymbolsMapKey(MachO::SymbolKind::ObjectiveCInstanceVariable,
+    return SymbolsMapKey(MachO::EncodeKind::ObjectiveCInstanceVariable,
                          StringRef{});
   }
 
@@ -87,27 +87,27 @@ private:
   using SymbolsMapType = llvm::DenseMap<SymbolsMapKey, Symbol *>;
   SymbolsMapType Symbols;
 
-  Symbol *addGlobalImpl(SymbolKind, StringRef Name, SymbolFlags Flags);
+  Symbol *addGlobalImpl(EncodeKind, StringRef Name, SymbolFlags Flags);
 
 public:
   SymbolSet() = default;
-  Symbol *addGlobal(SymbolKind Kind, StringRef Name, SymbolFlags Flags,
+  Symbol *addGlobal(EncodeKind Kind, StringRef Name, SymbolFlags Flags,
                     const Target &Targ);
   size_t size() const { return Symbols.size(); }
 
   template <typename RangeT, typename ElT = std::remove_reference_t<
                                  decltype(*std::begin(std::declval<RangeT>()))>>
-  Symbol *addGlobal(SymbolKind Kind, StringRef Name, SymbolFlags Flags,
+  Symbol *addGlobal(EncodeKind Kind, StringRef Name, SymbolFlags Flags,
                     RangeT &&Targets) {
     auto *Global = addGlobalImpl(Kind, Name, Flags);
     for (const auto &Targ : Targets)
       Global->addTarget(Targ);
-    if (Kind == SymbolKind::ObjectiveCClassEHType)
-      addGlobal(SymbolKind::ObjectiveCClass, Name, Flags, Targets);
+    if (Kind == EncodeKind::ObjectiveCClassEHType)
+      addGlobal(EncodeKind::ObjectiveCClass, Name, Flags, Targets);
     return Global;
   }
 
-  const Symbol *findSymbol(SymbolKind Kind, StringRef Name) const;
+  const Symbol *findSymbol(EncodeKind Kind, StringRef Name) const;
 
   struct const_symbol_iterator
       : public iterator_adaptor_base<

--- a/llvm/lib/Object/TapiFile.cpp
+++ b/llvm/lib/Object/TapiFile.cpp
@@ -56,11 +56,11 @@ TapiFile::TapiFile(MemoryBufferRef Source, const InterfaceFile &Interface,
       continue;
 
     switch (Symbol->getKind()) {
-    case SymbolKind::GlobalSymbol:
+    case EncodeKind::GlobalSymbol:
       Symbols.emplace_back(StringRef(), Symbol->getName(), getFlags(Symbol),
                            ::getType(Symbol));
       break;
-    case SymbolKind::ObjectiveCClass:
+    case EncodeKind::ObjectiveCClass:
       if (Interface.getPlatforms().count(PLATFORM_MACOS) && Arch == AK_i386) {
         Symbols.emplace_back(ObjC1ClassNamePrefix, Symbol->getName(),
                              getFlags(Symbol), ::getType(Symbol));
@@ -71,11 +71,11 @@ TapiFile::TapiFile(MemoryBufferRef Source, const InterfaceFile &Interface,
                              getFlags(Symbol), ::getType(Symbol));
       }
       break;
-    case SymbolKind::ObjectiveCClassEHType:
+    case EncodeKind::ObjectiveCClassEHType:
       Symbols.emplace_back(ObjC2EHTypePrefix, Symbol->getName(),
                            getFlags(Symbol), ::getType(Symbol));
       break;
-    case SymbolKind::ObjectiveCInstanceVariable:
+    case EncodeKind::ObjectiveCInstanceVariable:
       Symbols.emplace_back(ObjC2IVarPrefix, Symbol->getName(), getFlags(Symbol),
                            ::getType(Symbol));
       break;

--- a/llvm/lib/TextAPI/RecordVisitor.cpp
+++ b/llvm/lib/TextAPI/RecordVisitor.cpp
@@ -41,17 +41,17 @@ void SymbolConverter::addIVars(const ArrayRef<ObjCIVarRecord *> IVars,
       continue;
     std::string Name =
         ObjCIVarRecord::createScopedName(ContainerName, IV->getName());
-    Symbols->addGlobal(SymbolKind::ObjectiveCInstanceVariable, Name,
+    Symbols->addGlobal(EncodeKind::ObjectiveCInstanceVariable, Name,
                        IV->getFlags(), Targ);
   }
 }
 
 void SymbolConverter::visitObjCInterface(const ObjCInterfaceRecord &ObjCR) {
   if (!shouldSkipRecord(ObjCR, RecordUndefs)) {
-    Symbols->addGlobal(SymbolKind::ObjectiveCClass, ObjCR.getName(),
+    Symbols->addGlobal(EncodeKind::ObjectiveCClass, ObjCR.getName(),
                        ObjCR.getFlags(), Targ);
     if (ObjCR.hasExceptionAttribute())
-      Symbols->addGlobal(SymbolKind::ObjectiveCClassEHType, ObjCR.getName(),
+      Symbols->addGlobal(EncodeKind::ObjectiveCClassEHType, ObjCR.getName(),
                          ObjCR.getFlags(), Targ);
   }
 

--- a/llvm/lib/TextAPI/RecordsSlice.cpp
+++ b/llvm/lib/TextAPI/RecordsSlice.cpp
@@ -25,13 +25,13 @@ Record *RecordsSlice::addRecord(StringRef Name, SymbolFlags Flags,
   auto [APIName, SymKind] = parseSymbol(Name, Flags);
   Name = APIName;
   switch (SymKind) {
-  case SymbolKind::GlobalSymbol:
+  case EncodeKind::GlobalSymbol:
     return addGlobal(Name, Linkage, GV, Flags);
-  case SymbolKind::ObjectiveCClass:
+  case EncodeKind::ObjectiveCClass:
     return addObjCInterface(Name, Linkage);
-  case SymbolKind::ObjectiveCClassEHType:
+  case EncodeKind::ObjectiveCClassEHType:
     return addObjCInterface(Name, Linkage, /*HasEHType=*/true);
-  case SymbolKind::ObjectiveCInstanceVariable: {
+  case EncodeKind::ObjectiveCInstanceVariable: {
     auto [Super, IVar] = Name.split('.');
     // Attempt to find super class.
     ObjCContainerRecord *Container = findContainer(/*isIVar=*/false, Super);

--- a/llvm/lib/TextAPI/Symbol.cpp
+++ b/llvm/lib/TextAPI/Symbol.cpp
@@ -28,16 +28,16 @@ LLVM_DUMP_METHOD void Symbol::dump(raw_ostream &OS) const {
   if (isThreadLocalValue())
     Result += "(tlv) ";
   switch (Kind) {
-  case SymbolKind::GlobalSymbol:
+  case EncodeKind::GlobalSymbol:
     Result += Name.str();
     break;
-  case SymbolKind::ObjectiveCClass:
+  case EncodeKind::ObjectiveCClass:
     Result += "(ObjC Class) " + Name.str();
     break;
-  case SymbolKind::ObjectiveCClassEHType:
+  case EncodeKind::ObjectiveCClassEHType:
     Result += "(ObjC Class EH) " + Name.str();
     break;
-  case SymbolKind::ObjectiveCInstanceVariable:
+  case EncodeKind::ObjectiveCInstanceVariable:
     Result += "(ObjC IVar) " + Name.str();
     break;
   }
@@ -75,27 +75,27 @@ bool Symbol::operator==(const Symbol &O) const {
 SimpleSymbol parseSymbol(StringRef SymName, const SymbolFlags Flags) {
   if (SymName.starts_with(ObjC1ClassNamePrefix))
     return {SymName.drop_front(ObjC1ClassNamePrefix.size()),
-            SymbolKind::ObjectiveCClass};
+            EncodeKind::ObjectiveCClass};
   if (SymName.starts_with(ObjC2ClassNamePrefix))
     return {SymName.drop_front(ObjC2ClassNamePrefix.size()),
-            SymbolKind::ObjectiveCClass};
+            EncodeKind::ObjectiveCClass};
   if (SymName.starts_with(ObjC2MetaClassNamePrefix))
     return {SymName.drop_front(ObjC2MetaClassNamePrefix.size()),
-            SymbolKind::ObjectiveCClass};
+            EncodeKind::ObjectiveCClass};
   if (SymName.starts_with(ObjC2EHTypePrefix)) {
     // When classes without ehtype are used in try/catch blocks
     // a weak-defined symbol is exported. In those cases, treat these as a
     // global instead.
     if ((Flags & SymbolFlags::WeakDefined) == SymbolFlags::WeakDefined)
-      return {SymName, SymbolKind::GlobalSymbol};
+      return {SymName, EncodeKind::GlobalSymbol};
     return {SymName.drop_front(ObjC2EHTypePrefix.size()),
-            SymbolKind::ObjectiveCClassEHType};
+            EncodeKind::ObjectiveCClassEHType};
   }
 
   if (SymName.starts_with(ObjC2IVarPrefix))
     return {SymName.drop_front(ObjC2IVarPrefix.size()),
-            SymbolKind::ObjectiveCInstanceVariable};
-  return {SymName, SymbolKind::GlobalSymbol};
+            EncodeKind::ObjectiveCInstanceVariable};
+  return {SymName, EncodeKind::GlobalSymbol};
 }
 
 } // end namespace MachO.

--- a/llvm/lib/TextAPI/SymbolSet.cpp
+++ b/llvm/lib/TextAPI/SymbolSet.cpp
@@ -11,7 +11,7 @@
 using namespace llvm;
 using namespace llvm::MachO;
 
-Symbol *SymbolSet::addGlobalImpl(SymbolKind Kind, StringRef Name,
+Symbol *SymbolSet::addGlobalImpl(EncodeKind Kind, StringRef Name,
                                  SymbolFlags Flags) {
   Name = copyString(Name);
   auto Result = Symbols.try_emplace(SymbolsMapKey{Kind, Name}, nullptr);
@@ -21,13 +21,13 @@ Symbol *SymbolSet::addGlobalImpl(SymbolKind Kind, StringRef Name,
   return Result.first->second;
 }
 
-Symbol *SymbolSet::addGlobal(SymbolKind Kind, StringRef Name, SymbolFlags Flags,
+Symbol *SymbolSet::addGlobal(EncodeKind Kind, StringRef Name, SymbolFlags Flags,
                              const Target &Targ) {
   auto *Sym = addGlobalImpl(Kind, Name, Flags);
   Sym->addTarget(Targ);
   return Sym;
 }
 
-const Symbol *SymbolSet::findSymbol(SymbolKind Kind, StringRef Name) const {
+const Symbol *SymbolSet::findSymbol(EncodeKind Kind, StringRef Name) const {
   return Symbols.lookup({Kind, Name});
 }

--- a/llvm/lib/TextAPI/TextStub.cpp
+++ b/llvm/lib/TextAPI/TextStub.cpp
@@ -451,7 +451,7 @@ template <> struct MappingTraits<const InterfaceFile *> {
 
           const auto *Symbol = SymArch.first;
           switch (Symbol->getKind()) {
-          case SymbolKind::GlobalSymbol:
+          case EncodeKind::GlobalSymbol:
             if (Symbol->isWeakDefined())
               Section.WeakDefSymbols.emplace_back(Symbol->getName());
             else if (Symbol->isThreadLocalValue())
@@ -459,21 +459,21 @@ template <> struct MappingTraits<const InterfaceFile *> {
             else
               Section.Symbols.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCClass:
+          case EncodeKind::ObjectiveCClass:
             if (File->getFileType() != FileType::TBD_V3)
               Section.Classes.emplace_back(
                   copyString("_" + Symbol->getName().str()));
             else
               Section.Classes.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCClassEHType:
+          case EncodeKind::ObjectiveCClassEHType:
             if (File->getFileType() != FileType::TBD_V3)
               Section.Symbols.emplace_back(
                   copyString("_OBJC_EHTYPE_$_" + Symbol->getName().str()));
             else
               Section.ClassEHs.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCInstanceVariable:
+          case EncodeKind::ObjectiveCInstanceVariable:
             if (File->getFileType() != FileType::TBD_V3)
               Section.IVars.emplace_back(
                   copyString("_" + Symbol->getName().str()));
@@ -510,27 +510,27 @@ template <> struct MappingTraits<const InterfaceFile *> {
 
           const auto *Symbol = SymArch.first;
           switch (Symbol->getKind()) {
-          case SymbolKind::GlobalSymbol:
+          case EncodeKind::GlobalSymbol:
             if (Symbol->isWeakReferenced())
               Section.WeakRefSymbols.emplace_back(Symbol->getName());
             else
               Section.Symbols.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCClass:
+          case EncodeKind::ObjectiveCClass:
             if (File->getFileType() != FileType::TBD_V3)
               Section.Classes.emplace_back(
                   copyString("_" + Symbol->getName().str()));
             else
               Section.Classes.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCClassEHType:
+          case EncodeKind::ObjectiveCClassEHType:
             if (File->getFileType() != FileType::TBD_V3)
               Section.Symbols.emplace_back(
                   copyString("_OBJC_EHTYPE_$_" + Symbol->getName().str()));
             else
               Section.ClassEHs.emplace_back(Symbol->getName());
             break;
-          case SymbolKind::ObjectiveCInstanceVariable:
+          case EncodeKind::ObjectiveCInstanceVariable:
             if (File->getFileType() != FileType::TBD_V3)
               Section.IVars.emplace_back(
                   copyString("_" + Symbol->getName().str()));
@@ -615,32 +615,32 @@ template <> struct MappingTraits<const InterfaceFile *> {
         for (const auto &Symbol : Section.Symbols) {
           if (Ctx->FileKind != FileType::TBD_V3 &&
               Symbol.value.starts_with(ObjC2EHTypePrefix))
-            File->addSymbol(SymbolKind::ObjectiveCClassEHType,
+            File->addSymbol(EncodeKind::ObjectiveCClassEHType,
                             Symbol.value.drop_front(15), Targets, Flags);
           else
-            File->addSymbol(SymbolKind::GlobalSymbol, Symbol, Targets, Flags);
+            File->addSymbol(EncodeKind::GlobalSymbol, Symbol, Targets, Flags);
         }
         for (auto &Symbol : Section.Classes) {
           auto Name = Symbol.value;
           if (Ctx->FileKind != FileType::TBD_V3)
             Name = Name.drop_front();
-          File->addSymbol(SymbolKind::ObjectiveCClass, Name, Targets, Flags);
+          File->addSymbol(EncodeKind::ObjectiveCClass, Name, Targets, Flags);
         }
         for (auto &Symbol : Section.ClassEHs)
-          File->addSymbol(SymbolKind::ObjectiveCClassEHType, Symbol, Targets,
+          File->addSymbol(EncodeKind::ObjectiveCClassEHType, Symbol, Targets,
                           Flags);
         for (auto &Symbol : Section.IVars) {
           auto Name = Symbol.value;
           if (Ctx->FileKind != FileType::TBD_V3)
             Name = Name.drop_front();
-          File->addSymbol(SymbolKind::ObjectiveCInstanceVariable, Name, Targets,
+          File->addSymbol(EncodeKind::ObjectiveCInstanceVariable, Name, Targets,
                           Flags);
         }
         for (auto &Symbol : Section.WeakDefSymbols)
-          File->addSymbol(SymbolKind::GlobalSymbol, Symbol, Targets,
+          File->addSymbol(EncodeKind::GlobalSymbol, Symbol, Targets,
                           SymbolFlags::WeakDefined | Flags);
         for (auto &Symbol : Section.TLVSymbols)
-          File->addSymbol(SymbolKind::GlobalSymbol, Symbol, Targets,
+          File->addSymbol(EncodeKind::GlobalSymbol, Symbol, Targets,
                           SymbolFlags::ThreadLocalValue | Flags);
       }
 
@@ -650,32 +650,32 @@ template <> struct MappingTraits<const InterfaceFile *> {
         for (auto &Symbol : Section.Symbols) {
           if (Ctx->FileKind != FileType::TBD_V3 &&
               Symbol.value.starts_with(ObjC2EHTypePrefix))
-            File->addSymbol(SymbolKind::ObjectiveCClassEHType,
+            File->addSymbol(EncodeKind::ObjectiveCClassEHType,
                             Symbol.value.drop_front(15), Targets,
                             SymbolFlags::Undefined | Flags);
           else
-            File->addSymbol(SymbolKind::GlobalSymbol, Symbol, Targets,
+            File->addSymbol(EncodeKind::GlobalSymbol, Symbol, Targets,
                             SymbolFlags::Undefined | Flags);
         }
         for (auto &Symbol : Section.Classes) {
           auto Name = Symbol.value;
           if (Ctx->FileKind != FileType::TBD_V3)
             Name = Name.drop_front();
-          File->addSymbol(SymbolKind::ObjectiveCClass, Name, Targets,
+          File->addSymbol(EncodeKind::ObjectiveCClass, Name, Targets,
                           SymbolFlags::Undefined | Flags);
         }
         for (auto &Symbol : Section.ClassEHs)
-          File->addSymbol(SymbolKind::ObjectiveCClassEHType, Symbol, Targets,
+          File->addSymbol(EncodeKind::ObjectiveCClassEHType, Symbol, Targets,
                           SymbolFlags::Undefined | Flags);
         for (auto &Symbol : Section.IVars) {
           auto Name = Symbol.value;
           if (Ctx->FileKind != FileType::TBD_V3)
             Name = Name.drop_front();
-          File->addSymbol(SymbolKind::ObjectiveCInstanceVariable, Name, Targets,
+          File->addSymbol(EncodeKind::ObjectiveCInstanceVariable, Name, Targets,
                           SymbolFlags::Undefined | Flags);
         }
         for (auto &Symbol : Section.WeakRefSymbols)
-          File->addSymbol(SymbolKind::GlobalSymbol, Symbol, Targets,
+          File->addSymbol(EncodeKind::GlobalSymbol, Symbol, Targets,
                           SymbolFlags::Undefined | SymbolFlags::WeakReferenced |
                               Flags);
       }
@@ -825,7 +825,7 @@ template <> struct MappingTraits<const InterfaceFile *> {
 
                 const auto *Symbol = IT.first;
                 switch (Symbol->getKind()) {
-                case SymbolKind::GlobalSymbol:
+                case EncodeKind::GlobalSymbol:
                   if (Symbol->isWeakDefined())
                     CurrentSection.WeakSymbols.emplace_back(Symbol->getName());
                   else if (Symbol->isThreadLocalValue())
@@ -833,13 +833,13 @@ template <> struct MappingTraits<const InterfaceFile *> {
                   else
                     CurrentSection.Symbols.emplace_back(Symbol->getName());
                   break;
-                case SymbolKind::ObjectiveCClass:
+                case EncodeKind::ObjectiveCClass:
                   CurrentSection.Classes.emplace_back(Symbol->getName());
                   break;
-                case SymbolKind::ObjectiveCClassEHType:
+                case EncodeKind::ObjectiveCClassEHType:
                   CurrentSection.ClassEHs.emplace_back(Symbol->getName());
                   break;
-                case SymbolKind::ObjectiveCInstanceVariable:
+                case EncodeKind::ObjectiveCInstanceVariable:
                   CurrentSection.Ivars.emplace_back(Symbol->getName());
                   break;
                 }
@@ -901,19 +901,19 @@ template <> struct MappingTraits<const InterfaceFile *> {
 
         for (const auto &CurrentSection : CurrentSections) {
           for (auto &sym : CurrentSection.Symbols)
-            File->addSymbol(SymbolKind::GlobalSymbol, sym,
+            File->addSymbol(EncodeKind::GlobalSymbol, sym,
                             CurrentSection.Targets, Flag);
 
           for (auto &sym : CurrentSection.Classes)
-            File->addSymbol(SymbolKind::ObjectiveCClass, sym,
+            File->addSymbol(EncodeKind::ObjectiveCClass, sym,
                             CurrentSection.Targets, Flag);
 
           for (auto &sym : CurrentSection.ClassEHs)
-            File->addSymbol(SymbolKind::ObjectiveCClassEHType, sym,
+            File->addSymbol(EncodeKind::ObjectiveCClassEHType, sym,
                             CurrentSection.Targets, Flag);
 
           for (auto &sym : CurrentSection.Ivars)
-            File->addSymbol(SymbolKind::ObjectiveCInstanceVariable, sym,
+            File->addSymbol(EncodeKind::ObjectiveCInstanceVariable, sym,
                             CurrentSection.Targets, Flag);
 
           SymbolFlags SymFlag =
@@ -921,12 +921,12 @@ template <> struct MappingTraits<const InterfaceFile *> {
                   ? SymbolFlags::WeakReferenced
                   : SymbolFlags::WeakDefined;
           for (auto &sym : CurrentSection.WeakSymbols) {
-            File->addSymbol(SymbolKind::GlobalSymbol, sym,
+            File->addSymbol(EncodeKind::GlobalSymbol, sym,
                             CurrentSection.Targets, Flag | SymFlag);
           }
 
           for (auto &sym : CurrentSection.TlvSymbols)
-            File->addSymbol(SymbolKind::GlobalSymbol, sym,
+            File->addSymbol(EncodeKind::GlobalSymbol, sym,
                             CurrentSection.Targets,
                             Flag | SymbolFlags::ThreadLocalValue);
         }

--- a/llvm/lib/TextAPI/TextStubV5.cpp
+++ b/llvm/lib/TextAPI/TextStubV5.cpp
@@ -74,7 +74,7 @@ using namespace llvm::MachO;
 
 namespace {
 struct JSONSymbol {
-  SymbolKind Kind;
+  EncodeKind Kind;
   std::string Name;
   SymbolFlags Flags;
 };
@@ -306,7 +306,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
                                 SymbolFlags SectionFlag) {
   auto Err = collectFromArray(
       TBDKey::Globals, Segment, [&Result, &SectionFlag](StringRef Name) {
-        JSONSymbol Sym = {SymbolKind::GlobalSymbol, Name.str(), SectionFlag};
+        JSONSymbol Sym = {EncodeKind::GlobalSymbol, Name.str(), SectionFlag};
         Result.back().second.emplace_back(Sym);
       });
   if (Err)
@@ -314,7 +314,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
 
   Err = collectFromArray(
       TBDKey::ObjCClass, Segment, [&Result, &SectionFlag](StringRef Name) {
-        JSONSymbol Sym = {SymbolKind::ObjectiveCClass, Name.str(), SectionFlag};
+        JSONSymbol Sym = {EncodeKind::ObjectiveCClass, Name.str(), SectionFlag};
         Result.back().second.emplace_back(Sym);
       });
   if (Err)
@@ -322,7 +322,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
 
   Err = collectFromArray(TBDKey::ObjCEHType, Segment,
                          [&Result, &SectionFlag](StringRef Name) {
-                           JSONSymbol Sym = {SymbolKind::ObjectiveCClassEHType,
+                           JSONSymbol Sym = {EncodeKind::ObjectiveCClassEHType,
                                              Name.str(), SectionFlag};
                            Result.back().second.emplace_back(Sym);
                          });
@@ -331,7 +331,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
 
   Err = collectFromArray(
       TBDKey::ObjCIvar, Segment, [&Result, &SectionFlag](StringRef Name) {
-        JSONSymbol Sym = {SymbolKind::ObjectiveCInstanceVariable, Name.str(),
+        JSONSymbol Sym = {EncodeKind::ObjectiveCInstanceVariable, Name.str(),
                           SectionFlag};
         Result.back().second.emplace_back(Sym);
       });
@@ -345,7 +345,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
            : SymbolFlags::WeakDefined);
   Err = collectFromArray(
       TBDKey::Weak, Segment, [&Result, WeakFlag](StringRef Name) {
-        JSONSymbol Sym = {SymbolKind::GlobalSymbol, Name.str(), WeakFlag};
+        JSONSymbol Sym = {EncodeKind::GlobalSymbol, Name.str(), WeakFlag};
         Result.back().second.emplace_back(Sym);
       });
   if (Err)
@@ -353,7 +353,7 @@ Error collectSymbolsFromSegment(const Object *Segment, TargetsToSymbols &Result,
 
   Err = collectFromArray(
       TBDKey::ThreadLocal, Segment, [&Result, SectionFlag](StringRef Name) {
-        JSONSymbol Sym = {SymbolKind::GlobalSymbol, Name.str(),
+        JSONSymbol Sym = {EncodeKind::GlobalSymbol, Name.str(),
                           SymbolFlags::ThreadLocalValue | SectionFlag};
         Result.back().second.emplace_back(Sym);
       });
@@ -857,16 +857,16 @@ Array serializeSymbols(InterfaceFile::const_filtered_symbol_range Symbols,
   auto AssignForSymbolType = [](SymbolFields::SymbolTypes &Assignment,
                                 const Symbol *Sym) {
     switch (Sym->getKind()) {
-    case SymbolKind::ObjectiveCClass:
+    case EncodeKind::ObjectiveCClass:
       Assignment.ObjCClasses.emplace_back(Sym->getName());
       return;
-    case SymbolKind::ObjectiveCClassEHType:
+    case EncodeKind::ObjectiveCClassEHType:
       Assignment.EHTypes.emplace_back(Sym->getName());
       return;
-    case SymbolKind::ObjectiveCInstanceVariable:
+    case EncodeKind::ObjectiveCInstanceVariable:
       Assignment.IVars.emplace_back(Sym->getName());
       return;
-    case SymbolKind::GlobalSymbol: {
+    case EncodeKind::GlobalSymbol: {
       if (Sym->isWeakReferenced() || Sym->isWeakDefined())
         Assignment.Weaks.emplace_back(Sym->getName());
       else if (Sym->isThreadLocalValue())

--- a/llvm/tools/llvm-ifs/llvm-ifs.cpp
+++ b/llvm/tools/llvm-ifs/llvm-ifs.cpp
@@ -212,17 +212,17 @@ static int writeTbdStub(const Triple &T, const std::vector<IFSSymbol> &Symbols,
 
   for (const auto &Symbol : Symbols) {
     auto Name = Symbol.Name;
-    auto Kind = SymbolKind::GlobalSymbol;
+    auto Kind = EncodeKind::GlobalSymbol;
     switch (Symbol.Type) {
     default:
     case IFSSymbolType::NoType:
-      Kind = SymbolKind::GlobalSymbol;
+      Kind = EncodeKind::GlobalSymbol;
       break;
     case IFSSymbolType::Object:
-      Kind = SymbolKind::GlobalSymbol;
+      Kind = EncodeKind::GlobalSymbol;
       break;
     case IFSSymbolType::Func:
-      Kind = SymbolKind::GlobalSymbol;
+      Kind = EncodeKind::GlobalSymbol;
       break;
     }
     if (Symbol.Weak)

--- a/llvm/tools/llvm-readtapi/DiffEngine.cpp
+++ b/llvm/tools/llvm-readtapi/DiffEngine.cpp
@@ -62,18 +62,18 @@ DiffScalarVal<bool, AD_Diff_Scalar_Bool>::print(raw_ostream &OS,
 
 } // end namespace llvm
 
-StringLiteral SymScalar::getSymbolNamePrefix(MachO::SymbolKind Kind) {
+StringLiteral SymScalar::getSymbolNamePrefix(MachO::EncodeKind Kind) {
   switch (Kind) {
-  case MachO::SymbolKind::GlobalSymbol:
+  case MachO::EncodeKind::GlobalSymbol:
     return StringLiteral("");
-  case MachO::SymbolKind::ObjectiveCClass:
+  case MachO::EncodeKind::ObjectiveCClass:
     return ObjC2MetaClassNamePrefix;
-  case MachO::SymbolKind ::ObjectiveCClassEHType:
+  case MachO::EncodeKind ::ObjectiveCClassEHType:
     return ObjC2EHTypePrefix;
-  case MachO::SymbolKind ::ObjectiveCInstanceVariable:
+  case MachO::EncodeKind ::ObjectiveCInstanceVariable:
     return ObjC2IVarPrefix;
   }
-  llvm_unreachable("Unknown llvm::MachO::SymbolKind enum");
+  llvm_unreachable("Unknown llvm::MachO::EncodeKind enum");
 }
 
 std::string SymScalar::getFlagString(const MachO::Symbol *Sym) {
@@ -99,7 +99,7 @@ std::string SymScalar::getFlagString(const MachO::Symbol *Sym) {
 }
 
 void SymScalar::print(raw_ostream &OS, std::string Indent, MachO::Target Targ) {
-  if (Val->getKind() == MachO::SymbolKind::ObjectiveCClass) {
+  if (Val->getKind() == MachO::EncodeKind::ObjectiveCClass) {
     if (Targ.Arch == MachO::AK_i386 && Targ.Platform == MachO::PLATFORM_MACOS) {
       OS << Indent << "\t\t" << ((Order == lhs) ? "< " : "> ")
          << ObjC1ClassNamePrefix << Val->getName() << getFlagString(Val)

--- a/llvm/tools/llvm-readtapi/DiffEngine.h
+++ b/llvm/tools/llvm-readtapi/DiffEngine.h
@@ -94,7 +94,7 @@ private:
   /// The order is the file from which the diff is found.
   InterfaceInputOrder Order;
   const MachO::Symbol *Val;
-  StringLiteral getSymbolNamePrefix(MachO::SymbolKind Kind);
+  StringLiteral getSymbolNamePrefix(MachO::EncodeKind Kind);
 };
 
 class DiffStrVec : public AttributeDiff {

--- a/llvm/unittests/TextAPI/TextStubHelpers.h
+++ b/llvm/unittests/TextAPI/TextStubHelpers.h
@@ -16,7 +16,7 @@
 
 namespace llvm {
 struct ExportedSymbol {
-  MachO::SymbolKind Kind = MachO::SymbolKind::GlobalSymbol;
+  MachO::EncodeKind Kind = MachO::EncodeKind::GlobalSymbol;
   std::string Name = {};
   bool Weak = false;
   bool ThreadLocalValue = false;

--- a/llvm/unittests/TextAPI/TextStubV1Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV1Tests.cpp
@@ -18,24 +18,24 @@ using namespace llvm;
 using namespace llvm::MachO;
 
 static ExportedSymbol TBDv1Symbols[] = {
-    {SymbolKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym2", false, false},
-    {SymbolKind::GlobalSymbol, "_sym3", false, false},
-    {SymbolKind::GlobalSymbol, "_sym4", false, false},
-    {SymbolKind::GlobalSymbol, "_sym5", false, false},
-    {SymbolKind::GlobalSymbol, "_tlv1", false, true},
-    {SymbolKind::GlobalSymbol, "_tlv2", false, true},
-    {SymbolKind::GlobalSymbol, "_tlv3", false, true},
-    {SymbolKind::GlobalSymbol, "_weak1", true, false},
-    {SymbolKind::GlobalSymbol, "_weak2", true, false},
-    {SymbolKind::GlobalSymbol, "_weak3", true, false},
-    {SymbolKind::ObjectiveCClass, "class1", false, false},
-    {SymbolKind::ObjectiveCClass, "class2", false, false},
-    {SymbolKind::ObjectiveCClass, "class3", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
+    {EncodeKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym2", false, false},
+    {EncodeKind::GlobalSymbol, "_sym3", false, false},
+    {EncodeKind::GlobalSymbol, "_sym4", false, false},
+    {EncodeKind::GlobalSymbol, "_sym5", false, false},
+    {EncodeKind::GlobalSymbol, "_tlv1", false, true},
+    {EncodeKind::GlobalSymbol, "_tlv2", false, true},
+    {EncodeKind::GlobalSymbol, "_tlv3", false, true},
+    {EncodeKind::GlobalSymbol, "_weak1", true, false},
+    {EncodeKind::GlobalSymbol, "_weak2", true, false},
+    {EncodeKind::GlobalSymbol, "_weak3", true, false},
+    {EncodeKind::ObjectiveCClass, "class1", false, false},
+    {EncodeKind::ObjectiveCClass, "class2", false, false},
+    {EncodeKind::ObjectiveCClass, "class3", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
 };
 
 namespace TBDv1 {
@@ -107,8 +107,8 @@ TEST(TBDv1, ReadFile) {
   EXPECT_TRUE(
       std::equal(Exports.begin(), Exports.end(), std::begin(TBDv1Symbols)));
 
-  File->addSymbol(SymbolKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
-  File->addSymbol(SymbolKind::ObjectiveCInstanceVariable, "Class1._ivar1",
+  File->addSymbol(EncodeKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
+  File->addSymbol(EncodeKind::ObjectiveCInstanceVariable, "Class1._ivar1",
                   {Targets[1]});
 }
 
@@ -179,14 +179,14 @@ TEST(TBDv1, WriteFile) {
   File.setObjCConstraint(ObjCConstraintType::Retain_Release);
   File.addAllowableClient("clientA", Targets[1]);
   File.addReexportedLibrary("/usr/lib/libfoo.dylib", Targets[1]);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym1", {Targets[0]});
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym2", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym1", {Targets[0]});
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym2", {Targets[0]},
                  SymbolFlags::WeakDefined);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym3", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym3", {Targets[0]},
                  SymbolFlags::ThreadLocalValue);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "Class1._ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCClass, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "Class1._ivar1",
                  {Targets[1]});
 
   SmallString<4096> Buffer;

--- a/llvm/unittests/TextAPI/TextStubV2Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV2Tests.cpp
@@ -17,24 +17,24 @@ using namespace llvm;
 using namespace llvm::MachO;
 
 static ExportedSymbol TBDv2Symbols[] = {
-    {SymbolKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym2", false, false},
-    {SymbolKind::GlobalSymbol, "_sym3", false, false},
-    {SymbolKind::GlobalSymbol, "_sym4", false, false},
-    {SymbolKind::GlobalSymbol, "_sym5", false, false},
-    {SymbolKind::GlobalSymbol, "_tlv1", false, true},
-    {SymbolKind::GlobalSymbol, "_tlv2", false, true},
-    {SymbolKind::GlobalSymbol, "_tlv3", false, true},
-    {SymbolKind::GlobalSymbol, "_weak1", true, false},
-    {SymbolKind::GlobalSymbol, "_weak2", true, false},
-    {SymbolKind::GlobalSymbol, "_weak3", true, false},
-    {SymbolKind::ObjectiveCClass, "class1", false, false},
-    {SymbolKind::ObjectiveCClass, "class2", false, false},
-    {SymbolKind::ObjectiveCClass, "class3", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
+    {EncodeKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym2", false, false},
+    {EncodeKind::GlobalSymbol, "_sym3", false, false},
+    {EncodeKind::GlobalSymbol, "_sym4", false, false},
+    {EncodeKind::GlobalSymbol, "_sym5", false, false},
+    {EncodeKind::GlobalSymbol, "_tlv1", false, true},
+    {EncodeKind::GlobalSymbol, "_tlv2", false, true},
+    {EncodeKind::GlobalSymbol, "_tlv3", false, true},
+    {EncodeKind::GlobalSymbol, "_weak1", true, false},
+    {EncodeKind::GlobalSymbol, "_weak2", true, false},
+    {EncodeKind::GlobalSymbol, "_weak3", true, false},
+    {EncodeKind::ObjectiveCClass, "class1", false, false},
+    {EncodeKind::ObjectiveCClass, "class2", false, false},
+    {EncodeKind::ObjectiveCClass, "class3", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
 };
 
 namespace TBDv2 {
@@ -199,14 +199,14 @@ TEST(TBDv2, WriteFile) {
   File.setObjCConstraint(ObjCConstraintType::Retain_Release);
   File.addAllowableClient("clientA", Targets[1]);
   File.addReexportedLibrary("/usr/lib/libfoo.dylib", Targets[1]);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym1", {Targets[0]});
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym2", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym1", {Targets[0]});
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym2", {Targets[0]},
                  SymbolFlags::WeakDefined);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym3", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym3", {Targets[0]},
                  SymbolFlags::ThreadLocalValue);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "Class1._ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCClass, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "Class1._ivar1",
                  {Targets[1]});
 
   SmallString<4096> Buffer;

--- a/llvm/unittests/TextAPI/TextStubV3Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV3Tests.cpp
@@ -17,24 +17,24 @@ using namespace llvm;
 using namespace llvm::MachO;
 
 static ExportedSymbol TBDv3Symbols[] = {
-    {SymbolKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym1", false, false},
-    {SymbolKind::GlobalSymbol, "_sym2", false, false},
-    {SymbolKind::GlobalSymbol, "_sym3", false, false},
-    {SymbolKind::GlobalSymbol, "_sym4", false, false},
-    {SymbolKind::GlobalSymbol, "_sym5", false, false},
-    {SymbolKind::GlobalSymbol, "_tlv1", false, true},
-    {SymbolKind::GlobalSymbol, "_tlv3", false, true},
-    {SymbolKind::GlobalSymbol, "_weak1", true, false},
-    {SymbolKind::GlobalSymbol, "_weak2", true, false},
-    {SymbolKind::GlobalSymbol, "_weak3", true, false},
-    {SymbolKind::ObjectiveCClass, "class1", false, false},
-    {SymbolKind::ObjectiveCClass, "class2", false, false},
-    {SymbolKind::ObjectiveCClass, "class3", false, false},
-    {SymbolKind::ObjectiveCClassEHType, "class1", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
-    {SymbolKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
+    {EncodeKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym1", false, false},
+    {EncodeKind::GlobalSymbol, "_sym2", false, false},
+    {EncodeKind::GlobalSymbol, "_sym3", false, false},
+    {EncodeKind::GlobalSymbol, "_sym4", false, false},
+    {EncodeKind::GlobalSymbol, "_sym5", false, false},
+    {EncodeKind::GlobalSymbol, "_tlv1", false, true},
+    {EncodeKind::GlobalSymbol, "_tlv3", false, true},
+    {EncodeKind::GlobalSymbol, "_weak1", true, false},
+    {EncodeKind::GlobalSymbol, "_weak2", true, false},
+    {EncodeKind::GlobalSymbol, "_weak3", true, false},
+    {EncodeKind::ObjectiveCClass, "class1", false, false},
+    {EncodeKind::ObjectiveCClass, "class2", false, false},
+    {EncodeKind::ObjectiveCClass, "class3", false, false},
+    {EncodeKind::ObjectiveCClassEHType, "class1", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar1", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar2", false, false},
+    {EncodeKind::ObjectiveCInstanceVariable, "class1._ivar3", false, false},
 };
 
 namespace TBDv3 {
@@ -222,8 +222,8 @@ TEST(TBDv3, ReadMultipleDocuments) {
   llvm::sort(Exports);
 
   ExportedSymbolSeq DocumentSymbols{
-      {SymbolKind::GlobalSymbol, "_sym5", false, false},
-      {SymbolKind::GlobalSymbol, "_sym6", false, false},
+      {EncodeKind::GlobalSymbol, "_sym5", false, false},
+      {EncodeKind::GlobalSymbol, "_sym6", false, false},
   };
 
   EXPECT_EQ(DocumentSymbols.size(), Exports.size());
@@ -268,14 +268,14 @@ TEST(TBDv3, WriteFile) {
   File.setObjCConstraint(ObjCConstraintType::Retain_Release);
   File.addAllowableClient("clientA", Targets[1]);
   File.addReexportedLibrary("/usr/lib/libfoo.dylib", Targets[1]);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym1", {Targets[0]});
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym2", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym1", {Targets[0]});
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym2", {Targets[0]},
                  SymbolFlags::WeakDefined);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym3", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym3", {Targets[0]},
                  SymbolFlags::ThreadLocalValue);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "Class1._ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCClass, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "Class1", {Targets[1]});
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "Class1._ivar1",
                  {Targets[1]});
 
   SmallString<4096> Buffer;
@@ -335,14 +335,14 @@ TEST(TBDv3, WriteMultipleDocuments) {
   File.setObjCConstraint(ObjCConstraintType::Retain_Release);
   File.addAllowableClient("clientA", Targets[2]);
   File.addReexportedLibrary("/usr/lib/libbar.dylib", Targets[2]);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym1", Targets);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_sym2", Targets,
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym1", Targets);
+  File.addSymbol(EncodeKind::GlobalSymbol, "_sym2", Targets,
                  SymbolFlags::WeakDefined);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_symA", Targets,
+  File.addSymbol(EncodeKind::GlobalSymbol, "_symA", Targets,
                  SymbolFlags::ThreadLocalValue);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "Class1", Targets);
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "Class1", Targets);
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "Class1._ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCClass, "Class1", Targets);
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "Class1", Targets);
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "Class1._ivar1",
                  Targets);
 
   // Inline document
@@ -355,8 +355,8 @@ TEST(TBDv3, WriteMultipleDocuments) {
   Document.setTwoLevelNamespace();
   Document.setApplicationExtensionSafe();
   Document.setSwiftABIVersion(5);
-  Document.addSymbol(SymbolKind::GlobalSymbol, "_sym3", Targets);
-  Document.addSymbol(SymbolKind::GlobalSymbol, "_sym4", Targets);
+  Document.addSymbol(EncodeKind::GlobalSymbol, "_sym3", Targets);
+  Document.addSymbol(EncodeKind::GlobalSymbol, "_sym4", Targets);
   File.addDocument(std::make_shared<InterfaceFile>(std::move(Document)));
   
   SmallString<4096> Buffer;
@@ -924,7 +924,7 @@ TEST(TBDv3, InterfaceInequality) {
                                Target(AK_armv7, PLATFORM_IOS));
   }));
   EXPECT_TRUE(checkEqualityOnTransform(FileA, FileB, [](InterfaceFile *File) {
-    File->addSymbol(SymbolKind::GlobalSymbol, "_symA",
+    File->addSymbol(EncodeKind::GlobalSymbol, "_symA",
                     {Target(AK_arm64, PLATFORM_IOS)});
   }));
   EXPECT_TRUE(checkEqualityOnTransform(FileA, FileB, [](InterfaceFile *File) {

--- a/llvm/unittests/TextAPI/TextStubV4Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV4Tests.cpp
@@ -133,19 +133,19 @@ TEST(TBDv4, ReadFile) {
   llvm::sort(Undefineds);
 
   static ExportedSymbol ExpectedExportedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symA", false, false},
-      {SymbolKind::GlobalSymbol, "_symAB", false, false},
-      {SymbolKind::GlobalSymbol, "_symB", false, false},
+      {EncodeKind::GlobalSymbol, "_symA", false, false},
+      {EncodeKind::GlobalSymbol, "_symAB", false, false},
+      {EncodeKind::GlobalSymbol, "_symB", false, false},
   };
 
   static ExportedSymbol ExpectedReexportedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symC", false, false},
-      {SymbolKind::GlobalSymbol, "weakReexport", true, false},
+      {EncodeKind::GlobalSymbol, "_symC", false, false},
+      {EncodeKind::GlobalSymbol, "weakReexport", true, false},
   };
 
   static ExportedSymbol ExpectedUndefinedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symD", false, false},
-      {SymbolKind::GlobalSymbol, "weakReference", true, false},
+      {EncodeKind::GlobalSymbol, "_symD", false, false},
+      {EncodeKind::GlobalSymbol, "weakReference", true, false},
   };
 
   EXPECT_EQ(std::size(ExpectedExportedSymbols), Exports.size());
@@ -290,16 +290,16 @@ TEST(TBDv4, ReadMultipleDocuments) {
   llvm::sort(Undefineds);
 
   static ExportedSymbol ExpectedExportedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symA", false, false},
-      {SymbolKind::GlobalSymbol, "_symAB", false, false},
+      {EncodeKind::GlobalSymbol, "_symA", false, false},
+      {EncodeKind::GlobalSymbol, "_symAB", false, false},
   };
 
   static ExportedSymbol ExpectedReexportedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symC", false, false},
+      {EncodeKind::GlobalSymbol, "_symC", false, false},
   };
 
   static ExportedSymbol ExpectedUndefinedSymbols[] = {
-      {SymbolKind::GlobalSymbol, "_symD", false, false},
+      {EncodeKind::GlobalSymbol, "_symD", false, false},
   };
 
   EXPECT_EQ(std::size(ExpectedExportedSymbols), Exports.size());
@@ -352,11 +352,11 @@ TEST(TBDv4, WriteFile) {
   File.addAllowableClient("ClientA", Targets[0]);
   File.addParentUmbrella(Targets[0], "System");
   File.addParentUmbrella(Targets[1], "System");
-  File.addSymbol(SymbolKind::GlobalSymbol, "_symA", {Targets[0]});
-  File.addSymbol(SymbolKind::GlobalSymbol, "_symB", {Targets[1]});
-  File.addSymbol(SymbolKind::GlobalSymbol, "_symC", {Targets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_symA", {Targets[0]});
+  File.addSymbol(EncodeKind::GlobalSymbol, "_symB", {Targets[1]});
+  File.addSymbol(EncodeKind::GlobalSymbol, "_symC", {Targets[0]},
                  SymbolFlags::WeakDefined);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "Class1", {Targets[0]});
+  File.addSymbol(EncodeKind::ObjectiveCClass, "Class1", {Targets[0]});
 
   SmallString<4096> Buffer;
   raw_svector_ostream OS(Buffer);
@@ -420,11 +420,11 @@ TEST(TBDv4, WriteMultipleDocuments) {
   Document.setCurrentVersion(PackedVersion(1, 0, 0));
   Document.setTwoLevelNamespace();
   Document.setApplicationExtensionSafe(true);
-  Document.addSymbol(SymbolKind::GlobalSymbol, "_symA", Targets);
-  Document.addSymbol(SymbolKind::GlobalSymbol, "_symAB", {Targets[1]});
-  Document.addSymbol(SymbolKind::GlobalSymbol, "_symC", {Targets[0]},
+  Document.addSymbol(EncodeKind::GlobalSymbol, "_symA", Targets);
+  Document.addSymbol(EncodeKind::GlobalSymbol, "_symAB", {Targets[1]});
+  Document.addSymbol(EncodeKind::GlobalSymbol, "_symC", {Targets[0]},
                      SymbolFlags::WeakDefined);
-  Document.addSymbol(SymbolKind::ObjectiveCClass, "Class1", Targets);
+  Document.addSymbol(EncodeKind::ObjectiveCClass, "Class1", Targets);
   File.addDocument(std::make_shared<InterfaceFile>(std::move(Document)));
 
   SmallString<4096> Buffer;
@@ -1163,7 +1163,7 @@ TEST(TBDv4, InterfaceInequality) {
                                Target(AK_i386, PLATFORM_MACOS));
   }));
   EXPECT_TRUE(checkEqualityOnTransform(FileA, FileB, [](InterfaceFile *File) {
-    File->addSymbol(SymbolKind::GlobalSymbol, "_symA",
+    File->addSymbol(EncodeKind::GlobalSymbol, "_symA",
                     {Target(AK_x86_64, PLATFORM_MACOS)});
   }));
   EXPECT_TRUE(checkEqualityOnTransform(FileA, FileB, [](InterfaceFile *File) {

--- a/llvm/unittests/TextAPI/TextStubV5Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV5Tests.cpp
@@ -267,63 +267,63 @@ TEST(TBDv5, ReadFile) {
                              Target(AK_arm64, PLATFORM_MACOS)};
 
   std::vector<ExportedSymbol> ExpectedExportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol,
        "_funcFoo",
        false,
        false,
        false,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
+      {EncodeKind::GlobalSymbol,
        "_globalVar",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassA",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassB",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassData",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassA",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassB",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassA.ivar1",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassA.ivar2",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassC.ivar1",
        false,
        false,
@@ -331,20 +331,20 @@ TEST(TBDv5, ReadFile) {
        {Target(AK_x86_64, PLATFORM_MACOS)}},
   };
   std::vector<ExportedSymbol> ExpectedReexportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassRexport", false, false, true,
+      {EncodeKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassRexport", false, false, true,
        MacOSTargets},
   };
 
   std::vector<ExportedSymbol> ExpectedUndefinedSymbols = {
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "_globalBind",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "referenced_sym",
        true,
        false,
@@ -363,7 +363,7 @@ TEST(TBDv5, ReadFile) {
                          std::begin(ExpectedUndefinedSymbols)));
 
   EXPECT_TRUE(
-      File->getSymbol(SymbolKind::GlobalSymbol, "_globalBind").has_value());
+      File->getSymbol(EncodeKind::GlobalSymbol, "_globalBind").has_value());
 }
 
 TEST(TBDv5, ReadMultipleTargets) {
@@ -524,23 +524,23 @@ TEST(TBDv5, ReadMultipleDocuments) {
 
   llvm::sort(Exports);
   ExportedSymbolSeq ExpectedExports = {
-      {SymbolKind::GlobalSymbol, "_funcFoo", false, false, false, {iOSTarget}},
-      {SymbolKind::GlobalSymbol, "_globalVar", false, true, true, {iOSTarget}},
-      {SymbolKind::ObjectiveCClass, "ClassA", false, false, true, {iOSTarget}},
-      {SymbolKind::ObjectiveCClass, "ClassB", false, false, true, {iOSTarget}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::GlobalSymbol, "_funcFoo", false, false, false, {iOSTarget}},
+      {EncodeKind::GlobalSymbol, "_globalVar", false, true, true, {iOSTarget}},
+      {EncodeKind::ObjectiveCClass, "ClassA", false, false, true, {iOSTarget}},
+      {EncodeKind::ObjectiveCClass, "ClassB", false, false, true, {iOSTarget}},
+      {EncodeKind::ObjectiveCClass,
        "ClassData",
        false,
        false,
        true,
        {iOSTarget}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassA",
        false,
        false,
        true,
        {iOSTarget}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassB",
        false,
        false,
@@ -734,43 +734,43 @@ TEST(TBDv5, WriteFile) {
 
   SymbolFlags Flags = SymbolFlags::None;
   // Exports.
-  File.addSymbol(SymbolKind::GlobalSymbol, "_global",
+  File.addSymbol(EncodeKind::GlobalSymbol, "_global",
                  {AllTargets[0], AllTargets[1]}, Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_func",
+  File.addSymbol(EncodeKind::GlobalSymbol, "_func",
                  {AllTargets[0], AllTargets[1]}, Flags | SymbolFlags::Text);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "ClassA",
+  File.addSymbol(EncodeKind::ObjectiveCClass, "ClassA",
                  {AllTargets[0], AllTargets[1]}, Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_funcFoo", {AllTargets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_funcFoo", {AllTargets[0]},
                  Flags | SymbolFlags::Text);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_globalVar", {AllTargets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_globalVar", {AllTargets[0]},
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "ClassData", {AllTargets[0]},
+  File.addSymbol(EncodeKind::ObjectiveCClass, "ClassData", {AllTargets[0]},
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "ClassA", {AllTargets[0]},
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "ClassA", {AllTargets[0]},
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCClassEHType, "ClassB", {AllTargets[0]},
+  File.addSymbol(EncodeKind::ObjectiveCClassEHType, "ClassB", {AllTargets[0]},
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "ClassA.ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "ClassA.ivar1",
                  {AllTargets[0]}, Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "ClassA.ivar2",
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "ClassA.ivar2",
                  {AllTargets[0]}, Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::ObjectiveCInstanceVariable, "ClassC.ivar1",
+  File.addSymbol(EncodeKind::ObjectiveCInstanceVariable, "ClassC.ivar1",
                  {AllTargets[0]}, Flags | SymbolFlags::Data);
 
   // Reexports.
   Flags = SymbolFlags::Rexported;
-  File.addSymbol(SymbolKind::GlobalSymbol, "_globalRe", AllTargets,
+  File.addSymbol(EncodeKind::GlobalSymbol, "_globalRe", AllTargets,
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::GlobalSymbol, "_funcA", AllTargets,
+  File.addSymbol(EncodeKind::GlobalSymbol, "_funcA", AllTargets,
                  Flags | SymbolFlags::Text);
-  File.addSymbol(SymbolKind::ObjectiveCClass, "ClassRexport", AllTargets,
+  File.addSymbol(EncodeKind::ObjectiveCClass, "ClassRexport", AllTargets,
                  Flags | SymbolFlags::Data);
 
   // Undefineds.
   Flags = SymbolFlags::Undefined;
-  File.addSymbol(SymbolKind::GlobalSymbol, "_globalBind", {AllTargets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "_globalBind", {AllTargets[0]},
                  Flags | SymbolFlags::Data);
-  File.addSymbol(SymbolKind::GlobalSymbol, "referenced_sym", {AllTargets[0]},
+  File.addSymbol(EncodeKind::GlobalSymbol, "referenced_sym", {AllTargets[0]},
                  Flags | SymbolFlags::Data | SymbolFlags::WeakReferenced);
 
   File.setTwoLevelNamespace(false);
@@ -900,7 +900,7 @@ TEST(TBDv5, WriteMultipleDocuments) {
   NestedFile.addRPath(AllTargets[0], "@executable_path/.../Frameworks");
   for (const auto &Targ : AllTargets)
     NestedFile.addReexportedLibrary("@rpath/libfoo.dylib", Targ);
-  NestedFile.addSymbol(SymbolKind::GlobalSymbol, "_funcFoo", AllTargets,
+  NestedFile.addSymbol(EncodeKind::GlobalSymbol, "_funcFoo", AllTargets,
                        SymbolFlags::Text);
   File.addDocument(std::make_shared<InterfaceFile>(std::move(NestedFile)));
 
@@ -912,7 +912,7 @@ TEST(TBDv5, WriteMultipleDocuments) {
   NestedFileB.setCurrentVersion(PackedVersion(1, 0, 0));
   NestedFileB.setTwoLevelNamespace();
   NestedFileB.setApplicationExtensionSafe(true);
-  NestedFileB.addSymbol(SymbolKind::GlobalSymbol, "_varFooBaz", {AllTargets[0]},
+  NestedFileB.addSymbol(EncodeKind::GlobalSymbol, "_varFooBaz", {AllTargets[0]},
                         SymbolFlags::Data);
   File.addDocument(std::make_shared<InterfaceFile>(std::move(NestedFileB)));
 
@@ -1568,119 +1568,119 @@ TEST(TBDv5, MergeIF) {
                              Target(AK_arm64, PLATFORM_MACOS)};
 
   std::vector<ExportedSymbol> ExpectedExportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol,
        "_funcFoo",
        false,
        false,
        false,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "_funcFooZ",
        false,
        false,
        false,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol, "_funcZ", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol, "_funcZ", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
+      {EncodeKind::GlobalSymbol,
        "_globalVar",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "_globalVarZ",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol, "_globalZ", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::GlobalSymbol, "_globalZ", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass,
        "ClassA",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassB",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassData",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassF",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClass,
+      {EncodeKind::ObjectiveCClass,
        "ClassZ",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassA",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassB",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassF",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCClassEHType,
+      {EncodeKind::ObjectiveCClassEHType,
        "ClassZ",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassA.ivar1",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassA.ivar2",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassC.ivar1",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassF.ivar1",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassZ.ivar1",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::ObjectiveCInstanceVariable,
+      {EncodeKind::ObjectiveCInstanceVariable,
        "ClassZ.ivar2",
        false,
        false,
@@ -1689,20 +1689,20 @@ TEST(TBDv5, MergeIF) {
   };
 
   std::vector<ExportedSymbol> ExpectedReexportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassRexport", false, false, true,
+      {EncodeKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassRexport", false, false, true,
        MacOSTargets},
   };
 
   std::vector<ExportedSymbol> ExpectedUndefinedSymbols = {
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "_globalBind",
        false,
        false,
        true,
        {Target(AK_x86_64, PLATFORM_MACOS)}},
-      {SymbolKind::GlobalSymbol,
+      {EncodeKind::GlobalSymbol,
        "referenced_sym",
        true,
        false,
@@ -1955,14 +1955,14 @@ TEST(TBDv5, ExtractIF) {
   TargetList MacOSTargets = {Target(AK_arm64, PLATFORM_MACOS)};
 
   std::vector<ExportedSymbol> ExpectedExportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassA", false, false, true, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassA", false, false, true, MacOSTargets},
   };
   std::vector<ExportedSymbol> ExpectedReexportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassRexport", false, false, true,
+      {EncodeKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassRexport", false, false, true,
        MacOSTargets},
   };
 
@@ -2208,14 +2208,14 @@ TEST(TBDv5, RemoveIF) {
   TargetList MacOSTargets = {Target(AK_arm64, PLATFORM_MACOS)};
 
   std::vector<ExportedSymbol> ExpectedExportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassA", false, false, true, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_func", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_global", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassA", false, false, true, MacOSTargets},
   };
   std::vector<ExportedSymbol> ExpectedReexportedSymbols = {
-      {SymbolKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
-      {SymbolKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
-      {SymbolKind::ObjectiveCClass, "ClassRexport", false, false, true,
+      {EncodeKind::GlobalSymbol, "_funcA", false, false, false, MacOSTargets},
+      {EncodeKind::GlobalSymbol, "_globalRe", false, false, true, MacOSTargets},
+      {EncodeKind::ObjectiveCClass, "ClassRexport", false, false, true,
        MacOSTargets},
   };
 
@@ -2364,8 +2364,8 @@ TEST(TBDv5, InlineIF) {
   llvm::sort(Exports);
 
   ExportedSymbolSeq ExpectedExports = {
-      {SymbolKind::GlobalSymbol, "_global", false, false, true, AllTargets},
-      {SymbolKind::ObjectiveCClass, "ClassA", false, false, true, AllTargets},
+      {EncodeKind::GlobalSymbol, "_global", false, false, true, AllTargets},
+      {EncodeKind::ObjectiveCClass, "ClassA", false, false, true, AllTargets},
   };
   EXPECT_EQ(ExpectedExports.size(), Exports.size());
   EXPECT_TRUE(


### PR DESCRIPTION
A distinction that doesn't _usually_ matter is that the MachO::SymbolKind is really a mapping of entries in TBD files not symbols. To better understand this, rename the enum so it represents an encoding mapped to TBDs as opposed to symbols alone.

For example, it can be a bit confusing that "GlobalSymbol" is a enum value when all of those values can represent a GlobalSymbol.