### PR TITLE
[Libomptarget] Remove handling of old ctor / dtor entries

### DIFF
--- a/openmp/libomptarget/include/OffloadEntry.h
+++ b/openmp/libomptarget/include/OffloadEntry.h
@@ -36,8 +36,6 @@ public:
   const char *getNameAsCStr() const { return OffloadEntry.name; }
   __tgt_bin_desc *getBinaryDescription() const;
 
-  bool isCTor() const { return hasFlags(OMP_DECLARE_TARGET_CTOR); }
-  bool isDTor() const { return hasFlags(OMP_DECLARE_TARGET_DTOR); }
   bool isLink() const { return hasFlags(OMP_DECLARE_TARGET_LINK); }
 
   bool hasFlags(OpenMPOffloadingDeclareTargetFlags Flags) const {

--- a/openmp/libomptarget/include/PluginManager.h
+++ b/openmp/libomptarget/include/PluginManager.h
@@ -58,10 +58,6 @@ struct PluginAdaptorTy {
   /// user.
   int32_t getNumberOfUserDevices() const { return NumberOfUserDevices; }
 
-  /// Add all offload entries described by \p DI to the devices managed by this
-  /// plugin.
-  void addOffloadEntries(DeviceImageTy &DI);
-
   /// RTL index, index is the number of devices of other RTLs that were
   /// registered before, i.e. the OpenMP index of the first device to be
   /// registered with this RTL.

--- a/openmp/libomptarget/include/device.h
+++ b/openmp/libomptarget/include/device.h
@@ -38,24 +38,12 @@ struct PluginAdaptorTy;
 struct __tgt_bin_desc;
 struct __tgt_target_table;
 
-///
-struct PendingCtorDtorListsTy {
-  std::list<void *> PendingCtors;
-  std::list<void *> PendingDtors;
-};
-typedef std::map<__tgt_bin_desc *, PendingCtorDtorListsTy>
-    PendingCtorsDtorsPerLibrary;
-
 struct DeviceTy {
   int32_t DeviceID;
   PluginAdaptorTy *RTL;
   int32_t RTLDeviceID;
 
   bool HasMappedGlobalData = false;
-
-  PendingCtorsDtorsPerLibrary PendingCtorsDtors;
-
-  std::mutex PendingGlobalsMtx;
 
   DeviceTy(PluginAdaptorTy *RTL, int32_t DeviceID, int32_t RTLDeviceID);
   // DeviceTy is not copyable
@@ -157,9 +145,6 @@ struct DeviceTy {
   /// Destroy the event.
   int32_t destroyEvent(void *Event);
   /// }
-
-  /// Register \p Entry as an offload entry that is avalable on this device.
-  void addOffloadEntry(const OffloadEntryTy &Entry);
 
   /// Print all offload entries to stderr.
   void dumpOffloadEntries();

--- a/openmp/libomptarget/include/omptarget.h
+++ b/openmp/libomptarget/include/omptarget.h
@@ -91,10 +91,6 @@ enum tgt_map_type {
 enum OpenMPOffloadingDeclareTargetFlags {
   /// Mark the entry global as having a 'link' attribute.
   OMP_DECLARE_TARGET_LINK = 0x01,
-  /// Mark the entry kernel as being a global constructor.
-  OMP_DECLARE_TARGET_CTOR = 0x02,
-  /// Mark the entry kernel as being a global destructor.
-  OMP_DECLARE_TARGET_DTOR = 0x04,
   /// Mark the entry global as being an indirectly callable function.
   OMP_DECLARE_TARGET_INDIRECT = 0x08
 };

--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -66,7 +66,7 @@ int HostDataToTargetTy::addEventIfNecessary(DeviceTy &Device,
 
 DeviceTy::DeviceTy(PluginAdaptorTy *RTL, int32_t DeviceID, int32_t RTLDeviceID)
     : DeviceID(DeviceID), RTL(RTL), RTLDeviceID(RTLDeviceID),
-      PendingCtorsDtors(), PendingGlobalsMtx(), MappingInfo(*this) {}
+      MappingInfo(*this) {}
 
 DeviceTy::~DeviceTy() {
   if (DeviceID == -1 || !(getInfoLevel() & OMP_INFOTYPE_DUMP_TABLE))
@@ -297,48 +297,11 @@ int32_t DeviceTy::destroyEvent(void *Event) {
   return OFFLOAD_SUCCESS;
 }
 
-void DeviceTy::addOffloadEntry(const OffloadEntryTy &Entry) {
-  std::lock_guard<decltype(PendingGlobalsMtx)> Lock(PendingGlobalsMtx);
-  DeviceOffloadEntries.getExclusiveAccessor()->insert({Entry.getName(), Entry});
-  if (Entry.isGlobal())
-    return;
-
-  if (Entry.isCTor()) {
-    DP("Adding ctor " DPxMOD " to the pending list.\n",
-       DPxPTR(Entry.getAddress()));
-    MESSAGE("WARNING: Calling deprecated constructor for entry %s will be "
-            "removed in a future release \n",
-            Entry.getNameAsCStr());
-    PendingCtorsDtors[Entry.getBinaryDescription()].PendingCtors.push_back(
-        Entry.getAddress());
-  } else if (Entry.isDTor()) {
-    // Dtors are pushed in reverse order so they are executed from end
-    // to beginning when unregistering the library!
-    DP("Adding dtor " DPxMOD " to the pending list.\n",
-       DPxPTR(Entry.getAddress()));
-    MESSAGE("WARNING: Calling deprecated destructor for entry %s will be "
-            "removed in a future release \n",
-            Entry.getNameAsCStr());
-    PendingCtorsDtors[Entry.getBinaryDescription()].PendingDtors.push_front(
-        Entry.getAddress());
-  }
-
-  if (Entry.isLink()) {
-    MESSAGE(
-        "WARNING: The \"link\" attribute is not yet supported for entry: %s!\n",
-        Entry.getNameAsCStr());
-  }
-}
-
 void DeviceTy::dumpOffloadEntries() {
   fprintf(stderr, "Device %i offload entries:\n", DeviceID);
   for (auto &It : *DeviceOffloadEntries.getExclusiveAccessor()) {
     const char *Kind = "kernel";
-    if (It.second.isCTor())
-      Kind = "constructor";
-    else if (It.second.isDTor())
-      Kind = "destructor";
-    else if (It.second.isLink())
+    if (It.second.isLink())
       Kind = "link";
     else if (It.second.isGlobal())
       Kind = "global var.";

--- a/openmp/libomptarget/test/offloading/ctor_dtor.cpp
+++ b/openmp/libomptarget/test/offloading/ctor_dtor.cpp
@@ -1,13 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// RUN: %libomptarget-compilexx-generic && \
-// RUN: env OMPTARGET_DUMP_OFFLOAD_ENTRIES=0 %libomptarget-run-generic 2>&1 | \
-// RUN: %fcheck-generic --check-prefix=DUMP
-//
-// DUMP:     Device 0 offload entries:
-// DUMP-DAG:   global var.: s
-// DUMP-DAG:        kernel: __omp_offloading_{{.*}}_main_
-//
+
 #include <cstdio>
 struct S {
   S() : i(7) {}


### PR DESCRIPTION
Summary:
A previous patch removed creating these entries in clang in favor of the
backend emitting a callable kernel and having the runtime call that if
present. The support for the old style was kept around in LLVM 18.0 but
now that we have forked to 19.0 we should remove the support.

The effect of this would be that an application linking against a newer
libomptarget that still had the old constructors will no longer be
called. In that case, they can either recompile or use the
`libomptarget.so.18` that comes with the previous release.
