### PR TITLE
[llvm-jitlink] Fix detectStubKind() for big endian systems

### DIFF
--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1294,10 +1294,11 @@ private:
 };
 
 static StringRef detectStubKind(const Session::MemoryRegionInfo &Stub) {
-  constexpr uint32_t Armv7MovWTle = 0xe300c000;
-  constexpr uint32_t Armv7BxR12le = 0xe12fff1c;
-  constexpr uint32_t Thumbv7MovWTle = 0x0c00f240;
-  constexpr uint16_t Thumbv7BxR12le = 0x4760;
+  using namespace support::endian;
+  auto Armv7MovWTle = byte_swap<uint32_t, endianness::little>(0xe300c000);
+  auto Armv7BxR12le = byte_swap<uint32_t, endianness::little>(0xe12fff1c);
+  auto Thumbv7MovWTle = byte_swap<uint32_t, endianness::little>(0x0c00f240);
+  auto Thumbv7BxR12le = byte_swap<uint16_t, endianness::little>(0x4760);
 
   MemoryMatcher M(Stub.getContent());
   if (M.matchMask(Thumbv7MovWTle)) {


### PR DESCRIPTION
This function is used in `jitlink-check` lines in LIT tests. In #78371 I missed to swap initial instruction bytes for systems that store the constants as big-endian.