### PR TITLE
[CodeGen] Support MachineFunctionProperties in PassConcept

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -55,19 +55,6 @@ struct MachinePassInfoMixin : public PassInfoMixin<DerivedT> {
   }
 };
 
-/// A CRTP mix-in that provides informational APIs needed for MachineFunction
-/// analysis passes. See also \c PassInfoMixin.
-template <typename DerivedT>
-struct MachineFunctionAnalysisInfoMixin
-    : public MachinePassInfoMixin<DerivedT> {
-  static AnalysisKey *ID() {
-    static_assert(
-        std::is_base_of<MachineFunctionAnalysisInfoMixin, DerivedT>::value,
-        "Must pass the derived type as the template argument!");
-    return &DerivedT::Key;
-  }
-};
-
 /// An AnalysisManager<MachineFunction> that also exposes IR analysis results.
 class MachineFunctionAnalysisManager : public AnalysisManager<MachineFunction> {
 public:
@@ -192,7 +179,8 @@ public:
     addRunOnModule<PassT>(P);
   }
 
-  // Avoid diamond problem.
+  // Avoid diamond problem. Both MachinePassInfoMixin and PassManager inherit
+  // PassInfoMixin.
   static MachineFunctionProperties getRequiredProperties() {
     return MachineFunctionProperties();
   }

--- a/llvm/include/llvm/CodeGen/MachinePassManagerInternal.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManagerInternal.h
@@ -1,0 +1,68 @@
+//===- MachinePassManagerInternal.h --------------------------- -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+///
+/// This header provides internal APIs and implementation details used by the
+/// pass management interfaces exposed in MachinePassManager.h. Most of them are
+/// copied from PassManagerInternal.h.
+/// See also PassManagerInternal.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CODEGEN_MACHINEPASSMANAGERINTERNAL_H
+#define LLVM_CODEGEN_MACHINEPASSMANAGERINTERNAL_H
+
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class MachineFunctionAnalysisManager;
+
+using MachinePassConcept =
+    detail::PassConcept<MachineFunction, MachineFunctionAnalysisManager>;
+
+namespace detail {
+
+/// Template for the abstract base class used to dispatch
+/// polymorphically over pass objects. See also \c PassConcept.
+template <>
+struct PassConcept<MachineFunction, MachineFunctionAnalysisManager>
+    : public PassConceptBase<MachineFunction, MachineFunctionAnalysisManager> {
+  /// MachineFunction Properties.
+  PassConcept(MachineFunctionProperties RequiredProperties,
+              MachineFunctionProperties SetProperties,
+              MachineFunctionProperties ClearedProperties)
+      : RequiredProperties(RequiredProperties), SetProperties(SetProperties),
+        ClearedProperties(ClearedProperties) {}
+
+  MachineFunctionProperties RequiredProperties;
+  MachineFunctionProperties SetProperties;
+  MachineFunctionProperties ClearedProperties;
+};
+
+template <typename IRUnitT, typename PassT, typename PreservedAnalysesT,
+          typename AnalysisManagerT, typename... ExtraArgTs>
+template <typename MachineFunctionT, typename>
+PassModel<IRUnitT, PassT, PreservedAnalysesT, AnalysisManagerT, ExtraArgTs...>::
+    PassModel(PassT Pass, MachineFunctionProperties RequiredProperties,
+              MachineFunctionProperties SetProperties,
+              MachineFunctionProperties ClearedProperties)
+    : PassConcept<MachineFunction, MachineFunctionAnalysisManager>(
+          RequiredProperties, SetProperties, ClearedProperties),
+      Pass(std::move(Pass)) {}
+
+template <typename PassT>
+using MachinePassModel = PassModel<MachineFunction, PassT, PreservedAnalyses,
+                                   MachineFunctionAnalysisManager>;
+
+} // namespace detail
+
+} // namespace llvm
+
+#endif // LLVM_CODEGEN_MACHINEPASSMANAGERINTERNAL_H

--- a/llvm/include/llvm/CodeGen/MachinePassManagerInternal.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManagerInternal.h
@@ -41,9 +41,9 @@ struct PassConcept<MachineFunction, MachineFunctionAnalysisManager>
       : RequiredProperties(RequiredProperties), SetProperties(SetProperties),
         ClearedProperties(ClearedProperties) {}
 
-  MachineFunctionProperties RequiredProperties;
-  MachineFunctionProperties SetProperties;
-  MachineFunctionProperties ClearedProperties;
+  MachineFunctionProperties RequiredProperties = MachineFunctionProperties();
+  MachineFunctionProperties SetProperties = MachineFunctionProperties();
+  MachineFunctionProperties ClearedProperties = MachineFunctionProperties();
 };
 
 template <typename IRUnitT, typename PassT, typename PreservedAnalysesT,

--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -1299,7 +1299,7 @@ struct RequireAnalysisPass
   }
   static bool isRequired() { return true; }
 
