### PR TITLE
[DebugNames] Compare TableEntry names more efficiently

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -550,8 +550,8 @@ public:
       // Note: this is not the name, but the rest of debug_str starting from
       // name. This handles corrupt data (non-null terminated) without
       // overrunning the buffer.
-      auto Data = StrData.getData().substr(StringOffset);
-      auto TargetSize = Target.size();
+      StringRef Data = StrData.getData().substr(StringOffset);
+      size_t TargetSize = Target.size();
       return Data.size() > TargetSize && !Data[TargetSize] &&
              strncmp(Data.data(), Target.data(), TargetSize) == 0;
     }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -544,8 +544,8 @@ public:
     }
 
     /// Compares the name of this entry against Target, returning true if they
-    /// are equal. This is helpful is hot code paths that do not need the length
-    /// of the name.
+    /// are equal. This is more efficient in hot code paths that do not need the
+    /// length of the name.
     bool sameNameAs(StringRef Target) const {
       // Note: this is not the name, but the rest of debug_str starting from
       // name. This handles corrupt data (non-null terminated) without

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -547,7 +547,7 @@ public:
     /// are equal. This is helpful is hot code paths that do not need the length
     /// of the name.
     bool sameNameAs(StringRef Target) const {
-      // Note: this is not the name, but the rest of debug_names starting from
+      // Note: this is not the name, but the rest of debug_str starting from
       // name. This handles corrupt data (non-null terminated) without
       // overrunning the buffer.
       auto Data = StrData.getData().substr(StringOffset);

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -543,6 +543,19 @@ public:
       return StrData.getCStr(&Off);
     }
 
+    /// Compares the name of this entry against Target, returning true if they
+    /// are equal. This is helpful is hot code paths that do not need the length
+    /// of the name.
+    bool sameNameAs(StringRef Target) const {
+      // Note: this is not the name, but the rest of debug_names starting from
+      // name. This handles corrupt data (non-null terminated) without
+      // overrunning the buffer.
+      auto Data = StrData.getData().substr(StringOffset);
+      auto TargetSize = Target.size();
+      return Data.size() > TargetSize && !Data[TargetSize] &&
+             strncmp(Data.data(), Target.data(), TargetSize) == 0;
+    }
+
     /// Returns the offset of the first Entry in the list.
     uint64_t getEntryOffset() const { return EntryOffset; }
   };

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -921,7 +921,7 @@ DWARFDebugNames::ValueIterator::findEntryOffsetInCurrentIndex() {
   if (Hdr.BucketCount == 0) {
     // No Hash Table, We need to search through all names in the Name Index.
     for (const NameTableEntry &NTE : *CurrentIndex) {
-      if (NTE.getString() == Key)
+      if (NTE.sameNameAs(Key))
         return NTE.getEntryOffset();
     }
     return std::nullopt;
@@ -942,7 +942,7 @@ DWARFDebugNames::ValueIterator::findEntryOffsetInCurrentIndex() {
       return std::nullopt; // End of bucket
 
     NameTableEntry NTE = CurrentIndex->getNameTableEntry(Index);
-    if (NTE.getString() == Key)
+    if (NTE.sameNameAs(Key))
       return NTE.getEntryOffset();
   }
   return std::nullopt;


### PR DESCRIPTION
TableEntry names are pointers into the string table section, and accessing their
length requires a search for `\0`. However, 99% of the time we only need to
compare the name against some other other, and such a comparison will fail as
early as the first character.

This commit adds a method to the interface of TableEntry so that such a
comparison can be done without extracting the full name. It saves 10% in the
time (1250ms -> 1100 ms) to evaluate the following expression.

```
lldb \
  --batch \
  -o "b CodeGenFunction::GenerateCode" \
  -o run \
  -o "expr Fn" \
  -- \
  clang++ -c -g test.cpp -o /dev/null &> output
```