### PR TITLE
[clang-format] Explicitly open DOC_FILE with utf-8 in dump_format_style.py

### DIFF
--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -474,7 +474,7 @@ with open(INCLUDE_STYLE_FILE) as f:
 opts = sorted(opts, key=lambda x: x.name)
 options_text = "\n\n".join(map(str, opts))
 
-with open(DOC_FILE) as f:
+with open(DOC_FILE, encoding="utf-8") as f:
     contents = f.read()
 
 contents = substitute(contents, "FORMAT_STYLE_OPTIONS", options_text)


### PR DESCRIPTION
The dump_format_style.py script generates the clang-format style options documentation.
There was an issue where the script could include spurious characters in the output when run in windows. It appears that it wasn't defaulting to the correct encoding when reading the input.
This has been addressed by explicitly setting the encoding when opening the file.