### PR TITLE
[DAGCombiner] Use SmallDenseMap (NFC)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -174,7 +174,7 @@ namespace {
     /// This is used to find and remove nodes from the worklist (by nulling
     /// them) when they are deleted from the underlying DAG. It relies on
     /// stable indices of nodes within the worklist.
-    DenseMap<SDNode *, unsigned> WorklistMap;
+    SmallDenseMap<SDNode *, unsigned, 32> WorklistMap;
 
     /// This records all nodes attempted to be added to the worklist since we
     /// considered a new worklist entry. As we keep do not add duplicate nodes


### PR DESCRIPTION
The use of SmallDenseMap saves 0.48% of heap allocations during the
compilation of a large preprocessed file, namely X86ISelLowering.cpp,
for the X86 target.  During the experiment, the maximum size of
WorklistMap was 24 or less 74% of the time.  (Note that DenseMap has
the maximum occupancy rate of 3/4.)
