### PR TITLE
[Preprocessor] Fix __has_builtin for CPU ID functions

### DIFF
--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1672,6 +1672,12 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
           return false;
         else if (II->getBuiltinID() != 0) {
           switch (II->getBuiltinID()) {
+          case Builtin::BI__builtin_cpu_is:
+            return getTargetInfo().supportsCpuIs();
+          case Builtin::BI__builtin_cpu_init:
+            return getTargetInfo().supportsCpuInit();
+          case Builtin::BI__builtin_cpu_supports:
+            return getTargetInfo().supportsCpuSupports();
           case Builtin::BI__builtin_operator_new:
           case Builtin::BI__builtin_operator_delete:
             // denotes date of behavior change to support calling arbitrary

--- a/clang/test/Preprocessor/has_builtin_cpuid.c
+++ b/clang/test/Preprocessor/has_builtin_cpuid.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fsyntax-only -triple arm64-- -DARM -verify %s
+// RUN: %clang_cc1 -fsyntax-only -triple x86_64-- -DX86 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -triple powerpc64-unknown-linux-gnu -DPPC \
+// RUN:   -verify %s
+// expected-no-diagnostics
+#if __has_builtin(__builtin_cpu_is)
+# ifdef ARM
+#   error "ARM shouldn't have __builtin_cpu_is"
+# endif
+#endif
+#if __has_builtin(__builtin_cpu_init)
+# if defined(ARM) || defined(PPC)
+#   error "ARM/PPC shouldn't have __builtin_cpu_init"
+# endif
+#endif
+#if __has_builtin(__builtin_cpu_supports)
+# ifdef ARM
+#   error "ARM shouldn't have __builtin_cpu_supports"
+# endif
+#endif


### PR DESCRIPTION
My recent commit (67c1c1d) made the CPU ID builtins target-independent so they can be used on PPC as well. However, that had the unintended consequence of changing the behaviour of __has_builtin in that it reports these as supported at the pre-processor level. This makes it impossible to guard the use of these with this feature test macro which is clearly not ideal.
This patch restores the behaviour of __has_builtin for __builtin_cpu_is, __builtin_cpu_init,
__builtin_cpu_supports. Now the preprocessor queries the target to determine whether the target supports the builtin.