### PR TITLE
[ADT] Use a constexpr version of llvm::bit_ceil (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -443,8 +443,7 @@ class SmallPtrSet : public SmallPtrSetImpl<PtrType> {
   }
 
   // Make sure that SmallSize is a power of two, round up if not.
-  static constexpr size_t SmallSizePowTwo =
-      detail::RoundUpToPowerOfTwo(SmallSize);
+  static constexpr size_t SmallSizePowTwo = RoundUpToPowerOfTwo(SmallSize);
   /// SmallStorage - Fixed size storage used in 'small mode'.
   const void *SmallStorage[SmallSizePowTwo];
 

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <initializer_list>
 #include <iterator>
+#include <limits>
 #include <utility>
 
 namespace llvm {
@@ -311,30 +312,17 @@ public:
   }
 };
 
-/// RoundUpToPowerOfTwo - This is a helper template that rounds N up to the next
-/// power of two (which means N itself if N is already a power of two).
-template<unsigned N>
-struct RoundUpToPowerOfTwo;
-
-/// RoundUpToPowerOfTwoH - If N is not a power of two, increase it.  This is a
-/// helper template used to implement RoundUpToPowerOfTwo.
-template<unsigned N, bool isPowerTwo>
-struct RoundUpToPowerOfTwoH {
-  enum { Val = N };
-};
-template<unsigned N>
-struct RoundUpToPowerOfTwoH<N, false> {
-  enum {
-    // We could just use NextVal = N+1, but this converges faster.  N|(N-1) sets
-    // the right-most zero bits to one all at once, e.g. 0b0011000 -> 0b0011111.
-    Val = RoundUpToPowerOfTwo<(N|(N-1)) + 1>::Val
-  };
-};
-
-template<unsigned N>
-struct RoundUpToPowerOfTwo {
-  enum { Val = RoundUpToPowerOfTwoH<N, (N&(N-1)) == 0>::Val };
-};
+namespace detail {
+// A constexpr version of llvm::bit_ceil.
+// TODO: Replace this with std::bit_ceil once C++20 is available.
+static constexpr size_t RoundUpToPowerOfTwo(size_t X) {
+  size_t C = 1;
+  size_t CMax = C << (std::numeric_limits<size_t>::digits - 1);
+  while (C < X && C < CMax)
+    C <<= 1;
+  return C;
+}
+} // namespace detail
 
 /// A templated base class for \c SmallPtrSet which provides the
 /// typesafe interface that is common across all small sizes.
@@ -457,7 +445,8 @@ class SmallPtrSet : public SmallPtrSetImpl<PtrType> {
   using BaseT = SmallPtrSetImpl<PtrType>;
 
   // Make sure that SmallSize is a power of two, round up if not.
-  enum { SmallSizePowTwo = RoundUpToPowerOfTwo<SmallSize>::Val };
+  static constexpr size_t SmallSizePowTwo =
+      detail::RoundUpToPowerOfTwo(SmallSize);
   /// SmallStorage - Fixed size storage used in 'small mode'.
   const void *SmallStorage[SmallSizePowTwo];
 

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -312,18 +312,6 @@ public:
   }
 };
 
-namespace detail {
-// A constexpr version of llvm::bit_ceil.
-// TODO: Replace this with std::bit_ceil once C++20 is available.
-static constexpr size_t RoundUpToPowerOfTwo(size_t X) {
-  size_t C = 1;
-  size_t CMax = C << (std::numeric_limits<size_t>::digits - 1);
-  while (C < X && C < CMax)
-    C <<= 1;
-  return C;
-}
-} // namespace detail
-
 /// A templated base class for \c SmallPtrSet which provides the
 /// typesafe interface that is common across all small sizes.
 ///
@@ -443,6 +431,16 @@ class SmallPtrSet : public SmallPtrSetImpl<PtrType> {
   static_assert(SmallSize <= 32, "SmallSize should be small");
 
   using BaseT = SmallPtrSetImpl<PtrType>;
+
+  // A constexpr version of llvm::bit_ceil.
+  // TODO: Replace this with std::bit_ceil once C++20 is available.
+  static constexpr size_t RoundUpToPowerOfTwo(size_t X) {
+    size_t C = 1;
+    size_t CMax = C << (std::numeric_limits<size_t>::digits - 1);
+    while (C < X && C < CMax)
+      C <<= 1;
+    return C;
+  }
 
   // Make sure that SmallSize is a power of two, round up if not.
   static constexpr size_t SmallSizePowTwo =


### PR DESCRIPTION
This patch replaces the template trick with a constexpr function that
is more readable.  Once C++20 is available in our code base, we can
remove the constexpr function in favor of std::bit_ceil.
