### PR TITLE
[Clang][Sema] fix deducing auto& from const int in template parameters is impossible in partial specializations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -130,6 +130,9 @@ Bug Fixes to C++ Support
 - Fixed a bug where variables referenced by requires-clauses inside
   nested generic lambdas were not properly injected into the constraint scope.
   (`#73418 <https://github.com/llvm/llvm-project/issues/73418>`_)
+- Fixed deducing auto& from const int in template parameters of partial
+  specializations.
+  (`#77189 <https://github.com/llvm/llvm-project/issues/77189>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -649,6 +649,7 @@ static bool IsPossiblyOpaquelyQualifiedTypeInternal(const Type *T) {
   case Type::PackIndexing:
   case Type::UnresolvedUsing:
   case Type::TemplateTypeParm:
+  case Type::Auto:
     return true;
 
   case Type::ConstantArray:

--- a/clang/test/SemaTemplate/PR77189.cpp
+++ b/clang/test/SemaTemplate/PR77189.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++17 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -verify %s
+// expected-no-diagnostics
+
+struct false_type {
+	static constexpr bool value = false;
+};
+
+struct true_type {
+	static constexpr bool value = true;
+};
+
+template <auto& Value, int>
+struct test : false_type {};
+
+template <auto& Value>
+struct test<Value, 0> : true_type {};
+
+int main() {
+    static constexpr int v = 42;
+    static_assert(test<v, 0>::value);
+}


### PR DESCRIPTION
Fix [issue](https://github.com/llvm/llvm-project/issues/77189)
AutoType is possible cv qualified.

Also fixes #75843.