### PR TITLE
[Support] Report EISDIR when opening a directory

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1024,17 +1024,6 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
   auto Open = [&]() { return ::open(P.begin(), OpenFlags, Mode); };
   if ((ResultFD = sys::RetryAfterSignal(-1, Open)) < 0)
     return errnoAsErrorCode();
-// The underlying operation on these platforms allow opening directories
-// for reading in more cases than other platforms.
-#if defined(__MVS__) || defined(_AIX)
-  if (Access == FA_Read) {
-    struct stat Status;
-    if (fstat(ResultFD, &Status) == -1)
-      return errnoAsErrorCode();
-    if (S_ISDIR(Status.st_mode))
-      return make_error_code(errc::is_a_directory);
-  }
-#endif
 #ifndef O_CLOEXEC
   if (!(Flags & OF_ChildInherit)) {
     int r = fcntl(ResultFD, F_SETFD, FD_CLOEXEC);
@@ -1202,6 +1191,15 @@ Expected<size_t> readNativeFile(file_t FD, MutableArrayRef<char> Buf) {
   ssize_t NumRead = sys::RetryAfterSignal(-1, ::read, FD, Buf.data(), Size);
   if (ssize_t(NumRead) == -1)
     return errorCodeToError(errnoAsErrorCode());
+// The underlying operation on these platforms allow opening directories
+// for reading in more cases than other platforms.
+#if defined(__MVS__) || defined(_AIX)
+  struct stat Status;
+  if (fstat(FD, &Status) == -1)
+    return errorCodeToError(errnoAsErrorCode());
+  if (S_ISDIR(Status.st_mode))
+    return errorCodeToError(make_error_code(errc::is_a_directory));
+#endif    
   return NumRead;
 }
 

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1024,17 +1024,17 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
   auto Open = [&]() { return ::open(P.begin(), OpenFlags, Mode); };
   if ((ResultFD = sys::RetryAfterSignal(-1, Open)) < 0)
     return errnoAsErrorCode();
-  // The underlying operation on these platforms allow opening directories 
-  // for reading in more cases than other platforms. 
-  #if defined(__MVS__) || defined(_AIX)        
-    if (Access == FA_Read) {
-      struct stat Status;
-      if (fstat(ResultFD, &Status) == -1)
-        return errnoAsErrorCode();
-      if (S_ISDIR(Status.st_mode))
-        return make_error_code(errc::is_a_directory);
-    }
-  #endif  
+// The underlying operation on these platforms allow opening directories
+// for reading in more cases than other platforms.
+#if defined(__MVS__) || defined(_AIX)
+  if (Access == FA_Read) {
+    struct stat Status;
+    if (fstat(ResultFD, &Status) == -1)
+      return errnoAsErrorCode();
+    if (S_ISDIR(Status.st_mode))
+      return make_error_code(errc::is_a_directory);
+  }
+#endif
 #ifndef O_CLOEXEC
   if (!(Flags & OF_ChildInherit)) {
     int r = fcntl(ResultFD, F_SETFD, FD_CLOEXEC);

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1025,12 +1025,12 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
   if ((ResultFD = sys::RetryAfterSignal(-1, Open)) < 0)
     return errnoAsErrorCode();
   if (Access == FA_Read) {
-    struct stat Status;    
+    struct stat Status;
     if (fstat(ResultFD, &Status) == -1)
       return errnoAsErrorCode();
     if (S_ISDIR(Status.st_mode))
       return make_error_code(errc::is_a_directory);
-  } 
+  }
 #ifndef O_CLOEXEC
   if (!(Flags & OF_ChildInherit)) {
     int r = fcntl(ResultFD, F_SETFD, FD_CLOEXEC);

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1024,13 +1024,17 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
   auto Open = [&]() { return ::open(P.begin(), OpenFlags, Mode); };
   if ((ResultFD = sys::RetryAfterSignal(-1, Open)) < 0)
     return errnoAsErrorCode();
-  if (Access == FA_Read) {
-    struct stat Status;
-    if (fstat(ResultFD, &Status) == -1)
-      return errnoAsErrorCode();
-    if (S_ISDIR(Status.st_mode))
-      return make_error_code(errc::is_a_directory);
-  }
+  // The underlying operation on these platforms allow opening directories 
+  // for reading in more cases than other platforms. 
+  #if defined(__MVS__) || defined(_AIX)        
+    if (Access == FA_Read) {
+      struct stat Status;
+      if (fstat(ResultFD, &Status) == -1)
+        return errnoAsErrorCode();
+      if (S_ISDIR(Status.st_mode))
+        return make_error_code(errc::is_a_directory);
+    }
+  #endif  
 #ifndef O_CLOEXEC
   if (!(Flags & OF_ChildInherit)) {
     int r = fcntl(ResultFD, F_SETFD, FD_CLOEXEC);

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1024,6 +1024,13 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
   auto Open = [&]() { return ::open(P.begin(), OpenFlags, Mode); };
   if ((ResultFD = sys::RetryAfterSignal(-1, Open)) < 0)
     return errnoAsErrorCode();
+  if (Access == FA_Read) {
+    struct stat Status;    
+    if (fstat(ResultFD, &Status) == -1)
+      return errnoAsErrorCode();
+    if (S_ISDIR(Status.st_mode))
+      return make_error_code(errc::is_a_directory);
+  } 
 #ifndef O_CLOEXEC
   if (!(Flags & OF_ChildInherit)) {
     int r = fcntl(ResultFD, F_SETFD, FD_CLOEXEC);

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1199,7 +1199,7 @@ Expected<size_t> readNativeFile(file_t FD, MutableArrayRef<char> Buf) {
     return errorCodeToError(errnoAsErrorCode());
   if (S_ISDIR(Status.st_mode))
     return errorCodeToError(make_error_code(errc::is_a_directory));
-#endif    
+#endif
   return NumRead;
 }
 

--- a/llvm/test/tools/llvm-symbolizer/input-file-err.test
+++ b/llvm/test/tools/llvm-symbolizer/input-file-err.test
@@ -1,5 +1,3 @@
-Failing on AIX due to D153595. The test expects a different error message from the one given on AIX.
-XFAIL: target={{.*}}-aix{{.*}}
 RUN: not llvm-addr2line -e %p/Inputs/nonexistent 0x12 2>&1 | FileCheck %s --check-prefix=CHECK-NONEXISTENT-A2L -DMSG=%errc_ENOENT
 RUN: not llvm-addr2line -e %p/Inputs/nonexistent 2>&1 | FileCheck %s --check-prefix=CHECK-NONEXISTENT-A2L -DMSG=%errc_ENOENT
 CHECK-NONEXISTENT-A2L: llvm-addr2line{{.*}}: error: '{{.*}}Inputs/nonexistent': [[MSG]]

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -1117,7 +1117,6 @@ TEST(CommandLineTest, BadResponseFile) {
   ASSERT_STREQ(Argv[0], "clang");
   ASSERT_STREQ(Argv[1], AFileExp.c_str());
 
-#if !defined(_AIX) && !defined(__MVS__)
   std::string ADirExp = std::string("@") + std::string(ADir.path());
   Argv = {"clang", ADirExp.c_str()};
   Res = cl::ExpandResponseFiles(Saver, cl::TokenizeGNUCommandLine, Argv);
@@ -1125,7 +1124,6 @@ TEST(CommandLineTest, BadResponseFile) {
   ASSERT_EQ(2U, Argv.size());
   ASSERT_STREQ(Argv[0], "clang");
   ASSERT_STREQ(Argv[1], ADirExp.c_str());
-#endif
 }
 
 TEST(CommandLineTest, SetDefaultValue) {

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1296,21 +1296,34 @@ TEST_F(FileSystemTest, UTF8ToUTF16DirectoryIteration) {
 }
 #endif
 
-TEST_F(FileSystemTest, OpenDirectoryAsFile) {
+TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
   ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
             errc::file_exists);
 
+  std::string Buf(5, '?');
+  Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
+  ASSERT_NO_ERROR(errorToErrorCode(FD.takeError()));
+  auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
+  Expected<size_t> BytesRead = fs::readNativeFile(
+          *FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
+  ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), 
+          errc::is_a_directory);
+}
+
+TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
+  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory))); 
+  ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
+            errc::file_exists); 
+   
   int FD;
