### PR TITLE
[WIP] Delayed privatization.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -16,6 +16,7 @@
 #include "flang/Common/Fortran.h"
 #include "flang/Lower/LoweringOptions.h"
 #include "flang/Lower/PFTDefs.h"
+#include "flang/Lower/SymbolMap.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Semantics/symbol.h"
 #include "mlir/IR/Builders.h"
@@ -295,6 +296,9 @@ public:
   const Fortran::lower::LoweringOptions &getLoweringOptions() const {
     return loweringOptions;
   }
+
+  virtual Fortran::lower::SymbolBox
+  lookupOneLevelUpSymbol(const Fortran::semantics::Symbol &sym) = 0;
 
 private:
   /// Options controlling lowering behavior.

--- a/flang/include/flang/Lower/SymbolMap.h
+++ b/flang/include/flang/Lower/SymbolMap.h
@@ -312,6 +312,7 @@ public:
   lookupVariableDefinition(semantics::SymbolRef sym) {
     if (auto symBox = lookupSymbol(sym))
       return symBox.getIfFortranVariableOpInterface();
+
     return std::nullopt;
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1070,7 +1070,7 @@ private:
   /// Find the symbol in one level up of symbol map such as for host-association
   /// in OpenMP code or return null.
   Fortran::lower::SymbolBox
-  lookupOneLevelUpSymbol(const Fortran::semantics::Symbol &sym) {
+  lookupOneLevelUpSymbol(const Fortran::semantics::Symbol &sym) override {
     if (Fortran::lower::SymbolBox v = localSymbols.lookupOneLevelUpSymbol(sym))
       return v;
     return {};

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1052,7 +1052,10 @@ private:
       if (sym.detailsIf<Fortran::semantics::CommonBlockDetails>())
         return symMap->lookupSymbol(sym);
 
-      return {};
+      // With delayed privatization, Fortran symbols might now be mapped to
+      // simple `mlir::Value`s (arguments to the `omp.private` ops in this
+      // case). Therefore, it is possible that none of the above cases applies.
+      // return {};
     }
     if (Fortran::lower::SymbolBox v = symMap->lookupSymbol(sym))
       return v;

--- a/flang/test/Lower/OpenMP/FIR/delayed_privatization.f90
+++ b/flang/test/Lower/OpenMP/FIR/delayed_privatization.f90
@@ -1,0 +1,182 @@
+! TODO Convert this file into a bunch of lit tests for each conversion step.
+
+! RUN: bbc -fopenmp -emit-fir --openmp-enable-delayed-privatization -hlfir=false %s -o - 
+
+subroutine delayed_privatization()
+  integer :: var1
+  integer :: var2
+
+  var1 = 111
+  var2 = 222
+
+!$OMP PARALLEL FIRSTPRIVATE(var1, var2)
+  var1 = var1 + var2 + 2
+!$OMP END PARALLEL
+
+end subroutine
+
+! -----------------------------------------
+! ## This is what flang emits with the PoC:
+! -----------------------------------------
+!
+! ----------------------------
+! ### Conversion to FIR + OMP:
+! ----------------------------
+!module {
+!  func.func @_QPdelayed_privatization() {
+!    %0 = fir.alloca i32 {bindc_name = "var1", uniq_name = "_QFdelayed_privatizationEvar1"}
+!    %1 = fir.alloca i32 {bindc_name = "var2", uniq_name = "_QFdelayed_privatizationEvar2"}
+!    %c111_i32 = arith.constant 111 : i32
+!    fir.store %c111_i32 to %0 : !fir.ref<i32>
+!    %c222_i32 = arith.constant 222 : i32
+!    fir.store %c222_i32 to %1 : !fir.ref<i32>
+!    omp.parallel private(@var1.privatizer %0, @var2.privatizer %1 : !fir.ref<i32>, !fir.ref<i32>) {
+!    ^bb0(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>):
+!      %2 = fir.load %arg0 : !fir.ref<i32>
+!      %3 = fir.load %arg1 : !fir.ref<i32>
+!      %4 = arith.addi %2, %3 : i32
+!      %c2_i32 = arith.constant 2 : i32
+!      %5 = arith.addi %4, %c2_i32 : i32
+!      fir.store %5 to %arg0 : !fir.ref<i32>
+!      omp.terminator
+!    }
+!    return
+!  }
+!  "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "var1.privatizer"}> ({
+!  ^bb0(%arg0: !fir.ref<i32>):
+!    %0 = fir.alloca i32 {bindc_name = "var1", pinned, uniq_name = "_QFdelayed_privatizationEvar1"}
+!    %1 = fir.load %arg0 : !fir.ref<i32>
+!    fir.store %1 to %0 : !fir.ref<i32>
+!    omp.yield(%0 : !fir.ref<i32>)
+!  }) : () -> ()
+!  "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "var2.privatizer"}> ({
+!  ^bb0(%arg0: !fir.ref<i32>):
+!    %0 = fir.alloca i32 {bindc_name = "var2", pinned, uniq_name = "_QFdelayed_privatizationEvar2"}
+!    %1 = fir.load %arg0 : !fir.ref<i32>
+!    fir.store %1 to %0 : !fir.ref<i32>
+!    omp.yield(%0 : !fir.ref<i32>)
+!  }) : () -> ()
+!
+! -----------------------------
+! ### Conversion to LLVM + OMP:
+! -----------------------------
+!module {
+!  llvm.func @_QPdelayed_privatization() {
+!    %0 = llvm.mlir.constant(1 : i64) : i64
+!    %1 = llvm.alloca %0 x i32 {bindc_name = "var1"} : (i64) -> !llvm.ptr
+!    %2 = llvm.mlir.constant(1 : i64) : i64
+!    %3 = llvm.alloca %2 x i32 {bindc_name = "var2"} : (i64) -> !llvm.ptr
+!    %4 = llvm.mlir.constant(111 : i32) : i32
+!    llvm.store %4, %1 : i32, !llvm.ptr
+!    %5 = llvm.mlir.constant(222 : i32) : i32
+!    llvm.store %5, %3 : i32, !llvm.ptr
+!    omp.parallel private(@var1.privatizer %1, @var2.privatizer %3 : !llvm.ptr, !llvm.ptr) {
+!    ^bb0(%arg0: !llvm.ptr, %arg1: !llvm.ptr):
+!      %6 = llvm.load %arg0 : !llvm.ptr -> i32
+!      %7 = llvm.load %arg1 : !llvm.ptr -> i32
+!      %8 = llvm.add %6, %7  : i32
+!      %9 = llvm.mlir.constant(2 : i32) : i32
+!      %10 = llvm.add %8, %9  : i32
+!      llvm.store %10, %arg0 : i32, !llvm.ptr
+!      omp.terminator
+!    }
+!    llvm.return
+!  }
+!  "omp.private"() <{function_type = (!llvm.ptr) -> !llvm.ptr, sym_name = "var1.privatizer"}> ({
+!  ^bb0(%arg0: !llvm.ptr):
+!    %0 = llvm.mlir.constant(1 : i64) : i64
+!    %1 = llvm.alloca %0 x i32 {bindc_name = "var1", pinned} : (i64) -> !llvm.ptr
+!    %2 = llvm.load %arg0 : !llvm.ptr -> i32
+!    llvm.store %2, %1 : i32, !llvm.ptr
+!    omp.yield(%1 : !llvm.ptr)
+!  }) : () -> ()
+!  "omp.private"() <{function_type = (!llvm.ptr) -> !llvm.ptr, sym_name = "var2.privatizer"}> ({
+!  ^bb0(%arg0: !llvm.ptr):
+!    %0 = llvm.mlir.constant(1 : i64) : i64
+!    %1 = llvm.alloca %0 x i32 {bindc_name = "var2", pinned} : (i64) -> !llvm.ptr
+!    %2 = llvm.load %arg0 : !llvm.ptr -> i32
+!    llvm.store %2, %1 : i32, !llvm.ptr
+!    omp.yield(%1 : !llvm.ptr)
+!  }) : () -> ()
+!}
+!
+! --------------------------
+! ### Conversion to LLVM IR:
+! --------------------------
+!%struct.ident_t = type { i32, i32, i32, i32, ptr }
+
+!@0 = private unnamed_addr constant [23 x i8] c";unknown;unknown;0;0;;\00", align 1
+!@1 = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 22, ptr @0 }, align 8
+
+!define void @_QPdelayed_privatization() {
+!  %structArg = alloca { ptr, ptr }, align 8
+!  %1 = alloca i32, i64 1, align 4
+!  %2 = alloca i32, i64 1, align 4
+!  store i32 111, ptr %1, align 4
+!  store i32 222, ptr %2, align 4
+!  br label %entry
+
+!entry:                                            ; preds = %0
+!  %omp_global_thread_num = call i32 @__kmpc_global_thread_num(ptr @1)
+!  br label %omp_parallel
+
+!omp_parallel:                                     ; preds = %entry
+!  %gep_ = getelementptr { ptr, ptr }, ptr %structArg, i32 0, i32 0
+!  store ptr %1, ptr %gep_, align 8
+!  %gep_2 = getelementptr { ptr, ptr }, ptr %structArg, i32 0, i32 1
+!  store ptr %2, ptr %gep_2, align 8
+!  call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr @1, i32 1, ptr @_QPdelayed_privatization..omp_par, ptr %structArg)
+!  br label %omp.par.outlined.exit
+
+!omp.par.outlined.exit:                            ; preds = %omp_parallel
+!  br label %omp.par.exit.split
+
+!omp.par.exit.split:                               ; preds = %omp.par.outlined.exit
+!  ret void
+!}
+
+!; Function Attrs: nounwind
+!define internal void @_QPdelayed_privatization..omp_par(ptr noalias %tid.addr, ptr noalias %zero.addr, ptr %0) #0 {
+!omp.par.entry:
+!  %gep_ = getelementptr { ptr, ptr }, ptr %0, i32 0, i32 0
+!  %loadgep_ = load ptr, ptr %gep_, align 8
+!  %gep_1 = getelementptr { ptr, ptr }, ptr %0, i32 0, i32 1
+!  %loadgep_2 = load ptr, ptr %gep_1, align 8
+!  %tid.addr.local = alloca i32, align 4
+!  %1 = load i32, ptr %tid.addr, align 4
+!  store i32 %1, ptr %tid.addr.local, align 4
+!  %tid = load i32, ptr %tid.addr.local, align 4
+!  %2 = alloca i32, i64 1, align 4
+!  %3 = load i32, ptr %loadgep_, align 4
+!  store i32 %3, ptr %2, align 4
+!  %4 = alloca i32, i64 1, align 4
+!  %5 = load i32, ptr %loadgep_2, align 4
+!  store i32 %5, ptr %4, align 4
+!  br label %omp.par.region
+
+!omp.par.region:                                   ; preds = %omp.par.entry
+!  br label %omp.par.region1
+
+!omp.par.region1:                                  ; preds = %omp.par.region
+!  %6 = load i32, ptr %2, align 4
+!  %7 = load i32, ptr %4, align 4
+!  %8 = add i32 %6, %7
+!  %9 = add i32 %8, 2
+!  store i32 %9, ptr %2, align 4
+!  br label %omp.region.cont
+
+!omp.region.cont:                                  ; preds = %omp.par.region1
+!  br label %omp.par.pre_finalize
+
+!omp.par.pre_finalize:                             ; preds = %omp.region.cont
+!  br label %omp.par.outlined.exit.exitStub
+
+!omp.par.outlined.exit.exitStub:                   ; preds = %omp.par.pre_finalize
+!  ret void
+!}
+
+!; Function Attrs: nounwind
+!declare i32 @__kmpc_global_thread_num(ptr) #0
+
+!; Function Attrs: nounwind
+!declare !callback !2 void @__kmpc_fork_call(ptr, i32, ptr, ...) #0

