### PR TITLE
[libc][NFC] Simplify AMDGPU constant frequency checks

### DIFF
--- a/libc/src/time/gpu/time_utils.h
+++ b/libc/src/time/gpu/time_utils.h
@@ -17,18 +17,11 @@ namespace LIBC_NAMESPACE {
 // AMDGPU does not have a single set frequency. Different architectures and
 // cards can have vary values. Here we default to a few known values, but for
 // complete support the frequency needs to be read from the kernel driver.
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) ||       \
-    defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) ||    \
-    defined(__gfx1013__) || defined(__gfx1030__) || defined(__gfx1031__) ||    \
-    defined(__gfx1032__) || defined(__gfx1033__) || defined(__gfx1034__) ||    \
-    defined(__gfx1035__) || defined(__gfx1036__) || defined(__gfx1100__) ||    \
-    defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) ||    \
-    defined(__gfx1150__) || defined(__gfx1151__)
+#if defined(__GFX10__) || defined(__GFX11__) || defined(__GFX12__) ||          \
+    defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
 // These architectures use a 100 MHz fixed frequency clock.
 constexpr uint64_t clock_freq = 100000000;
-#elif defined(__gfx900__) || defined(__gfx902__) || defined(__gfx904__) ||     \
-    defined(__gfx906__) || defined(__gfx908__) || defined(__gfx909__) ||       \
-    defined(__gfx90a__) || defined(__gfx90c__)
+#elif defined(__GFX9__)
 // These architectures use a 25 MHz fixed frequency clock expect for Vega 10
 // which is actually 27 Mhz. We default to 25 MHz in all cases anyway.
 constexpr uint64_t clock_freq = 25000000;


### PR DESCRIPTION
Summary:
The AMDGPU fixed frequency clock is fixed to a chip dependent frequency.
More modern chips have started to fix this at known values of 25 MHz or
100 MHz, so this function forwards those values. This was done using the
individual architectures. This patch simply uses the more concise
`__GFXn__` macro which indicates the major revision
