### PR TITLE
[RISCV] Remove StackAlign attribute enum. NFC

### DIFF
--- a/llvm/include/llvm/Support/RISCVAttributes.h
+++ b/llvm/include/llvm/Support/RISCVAttributes.h
@@ -34,8 +34,6 @@ enum AttrType : unsigned {
   PRIV_SPEC_REVISION = 12,
 };
 
-enum StackAlign { ALIGN_4 = 4, ALIGN_8 = 8, ALIGN_16 = 16 };
-
 enum { NOT_ALLOWED = 0, ALLOWED = 1 };
 
 } // namespace RISCVAttrs

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -51,12 +51,14 @@ void RISCVTargetStreamer::setTargetABI(RISCVABI::ABI ABI) {
 void RISCVTargetStreamer::emitTargetAttributes(const MCSubtargetInfo &STI,
                                                bool EmitStackAlign) {
   if (EmitStackAlign) {
+    unsigned StackAlign;
     if (TargetABI == RISCVABI::ABI_ILP32E)
-      emitAttribute(RISCVAttrs::STACK_ALIGN, RISCVAttrs::ALIGN_4);
+      StackAlign = 4;
     else if (TargetABI == RISCVABI::ABI_LP64E)
-      emitAttribute(RISCVAttrs::STACK_ALIGN, RISCVAttrs::ALIGN_8);
+      StackAlign = 8;
     else
-      emitAttribute(RISCVAttrs::STACK_ALIGN, RISCVAttrs::ALIGN_16);
+      StackAlign = 16;
+    emitAttribute(RISCVAttrs::STACK_ALIGN, StackAlign);
   }
 
   auto ParseResult = RISCVFeatures::parseFeatureBits(

--- a/llvm/unittests/Support/RISCVAttributeParserTest.cpp
+++ b/llvm/unittests/Support/RISCVAttributeParserTest.cpp
@@ -55,10 +55,8 @@ static bool testTagString(unsigned Tag, const char *name) {
 
 TEST(StackAlign, testAttribute) {
   EXPECT_TRUE(testTagString(4, "Tag_stack_align"));
-  EXPECT_TRUE(
-      testAttribute(4, 4, RISCVAttrs::STACK_ALIGN, 4));
-  EXPECT_TRUE(
-      testAttribute(4, 16, RISCVAttrs::STACK_ALIGN, 16));
+  EXPECT_TRUE(testAttribute(4, 4, RISCVAttrs::STACK_ALIGN, 4));
+  EXPECT_TRUE(testAttribute(4, 16, RISCVAttrs::STACK_ALIGN, 16));
 }
 
 TEST(UnalignedAccess, testAttribute) {

--- a/llvm/unittests/Support/RISCVAttributeParserTest.cpp
+++ b/llvm/unittests/Support/RISCVAttributeParserTest.cpp
@@ -56,9 +56,9 @@ static bool testTagString(unsigned Tag, const char *name) {
 TEST(StackAlign, testAttribute) {
   EXPECT_TRUE(testTagString(4, "Tag_stack_align"));
   EXPECT_TRUE(
-      testAttribute(4, 4, RISCVAttrs::STACK_ALIGN, RISCVAttrs::ALIGN_4));
+      testAttribute(4, 4, RISCVAttrs::STACK_ALIGN, 4));
   EXPECT_TRUE(
-      testAttribute(4, 16, RISCVAttrs::STACK_ALIGN, RISCVAttrs::ALIGN_16));
+      testAttribute(4, 16, RISCVAttrs::STACK_ALIGN, 16));
 }
 
 TEST(UnalignedAccess, testAttribute) {


### PR DESCRIPTION
The alignment is directly encoded in the attribute. There doesn't seem to be a good reason to give the possible alignments a name.