### PR TITLE
[libc] Support epoll_wait using epoll_pwait

### DIFF
--- a/libc/src/sys/epoll/linux/epoll_wait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_wait.cpp
@@ -10,11 +10,11 @@
 
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 // TODO: Use this include once the include headers are also using quotes.
+// #include "include/llvm-libc-types/sigset_t.h"
 // #include "include/llvm-libc-types/struct_epoll_event.h"
 
 #include <sys/epoll.h>
@@ -24,9 +24,16 @@ namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(int, epoll_wait,
                    (int epfd, struct epoll_event *events, int maxevents,
                     int timeout)) {
+#ifdef SYS_epoll_wait
   int ret = LIBC_NAMESPACE::syscall_impl<int>(
       SYS_epoll_wait, epfd, reinterpret_cast<long>(events), maxevents, timeout);
-
+#elif defined(SYS_epoll_pwait)
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(
+      SYS_epoll_pwait, epfd, reinterpret_cast<long>(events), maxevents, timeout,
+      reinterpret_cast<long>(nullptr), sizeof(sigset_t));
+#else
+#error epoll_wait and epoll_pwait are unavailable. Unable to build epoll_wait.
+#endif
   // A negative return value indicates an error with the magnitude of the
   // value being the error code.
   if (ret < 0) {

--- a/libc/src/sys/epoll/linux/epoll_wait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_wait.cpp
@@ -32,7 +32,7 @@ LLVM_LIBC_FUNCTION(int, epoll_wait,
       SYS_epoll_pwait, epfd, reinterpret_cast<long>(events), maxevents, timeout,
       reinterpret_cast<long>(nullptr), sizeof(sigset_t));
 #else
-#error epoll_wait and epoll_pwait are unavailable. Unable to build epoll_wait.
+#error "epoll_wait and epoll_pwait are unavailable. Unable to build epoll_wait."
 #endif
   // A negative return value indicates an error with the magnitude of the
   // value being the error code.


### PR DESCRIPTION
The epoll_wait syscall is equivalent to calling epoll_pwait with a null
sigset. This is useful to support systems that have epoll_pwait but not
epoll_wait.
