### PR TITLE
[clang][dataflow] Drop block-relative cap on worklist iterations.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -540,14 +540,6 @@ runTypeErasedDataflowAnalysis(
   Worklist.enqueueSuccessors(&Entry);
 
   AnalysisContext AC(CFCtx, Analysis, StartingEnv, BlockStates);
-
-  // FIXME: remove relative cap. There isn't really any good setting for
-  // `MaxAverageVisitsPerBlock`, so it has no clear value over using
-  // `MaxBlockVisits` directly.
-  static constexpr std::int32_t MaxAverageVisitsPerBlock = 4;
-  const std::int32_t RelativeMaxBlockVisits =
-      MaxAverageVisitsPerBlock * BlockStates.size();
-  MaxBlockVisits = std::min(RelativeMaxBlockVisits, MaxBlockVisits);
   std::int32_t BlockVisits = 0;
   while (const CFGBlock *Block = Worklist.dequeue()) {
     LLVM_DEBUG(llvm::dbgs()


### PR DESCRIPTION
As per the FIXME, this cap never really served its purpose. This patch
simplifies to a single, caller-specified, absolute cap.
