### PR TITLE
[AArch64][GlobalISel] Legalize BSWAP for Vector Types

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -5166,6 +5166,18 @@ def : Pat<(v8i16 (concat_vectors
                                            (v4i32 VImm8000)))))),
           (SQXTNv8i16 (INSERT_SUBREG (IMPLICIT_DEF), V64:$Vd, dsub), V128:$Vn)>;
 
+// Select BSWAP vector instructions into REV instructions
+def : Pat<(v4i16 (bswap (v4i16 V64:$Rn))), 
+          (v4i16 (REV16v8i8 (v4i16 V64:$Rn)))>;
+def : Pat<(v8i16 (bswap (v8i16 V128:$Rn))), 
+          (v8i16 (REV16v16i8 (v8i16 V128:$Rn)))>;
+def : Pat<(v2i32 (bswap (v2i32 V64:$Rn))), 
+          (v2i32 (REV32v8i8 (v2i32 V64:$Rn)))>;
+def : Pat<(v4i32 (bswap (v4i32 V128:$Rn))), 
+          (v4i32 (REV32v16i8 (v4i32 V128:$Rn)))>;
+def : Pat<(v2i64 (bswap (v2i64 V128:$Rn))), 
+          (v2i64 (REV64v16i8 (v2i64 V128:$Rn)))>;
+
 //===----------------------------------------------------------------------===//
 // Advanced SIMD three vector instructions.
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -2567,43 +2567,6 @@ bool AArch64InstructionSelector::select(MachineInstr &I) {
     return constrainSelectedInstRegOperands(*MovAddr, TII, TRI, RBI);
   }
 
-  case TargetOpcode::G_BSWAP: {
-    // Handle vector types for G_BSWAP directly.
-    Register DstReg = I.getOperand(0).getReg();
-    LLT DstTy = MRI.getType(DstReg);
-
-    // We should only get vector types here; everything else is handled by the
-    // importer right now.
-    if (!DstTy.isVector() || DstTy.getSizeInBits() > 128) {
-      LLVM_DEBUG(dbgs() << "Dst type for G_BSWAP currently unsupported.\n");
-      return false;
-    }
-
-    // Only handle 4 and 2 element vectors for now.
-    // TODO: 16-bit elements.
-    unsigned NumElts = DstTy.getNumElements();
-    if (NumElts != 4 && NumElts != 2) {
-      LLVM_DEBUG(dbgs() << "Unsupported number of elements for G_BSWAP.\n");
-      return false;
-    }
-
-    // Choose the correct opcode for the supported types. Right now, that's
-    // v2s32, v4s32, and v2s64.
-    unsigned Opc = 0;
-    unsigned EltSize = DstTy.getElementType().getSizeInBits();
-    if (EltSize == 32)
-      Opc = (DstTy.getNumElements() == 2) ? AArch64::REV32v8i8
-                                          : AArch64::REV32v16i8;
-    else if (EltSize == 64)
-      Opc = AArch64::REV64v16i8;
-
-    // We should always get something by the time we get here...
-    assert(Opc != 0 && "Didn't get an opcode for G_BSWAP?");
-
-    I.setDesc(TII.get(Opc));
-    return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
-  }
-
   case TargetOpcode::G_FCONSTANT:
   case TargetOpcode::G_CONSTANT: {
     const bool isFP = Opcode == TargetOpcode::G_FCONSTANT;

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -118,9 +118,13 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
       .clampMaxNumElements(0, p0, 2);
 
   getActionDefinitionsBuilder(G_BSWAP)
-      .legalFor({s32, s64, v4s32, v2s32, v2s64})
-      .widenScalarToNextPow2(0)
-      .clampScalar(0, s32, s64);
+      .legalFor({s32, s64, v4s16, v8s16, v2s32, v4s32, v2s64})
+      .widenScalarOrEltToNextPow2(0, 16)
+      .clampScalar(0, s32, s64)
+      .clampNumElements(0, v4s16, v8s16)
+      .clampNumElements(0, v2s32, v4s32)
+      .clampNumElements(0, v2s64, v2s64)
+      .moreElementsToNextPow2(0);
 
   getActionDefinitionsBuilder({G_ADD, G_SUB, G_MUL, G_AND, G_OR, G_XOR})
       .legalFor({s32, s64, v2s32, v2s64, v4s32, v4s16, v8s16, v16s8, v8s8})

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bswap.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bswap.mir
@@ -11,12 +11,13 @@ body:             |
 
     ; CHECK-LABEL: name: bswap_s16
     ; CHECK: liveins: $w0
-    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $w0
-    ; CHECK: [[BSWAP:%[0-9]+]]:_(s32) = G_BSWAP [[COPY]]
-    ; CHECK: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
-    ; CHECK: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BSWAP]], [[C]](s64)
-    ; CHECK: $w0 = COPY [[LSHR]](s32)
-    ; CHECK: RET_ReallyLR implicit $w0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $w0
+    ; CHECK-NEXT: [[BSWAP:%[0-9]+]]:_(s32) = G_BSWAP [[COPY]]
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BSWAP]], [[C]](s64)
+    ; CHECK-NEXT: $w0 = COPY [[LSHR]](s32)
+    ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %1:_(s32) = COPY $w0
     %0:_(s16) = G_TRUNC %1(s32)
     %2:_(s16) = G_BSWAP %0
