### PR TITLE
[libc++] Officially remove _VSTD and _LIBCPP_INLINE_VISIBILITY

### DIFF
--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -70,9 +70,7 @@ Deprecations and Removals
 - TODO: The ``_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES`` and ``_LIBCPP_ENABLE_CXX20_REMOVED_FEATURES`` macros have
   been removed in LLVM 19. C++17 and C++20 removed features can still be re-enabled individually.
 
-- TODO: The macro ``_LIBCPP_INLINE_VISIBILITY`` has been removed in LLVM 19.
-
-- TODO: The macro ``_VSTD`` has been removed in LLVM 19.
+- The ``_LIBCPP_INLINE_VISIBILITY`` and ``_VSTD`` macros have been removed in LLVM 19.
 
 
 Upcoming Deprecations and Removals

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -874,11 +874,6 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_HIDE_FROM_ABI_AFTER_V1 _LIBCPP_HIDE_FROM_ABI
 #  endif
 
-// TODO(LLVM-19): Remove _LIBCPP_INLINE_VISIBILITY and _VSTD, which we're keeping around
-//                only to ease the renaming for downstreams.
-#  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
-#  define _VSTD std
-
 // Inline namespaces are available in Clang/GCC/MSVC regardless of C++ dialect.
 // clang-format off
 #  define _LIBCPP_BEGIN_NAMESPACE_STD namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {                                  \

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -67,14 +67,14 @@ using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args) {
-  return _VSTD::__format_arg_store<_Context, _Args...>(__args...);
+  return std::__format_arg_store<_Context, _Args...>(__args...);
 }
 
 #  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <class... _Args>
 _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI __format_arg_store<wformat_context, _Args...>
 make_wformat_args(_Args&... __args) {
-  return _VSTD::__format_arg_store<wformat_context, _Args...>(__args...);
+  return std::__format_arg_store<wformat_context, _Args...>(__args...);
 }
 #  endif
 


### PR DESCRIPTION
Those were deprecated and basically not used anymore after we renamed them in batch. This patch removes the macros entirely.