### PR TITLE
[compiler-rt] simplifying ::ReExec for freebsd.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_getauxval.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_getauxval.h
@@ -55,6 +55,20 @@ static inline decltype(AuxInfo::a_v) getauxval(decltype(AuxInfo::a_type) type) {
   return 0;
 }
 
+#elif SANITIZER_FREEBSD
+#  include <sys/auxv.h>
+
+#  define SANITIZER_USE_GETAUXVAL 1
+#  define AT_EXECFN AT_EXECPATH
+
+static inline unsigned long getauxval(unsigned long type) {
+  unsigned long buf = 0ul;
+
+  if (elf_aux_info(static_cast<int>(type), &buf, sizeof(buf)))
+    return 0ul;
+  return buf;
+}
+
 #endif
 
 #endif // SANITIZER_GETAUXVAL_H

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -934,14 +934,7 @@ u64 MonotonicNanoTime() {
 void ReExec() {
   const char *pathname = "/proc/self/exe";
 
-#  if SANITIZER_FREEBSD
-  for (const auto *aux = __elf_aux_vector; aux->a_type != AT_NULL; aux++) {
-    if (aux->a_type == AT_EXECPATH) {
-      pathname = static_cast<const char *>(aux->a_un.a_ptr);
-      break;
-    }
-  }
-#  elif SANITIZER_NETBSD
+#  if SANITIZER_NETBSD
   static const int name[] = {
       CTL_KERN,
       KERN_PROC_ARGS,


### PR DESCRIPTION
taking the getauxval route since elf_aux_info is available since FBSD 12.