### PR TITLE
[IR] Add more efficient getOperand methods to some of the Operator subclasses.

### DIFF
--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -128,9 +128,8 @@ public:
 };
 
 template <>
-struct OperandTraits<OverflowingBinaryOperator> :
-  public FixedNumOperandTraits<OverflowingBinaryOperator, 2> {
-};
+struct OperandTraits<OverflowingBinaryOperator>
+    : public FixedNumOperandTraits<OverflowingBinaryOperator, 2> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(OverflowingBinaryOperator, Value)
 
@@ -179,9 +178,8 @@ public:
 };
 
 template <>
-struct OperandTraits<PossiblyExactOperator> :
-  public FixedNumOperandTraits<PossiblyExactOperator, 2> {
-};
+struct OperandTraits<PossiblyExactOperator>
+    : public FixedNumOperandTraits<PossiblyExactOperator, 2> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(PossiblyExactOperator, Value)
 
@@ -530,9 +528,8 @@ public:
 };
 
 template <>
-struct OperandTraits<GEPOperator> :
-  public VariadicOperandTraits<GEPOperator, 1> {
-};
+struct OperandTraits<GEPOperator>
+    : public VariadicOperandTraits<GEPOperator, 1> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(GEPOperator, Value)
 
@@ -568,9 +565,8 @@ public:
 };
 
 template <>
-struct OperandTraits<PtrToIntOperator> :
-  public FixedNumOperandTraits<PtrToIntOperator, 1> {
-};
+struct OperandTraits<PtrToIntOperator>
+    : public FixedNumOperandTraits<PtrToIntOperator, 1> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(PtrToIntOperator, Value)
 
@@ -593,9 +589,8 @@ public:
 };
 
 template <>
-struct OperandTraits<BitCastOperator> :
-  public FixedNumOperandTraits<BitCastOperator, 1> {
-};
+struct OperandTraits<BitCastOperator>
+    : public FixedNumOperandTraits<BitCastOperator, 1> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(BitCastOperator, Value)
 
@@ -622,9 +617,8 @@ public:
 };
 
 template <>
-struct OperandTraits<AddrSpaceCastOperator> :
-  public FixedNumOperandTraits<AddrSpaceCastOperator, 1> {
-};
+struct OperandTraits<AddrSpaceCastOperator>
+    : public FixedNumOperandTraits<AddrSpaceCastOperator, 1> {};
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(AddrSpaceCastOperator, Value)
 

--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -94,6 +94,9 @@ private:
   }
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   /// Test whether this operation is known to never
   /// undergo unsigned overflow, aka the nuw property.
   bool hasNoUnsignedWrap() const {
@@ -124,6 +127,13 @@ public:
   }
 };
 
+template <>
+struct OperandTraits<OverflowingBinaryOperator> :
+  public FixedNumOperandTraits<OverflowingBinaryOperator, 2> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(OverflowingBinaryOperator, Value)
+
 /// A udiv or sdiv instruction, which can be marked as "exact",
 /// indicating that no bits are destroyed.
 class PossiblyExactOperator : public Operator {
@@ -141,6 +151,9 @@ private:
   }
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   /// Test whether this division is known to be exact, with zero remainder.
   bool isExact() const {
     return SubclassOptionalData & IsExact;
@@ -164,6 +177,13 @@ public:
            (isa<ConstantExpr>(V) && classof(cast<ConstantExpr>(V)));
   }
 };
+
+template <>
+struct OperandTraits<PossiblyExactOperator> :
+  public FixedNumOperandTraits<PossiblyExactOperator, 2> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(PossiblyExactOperator, Value)
 
 /// Utility class for floating point operations which can have
 /// information about relaxed accuracy requirements attached to them.
@@ -383,6 +403,9 @@ class GEPOperator
   }
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   /// Test whether this is an inbounds GEP, as defined by LangRef.html.
   bool isInBounds() const {
     return SubclassOptionalData & IsInBounds;
@@ -506,12 +529,22 @@ public:
                      APInt &ConstantOffset) const;
 };
 
+template <>
+struct OperandTraits<GEPOperator> :
+  public VariadicOperandTraits<GEPOperator, 1> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(GEPOperator, Value)
+
 class PtrToIntOperator
     : public ConcreteOperator<Operator, Instruction::PtrToInt> {
   friend class PtrToInt;
   friend class ConstantExpr;
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   Value *getPointerOperand() {
     return getOperand(0);
   }
@@ -534,12 +567,22 @@ public:
   }
 };
 
+template <>
+struct OperandTraits<PtrToIntOperator> :
+  public FixedNumOperandTraits<PtrToIntOperator, 1> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(PtrToIntOperator, Value)
+
 class BitCastOperator
     : public ConcreteOperator<Operator, Instruction::BitCast> {
   friend class BitCastInst;
   friend class ConstantExpr;
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   Type *getSrcTy() const {
     return getOperand(0)->getType();
   }
@@ -549,12 +592,22 @@ public:
   }
 };
 
+template <>
+struct OperandTraits<BitCastOperator> :
+  public FixedNumOperandTraits<BitCastOperator, 1> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(BitCastOperator, Value)
+
 class AddrSpaceCastOperator
     : public ConcreteOperator<Operator, Instruction::AddrSpaceCast> {
   friend class AddrSpaceCastInst;
   friend class ConstantExpr;
 
 public:
+  /// Transparently provide more efficient getOperand methods.
+  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
+
   Value *getPointerOperand() { return getOperand(0); }
 
   const Value *getPointerOperand() const { return getOperand(0); }
@@ -567,6 +620,13 @@ public:
     return getType()->getPointerAddressSpace();
   }
 };
+
+template <>
+struct OperandTraits<AddrSpaceCastOperator> :
+  public FixedNumOperandTraits<AddrSpaceCastOperator, 1> {
+};
+
+DEFINE_TRANSPARENT_OPERAND_ACCESSORS(AddrSpaceCastOperator, Value)
 
 } // end namespace llvm
 


### PR DESCRIPTION
ConstantExpr does not use HungOffUses. If we know that the Instruction the Operator subclass can represent also does not use HungOffUses, we can be more efficient than falling back to User::getOperand.