### PR TITLE
[Exegesis] Print epsilon value in the sched model inconsistency report

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/analysis-epsilons.test
+++ b/llvm/test/tools/llvm-exegesis/X86/analysis-epsilons.test
@@ -20,10 +20,12 @@
 # CHECK-CLUSTERS-ONE-NEXT: {{^}}0,
 # CHECK-CLUSTERS-ONE-SAME: ,100.00{{$}}
 
+# CHECK-INCONSISTENCIES-FAIL: Epsilon: <span class="mono">0.10</span>
 # CHECK-INCONSISTENCIES-FAIL: contains instructions whose performance characteristics do not match that of LLVM
 # CHECK-INCONSISTENCIES-FAIL: contains instructions whose performance characteristics do not match that of LLVM
 # CHECK-INCONSISTENCIES-FAIL-NOT: contains instructions whose performance characteristics do not match that of LLVM
 
+# CHECK-INCONSISTENCIES-PASS: Epsilon: <span class="mono">100.00</span>
 # CHECK-INCONSISTENCIES-PASS-NOT: contains instructions whose performance characteristics do not match that of LLVM
 
 ---

--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -524,6 +524,9 @@ Error Analysis::run<Analysis::PrintSchedClassInconsistencies>(
   OS << "</span></h3><h3>Cpu: <span class=\"mono\">";
   writeEscaped<kEscapeHtml>(OS, FirstPoint.CpuName);
   OS << "</span></h3>";
+  OS << "<h3>Epsilon: <span class=\"mono\">"
+     << format("%0.2f", std::sqrt(AnalysisInconsistencyEpsilonSquared_))
+     << "</span></h3>";
 
   const auto &SI = State_.getSubtargetInfo();
   for (const auto &RSCAndPoints : makePointsPerSchedClass()) {


### PR DESCRIPTION
Since I've formatted the epsilon value, I don't think it's necessary to escape it.