### PR TITLE
[AsmParser] Add missing globals declarations in incomplete IR mode

### DIFF
--- a/llvm/test/Assembler/incomplete-ir-declarations.ll
+++ b/llvm/test/Assembler/incomplete-ir-declarations.ll
@@ -1,0 +1,20 @@
+; RUN: opt -S -allow-incomplete-ir < %s | FileCheck %s
+
+; CHECK: @fn2 = external global i8
+; CHECK: @g1 = external global i8
+; CHECK: @g2 = external global i8
+; CHECK: @g3 = external global i8
+
+; CHECK: declare void @fn1(i32)
+
+define ptr @test() {
+  call void @fn1(i32 0)
+  call void @fn1(i32 1)
+  call void @fn2(i32 2)
+  call void @fn2(i32 2, i32 3)
+  load i32, ptr @g1
+  store i32 0, ptr @g1
+  load i32, ptr @g1
+  load i64, ptr @g2
+  ret ptr @g3
+}


### PR DESCRIPTION
If `-allow-incomplete-ir` is enabled, automatically insert declarations for missing globals.

If a global is only used in calls with the same function type, insert a function declaration with that type.

Otherwise, insert a dummy i8 global. The fallback case could be extended with various heuristics (e.g. we could look at load/store types), but I've chosen to keep it simple for now, because I'm unsure to what degree this would really useful without more experience. I expect that in most cases the declaration type doesn't really matter (note that the type of an external global specifies a *minimum* size only, not a precise size).

This is a followup to https://github.com/llvm/llvm-project/pull/78421.