### PR TITLE
[mlir][gpu] Add host-supports-nvptx to test gpu-lower-to-nvvm-pipeline

### DIFF
--- a/mlir/test/Dialect/GPU/test-nvvm-pipeline.mlir
+++ b/mlir/test/Dialect/GPU/test-nvvm-pipeline.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: host-supports-nvptx
 // RUN: mlir-opt %s \
 // RUN:  | mlir-opt -gpu-lower-to-nvvm-pipeline="cubin-format=isa" \ 
 // RUN:    -split-input-file | FileCheck %s


### PR DESCRIPTION
PR #78556 added a new mlir test with gpu-lower-to-nvvm-pipeline that checks the generated PTX. However, it causes a problem on host without cuda support.

This PR adds `REQUIRES: host-supports-nvptx`.