### PR TITLE
[llvm-exegesis] Remove llvm prefix where unnecessary

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -254,8 +254,7 @@ static void writeLatencySnippetHtml(raw_ostream &OS,
   }
 }
 
-void Analysis::printPointHtml(const Benchmark &Point,
-                              llvm::raw_ostream &OS) const {
+void Analysis::printPointHtml(const Benchmark &Point, raw_ostream &OS) const {
   OS << "<li><span class=\"mono\" title=\"";
   writeSnippet<EscapeTag, kEscapeHtmlString>(OS, Point.AssembledSnippet, "\n");
   OS << "\">";
@@ -410,9 +409,9 @@ void Analysis::printSchedClassDescHtml(const ResolvedSchedClass &RSC,
   OS << "</table>";
 }
 
-void Analysis::printClusterRawHtml(
-    const BenchmarkClustering::ClusterId &Id, StringRef display_name,
-    llvm::raw_ostream &OS) const {
+void Analysis::printClusterRawHtml(const BenchmarkClustering::ClusterId &Id,
+                                   StringRef display_name,
+                                   raw_ostream &OS) const {
   const auto &Points = Clustering_.getPoints();
   const auto &Cluster = Clustering_.getCluster(Id);
   if (Cluster.PointIndices.empty())
@@ -538,8 +537,8 @@ Error Analysis::run<Analysis::PrintSchedClassInconsistencies>(
         continue; // Ignore noise and errors. FIXME: take noise into account ?
       if (ClusterId.isUnstable() ^ AnalysisDisplayUnstableOpcodes_)
         continue; // Either display stable or unstable clusters only.
-      auto SchedClassClusterIt = llvm::find_if(
-          SchedClassClusters, [ClusterId](const SchedClassCluster &C) {
+      auto SchedClassClusterIt =
+          find_if(SchedClassClusters, [ClusterId](const SchedClassCluster &C) {
             return C.id() == ClusterId;
           });
       if (SchedClassClusterIt == SchedClassClusters.end()) {

--- a/llvm/tools/llvm-exegesis/lib/Analysis.h
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.h
@@ -76,10 +76,9 @@ private:
   void printInstructionRowCsv(size_t PointId, raw_ostream &OS) const;
 
   void printClusterRawHtml(const BenchmarkClustering::ClusterId &Id,
-                           StringRef display_name, llvm::raw_ostream &OS) const;
+                           StringRef display_name, raw_ostream &OS) const;
 
-  void printPointHtml(const Benchmark &Point,
-                      llvm::raw_ostream &OS) const;
+  void printPointHtml(const Benchmark &Point, raw_ostream &OS) const;
 
   void
   printSchedClassClustersHtml(const std::vector<SchedClassCluster> &Clusters,

--- a/llvm/tools/llvm-exegesis/lib/Assembler.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.cpp
@@ -366,14 +366,14 @@ Expected<ExecutableFunction> ExecutableFunction::create(
   auto SymbolSizes = object::computeSymbolSizes(*ObjectFileHolder.getBinary());
   // Get the size of the function that we want to call into (with the name of
   // FunctionID).
-  auto SymbolIt = llvm::find_if(SymbolSizes, [&](const auto &Pair) {
+  auto SymbolIt = find_if(SymbolSizes, [&](const auto &Pair) {
     auto SymbolName = Pair.first.getName();
     if (SymbolName)
       return *SymbolName == FunctionID;
     // We should always succeed in finding the FunctionID, hence we suppress
     // the error here and assert later on the search result, rather than
     // propagating the Expected<> error back to the caller.
-    llvm::consumeError(SymbolName.takeError());
+    consumeError(SymbolName.takeError());
     return false;
   });
   assert(SymbolIt != SymbolSizes.end() &&

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -63,8 +63,8 @@ BenchmarkRunner::BenchmarkRunner(const LLVMState &State, Benchmark::ModeE Mode,
 BenchmarkRunner::~BenchmarkRunner() = default;
 
 void BenchmarkRunner::FunctionExecutor::accumulateCounterValues(
-    const llvm::SmallVectorImpl<int64_t> &NewValues,
-    llvm::SmallVectorImpl<int64_t> *Result) {
+    const SmallVectorImpl<int64_t> &NewValues,
+    SmallVectorImpl<int64_t> *Result) {
   const size_t NumValues = std::max(NewValues.size(), Result->size());
   if (NumValues > Result->size())
     Result->resize(NumValues, 0);
@@ -72,13 +72,13 @@ void BenchmarkRunner::FunctionExecutor::accumulateCounterValues(
     (*Result)[I] += NewValues[I];
 }
 
-Expected<llvm::SmallVector<int64_t, 4>>
+Expected<SmallVector<int64_t, 4>>
 BenchmarkRunner::FunctionExecutor::runAndSample(
     const char *Counters, ArrayRef<const char *> ValidationCounters,
     SmallVectorImpl<int64_t> &ValidationCounterValues) const {
   // We sum counts when there are several counters for a single ProcRes
   // (e.g. P23 on SandyBridge).
-  llvm::SmallVector<int64_t, 4> CounterValues;
+  SmallVector<int64_t, 4> CounterValues;
   SmallVector<StringRef, 2> CounterNames;
   StringRef(Counters).split(CounterNames, '+');
   for (auto &CounterName : CounterNames) {
@@ -114,9 +114,8 @@ private:
                                 BenchmarkRunner::ScratchSpace *Scratch)
       : State(State), Function(std::move(Function)), Scratch(Scratch) {}
 
-  static void
-  accumulateCounterValues(const llvm::SmallVector<int64_t, 4> &NewValues,
-                          llvm::SmallVector<int64_t, 4> *Result) {
+  static void accumulateCounterValues(const SmallVector<int64_t, 4> &NewValues,
+                                      SmallVector<int64_t, 4> *Result) {
     const size_t NumValues = std::max(NewValues.size(), Result->size());
     if (NumValues > Result->size())
       Result->resize(NumValues, 0);
@@ -124,7 +123,7 @@ private:
       (*Result)[I] += NewValues[I];
   }
 
-  Expected<llvm::SmallVector<int64_t, 4>> runWithCounter(
+  Expected<SmallVector<int64_t, 4>> runWithCounter(
       StringRef CounterName, ArrayRef<const char *> ValidationCounters,
       SmallVectorImpl<int64_t> &ValidationCounterValues) const override {
     const ExegesisTarget &ET = State.getExegesisTarget();
@@ -314,7 +313,7 @@ private:
       close(PipeFiles[1]);
       // Unregister handlers, signal handling is now handled through ptrace in
       // the host process
-      llvm::sys::unregisterHandlers();
+      sys::unregisterHandlers();
       prepareAndRunBenchmark(PipeFiles[0], Key);
       // The child process terminates in the above function, so we should never
       // get to this point.
@@ -484,7 +483,7 @@ private:
     exit(0);
   }
 
-  Expected<llvm::SmallVector<int64_t, 4>> runWithCounter(
+  Expected<SmallVector<int64_t, 4>> runWithCounter(
       StringRef CounterName, ArrayRef<const char *> ValidationCounters,
       SmallVectorImpl<int64_t> &ValidationCounterValues) const override {
     SmallVector<int64_t, 4> Value(1, 0);

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h
@@ -93,16 +93,16 @@ public:
   public:
     virtual ~FunctionExecutor();
 
-    Expected<llvm::SmallVector<int64_t, 4>>
+    Expected<SmallVector<int64_t, 4>>
     runAndSample(const char *Counters,
                  ArrayRef<const char *> ValidationCounters,
                  SmallVectorImpl<int64_t> &ValidationCounterValues) const;
 
   protected:
     static void
-    accumulateCounterValues(const llvm::SmallVectorImpl<int64_t> &NewValues,
-                            llvm::SmallVectorImpl<int64_t> *Result);
-    virtual Expected<llvm::SmallVector<int64_t, 4>>
+    accumulateCounterValues(const SmallVectorImpl<int64_t> &NewValues,
+                            SmallVectorImpl<int64_t> *Result);
+    virtual Expected<SmallVector<int64_t, 4>>
     runWithCounter(StringRef CounterName,
                    ArrayRef<const char *> ValidationCounters,
                    SmallVectorImpl<int64_t> &ValidationCounterValues) const = 0;

--- a/llvm/tools/llvm-exegesis/lib/Clustering.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Clustering.cpp
@@ -307,7 +307,7 @@ void BenchmarkClustering::stabilize(unsigned NumOpcodes) {
       assert(std::distance(it, OldCluster.PointIndices.end()) > 0 &&
              "Should have found at least one bad point");
       // Mark to-be-moved points as belonging to the new cluster.
-      for (size_t P : llvm::make_range(it, OldCluster.PointIndices.end()))
+      for (size_t P : make_range(it, OldCluster.PointIndices.end()))
         ClusterIdForPoint_[P] = UnstableCluster.Id;
       // Actually append to-be-moved points to the new cluster.
       UnstableCluster.PointIndices.insert(UnstableCluster.PointIndices.end(),

--- a/llvm/tools/llvm-exegesis/lib/LatencyBenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LatencyBenchmarkRunner.cpp
@@ -33,7 +33,7 @@ LatencyBenchmarkRunner::LatencyBenchmarkRunner(
 
 LatencyBenchmarkRunner::~LatencyBenchmarkRunner() = default;
 
-static double computeVariance(const llvm::SmallVector<int64_t, 4> &Values) {
+static double computeVariance(const SmallVector<int64_t, 4> &Values) {
   if (Values.empty())
     return 0.0;
   double Sum = std::accumulate(Values.begin(), Values.end(), 0.0);
@@ -47,19 +47,19 @@ static double computeVariance(const llvm::SmallVector<int64_t, 4> &Values) {
   return Ret / Values.size();
 }
 
-static int64_t findMin(const llvm::SmallVector<int64_t, 4> &Values) {
+static int64_t findMin(const SmallVector<int64_t, 4> &Values) {
   if (Values.empty())
     return 0;
   return *std::min_element(Values.begin(), Values.end());
 }
 
-static int64_t findMax(const llvm::SmallVector<int64_t, 4> &Values) {
+static int64_t findMax(const SmallVector<int64_t, 4> &Values) {
   if (Values.empty())
     return 0;
   return *std::max_element(Values.begin(), Values.end());
 }
 
-static int64_t findMean(const llvm::SmallVector<int64_t, 4> &Values) {
+static int64_t findMean(const SmallVector<int64_t, 4> &Values) {
   if (Values.empty())
     return 0;
   return std::accumulate(Values.begin(), Values.end(), 0.0) /
@@ -71,7 +71,7 @@ Expected<std::vector<BenchmarkMeasure>> LatencyBenchmarkRunner::runMeasurements(
   // Cycle measurements include some overhead from the kernel. Repeat the
   // measure several times and return the aggregated value, as specified by
   // ResultAggMode.
-  llvm::SmallVector<int64_t, 4> AccumulatedValues;
+  SmallVector<int64_t, 4> AccumulatedValues;
   double MinVariance = std::numeric_limits<double>::infinity();
   const PfmCountersInfo &PCI = State.getPfmCounters();
   const char *CounterName = PCI.CycleCounter;
@@ -125,8 +125,8 @@ Expected<std::vector<BenchmarkMeasure>> LatencyBenchmarkRunner::runMeasurements(
   switch (ResultAggMode) {
   case Benchmark::MinVariance: {
     if (ValuesCount == 1)
-      llvm::errs() << "Each sample only has one value. result-aggregation-mode "
-                      "of min-variance is probably non-sensical\n";
+      errs() << "Each sample only has one value. result-aggregation-mode "
+                "of min-variance is probably non-sensical\n";
     std::vector<BenchmarkMeasure> Result;
     Result.reserve(AccumulatedValues.size());
     for (const int64_t Value : AccumulatedValues)
@@ -153,10 +153,10 @@ Expected<std::vector<BenchmarkMeasure>> LatencyBenchmarkRunner::runMeasurements(
     return std::move(Result);
   }
   }
-  return llvm::make_error<Failure>(llvm::Twine("Unexpected benchmark mode(")
-                                       .concat(std::to_string(Mode))
-                                       .concat(" and unexpected ResultAggMode ")
-                                       .concat(std::to_string(ResultAggMode)));
+  return make_error<Failure>(Twine("Unexpected benchmark mode(")
+                                 .concat(std::to_string(Mode))
+                                 .concat(" and unexpected ResultAggMode ")
+                                 .concat(std::to_string(ResultAggMode)));
 }
 
 } // namespace exegesis

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -35,43 +35,42 @@ Expected<LLVMState> LLVMState::Create(std::string TripleName,
   const Target *TheTarget =
       TargetRegistry::lookupTarget(/*MArch=*/"", TheTriple, Error);
   if (!TheTarget) {
-    return llvm::make_error<llvm::StringError>("no LLVM target for triple " +
-                                                   TripleName,
-                                               llvm::inconvertibleErrorCode());
+    return make_error<StringError>("no LLVM target for triple " + TripleName,
+                                   inconvertibleErrorCode());
   }
 
   // Update Triple with the updated triple from the target lookup.
   TripleName = TheTriple.str();
 
   if (CpuName == "native")
-    CpuName = std::string(llvm::sys::getHostCPUName());
+    CpuName = std::string(sys::getHostCPUName());
 
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TripleName, CpuName, ""));
   assert(STI && "Unable to create subtarget info!");
   if (!STI->isCPUStringValid(CpuName)) {
-    return llvm::make_error<llvm::StringError>(Twine("invalid CPU name (")
-                                                   .concat(CpuName)
-                                                   .concat(") for triple ")
-                                                   .concat(TripleName),
-                                               llvm::inconvertibleErrorCode());
+    return make_error<StringError>(Twine("invalid CPU name (")
+                                       .concat(CpuName)
+                                       .concat(") for triple ")
+                                       .concat(TripleName),
+                                   inconvertibleErrorCode());
   }
   const TargetOptions Options;
   std::unique_ptr<const TargetMachine> TM(
       static_cast<LLVMTargetMachine *>(TheTarget->createTargetMachine(
           TripleName, CpuName, Features, Options, Reloc::Model::Static)));
   if (!TM) {
-    return llvm::make_error<llvm::StringError>(
-        "unable to create target machine", llvm::inconvertibleErrorCode());
+    return make_error<StringError>("unable to create target machine",
+                                   inconvertibleErrorCode());
   }
 
   const ExegesisTarget *ET =
       TripleName.empty() ? &ExegesisTarget::getDefault()
                          : ExegesisTarget::lookup(TM->getTargetTriple());
   if (!ET) {
-    return llvm::make_error<llvm::StringError>(
-        "no Exegesis target for triple " + TripleName,
-        llvm::inconvertibleErrorCode());
+    return make_error<StringError>("no Exegesis target for triple " +
+                                       TripleName,
+                                   inconvertibleErrorCode());
   }
   const PfmCountersInfo &PCI = UseDummyPerfCounters
                                    ? ET->getDummyPfmCounters()

--- a/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
+++ b/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
@@ -105,7 +105,7 @@ std::unique_ptr<Instruction>
 Instruction::create(const MCInstrInfo &InstrInfo,
                     const RegisterAliasingTrackerCache &RATC,
                     const BitVectorCache &BVC, unsigned Opcode) {
-  const llvm::MCInstrDesc *const Description = &InstrInfo.get(Opcode);
+  const MCInstrDesc *const Description = &InstrInfo.get(Opcode);
   unsigned OpIndex = 0;
   SmallVector<Operand, 8> Operands;
   SmallVector<Variable, 4> Variables;

--- a/llvm/tools/llvm-exegesis/lib/Mips/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Mips/Target.cpp
@@ -58,7 +58,7 @@ public:
       : ExegesisTarget(MipsCpuPfmCounters, Mips_MC::isOpcodeAvailable) {}
 
 private:
-  unsigned getScratchMemoryRegister(const llvm::Triple &TT) const override;
+  unsigned getScratchMemoryRegister(const Triple &TT) const override;
   unsigned getMaxMemoryAccessSize() const override { return 64; }
   void fillMemoryOperands(InstructionTemplate &IT, unsigned Reg,
                           unsigned Offset) const override;

--- a/llvm/tools/llvm-exegesis/lib/PerfHelper.cpp
+++ b/llvm/tools/llvm-exegesis/lib/PerfHelper.cpp
@@ -136,8 +136,8 @@ ConfiguredEvent::readOrError(StringRef /*unused*/) const {
   ssize_t ReadSize = ::read(FileDescriptor, &Count, sizeof(Count));
 
   if (ReadSize != sizeof(Count))
-    return llvm::make_error<llvm::StringError>("Failed to read event counter",
-                                               llvm::errc::io_error);
+    return make_error<StringError>("Failed to read event counter",
+                                   errc::io_error);
 
   SmallVector<int64_t, 1> Result;
   Result.push_back(Count);
@@ -187,7 +187,7 @@ void CounterGroup::stop() {
     ioctl(getFileDescriptor(), PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
 }
 
-llvm::Expected<llvm::SmallVector<int64_t, 4>>
+Expected<SmallVector<int64_t, 4>>
 CounterGroup::readOrError(StringRef FunctionBytes) const {
   if (!IsDummyEvent)
     return EventCounter.readOrError(FunctionBytes);
@@ -195,9 +195,9 @@ CounterGroup::readOrError(StringRef FunctionBytes) const {
     return SmallVector<int64_t, 1>(1, 42);
 }
 
-llvm::Expected<llvm::SmallVector<int64_t>>
+Expected<SmallVector<int64_t>>
 CounterGroup::readValidationCountersOrError() const {
-  llvm::SmallVector<int64_t, 4> Result;
+  SmallVector<int64_t, 4> Result;
   for (const auto &ValCounter : ValidationEventCounters) {
     Expected<SmallVector<int64_t>> ValueOrError =
         ValCounter.readOrError(StringRef());
@@ -223,18 +223,17 @@ void CounterGroup::start() {}
 
 void CounterGroup::stop() {}
 
-llvm::Expected<llvm::SmallVector<int64_t, 4>>
+Expected<SmallVector<int64_t, 4>>
 CounterGroup::readOrError(StringRef /*unused*/) const {
   if (IsDummyEvent) {
-    llvm::SmallVector<int64_t, 4> Result;
+    SmallVector<int64_t, 4> Result;
     Result.push_back(42);
     return Result;
   }
-  return llvm::make_error<llvm::StringError>("Not implemented",
-                                             llvm::errc::io_error);
+  return make_error<StringError>("Not implemented", errc::io_error);
 }
 
-llvm::Expected<llvm::SmallVector<int64_t>>
+Expected<SmallVector<int64_t>>
 CounterGroup::readValidationCountersOrError() const {
   return SmallVector<int64_t>(0);
 }

--- a/llvm/tools/llvm-exegesis/lib/PerfHelper.h
+++ b/llvm/tools/llvm-exegesis/lib/PerfHelper.h
@@ -127,11 +127,10 @@ public:
   /// within the benchmarked code.
   /// If empty (or not specified), then no filtering will be done.
   /// Not all counters choose to use this.
-  virtual llvm::Expected<llvm::SmallVector<int64_t, 4>>
+  virtual Expected<SmallVector<int64_t, 4>>
   readOrError(StringRef FunctionBytes = StringRef()) const;
 
-  virtual llvm::Expected<llvm::SmallVector<int64_t>>
-  readValidationCountersOrError() const;
+  virtual Expected<SmallVector<int64_t>> readValidationCountersOrError() const;
 
   virtual int numValues() const;
 

--- a/llvm/tools/llvm-exegesis/lib/ProgressMeter.h
+++ b/llvm/tools/llvm-exegesis/lib/ProgressMeter.h
@@ -92,7 +92,7 @@ public:
     ProgressMeterStep &operator=(ProgressMeterStep &&) = delete;
   };
 
-  ProgressMeter(int NumStepsTotal_, raw_ostream &out_ = llvm::errs())
+  ProgressMeter(int NumStepsTotal_, raw_ostream &out_ = errs())
       : Out(out_), NumStepsTotal(NumStepsTotal_) {
     assert(NumStepsTotal > 0 && "No steps are planned?");
   }

--- a/llvm/tools/llvm-exegesis/lib/SchedClassResolution.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SchedClassResolution.cpp
@@ -67,8 +67,8 @@ getNonRedundantWriteProcRes(const MCSchedClassDesc &SCDesc,
   }
   sort(ResourceMaskAndEntries,
        [](const ResourceMaskAndEntry &A, const ResourceMaskAndEntry &B) {
-         unsigned popcntA = llvm::popcount(A.first);
-         unsigned popcntB = llvm::popcount(B.first);
+         unsigned popcntA = popcount(A.first);
+         unsigned popcntB = popcount(B.first);
          if (popcntA < popcntB)
            return true;
          if (popcntA > popcntB)
@@ -314,10 +314,10 @@ std::vector<BenchmarkMeasure> ResolvedSchedClass::getAsPoint(
       if (ProcResIdx > 0) {
         // Find the pressure on ProcResIdx `Key`.
         const auto ProcResPressureIt =
-            llvm::find_if(IdealizedProcResPressure,
-                          [ProcResIdx](const std::pair<uint16_t, float> &WPR) {
-                            return WPR.first == ProcResIdx;
-                          });
+            find_if(IdealizedProcResPressure,
+                    [ProcResIdx](const std::pair<uint16_t, float> &WPR) {
+                      return WPR.first == ProcResIdx;
+                    });
         Measure.PerInstructionValue =
             ProcResPressureIt == IdealizedProcResPressure.end()
                 ? 0.0

--- a/llvm/tools/llvm-exegesis/lib/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Target.cpp
@@ -41,17 +41,16 @@ ExegesisTarget::createCounter(StringRef CounterName, const LLVMState &,
                               const pid_t ProcessID) const {
   pfm::PerfEvent Event(CounterName);
   if (!Event.valid())
-    return llvm::make_error<Failure>(
-        llvm::Twine("Unable to create counter with name '")
-            .concat(CounterName)
-            .concat("'"));
+    return make_error<Failure>(Twine("Unable to create counter with name '")
+                                   .concat(CounterName)
+                                   .concat("'"));
 
   std::vector<pfm::PerfEvent> ValidationEvents;
   for (const char *ValCounterName : ValidationCounters) {
     ValidationEvents.emplace_back(ValCounterName);
     if (!ValidationEvents.back().valid())
-      return llvm::make_error<Failure>(
-          llvm::Twine("Unable to create validation counter with name '")
+      return make_error<Failure>(
+          Twine("Unable to create validation counter with name '")
               .concat(ValCounterName)
               .concat("'"));
   }
@@ -176,15 +175,15 @@ const PfmCountersInfo PfmCountersInfo::Dummy = {
     0u};
 
 const PfmCountersInfo &ExegesisTarget::getPfmCounters(StringRef CpuName) const {
-  assert(llvm::is_sorted(
-             CpuPfmCounters,
-             [](const CpuAndPfmCounters &LHS, const CpuAndPfmCounters &RHS) {
-               return strcmp(LHS.CpuName, RHS.CpuName) < 0;
-             }) &&
-         "CpuPfmCounters table is not sorted");
+  assert(
+      is_sorted(CpuPfmCounters,
+                [](const CpuAndPfmCounters &LHS, const CpuAndPfmCounters &RHS) {
+                  return strcmp(LHS.CpuName, RHS.CpuName) < 0;
+                }) &&
+      "CpuPfmCounters table is not sorted");
 
   // Find entry
-  auto Found = llvm::lower_bound(CpuPfmCounters, CpuName);
+  auto Found = lower_bound(CpuPfmCounters, CpuName);
   if (Found == CpuPfmCounters.end() || StringRef(Found->CpuName) != CpuName) {
     // Use the default.
     if (!CpuPfmCounters.empty() && CpuPfmCounters.begin()->CpuName[0] == '\0') {

--- a/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
@@ -696,17 +696,17 @@ public:
       // TODO(boomanaiden154): Add in support for using validation counters when
       // using LBR counters.
       if (ValidationCounters.size() > 0)
-        return llvm::make_error<llvm::StringError>(
+        return make_error<StringError>(
             "Using LBR is not currently supported with validation counters",
-            llvm::errc::invalid_argument);
+            errc::invalid_argument);
 
       return std::make_unique<X86LbrCounter>(
           X86LbrPerfEvent(LbrSamplingPeriod));
 #else
-      return llvm::make_error<llvm::StringError>(
+      return make_error<StringError>(
           "LBR counter requested without HAVE_LIBPFM, LIBPFM_HAS_FIELD_CYCLES, "
           "or running on Linux.",
-          llvm::errc::invalid_argument);
+          errc::invalid_argument);
 #endif
     }
     return ExegesisTarget::createCounter(CounterName, State, ValidationCounters,
@@ -825,9 +825,9 @@ private:
     report_fatal_error("Running X86 exegesis on unsupported target");
 #endif
 #endif
-    return llvm::make_error<llvm::StringError>(
+    return make_error<StringError>(
         "LBR not supported on this kernel and/or platform",
-        llvm::errc::not_supported);
+        errc::not_supported);
   }
 
   std::unique_ptr<SavedState> withSavedState() const override {
@@ -1296,7 +1296,7 @@ std::vector<InstructionTemplate> ExegesisX86Target::generateInstructionVariants(
   bool Exploration = false;
   SmallVector<SmallVector<MCOperand, 1>, 4> VariableChoices;
   VariableChoices.resize(Instr.Variables.size());
-  for (auto I : llvm::zip(Instr.Variables, VariableChoices)) {
+  for (auto I : zip(Instr.Variables, VariableChoices)) {
     const Variable &Var = std::get<0>(I);
     SmallVectorImpl<MCOperand> &Choices = std::get<1>(I);
 

--- a/llvm/tools/llvm-exegesis/lib/X86/X86Counter.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/X86Counter.cpp
@@ -74,9 +74,9 @@ static void copyDataBuffer(void *MMappedBuffer, char *Buf, uint64_t Tail,
 // Parses the given data-buffer for stats and fill the CycleArray.
 // If data has been extracted successfully, also modifies the code to jump
 // out the benchmark loop.
-static llvm::Error parseDataBuffer(const char *DataBuf, size_t DataSize,
-                                   const void *From, const void *To,
-                                   llvm::SmallVector<int64_t, 4> *CycleArray) {
+static Error parseDataBuffer(const char *DataBuf, size_t DataSize,
+                             const void *From, const void *To,
+                             SmallVector<int64_t, 4> *CycleArray) {
   const char *DataPtr = DataBuf;
   while (DataPtr < DataBuf + DataSize) {
     struct perf_event_header Header;
@@ -87,8 +87,7 @@ static llvm::Error parseDataBuffer(const char *DataBuf, size_t DataSize,
       continue;
     }
     DataPtr += sizeof(Header);
-    uint64_t Count =
-        llvm::support::endian::read64(DataPtr, llvm::endianness::native);
+    uint64_t Count = support::endian::read64(DataPtr, endianness::native);
     DataPtr += sizeof(Count);
 
     struct perf_branch_entry Entry;
@@ -108,15 +107,14 @@ static llvm::Error parseDataBuffer(const char *DataBuf, size_t DataSize,
 
       if (i == Count - 1)
         // We've reached the last entry.
-        return llvm::Error::success();
+        return Error::success();
 
       // Advance to next entry
       DataPtr += sizeof(Entry);
       memcpy(&Entry, DataPtr, sizeof(struct perf_branch_entry));
     }
   }
-  return llvm::make_error<llvm::StringError>("Unable to parse databuffer.",
-                                             llvm::errc::io_error);
+  return make_error<StringError>("Unable to parse databuffer.", errc::io_error);
 }
 
 X86LbrPerfEvent::X86LbrPerfEvent(unsigned SamplingPeriod) {
@@ -145,19 +143,19 @@ X86LbrCounter::X86LbrCounter(pfm::PerfEvent &&NewEvent)
   MMappedBuffer = mmap(nullptr, kMappedBufferSize, PROT_READ | PROT_WRITE,
                        MAP_SHARED, getFileDescriptor(), 0);
   if (MMappedBuffer == MAP_FAILED)
-    llvm::errs() << "Failed to mmap buffer.";
+    errs() << "Failed to mmap buffer.";
 }
 
 X86LbrCounter::~X86LbrCounter() {
   if (0 != munmap(MMappedBuffer, kMappedBufferSize))
-    llvm::errs() << "Failed to munmap buffer.";
+    errs() << "Failed to munmap buffer.";
 }
 
 void X86LbrCounter::start() {
   ioctl(getFileDescriptor(), PERF_EVENT_IOC_REFRESH, 1024 /* kMaxPollsPerFd */);
 }
 
-llvm::Error X86LbrCounter::checkLbrSupport() {
+Error X86LbrCounter::checkLbrSupport() {
   // Do a sample read and check if the results contain non-zero values.
 
   X86LbrCounter counter(X86LbrPerfEvent(123));
@@ -189,12 +187,12 @@ llvm::Error X86LbrCounter::checkLbrSupport() {
         if (Value != 0)
           return Error::success();
 
-  return llvm::make_error<llvm::StringError>(
+  return make_error<StringError>(
       "LBR format with cycles is not suppported on the host.",
-      llvm::errc::not_supported);
+      errc::not_supported);
 }
 
-llvm::Expected<llvm::SmallVector<int64_t, 4>>
+Expected<SmallVector<int64_t, 4>>
 X86LbrCounter::readOrError(StringRef FunctionBytes) const {
   // Disable the event before reading
   ioctl(getFileDescriptor(), PERF_EVENT_IOC_DISABLE, 0);
@@ -202,22 +200,22 @@ X86LbrCounter::readOrError(StringRef FunctionBytes) const {
   // Find the boundary of the function so that we could filter the LBRs
   // to keep only the relevant records.
   if (FunctionBytes.empty())
-    return llvm::make_error<llvm::StringError>("Empty function bytes",
-                                               llvm::errc::invalid_argument);
+    return make_error<StringError>("Empty function bytes",
+                                   errc::invalid_argument);
   const void *From = reinterpret_cast<const void *>(FunctionBytes.data());
   const void *To = reinterpret_cast<const void *>(FunctionBytes.data() +
                                                   FunctionBytes.size());
   return doReadCounter(From, To);
 }
 
-llvm::Expected<llvm::SmallVector<int64_t, 4>>
+Expected<SmallVector<int64_t, 4>>
 X86LbrCounter::doReadCounter(const void *From, const void *To) const {
   // The max number of time-outs/retries before we give up.
   static constexpr int kMaxTimeouts = 160;
 
   // Parses the LBR buffer and fills CycleArray with the sequence of cycle
   // counts from the buffer.
-  llvm::SmallVector<int64_t, 4> CycleArray;
+  SmallVector<int64_t, 4> CycleArray;
   auto DataBuf = std::make_unique<char[]>(kDataBufferSize);
   int NumTimeouts = 0;
   int PollResult = 0;
@@ -227,12 +225,12 @@ X86LbrCounter::doReadCounter(const void *From, const void *To) const {
     if (PollResult > 0)
       break;
     if (PollResult == -1)
-      return llvm::make_error<llvm::StringError>("Cannot poll LBR perf event.",
-                                                 llvm::errc::io_error);
+      return make_error<StringError>("Cannot poll LBR perf event.",
+                                     errc::io_error);
     if (NumTimeouts++ >= kMaxTimeouts)
-      return llvm::make_error<llvm::StringError>(
+      return make_error<StringError>(
           "LBR polling still timed out after max number of attempts.",
-          llvm::errc::device_or_resource_busy);
+          errc::device_or_resource_busy);
   }
 
   struct perf_event_mmap_page Page;
@@ -244,12 +242,11 @@ X86LbrCounter::doReadCounter(const void *From, const void *To) const {
   std::atomic_thread_fence(std::memory_order_acq_rel);
   const size_t DataSize = DataHead - DataTail;
   if (DataSize > kDataBufferSize)
-    return llvm::make_error<llvm::StringError>(
-        "DataSize larger than buffer size.", llvm::errc::invalid_argument);
+    return make_error<StringError>("DataSize larger than buffer size.",
+                                   errc::invalid_argument);
 
   copyDataBuffer(MMappedBuffer, DataBuf.get(), DataTail, DataSize);
-  llvm::Error error =
-      parseDataBuffer(DataBuf.get(), DataSize, From, To, &CycleArray);
+  Error error = parseDataBuffer(DataBuf.get(), DataSize, From, To, &CycleArray);
   if (!error)
     return CycleArray;
   return std::move(error);

--- a/llvm/tools/llvm-exegesis/lib/X86/X86Counter.h
+++ b/llvm/tools/llvm-exegesis/lib/X86/X86Counter.h
@@ -33,7 +33,7 @@ public:
 
 class X86LbrCounter : public pfm::CounterGroup {
 public:
-  static llvm::Error checkLbrSupport();
+  static Error checkLbrSupport();
 
   explicit X86LbrCounter(pfm::PerfEvent &&Event);
 
@@ -41,12 +41,12 @@ public:
 
   void start() override;
 
-  llvm::Expected<llvm::SmallVector<int64_t, 4>>
+  Expected<SmallVector<int64_t, 4>>
   readOrError(StringRef FunctionBytes) const override;
 
 private:
-  llvm::Expected<llvm::SmallVector<int64_t, 4>>
-  doReadCounter(const void *From, const void *To) const;
+  Expected<SmallVector<int64_t, 4>> doReadCounter(const void *From,
+                                                  const void *To) const;
 
   void *MMappedBuffer = nullptr;
 };

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -438,7 +438,7 @@ static void runBenchmarkConfigurations(
         // Errors from executing the snippets are fine.
         // All other errors are a framework issue and should fail.
         if (!Err.isA<SnippetExecutionFailure>()) {
-          llvm::errs() << "llvm-exegesis error: " << toString(std::move(Err));
+          errs() << "llvm-exegesis error: " << toString(std::move(Err));
           exit(1);
         }
         BenchmarkResult.Error = toString(std::move(Err));
@@ -457,8 +457,7 @@ static void runBenchmarkConfigurations(
     if (RepetitionMode == Benchmark::RepetitionModeE::AggregateMin) {
       for (const Benchmark &OtherResult :
            ArrayRef<Benchmark>(AllResults).drop_front()) {
-        llvm::append_range(Result.AssembledSnippet,
-                           OtherResult.AssembledSnippet);
+        append_range(Result.AssembledSnippet, OtherResult.AssembledSnippet);
         // Aggregate measurements, but only if all measurements succeeded.
         if (Result.Measurements.empty())
           continue;
@@ -667,14 +666,14 @@ static void analysisMain() {
   }
   auto TripleAndCpu = *TriplesAndCpus.begin();
   if (AnalysisOverrideBenchmarksTripleAndCpu) {
-    llvm::errs() << "overridding file CPU name (" << TripleAndCpu.CpuName
-                 << ") with provided tripled (" << TripleName
-                 << ") and CPU name (" << MCPU << ")\n";
+    errs() << "overridding file CPU name (" << TripleAndCpu.CpuName
+           << ") with provided tripled (" << TripleName << ") and CPU name ("
+           << MCPU << ")\n";
     TripleAndCpu.LLVMTriple = TripleName;
     TripleAndCpu.CpuName = MCPU;
   }
-  llvm::errs() << "using Triple '" << TripleAndCpu.LLVMTriple << "' and CPU '"
-               << TripleAndCpu.CpuName << "'\n";
+  errs() << "using Triple '" << TripleAndCpu.LLVMTriple << "' and CPU '"
+         << TripleAndCpu.CpuName << "'\n";
 
   // Read benchmarks.
   const LLVMState State = ExitOnErr(
@@ -725,9 +724,8 @@ int main(int Argc, char **Argv) {
   // Enable printing of available targets when flag --version is specified.
   cl::AddExtraVersionPrinter(TargetRegistry::printRegisteredTargetsForVersion);
 
-  cl::HideUnrelatedOptions({&llvm::exegesis::Options,
-                            &llvm::exegesis::BenchmarkOptions,
-                            &llvm::exegesis::AnalysisOptions});
+  cl::HideUnrelatedOptions({&exegesis::Options, &exegesis::BenchmarkOptions,
+                            &exegesis::AnalysisOptions});
 
   cl::ParseCommandLineOptions(Argc, Argv,
                               "llvm host machine instruction characteristics "


### PR DESCRIPTION
This patch removes the llvm:: prefix within llvm-exegesis where it is not necessary. This is most occurrences of the prefix within exegesis as exegesis is within the llvm namespace. This patch makes things more consistent as the vast majority of the code did not use the llvm:: prefix for anything.