@@ -32,10 +33,11 @@ body:             |
     liveins: $w0
     ; CHECK-LABEL: name: bswap_s32_legal
     ; CHECK: liveins: $w0
-    ; CHECK: %copy:_(s32) = COPY $w0
-    ; CHECK: %bswap:_(s32) = G_BSWAP %copy
-    ; CHECK: $w0 = COPY %bswap(s32)
-    ; CHECK: RET_ReallyLR implicit $w0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(s32) = COPY $w0
+    ; CHECK-NEXT: %bswap:_(s32) = G_BSWAP %copy
+    ; CHECK-NEXT: $w0 = COPY %bswap(s32)
+    ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %copy:_(s32) = COPY $w0
     %bswap:_(s32) = G_BSWAP %copy
     $w0 = COPY %bswap(s32)
@@ -49,14 +51,51 @@ body:             |
     liveins: $x0
     ; CHECK-LABEL: name: bswap_s64_legal
     ; CHECK: liveins: $x0
-    ; CHECK: %copy:_(s64) = COPY $x0
-    ; CHECK: %bswap:_(s64) = G_BSWAP %copy
-    ; CHECK: $x0 = COPY %bswap(s64)
-    ; CHECK: RET_ReallyLR implicit $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(s64) = COPY $x0
+    ; CHECK-NEXT: %bswap:_(s64) = G_BSWAP %copy
+    ; CHECK-NEXT: $x0 = COPY %bswap(s64)
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
     %copy:_(s64) = COPY $x0
     %bswap:_(s64) = G_BSWAP %copy
     $x0 = COPY %bswap(s64)
     RET_ReallyLR implicit $x0
+...
+---
+name:            bswap_v4s16_legal
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $d0
+    ; CHECK-LABEL: name: bswap_v4s16_legal
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(<4 x s16>) = COPY $d0
+    ; CHECK-NEXT: %bswap:_(<4 x s16>) = G_BSWAP %copy
+    ; CHECK-NEXT: $d0 = COPY %bswap(<4 x s16>)
+    ; CHECK-NEXT: RET_ReallyLR implicit $d0
+    %copy:_(<4 x s16>) = COPY $d0
+    %bswap:_(<4 x s16>) = G_BSWAP %copy
+    $d0 = COPY %bswap(<4 x s16>)
+    RET_ReallyLR implicit $d0
+...
+---
+name:            bswap_v8s16_legal
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $q0
+    ; CHECK-LABEL: name: bswap_v8s16_legal
+    ; CHECK: liveins: $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(<8 x s16>) = COPY $q0
+    ; CHECK-NEXT: %bswap:_(<8 x s16>) = G_BSWAP %copy
+    ; CHECK-NEXT: $q0 = COPY %bswap(<8 x s16>)
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
+    %copy:_(<8 x s16>) = COPY $q0
+    %bswap:_(<8 x s16>) = G_BSWAP %copy
+    $q0 = COPY %bswap(<8 x s16>)
+    RET_ReallyLR implicit $q0
 ...
 ---
 name:            bswap_v4s32_legal
