### PR TITLE
[clang-format] Handles Elaborated type specifier for enum in trailing return

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1761,7 +1761,7 @@ void UnwrappedLineParser::parseStructuralElement(
     }
     case tok::kw_enum:
       // Ignore if this is part of "template <enum ..." or "... -> enum".
-      if (Previous && (Previous->is(tok::less) || Previous->is(tok::arrow))) {
+      if (Previous && Previous->isOneOf(tok::less, tok::arrow)) {
         nextToken();
         break;
       }

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1760,8 +1760,8 @@ void UnwrappedLineParser::parseStructuralElement(
       break;
     }
     case tok::kw_enum:
-      // Ignore if this is part of "template <enum ...".
-      if (Previous && Previous->is(tok::less)) {
+      // Ignore if this is part of "template <enum ..." or "... -> enum".
+      if (Previous && (Previous->is(tok::less) || Previous->is(tok::arrow))) {
         nextToken();
         break;
       }

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2606,6 +2606,12 @@ TEST_F(TokenAnnotatorTest, StreamOperator) {
   EXPECT_TRUE(Tokens[5]->MustBreakBefore);
 }
 
+TEST_F(TokenAnnotatorTest, UnderstandsElaboratedTypeSpecifier) {
+  auto Tokens = annotate("auto foo() -> enum En {}");
+  ASSERT_EQ(Tokens.size(), 10u);
+  EXPECT_TOKEN(Tokens[7], tok::l_brace, TT_FunctionLBrace);
+}
+
 } // namespace
 } // namespace format
 } // namespace clang

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2608,7 +2608,7 @@ TEST_F(TokenAnnotatorTest, StreamOperator) {
 
 TEST_F(TokenAnnotatorTest, UnderstandsElaboratedTypeSpecifier) {
   auto Tokens = annotate("auto foo() -> enum En {}");
-  ASSERT_EQ(Tokens.size(), 10u);
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[7], tok::l_brace, TT_FunctionLBrace);
 }
 


### PR DESCRIPTION
Fixes llvm/llvm-project#80062