### PR TITLE
[libc][NFC] Rename `FPBits` nan functions

### DIFF
--- a/libc/src/__support/FPUtil/DivisionAndRemainderOperations.h
+++ b/libc/src/__support/FPUtil/DivisionAndRemainderOperations.h
@@ -31,7 +31,7 @@ LIBC_INLINE T remquo(T x, T y, int &q) {
   if (ybits.is_nan())
     return y;
   if (xbits.is_inf() || ybits.is_zero())
-    return FPBits<T>::build_quiet_nan().get_val();
+    return FPBits<T>::quiet_nan().get_val();
 
   if (xbits.is_zero()) {
     q = 0;

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -359,8 +359,8 @@ public:
   LIBC_INLINE static constexpr RetT inf(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(), Sig::ZERO()));
   }
-  LIBC_INLINE static constexpr RetT build_signaling_nan(Sign sign = Sign::POS,
-                                                        StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT signaling_nan(Sign sign = Sign::POS,
+                                                  StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        (v ? Sig(v) : (Sig::MSB() >> 1))));
   }
@@ -448,8 +448,8 @@ public:
   LIBC_INLINE static constexpr RetT inf(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(), Sig::MSB()));
   }
-  LIBC_INLINE static constexpr RetT build_signaling_nan(Sign sign = Sign::POS,
-                                                        StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT signaling_nan(Sign sign = Sign::POS,
+                                                  StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        Sig::MSB() | (v ? Sig(v) : (Sig::MSB() >> 2))));
   }
@@ -578,13 +578,13 @@ public:
     return RetT(encode(sign, BiasedExp::BITS_ALL_ZEROES(), Sig::ZERO()));
   }
   using UP::build_quiet_nan;
-  using UP::build_signaling_nan;
   using UP::inf;
   using UP::max_normal;
   using UP::max_subnormal;
   using UP::min_normal;
   using UP::min_subnormal;
   using UP::one;
+  using UP::signaling_nan;
 
   // Modifiers
   LIBC_INLINE constexpr RetT abs() const {

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -364,8 +364,8 @@ public:
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        (v ? Sig(v) : (Sig::MSB() >> 1))));
   }
-  LIBC_INLINE static constexpr RetT build_quiet_nan(Sign sign = Sign::POS,
-                                                    StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT quiet_nan(Sign sign = Sign::POS,
+                                              StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(), Sig::MSB() | Sig(v)));
   }
 
@@ -453,8 +453,8 @@ public:
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        Sig::MSB() | (v ? Sig(v) : (Sig::MSB() >> 2))));
   }
-  LIBC_INLINE static constexpr RetT build_quiet_nan(Sign sign = Sign::POS,
-                                                    StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT quiet_nan(Sign sign = Sign::POS,
+                                              StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        Sig::MSB() | (Sig::MSB() >> 1) | Sig(v)));
   }
@@ -577,13 +577,13 @@ public:
   LIBC_INLINE static constexpr RetT zero(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ZEROES(), Sig::ZERO()));
   }
-  using UP::build_quiet_nan;
   using UP::inf;
   using UP::max_normal;
   using UP::max_subnormal;
   using UP::min_normal;
   using UP::min_subnormal;
   using UP::one;
+  using UP::quiet_nan;
   using UP::signaling_nan;
 
   // Modifiers

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -359,8 +359,8 @@ public:
   LIBC_INLINE static constexpr RetT inf(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(), Sig::ZERO()));
   }
-  LIBC_INLINE static constexpr RetT build_nan(Sign sign = Sign::POS,
-                                              StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT build_signaling_nan(Sign sign = Sign::POS,
+                                                        StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        (v ? Sig(v) : (Sig::MSB() >> 1))));
   }
@@ -448,8 +448,8 @@ public:
   LIBC_INLINE static constexpr RetT inf(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(), Sig::MSB()));
   }
-  LIBC_INLINE static constexpr RetT build_nan(Sign sign = Sign::POS,
-                                              StorageType v = 0) {
+  LIBC_INLINE static constexpr RetT build_signaling_nan(Sign sign = Sign::POS,
+                                                        StorageType v = 0) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ONES(),
                        Sig::MSB() | (v ? Sig(v) : (Sig::MSB() >> 2))));
   }
@@ -577,8 +577,8 @@ public:
   LIBC_INLINE static constexpr RetT zero(Sign sign = Sign::POS) {
     return RetT(encode(sign, BiasedExp::BITS_ALL_ZEROES(), Sig::ZERO()));
   }
-  using UP::build_nan;
   using UP::build_quiet_nan;
+  using UP::build_signaling_nan;
   using UP::inf;
   using UP::max_normal;
   using UP::max_subnormal;

