### PR TITLE
[BOLT] Fix comparison function for Linux ORC entries

### DIFF
--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -95,7 +95,7 @@ class LinuxKernelRewriter final : public MetadataRewriter {
         return 1;
       if (IP > Other.IP)
         return 0;
-      return ORC == NullORC;
+      return ORC == NullORC && Other.ORC != NullORC;
     }
   };
 

--- a/bolt/test/X86/linux-orc.s
+++ b/bolt/test/X86/linux-orc.s
@@ -1,6 +1,6 @@
 # REQUIRES: system-linux
 
-## Check that BOLT correctly reads ORC unwind information used by Linux Kernel.
+## Check that BOLT correctly reads ORC unwind information used by Linux kernel.
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe
@@ -15,6 +15,7 @@
 # CHECK-NEXT: {sp: 16, bp: -16, info: 0x15}: foo
 # CHECK-NEXT: {sp: 16, bp: -16, info: 0x14}: foo
 # CHECK-NEXT: {sp: 8, bp: 0, info: 0x5}: foo
+# CHECK-NEXT: {sp: 0, bp: 0, info: 0x0}: bar
 # CHECK-NEXT: {sp: 0, bp: 0, info: 0x0}: bar
 
   .text
@@ -50,7 +51,7 @@ foo:
 bar:
   .cfi_startproc
 	ret
-# Same ORC info propagated from foo above.
+## Same ORC info propagated from foo above.
 # CHECK:      retq                # ORC: {sp: 8, bp: 0, info: 0x5}
 .L4:
   .cfi_endproc
@@ -61,7 +62,7 @@ bar:
   .section .orc_unwind_ip,"a",@progbits
   .align 4
 
-# ORC for _start
+## ORC for _start.
   .section .orc_unwind
   .2byte 8
   .2byte 0
@@ -76,7 +77,7 @@ bar:
   .section .orc_unwind_ip
   .long foo - .
 
-# ORC for foo
+## ORC for foo.
   .section .orc_unwind
   .2byte 8
   .2byte 0
@@ -112,7 +113,22 @@ bar:
   .section .orc_unwind_ip
   .long .L4 - .
 
-# Fake Linux Kernel sections
+## Duplicate terminator entries to test ORC reader.
+  .section .orc_unwind
+  .2byte 0
+  .2byte 0
+  .2byte 0
+  .section .orc_unwind_ip
+  .long .L4 - .
+
+  .section .orc_unwind
+  .2byte 0
+  .2byte 0
+  .2byte 0
+  .section .orc_unwind_ip
+  .long .L4 - .
+
+## Fake Linux Kernel sections.
   .section __ksymtab,"a",@progbits
   .section __ksymtab_gpl,"a",@progbits
   .section .pci_fixup,"a",@progbits


### PR DESCRIPTION
Fix ORC entry comparison function to cover a case with multiple terminator entries matching at the same IP.