### PR TITLE
[lldb] Fix progress reporting for SymbolLocatorDebugSymbols

### DIFF
--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -1049,28 +1049,26 @@ bool SymbolLocatorDebugSymbols::DownloadObjectAndSymbolFile(
   if (!dsymForUUID_exe_spec)
     return false;
 
+  // Create the dsymForUUID command.
   const std::string dsymForUUID_exe_path = dsymForUUID_exe_spec.GetPath();
   const std::string uuid_str = uuid_ptr ? uuid_ptr->GetAsString() : "";
-  const std::string file_path_str =
-      file_spec_ptr ? file_spec_ptr->GetPath() : "";
 
-  if (uuid_str.empty() && file_path_str.empty())
+  std::string lookup_arg = uuid_str;
+  if (lookup_arg.empty())
+    lookup_arg = file_spec_ptr ? file_spec_ptr->GetPath() : "";
+  if (lookup_arg.empty())
     return false;
 
-  // Create the dsymForUUID command.
-  const char *lookup_arg =
-      !uuid_str.empty() ? uuid_str.c_str() : file_path_str.c_str();
-  const char *copy_executable_arg = copy_executable ? "--copyExecutable " : "";
-
   StreamString command;
-  command.Printf("%s --ignoreNegativeCache %s%s", dsymForUUID_exe_path.c_str(),
-                 copy_executable_arg, lookup_arg);
+  command << dsymForUUID_exe_path << " --ignoreNegativeCache ";
+  if (copy_executable)
+    command << "--copyExecutable ";
+  command << lookup_arg;
 
   // Log and report progress.
   Log *log = GetLog(LLDBLog::Host);
-  LLDB_LOGF(log, "Calling %s with %s to find dSYM: %s",
-            dsymForUUID_exe_path.c_str(), lookup_arg,
-            command.GetString().data());
+  LLDB_LOG(log, "Calling {0} with {1} to find dSYM: {2}", dsymForUUID_exe_path,
+           lookup_arg, command.GetString());
 
   Progress progress("Downloading symbol file", lookup_arg);
 


### PR DESCRIPTION
This fixes two issues related to the DebugSymbols symbol locator:

  1. Only the default symbol locator plugin reports progress. On Darwin, which uses the DebugSymbols framework we need to report the same progress form the corresponding SymbolLocator plugin.

  2. Forceful dSYM lookups, for example when using `add-dsym`, use a different code path that currently does not report progress, which is confusing. Here the progress event can be more specific and specify its downloading a symbol file rather than just locating it as we'll always shell out to dsymForUUID or its equivalent.

rdar://121629777