-  std::error_code EC;
-  EC = fs::openFileForRead(Twine(TestDirectory), FD);
-  ASSERT_EQ(EC, errc::is_a_directory);
+  std::error_code EC; 
   EC = fs::openFileForWrite(Twine(TestDirectory), FD);
   ASSERT_EQ(EC, errc::is_a_directory);
 
   ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory)));
   ::close(FD);
-}
+}            
 
 TEST_F(FileSystemTest, Remove) {
   SmallString<64> BaseDir;

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1296,6 +1296,22 @@ TEST_F(FileSystemTest, UTF8ToUTF16DirectoryIteration) {
 }
 #endif
 
+TEST_F(FileSystemTest, OpenDirectoryAsFile) {
+  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
+  ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
+            errc::file_exists);
+
+  int FD;
+  std::error_code EC;
+  EC = fs::openFileForRead(Twine(TestDirectory), FD);
+  ASSERT_EQ(EC, errc::is_a_directory);
+  EC = fs::openFileForWrite(Twine(TestDirectory), FD);
+  ASSERT_EQ(EC, errc::is_a_directory);
+
+  ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory)));
+  ::close(FD);
+}
+
 TEST_F(FileSystemTest, Remove) {
   SmallString<64> BaseDir;
   SmallString<64> Paths[4];

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1300,13 +1300,13 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   std::string Buf(5, '?');
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
 #ifdef _WIN32
-  ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
+  EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
 #else
   ASSERT_THAT_EXPECTED(FD, Succeeded());
   auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
   Expected<size_t> BytesRead =
       fs::readNativeFile(*FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
-  ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
+  EXPECT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
 #endif
 }
 
@@ -1315,7 +1315,7 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
   std::error_code EC = fs::openFileForWrite(Twine(TestDirectory), FD);
   if (!EC)
     ::close(FD);
-  ASSERT_EQ(EC, errc::is_a_directory);
+  EXPECT_EQ(EC, errc::is_a_directory);
 }
 
 TEST_F(FileSystemTest, Remove) {

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1296,6 +1296,7 @@ TEST_F(FileSystemTest, UTF8ToUTF16DirectoryIteration) {
 }
 #endif
 
+#ifndef _WIN32
 TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
   ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
@@ -1309,6 +1310,7 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
       fs::readNativeFile(*FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
   ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
 }
+#endif
 
 TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
   ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1312,8 +1312,7 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
 
 TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
   int FD;
-  std::error_code EC;
-  EC = fs::openFileForWrite(Twine(TestDirectory), FD);
+  std::error_code EC = fs::openFileForWrite(Twine(TestDirectory), FD);
   if (!EC)
     ::close(FD);
   ASSERT_EQ(EC, errc::is_a_directory);

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1297,10 +1297,6 @@ TEST_F(FileSystemTest, UTF8ToUTF16DirectoryIteration) {
 #endif
 
 TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
-  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
-  ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
-            errc::file_exists);
-
   std::string Buf(5, '?');
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
 #ifdef _WIN32
@@ -1315,18 +1311,12 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
 }
 
 TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
