### PR TITLE
[flang][runtime] Add special-case faster path to real MOD/MODULO

### DIFF
--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -144,7 +144,18 @@ inline RT_API_ATTRS T RealMod(
     return std::numeric_limits<T>::quiet_NaN();
   } else if (std::isinf(p)) {
     return a;
-  } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double> ||
+  }
+  if (auto aInt{static_cast<std::int64_t>(a)}; a == aInt) {
+    if (auto pInt{static_cast<std::int64_t>(p)}; p == pInt) {
+      // Fast exact case for integer operands
+      auto mod{aInt - (aInt / pInt) * pInt};
+      if (IS_MODULO && (aInt > 0) != (pInt > 0)) {
+        mod += pInt;
+      }
+      return static_cast<T>(mod);
+    }
+  }
+  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double> ||
       std::is_same_v<T, long double>) {
     // std::fmod() semantics on signed operands seems to match
     // the requirements of MOD().  MODULO() needs adjustment.


### PR DESCRIPTION
When a real-valued reference to the MOD/MODULO intrinsic functions has operands that are exact integers, use the fast exact integer algorithm rather than calling std::fmod.