@@ -66,10 +105,11 @@ body:             |
     liveins: $q0
     ; CHECK-LABEL: name: bswap_v4s32_legal
     ; CHECK: liveins: $q0
-    ; CHECK: %copy:_(<4 x s32>) = COPY $q0
-    ; CHECK: %bswap:_(<4 x s32>) = G_BSWAP %copy
-    ; CHECK: $q0 = COPY %bswap(<4 x s32>)
-    ; CHECK: RET_ReallyLR implicit $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(<4 x s32>) = COPY $q0
+    ; CHECK-NEXT: %bswap:_(<4 x s32>) = G_BSWAP %copy
+    ; CHECK-NEXT: $q0 = COPY %bswap(<4 x s32>)
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
     %copy:_(<4 x s32>) = COPY $q0
     %bswap:_(<4 x s32>) = G_BSWAP %copy
     $q0 = COPY %bswap(<4 x s32>)
@@ -83,10 +123,11 @@ body:             |
     liveins: $d0
     ; CHECK-LABEL: name: bswap_v2s32_legal
     ; CHECK: liveins: $d0
-    ; CHECK: %copy:_(<2 x s32>) = COPY $d0
-    ; CHECK: %bswap:_(<2 x s32>) = G_BSWAP %copy
-    ; CHECK: $d0 = COPY %bswap(<2 x s32>)
-    ; CHECK: RET_ReallyLR implicit $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(<2 x s32>) = COPY $d0
+    ; CHECK-NEXT: %bswap:_(<2 x s32>) = G_BSWAP %copy
+    ; CHECK-NEXT: $d0 = COPY %bswap(<2 x s32>)
+    ; CHECK-NEXT: RET_ReallyLR implicit $d0
     %copy:_(<2 x s32>) = COPY $d0
     %bswap:_(<2 x s32>) = G_BSWAP %copy
     $d0 = COPY %bswap(<2 x s32>)
@@ -100,10 +141,11 @@ body:             |
     liveins: $q0
     ; CHECK-LABEL: name: bswap_v2s64_legal
     ; CHECK: liveins: $q0
-    ; CHECK: %copy:_(<2 x s64>) = COPY $q0
-    ; CHECK: %bswap:_(<2 x s64>) = G_BSWAP %copy
-    ; CHECK: $q0 = COPY %bswap(<2 x s64>)
-    ; CHECK: RET_ReallyLR implicit $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %copy:_(<2 x s64>) = COPY $q0
+    ; CHECK-NEXT: %bswap:_(<2 x s64>) = G_BSWAP %copy
+    ; CHECK-NEXT: $q0 = COPY %bswap(<2 x s64>)
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
     %copy:_(<2 x s64>) = COPY $q0
     %bswap:_(<2 x s64>) = G_BSWAP %copy
     $q0 = COPY %bswap(<2 x s64>)
@@ -133,4 +175,40 @@ body:             |
     %trunc:_(s64) = G_TRUNC %bswap
     $x0 = COPY %trunc(s64)
     RET_ReallyLR implicit $x0
