### PR TITLE
[Driver] Fix erroneous warning for -fcx-limited-range and -fcx-fortran-rules.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2705,7 +2705,7 @@ static StringRef EnumComplexRangeToStr(LangOptions::ComplexRangeKind Range) {
 static void EmitComplexRangeDiag(const Driver &D,
                                  LangOptions::ComplexRangeKind Range1,
                                  LangOptions::ComplexRangeKind Range2) {
-  if (Range1 != LangOptions::ComplexRangeKind::CX_Full)
+  if (Range1 != Range2 && Range1 != LangOptions::ComplexRangeKind::CX_None)
     D.Diag(clang::diag::warn_drv_overriding_option)
         << EnumComplexRangeToStr(Range1) << EnumComplexRangeToStr(Range2);
 }

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -35,8 +35,11 @@
 // RUN: %clang -### -target x86_64 -ffast-math -fno-cx-limited-range -c %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=FULL %s
 
-// RUN: %clang -c -target x86_64 -fcx-limited-range %s -Xclang -verify=range
-// RUN: %clang -c -target x86_64 -fcx-fortran-rules %s -Xclang -verify=range
+// RUN: %clang -### -Werror -target x86_64 -fcx-limited-range -c %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=LMTD %s
+
+// RUN: %clang -### -Werror -target x86_64 -fcx-fortran-rules -c %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=FRTRN %s
 
 // LMTD: -complex-range=limited
 // FULL: -complex-range=full

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -50,4 +50,3 @@
 // CHECK-NOT: -complex-range=fortran
 // WARN1: warning: overriding '-fcx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
 // WARN2: warning: overriding '-fcx-fortran-rules' option with '-fcx-limited-range' [-Woverriding-option]
-// range-no-diagnostics

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -35,6 +35,9 @@
 // RUN: %clang -### -target x86_64 -ffast-math -fno-cx-limited-range -c %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=FULL %s
 
+// RUN: %clang -c -target x86_64 -fcx-limited-range %s -Xclang -verify=range
+// RUN: %clang -c -target x86_64 -fcx-fortran-rules %s -Xclang -verify=range
+
 // LMTD: -complex-range=limited
 // FULL: -complex-range=full
 // LMTD-NOT: -complex-range=fortran
@@ -44,3 +47,4 @@
 // CHECK-NOT: -complex-range=fortran
 // WARN1: warning: overriding '-fcx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
 // WARN2: warning: overriding '-fcx-fortran-rules' option with '-fcx-limited-range' [-Woverriding-option]
+// range-no-diagnostics


### PR DESCRIPTION
The options `-fcx-limited-range` and `-fcx-fortran-rules` were added in _https://github.com/llvm/llvm-project/pull/70244_ 

The code adding the options introduced an erroneous warning.
`$ clang -c -fcx-limited-range t1.c` 
`clang: warning: overriding '' option with '-fcx-limited-range' [-Woverriding-option]`
and
`$ clang -c -fcx-fortran-rules t1.c`
`clang: warning: overriding '' option with '-fcx-fortran-rules' [-Woverriding-option]`

The warning doesn't make sense. This patch removes it.