### PR TITLE
[OpenMP52][LIBOMPTARGET] Do not throw error in omp_get_mapped_ptr for the host

### DIFF
--- a/openmp/libomptarget/src/OpenMP/API.cpp
+++ b/openmp/libomptarget/src/OpenMP/API.cpp
@@ -598,7 +598,7 @@ EXTERN void *omp_get_mapped_ptr(const void *Ptr, int DeviceNum) {
 
   size_t NumDevices = omp_get_initial_device();
   if (DeviceNum == NumDevices) {
-    REPORT("Device %d is initial device, returning Ptr " DPxMOD ".\n",
+    DP("Device %d is initial device, returning Ptr " DPxMOD ".\n",
            DeviceNum, DPxPTR(Ptr));
     return const_cast<void *>(Ptr);
   }


### PR DESCRIPTION
OpenMP spec 5.2 specifies return value to be the host ptr
in case of device_num being same as omp_get_initial_device().