--- a/flang/test/Lower/OpenMP/FIR/delayed_privatization.f90
+++ b/flang/test/Lower/OpenMP/FIR/delayed_privatization.f90
@@ -3,6 +3,7 @@
 ! RUN: bbc -fopenmp -emit-fir --openmp-enable-delayed-privatization -hlfir=false %s -o - 
 
 subroutine delayed_privatization()
+  implicit none
   integer :: var1
   integer :: var2
 

--- a/flang/test/Lower/OpenMP/FIR/delayed_privatization_hlfir.f90
+++ b/flang/test/Lower/OpenMP/FIR/delayed_privatization_hlfir.f90
@@ -1,0 +1,71 @@
+! TODO Convert this file into a bunch of lit tests for each conversion step.
+
+! RUN: bbc -fopenmp -emit-hlfir --openmp-enable-delayed-privatization %s -o - 
+
+subroutine delayed_privatization()
+  implicit none
+  integer :: var1
+  integer :: var2
+
+  var1 = 111
+  var2 = 222
+
+!$OMP PARALLEL FIRSTPRIVATE(var1, var2)
+  var1 = var1 + var2 + 2
+!$OMP END PARALLEL
+
+end subroutine
+
+
+! -----------------------------------------
+! ## This is what flang emits with the PoC:
+! -----------------------------------------
+!
+! ----------------------------
+! ### Conversion to HLFIR + OMP:
+! ----------------------------
+!module {
+!  func.func @_QPdelayed_privatization() {
+!    %0 = fir.alloca i32 {bindc_name = "var1", uniq_name = "_QFdelayed_privatizationEvar1"}
+!    %1:2 = hlfir.declare %0 {uniq_name = "_QFdelayed_privatizationEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!    %2 = fir.alloca i32 {bindc_name = "var2", uniq_name = "_QFdelayed_privatizationEvar2"}
+!    %3:2 = hlfir.declare %2 {uniq_name = "_QFdelayed_privatizationEvar2"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!    %c111_i32 = arith.constant 111 : i32
+!    hlfir.assign %c111_i32 to %1#0 : i32, !fir.ref<i32>
+!    %c222_i32 = arith.constant 222 : i32
+!    hlfir.assign %c222_i32 to %3#0 : i32, !fir.ref<i32>
+!    omp.parallel private(@var1.privatizer_0 %1#0, @var2.privatizer_0 %3#0 : !fir.ref<i32>, !fir.ref<i32>) {
+!    ^bb0(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>):
+!      %4:2 = hlfir.declare %arg0 {uniq_name = "_QFdelayed_privatizationEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!      %5:2 = hlfir.declare %arg1 {uniq_name = "_QFdelayed_privatizationEvar2"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!      %6 = fir.load %4#0 : !fir.ref<i32>
+!      %7 = fir.load %5#0 : !fir.ref<i32>
+!      %8 = arith.addi %6, %7 : i32
+!      %c2_i32 = arith.constant 2 : i32
+!      %9 = arith.addi %8, %c2_i32 : i32
+!      hlfir.assign %9 to %4#0 : i32, !fir.ref<i32>
+!      omp.terminator
+!    }
+!    return
+!  }
+!  "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "var1.privatizer_0"}> ({
+!  ^bb0(%arg0: !fir.ref<i32>):
+!    %0 = fir.alloca i32 {bindc_name = "var1", pinned, uniq_name = "_QFdelayed_privatizationEvar1"}
+!    %1:2 = hlfir.declare %0 {uniq_name = "_QFdelayed_privatizationEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!    %2 = fir.load %arg0 : !fir.ref<i32>
+!    hlfir.assign %2 to %1#0 temporary_lhs : i32, !fir.ref<i32>
+!    omp.yield(%1#0 : !fir.ref<i32>)
+!  }) : () -> ()
+!  "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "var2.privatizer_0"}> ({
+!  ^bb0(%arg0: !fir.ref<i32>):
+!    %0 = fir.alloca i32 {bindc_name = "var2", pinned, uniq_name = "_QFdelayed_privatizationEvar2"}
+!    %1:2 = hlfir.declare %0 {uniq_name = "_QFdelayed_privatizationEvar2"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!    %2 = fir.load %arg0 : !fir.ref<i32>
+!    hlfir.assign %2 to %1#0 temporary_lhs : i32, !fir.ref<i32>
+!    omp.yield(%1#0 : !fir.ref<i32>)
+!  }) : () -> ()
+!}
+!
+!
+! ### After lowring `hlfir` to `fir`, conversion to LLVM + OMP -> LLVM IR produces the exact same result as for
+! `delayed_privatization.f90`.

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -16,6 +16,7 @@
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -179,7 +180,9 @@ def ParallelOp : OpenMP_Op<"parallel", [
              Variadic<AnyType>:$allocators_vars,
              Variadic<OpenMP_PointerLikeType>:$reduction_vars,
              OptionalAttr<SymbolRefArrayAttr>:$reductions,
-             OptionalAttr<ProcBindKindAttr>:$proc_bind_val);
+             OptionalAttr<ProcBindKindAttr>:$proc_bind_val,
+             Variadic<AnyType>:$private_vars,
+             OptionalAttr<SymbolRefArrayAttr>:$privatizers);
 
   let regions = (region AnyRegion:$region);
 
@@ -203,6 +206,10 @@ def ParallelOp : OpenMP_Op<"parallel", [
                 $allocators_vars, type($allocators_vars)
               ) `)`
           | `proc_bind` `(` custom<ClauseAttr>($proc_bind_val) `)`
+          | `private` `(`
+              custom<PrivateVarList>(
+                $private_vars, type($private_vars), $privatizers
+              ) `)`
     ) $region attr-dict
   }];
   let hasVerifier = 1;
