### PR TITLE
[libc++abi] Always use thread_local for cxa_exception_storage

### DIFF
--- a/libcxxabi/src/cxa_exception_storage.cpp
+++ b/libcxxabi/src/cxa_exception_storage.cpp
@@ -12,8 +12,6 @@
 
 #include "cxa_exception.h"
 
-#include <__thread/support.h>
-
 #if defined(_LIBCXXABI_HAS_NO_THREADS)
 
 namespace __cxxabiv1 {
@@ -24,7 +22,7 @@ extern "C" {
 } // extern "C"
 } // namespace __cxxabiv1
 
-#elif defined(HAS_THREAD_LOCAL)
+#else
 
 namespace __cxxabiv1 {
 namespace {
@@ -37,66 +35,6 @@ namespace {
 extern "C" {
     __cxa_eh_globals *__cxa_get_globals() { return __globals(); }
     __cxa_eh_globals *__cxa_get_globals_fast() { return __globals(); }
-} // extern "C"
-} // namespace __cxxabiv1
-
-#else
-
-#include "abort_message.h"
-#include "fallback_malloc.h"
-
-#if defined(__ELF__) && defined(_LIBCXXABI_LINK_PTHREAD_LIB)
-#pragma comment(lib, "pthread")
-#endif
-
-//  In general, we treat all threading errors as fatal.
-//  We cannot call std::terminate() because that will in turn
-//  call __cxa_get_globals() and cause infinite recursion.
-
-namespace __cxxabiv1 {
-namespace {
-    std::__libcpp_tls_key key_;
-    std::__libcpp_exec_once_flag flag_ = _LIBCPP_EXEC_ONCE_INITIALIZER;
-
-    void _LIBCPP_TLS_DESTRUCTOR_CC destruct_(void *p) {
-        __free_with_fallback(p);
-        if (0 != std::__libcpp_tls_set(key_, NULL))
-            abort_message("cannot zero out thread value for __cxa_get_globals()");
-    }
-
-    void construct_() {
-        if (0 != std::__libcpp_tls_create(&key_, destruct_))
-            abort_message("cannot create thread specific key for __cxa_get_globals()");
-    }
-} // namespace
-
-extern "C" {
-    __cxa_eh_globals *__cxa_get_globals() {
-        // Try to get the globals for this thread
-        __cxa_eh_globals *retVal = __cxa_get_globals_fast();
-
-        // If this is the first time we've been asked for these globals, create them
-        if (NULL == retVal) {
-            retVal = static_cast<__cxa_eh_globals*>(
-                __calloc_with_fallback(1, sizeof(__cxa_eh_globals)));
-            if (NULL == retVal)
-                abort_message("cannot allocate __cxa_eh_globals");
-            if (0 != std::__libcpp_tls_set(key_, retVal))
-               abort_message("std::__libcpp_tls_set failure in __cxa_get_globals()");
-        }
-        return retVal;
-    }
-
-    // Note that this implementation will reliably return NULL if not
-    // preceded by a call to __cxa_get_globals().  This is an extension
-    // to the Itanium ABI and is taken advantage of in several places in
-    // libc++abi.
-    __cxa_eh_globals *__cxa_get_globals_fast() {
-        // First time through, create the key.
-        if (0 != std::__libcpp_execute_once(&flag_, construct_))
-            abort_message("execute once failure in __cxa_get_globals_fast()");
-        return static_cast<__cxa_eh_globals*>(std::__libcpp_tls_get(key_));
-    }
 } // extern "C"
 } // namespace __cxxabiv1
 

--- a/libcxxabi/src/fallback_malloc.cpp
+++ b/libcxxabi/src/fallback_malloc.cpp
@@ -271,17 +271,6 @@ void* __aligned_malloc_with_fallback(size_t size) {
   return fallback_malloc(size);
 }
 
-void* __calloc_with_fallback(size_t count, size_t size) {
-  void* ptr = ::calloc(count, size);
-  if (NULL != ptr)
-    return ptr;
-  // if calloc fails, fall back to emergency stash
-  ptr = fallback_malloc(size * count);
-  if (NULL != ptr)
-    ::memset(ptr, 0, size * count);
-  return ptr;
-}
-
 void __aligned_free_with_fallback(void* ptr) {
   if (is_fallback_ptr(ptr))
     fallback_free(ptr);

--- a/libcxxabi/src/fallback_malloc.h
+++ b/libcxxabi/src/fallback_malloc.h
@@ -17,9 +17,6 @@ namespace __cxxabiv1 {
 // Allocate some memory from _somewhere_
 _LIBCXXABI_HIDDEN void * __aligned_malloc_with_fallback(size_t size);
 
-// Allocate and zero-initialize memory from _somewhere_
-_LIBCXXABI_HIDDEN void * __calloc_with_fallback(size_t count, size_t size);
-
 _LIBCXXABI_HIDDEN void __aligned_free_with_fallback(void *ptr);
 _LIBCXXABI_HIDDEN void __free_with_fallback(void *ptr);
 


### PR DESCRIPTION
This was previously guarded by HAS_THREAD_LOCAL, which was never set by CMake and had to be specified manually. Android has been setting this to solve https://github.com/android/ndk/issues/1200 [1], but every compiler and platform libc++abi supports should have thread_local by now, so we can just get rid of the fallback implementation and simplify things significantly (including removing the now unused fallback calloc).

This is a re-application of https://reviews.llvm.org/D138461.
Fixes #78207.

[1]: https://android-review.googlesource.com/c/toolchain/llvm-project/+/1285596

Co-Authored-By: Shoaib Meenai <smeenai@fb.com>