### PR TITLE
[bazel] Allow configuring to exclude the native target …

### DIFF
--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -140,6 +140,27 @@ def _write_dict_to_file(repository_ctx, filepath, header, vars):
 
     repository_ctx.file(filepath, content = fci + fcd + fct)
 
+def _native_target_defines(arch, triple, include_native_target):
+    llvm_native_target_defines = []
+    if include_native_target:
+        # Not having these defined for the project is useful when building a compiler that can _only_ cross-compile.
+        llvm_native_target_defines = [
+            "LLVM_NATIVE_ASMPARSER=LLVMInitialize{}AsmParser".format(arch),
+            "LLVM_NATIVE_ASMPRINTER=LLVMInitialize{}AsmPrinter".format(arch),
+            "LLVM_NATIVE_DISASSEMBLER=LLVMInitialize{}Disassembler".format(arch),
+            "LLVM_NATIVE_TARGET=LLVMInitialize{}Target".format(arch),
+            "LLVM_NATIVE_TARGETINFO=LLVMInitialize{}TargetInfo".format(arch),
+            "LLVM_NATIVE_TARGETMC=LLVMInitialize{}TargetMC".format(arch),
+            "LLVM_NATIVE_TARGETMCA=LLVMInitialize{}TargetMCA".format(arch),
+        ]
+
+    return llvm_native_target_defines + [
+        # These are required to be defined, otherwise the build will fail.
+        r'LLVM_NATIVE_ARCH=\"{}\"'.format(arch if include_native_target else ""),
+        r'LLVM_HOST_TRIPLE=\"{}\"'.format(triple if include_native_target else ""),
+        r'LLVM_DEFAULT_TARGET_TRIPLE=\"{}\"'.format(triple if include_native_target else ""),
+    ]
+
 def _llvm_configure_impl(repository_ctx):
     _overlay_directories(repository_ctx)
 
@@ -158,9 +179,22 @@ def _llvm_configure_impl(repository_ctx):
 
     # Create a starlark file with the requested LLVM targets.
     targets = repository_ctx.attr.targets
+    include_native_target = repository_ctx.attr.include_native_target
+    llvm_native_target_defines = select({
+        "@bazel_tools//src/conditions:windows": _native_target_defines("X86", "x86_64-pc-win32", include_native_target),
+        "@bazel_tools//src/conditions:darwin_arm64": _native_target_defines("AArch64", "arm64-apple-darwin", include_native_target),
+        "@bazel_tools//src/conditions:darwin_x86_64": _native_target_defines("X86", "x86_64-unknown-darwin", include_native_target),
+        "@bazel_tools//src/conditions:linux_aarch64": _native_target_defines("AArch64", "aarch64-unknown-linux-gnu", include_native_target),
+        "@bazel_tools//src/conditions:linux_ppc64le": _native_target_defines("PowerPC", "powerpc64le-unknown-linux-gnu", include_native_target),
+        "@bazel_tools//src/conditions:linux_s390x": _native_target_defines("SystemZ", "systemz-unknown-linux_gnu", include_native_target),
+        "//conditions:default": _native_target_defines("X86", "x86_64-unknown-linux-gnu", include_native_target),
+    })
     repository_ctx.file(
         "llvm/targets.bzl",
-        content = "llvm_targets = " + str(targets),
+        content = "\n".join([
+            "llvm_targets = " + str(targets),
+            "llvm_native_target_defines = " + str(llvm_native_target_defines),
+        ]),
         executable = False,
     )
 
@@ -170,5 +204,6 @@ llvm_configure = repository_rule(
     configure = True,
     attrs = {
         "targets": attr.string_list(default = DEFAULT_TARGETS),
+        "include_native_target": attr.bool(default = True),
     },
 )

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -7,7 +7,7 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load(":binary_alias.bzl", "binary_alias")
 load(":config.bzl", "llvm_config_defines")
 load(":enum_targets_gen.bzl", "enum_targets_gen")
-load(":targets.bzl", "llvm_targets")
+load(":targets.bzl", "llvm_targets", "llvm_native_target_defines")
 load(":tblgen.bzl", "gentbl")
 
 package(
@@ -150,7 +150,7 @@ cc_library(
         "include/llvm/Config/llvm-config.h",
     ],
     copts = llvm_copts,
-    defines = llvm_config_defines,
+    defines = llvm_config_defines + llvm_native_target_defines,
     includes = ["include"],
     textual_hdrs = [
         "include/llvm/Config/AsmParsers.def",

--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -12,20 +12,6 @@ load(
     "LLVM_VERSION_PATCH",
 )
 
-def native_arch_defines(arch, triple):
-    return [
-        r'LLVM_NATIVE_ARCH=\"{}\"'.format(arch),
-        "LLVM_NATIVE_ASMPARSER=LLVMInitialize{}AsmParser".format(arch),
-        "LLVM_NATIVE_ASMPRINTER=LLVMInitialize{}AsmPrinter".format(arch),
-        "LLVM_NATIVE_DISASSEMBLER=LLVMInitialize{}Disassembler".format(arch),
-        "LLVM_NATIVE_TARGET=LLVMInitialize{}Target".format(arch),
-        "LLVM_NATIVE_TARGETINFO=LLVMInitialize{}TargetInfo".format(arch),
-        "LLVM_NATIVE_TARGETMC=LLVMInitialize{}TargetMC".format(arch),
-        "LLVM_NATIVE_TARGETMCA=LLVMInitialize{}TargetMCA".format(arch),
-        r'LLVM_HOST_TRIPLE=\"{}\"'.format(triple),
-        r'LLVM_DEFAULT_TARGET_TRIPLE=\"{}\"'.format(triple),
-    ]
-
 posix_defines = [
     "LLVM_ON_UNIX=1",
     "HAVE_BACKTRACE=1",
@@ -96,15 +82,7 @@ builtin_thread_pointer = select({
 })
 
 # TODO: We should split out host vs. target here.
-llvm_config_defines = os_defines + builtin_thread_pointer + select({
-    "@bazel_tools//src/conditions:windows": native_arch_defines("X86", "x86_64-pc-win32"),
-    "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
-    "@bazel_tools//src/conditions:darwin_x86_64": native_arch_defines("X86", "x86_64-unknown-darwin"),
-    "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
-    "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
-    "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
-    "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
-}) + [
+llvm_config_defines = os_defines + builtin_thread_pointer + [
     "LLVM_VERSION_MAJOR={}".format(LLVM_VERSION_MAJOR),
     "LLVM_VERSION_MINOR={}".format(LLVM_VERSION_MINOR),
     "LLVM_VERSION_PATCH={}".format(LLVM_VERSION_PATCH),


### PR DESCRIPTION
… from the set of compilation targets

This is useful for creating a compiler that strictly cross compiles

The set of allowed targets is checked for the current native target, and if found, the `LLVM_NATIVE_*` macros are defined to the correct value. Otherwise they are not defined

This is needed to prevent linker errors due to the LLVM initialize functions (eg: `llvm::InitializeNativeTarget()`) that attempt to call the functions if these macros are defined