@@ -612,7 +619,7 @@ def SimdLoopOp : OpenMP_Op<"simdloop", [AttrSizedOperandSegments,
 def YieldOp : OpenMP_Op<"yield",
     [Pure, ReturnLike, Terminator,
      ParentOneOf<["WsLoopOp", "ReductionDeclareOp",
-     "AtomicUpdateOp", "SimdLoopOp"]>]> {
+     "AtomicUpdateOp", "SimdLoopOp", "PrivateClauseOp"]>]> {
   let summary = "loop yield and termination operation";
   let description = [{
     "omp.yield" yields SSA values from the OpenMP dialect op region and
@@ -1479,6 +1486,38 @@ def Target_UpdateDataOp: OpenMP_Op<"target_update_data",
 //===----------------------------------------------------------------------===//
 // 2.14.5 target construct
 //===----------------------------------------------------------------------===//
+def PrivateClauseOp : OpenMP_Op<"private", [
+    IsolatedFromAbove, FunctionOpInterface
+  ]> {
+  let summary = "TODO";
+  let description = [{}];
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<FunctionType>:$function_type);
+
+  let regions = (region AnyRegion:$body);
+
+  let builders = [OpBuilder<(ins
+    "::mlir::Type":$privateVarType,
+    "::llvm::StringRef":$privatizerName
+  )>];
+
+  let extraClassDeclaration = [{
+    ::mlir::Region *getCallableRegion() {
+      return &getBody();
+    }
+
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() {
+      return getFunctionType().getInputs();
+    }
+
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() {
+      return getFunctionType().getResults();
+    }
+  }];
+}
 
 def TargetOp : OpenMP_Op<"target",[IsolatedFromAbove, MapClauseOwningOpInterface,
                                    OutlineableOpenMPOpInterface, AttrSizedOperandSegments]> {

--- a/mlir/lib/Conversion/SCFToOpenMP/SCFToOpenMP.cpp
+++ b/mlir/lib/Conversion/SCFToOpenMP/SCFToOpenMP.cpp
@@ -420,7 +420,9 @@ struct ParallelOpLowering : public OpRewritePattern<scf::ParallelOp> {
         /* allocators_vars = */ llvm::SmallVector<Value>{},
         /* reduction_vars = */ llvm::SmallVector<Value>{},
         /* reductions = */ ArrayAttr{},
-        /* proc_bind_val = */ omp::ClauseProcBindKindAttr{});
+        /* proc_bind_val = */ omp::ClauseProcBindKindAttr{},
+        /*private_vars=*/mlir::ValueRange{},
+        /*privatizers=*/nullptr);
     {
 
       OpBuilder::InsertionGuard guard(rewriter);

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -59,7 +59,7 @@ func.func @omp_parallel(%data_var : memref<i32>, %if_cond : i1, %num_threads : i
   // CHECK: omp.parallel num_threads(%{{.*}} : i32) allocate(%{{.*}} : memref<i32> -> %{{.*}} : memref<i32>)
     "omp.parallel"(%num_threads, %data_var, %data_var) ({
       omp.terminator
-    }) {operandSegmentSizes = array<i32: 0,1,1,1,0>} : (i32, memref<i32>, memref<i32>) -> ()
+    }) {operandSegmentSizes = array<i32: 0,1,1,1,0,0>} : (i32, memref<i32>, memref<i32>) -> ()
 
   // CHECK: omp.barrier
     omp.barrier
@@ -68,22 +68,22 @@ func.func @omp_parallel(%data_var : memref<i32>, %if_cond : i1, %num_threads : i
   // CHECK: omp.parallel if(%{{.*}}) allocate(%{{.*}} : memref<i32> -> %{{.*}} : memref<i32>)
     "omp.parallel"(%if_cond, %data_var, %data_var) ({
       omp.terminator
-    }) {operandSegmentSizes = array<i32: 1,0,1,1,0>} : (i1, memref<i32>, memref<i32>) -> ()
+    }) {operandSegmentSizes = array<i32: 1,0,1,1,0,0>} : (i1, memref<i32>, memref<i32>) -> ()
 
   // test without allocate
   // CHECK: omp.parallel if(%{{.*}}) num_threads(%{{.*}} : i32)
     "omp.parallel"(%if_cond, %num_threads) ({
       omp.terminator
-    }) {operandSegmentSizes = array<i32: 1,1,0,0,0>} : (i1, i32) -> ()
+    }) {operandSegmentSizes = array<i32: 1,1,0,0,0,0>} : (i1, i32) -> ()
 
     omp.terminator
