### PR TITLE
[Github] Build PGO optimized toolchain in container

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -2,29 +2,35 @@ FROM docker.io/library/ubuntu:22.04 as base
 ENV LLVM_SYSROOT=/opt/llvm/
 
 FROM base as toolchain
-ENV LLVM_MAJOR=17
-ENV LLVM_VERSION=${LLVM_MAJOR}.0.6
-ENV LLVM_DIRNAME=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-22.04
-ENV LLVM_FILENAME=${LLVM_DIRNAME}.tar.xz
+ENV LLVM_VERSION=17.0.6
 
 RUN apt-get update && \
     apt-get install -y \
-    curl \
-    xz-utils
+    wget \
+    gcc \
+    g++ \
+    cmake \
+    ninja-build \
+    python3
 
-RUN mkdir -p $LLVM_SYSROOT/bin/ $LLVM_SYSROOT/lib/
+RUN wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-$LLVM_VERSION.tar.gz && tar -xf llvmorg-$LLVM_VERSION.tar.gz
 
-RUN curl -O -L https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VERSION/$LLVM_FILENAME
+WORKDIR /llvm-project-llvmorg-$LLVM_VERSION
 
-RUN tar -C $LLVM_SYSROOT --strip-components=1 -xJf $LLVM_FILENAME \
-    $LLVM_DIRNAME/bin/clang \
-    $LLVM_DIRNAME/bin/clang++ \
-    $LLVM_DIRNAME/bin/clang-cl \
-    $LLVM_DIRNAME/bin/clang-$LLVM_MAJOR \
-    $LLVM_DIRNAME/bin/lld \
-    $LLVM_DIRNAME/bin/ld.lld \
-    $LLVM_DIRNAME/lib/clang/
+RUN mkdir build
 
+RUN cmake -B ./build -G Ninja ./llvm \
+  -C ./clang/cmake/caches/BOLT-PGO.cmake \
+  -DBOOTSTRAP_LLVM_ENABLE_LLD=ON \
+  -DBOOTSTRAP_BOOTSTRAP_LLVM_ENABLE_LLD=ON \
+  -DPGO_INSTRUMENT_LTO=Thin \
+  -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+  -DCMAKE_INSTALL_PREFIX="$LLVM_SYSROOT" \
+  -DLLVM_ENABLE_PROJECTS="bolt;clang;lld;clang-tools-extra" \
+  -DLLVM_DISTRIBUTION_COMPONENTS="lld;compiler-rt;clang-format" \
+  -DCLANG_DEFAULT_LINKER="lld"
+
+RUN ninja -C ./build stage2-install-distribution && ninja -C ./build install-distribution && rm -rf ./build
 
 FROM base
 


### PR DESCRIPTION
This patch adjusts the Docker container intended for CI use to contain a PGO+ThinLTO+BOLT optimized clang. The toolchain is built within a Github action and takes ~3.5 hours. No caching is utilized. The current PGO optimization is fairly minimal, only running clang over hello world. This can be adjusted as needed.