### PR TITLE
[libc] Fix condition ordering in scanf

### DIFF
--- a/libc/src/stdio/scanf_core/float_converter.cpp
+++ b/libc/src/stdio/scanf_core/float_converter.cpp
@@ -57,8 +57,8 @@ int convert_float(Reader *reader, const FormatSection &to_conv) {
   if (to_lower(cur_char) == inf_string[0]) {
     size_t inf_index = 0;
 
-    for (; to_lower(cur_char) == inf_string[inf_index] &&
-           inf_index < sizeof(inf_string) && out_str.length() < max_width;
+    for (; inf_index < sizeof(inf_string) && out_str.length() < max_width &&
+           to_lower(cur_char) == inf_string[inf_index];
          ++inf_index) {
       if (!out_str.append(cur_char)) {
         return ALLOCATION_FAILURE;
@@ -80,8 +80,8 @@ int convert_float(Reader *reader, const FormatSection &to_conv) {
   if (to_lower(cur_char) == nan_string[0]) {
     size_t nan_index = 0;
 
-    for (; to_lower(cur_char) == nan_string[nan_index] &&
-           nan_index < sizeof(nan_string) && out_str.length() < max_width;
+    for (; nan_index < sizeof(nan_string) && out_str.length() < max_width &&
+           to_lower(cur_char) == nan_string[nan_index];
          ++nan_index) {
       if (!out_str.append(cur_char)) {
         return ALLOCATION_FAILURE;


### PR DESCRIPTION
The inf and nan string index bounds checks were after the index was
being used. This patch moves the index usage to the end of the
condition.

Fixes #79988
