### PR TITLE
[libc++] Avoid including libc++ private header in std/ test

### DIFF
--- a/libcxx/test/std/containers/sequences/array/size_and_alignment.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/array/size_and_alignment.compile.pass.cpp
@@ -22,7 +22,10 @@
 #include <array>
 #include <cstddef>
 #include <type_traits>
-#include <__type_traits/datasizeof.h>
+
+#ifdef _LIBCPP_VERSION
+#  include <__type_traits/datasizeof.h>
+#endif
 
 #include "test_macros.h"
 


### PR DESCRIPTION
Fixes #79783