### PR TITLE
[Clang][Sema] Fix crash when type used in return statement contains errors

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -138,6 +138,9 @@ Bug Fixes to C++ Support
 - Fixed deducing auto& from const int in template parameters of partial
   specializations.
   (`#77189 <https://github.com/llvm/llvm-project/issues/77189>`_)
+- Fix for crash when using a erroneous type in a return statement.
+  Fixes (`#63244 <https://github.com/llvm/llvm-project/issues/63244>`_)
+  and (`#79745 <https://github.com/llvm/llvm-project/issues/79745>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3391,6 +3391,8 @@ Sema::NamedReturnInfo Sema::getNamedReturnInfo(Expr *&E,
   const auto *VD = dyn_cast<VarDecl>(DR->getDecl());
   if (!VD)
     return NamedReturnInfo();
+  if (VD->getInit() && VD->getInit()->containsErrors())
+    return NamedReturnInfo();
   NamedReturnInfo Res = getNamedReturnInfo(VD);
   if (Res.Candidate && !E->isXValue() &&
       (Mode == SimplerImplicitMoveMode::ForceOn ||

--- a/clang/test/SemaCXX/deduced-return-type-cxx14.cpp
+++ b/clang/test/SemaCXX/deduced-return-type-cxx14.cpp
@@ -724,3 +724,12 @@ struct DeducedTargetTypeOfConversionFunction {
   // since-cxx20-error@-1 {{'decltype(auto)' not allowed in declaration of conversion function template}}
 #endif
 };
+
+namespace GH79745 {
+template <typename = int> struct a; // expected-note {{template is declared here}}
+auto f() {
+  a c; // cxx20_23-error {{implicit instantiation of undefined template}} \
+       // cxx14-error {{use of class template 'a' requires template arguments}}
+  return c;
+}
+}


### PR DESCRIPTION
In Sema in `BuildReturnStmt(...)` when we try to determine is the type is move eligible or copy elidable we don't currently check of the init of the `VarDecl` contain errors or not. This can lead to a crash since we may send a type that is not complete into `getTypeInfo(...)` which does not allow this.

This fixes: https://github.com/llvm/llvm-project/issues/63244
https://github.com/llvm/llvm-project/issues/79745