### PR TITLE
[libc] add bazel support for most of unistd

### DIFF
--- a/libc/test/src/stdio/remove_test.cpp
+++ b/libc/test/src/stdio/remove_test.cpp
@@ -23,7 +23,9 @@ TEST(LlvmLibcRemoveTest, CreateAndRemoveFile) {
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/remove.test.file";
+
+  constexpr const char *FILENAME = "remove.test.file";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);
@@ -40,7 +42,8 @@ TEST(LlvmLibcRemoveTest, CreateAndRemoveDir) {
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata/remove.test.dir";
+  constexpr const char *FILENAME = "remove.test.dir";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
               Succeeds(0));
 
@@ -51,5 +54,5 @@ TEST(LlvmLibcRemoveTest, CreateAndRemoveDir) {
 
 TEST(LlvmLibcRemoveTest, RemoveNonExistent) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  ASSERT_THAT(LIBC_NAMESPACE::remove("testdata/non-existent"), Fails(ENOENT));
+  ASSERT_THAT(LIBC_NAMESPACE::remove("non-existent"), Fails(ENOENT));
 }

--- a/libc/test/src/sys/stat/mkdirat_test.cpp
+++ b/libc/test/src/sys/stat/mkdirat_test.cpp
@@ -15,7 +15,8 @@
 
 TEST(LlvmLibcMkdiratTest, CreateAndRemove) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata/mkdirat.testdir";