-  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
-  ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
-            errc::file_exists);
-
   int FD;
   std::error_code EC;
   EC = fs::openFileForWrite(Twine(TestDirectory), FD);
   if (!EC)
     ::close(FD);
   ASSERT_EQ(EC, errc::is_a_directory);
-
-  ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory)));
 }
 
 TEST_F(FileSystemTest, Remove) {

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1305,25 +1305,24 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
   ASSERT_NO_ERROR(errorToErrorCode(FD.takeError()));
   auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
-  Expected<size_t> BytesRead = fs::readNativeFile(
-          *FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
-  ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), 
-          errc::is_a_directory);
+  Expected<size_t> BytesRead =
+      fs::readNativeFile(*FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
+  ASSERT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
 }
 
 TEST_F(FileSystemTest, OpenDirectoryAsFileForWrite) {
-  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory))); 
+  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory)));
   ASSERT_EQ(fs::create_directory(Twine(TestDirectory), false),
-            errc::file_exists); 
-   
+            errc::file_exists);
+
   int FD;
-  std::error_code EC; 
+  std::error_code EC;
   EC = fs::openFileForWrite(Twine(TestDirectory), FD);
   ASSERT_EQ(EC, errc::is_a_directory);
 
   ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory)));
   ::close(FD);
-}            
+}
 
 TEST_F(FileSystemTest, Remove) {
   SmallString<64> BaseDir;


### PR DESCRIPTION
The test `llvm/unittests/Support/CommandLineTest.cpp` that handles errors in expansion of response files was previously disabled for AIX. Originally the code was dependent on `read` returning `EISDIR` which occurs on platforms such as Linux. However, other platforms such as AIX allow use of `read` on file descriptors for directories. This change updates `readNativeFile` to produce `EISDIR` on AIX and z/OS when used on a directory (instead of relying on the call to `read` to do so).

