### PR TITLE
[libc] fix type generic stdc_leading_zeros for GCC

### DIFF
--- a/libc/include/llvm-libc-macros/stdbit-macros.h
+++ b/libc/include/llvm-libc-macros/stdbit-macros.h
@@ -9,6 +9,23 @@
 #ifndef __LLVM_LIBC_MACROS_STDBIT_MACROS_H
 #define __LLVM_LIBC_MACROS_STDBIT_MACROS_H
 
+#ifdef __cplusplus
+inline unsigned char stdc_leading_zeros(unsigned char x) {
+  return stdc_leading_zeros_uc(x);
+}
+inline unsigned short stdc_leading_zeros(unsigned short x) {
+  return stdc_leading_zeros_us(x);
+}
+inline unsigned stdc_leading_zeros(unsigned x) {
+  return stdc_leading_zeros_ui(x);
+}
+inline unsigned long stdc_leading_zeros(unsigned long x) {
+  return stdc_leading_zeros_ul(x);
+}
+inline unsigned long long stdc_leading_zeros(unsigned long long x) {
+  return stdc_leading_zeros_ull(x);
+}
+#else
 #define stdc_leading_zeros(x)                                                  \
   _Generic((x),                                                                \
       unsigned char: stdc_leading_zeros_uc,                                    \
@@ -16,5 +33,6 @@
       unsigned: stdc_leading_zeros_ui,                                         \
       unsigned long: stdc_leading_zeros_ul,                                    \
       unsigned long long: stdc_leading_zeros_ull)(x)
+#endif // __cplusplus
 
 #endif // __LLVM_LIBC_MACROS_STDBIT_MACROS_H

--- a/libc/include/stdbit.h.def
+++ b/libc/include/stdbit.h.def
@@ -10,8 +10,9 @@
 #define LLVM_LIBC_STDBIT_H
 
 #include <__llvm-libc-common.h>
-#include <llvm-libc-macros/stdbit-macros.h>
 
 %%public_api()
+
+#include <llvm-libc-macros/stdbit-macros.h>
 
 #endif // LLVM_LIBC_STDBIT_H

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -27,13 +27,5 @@ if (LLVM_LIBC_FULL_BUILD)
     DEPENDS
       libc.include.llvm-libc-macros.stdbit_macros
       libc.include.stdbit
-      # Intentionally do not depend on libc.src.stdbit.*. The include test is
-      # simply testing the macros provided by stdbit.h, not the implementation
-      # of the underlying functions which the type generic macros may dispatch
-      # to.
-    COMPILE_OPTIONS
-      # stdbit.h is full of type generic macros implemented via C11 _Generic.
-      # Clang will produce -Wno-c11-extensions when using _Generic in C++ mode.
-      -Wno-c11-extensions
   )
 endif()

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -27,5 +27,9 @@ if (LLVM_LIBC_FULL_BUILD)
     DEPENDS
       libc.include.llvm-libc-macros.stdbit_macros
       libc.include.stdbit
+      # Intentionally do not depend on libc.src.stdbit.*. The include test is
+      # simply testing the macros provided by stdbit.h, not the implementation
+      # of the underlying functions which the type generic macros may dispatch
+      # to.
   )
 endif()


### PR DESCRIPTION
GCC does not support _Generic in C++ mode. Use inline function definitions
with function overloading in __cplusplus mode.