--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -124,7 +124,7 @@ template <typename T> struct FModExceptionalInputHandler {
 
   LIBC_INLINE static bool pre_check(T x, T y, T &out) {
     using FPB = fputil::FPBits<T>;
-    const T quiet_nan = FPB::build_quiet_nan().get_val();
+    const T quiet_nan = FPB::quiet_nan().get_val();
     FPB sx(x), sy(y);
     if (LIBC_LIKELY(!sy.is_zero() && !sy.is_inf_or_nan() &&
                     !sx.is_inf_or_nan())) {

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -74,7 +74,7 @@ LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<T>, T> sqrt(T x) {
     using FPBits_t = typename fputil::FPBits<T>;
     using StorageType = typename FPBits_t::StorageType;
     constexpr StorageType ONE = StorageType(1) << FPBits_t::FRACTION_LEN;
-    constexpr auto FLT_NAN = FPBits_t::build_quiet_nan().get_val();
+    constexpr auto FLT_NAN = FPBits_t::quiet_nan().get_val();
 
     FPBits_t bits(x);
 

--- a/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
+++ b/libc/src/__support/FPUtil/generic/sqrt_80_bit_long_double.h
@@ -39,7 +39,7 @@ LIBC_INLINE long double sqrt(long double x) {
   using LDBits = FPBits<long double>;
   using StorageType = typename LDBits::StorageType;
   constexpr StorageType ONE = StorageType(1) << int(LDBits::FRACTION_LEN);
-  constexpr auto LDNAN = LDBits::build_quiet_nan().get_val();
+  constexpr auto LDNAN = LDBits::quiet_nan().get_val();
 
   LDBits bits(x);
 

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -1167,7 +1167,7 @@ LIBC_INLINE StrToNumResult<T> strtofloatingpoint(const char *__restrict src) {
           index = left_paren;
         }
       }
-      result = FPBits(result.build_quiet_nan(result.sign(), nan_mantissa));
+      result = FPBits(result.quiet_nan(result.sign(), nan_mantissa));
     }
   } else if (tolower(src[index]) == 'i') { // INF
     if (tolower(src[index + 1]) == inf_string[1] &&
@@ -1215,7 +1215,7 @@ template <class T> LIBC_INLINE StrToNumResult<T> strtonan(const char *arg) {
     nan_mantissa = static_cast<StorageType>(nan_mantissa_result);
   }
 
-  result = FPBits::build_quiet_nan(fputil::Sign::POS, nan_mantissa);
+  result = FPBits::quiet_nan(fputil::Sign::POS, nan_mantissa);
   return {result.get_val(), 0, error};
 }
 

--- a/libc/src/math/generic/acosf.cpp
+++ b/libc/src/math/generic/acosf.cpp
@@ -85,7 +85,7 @@ LLVM_LIBC_FUNCTION(float, acosf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return x + FPBits::build_quiet_nan().get_val();
+    return x + FPBits::quiet_nan().get_val();
   }
 
   // When 0.5 < |x| < 1, we perform range reduction as follow:

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -29,7 +29,7 @@ LLVM_LIBC_FUNCTION(float, acoshf, (float x)) {
     // x < 1.
     fputil::set_errno_if_required(EDOM);
     fputil::raise_except_if_required(FE_INVALID);
-    return FPBits_t::build_quiet_nan().get_val();
+    return FPBits_t::quiet_nan().get_val();
   }
 
   if (LIBC_UNLIKELY(x_u >= 0x4f8ffb03)) {

--- a/libc/src/math/generic/asinf.cpp
+++ b/libc/src/math/generic/asinf.cpp
@@ -109,7 +109,7 @@ LLVM_LIBC_FUNCTION(float, asinf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return FPBits::build_quiet_nan().get_val();
+    return FPBits::quiet_nan().get_val();
   }
 
   // Check for exceptional values

--- a/libc/src/math/generic/atanhf.cpp
+++ b/libc/src/math/generic/atanhf.cpp
@@ -33,7 +33,7 @@ LLVM_LIBC_FUNCTION(float, atanhf, (float x)) {
     } else {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits::build_quiet_nan().get_val();
+      return FPBits::quiet_nan().get_val();
     }
   }
 

--- a/libc/src/math/generic/cosf.cpp
+++ b/libc/src/math/generic/cosf.cpp
@@ -118,7 +118,7 @@ LLVM_LIBC_FUNCTION(float, cosf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return x + FPBits::build_quiet_nan().get_val();
+    return x + FPBits::quiet_nan().get_val();
   }
 
   // Combine the results with the sine of sum formula:

--- a/libc/src/math/generic/log.cpp
+++ b/libc/src/math/generic/log.cpp
@@ -754,7 +754,7 @@ LLVM_LIBC_FUNCTION(double, log, (double x)) {
     if (xbits.is_neg() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan().get_val();
+      return FPBits_t::quiet_nan().get_val();
     }
     if (xbits.is_inf_or_nan()) {
       return x;

--- a/libc/src/math/generic/log10.cpp
+++ b/libc/src/math/generic/log10.cpp
@@ -755,7 +755,7 @@ LLVM_LIBC_FUNCTION(double, log10, (double x)) {
     if (xbits.is_neg() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan().get_val();
+      return FPBits_t::quiet_nan().get_val();
     }
     if (xbits.is_inf_or_nan()) {
       return x;

--- a/libc/src/math/generic/log10f.cpp
+++ b/libc/src/math/generic/log10f.cpp
@@ -173,7 +173,7 @@ LLVM_LIBC_FUNCTION(float, log10f, (float x)) {
       // Return NaN and raise FE_INVALID
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits::build_quiet_nan().get_val();
+      return FPBits::quiet_nan().get_val();
     }
     if (xbits.is_inf_or_nan()) {
       return x;

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -900,7 +900,7 @@ LLVM_LIBC_FUNCTION(double, log1p, (double x)) {
           // x < -1.0
           fputil::set_errno_if_required(EDOM);
           fputil::raise_except_if_required(FE_INVALID);
-          return FPBits_t::build_quiet_nan().get_val();
+          return FPBits_t::quiet_nan().get_val();
         }
         // x is +Inf or NaN
         return x;

--- a/libc/src/math/generic/log1pf.cpp
+++ b/libc/src/math/generic/log1pf.cpp
@@ -47,7 +47,7 @@ LIBC_INLINE float log(double x) {
     if (xbits.is_neg() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return fputil::FPBits<float>::build_quiet_nan().get_val();
+      return fputil::FPBits<float>::quiet_nan().get_val();
     }
     return static_cast<float>(x);
   }

--- a/libc/src/math/generic/log2.cpp
+++ b/libc/src/math/generic/log2.cpp
@@ -876,7 +876,7 @@ LLVM_LIBC_FUNCTION(double, log2, (double x)) {
     if (xbits.is_neg() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
-      return FPBits_t::build_quiet_nan().get_val();
+      return FPBits_t::quiet_nan().get_val();
     }
     if (xbits.is_inf_or_nan()) {
       return x;

--- a/libc/src/math/generic/log2f.cpp
+++ b/libc/src/math/generic/log2f.cpp
@@ -79,7 +79,7 @@ LLVM_LIBC_FUNCTION(float, log2f, (float x)) {
     if (xbits.is_neg() && !xbits.is_nan()) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except(FE_INVALID);
-      return FPBits::build_quiet_nan().get_val();
+      return FPBits::quiet_nan().get_val();
     }
     if (xbits.is_inf_or_nan()) {
       return x;

--- a/libc/src/math/generic/logf.cpp
+++ b/libc/src/math/generic/logf.cpp
@@ -124,7 +124,7 @@ LLVM_LIBC_FUNCTION(float, logf, (float x)) {
         // Return NaN and raise FE_INVALID
         fputil::set_errno_if_required(EDOM);
         fputil::raise_except_if_required(FE_INVALID);
-        return FPBits::build_quiet_nan().get_val();
+        return FPBits::quiet_nan().get_val();
       }
       // x is +inf or nan
       return x;

--- a/libc/src/math/generic/powf.cpp
+++ b/libc/src/math/generic/powf.cpp
@@ -657,7 +657,7 @@ LLVM_LIBC_FUNCTION(float, powf, (float x, float y)) {
         // pow( negative, non-integer ) = NaN
         fputil::set_errno_if_required(EDOM);
         fputil::raise_except_if_required(FE_INVALID);
-        return FloatBits::build_quiet_nan().get_val();
+        return FloatBits::quiet_nan().get_val();
       }
     }
   }

--- a/libc/src/math/generic/sincosf.cpp
+++ b/libc/src/math/generic/sincosf.cpp
@@ -148,7 +148,7 @@ LLVM_LIBC_FUNCTION(void, sincosf, (float x, float *sinp, float *cosp)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    *sinp = FPBits::build_quiet_nan().get_val();
+    *sinp = FPBits::quiet_nan().get_val();
     *cosp = *sinp;
     return;
   }

--- a/libc/src/math/generic/sinf.cpp
+++ b/libc/src/math/generic/sinf.cpp
@@ -139,7 +139,7 @@ LLVM_LIBC_FUNCTION(float, sinf, (float x)) {
       fputil::set_errno_if_required(EDOM);
       fputil::raise_except_if_required(FE_INVALID);
     }
-    return x + FPBits::build_quiet_nan().get_val();
+    return x + FPBits::quiet_nan().get_val();
   }
 
   // Combine the results with the sine of sum formula:

--- a/libc/src/math/generic/tanf.cpp
+++ b/libc/src/math/generic/tanf.cpp
@@ -114,7 +114,7 @@ LLVM_LIBC_FUNCTION(float, tanf, (float x)) {
         fputil::set_errno_if_required(EDOM);
         fputil::raise_except_if_required(FE_INVALID);
       }
-      return x + FPBits::build_quiet_nan().get_val();
+      return x + FPBits::quiet_nan().get_val();
     }
     // Other large exceptional values
     if (auto r = TANF_EXCEPTS.lookup_odd(x_abs, x_sign);

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -69,7 +69,7 @@ template <typename T> struct FPTest : public Test {
   static constexpr T zero = FPBits::zero(Sign::POS).get_val();
   static constexpr T neg_zero = FPBits::zero(Sign::NEG).get_val();
   static constexpr T aNaN = FPBits::build_quiet_nan().get_val();
-  static constexpr T sNaN = FPBits::build_signaling_nan().get_val();
+  static constexpr T sNaN = FPBits::signaling_nan().get_val();
   static constexpr T inf = FPBits::inf(Sign::POS).get_val();
   static constexpr T neg_inf = FPBits::inf(Sign::NEG).get_val();
   static constexpr T min_normal = FPBits::min_normal().get_val();
@@ -98,7 +98,7 @@ template <typename T> struct FPTest : public Test {
   const T zero = FPBits::zero(Sign::POS).get_val();                            \
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();                        \
   const T aNaN = FPBits::build_quiet_nan().get_val();                          \
-  const T sNaN = FPBits::build_signaling_nan().get_val();                      \
+  const T sNaN = FPBits::signaling_nan().get_val();                            \
   const T inf = FPBits::inf(Sign::POS).get_val();                              \
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();                          \
   const T min_normal = FPBits::min_normal().get_val();                         \

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -69,7 +69,7 @@ template <typename T> struct FPTest : public Test {
   static constexpr T zero = FPBits::zero(Sign::POS).get_val();
   static constexpr T neg_zero = FPBits::zero(Sign::NEG).get_val();
   static constexpr T aNaN = FPBits::build_quiet_nan().get_val();
-  static constexpr T sNaN = FPBits::build_nan().get_val();
+  static constexpr T sNaN = FPBits::build_signaling_nan().get_val();
   static constexpr T inf = FPBits::inf(Sign::POS).get_val();
   static constexpr T neg_inf = FPBits::inf(Sign::NEG).get_val();
   static constexpr T min_normal = FPBits::min_normal().get_val();
@@ -98,7 +98,7 @@ template <typename T> struct FPTest : public Test {
   const T zero = FPBits::zero(Sign::POS).get_val();                            \
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();                        \
   const T aNaN = FPBits::build_quiet_nan().get_val();                          \
-  const T sNaN = FPBits::build_nan().get_val();                                \
+  const T sNaN = FPBits::build_signaling_nan().get_val();                      \
   const T inf = FPBits::inf(Sign::POS).get_val();                              \
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();                          \
   const T min_normal = FPBits::min_normal().get_val();                         \

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -68,7 +68,7 @@ template <typename T> struct FPTest : public Test {
       LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();
   static constexpr T zero = FPBits::zero(Sign::POS).get_val();
   static constexpr T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  static constexpr T aNaN = FPBits::build_quiet_nan().get_val();
+  static constexpr T aNaN = FPBits::quiet_nan().get_val();
   static constexpr T sNaN = FPBits::signaling_nan().get_val();
   static constexpr T inf = FPBits::inf(Sign::POS).get_val();
   static constexpr T neg_inf = FPBits::inf(Sign::NEG).get_val();
@@ -97,7 +97,7 @@ template <typename T> struct FPTest : public Test {
       LIBC_NAMESPACE::cpp::numeric_limits<StorageType>::max();                 \
   const T zero = FPBits::zero(Sign::POS).get_val();                            \
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();                        \
-  const T aNaN = FPBits::build_quiet_nan().get_val();                          \
+  const T aNaN = FPBits::quiet_nan().get_val();                                \
   const T sNaN = FPBits::signaling_nan().get_val();                            \
   const T inf = FPBits::inf(Sign::POS).get_val();                              \
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();                          \

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -26,7 +26,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary16) {
   EXPECT_EQ(u16(0b0'00001'0000000000), u16(Rep::min_normal()));
   EXPECT_EQ(u16(0b0'11110'1111111111), u16(Rep::max_normal()));
   EXPECT_EQ(u16(0b0'11111'0000000000), u16(Rep::inf()));
-  EXPECT_EQ(u16(0b0'11111'0100000000), u16(Rep::build_signaling_nan()));
+  EXPECT_EQ(u16(0b0'11111'0100000000), u16(Rep::signaling_nan()));
   EXPECT_EQ(u16(0b0'11111'1000000000), u16(Rep::build_quiet_nan()));
 }
 
@@ -44,7 +44,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary32) {
   EXPECT_EQ(u32(0b0'11111110'11111111111111111111111), u32(Rep::max_normal()));
   EXPECT_EQ(u32(0b0'11111111'00000000000000000000000), u32(Rep::inf()));
   EXPECT_EQ(u32(0b0'11111111'01000000000000000000000),
-            u32(Rep::build_signaling_nan()));
+            u32(Rep::signaling_nan()));
   EXPECT_EQ(u32(0b0'11111111'10000000000000000000000),
             u32(Rep::build_quiet_nan()));
 }
@@ -76,7 +76,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary64) {
       u64(Rep::inf()));
   EXPECT_EQ(
       u64(0b0'11111111111'0100000000000000000000000000000000000000000000000000),
-      u64(Rep::build_signaling_nan()));
+      u64(Rep::signaling_nan()));
   EXPECT_EQ(
       u64(0b0'11111111111'1000000000000000000000000000000000000000000000000000),
       u64(Rep::build_quiet_nan()));
@@ -124,7 +124,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary128) {
   EXPECT_EQ(
       u128(0b0'111111111111111'010000000000000000000000000000000000000000000000,
            0b0000000000000000000000000000000000000000000000000000000000000000),
-      UInt128(Rep::build_signaling_nan()));
+      UInt128(Rep::signaling_nan()));
   EXPECT_EQ(
       u128(0b0'111111111111111'100000000000000000000000000000000000000000000000,
            0b0000000000000000000000000000000000000000000000000000000000000000),
@@ -165,7 +165,7 @@ TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80) {
   EXPECT_EQ(
       u128(0b0'111111111111111,
            0b1010000000000000000000000000000000000000000000000000000000000000),
-      UInt128(Rep::build_signaling_nan()));
+      UInt128(Rep::signaling_nan()));
   EXPECT_EQ(
       u128(0b0'111111111111111,
            0b1100000000000000000000000000000000000000000000000000000000000000),
@@ -256,7 +256,7 @@ TYPED_TEST(LlvmLibcFPBitsTest, Properties, FPTypes) {
     case FP::INF:
       return T::inf(sign);
     case FP::SIGNALING_NAN:
-      return T::build_signaling_nan(sign);
+      return T::signaling_nan(sign);
     case FP::QUIET_NAN:
       return T::build_quiet_nan(sign);
     }
@@ -314,7 +314,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
                "(+Infinity)");
   EXPECT_STREQ(LIBC_NAMESPACE::str(FloatBits::inf(Sign::NEG)).c_str(),
                "(-Infinity)");
-  EXPECT_STREQ(LIBC_NAMESPACE::str(FloatBits::build_signaling_nan()).c_str(),
+  EXPECT_STREQ(LIBC_NAMESPACE::str(FloatBits::signaling_nan()).c_str(),
                "(NaN)");
 
   FloatBits zero(0.0f);
@@ -376,7 +376,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
                "(+Infinity)");
   EXPECT_STREQ(LIBC_NAMESPACE::str(DoubleBits::inf(Sign::NEG)).c_str(),
                "(-Infinity)");
-  EXPECT_STREQ(LIBC_NAMESPACE::str(DoubleBits::build_signaling_nan()).c_str(),
+  EXPECT_STREQ(LIBC_NAMESPACE::str(DoubleBits::signaling_nan()).c_str(),
                "(NaN)");
 
   DoubleBits zero(0.0);
@@ -442,9 +442,8 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
                "(+Infinity)");
   EXPECT_STREQ(LIBC_NAMESPACE::str(LongDoubleBits::inf(Sign::NEG)).c_str(),
                "(-Infinity)");
-  EXPECT_STREQ(
-      LIBC_NAMESPACE::str(LongDoubleBits::build_signaling_nan()).c_str(),
-      "(NaN)");
+  EXPECT_STREQ(LIBC_NAMESPACE::str(LongDoubleBits::signaling_nan()).c_str(),
+               "(NaN)");
 
   LongDoubleBits zero(0.0l);
   EXPECT_TRUE(zero.is_pos());
@@ -523,9 +522,8 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
                "(+Infinity)");
   EXPECT_STREQ(LIBC_NAMESPACE::str(LongDoubleBits::inf(Sign::NEG)).c_str(),
                "(-Infinity)");
-  EXPECT_STREQ(
-      LIBC_NAMESPACE::str(LongDoubleBits::build_signaling_nan()).c_str(),
-      "(NaN)");
+  EXPECT_STREQ(LIBC_NAMESPACE::str(LongDoubleBits::signaling_nan()).c_str(),
+               "(NaN)");
 
   LongDoubleBits zero(0.0l);
   EXPECT_TRUE(zero.is_pos());
@@ -598,7 +596,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
                "(+Infinity)");
   EXPECT_STREQ(LIBC_NAMESPACE::str(Float128Bits::inf(Sign::NEG)).c_str(),
                "(-Infinity)");
-  EXPECT_STREQ(LIBC_NAMESPACE::str(Float128Bits::build_signaling_nan()).c_str(),
+  EXPECT_STREQ(LIBC_NAMESPACE::str(Float128Bits::signaling_nan()).c_str(),
                "(NaN)");
 
   Float128Bits zero = Float128Bits::zero(Sign::POS);

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -27,7 +27,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary16) {
   EXPECT_EQ(u16(0b0'11110'1111111111), u16(Rep::max_normal()));
   EXPECT_EQ(u16(0b0'11111'0000000000), u16(Rep::inf()));
   EXPECT_EQ(u16(0b0'11111'0100000000), u16(Rep::signaling_nan()));
-  EXPECT_EQ(u16(0b0'11111'1000000000), u16(Rep::build_quiet_nan()));
+  EXPECT_EQ(u16(0b0'11111'1000000000), u16(Rep::quiet_nan()));
 }
 
 TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary32) {
@@ -45,8 +45,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary32) {
   EXPECT_EQ(u32(0b0'11111111'00000000000000000000000), u32(Rep::inf()));
   EXPECT_EQ(u32(0b0'11111111'01000000000000000000000),
             u32(Rep::signaling_nan()));
-  EXPECT_EQ(u32(0b0'11111111'10000000000000000000000),
-            u32(Rep::build_quiet_nan()));
+  EXPECT_EQ(u32(0b0'11111111'10000000000000000000000), u32(Rep::quiet_nan()));
 }
 
 TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary64) {
@@ -79,7 +78,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary64) {
       u64(Rep::signaling_nan()));
   EXPECT_EQ(
       u64(0b0'11111111111'1000000000000000000000000000000000000000000000000000),
-      u64(Rep::build_quiet_nan()));
+      u64(Rep::quiet_nan()));
 }
 
 static constexpr UInt128 u128(uint64_t hi, uint64_t lo) {
@@ -128,7 +127,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary128) {
   EXPECT_EQ(
       u128(0b0'111111111111111'100000000000000000000000000000000000000000000000,
            0b0000000000000000000000000000000000000000000000000000000000000000),
-      UInt128(Rep::build_quiet_nan()));
+      UInt128(Rep::quiet_nan()));
 }
 
 TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80) {
@@ -169,7 +168,7 @@ TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80) {
   EXPECT_EQ(
       u128(0b0'111111111111111,
            0b1100000000000000000000000000000000000000000000000000000000000000),
-      UInt128(Rep::build_quiet_nan()));
+      UInt128(Rep::quiet_nan()));
 }
 
 TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80_IsNan) {
@@ -258,7 +257,7 @@ TYPED_TEST(LlvmLibcFPBitsTest, Properties, FPTypes) {
     case FP::SIGNALING_NAN:
       return T::signaling_nan(sign);
     case FP::QUIET_NAN:
-      return T::build_quiet_nan(sign);
+      return T::quiet_nan(sign);
     }
   };
   static constexpr auto make = [](Sign sign, FP fp) -> T {
@@ -365,7 +364,7 @@ TEST(LlvmLibcFPBitsTest, FloatType) {
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),
                "0xBF900000 = (S: 1, E: 0x007F, M: 0x00100000)");
 
