### PR TITLE
[lldb] Remove obsolete signBinary helper

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -442,8 +442,6 @@ def parseOptionsAndInitTestdirs():
             os.path.realpath(os.path.abspath(x)) for x in args.args
         ]
 
-    lldbtest_config.codesign_identity = args.codesign_identity
-
 
 def registerFaulthandler():
     try:

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -218,12 +218,6 @@ def create_parser():
         help="Leave logs/traces even for successful test runs (useful for creating reference log files during debugging.)",
     )
     group.add_argument(
-        "--codesign-identity",
-        metavar="Codesigning identity",
-        default="lldb_codesign",
-        help="The codesigning identity to use",
-    )
-    group.add_argument(
         "--build-dir",
         dest="test_build_dir",
         metavar="Test build directory",

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1543,14 +1543,6 @@ class Base(unittest2.TestCase):
         d = {"CXX_SOURCES": sources, "EXE": exe_name}
         self.build(dictionary=d)
 
-    def signBinary(self, binary_path):
-        if sys.platform.startswith("darwin"):
-            codesign_cmd = 'codesign --force --sign "%s" %s' % (
-                lldbtest_config.codesign_identity,
-                binary_path,
-            )
-            call(codesign_cmd, shell=True)
-
     def findBuiltClang(self):
         """Tries to find and use Clang from the build directory as the compiler (instead of the system compiler)."""
         paths_to_try = [

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -98,12 +98,6 @@ if(CMAKE_HOST_APPLE)
     set(LLDB_FRAMEWORK_DIR ${LLDB_FRAMEWORK_ABSOLUTE_BUILD_DIR}/LLDB.framework)
   endif()
 
-  # Use the same identity for testing
-  get_property(code_sign_identity_used GLOBAL PROPERTY LLDB_DEBUGSERVER_CODESIGN_IDENTITY)
-  if(code_sign_identity_used)
-    list(APPEND LLDB_TEST_COMMON_ARGS_VAR --codesign-identity "${code_sign_identity_used}")
-  endif()
-
   if(LLDB_USE_SYSTEM_DEBUGSERVER)
     lldb_find_system_debugserver(system_debugserver_path)
     if(LLDB_BUILD_FRAMEWORK)

--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -18,7 +18,6 @@ class TestSBCommandReturnObject(TestBase):
         self.driver_exe = self.getBuildArtifact("command-return-object")
         self.buildDriver("main.cpp", self.driver_exe)
         self.addTearDownHook(lambda: os.remove(self.driver_exe))
-        self.signBinary(self.driver_exe)
 
         if self.TraceOn():
             print("Running test %s" % self.driver_exe)

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -24,7 +24,6 @@ class TestMultipleSimultaneousDebuggers(TestBase):
         self.driver_exe = self.getBuildArtifact("multi-process-driver")
         self.buildDriver("multi-process-driver.cpp", self.driver_exe)
         self.addTearDownHook(lambda: os.remove(self.driver_exe))
-        self.signBinary(self.driver_exe)
 
         self.inferior_exe = self.getBuildArtifact("testprog")
         self.buildDriver("testprog.cpp", self.inferior_exe)

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -24,7 +24,6 @@ class TestMultipleTargets(TestBase):
         self.driver_exe = self.getBuildArtifact("multi-target")
         self.buildDriver("main.cpp", self.driver_exe)
         self.addTearDownHook(lambda: os.remove(self.driver_exe))
-        self.signBinary(self.driver_exe)
 
         # check_call will raise a CalledProcessError if multi-process-driver doesn't return
         # exit code 0 to indicate success.  We can let this exception go - the test harness

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -106,7 +106,6 @@ class SBBreakpointCallbackCase(TestBase):
         self.addTearDownHook(lambda: os.remove(self.getBuildArtifact(test_name)))
 
         test_exe = self.getBuildArtifact(test_name)
-        self.signBinary(test_exe)
         exe = [test_exe, self.getBuildArtifact(self.inferior)]
 
         env = {self.dylibPath: self.getLLDBLibraryEnvVal()}


### PR DESCRIPTION
On Darwin, the Makefile already (ad-hoc) signs everything it builds. There's also no need to use lldb_codesign for this.