### PR TITLE
[RISCV] Exclude X1 and X5 from register scavenging for long branch.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1115,7 +1115,7 @@ void RISCVInstrInfo::insertIndirectBranch(MachineBasicBlock &MBB,
   // FIXME: A virtual register must be used initially, as the register
   // scavenger won't work with empty blocks (SIInstrInfo::insertIndirectBranch
   // uses the same workaround).
-  Register ScratchReg = MRI.createVirtualRegister(&RISCV::GPRRegClass);
+  Register ScratchReg = MRI.createVirtualRegister(&RISCV::GPRJALRRegClass);
   auto II = MBB.end();
   // We may also update the jump target to RestoreBB later.
   MachineInstr &MI = *BuildMI(MBB, II, DL, get(RISCV::PseudoJump))


### PR DESCRIPTION
When a branch target is too far away we need to emit an indirect branch. We scavenge a register for this since we don't know we need this until after register allocation.

Jumps using X1 and X5 as the source are hints to the hardware to pop the return-address stack. We should avoiding using them for jumps that aren't a return or tail call.

Need to look into how to create enough register pressure to test this.