### PR TITLE
[lldb][DataFormatter][NFC] Use GetFirstValueOfLibCXXCompressedPair throughout formatters

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -213,30 +213,20 @@ size_t lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     CalculateNumChildren() {
   if (m_count != UINT32_MAX)
     return m_count;
+
   if (m_tree == nullptr)
     return 0;
-  ValueObjectSP m_item(m_tree->GetChildMemberWithName("__pair3_"));
-  if (!m_item)
+
+  ValueObjectSP size_node(m_tree->GetChildMemberWithName("__pair3_"));
+  if (!size_node)
     return 0;
 
-  switch (m_item->GetCompilerType().GetNumDirectBaseClasses()) {
-  case 1:
-    // Assume a pre llvm r300140 __compressed_pair implementation:
-    m_item = m_item->GetChildMemberWithName("__first_");
-    break;
-  case 2: {
-    // Assume a post llvm r300140 __compressed_pair implementation:
-    ValueObjectSP first_elem_parent = m_item->GetChildAtIndex(0);
-    m_item = first_elem_parent->GetChildMemberWithName("__value_");
-    break;
-  }
-  default:
-    return false;
-  }
+  size_node = GetFirstValueOfLibCXXCompressedPair(*size_node);
 
-  if (!m_item)
+  if (!size_node)
     return 0;
-  m_count = m_item->GetValueAsUnsigned(0);
+
+  m_count = size_node->GetValueAsUnsigned(0);
   return m_count;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -214,7 +214,11 @@ bool lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
   if (!p1_sp)
     return false;
 
-  m_tree = GetFirstValueOfLibCXXCompressedPair(*p1_sp).get();
+  ValueObjectSP value_sp = GetFirstValueOfLibCXXCompressedPair(*p1_sp);
+  if (!value_sp)
+    return false;
+
+  m_tree = value_sp->GetChildMemberWithName("__next_").get();
   if (m_tree == nullptr)
     return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -116,25 +116,10 @@ lldb::ValueObjectSP lldb_private::formatters::
         if (!p1_sp)
           return nullptr;
 
-        ValueObjectSP first_sp = nullptr;
-        switch (p1_sp->GetCompilerType().GetNumDirectBaseClasses()) {
-        case 1:
-          // Assume a pre llvm r300140 __compressed_pair implementation:
-          first_sp = p1_sp->GetChildMemberWithName("__first_");
-          break;
-        case 2: {
-          // Assume a post llvm r300140 __compressed_pair implementation:
-          ValueObjectSP first_elem_parent_sp =
-            p1_sp->GetChildAtIndex(0);
-          first_sp = p1_sp->GetChildMemberWithName("__value_");
-          break;
-        }
-        default:
-          return nullptr;
-        }
-
+        ValueObjectSP first_sp = GetFirstValueOfLibCXXCompressedPair(*p1_sp);
         if (!first_sp)
           return nullptr;
+
         m_element_type = first_sp->GetCompilerType();
         m_element_type = m_element_type.GetTypeTemplateArgument(0);
         m_element_type = m_element_type.GetPointeeType();
@@ -218,37 +203,26 @@ bool lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     return false;
 
   ValueObjectSP p2_sp = table_sp->GetChildMemberWithName("__p2_");
-  ValueObjectSP num_elements_sp = nullptr;
-  llvm::SmallVector<llvm::StringRef, 3> next_path;
-  switch (p2_sp->GetCompilerType().GetNumDirectBaseClasses()) {
-  case 1:
-    // Assume a pre llvm r300140 __compressed_pair implementation:
-    num_elements_sp = p2_sp->GetChildMemberWithName("__first_");
-    next_path.append({"__p1_", "__first_", "__next_"});
-    break;
-  case 2: {
-    // Assume a post llvm r300140 __compressed_pair implementation:
-    ValueObjectSP first_elem_parent = p2_sp->GetChildAtIndex(0);
-    num_elements_sp = first_elem_parent->GetChildMemberWithName("__value_");
-    next_path.append({"__p1_", "__value_", "__next_"});
-    break;
-  }
-  default:
+  if (!p2_sp)
     return false;
-  }
 
+  ValueObjectSP num_elements_sp = GetFirstValueOfLibCXXCompressedPair(*p2_sp);
   if (!num_elements_sp)
     return false;
 
-  m_tree = table_sp->GetChildAtNamePath(next_path).get();
+  ValueObjectSP p1_sp = table_sp->GetChildMemberWithName("__p1_");
+  if (!p1_sp)
+    return false;
+
+  m_tree = GetFirstValueOfLibCXXCompressedPair(*p1_sp).get();
   if (m_tree == nullptr)
     return false;
 
   m_num_elements = num_elements_sp->GetValueAsUnsigned(0);
 
   if (m_num_elements > 0)
-    m_next_element =
-        table_sp->GetChildAtNamePath(next_path).get();
+    m_next_element = m_tree;
+
   return false;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -123,7 +123,8 @@ bool lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::Update() {
   if (!data_type_finder_sp)
     return false;
 
-  data_type_finder_sp = GetFirstValueOfLibCXXCompressedPair(*data_type_finder_sp);
+  data_type_finder_sp =
+      GetFirstValueOfLibCXXCompressedPair(*data_type_finder_sp);
   if (!data_type_finder_sp)
     return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Utility/ConstString.h"
+#include <iterator>
 #include <optional>
 
 using namespace lldb;
@@ -123,26 +124,10 @@ bool lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::Update() {
   if (!data_type_finder_sp)
     return false;
 
-  switch (data_type_finder_sp->GetCompilerType().GetNumDirectBaseClasses()) {
-  case 1:
-    // Assume a pre llvm r300140 __compressed_pair implementation:
-    data_type_finder_sp =
-        data_type_finder_sp->GetChildMemberWithName("__first_");
-    break;
-  case 2: {
-    // Assume a post llvm r300140 __compressed_pair implementation:
-    ValueObjectSP first_elem_parent_sp =
-      data_type_finder_sp->GetChildAtIndex(0);
-    data_type_finder_sp =
-        first_elem_parent_sp->GetChildMemberWithName("__value_");
-    break;
-  }
-  default:
-    return false;
-  }
-
+  data_type_finder_sp = GetFirstValueOfLibCXXCompressedPair(*data_type_finder_sp);
   if (!data_type_finder_sp)
     return false;
+
   m_element_type = data_type_finder_sp->GetCompilerType().GetPointeeType();
   if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr)) {
     m_element_size = *size;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -11,7 +11,6 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Utility/ConstString.h"
-#include <iterator>
 #include <optional>
 
 using namespace lldb;


### PR DESCRIPTION
This avoids duplicating the logic to get the first
element of a libc++ `__compressed_pair`. This will
be useful in supporting upcoming changes to the layout
of `__compressed_pair`.

Drive-by changes:
* Renamed `m_item` to `size_node` for readability;
  `m_item` suggests it's a member variable, which it
  is not.