### PR TITLE
[Clang, SystemZ] Split test into Driver and CodeGen parts (NFC)

### DIFF
--- a/clang/test/CodeGen/SystemZ/unaligned-symbols.c
+++ b/clang/test/CodeGen/SystemZ/unaligned-symbols.c
@@ -1,13 +1,10 @@
-// RUN: %clang -target s390x-linux-gnu %s -o - -emit-llvm -S \
+// RUN: %clang_cc1 -triple s390x-linux-gnu %s -o - -emit-llvm \
 // RUN:    | FileCheck %s -check-prefixes=CHECK,ALIGNED
 
-// RUN: %clang -target s390x-linux-gnu %s -o - -emit-llvm -S \
-// RUN:    -mno-unaligned-symbols | FileCheck %s -check-prefixes=CHECK,ALIGNED
+// RUN: %clang_cc1 -triple s390x-linux-gnu %s -o - -emit-llvm \
+// RUN:    -target-feature -unaligned-symbols | FileCheck %s -check-prefixes=CHECK,ALIGNED
 
-// RUN: %clang -target s390x-linux-gnu %s -o - -emit-llvm -S \
-// RUN:    -munaligned-symbols | FileCheck %s -check-prefixes=CHECK,UNALIGN
-
-// RUN: %clang -cc1 -triple s390x-linux-gnu %s -o - -emit-llvm \
+// RUN: %clang_cc1 -triple s390x-linux-gnu %s -o - -emit-llvm \
 // RUN:    -target-feature +unaligned-symbols | FileCheck %s -check-prefixes=CHECK,UNALIGN
 
 

--- a/clang/test/Driver/s390x-unaligned-symbols.c
+++ b/clang/test/Driver/s390x-unaligned-symbols.c
@@ -1,0 +1,7 @@
+// RUN: %clang -target s390x-linux-gnu -### -c %s 2>&1 | FileCheck -check-prefix=DEFAULT %s
+// RUN: %clang -target s390x-linux-gnu -mno-unaligned-symbols -### -c %s 2>&1 | FileCheck -check-prefix=ALIGNED %s
+// RUN: %clang -target s390x-linux-gnu -munaligned-symbols -### -c %s 2>&1 | FileCheck -check-prefix=UNALIGN %s
+
+// DEFAULT-NOT: unaligned-symbols"
+// ALIGNED: "-target-feature" "-unaligned-symbols"
+// UNALIGN: "-target-feature" "+unaligned-symbols"


### PR DESCRIPTION
The test added in #73511 currently fails in
CLANG_DEFAULT_PIE_ON_LINUX=OFF configuration, because it uses the clang driver in a codegen test.

Split the test into two, a driver test that checks that the appropriate target feature is passed, and a codegen test that uses cc1.