### PR TITLE
[fuchsia][libc] Include missing macro definitions

### DIFF
--- a/libc/test/UnitTest/FuchsiaTest.h
+++ b/libc/test/UnitTest/FuchsiaTest.h
@@ -13,6 +13,11 @@
 
 #define WITH_SIGNAL(X) #X
 
+// These macros are used in string unittests.
+#define ASSERT_ERRNO_EQ(VAL) ASSERT_EQ(VAL, static_cast<int>(libc_errno))
+#define ASSERT_ERRNO_SUCCESS() ASSERT_EQ(0, static_cast<int>(libc_errno))
+#define ASSERT_ERRNO_FAILURE() ASSERT_NE(0, static_cast<int>(libc_errno))
+
 #ifndef EXPECT_DEATH
 // Since zxtest has ASSERT_DEATH but not EXPECT_DEATH, wrap calling it
 // in a lambda returning void to swallow any early returns so that this


### PR DESCRIPTION
PR 79573 introduced `ASSERT_ERRNO_*` macros for use in libc tests. Introduce these macro definitions to FuchsiaTest.h for string tests to compile on Fuchsia.