### PR TITLE
[OpenMP] Move unsupported structured bindings diagnostic

### DIFF
--- a/clang/test/SemaCXX/decomposition-openmp.cpp
+++ b/clang/test/SemaCXX/decomposition-openmp.cpp
@@ -1,13 +1,32 @@
-
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 -fopenmp %s
 
-// FIXME: OpenMP should support capturing structured bindings
+// Okay, not an OpenMP capture.
 auto f() {
   int i[2] = {};
-  auto [a, b] = i; // expected-note 2{{declared here}}
+  auto [a, b] = i;
   return [=, &a] {
-    // expected-error@-1 {{capturing a structured binding is not yet supported in OpenMP}}
     return a + b;
-    // expected-error@-1 {{capturing a structured binding is not yet supported in OpenMP}}
   };
+}
+
+// Okay, not an OpenMP capture.
+void foo(int);
+void g() {
+  #pragma omp parallel
+  {
+    int i[2] = {};
+    auto [a, b] = i;
+    auto L = [&] { foo(a+b); };
+  }
+}
+
+// FIXME: OpenMP should support capturing structured bindings
+void h() {
+  int i[2] = {};
+  auto [a, b] = i; // expected-note 2{{declared here}}
+  #pragma omp parallel
+  {
+    // expected-error@+1 2{{capturing a structured binding is not yet supported in OpenMP}}
+    foo(a + b);
+  }
 }


### PR DESCRIPTION
Move the diagnostic so it fires only when doing an OpenMP capture, not for non-OpenMP captures. This allows non-OpenMP code to work when using OpenMP elsewhere, such as the code reported in
https://github.com/llvm/llvm-project/issues/66999.