-  }) {operandSegmentSizes = array<i32: 1,1,1,1,0>, proc_bind_val = #omp<procbindkind spread>} : (i1, i32, memref<i32>, memref<i32>) -> ()
+  }) {operandSegmentSizes = array<i32: 1,1,1,1,0,0>, proc_bind_val = #omp<procbindkind spread>} : (i1, i32, memref<i32>, memref<i32>) -> ()
 
   // test with multiple parameters for single variadic argument
   // CHECK: omp.parallel allocate(%{{.*}} : memref<i32> -> %{{.*}} : memref<i32>)
   "omp.parallel" (%data_var, %data_var) ({
     omp.terminator
-  }) {operandSegmentSizes = array<i32: 0,0,1,1,0>} : (memref<i32>, memref<i32>) -> ()
+  }) {operandSegmentSizes = array<i32: 0,0,1,1,0,0>} : (memref<i32>, memref<i32>) -> ()
 
   return
 }

--- a/mlir/test/Dialect/OpenMP/roundtrip.mlir
+++ b/mlir/test/Dialect/OpenMP/roundtrip.mlir
@@ -1,0 +1,36 @@
+// RUN: fir-opt -verify-diagnostics %s | fir-opt | FileCheck %s
+
+// CHECK-LABEL: _QPprivate_clause
+func.func @_QPprivate_clause() {
+  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFprivate_clause_allocatableEx"}
+  %1 = fir.alloca i32 {bindc_name = "y", uniq_name = "_QFprivate_clause_allocatableEy"}
+
+  // CHECK: omp.parallel private(@x.privatizer %0, @y.privatizer %1 : !fir.ref<i32>, !fir.ref<i32>)
+  omp.parallel private(@x.privatizer %0, @y.privatizer %1: !fir.ref<i32>, !fir.ref<i32>) {
+    omp.terminator
+  }
+  return
+}
+
+// CHECK: "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "x.privatizer"}> ({
+"omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "x.privatizer"}> ({
+// CHECK: ^bb0(%arg0: {{.*}}):
+^bb0(%arg0: !fir.ref<i32>):
+
+  // CHECK: %0 = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFprivate_clause_allocatableEx"}
+  %0 = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFprivate_clause_allocatableEx"}
+
+  // CHECK: omp.yield(%0 : !fir.ref<i32>)
+  omp.yield(%0 : !fir.ref<i32>)
+}) : () -> ()
+
+// CHECK: "omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "y.privatizer"}> ({
+"omp.private"() <{function_type = (!fir.ref<i32>) -> !fir.ref<i32>, sym_name = "y.privatizer"}> ({
+^bb0(%arg0: !fir.ref<i32>):
+
+  // CHECK: %0 = fir.alloca i32 {bindc_name = "y", pinned, uniq_name = "_QFprivate_clause_allocatableEy"}
+  %0 = fir.alloca i32 {bindc_name = "y", pinned, uniq_name = "_QFprivate_clause_allocatableEy"}
+
+  // CHECK: omp.yield(%0 : !fir.ref<i32>)
+  omp.yield(%0 : !fir.ref<i32>)
+}) : () -> ()