+...
+---
+name:            bswap_v2s48
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $q0, $x8
+    ; CHECK-LABEL: name: bswap_v2s48
+    ; CHECK: liveins: $q0, $x8
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x8
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q0
+    ; CHECK-NEXT: [[BSWAP:%[0-9]+]]:_(<2 x s64>) = G_BSWAP [[COPY1]]
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[C]](s64), [[C]](s64)
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(<2 x s64>) = G_LSHR [[BSWAP]], [[BUILD_VECTOR]](<2 x s64>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[LSHR]](<2 x s64>)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 32
+    ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s64) = G_LSHR [[UV]], [[C1]](s64)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](s64)
+    ; CHECK-NEXT: G_STORE [[UV]](s64), [[COPY]](p0) :: (store (s32), align 16)
+    ; CHECK-NEXT: G_STORE [[LSHR1]](s64), [[PTR_ADD]](p0) :: (store (s16) into unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C3]](s64)
+    ; CHECK-NEXT: [[LSHR2:%[0-9]+]]:_(s64) = G_LSHR [[UV1]], [[C1]](s64)
+    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = G_PTR_ADD [[PTR_ADD1]], [[C2]](s64)
+    ; CHECK-NEXT: G_STORE [[UV1]](s64), [[PTR_ADD1]](p0) :: (store (s32) into unknown-address + 6, align 2)
+    ; CHECK-NEXT: G_STORE [[LSHR2]](s64), [[PTR_ADD2]](p0) :: (store (s16) into unknown-address + 10)
+    ; CHECK-NEXT: RET_ReallyLR
+  %1:_(p0) = COPY $x8
+  %2:_(<2 x s64>) = COPY $q0
+  %0:_(<2 x s48>) = G_TRUNC %2:_(<2 x s64>)
+  %bswap:_(<2 x s48>) = G_BSWAP %0
+  G_STORE %bswap:_(<2 x s48>), %1:_(p0) :: (store (<2 x s48>), align 16)
+  RET_ReallyLR
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-bswap.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-bswap.mir
@@ -16,9 +16,11 @@ body:             |
     liveins: $w0
 
     ; CHECK-LABEL: name: bswap_s32
-    ; CHECK: [[COPY:%[0-9]+]]:gpr32 = COPY $w0
-    ; CHECK: [[REVWr:%[0-9]+]]:gpr32 = REVWr [[COPY]]
-    ; CHECK: $w0 = COPY [[REVWr]]
+    ; CHECK: liveins: $w0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32 = COPY $w0
+    ; CHECK-NEXT: [[REVWr:%[0-9]+]]:gpr32 = REVWr [[COPY]]
+    ; CHECK-NEXT: $w0 = COPY [[REVWr]]
     %0(s32) = COPY $w0
     %1(s32) = G_BSWAP %0
     $w0 = COPY %1
@@ -38,12 +40,61 @@ body:             |
     liveins: $x0
 
     ; CHECK-LABEL: name: bswap_s64
-    ; CHECK: [[COPY:%[0-9]+]]:gpr64 = COPY $x0
-    ; CHECK: [[REVXr:%[0-9]+]]:gpr64 = REVXr [[COPY]]
-    ; CHECK: $x0 = COPY [[REVXr]]
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+    ; CHECK-NEXT: [[REVXr:%[0-9]+]]:gpr64 = REVXr [[COPY]]
+    ; CHECK-NEXT: $x0 = COPY [[REVXr]]
     %0(s64) = COPY $x0
     %1(s64) = G_BSWAP %0
     $x0 = COPY %1