-  FloatBits quiet_nan = FloatBits::build_quiet_nan();
+  FloatBits quiet_nan = FloatBits::quiet_nan();
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 }
 
@@ -427,7 +426,7 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
   EXPECT_STREQ(LIBC_NAMESPACE::str(negnum).c_str(),
                "0xBFF2000000000000 = (S: 1, E: 0x03FF, M: 0x0002000000000000)");
 
-  DoubleBits quiet_nan = DoubleBits::build_quiet_nan();
+  DoubleBits quiet_nan = DoubleBits::quiet_nan();
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 }
 
@@ -508,7 +507,7 @@ TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
       "0x000000000000BFFF9000000000000000 = "
       "(S: 1, E: 0x3FFF, I: 1, M: 0x00000000000000001000000000000000)");
 
-  LongDoubleBits quiet_nan = LongDoubleBits::build_quiet_nan();
+  LongDoubleBits quiet_nan = LongDoubleBits::quiet_nan();
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 }
 #else
@@ -582,7 +581,7 @@ TEST(LlvmLibcFPBitsTest, LongDoubleType) {
                "0xBFFF2000000000000000000000000000 = "
                "(S: 1, E: 0x3FFF, M: 0x00002000000000000000000000000000)");
 
-  LongDoubleBits quiet_nan = LongDoubleBits::build_quiet_nan();
+  LongDoubleBits quiet_nan = LongDoubleBits::quiet_nan();
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 #endif
 }
