### PR TITLE
[OpenMP][test]Flip bit-fields in 'struct flags' for big-endian in test cases

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2494,7 +2494,8 @@ typedef struct kmp_dephash_entry kmp_dephash_entry_t;
 #define KMP_DEP_MTX 0x4
 #define KMP_DEP_SET 0x8
 #define KMP_DEP_ALL 0x80
-// Compiler sends us this info:
+// Compiler sends us this info. Note: some test cases contain an explicit copy
+// of this struct and should be in sync with any changes here.
 typedef struct kmp_depend_info {
   kmp_intptr_t base_addr;
   size_t len;

--- a/openmp/runtime/test/tasking/bug_nested_proxy_task.c
+++ b/openmp/runtime/test/tasking/bug_nested_proxy_task.c
@@ -50,12 +50,21 @@ typedef struct kmp_depend_info {
      union {
         kmp_uint8 flag; // flag as an unsigned char
         struct { // flag as a set of 8 bits
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            unsigned all : 1;
+            unsigned unused : 3;
+            unsigned set : 1;
+            unsigned mtx : 1;
+            unsigned out : 1;
+            unsigned in : 1;
+#else
             unsigned in : 1;
             unsigned out : 1;
             unsigned mtx : 1;
             unsigned set : 1;
             unsigned unused : 3;
             unsigned all : 1;
+#endif
         } flags;
      };
 } kmp_depend_info_t;

--- a/openmp/runtime/test/tasking/bug_nested_proxy_task.c
+++ b/openmp/runtime/test/tasking/bug_nested_proxy_task.c
@@ -51,19 +51,19 @@ typedef struct kmp_depend_info {
         kmp_uint8 flag; // flag as an unsigned char
         struct { // flag as a set of 8 bits
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-            unsigned all : 1;
-            unsigned unused : 3;
-            unsigned set : 1;
-            unsigned mtx : 1;
-            unsigned out : 1;
-            unsigned in : 1;
+          unsigned all : 1;
+          unsigned unused : 3;
+          unsigned set : 1;
+          unsigned mtx : 1;
+          unsigned out : 1;
+          unsigned in : 1;
 #else
-            unsigned in : 1;
-            unsigned out : 1;
-            unsigned mtx : 1;
-            unsigned set : 1;
-            unsigned unused : 3;
-            unsigned all : 1;
+          unsigned in : 1;
+          unsigned out : 1;
+          unsigned mtx : 1;
+          unsigned set : 1;
+          unsigned unused : 3;
+          unsigned all : 1;
 #endif
         } flags;
      };

--- a/openmp/runtime/test/tasking/bug_proxy_task_dep_waiting.c
+++ b/openmp/runtime/test/tasking/bug_proxy_task_dep_waiting.c
@@ -47,12 +47,21 @@ typedef struct kmp_depend_info {
      union {
         kmp_uint8 flag; // flag as an unsigned char
         struct { // flag as a set of 8 bits
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            unsigned all : 1;
+            unsigned unused : 3;
+            unsigned set : 1;
+            unsigned mtx : 1;
+            unsigned out : 1;
+            unsigned in : 1;
+#else
             unsigned in : 1;
             unsigned out : 1;
             unsigned mtx : 1;
             unsigned set : 1;
             unsigned unused : 3;
             unsigned all : 1;
+#endif
         } flags;
     };
 } kmp_depend_info_t;

--- a/openmp/runtime/test/tasking/bug_proxy_task_dep_waiting.c
+++ b/openmp/runtime/test/tasking/bug_proxy_task_dep_waiting.c
@@ -48,19 +48,19 @@ typedef struct kmp_depend_info {
         kmp_uint8 flag; // flag as an unsigned char
         struct { // flag as a set of 8 bits
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-            unsigned all : 1;
-            unsigned unused : 3;
-            unsigned set : 1;
-            unsigned mtx : 1;
-            unsigned out : 1;
-            unsigned in : 1;
+          unsigned all : 1;
+          unsigned unused : 3;
+          unsigned set : 1;
+          unsigned mtx : 1;
+          unsigned out : 1;
+          unsigned in : 1;
 #else
-            unsigned in : 1;
-            unsigned out : 1;
-            unsigned mtx : 1;
-            unsigned set : 1;
-            unsigned unused : 3;
-            unsigned all : 1;
+          unsigned in : 1;
+          unsigned out : 1;
+          unsigned mtx : 1;
+          unsigned set : 1;
+          unsigned unused : 3;
+          unsigned all : 1;
 #endif
         } flags;
     };

--- a/openmp/runtime/test/tasking/hidden_helper_task/common.h
+++ b/openmp/runtime/test/tasking/hidden_helper_task/common.h
@@ -17,9 +17,21 @@ typedef struct kmp_depend_info {
   union {
     unsigned char flag;
     struct {
-      bool in : 1;
-      bool out : 1;
-      bool mtx : 1;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      unsigned all : 1;
+      unsigned unused : 3;
+      unsigned set : 1;
+      unsigned mtx : 1;
+      unsigned out : 1;
+      unsigned in : 1;
+#else
+      unsigned in : 1;
+      unsigned out : 1;
+      unsigned mtx : 1;
+      unsigned set : 1;
+      unsigned unused : 3;
+      unsigned all : 1;
+#endif
     } flags;
   };
 } kmp_depend_info_t;


### PR DESCRIPTION
This patch flips bit-fields in `struct flags` for big-endian in test cases to be consistent with the definition of the structure in libomp `kmp.h`.