+  constexpr const char *FILENAME = "testdata/mkdirat.testdir";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
               Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::rmdir(TEST_DIR), Succeeds(0));

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -159,6 +159,7 @@ add_libc_unittest(
     libc.src.unistd.fsync
     libc.src.unistd.read
     libc.src.unistd.write
+    libc.src.stdio.remove
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 

--- a/libc/test/src/unistd/access_test.cpp
+++ b/libc/test/src/unistd/access_test.cpp
@@ -12,6 +12,7 @@
 #include "src/unistd/close.h"
 #include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/LibcTest.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/stat.h>
@@ -22,7 +23,8 @@ TEST(LlvmLibcAccessTest, CreateAndTest) {
   // test that it is accessable in those modes but not in others.
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/access.test";
+  constexpr const char *FILENAME = "access.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/chdir_test.cpp
+++ b/libc/test/src/unistd/chdir_test.cpp
@@ -21,9 +21,12 @@ TEST(LlvmLibcChdirTest, ChangeAndOpen) {
   // directory and open the same file to make sure that the "chdir" operation
   // succeeded.
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "testdata/chdir.test";
-  constexpr const char *TEST_FILE_BASE = "chdir.test";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "testdata/chdir.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
+  constexpr const char *FILENAME3 = "chdir.test";
+  auto TEST_FILE_BASE = libc_make_test_file_path(FILENAME3);
   libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_PATH);

--- a/libc/test/src/unistd/dup2_test.cpp
+++ b/libc/test/src/unistd/dup2_test.cpp
@@ -22,7 +22,8 @@ TEST(LlvmLibcdupTest, ReadAndWriteViaDup) {
   constexpr int DUPFD = 0xD0;
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/dup2.test";
+  constexpr const char *FILENAME = "dup2.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/dup3_test.cpp
+++ b/libc/test/src/unistd/dup3_test.cpp
@@ -28,7 +28,8 @@ TEST(LlvmLibcdupTest, ReadAndWriteViaDup) {
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/dup3.test";
+  constexpr const char *FILENAME = "dup3.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/dup_test.cpp
+++ b/libc/test/src/unistd/dup_test.cpp
@@ -21,7 +21,8 @@
 TEST(LlvmLibcdupTest, ReadAndWriteViaDup) {
   libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/dup.test";
+  constexpr const char *FILENAME = "dup.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/fchdir_test.cpp
+++ b/libc/test/src/unistd/fchdir_test.cpp
@@ -21,9 +21,12 @@ TEST(LlvmLibcChdirTest, ChangeAndOpen) {
   // directory and open the same file to make sure that the "fchdir" operation
   // succeeded.
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "testdata/fchdir.test";
-  constexpr const char *TEST_FILE_BASE = "fchdir.test";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "testdata/fchdir.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
+  constexpr const char *FILENAME3 = "fchdir.test";
+  auto TEST_FILE_BASE = libc_make_test_file_path(FILENAME3);
   libc_errno = 0;
 
   int dir_fd = LIBC_NAMESPACE::open(TEST_DIR, O_DIRECTORY);

--- a/libc/test/src/unistd/ftruncate_test.cpp
+++ b/libc/test/src/unistd/ftruncate_test.cpp
@@ -23,7 +23,8 @@ namespace cpp = LIBC_NAMESPACE::cpp;
 
 TEST(LlvmLibcFtruncateTest, CreateAndTruncate) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char TEST_FILE[] = "testdata/ftruncate.test";
+  constexpr const char *FILENAME = "ftruncate.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   constexpr const char WRITE_DATA[] = "hello, ftruncate";
   constexpr size_t WRITE_SIZE = sizeof(WRITE_DATA);
   char buf[WRITE_SIZE];
@@ -68,5 +69,5 @@ TEST(LlvmLibcFtruncateTest, CreateAndTruncate) {
 
 TEST(LlvmLibcFtruncateTest, TruncateBadFD) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  ASSERT_THAT(LIBC_NAMESPACE::ftruncate(1, off_t(1)), Fails(EINVAL));
+  ASSERT_THAT(LIBC_NAMESPACE::ftruncate(0, off_t(1)), Fails(EINVAL));
 }

--- a/libc/test/src/unistd/isatty_test.cpp
+++ b/libc/test/src/unistd/isatty_test.cpp
@@ -39,7 +39,8 @@ TEST(LlvmLibcIsATTYTest, BadFdTest) {
 }
 
 TEST(LlvmLibcIsATTYTest, DevTTYTest) {
-  constexpr const char *TTY_FILE = "/dev/tty";
+  constexpr const char *FILENAME = "/dev/tty";
+  auto TTY_FILE = libc_make_test_file_path(FILENAME);
   libc_errno = 0;
   int fd = LIBC_NAMESPACE::open(TTY_FILE, O_RDONLY);
   if (fd > 0) {
@@ -50,7 +51,8 @@ TEST(LlvmLibcIsATTYTest, DevTTYTest) {
 }
 
 TEST(LlvmLibcIsATTYTest, FileTest) {
-  constexpr const char *TEST_FILE = "testdata/isatty.test";
+  constexpr const char *FILENAME = "isatty.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   libc_errno = 0;
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/link_test.cpp
+++ b/libc/test/src/unistd/link_test.cpp
@@ -18,8 +18,10 @@
 
 TEST(LlvmLibcLinkTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/link.test";
-  constexpr const char *TEST_FILE_LINK = "testdata/link.test.link";
+  constexpr const char *FILENAME = "link.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "link.test.link";
+  auto TEST_FILE_LINK = libc_make_test_file_path(FILENAME2);
 
   // The test strategy is as follows:
   //   1. Create a normal file
@@ -44,7 +46,6 @@ TEST(LlvmLibcLinkTest, CreateAndUnlink) {
 
 TEST(LlvmLibcLinkTest, LinkToNonExistentFile) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  ASSERT_THAT(
-      LIBC_NAMESPACE::link("testdata/non-existent-file", "testdata/bad-link"),
-      Fails(ENOENT));
+  ASSERT_THAT(LIBC_NAMESPACE::link("non-existent-file", "bad-link"),
+              Fails(ENOENT));
 }

--- a/libc/test/src/unistd/linkat_test.cpp
+++ b/libc/test/src/unistd/linkat_test.cpp
@@ -18,11 +18,16 @@
 
 TEST(LlvmLibcLinkatTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "linkat.test";
-  constexpr const char *TEST_FILE_PATH = "testdata/linkat.test";
-  constexpr const char *TEST_FILE_LINK = "linkat.test.link";
-  constexpr const char *TEST_FILE_LINK_PATH = "testdata/linkat.test.link";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "linkat.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
+  constexpr const char *FILENAME3 = "testdata/linkat.test";
+  auto TEST_FILE_PATH = libc_make_test_file_path(FILENAME3);
+  constexpr const char *FILENAME4 = "linkat.test.link";
+  auto TEST_FILE_LINK = libc_make_test_file_path(FILENAME4);
+  constexpr const char *FILENAME5 = "testdata/linkat.test.link";
+  auto TEST_FILE_LINK_PATH = libc_make_test_file_path(FILENAME5);
 
   // The test strategy is as follows:
   //   1. Create a normal file

--- a/libc/test/src/unistd/lseek_test.cpp
+++ b/libc/test/src/unistd/lseek_test.cpp
@@ -18,7 +18,8 @@
 
 TEST(LlvmLibcUniStd, LseekTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/lseek.test";
+  constexpr const char *FILENAME = "testdata/lseek.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_RDONLY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);
@@ -52,7 +53,8 @@ TEST(LlvmLibcUniStd, LseekTest) {
 TEST(LlvmLibcUniStd, LseekFailsTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/lseek.test";
+  constexpr const char *FILENAME = "testdata/lseek.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_RDONLY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/pread_pwrite_test.cpp
+++ b/libc/test/src/unistd/pread_pwrite_test.cpp
@@ -32,7 +32,8 @@ TEST(LlvmLibcUniStd, PWriteAndPReadBackTest) {
 
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *TEST_FILE = "testdata/pread_pwrite.test";
+  constexpr const char *FILENAME = "pread_pwrite.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/read_write_test.cpp
+++ b/libc/test/src/unistd/read_write_test.cpp
@@ -8,6 +8,7 @@
 
 #include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
+#include "src/stdio/remove.h"
 #include "src/unistd/close.h"
 #include "src/unistd/fsync.h"
 #include "src/unistd/read.h"
@@ -19,7 +20,9 @@
 
 TEST(LlvmLibcUniStd, WriteAndReadBackTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "__unistd_read_write.test";
+  constexpr const char *FILENAME = "__unistd_read_write.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
+
   int write_fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(write_fd, 0);
@@ -39,7 +42,7 @@ TEST(LlvmLibcUniStd, WriteAndReadBackTest) {
   EXPECT_STREQ(read_buf, HELLO);
   ASSERT_THAT(LIBC_NAMESPACE::close(read_fd), Succeeds(0));
 
-  // TODO: 'remove' the test file after the test.
+  ASSERT_THAT(LIBC_NAMESPACE::remove(TEST_FILE), Succeeds(0));
 }
 
 TEST(LlvmLibcUniStd, WriteFails) {

--- a/libc/test/src/unistd/readlink_test.cpp
+++ b/libc/test/src/unistd/readlink_test.cpp
@@ -18,8 +18,10 @@ namespace cpp = LIBC_NAMESPACE::cpp;
 
 TEST(LlvmLibcReadlinkTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char LINK_VAL[] = "readlink_test_value";
-  constexpr const char LINK[] = "testdata/readlink.test.link";
+  constexpr const char *FILENAME = "readlink_test_value";
+  auto LINK_VAL = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "readlink.test.link";
+  auto LINK = libc_make_test_file_path(FILENAME2);
   libc_errno = 0;
 
   // The test strategy is as follows:

--- a/libc/test/src/unistd/readlinkat_test.cpp
+++ b/libc/test/src/unistd/readlinkat_test.cpp
@@ -20,8 +20,10 @@ namespace cpp = LIBC_NAMESPACE::cpp;
 
 TEST(LlvmLibcReadlinkatTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char LINK_VAL[] = "readlinkat_test_value";
-  constexpr const char LINK[] = "testdata/readlinkat.test.link";
+  constexpr const char *FILENAME = "readlinkat_test_value";
+  auto LINK_VAL = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "readlinkat.test.link";
+  auto LINK = libc_make_test_file_path(FILENAME2);
   libc_errno = 0;
 
   // The test strategy is as follows:

--- a/libc/test/src/unistd/rmdir_test.cpp
+++ b/libc/test/src/unistd/rmdir_test.cpp
@@ -16,13 +16,13 @@
 
 TEST(LlvmLibcRmdirTest, CreateAndRemove) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata/rmdir.testdir";
+  constexpr const char *FILENAME = "rmdir.testdir";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
   ASSERT_THAT(LIBC_NAMESPACE::mkdir(TEST_DIR, S_IRWXU), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::rmdir(TEST_DIR), Succeeds(0));
 }
 
 TEST(LlvmLibcRmdirTest, RemoveNonExistentDir) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  ASSERT_THAT(LIBC_NAMESPACE::rmdir("testdata/non-existent-dir"),
-              Fails(ENOENT));
+  ASSERT_THAT(LIBC_NAMESPACE::rmdir("non-existent-dir"), Fails(ENOENT));
 }

--- a/libc/test/src/unistd/symlink_test.cpp
+++ b/libc/test/src/unistd/symlink_test.cpp
@@ -18,9 +18,12 @@
 
 TEST(LlvmLibcSymlinkTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE_BASE = "symlink.test";
-  constexpr const char *TEST_FILE = "testdata/symlink.test";
-  constexpr const char *TEST_FILE_LINK = "testdata/symlink.test.symlink";
+  constexpr const char *FILENAME = "symlink.test";
+  auto TEST_FILE_BASE = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "symlink.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
+  constexpr const char *FILENAME3 = "symlink.test.symlink";
+  auto TEST_FILE_LINK = libc_make_test_file_path(FILENAME3);
 
   // The test strategy is as follows:
   //   1. Create a normal file

--- a/libc/test/src/unistd/symlinkat_test.cpp
+++ b/libc/test/src/unistd/symlinkat_test.cpp
@@ -18,11 +18,16 @@
 
 TEST(LlvmLibcSymlinkatTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "symlinkat.test";
-  constexpr const char *TEST_FILE_PATH = "testdata/symlinkat.test";
-  constexpr const char *TEST_FILE_LINK = "symlinkat.test.link";
-  constexpr const char *TEST_FILE_LINK_PATH = "testdata/symlinkat.test.link";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "symlinkat.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
+  constexpr const char *FILENAME3 = "testdata/symlinkat.test";
+  auto TEST_FILE_PATH = libc_make_test_file_path(FILENAME3);
+  constexpr const char *FILENAME4 = "symlinkat.test.link";
+  auto TEST_FILE_LINK = libc_make_test_file_path(FILENAME4);
+  constexpr const char *FILENAME5 = "testdata/symlinkat.test.link";
+  auto TEST_FILE_LINK_PATH = libc_make_test_file_path(FILENAME5);
 
   // The test strategy is as follows:
   //   1. Create a normal file

--- a/libc/test/src/unistd/truncate_test.cpp
+++ b/libc/test/src/unistd/truncate_test.cpp
@@ -23,7 +23,8 @@ namespace cpp = LIBC_NAMESPACE::cpp;
 
 TEST(LlvmLibcTruncateTest, CreateAndTruncate) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char TEST_FILE[] = "testdata/truncate.test";
+  constexpr const char *FILENAME = "truncate.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   constexpr const char WRITE_DATA[] = "hello, truncate";
   constexpr size_t WRITE_SIZE = sizeof(WRITE_DATA);
   char buf[WRITE_SIZE];

--- a/libc/test/src/unistd/unlink_test.cpp
+++ b/libc/test/src/unistd/unlink_test.cpp
@@ -17,7 +17,8 @@
 
 TEST(LlvmLibcUnlinkTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE = "testdata/unlink.test";
+  constexpr const char *FILENAME = "unlink.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int write_fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(write_fd, 0);
@@ -27,6 +28,5 @@ TEST(LlvmLibcUnlinkTest, CreateAndUnlink) {
 
 TEST(LlvmLibcUnlinkTest, UnlinkNonExistentFile) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  ASSERT_THAT(LIBC_NAMESPACE::unlink("testdata/non-existent-file"),
-              Fails(ENOENT));
+  ASSERT_THAT(LIBC_NAMESPACE::unlink("non-existent-file"), Fails(ENOENT));
 }

--- a/libc/test/src/unistd/unlinkat_test.cpp
+++ b/libc/test/src/unistd/unlinkat_test.cpp
@@ -18,8 +18,10 @@
 
 TEST(LlvmLibcUnlinkatTest, CreateAndDeleteTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "openat.test";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
+  constexpr const char *FILENAME2 = "openat.test";
+  auto TEST_FILE = libc_make_test_file_path(FILENAME2);
   int dir_fd = LIBC_NAMESPACE::open(TEST_DIR, O_DIRECTORY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(dir_fd, 0);
@@ -33,7 +35,8 @@ TEST(LlvmLibcUnlinkatTest, CreateAndDeleteTest) {
 }
 
 TEST(LlvmLibcUnlinkatTest, UnlinkatNonExistentFile) {
-  constexpr const char *TEST_DIR = "testdata";
+  constexpr const char *FILENAME = "testdata";
+  auto TEST_DIR = libc_make_test_file_path(FILENAME);
   int dir_fd = LIBC_NAMESPACE::open(TEST_DIR, O_DIRECTORY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(dir_fd, 0);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2502,7 +2502,53 @@ libc_function(
     ],
 )
 
-############################### unistd targets ###############################
+################################ fcntl targets #################################
+
+libc_function(
+    name = "open",
+    srcs = ["src/fcntl/linux/open.cpp"],
+    hdrs = ["src/fcntl/open.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "openat",
+    srcs = ["src/fcntl/linux/openat.cpp"],
+    hdrs = ["src/fcntl/openat.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "creat",
+    srcs = ["src/fcntl/linux/creat.cpp"],
+    hdrs = ["src/fcntl/creat.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+################################ unistd targets ################################
+
+libc_function(
+    name = "access",
+    srcs = ["src/unistd/linux/access.cpp"],
+    hdrs = ["src/unistd/access.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
 
 libc_function(
     name = "chdir",
@@ -2519,6 +2565,50 @@ libc_function(
     name = "close",
     srcs = ["src/unistd/linux/close.cpp"],
     hdrs = ["src/unistd/close.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "dup",
+    srcs = ["src/unistd/linux/dup.cpp"],
+    hdrs = ["src/unistd/dup.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "dup2",
+    srcs = ["src/unistd/linux/dup2.cpp"],
+    hdrs = ["src/unistd/dup2.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "dup3",
+    srcs = ["src/unistd/linux/dup3.cpp"],
+    hdrs = ["src/unistd/dup3.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "environ",
+    srcs = ["src/unistd/environ.cpp"],
+    hdrs = ["src/unistd/environ.h"],
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2559,6 +2649,86 @@ libc_function(
     ],
 )
 
+# libc_function(
+#     name = "getcwd",
+#     srcs = ["src/unistd/linux/getcwd.cpp"],
+#     hdrs = ["src/unistd/getcwd.h"],
+#     deps = [
+#         ":__support_common",
+#         ":__support_osutil_syscall",
+#         ":errno",
+#     ],
+# )
+
+libc_function(
+    name = "geteuid",
+    srcs = ["src/unistd/linux/geteuid.cpp"],
+    hdrs = ["src/unistd/geteuid.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "getpid",
+    srcs = ["src/unistd/linux/getpid.cpp"],
+    hdrs = ["src/unistd/getpid.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "getppid",
+    srcs = ["src/unistd/linux/getppid.cpp"],
+    hdrs = ["src/unistd/getppid.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "getuid",
+    srcs = ["src/unistd/linux/getuid.cpp"],
+    hdrs = ["src/unistd/getuid.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+# libc_function(
+#     name = "getopt",
+#     srcs = ["src/unistd/getopt.cpp"],
+#     hdrs = ["src/unistd/getopt.h"],
+#     deps = [
+#         ":__support_common",
+#         ":__support_cpp_optional",
+#         ":__support_cpp_string_view",
+#         ":__support_file_file",
+#         ":__support_osutil_syscall",
+#         ":errno",
+#     ],
+# )
+
+libc_function(
+    name = "isatty",
+    srcs = ["src/unistd/linux/isatty.cpp"],
+    hdrs = ["src/unistd/isatty.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
 libc_function(
     name = "link",
     srcs = ["src/unistd/linux/link.cpp"],
@@ -2588,6 +2758,28 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_file_linux_lseekimpl",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "pread",
+    srcs = ["src/unistd/linux/pread.cpp"],
+    hdrs = ["src/unistd/pread.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "pwrite",
+    srcs = ["src/unistd/linux/pwrite.cpp"],
+    hdrs = ["src/unistd/pwrite.h"],
+    deps = [
+        ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -2652,6 +2844,31 @@ libc_function(
     name = "symlinkat",
     srcs = ["src/unistd/linux/symlinkat.cpp"],
     hdrs = ["src/unistd/symlinkat.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+#TODO: Enable once fullbuild is added to bazel, since this depends on a macro
+# definition in the public header
+
+# libc_function(
+#     name = "syscall",
+#     srcs = ["src/unistd/linux/syscall.cpp"],
+#     hdrs = ["src/unistd/syscall.h"],
+#     deps = [
+#         ":__support_common",
+#         ":__support_osutil_syscall",
+#         ":errno",
+#     ],
+# )
+
+libc_function(
+    name = "swab",
+    srcs = ["src/unistd/swab.cpp"],
+    hdrs = ["src/unistd/swab.h"],
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2940,6 +3157,41 @@ libc_function(
         ":__support_file_file",
         ":errno",
         ":vfprintf_internal",
+    ],
+)
+
+libc_function(
+    name = "remove",
+    srcs = ["src/stdio/linux/remove.cpp"],
+    hdrs = ["src/stdio/remove.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+############################### sys/stat targets ###############################
+
+libc_function(
+    name = "mkdir",
+    srcs = ["src/sys/stat/linux/mkdir.cpp"],
+    hdrs = ["src/sys/stat/mkdir.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "mkdirat",
+    srcs = ["src/sys/stat/linux/mkdirat.cpp"],
+    hdrs = ["src/sys/stat/mkdirat.h"],
+    deps = [
+        ":__support_common",
+        ":__support_osutil_syscall",
+        ":errno",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
@@ -120,3 +120,15 @@ libc_test(
         "//libc:vfprintf",
     ],
 )
+
+libc_test(
+    name = "remove_test",
+    srcs = ["remove_test.cpp"],
+    libc_function_deps = [
+        "//libc:remove",
+        "//libc:open",
+        "//libc:mkdirat",
+        "//libc:access",
+        "//libc:close",
+    ],
+)

--- a/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
@@ -1,0 +1,340 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc unistd.h functions.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+libc_test(
+    name = "access_test",
+    srcs = ["access_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:access",
+        "//libc:close",
+        "//libc:unlink",
+    ],
+)
+
+# libc_test(
+#     name = "chdir_test",
+#     srcs = ["chdir_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:chdir",
+#         "//libc:close",
+#     ],
+# )
+
+libc_test(
+    name = "dup_test",
+    srcs = ["dup_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:dup",
+        "//libc:read",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+)
+
+libc_test(
+    name = "dup2_test",
+    srcs = ["dup2_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:dup2",
+        "//libc:read",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+)
+
+libc_test(
+    name = "dup3_test",
+    srcs = ["dup3_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:dup3",
+        "//libc:read",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+)
+
+# libc_test(
+#     name = "fchdir_test",
+#     srcs = ["fchdir_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:fchdir",
+#         "//libc:close",
+#     ],
+# )
+
+libc_test(
+    name = "ftruncate_test",
+    srcs = ["ftruncate_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:read",
+        "//libc:ftruncate",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+    deps = [
+        "//libc:__support_cpp_string_view",
+    ],
+)
+
+libc_test(
+    name = "pread_pwrite_test",
+    srcs = ["pread_pwrite_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:fsync",
+        "//libc:pread",
+        "//libc:pwrite",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+)
+
+libc_test(
+    name = "read_write_test",
+    srcs = ["read_write_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:fsync",
+        "//libc:read",
+        "//libc:write",
+        "//libc:remove",
+    ],
+)
+
+libc_test(
+    name = "link_test",
+    srcs = ["link_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:link",
+        "//libc:unlink",
+    ],
+)
+
+# libc_test(
+#     name = "linkat_test",
+#     srcs = ["linkat_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:close",
+#         "//libc:linkat",
+#         "//libc:unlink",
+#     ],
+# )
+
+# libc_test(
+#     name = "lseek_test",
+#     srcs = ["lseek_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:close",
+#         "//libc:lseek",
+#         "//libc:read",
+#     ],
+# )
+
+# libc_test(
+#     name = "rmdir_test",
+#     srcs = ["rmdir_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:mkdir",
+#         "//libc:rmdir",
+#     ],
+# )
+
+libc_test(
+    name = "swab_test",
+    srcs = ["swab_test.cpp"],
+    libc_function_deps = [
+        "//libc:swab",
+    ],
+    deps = [
+        "//libc:string_utils",
+    ],
+)
+
+# libc_test(
+#     name = "readlink_test",
+#     srcs = ["readlink_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:readlink",
+#         "//libc:symlink",
+#         "//libc:unlink",
+#     ],
+#     deps = [
+#         "//libc:__support_cpp_string_view",
+#     ],
+# )
+
+# libc_test(
+#     name = "readlinkat_test",
+#     srcs = ["readlinkat_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:readlinkat",
+#         "//libc:symlink",
+#         "//libc:unlink",
+#     ],
+#     deps = [
+#         "//libc:__support_cpp_string_view",
+#     ],
+# )
+
+libc_test(
+    name = "symlink_test",
+    srcs = ["symlink_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:symlink",
+        "//libc:unlink",
+    ],
+)
+
+# libc_test(
+#     name = "symlinkat_test",
+#     srcs = ["symlinkat_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:close",
+#         "//libc:symlinkat",
+#         "//libc:unlink",
+#     ],
+# )
+
+libc_test(
+    name = "truncate_test",
+    srcs = ["truncate_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:read",
+        "//libc:truncate",
+        "//libc:unlink",
+        "//libc:write",
+    ],
+    deps = [
+        "//libc:__support_cpp_string_view",
+    ],
+)
+
+libc_test(
+    name = "unlink_test",
+    srcs = ["unlink_test.cpp"],
+    libc_function_deps = [
+        "//libc:open",
+        "//libc:close",
+        "//libc:unlink",
+    ],
+)
+
+# libc_test(
+#     name = "unlinkat_test",
+#     srcs = ["unlinkat_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:open",
+#         "//libc:openat",
+#         "//libc:close",
+#         "//libc:unlinkat",
+#     ],
+# )
+
+libc_test(
+    name = "getpid_test",
+    srcs = ["getpid_test.cpp"],
+    libc_function_deps = [
+        "//libc:getpid",
+    ],
+)
+
+libc_test(
+    name = "getppid_test",
+    srcs = ["getppid_test.cpp"],
+    libc_function_deps = [
+        "//libc:getppid",
+    ],
+)
+
+libc_test(
+    name = "getuid_test",
+    srcs = ["getuid_test.cpp"],
+    libc_function_deps = [
+        "//libc:getuid",
+    ],
+)
+
+libc_test(
+    name = "isatty_test",
+    srcs = ["isatty_test.cpp"],
+    libc_function_deps = [
+        "//libc:isatty",
+        "//libc:open",
+        "//libc:close",
+    ],
+)
+
+libc_test(
+    name = "geteuid_test",
+    srcs = ["geteuid_test.cpp"],
+    libc_function_deps = [
+        "//libc:geteuid",
+    ],
+)
+
+#TODO: Enable once fullbuild is added to bazel, since this depends on a macro
+# definition in the public header
+
+# libc_test(
+#     name = "syscall_test",
+#     srcs = ["syscall_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:syscall",
+#     ],
+# )
+
+# TODO: add once sysconf is complete
+
+# libc_test(
+#     name = "sysconf_test",
+#     srcs = ["sysconf_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:sysconf",
+#     ],
+# )
+
+# TODO: add fopencookie and fflush
+
+# libc_test(
+#     name = "getopt_test",
+#     srcs = ["getopt_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:getopt",
+#         "//libc:fopencookie",
+#         "//libc:fflush",
+#     ],
+#     deps = [
+#         "//libc:__support_cpp_array",
+#     ],
+# )


### PR DESCRIPTION
Much of unistd involves modifying files. The tests for these functions
need to use libc_make_test_file_path which didn't exist when they were
first implemented. This patch adds most of unistd to the bazel along
with the corresponding tests. Tests that modify directories had to be
disabled since bazel doesn't seem to handle them properly.
