### PR TITLE
[flang] Restore error status for many indistinguishable specifics

### DIFF
--- a/flang/include/flang/Evaluate/characteristics.h
+++ b/flang/include/flang/Evaluate/characteristics.h
@@ -45,11 +45,12 @@ namespace Fortran::evaluate::characteristics {
 using common::CopyableIndirection;
 
 // Are these procedures distinguishable for a generic name or FINAL?
-bool Distinguishable(const common::LanguageFeatureControl &, const Procedure &,
-    const Procedure &);
-// Are these procedures distinguishable for a generic operator or assignment?
-bool DistinguishableOpOrAssign(const common::LanguageFeatureControl &,
+std::optional<bool> Distinguishable(const common::LanguageFeatureControl &,
     const Procedure &, const Procedure &);
+// Are these procedures distinguishable for a generic operator or assignment?
+std::optional<bool> DistinguishableOpOrAssign(
+    const common::LanguageFeatureControl &, const Procedure &,
+    const Procedure &);
 
 // Shapes of function results and dummy arguments have to have
 // the same rank, the same deferred dimensions, and the same

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -192,7 +192,7 @@ public:
 
 private:
   void SayNotDistinguishable(const Scope &, const SourceName &, GenericKind,
-      const Symbol &, const Symbol &);
+      const Symbol &, const Symbol &, bool isError);
   void AttachDeclaration(parser::Message &, const Scope &, const Symbol &);
 
   SemanticsContext &context_;
@@ -1704,8 +1704,9 @@ bool CheckHelper::CheckDistinguishableFinals(const Symbol &f1,
   const Procedure *p1{Characterize(f1)};
   const Procedure *p2{Characterize(f2)};
   if (p1 && p2) {
-    if (characteristics::Distinguishable(
-            context_.languageFeatures(), *p1, *p2)) {
+    std::optional<bool> areDistinct{characteristics::Distinguishable(
+        context_.languageFeatures(), *p1, *p2)};
+    if (areDistinct.value_or(false)) {
       return true;
     }
     if (auto *msg{messages_.Say(f1Name,
@@ -3519,10 +3520,11 @@ void DistinguishabilityHelper::Check(const Scope &scope) {
         auto distinguishable{kind.IsName()
                 ? evaluate::characteristics::Distinguishable
                 : evaluate::characteristics::DistinguishableOpOrAssign};
-        if (!distinguishable(
-                context_.languageFeatures(), proc, iter2->second.procedure)) {
+        std::optional<bool> distinct{distinguishable(
+            context_.languageFeatures(), proc, iter2->second.procedure)};
+        if (!distinct.value_or(false)) {
           SayNotDistinguishable(GetTopLevelUnitContaining(scope), name, kind,
-              *ultimate, *iter2->first);
+              *ultimate, *iter2->first, distinct.has_value());
         }
       }
     }
@@ -3531,15 +3533,15 @@ void DistinguishabilityHelper::Check(const Scope &scope) {
 
 void DistinguishabilityHelper::SayNotDistinguishable(const Scope &scope,
     const SourceName &name, GenericKind kind, const Symbol &proc1,
-    const Symbol &proc2) {
-  if (!context_.ShouldWarn(
+    const Symbol &proc2, bool isError) {
+  if (!isError &&
+      !context_.ShouldWarn(
           common::LanguageFeature::IndistinguishableSpecifics)) {
     // The rules for distinguishing specific procedures (F'2023 15.4.3.4.5)
-    // are inadequate for some real-world cases like pFUnit, which has
-    // some generic interfaces whose specific procedures are provably
-    // unambiguous, but fail all of the standard's criteria for being
-    // conformably distinct.  So the best we can do here is to emit optional
-    // portability warnings for such cases.
+    // are inadequate for some real-world cases like pFUnit.
+    // When there are optional dummy arguments or unlimited polymorphic
+    // dummy data object arguments, the best that we can do is emit an optional
+    // portability warning.
     return;
   }
   std::string name1{proc1.name().ToString()};
@@ -3556,11 +3558,15 @@ void DistinguishabilityHelper::SayNotDistinguishable(const Scope &scope,
   parser::Message *msg;
   if (scope.sourceRange().Contains(name)) {
     msg = &context_.Say(name,
-        "Generic '%s' should not have specific procedures '%s' and '%s' as their interfaces are not distinguishable by the incomplete rules in the standard"_port_en_US,
+        isError
+            ? "Generic '%s' may not have specific procedures '%s' and '%s' as their interfaces are not distinguishable"_err_en_US
+            : "Generic '%s' should not have specific procedures '%s' and '%s' as their interfaces are not distinguishable by the rules in the standard"_port_en_US,
         MakeOpName(name), name1, name2);
   } else {
     msg = &context_.Say(*GetTopLevelUnitContaining(proc1).GetName(),
-        "USE-associated generic '%s' should not have specific procedures '%s' and '%s' as their interfaces are not distinguishable by the incomplete rules in the standard"_port_en_US,
+        isError
+            ? "USE-associated generic '%s' may not have specific procedures '%s' and '%s' as their interfaces are not distinguishable"_err_en_US
+            : "USE-associated generic '%s' should not have specific procedures '%s' and '%s' as their interfaces are not distinguishable by the incomplete rules in the standard"_port_en_US,
         MakeOpName(name), name1, name2);
   }
   AttachDeclaration(*msg, scope, proc1);

--- a/flang/test/Semantics/generic05.F90
+++ b/flang/test/Semantics/generic05.F90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Check for distinguishability of defined I/O procedures defined within
 ! and outside their types.
 module m1
@@ -6,7 +6,7 @@ module m1
     integer n
    contains
     procedure :: readt1a, readt1b
-    !PORTABILITY: Generic 'read(unformatted)' should not have specific procedures 'readt1a' and 'readt1b' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !ERROR: Generic 'read(unformatted)' may not have specific procedures 'readt1a' and 'readt1b' as their interfaces are not distinguishable
     generic :: read(unformatted) => readt1a, readt1b
   end type
   type t2
@@ -15,7 +15,7 @@ module m1
   type t3
     integer n
   end type
-  !PORTABILITY: Generic 'read(unformatted)' should not have specific procedures 'readt2a' and 'readt2b' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'read(unformatted)' may not have specific procedures 'readt2a' and 'readt2b' as their interfaces are not distinguishable
   interface read(unformatted)
     module procedure :: readt1a, readt2a, readt2b, readt3
   end interface

--- a/flang/test/Semantics/generic07.f90
+++ b/flang/test/Semantics/generic07.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1
 module m1
   type :: t1
     sequence
@@ -74,7 +74,7 @@ program test
   interface distinguishable3
     procedure :: s1a, s1b
   end interface
-  !PORTABILITY: Generic 'indistinguishable' should not have specific procedures 's2b' and 's2a' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'indistinguishable' may not have specific procedures 's2b' and 's2a' as their interfaces are not distinguishable
   interface indistinguishable
     procedure :: s2a, s2b
   end interface

--- a/flang/test/Semantics/resolve17.f90
+++ b/flang/test/Semantics/resolve17.f90
@@ -96,7 +96,7 @@ contains
   end
 end
 subroutine s6
-  !ERROR: Generic 'g' should not have specific procedures 'sa' and 'sb' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'sa' and 'sb' as their interfaces are not distinguishable
   use m6a, g => gg
   use m6b, g => gg
 end
@@ -180,7 +180,7 @@ contains
   end
 end module
 subroutine s9
-  !PORTABILITY: USE-associated generic 'g' should not have specific procedures 'g' and 'g' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: USE-associated generic 'g' may not have specific procedures 'g' and 'g' as their interfaces are not distinguishable
   use m9a
   use m9b
 end
@@ -197,7 +197,7 @@ contains
 end
 module m10b
   use m10a
-  !PORTABILITY: Generic 'g' should not have specific procedures 's' and 's' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 's' and 's' as their interfaces are not distinguishable
   interface g
     module procedure s
   end interface

--- a/flang/test/Semantics/resolve53.f90
+++ b/flang/test/Semantics/resolve53.f90
@@ -3,7 +3,7 @@
 ! Specific procedures of generic interfaces must be distinguishable.
 
 module m1
-  !PORTABILITY: Generic 'g' should not have specific procedures 's2' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 's2' and 's4' as their interfaces are not distinguishable
   interface g
     procedure s1
     procedure s2
@@ -25,7 +25,7 @@ contains
 end
 
 module m2
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm2s1' and 'm2s2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm2s1' and 'm2s2' as their interfaces are not distinguishable
   interface g
     subroutine m2s1(x)
     end subroutine
@@ -36,7 +36,7 @@ module m2
 end
 
 module m3
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm3f1' and 'm3f2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm3f1' and 'm3f2' as their interfaces are not distinguishable
   interface g
     integer function m3f1()
     end function
@@ -79,7 +79,7 @@ end
 
 module m6
   use m5
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s1' and 'm6s4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm5s1' and 'm6s4' as their interfaces are not distinguishable
   interface g
     subroutine m6s4(x)
     end subroutine
@@ -88,9 +88,9 @@ end
 
 module m7
   use m5
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s1' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s2' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm5s3' and 'm7s5' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm5s1' and 'm7s5' as their interfaces are not distinguishable
+  !ERROR: Generic 'g' may not have specific procedures 'm5s2' and 'm7s5' as their interfaces are not distinguishable
+  !ERROR: Generic 'g' may not have specific procedures 'm5s3' and 'm7s5' as their interfaces are not distinguishable
   interface g
     subroutine m7s5(x)
       real x(..)
@@ -100,7 +100,7 @@ end
 
 ! Two procedures that differ only by attributes are not distinguishable
 module m8
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm8s1' and 'm8s2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm8s1' and 'm8s2' as their interfaces are not distinguishable
   interface g
     pure subroutine m8s1(x)
       real, intent(in) :: x
@@ -112,7 +112,7 @@ module m8
 end
 
 module m9
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm9s1' and 'm9s2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm9s1' and 'm9s2' as their interfaces are not distinguishable
   interface g
     subroutine m9s1(x)
       real :: x(10)
@@ -124,7 +124,7 @@ module m9
 end
 
 module m10
-  !PORTABILITY: Generic 'g' should not have specific procedures 'm10s1' and 'm10s2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g' may not have specific procedures 'm10s1' and 'm10s2' as their interfaces are not distinguishable
   interface g
     subroutine m10s1(x)
       real :: x(10)
@@ -144,7 +144,7 @@ program m11
       real, allocatable :: x
     end subroutine
   end interface
-  !PORTABILITY: Generic 'g2' should not have specific procedures 'm11s3' and 'm11s4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g2' may not have specific procedures 'm11s3' and 'm11s4' as their interfaces are not distinguishable
   interface g2
     subroutine m11s3(x)
       real, pointer, intent(in) :: x
@@ -156,11 +156,11 @@ program m11
 end
 
 module m12
-  !PORTABILITY: Generic 'g1' should not have specific procedures 's1' and 's2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g1' may not have specific procedures 's1' and 's2' as their interfaces are not distinguishable
   generic :: g1 => s1, s2  ! rank-1 and assumed-rank
-  !PORTABILITY: Generic 'g2' should not have specific procedures 's2' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g2' may not have specific procedures 's2' and 's3' as their interfaces are not distinguishable
   generic :: g2 => s2, s3  ! scalar and assumed-rank
-  !PORTABILITY: Generic 'g3' should not have specific procedures 's1' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g3' may not have specific procedures 's1' and 's4' as their interfaces are not distinguishable
   generic :: g3 => s1, s4  ! different shape, same rank
 contains
   subroutine s1(x)
@@ -209,7 +209,7 @@ module m14
     module procedure f1
     module procedure f2
   end interface
-  !PORTABILITY: Generic 'OPERATOR(+)' should not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'OPERATOR(+)' may not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable
   interface operator(+)
     module procedure f1
     module procedure f3
@@ -218,7 +218,7 @@ module m14
     module procedure f1
     module procedure f2
   end interface
-  !PORTABILITY: Generic 'OPERATOR(.bar.)' should not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'OPERATOR(.bar.)' may not have specific procedures 'f1' and 'f3' as their interfaces are not distinguishable
   interface operator(.bar.)
     module procedure f1
     module procedure f3
@@ -260,12 +260,12 @@ module m15
     procedure s1
     procedure s2
   end interface
-  !PORTABILITY: Generic 'g2' should not have specific procedures 's1' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g2' may not have specific procedures 's1' and 's3' as their interfaces are not distinguishable
   interface g2
     procedure s1
     procedure s3
   end interface
-  !PORTABILITY: Generic 'g3' should not have specific procedures 's4' and 's5' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g3' may not have specific procedures 's4' and 's5' as their interfaces are not distinguishable
   interface g3
     procedure s4
     procedure s5
@@ -285,17 +285,17 @@ module m15
     procedure s8
     procedure s9
   end interface
-  !PORTABILITY: Generic 'g7' should not have specific procedures 's6' and 's7' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g7' may not have specific procedures 's6' and 's7' as their interfaces are not distinguishable
   interface g7
     procedure s6
     procedure s7
   end interface
-  !PORTABILITY: Generic 'g8' should not have specific procedures 's6' and 's8' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g8' may not have specific procedures 's6' and 's8' as their interfaces are not distinguishable
   interface g8
     procedure s6
     procedure s8
   end interface
-  !PORTABILITY: Generic 'g9' should not have specific procedures 's7' and 's8' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g9' may not have specific procedures 's7' and 's8' as their interfaces are not distinguishable
   interface g9
     procedure s7
     procedure s8
@@ -339,7 +339,7 @@ module m16
     procedure, nopass :: s2
     procedure, nopass :: s3
     generic :: g1 => s1, s2
-    !PORTABILITY: Generic 'g2' should not have specific procedures 's1' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !ERROR: Generic 'g2' may not have specific procedures 's1' and 's3' as their interfaces are not distinguishable
     generic :: g2 => s1, s3
   end type
 contains
@@ -368,7 +368,7 @@ module m17
     procedure s1
     procedure s2
   end interface
-  !PORTABILITY: Generic 'g2' should not have specific procedures 's3' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g2' may not have specific procedures 's3' and 's4' as their interfaces are not distinguishable
   interface g2
     procedure s3
     procedure s4
@@ -377,17 +377,17 @@ module m17
     procedure s1
     procedure s4
   end interface
-  !PORTABILITY: Generic 'g4' should not have specific procedures 's2' and 's3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g4' may not have specific procedures 's2' and 's3' as their interfaces are not distinguishable
   interface g4
     procedure s2
     procedure s3
   end interface
-  !PORTABILITY: Generic 'g5' should not have specific procedures 's2' and 's5' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g5' may not have specific procedures 's2' and 's5' as their interfaces are not distinguishable
   interface g5
     procedure s2
     procedure s5
   end interface
-  !PORTABILITY: Generic 'g6' should not have specific procedures 's2' and 's6' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'g6' may not have specific procedures 's2' and 's6' as their interfaces are not distinguishable
   interface g6
     procedure s2
     procedure s6
@@ -439,7 +439,7 @@ module m19
     module procedure f1
     module procedure f2
   end interface
-  !PORTABILITY: Generic 'OPERATOR(.bar.)' should not have specific procedures 'f2' and 'f3' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'OPERATOR(.bar.)' may not have specific procedures 'f2' and 'f3' as their interfaces are not distinguishable
   interface operator(.bar.)
     module procedure f2
     module procedure f3
@@ -507,7 +507,7 @@ end module
 
 ! Example reduced from pFUnit
 module m22
-  !PORTABILITY: Generic 'generic' should not have specific procedures 'sub1' and 'sub2' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !PORTABILITY: Generic 'generic' should not have specific procedures 'sub1' and 'sub2' as their interfaces are not distinguishable by the rules in the standard
   interface generic
     procedure sub1, sub2
   end interface

--- a/flang/test/Semantics/resolve54.f90
+++ b/flang/test/Semantics/resolve54.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Tests based on examples in C.10.6
 
 ! C.10.6(10)
@@ -55,7 +55,7 @@ end
 ! C.10.6(17)
 ! BAD4(1.0,2,Y=3.0,Z=4) could apply to either procedure
 module m4
-  !PORTABILITY: Generic 'bad4' should not have specific procedures 's4a' and 's4b' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'bad4' may not have specific procedures 's4a' and 's4b' as their interfaces are not distinguishable
   interface BAD4
     subroutine S4A(W, X, Y, Z)
       real :: W, Y
@@ -68,7 +68,7 @@ module m4
   end interface
 end
 module m4b
-  !PORTABILITY: Generic 'bad4' should not have specific procedures 's4b' and 's4a' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'bad4' may not have specific procedures 's4b' and 's4a' as their interfaces are not distinguishable
   interface BAD4
     subroutine S4B(X, W, Z, Y)
       real :: X, Y
@@ -109,7 +109,7 @@ end
 ! type(BOSC) :: A_BOSC
 ! BAD6(A_PEAR,A_BOSC)  ! could be s6a or s6b
 module m6
-  !PORTABILITY: Generic 'bad6' should not have specific procedures 's6a' and 's6b' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'bad6' may not have specific procedures 's6a' and 's6b' as their interfaces are not distinguishable
   interface BAD6
     subroutine S6A(X, Y)
       use FRUITS
@@ -123,7 +123,7 @@ module m6
   end interface
 end
 module m6b
-  !PORTABILITY: Generic 'bad6' should not have specific procedures 's6b' and 's6a' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'bad6' may not have specific procedures 's6b' and 's6a' as their interfaces are not distinguishable
   interface BAD6
     subroutine S6B(X, Y)
       use FRUITS
@@ -170,7 +170,7 @@ end
 ! C.10.6(25)
 ! Invalid generic (according to the rules), despite the fact that it is unambiguous
 module m8
-  !PORTABILITY: Generic 'bad8' should not have specific procedures 's8a' and 's8b' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !PORTABILITY: Generic 'bad8' should not have specific procedures 's8a' and 's8b' as their interfaces are not distinguishable by the rules in the standard
   interface BAD8
     subroutine S8A(X, Y, Z)
       real, optional :: X

--- a/flang/test/Semantics/resolve65.f90
+++ b/flang/test/Semantics/resolve65.f90
@@ -5,9 +5,9 @@ module m1
   implicit none
   type :: t
   contains
-    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t4' and 't%assign_t5' as their interfaces are not distinguishable by the incomplete rules in the standard
-    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t4' and 't%assign_t6' as their interfaces are not distinguishable by the incomplete rules in the standard
-    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't%assign_t5' and 't%assign_t6' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t4' and 't%assign_t5' as their interfaces are not distinguishable
+    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t4' and 't%assign_t6' as their interfaces are not distinguishable
+    !ERROR: Generic 'assignment(=)' may not have specific procedures 't%assign_t5' and 't%assign_t6' as their interfaces are not distinguishable
     !ERROR: Defined assignment procedure 'binding' must be a subroutine
     generic :: assignment(=) => binding
     procedure :: binding => assign_t1
@@ -63,7 +63,7 @@ end
 module m2
   type :: t
   end type
-  !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 's3' and 's4' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'assignment(=)' may not have specific procedures 's3' and 's4' as their interfaces are not distinguishable
   interface assignment(=)
     !ERROR: In defined assignment subroutine 's1', dummy argument 'y' may not be OPTIONAL
     subroutine s1(x, y)

--- a/flang/test/Semantics/resolve96.f90
+++ b/flang/test/Semantics/resolve96.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1
 
 ! Check distinguishability for specific procedures of defined operators and
 ! assignment. These are different from names because there a normal generic
@@ -18,7 +18,7 @@ module m1
   end type
   type :: t2
   end type
-  !PORTABILITY: Generic 'OPERATOR(.foo.)' should not have specific procedures 's2' and 't1%p' as their interfaces are not distinguishable by the incomplete rules in the standard
+  !ERROR: Generic 'OPERATOR(.foo.)' may not have specific procedures 's2' and 't1%p' as their interfaces are not distinguishable
   interface operator(.foo.)
     procedure :: s2
   end interface
@@ -39,7 +39,7 @@ module m2
     integer :: n
   contains
     procedure, pass(x1) :: p1 => s1
-    !PORTABILITY: Generic 'assignment(=)' should not have specific procedures 't1%p1' and 't2%p2' as their interfaces are not distinguishable by the incomplete rules in the standard
+    !ERROR: Generic 'assignment(=)' may not have specific procedures 't1%p1' and 't2%p2' as their interfaces are not distinguishable
     generic :: assignment(=) => p1
   end type
   type :: t2


### PR DESCRIPTION
A recent patch to allow pFUnit to compile softened the diagnostic about indistinguishable specific procedures to a portability warning. It turns out that this was overkill -- for specific procedures containing no optional or unlimited polymorphic dummy data arguments, a diagnosis of "indistinguishable" can still be a hard error.

So adjust the analysis to be tri-state: two procedures are either definitely distinguishable, definitely indistinguishable without optionals or unlimited polymorphics, or indeterminate.  Emit errors as before for the definitely indistinguishable cases; continue to emit portability warnings for the indeterminate cases.

When this patch is merged, all but one of the dozen or so tests that I disabled in llvm-test-suite can be re-enabled.