### PR TITLE
[mlir][EmitC] Remove unused attribute from verbatim op

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -574,10 +574,7 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     ```
   }];
 
-  let arguments = (ins
-    StrAttr:$value,
-    UnitAttr:$trailing_semicolon
-  );
+  let arguments = (ins StrAttr:$value);
   let assemblyFormat = "$value attr-dict";
 }
 


### PR DESCRIPTION
The uses of the attribute were removed in code review of #79584, but it's definition was inadvertently kept.