@@ -656,7 +655,7 @@ TEST(LlvmLibcFPBitsTest, Float128Type) {
                "0xBFFF2000000000000000000000000000 = "
                "(S: 1, E: 0x3FFF, M: 0x00002000000000000000000000000000)");
 
-  Float128Bits quiet_nan = Float128Bits::build_quiet_nan();
+  Float128Bits quiet_nan = Float128Bits::quiet_nan();
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 }
 #endif // LIBC_COMPILER_HAS_FLOAT128

--- a/libc/test/src/math/FDimTest.h
+++ b/libc/test/src/math/FDimTest.h
@@ -24,7 +24,7 @@ public:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   void test_na_n_arg(FuncPtr func) {
     EXPECT_FP_EQ(nan, func(nan, inf));

--- a/libc/test/src/math/FmaTest.h
+++ b/libc/test/src/math/FmaTest.h
@@ -32,7 +32,7 @@ private:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType MAX_NORMAL = FPBits::max_normal().uintval();
   static constexpr StorageType MIN_NORMAL = FPBits::min_normal().uintval();

--- a/libc/test/src/math/HypotTest.h
+++ b/libc/test/src/math/HypotTest.h
@@ -25,7 +25,7 @@ private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using Sign = LIBC_NAMESPACE::fputil::Sign;
   using StorageType = typename FPBits::StorageType;
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
   const T inf = FPBits::inf().get_val();
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero().get_val();

--- a/libc/test/src/math/ILogbTest.h
+++ b/libc/test/src/math/ILogbTest.h
@@ -27,7 +27,7 @@ public:
     using Sign = LIBC_NAMESPACE::fputil::Sign;
     EXPECT_EQ(FP_ILOGB0, func(FPBits::zero(Sign::POS).get_val()));
     EXPECT_EQ(FP_ILOGB0, func(FPBits::zero(Sign::NEG).get_val()));
-    EXPECT_EQ(FP_ILOGBNAN, func(FPBits::build_quiet_nan().get_val()));
+    EXPECT_EQ(FP_ILOGBNAN, func(FPBits::quiet_nan().get_val()));
     EXPECT_EQ(INT_MAX, func(FPBits::inf(Sign::POS).get_val()));
     EXPECT_EQ(INT_MAX, func(FPBits::inf(Sign::NEG).get_val()));
   }

