### PR TITLE
[BOLT] Add metadata pre-emit finalization interface

### DIFF
--- a/bolt/include/bolt/Rewrite/MetadataManager.h
+++ b/bolt/include/bolt/Rewrite/MetadataManager.h
@@ -36,6 +36,9 @@ public:
   /// Execute metadata initializers after CFG was constructed for functions.
   void runInitializersPostCFG();
 
+  /// Run finalization step of rewriters before the binary is emitted.
+  void runFinalizersPreEmit();
+
   /// Run finalization step of rewriters after code has been emitted.
   void runFinalizersAfterEmit();
 };

--- a/bolt/include/bolt/Rewrite/MetadataRewriter.h
+++ b/bolt/include/bolt/Rewrite/MetadataRewriter.h
@@ -52,6 +52,9 @@ public:
   /// Run the rewriter once the functions are in CFG state.
   virtual Error postCFGInitializer() { return Error::success(); }
 
+  /// Run the pass before the binary is emitted.
+  virtual Error preEmitFinalizer() { return Error::success(); }
+
   /// Finalize section contents based on the new context after the new code is
   /// emitted.
   virtual Error postEmitFinalizer() { return Error::success(); }

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -183,6 +183,9 @@ private:
   /// Process metadata in special sections after CFG is built for functions.
   void processMetadataPostCFG();
 
+  /// Make changes to metadata before the binary is emitted.
+  void finalizeMetadataPreEmit();
+
   /// Update debug and other auxiliary information in the file.
   void updateMetadata();
 

--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -163,11 +163,15 @@ public:
     return Error::success();
   }
 
-  Error postEmitFinalizer() override {
-    updateLKMarkers();
-
+  Error preEmitFinalizer() override {
     if (Error E = rewriteORCTables())
       return E;
+
+    return Error::success();
+  }
+
+  Error postEmitFinalizer() override {
+    updateLKMarkers();
 
     return Error::success();
   }

--- a/bolt/lib/Rewrite/MetadataManager.cpp
+++ b/bolt/lib/Rewrite/MetadataManager.cpp
@@ -44,6 +44,18 @@ void MetadataManager::runInitializersPostCFG() {
   }
 }
 
+void MetadataManager::runFinalizersPreEmit() {
+  for (auto &Rewriter : Rewriters) {
+    LLVM_DEBUG(dbgs() << "BOLT-DEBUG: invoking " << Rewriter->getName()
+                      << " before emitting binary context\n");
+    if (Error E = Rewriter->preEmitFinalizer()) {
+      errs() << "BOLT-ERROR: while running " << Rewriter->getName()
+             << " before emit: " << toString(std::move(E)) << '\n';
+      exit(1);
+    }
+  }
+}
+
 void MetadataManager::runFinalizersAfterEmit() {
   for (auto &Rewriter : Rewriters) {
     LLVM_DEBUG(dbgs() << "BOLT-DEBUG: invoking " << Rewriter->getName()

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -742,6 +742,8 @@ Error RewriteInstance::run() {
 
   runOptimizationPasses();
 
+  finalizeMetadataPreEmit();
+
   emitAndLink();
 
   updateMetadata();
@@ -3414,6 +3416,10 @@ void RewriteInstance::emitAndLink() {
     outs() << "BOLT-INFO: cache metrics after emitting functions:\n";
     CacheMetrics::printAll(BC->getSortedFunctions());
   }
+}
+
+void RewriteInstance::finalizeMetadataPreEmit() {
+  MetadataManager.runFinalizersPreEmit();
 }
 
 void RewriteInstance::updateMetadata() {


### PR DESCRIPTION
Some metadata needs to be updated/finalized before the binary context is emitted into the binary. Add the interface and use it for Linux ORC update invocation.