### PR TITLE
[clang][Interp] Bail out on missing ComparisonCategoryInfo

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -379,7 +379,8 @@ bool ByteCodeExprGen<Emitter>::VisitBinaryOperator(const BinaryOperator *BO) {
       return true;
     const ComparisonCategoryInfo *CmpInfo =
         Ctx.getASTContext().CompCategories.lookupInfoForType(BO->getType());
-    assert(CmpInfo);
+    if (!CmpInfo)
+      return false;
 
     // We need a temporary variable holding our return value.
     if (!Initializing) {

--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -374,13 +374,12 @@ bool ByteCodeExprGen<Emitter>::VisitBinaryOperator(const BinaryOperator *BO) {
   // Special case for C++'s three-way/spaceship operator <=>, which
   // returns a std::{strong,weak,partial}_ordering (which is a class, so doesn't
   // have a PrimType).
-  if (!T) {
+  if (!T && Ctx.getLangOpts().CPlusPlus) {
     if (DiscardResult)
       return true;
     const ComparisonCategoryInfo *CmpInfo =
         Ctx.getASTContext().CompCategories.lookupInfoForType(BO->getType());
-    if (!CmpInfo)
-      return false;
+    assert(CmpInfo);
 
     // We need a temporary variable holding our return value.
     if (!Initializing) {

--- a/clang/test/Sema/struct-cast.c
+++ b/clang/test/Sema/struct-cast.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only %s -verify
+// RUN: %clang_cc1 -fsyntax-only %s -fexperimental-new-constant-interpreter -verify
 // expected-no-diagnostics
 
 struct S {


### PR DESCRIPTION
Instead of asserting. This can happen in real-world code.