--- a/libc/test/src/math/LdExpTest.h
+++ b/libc/test/src/math/LdExpTest.h
@@ -29,7 +29,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   // A normalized mantissa to be used with tests.
   static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;

--- a/libc/test/src/math/NextAfterTest.h
+++ b/libc/test/src/math/NextAfterTest.h
@@ -27,7 +27,7 @@ class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   const StorageType min_subnormal = FPBits::min_subnormal().uintval();
   const StorageType max_subnormal = FPBits::max_subnormal().uintval();

--- a/libc/test/src/math/RIntTest.h
+++ b/libc/test/src/math/RIntTest.h
@@ -38,7 +38,7 @@ private:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType MIN_SUBNORMAL =
       FPBits::min_subnormal().uintval();

--- a/libc/test/src/math/RemQuoTest.h
+++ b/libc/test/src/math/RemQuoTest.h
@@ -28,7 +28,7 @@ class RemQuoTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType MIN_SUBNORMAL =
       FPBits::min_subnormal().uintval();

--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -37,7 +37,7 @@ private:
   const F neg_zero = FPBits::zero(Sign::NEG).get_val();
   const F inf = FPBits::inf().get_val();
   const F neg_inf = FPBits::inf(Sign::NEG).get_val();
-  const F nan = FPBits::build_quiet_nan().get_val();
+  const F nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType MAX_NORMAL = FPBits::max_normal().uintval();
   static constexpr StorageType MIN_NORMAL = FPBits::min_normal().uintval();

