### PR TITLE
[libc][CMake] fix CMake configure issues on openSUSE

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -165,13 +165,11 @@ if(LIBC_TARGET_OS STREQUAL "baremetal")
   set(LIBC_TARGET_OS_IS_BAREMETAL TRUE)
 elseif(LIBC_TARGET_OS STREQUAL "linux")
   set(LIBC_TARGET_OS_IS_LINUX TRUE)
-elseif(LIBC_TARGET_OS STREQUAL "poky")
+elseif(LIBC_TARGET_OS STREQUAL "poky" OR LIBC_TARGET_OS STREQUAL "suse")
   # poky are ustom Linux-base systems created by yocto. Since these are Linux
   # images, we change the LIBC_TARGET_OS to linux. This define is used to
   # include the right directories during compilation.
-  set(LIBC_TARGET_OS_IS_LINUX TRUE)
-  set(LIBC_TARGET_OS "linux")
-elseif(LIBC_TARGET_OS STREQUAL "suse")
+  #
   # openSUSE uses different triple format which causes LIBC_TARGET_OS to be
   # computed as "suse" instead of "linux".
   set(LIBC_TARGET_OS_IS_LINUX TRUE)

--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -171,6 +171,11 @@ elseif(LIBC_TARGET_OS STREQUAL "poky")
   # include the right directories during compilation.
   set(LIBC_TARGET_OS_IS_LINUX TRUE)
   set(LIBC_TARGET_OS "linux")
+elseif(LIBC_TARGET_OS STREQUAL "suse")
+  # openSUSE uses different triple format which causes LIBC_TARGET_OS to be
+  # computed as "suse" instead of "linux".
+  set(LIBC_TARGET_OS_IS_LINUX TRUE)
+  set(LIBC_TARGET_OS "linux")
 elseif(LIBC_TARGET_OS STREQUAL "darwin")
   set(LIBC_TARGET_OS_IS_DARWIN TRUE)
 elseif(LIBC_TARGET_OS STREQUAL "windows")


### PR DESCRIPTION
libc cannot be configured on openSUSE because openSUSE toolchain changes the triple format. This PR fixes this issue.