### PR TITLE
[LLDB] Default implementation for pack indexing types.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -4189,6 +4189,10 @@ TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
   case clang::Type::ConstantMatrix:
   case clang::Type::DependentSizedMatrix:
     break;
+
+  // We don't handle pack indexing yet
+  case clang::Type::PackIndexing:
+    break;
   }
   // We don't know hot to display this type...
   return lldb::eTypeClassOther;
@@ -5066,6 +5070,10 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
   case clang::Type::ConstantMatrix:
   case clang::Type::DependentSizedMatrix:
     break;
+
+  // We don't handle pack indexing yet
+  case clang::Type::PackIndexing:
+    break;
   }
   count = 0;
   return lldb::eEncodingInvalid;
@@ -5220,6 +5228,10 @@ lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
   // Matrix types we're not sure how to display yet.
   case clang::Type::ConstantMatrix:
   case clang::Type::DependentSizedMatrix:
+    break;
+
+  // We don't handle pack indexing yet
+  case clang::Type::PackIndexing:
     break;
   }
   // We don't know hot to display this type...


### PR DESCRIPTION
We do not handle these types yet but we add them to some switch statement to ensure CI build does not fail.