### PR TITLE
[BOLT] Enable re-writing of Linux kernel binary

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -757,12 +757,11 @@ Error RewriteInstance::run() {
   if (opts::Instrument && !BC->IsStaticExecutable)
     updateRtFiniReloc();
 
-  if (BC->IsLinuxKernel) {
-    errs() << "BOLT-WARNING: not writing the output file for Linux Kernel\n";
-    return Error::success();
-  } else if (opts::OutputFilename == "/dev/null") {
+  if (opts::OutputFilename == "/dev/null") {
     outs() << "BOLT-INFO: skipping writing final binary to disk\n";
     return Error::success();
+  } else if (BC->IsLinuxKernel) {
+    errs() << "BOLT-WARNING: Linux kernel support is experimental\n";
   }
 
   // Rewrite allocatable contents and copy non-allocatable parts with mods.
@@ -1859,6 +1858,11 @@ Error RewriteInstance::readSpecialSections() {
 
   BC->HasRelocations =
       HasTextRelocations && (opts::RelocationMode != cl::BOU_FALSE);
+
+  if (BC->IsLinuxKernel && BC->HasRelocations) {
+    outs() << "BOLT-INFO: disabling relocation mode for Linux kernel\n";
+    BC->HasRelocations = false;
+  }
 
   BC->IsStripped = !HasSymbolTable;
 
@@ -4369,8 +4373,10 @@ void RewriteInstance::patchELFSectionHeaderTable(ELFObjectFile<ELFT> *File) {
     assert((NewEhdr.e_entry || !Obj.getHeader().e_entry) &&
            "cannot find new address for entry point");
   }
-  NewEhdr.e_phoff = PHDRTableOffset;
-  NewEhdr.e_phnum = Phnum;
+  if (PHDRTableOffset) {
+    NewEhdr.e_phoff = PHDRTableOffset;
+    NewEhdr.e_phnum = Phnum;
+  }
   NewEhdr.e_shoff = SHTOffset;
   NewEhdr.e_shnum = OutputSections.size();
   NewEhdr.e_shstrndx = NewSectionIndex[NewEhdr.e_shstrndx];
@@ -5505,7 +5511,8 @@ void RewriteInstance::rewriteFile() {
     addBATSection();
 
   // Patch program header table.
-  patchELFPHDRTable();
+  if (!BC->IsLinuxKernel)
+    patchELFPHDRTable();
 
   // Finalize memory image of section string table.
   finalizeSectionStringTable();

--- a/bolt/test/X86/linux-orc.s
+++ b/bolt/test/X86/linux-orc.s
@@ -52,6 +52,8 @@ bar:
 .L4:
   .size bar, .-bar
 
+# CHECK: BOLT-WARNING: Linux kernel support is experimental
+
   .section .orc_unwind,"a",@progbits
   .align 4
   .section .orc_unwind_ip,"a",@progbits


### PR DESCRIPTION
Write modified Linux kernel binary to disk. The output is not supposed to be functional at the moment, but it will allow for future patches to test the output binary.