### PR TITLE
[Clang][test] Add fPIC when building shared library

### DIFF
--- a/clang/test/Interpreter/cxx20-modules.cppm
+++ b/clang/test/Interpreter/cxx20-modules.cppm
@@ -7,8 +7,8 @@
 //
 // RUN: %clang -std=c++20 %t/mod.cppm --precompile \
 // RUN:     -o %t/mod.pcm --target=x86_64-linux-gnu
-// RUN: %clang %t/mod.pcm -c -o %t/mod.o --target=x86_64-linux-gnu
-// RUN: %clang -shared %t/mod.o -o %t/libmod.so --target=x86_64-linux-gnu
+// RUN: %clang -fPIC %t/mod.pcm -c -o %t/mod.o --target=x86_64-linux-gnu
+// RUN: %clang -fPIC -shared %t/mod.o -o %t/libmod.so --target=x86_64-linux-gnu
 //
 // RUN: cat %t/import.cpp | env LD_LIBRARY_PATH=%t:$LD_LIBRARY_PATH \
 // RUN:     clang-repl -Xcc=-std=c++20 -Xcc=-fmodule-file=M=%t/mod.pcm \


### PR DESCRIPTION
Fix linking error: "ld: error: can't create dynamic relocation R_X86_64_64 against local symbol in readonly segment; recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output"