### PR TITLE
[libc] Fix read under msan

### DIFF
--- a/libc/src/unistd/linux/read.cpp
+++ b/libc/src/unistd/linux/read.cpp
@@ -11,6 +11,8 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
+#include "src/__support/macros/sanitizer.h" // for MSAN_UNPOISON
+
 #include "src/errno/libc_errno.h"
 #include <sys/syscall.h> // For syscall numbers.
 
@@ -22,6 +24,9 @@ LLVM_LIBC_FUNCTION(ssize_t, read, (int fd, void *buf, size_t count)) {
     libc_errno = static_cast<int>(-ret);
     return -1;
   }
+  // The cast is important since there is a check that dereferences the pointer
+  // which fails on void*.
+  MSAN_UNPOISON(reinterpret_cast<char *>(buf), count);
   return ret;
 }
 

--- a/libc/src/unistd/linux/read.cpp
+++ b/libc/src/unistd/linux/read.cpp
@@ -10,9 +10,7 @@
 
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/__support/macros/sanitizer.h" // for MSAN_UNPOISON
-
 #include "src/errno/libc_errno.h"
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2599,6 +2599,7 @@ libc_function(
     hdrs = ["src/unistd/read.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
     ],


### PR DESCRIPTION
The read function wasn't properly unpoisoning its result under msan,
causing test failures downstream when I tried to roll it out. This patch
adds the msan unpoison call that fixes the issue.