--- a/libc/test/src/math/smoke/FDimTest.h
+++ b/libc/test/src/math/smoke/FDimTest.h
@@ -24,7 +24,7 @@ public:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   void test_na_n_arg(FuncPtr func) {
     EXPECT_FP_EQ(nan, func(nan, inf));

--- a/libc/test/src/math/smoke/FmaTest.h
+++ b/libc/test/src/math/smoke/FmaTest.h
@@ -25,7 +25,7 @@ private:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
 public:
   void test_special_numbers(Func func) {

--- a/libc/test/src/math/smoke/HypotTest.h
+++ b/libc/test/src/math/smoke/HypotTest.h
@@ -22,7 +22,7 @@ private:
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
   using StorageType = typename FPBits::StorageType;
   using Sign = LIBC_NAMESPACE::fputil::Sign;
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
   const T inf = FPBits::inf(Sign::POS).get_val();
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();

--- a/libc/test/src/math/smoke/ILogbTest.h
+++ b/libc/test/src/math/smoke/ILogbTest.h
@@ -27,7 +27,7 @@ public:
     using Sign = LIBC_NAMESPACE::fputil::Sign;
     EXPECT_EQ(FP_ILOGB0, func(FPBits::zero(Sign::POS).get_val()));
     EXPECT_EQ(FP_ILOGB0, func(FPBits::zero(Sign::NEG).get_val()));
-    EXPECT_EQ(FP_ILOGBNAN, func(FPBits::build_quiet_nan().get_val()));
+    EXPECT_EQ(FP_ILOGBNAN, func(FPBits::quiet_nan().get_val()));
     EXPECT_EQ(INT_MAX, func(FPBits::inf(Sign::POS).get_val()));
     EXPECT_EQ(INT_MAX, func(FPBits::inf(Sign::NEG).get_val()));
   }

--- a/libc/test/src/math/smoke/LdExpTest.h
+++ b/libc/test/src/math/smoke/LdExpTest.h
@@ -29,7 +29,7 @@ class LdExpTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   // A normalized mantissa to be used with tests.
   static constexpr StorageType MANTISSA = NormalFloat::ONE + 0x1234;

--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -38,7 +38,7 @@ class NextAfterTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType min_subnormal =
       FPBits::min_subnormal().uintval();

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -40,11 +40,11 @@ class NextTowardTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
   const long double to_zero = ToFPBits::zero().get_val();
   const long double to_neg_zero = ToFPBits::zero(Sign::NEG).get_val();
-  const long double to_nan = ToFPBits::build_quiet_nan().get_val();
+  const long double to_nan = ToFPBits::quiet_nan().get_val();
 
   static constexpr StorageType min_subnormal =
       FPBits::min_subnormal().uintval();

--- a/libc/test/src/math/smoke/RIntTest.h
+++ b/libc/test/src/math/smoke/RIntTest.h
@@ -35,7 +35,7 @@ private:
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
 public:
   void testSpecialNumbers(RIntFunc func) {

--- a/libc/test/src/math/smoke/RemQuoTest.h
+++ b/libc/test/src/math/smoke/RemQuoTest.h
@@ -25,7 +25,7 @@ class RemQuoTestTemplate : public LIBC_NAMESPACE::testing::Test {
   const T neg_inf = FPBits::inf(Sign::NEG).get_val();
   const T zero = FPBits::zero(Sign::POS).get_val();
   const T neg_zero = FPBits::zero(Sign::NEG).get_val();
-  const T nan = FPBits::build_quiet_nan().get_val();
+  const T nan = FPBits::quiet_nan().get_val();
 
 public:
   typedef T (*RemQuoFunc)(T, T, int *);

--- a/libc/test/src/math/smoke/RoundToIntegerTest.h
+++ b/libc/test/src/math/smoke/RoundToIntegerTest.h
@@ -34,7 +34,7 @@ private:
   const F neg_zero = FPBits::zero(Sign::NEG).get_val();
   const F inf = FPBits::inf(Sign::POS).get_val();
   const F neg_inf = FPBits::inf(Sign::NEG).get_val();
-  const F nan = FPBits::build_quiet_nan().get_val();
+  const F nan = FPBits::quiet_nan().get_val();
 
   static constexpr StorageType MAX_SUBNORMAL =
       FPBits::max_subnormal().uintval();

--- a/libc/test/src/stdio/sprintf_test.cpp
+++ b/libc/test/src/stdio/sprintf_test.cpp
@@ -586,8 +586,7 @@ TEST(LlvmLibcSPrintfTest, OctConv) {
 TEST_F(LlvmLibcSPrintfTest, FloatHexExpConv) {
   ForceRoundingMode r(RoundingMode::Nearest);
   double inf = LIBC_NAMESPACE::fputil::FPBits<double>::inf().get_val();
-  double nan =
-      LIBC_NAMESPACE::fputil::FPBits<double>::build_quiet_nan().get_val();
+  double nan = LIBC_NAMESPACE::fputil::FPBits<double>::quiet_nan().get_val();
   written = LIBC_NAMESPACE::sprintf(buff, "%a", 1.0);
   ASSERT_STREQ_LEN(written, buff, "0x1p+0");
 
@@ -951,12 +950,11 @@ TEST_F(LlvmLibcSPrintfTest, FloatHexExpConv) {
 TEST_F(LlvmLibcSPrintfTest, FloatDecimalConv) {
   ForceRoundingMode r(RoundingMode::Nearest);
   double inf = LIBC_NAMESPACE::fputil::FPBits<double>::inf().get_val();
-  double nan =
-      LIBC_NAMESPACE::fputil::FPBits<double>::build_quiet_nan().get_val();
+  double nan = LIBC_NAMESPACE::fputil::FPBits<double>::quiet_nan().get_val();
   long double ld_inf =
       LIBC_NAMESPACE::fputil::FPBits<long double>::inf().get_val();
   long double ld_nan =
-      LIBC_NAMESPACE::fputil::FPBits<long double>::build_quiet_nan().get_val();
+      LIBC_NAMESPACE::fputil::FPBits<long double>::quiet_nan().get_val();
 
   char big_buff[10000]; // Used for long doubles and other extremely wide
                         // numbers.
@@ -1805,8 +1803,7 @@ TEST_F(LlvmLibcSPrintfTest, FloatDecimalLongDoubleConv) {
 TEST_F(LlvmLibcSPrintfTest, FloatExponentConv) {
   ForceRoundingMode r(RoundingMode::Nearest);
   double inf = LIBC_NAMESPACE::fputil::FPBits<double>::inf().get_val();
-  double nan =
-      LIBC_NAMESPACE::fputil::FPBits<double>::build_quiet_nan().get_val();
+  double nan = LIBC_NAMESPACE::fputil::FPBits<double>::quiet_nan().get_val();
 
   written = LIBC_NAMESPACE::sprintf(buff, "%e", 1.0);
   ASSERT_STREQ_LEN(written, buff, "1.000000e+00");
@@ -2413,8 +2410,7 @@ TEST_F(LlvmLibcSPrintfTest, FloatExponentLongDoubleConv) {
 TEST_F(LlvmLibcSPrintfTest, FloatAutoConv) {
   ForceRoundingMode r(RoundingMode::Nearest);
   double inf = LIBC_NAMESPACE::fputil::FPBits<double>::inf().get_val();
-  double nan =
-      LIBC_NAMESPACE::fputil::FPBits<double>::build_quiet_nan().get_val();
+  double nan = LIBC_NAMESPACE::fputil::FPBits<double>::quiet_nan().get_val();
 
   written = LIBC_NAMESPACE::sprintf(buff, "%g", 1.0);
   ASSERT_STREQ_LEN(written, buff, "1");

--- a/libc/test/src/stdio/sscanf_test.cpp
+++ b/libc/test/src/stdio/sscanf_test.cpp
@@ -231,8 +231,7 @@ TEST(LlvmLibcSScanfTest, FloatConvSimple) {
   float result = 0;
 
   float inf = LIBC_NAMESPACE::fputil::FPBits<float>::inf().get_val();
-  float nan =
-      LIBC_NAMESPACE::fputil::FPBits<float>::build_quiet_nan().get_val();
+  float nan = LIBC_NAMESPACE::fputil::FPBits<float>::quiet_nan().get_val();
 
   ret_val = LIBC_NAMESPACE::sscanf("123", "%f", &result);
   EXPECT_EQ(ret_val, 1);
@@ -297,7 +296,7 @@ TEST(LlvmLibcSScanfTest, FloatConvLengthModifier) {
 
   double d_inf = LIBC_NAMESPACE::fputil::FPBits<double>::inf().get_val();
   long double ld_nan =
-      LIBC_NAMESPACE::fputil::FPBits<long double>::build_quiet_nan().get_val();
+      LIBC_NAMESPACE::fputil::FPBits<long double>::quiet_nan().get_val();
 
   ret_val = LIBC_NAMESPACE::sscanf("123", "%lf", &d_result);
   EXPECT_EQ(ret_val, 1);
@@ -393,8 +392,7 @@ TEST(LlvmLibcSScanfTest, FloatConvComplexParsing) {
   float result = 0;
 
   float inf = LIBC_NAMESPACE::fputil::FPBits<float>::inf().get_val();
-  float nan =
-      LIBC_NAMESPACE::fputil::FPBits<float>::build_quiet_nan().get_val();
+  float nan = LIBC_NAMESPACE::fputil::FPBits<float>::quiet_nan().get_val();
 
   ret_val = LIBC_NAMESPACE::sscanf("0x1.0e3", "%f", &result);
   EXPECT_EQ(ret_val, 1);


### PR DESCRIPTION
- [libc][NFC] Rename FPBits nan functions
- rename build_signaling_nan in signaling_nan
- rename build_quiet_nan to quiet_nan
