### PR TITLE
[builtins] Update HAVE_SYSCONF configure check to adapt CMake

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -282,6 +282,10 @@ option(COMPILER_RT_USE_BUILTINS_LIBRARY
 
 include(config-ix)
 
+configure_file(
+  ${COMPILER_RT_SOURCE_DIR}/include/config/config.h.cmake
+  ${COMPILER_RT_BINARY_DIR}/include/config/config.h)
+
 #================================
 # Setup Compiler Flags
 #================================

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -168,6 +168,7 @@ check_cxx_compiler_flag(-Werror -Wsizeof-pointer-div COMPILER_RT_HAS_SIZEOF_POIN
 
 # Symbols.
 check_symbol_exists(__func__ "" COMPILER_RT_HAS_FUNC_SYMBOL)
+check_symbol_exists(sysconf unistd.h COMPILER_RT_HAS_SYSCONF)
 
 # Includes.
 check_cxx_compiler_flag(-nostdinc++ COMPILER_RT_HAS_NOSTDINCXX_FLAG)

--- a/compiler-rt/include/config/config.h.cmake
+++ b/compiler-rt/include/config/config.h.cmake
@@ -1,0 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#cmakedefine COMPILER_RT_HAS_SYSCONF
+
+#endif

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -64,6 +64,8 @@ include(CMakePushCheckState)
 option(COMPILER_RT_BUILTINS_HIDE_SYMBOLS
   "Do not export any symbols from the static library." ON)
 
+include_directories(${COMPILER_RT_BINARY_DIR}/include/config)
+
 # TODO: Need to add a mechanism for logging errors when builtin source files are
 # added to a sub-directory and not this CMakeLists file.
 set(GENERIC_SOURCES

--- a/compiler-rt/lib/builtins/enable_execute_stack.c
+++ b/compiler-rt/lib/builtins/enable_execute_stack.c
@@ -12,10 +12,7 @@
 #include <sys/mman.h>
 #endif
 
-// #include "config.h"
-// FIXME: CMake - include when cmake system is ready.
-// Remove #define HAVE_SYSCONF 1 line.
-#define HAVE_SYSCONF 1
+#include "config.h"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -50,11 +47,11 @@ COMPILER_RT_ABI void __enable_execute_stack(void *addr) {
 #if __APPLE__
   // On Darwin, pagesize is always 4096 bytes
   const uintptr_t pageSize = 4096;
-#elif !defined(HAVE_SYSCONF)
-#error "HAVE_SYSCONF not defined! See enable_execute_stack.c"
+#elif !defined(COMPILER_RT_HAS_SYSCONF)
+#error "COMPILER_RT_HAS_SYSCONF not defined! See enable_execute_stack.c"
 #else
   const uintptr_t pageSize = sysconf(_SC_PAGESIZE);
-#endif // __APPLE__
+#endif
 
   const uintptr_t pageAlignMask = ~(pageSize - 1);
   uintptr_t p = (uintptr_t)addr;


### PR DESCRIPTION
The cleans up the `HAVE_SYSCONF` check in enable_execute_stack.c from 2dbae9c334c4c250f16e105e5579b0c3f2f3fb22 and 40268af91e4a8cb2b7d1a90abc5453223fc54547. Those two commits were made when the CMake build system was not ready yet.