### PR TITLE
[NVPTX] improve Boolean ISel

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -1539,6 +1539,16 @@ defm OR  : BITWISE<"or", or>;
 defm AND : BITWISE<"and", and>;
 defm XOR : BITWISE<"xor", xor>;
 
+// PTX does not support mul on predicates, convert to and instructions
+def : Pat<(mul Int1Regs:$a, Int1Regs:$b), (ANDb1rr Int1Regs:$a, Int1Regs:$b)>;
+def : Pat<(mul Int1Regs:$a, (i1 imm:$b)), (ANDb1ri Int1Regs:$a, imm:$b)>;
+
+// These transformations were once reliably performed by instcombine, but thanks
+// to poison semantics they are no longer safe for LLVM IR, perform them here
+// instead.
+def : Pat<(select Int1Regs:$a, Int1Regs:$b, 0), (ANDb1rr Int1Regs:$a, Int1Regs:$b)>;
+def : Pat<(select Int1Regs:$a, 1, Int1Regs:$b), (ORb1rr Int1Regs:$a, Int1Regs:$b)>;
+
 // Lower logical v2i16/v4i8 ops as bitwise ops on b32.
 foreach vt = [v2i16, v4i8] in {
   def: Pat<(or (vt Int32Regs:$a), (vt Int32Regs:$b)),

--- a/llvm/test/CodeGen/NVPTX/boolean-patterns.ll
+++ b/llvm/test/CodeGen/NVPTX/boolean-patterns.ll
@@ -1,0 +1,33 @@
+; RUN: llc < %s -march=nvptx64 -mcpu=sm_20 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_20 | %ptxas-verify %}
+
+; CHECK-LABEL: m2and_rr
+define i1 @m2and_rr(i1 %a, i1 %b) {
+; CHECK: and.pred %p{{[0-9]+}}, %p{{[0-9]+}}, %p{{[0-9]+}}
+; CHECK-NOT: mul
+  %r = mul i1 %a, %b
+  ret i1 %r
+}
+
+; CHECK-LABEL: m2and_ri
+define i1 @m2and_ri(i1 %a) {
+; CHECK-NOT: mul
+  %r = mul i1 %a, 1
+  ret i1 %r
+}
+
+; CHECK-LABEL: select2or
+define i1 @select2or(i1 %a, i1 %b) {
+; CHECK: or.b16 %rs{{[0-9]+}}, %rs{{[0-9]+}}, %rs{{[0-9]+}}
+; CHECK-NOT: selp
+  %r = select i1 %a, i1 1, i1 %b
+  ret i1 %r
+}
+
+; CHECK-LABEL: select2and
+define i1 @select2and(i1 %a, i1 %b) {
+; CHECK: and.b16 %rs{{[0-9]+}}, %rs{{[0-9]+}}, %rs{{[0-9]+}}
+; CHECK-NOT: selp
+  %r = select i1 %a, i1 %b, i1 0
+  ret i1 %r
+}


### PR DESCRIPTION
Add TableGen patterns to convert more instructions to boolean expressions:

- **mul -> and/or**: i1 multiply instructions currently cannot be selected causing the compiler to crash. See https://github.com/llvm/llvm-project/issues/57404
- **select -> and/or**: Converting selects to and/or can enable more optimizations. `InstCombine` cannot do this as aggressively due to poison semantics.