### PR TITLE
[libc++][test] Silence MSVC warnings

### DIFF
--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -8,8 +8,12 @@
 
 // ADDITIONAL_COMPILE_FLAGS(gcc): -Wno-bool-compare
 // ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// MSVC warning C4245: conversion from 'int' to 'wchar_t', signed/unsigned mismatch
+// MSVC warning C4305: truncation from 'int' to 'bool'
+// MSVC warning C4310: cast truncates constant value
 // MSVC warning C4389: '==': signed/unsigned mismatch
-// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4389
+// MSVC warning C4805: '==': unsafe mix of type 'char' and type 'bool' in operation
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4245 /wd4305 /wd4310 /wd4389 /wd4805
 
 // <algorithm>
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
+// MSVC warning C4244: 'argument': conversion from 'double' to 'const int', possible loss of data
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4244
+
 // template<input_iterator I, sentinel_for<I> S, class T,
 //          indirectly-binary-left-foldable<T, I> F>
 //   constexpr see below ranges::fold_left_with_iter(I first, S last, T init, F f);

--- a/libcxx/test/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.pointer.pass.cpp
+++ b/libcxx/test/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.pointer.pass.cpp
@@ -7,6 +7,11 @@
 //===----------------------------------------------------------------------===//
 //
 // UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// MSVC warning C5215: a function parameter with a volatile qualified type is deprecated in C++20
+// MSVC warning C5216: a volatile qualified return type is deprecated in C++20
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd5215 /wd5216
+
 // <numeric>
 
 // template <class _Tp>


### PR DESCRIPTION
* `libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp` emits a bunch of warnings, all caused by what appears to be intentional code:
  + Silence MSVC warning C4245: conversion from `'int'` to `'wchar_t'`, signed/unsigned mismatch
    - Caused by: `test<U>(0, -1);`
  + Silence MSVC warning C4305: 'argument': truncation from `'int'` to `'bool'`
    - Caused by: `test<U>(0, -1);`
  + Silence MSVC warning C4310: cast truncates constant value
    - Caused by: `test<U>(T(-129), U(-129));`
  + Silence MSVC warning C4805: `'=='`: unsafe mix of type `'char'` and type `'bool'` in operation
    - Caused by: `bool expect_match = val == to_find;`
* `libcxx/test/std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp`
  + Silence MSVC warning C4244: 'argument': conversion from `'double'` to `'const int'`, possible loss of data
    - Caused by `[](int const x, double const y) { return x + y; }` deliberately being given `double`s to truncate.
* `libcxx/test/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.pointer.pass.cpp`
  + Silence MSVC warnings about C++20 deprecated `volatile`.
    - Caused by: `runtime_test<      volatile T>();`
