### PR TITLE
[lldb] Streamline ConstString -> std::string conversion (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -167,8 +167,14 @@ public:
 
   // Implicitly convert \class ConstString instances to \class StringRef.
   operator llvm::StringRef() const { return GetStringRef(); }
-  // Implicitly convert \class ConstString instances to \calss std::string_view.
-  operator std::string_view() const { return std::string_view(m_string, GetLength()); }
+
+  // Implicitly convert \class ConstString instances to \class std::string_view.
+  operator std::string_view() const {
+    return std::string_view(m_string, GetLength());
+  }
+
+  // Explicitly convert \class ConstString instances to \class std::string.
+  explicit operator std::string() const { return GetString(); }
 
   /// Get the string value as a C string.
   ///
@@ -191,6 +197,9 @@ public:
   llvm::StringRef GetStringRef() const {
     return llvm::StringRef(m_string, GetLength());
   }
+
+  /// Get the string value as a std::string
+  std::string GetString() const { return std::string(m_string, GetLength()); }
 
   /// Get the string value as a C string.
   ///

--- a/lldb/unittests/Utility/ConstStringTest.cpp
+++ b/lldb/unittests/Utility/ConstStringTest.cpp
@@ -137,3 +137,17 @@ TEST(ConstStringTest, CompareStringRef) {
   EXPECT_TRUE(null == static_cast<const char *>(nullptr));
   EXPECT_TRUE(null != "bar");
 }
+
+TEST(ConstStringTest, StringConversions) {
+  ConstString foo("foo");
+
+  // Member functions.
+  EXPECT_EQ(llvm::StringRef("foo"), foo.GetStringRef());
+  EXPECT_EQ(std::string("foo"), foo.GetString());
+  EXPECT_STREQ("foo", foo.AsCString());
+
+  // Conversion operators.
+  EXPECT_EQ(llvm::StringRef("foo"), llvm::StringRef(foo));
+  EXPECT_EQ(std::string("foo"), std::string_view(foo));
+  EXPECT_EQ(std::string("foo"), std::string(foo));
+}


### PR DESCRIPTION
Make it easier to go from a ConstString to a std::string without having to go through a C-String or a llvm::StringRef. I made the conversion operator explicit as this is a relatively expensive operations (compared to a StringRef or string_view).