### PR TITLE
Add compiler-rt:* to .github/new-prs-labeler.yml [NFC]

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -75,12 +75,49 @@ mc:
 clang:driver:
   - clang/*/Driver/**
 
+compiler-rt:asan:
+  - compiler-rt/lib/asan/**
+  - compiler-rt/include/sanitizer/asan_interface.h
+  - compiler-rt/test/asan/**
+  - compiler-rt/lib/asan_abi/**
+  - compiler-rt/test/asan_abi/**
+
+compiler-rt:builtins:
+  - compiler-rt/lib/builtins/**
+  - compiler-rt/test/builtins/**
+
+compiler-rt:cfi:
+  - compiler-rt/lib/cfi/**
+  - compiler-rt/test/cfi/**
+
+compiler-rt:fuzzer:
+  - compiler-rt/lib/fuzzer/**
+  - compiler-rt/include/fuzzer/**
+  - compiler-rt/test/fuzzer/**
+
+compiler-rt:hwasan:
+  - compiler-rt/lib/hwasan/**
+  - compiler-rt/include/sanitizer/hwasan_interface.h
+  - compiler-rt/test/hwasan/**
+
+compiler-rt:lsan:
+  - compiler-rt/lib/lsan/**
+  - compiler-rt/include/sanitizer/lsan_interface.h
+  - compiler-rt/test/lsan/**
+
+compiler-rt:msan:
+  - compiler-rt/lib/msan/**
+  - compiler-rt/include/sanitizer/msan_interface.h
+  - compiler-rt/test/msan/**
+
 compiler-rt:sanitizer:
   - llvm/lib/Transforms/Instrumentation/*Sanitizer*
   - compiler-rt/lib/interception/**
   - compiler-rt/lib/*san*/**
+  - compiler-rt/include/sanitizer/**
   - compiler-rt/test/*san*/**
   - compiler-rt/lib/fuzzer/**
+  - compiler-rt/include/fuzzer/**
   - compiler-rt/test/fuzzer/**
   - compiler-rt/lib/scudo/**
   - compiler-rt/test/scudo/**
@@ -88,6 +125,19 @@ compiler-rt:sanitizer:
 compiler-rt:scudo:
   - compiler-rt/lib/scudo/**
   - compiler-rt/test/scudo/**
+
+compiler-rt:tsan:
+  - compiler-rt/lib/tsan/**
+  - compiler-rt/include/sanitizer/tsan_interface.h
+  - compiler-rt/include/sanitizer/tsan_interface_atomic.h
+  - compiler-rt/test/tsan/**
+
+compiler-rt:ubsan:
+  - compiler-rt/lib/ubsan/**
+  - compiler-rt/include/sanitizer/ubsan_interface.h
+  - compiler-rt/test/ubsan/**
+  - compiler-rt/lib/ubsan_minimal/**
+  - compiler-rt/test/ubsan_minimal/**
 
 xray:
   - llvm/tools/llvm-xray/**


### PR DESCRIPTION
After this change, all current `compiler-rt:*` labels on GitHub are covered.
