### PR TITLE
[flang] Handle more use cases reported for issues/78797

### DIFF
--- a/flang/test/Preprocessing/pp005.F
+++ b/flang/test/Preprocessing/pp005.F
@@ -1,11 +1,11 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: res = 777
+! CHECK: res = (777)
 * KWM split across continuation, implicit padding
       integer, parameter :: KWM = 666
 #define KWM 777
       integer :: res
-      res = KW
-     +M
+      res = (KW
+     +M)
       if (res .eq. 777) then
         print *, 'pp005.F yes'
       else

--- a/flang/test/Preprocessing/pp006.F
+++ b/flang/test/Preprocessing/pp006.F
@@ -1,12 +1,12 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: res = 777
+! CHECK: res = (777)
 * ditto, but with intervening *comment line
       integer, parameter :: KWM = 666
 #define KWM 777
       integer :: res
-      res = KW
+      res = (KW
 *comment
-     +M
+     +M)
       if (res .eq. 777) then
         print *, 'pp006.F yes'
       else

--- a/flang/test/Preprocessing/pp105.F90
+++ b/flang/test/Preprocessing/pp105.F90
@@ -1,11 +1,11 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: res = 777
+! CHECK: res = (777)
 ! KWM call name split across continuation, with leading &
       integer, parameter :: KWM = 666
 #define KWM 777
       integer :: res
-      res = KW&
-&M
+      res = (KW&
+&M)
       if (res .eq. 777) then
         print *, 'pp105.F90 yes'
       else

--- a/flang/test/Preprocessing/pp106.F90
+++ b/flang/test/Preprocessing/pp106.F90
@@ -1,11 +1,11 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: res = 777
+! CHECK: res = (777)
 ! ditto, with & ! comment
       integer, parameter :: KWM = 666
 #define KWM 777
       integer :: res
-      res = KW& ! comment
-&M
+      res = (KW& ! comment
+&M)
       if (res .eq. 777) then
         print *, 'pp106.F90 yes'
       else

--- a/flang/test/Preprocessing/pp134.F90
+++ b/flang/test/Preprocessing/pp134.F90
@@ -1,9 +1,23 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: print *, ADC
+! CHECK: print *, ADC, 1
+! CHECK: print *, AD, 1
+! CHECK: print *, DC, 1
+! CHECK: print *, AD
+! CHECK: print *, AB
 #define B D
 implicit none
 real ADC
 print *, A&
   &B&
-  &C
+  &C, 1
+print *, A&
+  &B&
+  &, 1
+print *, &
+  &B&
+  &C, 1
+print *, A&
+  &B
+print *, A&
+  &B ! but not this
 end


### PR DESCRIPTION
I implemented legacy "token pasting" via line continuation for

  call prefix&
    &MACRO&
    &suffix(1)

in a recent patch; this patch addresses the related cases

  call prefix&
    &MACRO&
    &(1)

and

  call &
    &MACRO&
    &suffix(1)

Fixes the latest https://github.com/llvm/llvm-project/issues/79590.