### PR TITLE
[libc++] Move __libcpp_timespec_t into namespace std

### DIFF
--- a/libcxx/include/__thread/support.h
+++ b/libcxx/include/__thread/support.h
@@ -23,6 +23,8 @@
 // The following functionality must be provided by any implementation:
 //
 
+_LIBCPP_BEGIN_NAMESPACE_STD
+
 using __libcpp_timespec_t = ...;
 
 //
@@ -97,6 +99,8 @@ using __libcpp_tls_key = ...;
 int __libcpp_tls_create(__libcpp_tls_key*, void (*__at_exit)(void*));
 void* __libcpp_tls_get(__libcpp_tls_key);
 int __libcpp_tls_set(__libcpp_tls_key, void*);
+
+_LIBCPP_END_NAMESPACE_STD
 
 */
 

--- a/libcxx/include/__thread/support/c11.h
+++ b/libcxx/include/__thread/support/c11.h
@@ -20,9 +20,9 @@
 #  pragma GCC system_header
 #endif
 
-typedef ::timespec __libcpp_timespec_t;
-
 _LIBCPP_BEGIN_NAMESPACE_STD
+
+using __libcpp_timespec_t = ::timespec;
 
 //
 // Mutex

--- a/libcxx/include/__thread/support/pthread.h
+++ b/libcxx/include/__thread/support/pthread.h
@@ -36,9 +36,9 @@
 #  pragma GCC system_header
 #endif
 
-typedef ::timespec __libcpp_timespec_t;
-
 _LIBCPP_BEGIN_NAMESPACE_STD
+
+using __libcpp_timespec_t = ::timespec;
 
 //
 // Mutex

--- a/libcxx/include/__thread/support/windows.h
+++ b/libcxx/include/__thread/support/windows.h
@@ -18,9 +18,9 @@
 #  pragma GCC system_header
 #endif
 
-typedef ::timespec __libcpp_timespec_t;
-
 _LIBCPP_BEGIN_NAMESPACE_STD
+
+using __libcpp_timespec_t = ::timespec;
 
 //
 // Mutex


### PR DESCRIPTION
It was previously defined outside of namespace std for apparently no good reason.