### PR TITLE
[libc++][test] Fix zero-length arrays and copy-pasted lambdas in `ranges.contains.pass.cpp`

### DIFF
--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
@@ -165,7 +165,7 @@ constexpr bool test() {
     });
   });
 
-  { // count invocations of the projection for continuous iterators
+  { // count invocations of the projection for contiguous iterators
     int a[]              = {1, 9, 0, 13, 25};
     int projection_count = 0;
     {
@@ -216,22 +216,22 @@ constexpr bool test() {
     }
   }
 
-  { // check invocations of the projection for non-continuous iterators
+  { // check invocations of the projection for non-contiguous iterators
     std::vector<bool> whole{false, false, true, false};
     int projection_count = 0;
     {
-      bool ret = std::ranges::contains(whole.begin(), whole.end(), true, [&](int i) {
+      bool ret = std::ranges::contains(whole.begin(), whole.end(), true, [&](bool b) {
         ++projection_count;
-        return i;
+        return b;
       });
       assert(ret);
       assert(projection_count == 3);
       projection_count = 0;
     }
     {
-      bool ret = std::ranges::contains(whole, true, [&](int i) {
+      bool ret = std::ranges::contains(whole, true, [&](bool b) {
         ++projection_count;
-        return i;
+        return b;
       });
       assert(ret);
       assert(projection_count == 3);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
@@ -19,6 +19,7 @@
 //     constexpr bool ranges::contains(R&& r, const T& value, Proj proj = {});                 // since C++23
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <list>
 #include <ranges>
@@ -89,8 +90,8 @@ constexpr void test_iterators() {
   }
 
   { // check that an empty range works
-    ValueT a[] = {};
-    auto whole = std::ranges::subrange(Iter(a), Sent(Iter(a)));
+    std::array<ValueT, 0> a = {};
+    auto whole = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
     {
       bool ret = std::ranges::contains(whole.begin(), whole.end(), 1);
       assert(!ret);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.contains/ranges.contains.pass.cpp
@@ -91,7 +91,7 @@ constexpr void test_iterators() {
 
   { // check that an empty range works
     std::array<ValueT, 0> a = {};
-    auto whole = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
+    auto whole              = std::ranges::subrange(Iter(a.data()), Sent(Iter(a.data())));
     {
       bool ret = std::ranges::contains(whole.begin(), whole.end(), 1);
       assert(!ret);


### PR DESCRIPTION
* Fix MSVC error C2466: cannot allocate an array of constant size 0
  + MSVC rejects this non-Standard extension. Previous fixes: #74183
* Fix MSVC warning C4805: `'=='`: unsafe mix of type `'int'` and type `'const bool'` in operation
  + AFAICT, these lambdas were copy-pasted, and didn't intend to take and return `int` here. This part of the test is using `vector<bool>` for random-access but non-contiguous iterators, and it's checking how many times the projection is invoked, but the projection doesn't need to do anything squirrely, it should otherwise be an identity.
* Fix typos: "continuous" => "contiguous".