### PR TITLE
[mlir][vector] Disable transpose -> shuffle lowering for scalable vectors

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
@@ -434,6 +434,10 @@ public:
       return rewriter.notifyMatchFailure(
           op, "not using vector shuffle based lowering");
 
+    if (op.getSourceVectorType().isScalable())
+      return rewriter.notifyMatchFailure(
+          op, "vector shuffle lowering not supported for scalable vectors");
+
     auto srcGtOneDims = isTranspose2DSlice(op);
     if (failed(srcGtOneDims))
       return rewriter.notifyMatchFailure(


### PR DESCRIPTION
vector.shuffle is not supported for scalable vectors (outside of splats)