### PR TITLE
[clang][Interp] Fix MemberExpr initializing an existing value

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -1019,7 +1019,7 @@ bool ByteCodeExprGen<Emitter>::VisitMemberExpr(const MemberExpr *E) {
   if (DiscardResult)
     return this->discard(Base);
 
-  if (!this->visit(Base))
+  if (!this->delegate(Base))
     return false;
 
   // Base above gives us a pointer on the stack.
@@ -1507,8 +1507,10 @@ bool ByteCodeExprGen<Emitter>::VisitMaterializeTemporaryExpr(
       return this->emitGetPtrLocal(*LocalIndex, E);
     }
   } else {
+    const Expr *Inner = E->getSubExpr()->skipRValueSubobjectAdjustments();
+
     if (std::optional<unsigned> LocalIndex =
-            allocateLocal(SubExpr, /*IsExtended=*/true)) {
+            allocateLocal(Inner, /*IsExtended=*/true)) {
       if (!this->emitGetPtrLocal(*LocalIndex, E))
         return false;
       return this->visitInitializer(SubExpr);

--- a/clang/test/AST/Interp/cxx98.cpp
+++ b/clang/test/AST/Interp/cxx98.cpp
@@ -30,3 +30,11 @@ int NCI; // both-note {{declared here}}
 int NCIA[NCI]; // both-warning {{variable length array}} \
                // both-error {{variable length array}} \\
                // both-note {{read of non-const variable 'NCI'}}
+
+
+struct V {
+  char c[1];
+  banana V() : c("i") {} // both-error {{unknown type name 'banana'}} \
+                         // both-error {{constructor cannot have a return type}}
+};
+_Static_assert(V().c[0], ""); // both-error {{is not an integral constant expression}}

--- a/clang/test/SemaCXX/pr72025.cpp
+++ b/clang/test/SemaCXX/pr72025.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -verify -std=c++03 -fsyntax-only %s
+// RUN: %clang_cc1 -verify -std=c++03 -fsyntax-only -fexperimental-new-constant-interpreter %s
 struct V {
   char c[2];
   banana V() : c("i") {} // expected-error {{unknown type name}}


### PR DESCRIPTION
This is similar to c1ad363e6eba308fa94c47374ee98b3c79693a35, but with the additional twist that initializing an existing value from a `MemberExpr` was not working correctly.