### PR TITLE
[StackSafetyAnalysis] Don't call getTruncateOrZeroExtend for pointers of different sizes

### DIFF
--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -280,7 +280,11 @@ const SCEV *StackSafetyLocalAnalysis::getSCEVAsPointer(Value *Val) {
   Type *ValTy = Val->getType();
 
   // We don't handle targets with multiple address spaces.
-  assert(ValTy->isPointerTy());
+  if(!ValTy->isPointerTy()) {
+    auto *PtrTy = PointerType::getUnqual(SE.getContext());
+    return SE.getTruncateOrZeroExtend(SE.getSCEV(Val), PtrTy);
+  }
+
   if (ValTy->getPointerAddressSpace() != 0)
     return nullptr;
   return SE.getSCEV(Val);

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -280,7 +280,7 @@ const SCEV *StackSafetyLocalAnalysis::getSCEVAsPointer(Value *Val) {
   Type *ValTy = Val->getType();
 
   // We don't handle targets with multiple address spaces.
-  if(!ValTy->isPointerTy()) {
+  if (!ValTy->isPointerTy()) {
     auto *PtrTy = PointerType::getUnqual(SE.getContext());
     return SE.getTruncateOrZeroExtend(SE.getSCEV(Val), PtrTy);
   }

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -279,14 +279,11 @@ public:
 const SCEV *StackSafetyLocalAnalysis::getSCEVAsPointer(Value *Val) {
   Type *ValTy = Val->getType();
 
-  auto *PtrTy = PointerType::getUnqual(SE.getContext());
-  if (ValTy->isPointerTy()) {
-    if (ValTy->getPointerAddressSpace() != 0)
-      return nullptr;
-    return SE.getSCEV(Val);
-  }
-
-  return SE.getTruncateOrZeroExtend(SE.getSCEV(Val), PtrTy);
+  // We don't handle targets with multiple address spaces.
+  assert(ValTy->isPointerTy());
+  if (ValTy->getPointerAddressSpace() != 0)
+    return nullptr;
+  return SE.getSCEV(Val);
 }
 
 ConstantRange StackSafetyLocalAnalysis::offsetFrom(Value *Addr, Value *Base) {

--- a/llvm/test/Analysis/StackSafetyAnalysis/extend-ptr.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/extend-ptr.ll
@@ -1,0 +1,18 @@
+; RUN: opt %s -disable-output -S -passes="print<stack-safety-local>" 2>&1 | FileCheck %s
+
+; Datalayout from AMDGPU, p5 is 32 bits and p is 64.
+; We used to call SCEV getTruncateOrZeroExtend on %x.ascast/%x which caused an assertion failure.
+
+; CHECK:      @a dso_preemptable
+; CHECK-NEXT:   args uses:
+; CHECK-NEXT:     x[]: full-set
+; CHECK-NEXT:   allocas uses:
+
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+
+define void @a(ptr addrspace(5) %x) {
+entry:
+  %x.ascast = addrspacecast ptr addrspace(5) %x to ptr
+  store i64 0, ptr %x.ascast, align 8
+  ret void
+}

--- a/llvm/test/Analysis/StackSafetyAnalysis/extend-ptr.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/extend-ptr.ll
@@ -13,6 +13,7 @@ target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:3
 define void @a(ptr addrspace(5) %x) {
 entry:
   %x.ascast = addrspacecast ptr addrspace(5) %x to ptr
-  store i64 0, ptr %x.ascast, align 8
+  %tmp = load i64, ptr %x.ascast
+  store i64 %tmp, ptr %x.ascast, align 8
   ret void
 }


### PR DESCRIPTION
Otherwise SCEV asserts `Can't extend pointer!`
I assume the proper fix would be to teach SCEV about addrspacecast but this is a blocking issue downstream so I'm making a quick fix.

Fixes SWDEV-442670