-  // MachineFunctionPass interface, define Define these separately to prevent
+  // MachineFunctionPass interface, define them separately to prevent
   // dependency on CodeGen
   template <typename MachineFunctionT = IRUnitT,
             typename MachineFunctionPropertiesT = MachineFunctionProperties,
@@ -1352,31 +1352,19 @@ struct InvalidateAnalysisPass
     OS << "invalidate<" << PassName << '>';
   }
 
-  // MachineFunctionPass interface, define Define these separately to prevent
+  // MachineFunctionPass interface, define them separately to prevent
   // dependency on CodeGen
-  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
-            typename MachineFunctionAnalysisT = AnalysisT,
-            typename = std::enable_if_t<std::is_base_of_v<
-                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
-                MachineFunctionAnalysisT>>>
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties>
   static MachineFunctionPropertiesT getRequiredProperties() {
     return MachineFunctionPropertiesT();
   }
 
-  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
-            typename MachineFunctionAnalysisT = AnalysisT,
-            typename = std::enable_if_t<std::is_base_of_v<
-                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
-                MachineFunctionAnalysisT>>>
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties>
   static MachineFunctionPropertiesT getSetProperties() {
     return MachineFunctionPropertiesT();
   }
 
-  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
-            typename MachineFunctionAnalysisT = AnalysisT,
-            typename = std::enable_if_t<std::is_base_of_v<
-                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
-                MachineFunctionAnalysisT>>>
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties>
   static MachineFunctionPropertiesT getClearedProperties() {
     return MachineFunctionPropertiesT();
   }

--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -576,8 +576,14 @@ public:
                           ExtraArgTs...>;
     // Do not use make_unique or emplace_back, they cause too many template
     // instantiations, causing terrible compile times.
-    Passes.push_back(std::unique_ptr<PassConceptT>(
-        new PassModelT(std::forward<PassT>(Pass))));
+    if constexpr (std::is_same_v<IRUnitT, MachineFunction>) {
+      Passes.push_back(std::unique_ptr<PassConceptT>(new PassModelT(
+          std::forward<PassT>(Pass), PassT::getRequiredProperties(),
+          PassT::getSetProperties(), PassT::getClearedProperties())));
+    } else {
+      Passes.push_back(std::unique_ptr<PassConceptT>(
+          new PassModelT(std::forward<PassT>(Pass))));
+    }
   }
 
   /// When adding a pass manager pass that has the same type as this pass
@@ -1292,9 +1298,37 @@ struct RequireAnalysisPass
     OS << "require<" << PassName << '>';
   }
   static bool isRequired() { return true; }
+
+  // MachineFunctionPass interface, define Define these separately to prevent
+  // dependency on CodeGen
+  template <typename MachineFunctionT = IRUnitT,
+            typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename = std::enable_if_t<
+                std::is_same_v<MachineFunctionT, MachineFunction>>>
+  static MachineFunctionPropertiesT getRequiredProperties() {
+    return MachineFunctionPropertiesT();
+  }
+
+  template <typename MachineFunctionT = IRUnitT,
+            typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename = std::enable_if_t<
+                std::is_same_v<MachineFunctionT, MachineFunction>>>
+  static MachineFunctionPropertiesT getSetProperties() {
+    return MachineFunctionPropertiesT();
+  }
+
+  template <typename MachineFunctionT = IRUnitT,
+            typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename = std::enable_if_t<
+                std::is_same_v<MachineFunctionT, MachineFunction>>>
+  static MachineFunctionPropertiesT getClearedProperties() {
+    return MachineFunctionPropertiesT();
+  }
 };
 
-/// A no-op pass template which simply forces a specific analysis result
+template <typename DerivedT> struct MachineFunctionAnalysisInfoMixin;
+
+/// A no-op IR pass template which simply forces a specific analysis result
 /// to be invalidated.
 template <typename AnalysisT>
 struct InvalidateAnalysisPass
@@ -1316,6 +1350,35 @@ struct InvalidateAnalysisPass
     auto ClassName = AnalysisT::name();
     auto PassName = MapClassName2PassName(ClassName);
     OS << "invalidate<" << PassName << '>';
+  }
+
+  // MachineFunctionPass interface, define Define these separately to prevent
+  // dependency on CodeGen
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename MachineFunctionAnalysisT = AnalysisT,
+            typename = std::enable_if_t<std::is_base_of_v<
+                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
+                MachineFunctionAnalysisT>>>
+  static MachineFunctionPropertiesT getRequiredProperties() {
+    return MachineFunctionPropertiesT();
+  }
+
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename MachineFunctionAnalysisT = AnalysisT,
+            typename = std::enable_if_t<std::is_base_of_v<
+                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
+                MachineFunctionAnalysisT>>>
+  static MachineFunctionPropertiesT getSetProperties() {
+    return MachineFunctionPropertiesT();
+  }
+
+  template <typename MachineFunctionPropertiesT = MachineFunctionProperties,
+            typename MachineFunctionAnalysisT = AnalysisT,
+            typename = std::enable_if_t<std::is_base_of_v<
+                MachineFunctionAnalysisInfoMixin<MachineFunctionAnalysisT>,
+                MachineFunctionAnalysisT>>>
+  static MachineFunctionPropertiesT getClearedProperties() {
+    return MachineFunctionPropertiesT();
   }
 };
 

