### PR TITLE
[clang][dataflow] Display line numbers in the HTML logger timeline.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -29,6 +29,16 @@ section h2 {
 }
 #timeline {
   min-width: max-content;
+  counter-reset: entry_counter;
+}
+#timeline .entry .counter::before {
+  counter-increment: entry_counter;
+  content: counter(entry_counter) ":";
+}
+#timeline .entry .counter {
+  display: inline-block;
+  min-width: 2em; /* Enough space for two digits and a colon */
+  text-align: right;
 }
 #timeline .entry.hover {
   background-color: #aaa;

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
@@ -42,6 +42,7 @@
 <header>Timeline</header>
 <template data-for="entry in timeline">
   <div id="{{entry.block}}:{{entry.iter}}" data-bb="{{entry.block}}" class="entry">
+    <span class="counter"></span>
     {{entry.block}}
     <template data-if="entry.post_visit">(post-visit)</template>
     <template data-if="!entry.post_visit">({{entry.iter}})</template>


### PR DESCRIPTION
This makes it easier to count how many iterations an analysis takes to complete.
It also makes it easier to compare how a change to the analysis code affects
the timeline.

Here's a sample screenshot:

![image](https://github.com/llvm/llvm-project/assets/29098113/b3f44b4d-7037-4f28-9532-5418663250e1)