+
+...
+---
+name:            bswap_v4s16
+alignment:       4
+legalized:       true
+regBankSelected: true
+tracksRegLiveness: true
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $d0
+
+    ; CHECK-LABEL: name: bswap_v4s16
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr64 = COPY $d0
+    ; CHECK-NEXT: [[REV16v8i8_:%[0-9]+]]:fpr64 = REV16v8i8 [[COPY]]
+    ; CHECK-NEXT: $d0 = COPY [[REV16v8i8_]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $d0
+    %0:fpr(<4 x s16>) = COPY $d0
+    %1:fpr(<4 x s16>) = G_BSWAP %0
+    $d0 = COPY %1(<4 x s16>)
+    RET_ReallyLR implicit $d0
+
+...
+---
+name:            bswap_v8s16
+alignment:       4
+legalized:       true
+regBankSelected: true
+tracksRegLiveness: true
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $q0
+    ; CHECK-LABEL: name: bswap_v8s16
+    ; CHECK: liveins: $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr128 = COPY $q0
+    ; CHECK-NEXT: [[REV16v16i8_:%[0-9]+]]:fpr128 = REV16v16i8 [[COPY]]
+    ; CHECK-NEXT: $q0 = COPY [[REV16v16i8_]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
+    %0:fpr(<8 x s16>) = COPY $q0
+    %1:fpr(<8 x s16>) = G_BSWAP %0
+    $q0 = COPY %1(<8 x s16>)
+    RET_ReallyLR implicit $q0
 
 ...
 ---
@@ -59,10 +110,11 @@ body:             |
 
     ; CHECK-LABEL: name: bswap_v4s32
     ; CHECK: liveins: $q0
-    ; CHECK: [[COPY:%[0-9]+]]:fpr128 = COPY $q0
-    ; CHECK: [[REV32v16i8_:%[0-9]+]]:fpr128 = REV32v16i8 [[COPY]]
-    ; CHECK: $q0 = COPY [[REV32v16i8_]]
-    ; CHECK: RET_ReallyLR implicit $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr128 = COPY $q0
+    ; CHECK-NEXT: [[REV32v16i8_:%[0-9]+]]:fpr128 = REV32v16i8 [[COPY]]
+    ; CHECK-NEXT: $q0 = COPY [[REV32v16i8_]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
     %0:fpr(<4 x s32>) = COPY $q0
     %1:fpr(<4 x s32>) = G_BSWAP %0
     $q0 = COPY %1(<4 x s32>)
@@ -82,10 +134,11 @@ body:             |
 
     ; CHECK-LABEL: name: bswap_v2s32
     ; CHECK: liveins: $d0
-    ; CHECK: [[COPY:%[0-9]+]]:fpr64 = COPY $d0
-    ; CHECK: [[REV32v8i8_:%[0-9]+]]:fpr64 = REV32v8i8 [[COPY]]
-    ; CHECK: $d0 = COPY [[REV32v8i8_]]
-    ; CHECK: RET_ReallyLR implicit $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr64 = COPY $d0
+    ; CHECK-NEXT: [[REV32v8i8_:%[0-9]+]]:fpr64 = REV32v8i8 [[COPY]]
+    ; CHECK-NEXT: $d0 = COPY [[REV32v8i8_]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $d0
     %0:fpr(<2 x s32>) = COPY $d0
     %1:fpr(<2 x s32>) = G_BSWAP %0
     $d0 = COPY %1(<2 x s32>)
@@ -105,10 +158,11 @@ body:             |
 
     ; CHECK-LABEL: name: bswap_v2s64
     ; CHECK: liveins: $q0
-    ; CHECK: [[COPY:%[0-9]+]]:fpr128 = COPY $q0
-    ; CHECK: [[REV64v16i8_:%[0-9]+]]:fpr128 = REV64v16i8 [[COPY]]
-    ; CHECK: $q0 = COPY [[REV64v16i8_]]
-    ; CHECK: RET_ReallyLR implicit $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr128 = COPY $q0
+    ; CHECK-NEXT: [[REV64v16i8_:%[0-9]+]]:fpr128 = REV64v16i8 [[COPY]]
+    ; CHECK-NEXT: $q0 = COPY [[REV64v16i8_]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $q0
     %0:fpr(<2 x s64>) = COPY $q0
     %1:fpr(<2 x s64>) = G_BSWAP %0
     $q0 = COPY %1(<2 x s64>)

--- a/llvm/test/CodeGen/AArch64/bswap.ll
+++ b/llvm/test/CodeGen/AArch64/bswap.ll
@@ -2,14 +2,7 @@
 ; RUN: llc -mtriple=aarch64 %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc -mtriple=aarch64 -global-isel -global-isel-abort=2 %s -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:         warning: Instruction selection used fallback path for bswap_v8i16
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v2i16
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v16i16
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v8i32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v4i64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v3i16
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v7i16
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for bswap_v3i32
+; CHECK-GI:         warning: Instruction selection used fallback path for bswap_v2i16
 
 ; ====== Scalar Tests =====
 define i16 @bswap_i16(i16 %a){


### PR DESCRIPTION
Add support of i16 vector operation for BSWAP and change to TableGen to select instructions

Handle vector types that are smaller/larger than legal for BSWAP