### PR DESCRIPTION
This is a PoC for delayed privatization in OpenMP. Instead of directly
emitting privatization code in the frontend, we add a new op to outline
the privatization logic for a symbol and call-like mapping that maps
from the host symbol to an outlined function-like privatizer op.

Later, we would inline the delayed privatizer function-like op in the
OpenMP region to basically get the same code generated directly by the
fronend at the moment.

## Note: This is still a work-in-progress but giving comments on the taken approach or any advice is more than welcome :).

### This is my plan to productize this WIP (✅ means the item is already done, ⌛ means it is in progress):
1. In this PR: add a feature flag to control the usage of delayed privatization. This will be disabled by default and enabled gradually as we add support for delayed privatization for more cases. ✅ 
2. In this PR: handle the remaining comments so that you do not have to spend effort on them in later separate PRs.
3. This PR will **not** be merged since it is getting quite large. Instead I will split it into a number of PRs as explained in following points.
4. PR 1: a NFC PR to copy the refactoring of `genOpWithBody` introduced here. This will introduce the `genRegionEntryCB` callback and use it for worksharing loop ops. (#80817 #80839) ✅ 
5. PR 2: copy the `omp.private` op along with a roundtripping lit test to test parsing, printing, and verification. (#80955) ✅ 
6. PR 3: copy the extensions in `omp.parallel` op (i.e. adding the `private` clause) along with a roundtripping lit test as well. (#81452) ✅ 
7. PR 4: copy the changes introduced in the `OpenMPToLLVM.cpp` conversion pattern: `RegionOpConversion`. (#81414) ✅ 
9. PR 5: copy the changes introduced in `OpenMPToLLVMIRTranslation.cpp`: the `PrivCB` and `prepareOmpParallel`. (#81715) ✅ 
10. PR 6: copy the changes needed for creating the `omp.private` ops and modifying the creation of the `omp.parallel` op to use the new clause. These are most of the changes in `DataSharingProcessor` and `genParallelOp`. (https://github.com/llvm/llvm-project/pull/81833) ✅ 
11. PRs 7..N: Add delayed privatization support for more symbol types and more OMP ops (e.g. `target`). (https://github.com/llvm/llvm-project/pull/83761 https://github.com/llvm/llvm-project/pull/84123 https://github.com/llvm/llvm-project/pull/84296 https://github.com/llvm/llvm-project/pull/84740 https://github.com/llvm/llvm-project/pull/85023) ⌛ 
12. PR N+1: Remove the delayed privatization feature flag.

Please let me know if you disagree with anything.