### PR TITLE
[libc] disable epoll_pwait2 due to breakage

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -146,7 +146,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     # sys/epoll.h entrypoints
     libc.src.sys.epoll.epoll_wait
     libc.src.sys.epoll.epoll_pwait
-    # Need to check if pwait2 is available before providing.
+    # TODO: Need to check if pwait2 is available before providing.
+    # https://github.com/llvm/llvm-project/issues/80060
     # libc.src.sys.epoll.epoll_pwait2
 
     # sys/mman.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -146,7 +146,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     # sys/epoll.h entrypoints
     libc.src.sys.epoll.epoll_wait
     libc.src.sys.epoll.epoll_pwait
-    libc.src.sys.epoll.epoll_pwait2
+    # Need to check if pwait2 is available before providing.
+    # libc.src.sys.epoll.epoll_pwait2
 
     # sys/mman.h entrypoints
     libc.src.sys.mman.madvise


### PR DESCRIPTION
It appears that sys_epoll_pwait2 isn't always available, so we need to
add some sort of condition to enable it. This patch disables it until
that happens.


