### PR TITLE
[clang][Diagnostic] Don't warn about binary literals when using C23.

### DIFF
--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -1358,11 +1358,17 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
 
   // Handle simple binary numbers 0b01010
   if ((c1 == 'b' || c1 == 'B') && (s[1] == '0' || s[1] == '1')) {
-    // 0b101010 is a C++1y / GCC extension.
-    Diags.Report(TokLoc, LangOpts.CPlusPlus14
-                             ? diag::warn_cxx11_compat_binary_literal
-                         : LangOpts.CPlusPlus ? diag::ext_binary_literal_cxx14
-                                              : diag::ext_binary_literal);
+    // 0b101010 is a GCC extension subsequently standardized by C23 and C++14.
+    if (LangOpts.CPlusPlus) {
+      if (LangOpts.CPlusPlus14)
+        Diags.Report(TokLoc, diag::warn_cxx11_compat_binary_literal);
+      else
+        Diags.Report(TokLoc, diag::ext_binary_literal_cxx14);
+    } else {
+      // TODO: Need new DiagGroup for C23.
+      if (!LangOpts.C23)
+        Diags.Report(TokLoc, diag::ext_binary_literal);
+    }
     ++s;
     assert(s < ThisTokEnd && "didn't maximally munch?");
     radix = 2;


### PR DESCRIPTION
The C23 standard brought binary literals which were previously GNU extensions. Silence warnings from -Wgnu-binary-literal when using C23. This warning is implied by -Wpedantic.