### PR TITLE
Fix: CMake Error at cmake/modules/LLVMExternalProjectUtils.cmake:86 (is_msvc_triple)

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -83,7 +83,7 @@ function(llvm_ExternalProject_Add name source_dir)
     set(target_triple ${ARG_TARGET_TRIPLE})
   endif()
 
-  is_msvc_triple(is_msvc_target ${target_triple})
+  is_msvc_triple(is_msvc_target "${target_triple}")
 
   if(NOT ARG_TOOLCHAIN_TOOLS)
     set(ARG_TOOLCHAIN_TOOLS clang)


### PR DESCRIPTION
Adding quotes around the `${target_triple}`

Fix: #78530