--- a/llvm/unittests/CodeGen/PassManagerTest.cpp
+++ b/llvm/unittests/CodeGen/PassManagerTest.cpp
@@ -52,7 +52,7 @@ private:
 AnalysisKey TestFunctionAnalysis::Key;
 
 class TestMachineFunctionAnalysis
-    : public MachineFunctionAnalysisInfoMixin<TestMachineFunctionAnalysis> {
+    : public AnalysisInfoMixin<TestMachineFunctionAnalysis> {
 public:
   struct Result {
     Result(int Count) : InstructionCount(Count) {}
@@ -70,7 +70,7 @@ public:
   }
 
 private:
-  friend MachineFunctionAnalysisInfoMixin<TestMachineFunctionAnalysis>;
+  friend AnalysisInfoMixin<TestMachineFunctionAnalysis>;
   static AnalysisKey Key;
 };
 

--- a/llvm/unittests/CodeGen/PassManagerTest.cpp
+++ b/llvm/unittests/CodeGen/PassManagerTest.cpp
@@ -52,7 +52,7 @@ private:
 AnalysisKey TestFunctionAnalysis::Key;
 
 class TestMachineFunctionAnalysis
-    : public AnalysisInfoMixin<TestMachineFunctionAnalysis> {
+    : public MachineFunctionAnalysisInfoMixin<TestMachineFunctionAnalysis> {
 public:
   struct Result {
     Result(int Count) : InstructionCount(Count) {}
@@ -70,7 +70,7 @@ public:
   }
 
 private:
-  friend AnalysisInfoMixin<TestMachineFunctionAnalysis>;
+  friend MachineFunctionAnalysisInfoMixin<TestMachineFunctionAnalysis>;
   static AnalysisKey Key;
 };
 
@@ -79,7 +79,8 @@ AnalysisKey TestMachineFunctionAnalysis::Key;
 const std::string DoInitErrMsg = "doInitialization failed";
 const std::string DoFinalErrMsg = "doFinalization failed";
 
-struct TestMachineFunctionPass : public PassInfoMixin<TestMachineFunctionPass> {
+struct TestMachineFunctionPass
+    : public MachinePassInfoMixin<TestMachineFunctionPass> {
   TestMachineFunctionPass(int &Count, std::vector<int> &BeforeInitialization,
                           std::vector<int> &BeforeFinalization,
                           std::vector<int> &MachineFunctionPassCount)
@@ -139,7 +140,8 @@ struct TestMachineFunctionPass : public PassInfoMixin<TestMachineFunctionPass> {
   std::vector<int> &MachineFunctionPassCount;
 };
 
-struct TestMachineModulePass : public PassInfoMixin<TestMachineModulePass> {
+struct TestMachineModulePass
+    : public MachinePassInfoMixin<TestMachineModulePass> {
   TestMachineModulePass(int &Count, std::vector<int> &MachineModulePassCount)
       : Count(Count), MachineModulePassCount(MachineModulePassCount) {}
 

--- a/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
+++ b/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
@@ -174,8 +174,8 @@ struct MockPassInstrumentationCallbacks {
 
 template <typename DerivedT> class MockAnalysisHandleBase {
 public:
-  class Analysis : public AnalysisInfoMixin<Analysis> {
-    friend AnalysisInfoMixin<Analysis>;
+  class Analysis : public MachineFunctionAnalysisInfoMixin<Analysis> {
+    friend MachineFunctionAnalysisInfoMixin<Analysis>;
     friend MockAnalysisHandleBase;
     static AnalysisKey Key;
 

--- a/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
+++ b/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
@@ -174,8 +174,8 @@ struct MockPassInstrumentationCallbacks {
 
 template <typename DerivedT> class MockAnalysisHandleBase {
 public:
-  class Analysis : public MachineFunctionAnalysisInfoMixin<Analysis> {
-    friend MachineFunctionAnalysisInfoMixin<Analysis>;
+  class Analysis : public AnalysisInfoMixin<Analysis> {
+    friend AnalysisInfoMixin<Analysis>;
     friend MockAnalysisHandleBase;
     static AnalysisKey Key;
 


### PR DESCRIPTION
This patch extends `PassConcept` to support `MachineFunctionProperties`, `MachineFunctionProperties` verification work may be completed within the next few days, in new codegen instrumentations rather than pass manager.