### PR TITLE
[RISCV][NFC] Remove unused methods of tuimm5

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
@@ -15,17 +15,7 @@
 // Operand and SDNode transformation definitions.
 //===----------------------------------------------------------------------===//
 
-def tuimm5 : Operand<XLenVT>, TImmLeaf<XLenVT, [{return isUInt<5>(Imm);}]> {
-  let ParserMatchClass = UImmAsmOperand<5>;
-  let EncoderMethod = "getUImmOpValue";
-  let DecoderMethod = "decodeUImmOperand<5>";
-  let MCOperandPredicate = [{
-    int64_t UImm;
-    if (MCOp.evaluateAsConstantImm(UImm))
-      return isUInt<5>(UImm);
-    return MCOp.isBareSymbolRef();
-  }];
-}
+def tuimm5 : RISCVOp, TImmLeaf<XLenVT, [{return isUInt<5>(Imm);}]>;
 
 //===----------------------------------------------------------------------===//
 // Instruction class templates


### PR DESCRIPTION
Since we only use tuimm5 in patterns, it doesn't need those methods for MC layer. And there is not `getUImmOpValue` defination now, leave those methods is confusing.