### PR TITLE
[clang] Fix a possible out-of-bounds read

### DIFF
--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1251,7 +1251,7 @@ highlightLines(StringRef FileData, unsigned StartLineNumber,
     unsigned LineLength = 0;
     for (unsigned I = 0; I <= Spelling.size(); ++I) {
       // This line is done.
-      if (isVerticalWhitespace(Spelling[I]) || I == Spelling.size()) {
+      if (I == Spelling.size() || isVerticalWhitespace(Spelling[I])) {
         SmallVector<TextDiagnostic::StyleRange> &LineRanges =
             SnippetRanges[L - StartLineNumber];
 


### PR DESCRIPTION
Switch to using `std::string::at()` since that seems to assert the given index is in range (when such assertions are enabled).

Fixes #79964