### PR TITLE
[libc++] Fix `match_prev_avail` implementation in `std::regex_search`

### DIFF
--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -5100,8 +5100,19 @@ bool basic_regex<_CharT, _Traits>::__search(
     const _CharT* __last,
     match_results<const _CharT*, _Allocator>& __m,
     regex_constants::match_flag_type __flags) const {
-  if (__flags & regex_constants::match_prev_avail)
-    __flags &= ~(regex_constants::match_not_bol | regex_constants::match_not_bow);
+  if (__flags & regex_constants::match_prev_avail){
+    if (flags() & std::regex_constants::multiline){
+      if (*__first != '\n'  && *__first != '\r'){
+        __flags |= std::regex_constants::match_not_bol;
+      }
+    }
+    else{
+      __flags |= std::regex_constants::match_not_bol;
+    }
+    if (isalnum(*__first)) {
+      __flags |= std::regex_constants::match_not_bow;
+    }
+  }
 
   __m.__init(1 + mark_count(), __first, __last, __flags & regex_constants::__no_update_pos);
   if (__match_at_start(__first, __last, __m, __flags, !(__flags & regex_constants::__no_update_pos))) {


### PR DESCRIPTION
The implementation of the `match_prev_avail` flag in the `regex_search` is regressed after the fixed issue #41544. It resulted in many wrong search results especially those involving `"^"` regex pattern.

Fixes #74838