### PR TITLE
[HWASAN] NFC? Remove DW_OP_LLVM_tag_offset from DIExpression::isImplicit

### DIFF
--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1512,7 +1512,6 @@ bool DIExpression::isImplicit() const {
     default:
       break;
     case dwarf::DW_OP_stack_value:
-    case dwarf::DW_OP_LLVM_tag_offset:
       return true;
     }
   }


### PR DESCRIPTION
According to its doc-comment `isImplicit` is meant to return true if the expression is an implicit location description (describes an object or part of an object which has no location by computing the value from available program state).

There's a brief entry for `DW_OP_LLVM_tag_offset` in the LangRef and there's some info in the original commit [fb9ce100d19be130d004d03088ccd4af295f3435](https://github.com/llvm/llvm-project/commit/fb9ce100d19be130d004d03088ccd4af295f3435).

From what I can tell it doesn't look like `DW_OP_LLVM_tag_offset` affects whether or not the location is implicit; the opcode doesn't get included in the final location description but instead is added as a attribute to the variable.

I'm not 100% confident as I'm not very familiar with `DW_OP_LLVM_tag_offset`. However, applying this change builds (with assertions enabled) an identical clang self hosted binary built with -O2 -g and hwasan, which adds confidence.

This was tripping an assertion ([code](https://github.com/llvm/llvm-project/blob/febb4c42b192ed7c88c17f91cb903a59acf20baf/llvm/lib/IR/DebugInfoMetadata.cpp#L1968)) in the latest application of the fix to #76545, #78606, where an expression containing a `DW_OP_LLVM_tag_offset` is split into a fragment (i.e., describe a part of the whole variable).



