### PR TITLE
[mlir] Add FileRange location type.

### DIFF
--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -19,6 +19,7 @@ class AffineExpr;
 class IRMapping;
 class UnknownLoc;
 class FileLineColLoc;
+class FileLineColRange;
 class Type;
 class PrimitiveType;
 class IntegerType;

--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -100,7 +100,7 @@ def FileLineColRange : DialectAttribute<(attr
   StringAttr:$filename,
   WithBuilder<"$_args",
     WithType<"SmallVector<uint64_t>",
-    WithParser <"succeeded(readFileLineColRangeLocs($_reader, $_var))",
+    WithParser<"succeeded(readFileLineColRangeLocs($_reader, $_var))",
     WithPrinter<"writeFileLineColRangeLocs($_writer, $_name)">>>>:$rawLocData
 )> {
   let cBuilder = "getFileLineColRange(context, filename, rawLocData)";
@@ -109,8 +109,8 @@ def FileLineColRange : DialectAttribute<(attr
 
 def FileLineColLoc : DialectAttribute<(attr
   StringAttr:$filename,
-  PresentOptionalVarInt:$start_line,
-  PresentOptionalVarInt:$start_column
+  VarInt:$start_line,
+  VarInt:$start_column
 )> {
   let printerPredicate = "::llvm::isa<FileLineColLoc>($_val)";
 }

--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -95,11 +95,26 @@ def CallSiteLoc : DialectAttribute<(attr
   LocationAttr:$caller
 )>;
 
+let cType = "FileLineColRange" in {
+def FileLineColRange : DialectAttribute<(attr
+  StringAttr:$filename,
+  WithBuilder<"$_args",
+    WithType<"SmallVector<uint64_t>",
+    WithParser <"succeeded(readFileLineColRangeLocs($_reader, $_var))",
+    WithPrinter<"writeFileLineColRangeLocs($_writer, $_name)">>>>:$rawLocData
+)> {
+  let cBuilder = "getFileLineColRange(context, filename, rawLocData)";
+  let printerPredicate = "!::llvm::isa<FileLineColLoc>($_val)";
+}
+
 def FileLineColLoc : DialectAttribute<(attr
   StringAttr:$filename,
-  VarInt:$line,
-  VarInt:$column
-)>;
+  PresentOptionalVarInt:$start_line,
+  PresentOptionalVarInt:$start_column
+)> {
+  let printerPredicate = "::llvm::isa<FileLineColLoc>($_val)";
+}
+}
 
 let cType = "FusedLoc",
     cBuilder = "cast<FusedLoc>(get<FusedLoc>(context, $_args))" in {
@@ -321,7 +336,8 @@ def BuiltinDialectAttributes : DialectAttributes<"Builtin"> {
     DenseIntOrFPElementsAttr,
     DenseStringElementsAttr,
     SparseElementsAttr,
-    DistinctAttr
+    DistinctAttr,
+    FileLineColRange,
   ];
 }
 

--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.td
@@ -143,10 +143,10 @@ def FileLineColRange : Builtin_LocationAttr<"FileLineColRange"> {
 
   let extraClassDeclaration = [{
     ::mlir::StringAttr getFilename() const;
-    std::optional<unsigned> getStartLine() const;
-    std::optional<unsigned> getStartColumn() const;
-    std::optional<unsigned> getEndColumn() const;
-    std::optional<unsigned> getEndLine() const;
+    unsigned getStartLine() const;
+    unsigned getStartColumn() const;
+    unsigned getEndColumn() const;
+    unsigned getEndLine() const;
   }];
   let skipDefaultBuilders = 1;
   let genAccessors = 0;

--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.td
@@ -94,7 +94,6 @@ def FileLineColRange : Builtin_LocationAttr<"FileLineColRange"> {
   // locations are only set in storage.
   let parameters = (ins "StringAttr":$filename);
   let builders = [
-
     AttrBuilderWithInferredContext<(ins "StringAttr":$filename), [{
       return $_get(filename.getContext(), filename, ArrayRef<unsigned>{});
     }]>,

--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.td
@@ -90,9 +90,9 @@ def FileLineColRange : Builtin_LocationAttr<"FileLineColRange"> {
     ```
   }];
 
-  // Note: this only shows the parameters for which accessors are generated. The
-  // locations are only set in storage.
-  let parameters = (ins "StringAttr":$filename);
+  let parameters = (ins "StringAttr":$filename,
+    "unsigned":$start_line, "unsigned":$start_column,
+    "unsigned":$end_line, "unsigned":$end_column);
   let builders = [
     AttrBuilderWithInferredContext<(ins "StringAttr":$filename), [{
       return $_get(filename.getContext(), filename, ArrayRef<unsigned>{});
@@ -142,12 +142,14 @@ def FileLineColRange : Builtin_LocationAttr<"FileLineColRange"> {
   ];
 
   let extraClassDeclaration = [{
+    ::mlir::StringAttr getFilename() const;
     std::optional<unsigned> getStartLine() const;
     std::optional<unsigned> getStartColumn() const;
     std::optional<unsigned> getEndColumn() const;
     std::optional<unsigned> getEndLine() const;
   }];
   let skipDefaultBuilders = 1;
+  let genAccessors = 0;
   let genStorageClass = 0;
   let attrName = "builtin.file_line_range";
 }

--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.td
@@ -60,46 +60,97 @@ def CallSiteLoc : Builtin_LocationAttr<"CallSiteLoc"> {
 }
 
 //===----------------------------------------------------------------------===//
-// FileLineColLoc
+// FileLineColRange
 //===----------------------------------------------------------------------===//
 
-def FileLineColLoc : Builtin_LocationAttr<"FileLineColLoc"> {
-  let summary = "A file:line:column source location";
+def FileLineColRange : Builtin_LocationAttr<"FileLineColRange"> {
+  let summary = "A file:line:column source location range";
   let description = [{
     Syntax:
 
     ```
     filelinecol-location ::= string-literal `:` integer-literal `:`
                              integer-literal
+                             (`to` (integer-literal ?) `:` integer-literal ?)
     ```
 
-    An instance of this location represents a tuple of file, line number, and
-    column number. This is similar to the type of location that you get from
-    most source languages.
+    An instance of this location represents a tuple of file, start and end line
+    number, and start and end column number. It allows for the following
+    configurations:
+
+    *   A single file line location: `file:line`;
+    *   A single file line col location: `file:line:column`;
+    *   A single line range: `file:line:column to :column`;
+    *   A single file range: `file:line:column to line:column`;
 
     Example:
 
     ```mlir
-    loc("mysource.cc":10:8)
+    loc("mysource.cc":10:8 to 12:18)
     ```
   }];
-  let parameters = (ins "StringAttr":$filename, "unsigned":$line,
-                        "unsigned":$column);
+
+  // Note: this only shows the parameters for which accessors are generated. The
+  // locations are only set in storage.
+  let parameters = (ins "StringAttr":$filename);
   let builders = [
+
+    AttrBuilderWithInferredContext<(ins "StringAttr":$filename), [{
+      return $_get(filename.getContext(), filename, ArrayRef<unsigned>{});
+    }]>,
+    AttrBuilderWithInferredContext<(ins "StringAttr":$filename,
+                                        "unsigned":$line), [{
+      return $_get(filename.getContext(), filename,
+                   ArrayRef<unsigned>{line});
+    }]>,
     AttrBuilderWithInferredContext<(ins "StringAttr":$filename,
                                         "unsigned":$line,
                                         "unsigned":$column), [{
-      return $_get(filename.getContext(), filename, line, column);
+      return $_get(filename.getContext(), filename,
+                   ArrayRef<unsigned>{line, column});
     }]>,
-    AttrBuilder<(ins "StringRef":$filename, "unsigned":$line,
-                     "unsigned":$column), [{
+    AttrBuilder<(ins "::llvm::StringRef":$filename,
+                     "unsigned":$start_line,
+                     "unsigned":$start_column), [{
       return $_get($_ctxt,
-                   StringAttr::get($_ctxt, filename.empty() ? "-" : filename),
-                   line, column);
-    }]>
+        StringAttr::get($_ctxt, filename.empty() ? "-" : filename),
+        ArrayRef<unsigned>{start_line, start_column});
+    }]>,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$filename,
+                                        "unsigned":$line,
+                                        "unsigned":$start_column,
+                                        "unsigned":$end_column), [{
+      return $_get(filename.getContext(), filename,
+                   ArrayRef<unsigned>{line, start_column, end_column});
+    }]>,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$filename,
+                                        "unsigned":$start_line,
+                                        "unsigned":$start_column,
+                                        "unsigned":$end_line,
+                                        "unsigned":$end_column), [{
+      return $_get(filename.getContext(), filename,
+        ArrayRef<unsigned>{start_line, start_column, end_column, end_line});
+    }]>,
+    AttrBuilder<(ins "::llvm::StringRef":$filename,
+                     "unsigned":$start_line,
+                     "unsigned":$start_column,
+                     "unsigned":$end_line,
+                     "unsigned":$end_column), [{
+      return $_get($_ctxt,
+        StringAttr::get($_ctxt, filename.empty() ? "-" : filename),
+        ArrayRef<unsigned>{start_line, start_column, end_column, end_line});
+    }]>,
   ];
+
+  let extraClassDeclaration = [{
+    std::optional<unsigned> getStartLine() const;
+    std::optional<unsigned> getStartColumn() const;
+    std::optional<unsigned> getEndColumn() const;
+    std::optional<unsigned> getEndLine() const;
+  }];
   let skipDefaultBuilders = 1;
-  let attrName = "builtin.file_line_loc";
+  let genStorageClass = 0;
+  let attrName = "builtin.file_line_range";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/BytecodeBase.td
+++ b/mlir/include/mlir/IR/BytecodeBase.td
@@ -82,12 +82,6 @@ def VarInt :
   WithBuilder<"$_args",
   WithPrinter<"$_writer.writeVarInt($_getter)",
   WithType   <"uint64_t">>>>;
-// This is for optional ints which are guaranteed to be present.
-def PresentOptionalVarInt :
-  WithParser <"succeeded($_reader.readVarInt($_var))",
-  WithBuilder<"$_args",
-  WithPrinter<"$_writer.writeVarInt(*$_getter)",
-  WithType   <"uint64_t">>>>;
 def SignedVarInt :
   WithParser <"succeeded($_reader.readSignedVarInt($_var))",
   WithBuilder<"$_args",

--- a/mlir/include/mlir/IR/BytecodeBase.td
+++ b/mlir/include/mlir/IR/BytecodeBase.td
@@ -82,6 +82,12 @@ def VarInt :
   WithBuilder<"$_args",
   WithPrinter<"$_writer.writeVarInt($_getter)",
   WithType   <"uint64_t">>>>;
+// This is for optional ints which are guaranteed to be present.
+def PresentOptionalVarInt :
+  WithParser <"succeeded($_reader.readVarInt($_var))",
+  WithBuilder<"$_args",
+  WithPrinter<"$_writer.writeVarInt(*$_getter)",
+  WithType   <"uint64_t">>>>;
 def SignedVarInt :
   WithParser <"succeeded($_reader.readSignedVarInt($_var))",
   WithBuilder<"$_args",

--- a/mlir/include/mlir/IR/Location.h
+++ b/mlir/include/mlir/IR/Location.h
@@ -173,11 +173,11 @@ public:
 // FileLineColLoc
 //===----------------------------------------------------------------------===//
 
-// An instance of this location represents a tuple of file, line number, and
-// column number. This is similar to the type of location that you get from
-// most source languages.
-//
-// FileLineColLoc is a FileLineColRange with exactly one line and column.
+/// An instance of this location represents a tuple of file, line number, and
+/// column number. This is similar to the type of location that you get from
+/// most source languages.
+///
+/// FileLineColLoc is a FileLineColRange with exactly one line and column.
 class FileLineColLoc : public FileLineColRange {
 public:
   using FileLineColRange::FileLineColRange;

--- a/mlir/include/mlir/IR/Location.h
+++ b/mlir/include/mlir/IR/Location.h
@@ -136,6 +136,11 @@ inline ::llvm::hash_code hash_value(Location arg) {
 // Tablegen Attribute Declarations
 //===----------------------------------------------------------------------===//
 
+// Forward declaration for class created later.
+namespace mlir::detail {
+struct FileLineColRangeAttrStorage;
+} // namespace mlir::detail
+
 #define GET_ATTRDEF_CLASSES
 #include "mlir/IR/BuiltinLocationAttributes.h.inc"
 
@@ -162,6 +167,32 @@ public:
     auto fusedLoc = llvm::dyn_cast<FusedLoc>(attr);
     return fusedLoc && mlir::isa_and_nonnull<MetadataT>(fusedLoc.getMetadata());
   }
+};
+
+//===----------------------------------------------------------------------===//
+// FileLineColLoc
+//===----------------------------------------------------------------------===//
+
+// An instance of this location represents a tuple of file, line number, and
+// column number. This is similar to the type of location that you get from
+// most source languages.
+//
+// FileLineColLoc is a FileLineColRange with exactly one line and column.
+class FileLineColLoc : public FileLineColRange {
+public:
+  using FileLineColRange::FileLineColRange;
+
+  static FileLineColLoc get(StringAttr filename, unsigned line,
+                            unsigned column);
+  static FileLineColLoc get(MLIRContext *context, StringRef fileName,
+                            unsigned line, unsigned column);
+
+  StringAttr getFilename() const;
+  unsigned getLine() const;
+  unsigned getColumn() const;
+
+  /// Methods for support type inquiry through isa, cast, and dyn_cast.
+  static bool classof(Attribute attr);
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/AsmParser/LocationParser.cpp
+++ b/mlir/lib/AsmParser/LocationParser.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Support/LLVM.h"
+#include <optional>
 
 using namespace mlir;
 using namespace mlir::detail;
@@ -97,37 +98,82 @@ ParseResult Parser::parseFusedLocation(LocationAttr &loc) {
   return success();
 }
 
-ParseResult Parser::parseNameOrFileLineColLocation(LocationAttr &loc) {
+ParseResult Parser::parseNameOrFileLineColRange(LocationAttr &loc) {
   auto *ctx = getContext();
   auto str = getToken().getStringValue();
   consumeToken(Token::string);
+
+  std::optional<unsigned> startLine, startColumn, endLine, endColumn;
 
   // If the next token is ':' this is a filelinecol location.
   if (consumeIf(Token::colon)) {
     // Parse the line number.
     if (getToken().isNot(Token::integer))
       return emitWrongTokenError(
-          "expected integer line number in FileLineColLoc");
-    auto line = getToken().getUnsignedIntegerValue();
-    if (!line)
+          "expected integer line number in FileLineColRange");
+    startLine = getToken().getUnsignedIntegerValue();
+    if (!startLine)
       return emitWrongTokenError(
-          "expected integer line number in FileLineColLoc");
+          "expected integer line number in FileLineColRange");
     consumeToken(Token::integer);
 
     // Parse the ':'.
-    if (parseToken(Token::colon, "expected ':' in FileLineColLoc"))
-      return failure();
+    if (getToken().isNot(Token::colon)) {
+      loc = FileLineColRange::get(StringAttr::get(ctx, str), *startLine);
+      return success();
+    }
+    consumeToken(Token::colon);
 
     // Parse the column number.
-    if (getToken().isNot(Token::integer))
+    if (getToken().isNot(Token::integer)) {
       return emitWrongTokenError(
-          "expected integer column number in FileLineColLoc");
-    auto column = getToken().getUnsignedIntegerValue();
-    if (!column.has_value())
-      return emitError("expected integer column number in FileLineColLoc");
+          "expected integer column number in FileLineColRange");
+    }
+    startColumn = getToken().getUnsignedIntegerValue();
+    if (!startColumn.has_value())
+      return emitError("expected integer column number in FileLineColRange");
     consumeToken(Token::integer);
 
-    loc = FileLineColLoc::get(ctx, str, *line, *column);
+    if (!isCurrentTokenAKeyword() || getTokenSpelling() != "to") {
+      loc = FileLineColLoc::get(ctx, str, *startLine, *startColumn);
+      return success();
+    }
+    consumeToken();
+
+    // Parse the line number.
+    if (getToken().is(Token::integer)) {
+      endLine = getToken().getUnsignedIntegerValue();
+      if (!endLine) {
+        return emitWrongTokenError(
+            "expected integer line number in FileLineColRange");
+      }
+      consumeToken(Token::integer);
+    }
+
+    // Parse the ':'.
+    if (getToken().isNot(Token::colon)) {
+      return emitWrongTokenError(
+          "expected either integer or `:` post `to` in FileLineColRange");
+    }
+    consumeToken(Token::colon);
+
+    // Parse the column number.
+    if (getToken().isNot(Token::integer)) {
+      return emitWrongTokenError(
+          "expected integer column number in FileLineColRange");
+    }
+    endColumn = getToken().getUnsignedIntegerValue();
+    if (!endColumn.has_value())
+      return emitError("expected integer column number in FileLineColRange");
+    consumeToken(Token::integer);
+
+    if (endLine.has_value()) {
+      loc = FileLineColRange::get(StringAttr::get(ctx, str), *startLine,
+                                  *startColumn, *endLine, *endColumn);
+    } else {
+      loc = FileLineColRange::get(StringAttr::get(ctx, str), *startLine,
+                                  *startColumn, *endColumn);
+    }
     return success();
   }
 
@@ -166,7 +212,7 @@ ParseResult Parser::parseLocationInstance(LocationAttr &loc) {
 
   // Handle either name or filelinecol locations.
   if (getToken().is(Token::string))
-    return parseNameOrFileLineColLocation(loc);
+    return parseNameOrFileLineColRange(loc);
 
   // Bare tokens required for other cases.
   if (!getToken().is(Token::bare_identifier))

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -305,7 +305,7 @@ public:
   ParseResult parseFusedLocation(LocationAttr &loc);
 
   /// Parse a name or FileLineCol location instance.
-  ParseResult parseNameOrFileLineColLocation(LocationAttr &loc);
+  ParseResult parseNameOrFileLineColRange(LocationAttr &loc);
 
   //===--------------------------------------------------------------------===//
   // Affine Parsing

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2014,15 +2014,6 @@ void AsmPrinter::Impl::printLocationInternal(LocationAttr loc, bool pretty,
           os << loc.getFilename().getValue();
         else
           printEscapedString(loc.getFilename());
-        if (loc.getStartLine() == 0 && loc.getStartColumn() == 0 &&
-            loc.getEndLine() == 0 && loc.getEndColumn() == 0) {
-          return;
-        }
-        if (loc.getStartColumn() == 0 &&
-            loc.getStartLine() == loc.getEndLine()) {
-          os << ':' << loc.getStartLine();
-          return;
-        }
         if (loc.getEndColumn() == loc.getStartColumn() &&
             loc.getStartLine() == loc.getEndLine()) {
           os << ':' << loc.getStartLine() << ':' << loc.getStartColumn();

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2014,8 +2014,8 @@ void AsmPrinter::Impl::printLocationInternal(LocationAttr loc, bool pretty,
           os << loc.getFilename().getValue();
         else
           printEscapedString(loc.getFilename());
-        if (loc.getStartLine() == loc.getStartColumn() == loc.getEndLine() ==
-            loc.getEndColumn() == 0) {
+        if (loc.getStartLine() == 0 && loc.getStartColumn() == 0 &&
+            loc.getEndLine() == 0 && loc.getEndColumn() == 0) {
           return;
         }
         if (loc.getStartColumn() == 0 &&

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2014,16 +2014,27 @@ void AsmPrinter::Impl::printLocationInternal(LocationAttr loc, bool pretty,
           os << loc.getFilename().getValue();
         else
           printEscapedString(loc.getFilename());
-        os << ':' << *loc.getStartLine();
-        if (loc.getStartColumn()) {
-          os << ':' << *loc.getStartColumn();
-          if (loc.getEndColumn().has_value() || loc.getEndLine().has_value())
-            os << " to ";
-          if (loc.getEndLine().has_value())
-            os << *loc.getEndLine();
-          if (loc.getEndColumn().has_value())
-            os << ':' << *loc.getEndColumn();
+        if (loc.getStartLine() == loc.getStartColumn() == loc.getEndLine() ==
+            loc.getEndColumn() == 0) {
+          return;
         }
+        if (loc.getStartColumn() == 0 &&
+            loc.getStartLine() == loc.getEndLine()) {
+          os << ':' << loc.getStartLine();
+          return;
+        }
+        if (loc.getEndColumn() == loc.getStartColumn() &&
+            loc.getStartLine() == loc.getEndLine()) {
+          os << ':' << loc.getStartLine() << ':' << loc.getStartColumn();
+          return;
+        }
+        if (loc.getStartLine() == loc.getEndLine()) {
+          os << ':' << loc.getStartLine() << ':' << loc.getStartColumn()
+             << " to :" << loc.getEndColumn();
+          return;
+        }
+        os << ':' << loc.getStartLine() << ':' << loc.getStartColumn() << " to "
+           << loc.getEndLine() << ':' << loc.getEndColumn();
       })
       .Case<NameLoc>([&](NameLoc loc) {
         printEscapedString(loc.getName());

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2009,12 +2009,21 @@ void AsmPrinter::Impl::printLocationInternal(LocationAttr loc, bool pretty,
         else
           os << "unknown";
       })
-      .Case<FileLineColLoc>([&](FileLineColLoc loc) {
+      .Case<FileLineColRange>([&](FileLineColRange loc) {
         if (pretty)
           os << loc.getFilename().getValue();
         else
           printEscapedString(loc.getFilename());
-        os << ':' << loc.getLine() << ':' << loc.getColumn();
+        os << ':' << *loc.getStartLine();
+        if (loc.getStartColumn()) {
+          os << ':' << *loc.getStartColumn();
+          if (loc.getEndColumn().has_value() || loc.getEndLine().has_value())
+            os << " to ";
+          if (loc.getEndLine().has_value())
+            os << *loc.getEndLine();
+          if (loc.getEndColumn().has_value())
+            os << ':' << *loc.getEndColumn();
+        }
       })
       .Case<NameLoc>([&](NameLoc loc) {
         printEscapedString(loc.getName());

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -113,8 +113,8 @@ readFileLineColRangeLocs(DialectBytecodeReader &reader,
 
 static void writeFileLineColRangeLocs(DialectBytecodeWriter &writer,
                                       FileLineColRange range) {
-  if (range.getStartLine() == range.getStartColumn() == range.getEndLine() ==
-      range.getEndColumn() == 0) {
+  if (range.getStartLine() == 0 && range.getStartColumn() == 0 &&
+      range.getEndLine() == 0 && range.getEndColumn() == 0) {
     writer.writeVarInt(0);
     return;
   }

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -126,7 +126,7 @@ static void writeFileLineColRangeLocs(DialectBytecodeWriter &writer,
   }
   // The single file:line:col is handled by other writer, but checked here for
   // completeness.
-  if (range.endColumn() == range.startColumn() &&
+  if (range.getEndColumn() == range.getStartColumn() &&
       range.getStartLine() == range.getEndLine()) {
     writer.writeVarInt(2);
     writer.writeVarInt(range.getStartLine());

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -104,8 +104,9 @@ static FileLineColRange getFileLineColRange(MLIRContext *context,
   }
 }
 
-static LogicalResult readFileLineColRangeLocs(DialectBytecodeReader &reader,
-                                       SmallVectorImpl<uint64_t> &lineCols) {
+static LogicalResult
+readFileLineColRangeLocs(DialectBytecodeReader &reader,
+                         SmallVectorImpl<uint64_t> &lineCols) {
   return reader.readList(
       lineCols, [&reader](uint64_t &val) { return reader.readVarInt(val); });
 }

--- a/mlir/lib/IR/Location.cpp
+++ b/mlir/lib/IR/Location.cpp
@@ -78,21 +78,25 @@ struct FileLineColRangeAttrStorage final
             ArrayRef<unsigned>{std::get<1>(tblgenKey)}.drop_front());
   }
 
-  std::optional<unsigned> getLineCols(unsigned index) const {
-    if (size() <= index)
-      return std::nullopt;
+  unsigned getLineCols(unsigned index) const {
     return getTrailingObjects<unsigned>()[index - 1];
   }
 
-  std::optional<unsigned> getStartLine() const {
-    // Only return nullopt if there are no other locations and start line is 0.
-    if (startLine == 0 && filenameAndTrailing.getInt() == 0)
-      return std::nullopt;
+  unsigned getStartLine() const {
     return startLine;
   }
-  std::optional<unsigned> getStartColumn() const { return getLineCols(1); }
-  std::optional<unsigned> getEndColumn() const { return getLineCols(2); }
-  std::optional<unsigned> getEndLine() const { return getLineCols(3); }
+  unsigned getStartColumn() const {
+    if (size() <= 1) return 0;
+    return getLineCols(1);
+  }
+  unsigned getEndColumn() const {
+    if (size() <= 2) return getStartColumn();
+    return getLineCols(2);
+  }
+  unsigned getEndLine() const {
+    if (size() <= 3) return getStartLine();
+    return getLineCols(3);
+  }
 
   static ::llvm::hash_code hashKey(const KeyTy &tblgenKey) {
     return ::llvm::hash_combine(std::get<0>(tblgenKey), std::get<1>(tblgenKey));
@@ -188,16 +192,16 @@ StringAttr FileLineColRange::getFilename() const {
   return getImpl()->filenameAndTrailing.getPointer();
 }
 
-std::optional<unsigned> FileLineColRange::getStartLine() const {
+unsigned FileLineColRange::getStartLine() const {
   return getImpl()->getStartLine();
 }
-std::optional<unsigned> FileLineColRange::getStartColumn() const {
+unsigned FileLineColRange::getStartColumn() const {
   return getImpl()->getStartColumn();
 }
-std::optional<unsigned> FileLineColRange::getEndColumn() const {
+unsigned FileLineColRange::getEndColumn() const {
   return getImpl()->getEndColumn();
 }
-std::optional<unsigned> FileLineColRange::getEndLine() const {
+unsigned FileLineColRange::getEndLine() const {
   return getImpl()->getEndLine();
 }
 

--- a/mlir/lib/IR/Location.cpp
+++ b/mlir/lib/IR/Location.cpp
@@ -173,9 +173,9 @@ StringAttr FileLineColLoc::getFilename() const {
   return FileLineColRange::getFilename();
 }
 
-unsigned FileLineColLoc::getLine() const { return *getStartLine(); }
+unsigned FileLineColLoc::getLine() const { return getStartLine(); }
 
-unsigned FileLineColLoc::getColumn() const { return *getStartColumn(); }
+unsigned FileLineColLoc::getColumn() const { return getStartColumn(); }
 
 bool FileLineColLoc::classof(Attribute attr) {
   // This could also have been for <= 2. But given this is matching previous

--- a/mlir/lib/IR/Location.cpp
+++ b/mlir/lib/IR/Location.cpp
@@ -82,19 +82,20 @@ struct FileLineColRangeAttrStorage final
     return getTrailingObjects<unsigned>()[index - 1];
   }
 
-  unsigned getStartLine() const {
-    return startLine;
-  }
+  unsigned getStartLine() const { return startLine; }
   unsigned getStartColumn() const {
-    if (size() <= 1) return 0;
+    if (size() <= 1)
+      return 0;
     return getLineCols(1);
   }
   unsigned getEndColumn() const {
-    if (size() <= 2) return getStartColumn();
+    if (size() <= 2)
+      return getStartColumn();
     return getLineCols(2);
   }
   unsigned getEndLine() const {
-    if (size() <= 3) return getStartLine();
+    if (size() <= 3)
+      return getStartLine();
     return getLineCols(3);
   }
 

--- a/mlir/lib/IR/Location.cpp
+++ b/mlir/lib/IR/Location.cpp
@@ -7,13 +7,106 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/Location.h"
+#include "mlir/IR/AttributeSupport.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Visitors.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/TrailingObjects.h"
+#include <cassert>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <utility>
 
 using namespace mlir;
 using namespace mlir::detail;
+
+namespace mlir::detail {
+struct FileLineColRangeAttrStorage final
+    : public ::mlir::AttributeStorage,
+      public llvm::TrailingObjects<FileLineColRangeAttrStorage, unsigned> {
+  using PointerPair = llvm::PointerIntPair<StringAttr, 2>;
+  using KeyTy = std::tuple<StringAttr, ::llvm::ArrayRef<unsigned>>;
+
+  FileLineColRangeAttrStorage(StringAttr filename, int numLocs)
+      : filenameAndTrailing(filename, numLocs) {}
+
+  static FileLineColRangeAttrStorage *
+  construct(::mlir::AttributeStorageAllocator &allocator, KeyTy &&tblgenKey) {
+    auto numInArray = std::get<1>(tblgenKey).size();
+    // Note: Considered asserting that numInArray is at least 1, but this
+    // is not needed in memory or in printed form. This should very rarely be
+    // 0 here as that means a NamedLoc would have been more efficient. But this
+    // does allow for location with just a file, and also having the interface
+    // be more uniform.
+    auto locEnc = numInArray == 0 ? 1 : numInArray;
+    // Allocate a new storage instance.
+    auto byteSize =
+        FileLineColRangeAttrStorage::totalSizeToAlloc<unsigned>(locEnc - 1);
+    auto *rawMem =
+        allocator.allocate(byteSize, alignof(FileLineColRangeAttrStorage));
+    auto *result = ::new (rawMem) FileLineColRangeAttrStorage(
+        std::move(std::get<0>(tblgenKey)), locEnc - 1);
+    if (numInArray > 0) {
+      result->startLine = std::get<1>(tblgenKey)[0];
+      // Copy in the element types into the trailing storage.
+      std::uninitialized_copy(std::next(std::get<1>(tblgenKey).begin()),
+                              std::get<1>(tblgenKey).end(),
+                              result->getTrailingObjects<unsigned>());
+    }
+    return result;
+  }
+
+  // Return the number of held types.
+  unsigned size() const { return filenameAndTrailing.getInt() + 1; }
+
+  bool operator==(const KeyTy &tblgenKey) const {
+    return (filenameAndTrailing.getPointer() == std::get<0>(tblgenKey)) &&
+           (size() == std::get<1>(tblgenKey).size()) &&
+           (startLine == std::get<1>(tblgenKey)[0]) &&
+           (ArrayRef<unsigned>{getTrailingObjects<unsigned>(), size() - 1} ==
+            ArrayRef<unsigned>{std::get<1>(tblgenKey)}.drop_front());
+  }
+
+  std::optional<unsigned> getLineCols(unsigned index) const {
+    if (size() <= index)
+      return std::nullopt;
+    return getTrailingObjects<unsigned>()[index - 1];
+  }
+
+  std::optional<unsigned> getStartLine() const {
+    // Only return nullopt if there are no other locations and start line is 0.
+    if (startLine == 0 && filenameAndTrailing.getInt() == 0)
+      return std::nullopt;
+    return startLine;
+  }
+  std::optional<unsigned> getStartColumn() const { return getLineCols(1); }
+  std::optional<unsigned> getEndColumn() const { return getLineCols(2); }
+  std::optional<unsigned> getEndLine() const { return getLineCols(3); }
+
+  static ::llvm::hash_code hashKey(const KeyTy &tblgenKey) {
+    return ::llvm::hash_combine(std::get<0>(tblgenKey), std::get<1>(tblgenKey));
+  }
+
+  // Supports
+  //  - 0 (file:line)
+  //  - 1 (file:line:col)
+  //  - 2 (file:line:start_col to file:line:end_col) and
+  //  - 3 (file:start_line:start_col to file:end_line:end_col)
+  llvm::PointerIntPair<StringAttr, 2> filenameAndTrailing;
+  unsigned startLine = 0;
+};
+} // namespace mlir::detail
 
 //===----------------------------------------------------------------------===//
 /// Tablegen Attribute Definitions
@@ -21,17 +114,6 @@ using namespace mlir::detail;
 
 #define GET_ATTRDEF_CLASSES
 #include "mlir/IR/BuiltinLocationAttributes.cpp.inc"
-
-//===----------------------------------------------------------------------===//
-// BuiltinDialect
-//===----------------------------------------------------------------------===//
-
-void BuiltinDialect::registerLocationAttributes() {
-  addAttributes<
-#define GET_ATTRDEF_LIST
-#include "mlir/IR/BuiltinLocationAttributes.cpp.inc"
-      >();
-}
 
 //===----------------------------------------------------------------------===//
 // LocationAttr
@@ -64,6 +146,59 @@ CallSiteLoc CallSiteLoc::get(Location name, ArrayRef<Location> frames) {
   for (auto frame : llvm::reverse(frames.drop_back()))
     caller = CallSiteLoc::get(frame, caller);
   return CallSiteLoc::get(name, caller);
+}
+
+//===----------------------------------------------------------------------===//
+// FileLineColLoc
+//===----------------------------------------------------------------------===//
+
+FileLineColLoc FileLineColLoc::get(StringAttr filename, unsigned line,
+                                   unsigned column) {
+  return llvm::cast<FileLineColLoc>(
+      FileLineColRange::get(filename, line, column));
+}
+
+FileLineColLoc FileLineColLoc::get(MLIRContext *context, StringRef fileName,
+                                   unsigned line, unsigned column) {
+  return llvm::cast<FileLineColLoc>(
+      FileLineColRange::get(context, fileName, line, column));
+}
+
+StringAttr FileLineColLoc::getFilename() const {
+  return FileLineColRange::getFilename();
+}
+
+unsigned FileLineColLoc::getLine() const { return *getStartLine(); }
+
+unsigned FileLineColLoc::getColumn() const { return *getStartColumn(); }
+
+bool FileLineColLoc::classof(Attribute attr) {
+  // This could also have been for <= 2. But given this is matching previous
+  // behavior, it is left as is.
+  if (auto range = mlir::dyn_cast<FileLineColRange>(attr))
+    return range.getImpl()->size() == 2;
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// FileLineColRange
+//===----------------------------------------------------------------------===//
+
+StringAttr FileLineColRange::getFilename() const {
+  return getImpl()->filenameAndTrailing.getPointer();
+}
+
+std::optional<unsigned> FileLineColRange::getStartLine() const {
+  return getImpl()->getStartLine();
+}
+std::optional<unsigned> FileLineColRange::getStartColumn() const {
+  return getImpl()->getStartColumn();
+}
+std::optional<unsigned> FileLineColRange::getEndColumn() const {
+  return getImpl()->getEndColumn();
+}
+std::optional<unsigned> FileLineColRange::getEndLine() const {
+  return getImpl()->getEndLine();
 }
 
 //===----------------------------------------------------------------------===//
@@ -106,4 +241,15 @@ Location FusedLoc::get(ArrayRef<Location> locs, Attribute metadata,
     return locs.front();
 
   return Base::get(context, locs, metadata);
+}
+
+//===----------------------------------------------------------------------===//
+// BuiltinDialect
+//===----------------------------------------------------------------------===//
+
+void BuiltinDialect::registerLocationAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "mlir/IR/BuiltinLocationAttributes.cpp.inc"
+      >();
 }

--- a/mlir/test/IR/locations.mlir
+++ b/mlir/test/IR/locations.mlir
@@ -33,7 +33,7 @@ func.func @inline_notation() -> i32 {
 // CHECK-LABEL: func private @loc_attr(i1 {foo.loc_attr = loc(callsite("foo" at "mysource.cc":10:8))})
 func.func private @loc_attr(i1 {foo.loc_attr = loc(callsite("foo" at "mysource.cc":10:8))})
 
-// CHECK-LABEL: func.func private @filelocrange_attr1(i1 {foo.loc_attr = loc("mysource.cc":10)})
+// CHECK-LABEL: func.func private @filelocrange_attr1(i1 {foo.loc_attr = loc("mysource.cc":10:0)})
 func.func private @filelocrange_attr1(i1 {foo.loc_attr = loc("mysource.cc":10)})
 // CHECK-LABEL: func.func private @filelocrange_attr2(i1 {foo.loc_attr = loc("mysource.cc":10:8)})
 func.func private @filelocrange_attr2(i1 {foo.loc_attr = loc("mysource.cc":10:8)})

--- a/mlir/test/IR/locations.mlir
+++ b/mlir/test/IR/locations.mlir
@@ -33,6 +33,15 @@ func.func @inline_notation() -> i32 {
 // CHECK-LABEL: func private @loc_attr(i1 {foo.loc_attr = loc(callsite("foo" at "mysource.cc":10:8))})
 func.func private @loc_attr(i1 {foo.loc_attr = loc(callsite("foo" at "mysource.cc":10:8))})
 
+// CHECK-LABEL: func.func private @filelocrange_attr1(i1 {foo.loc_attr = loc("mysource.cc":10)})
+func.func private @filelocrange_attr1(i1 {foo.loc_attr = loc("mysource.cc":10)})
+// CHECK-LABEL: func.func private @filelocrange_attr2(i1 {foo.loc_attr = loc("mysource.cc":10:8)})
+func.func private @filelocrange_attr2(i1 {foo.loc_attr = loc("mysource.cc":10:8)})
+// CHECK-LABEL: func.func private @filelocrange_attr3(i1 {foo.loc_attr = loc("mysource.cc":10:8 to :12)})
+func.func private @filelocrange_attr3(i1 {foo.loc_attr = loc("mysource.cc":10:8 to :12)})
+// CHECK-LABEL: func.func private @filelocrange_attr4(i1 {foo.loc_attr = loc("mysource.cc":10:8 to 12:4)})
+func.func private @filelocrange_attr4(i1 {foo.loc_attr = loc("mysource.cc":10:8 to 12:4)})
+
   // Check that locations get properly escaped.
 // CHECK-LABEL: func @escape_strings()
 func.func @escape_strings() {


### PR DESCRIPTION
This location type represents a contiguous range inside a file. It is
effectively a pair of FileLineCols. Add new type and make FileLineCol a
view for case where it matches existing previous one.

The location includes filename and optional start line & col, and end
line & col. Considered common cases are file:line, file:line:col,
file:line:start_col to file:line:end_col and general range within same
file. In memory its encoded as trailing objects. This keeps the memory
requirement the same as FileLineColLoc today (makes the rather common
File:Line cheaper) at the expense of extra work at decoding time. I made
the line/columns accessors uniformly return optionals. Kept the unsigned
type.

There was the option to always have file range be castable to
FileLineColLoc. This cast would just drop other fields. That may result in
some simpler staging. TBD.

This is a rather minimal change, it does not yet add bindings (C or Python),
lowering to LLVM debug locations etc. that supports end line:cols.