### PR TITLE
[Clang][test] Limit library search when linking shared lib

### DIFF
--- a/clang/test/Interpreter/cxx20-modules.cppm
+++ b/clang/test/Interpreter/cxx20-modules.cppm
@@ -8,7 +8,7 @@
 // RUN: %clang -std=c++20 %t/mod.cppm --precompile \
 // RUN:     -o %t/mod.pcm --target=x86_64-linux-gnu
 // RUN: %clang -fPIC %t/mod.pcm -c -o %t/mod.o --target=x86_64-linux-gnu
-// RUN: %clang -fPIC -shared %t/mod.o -o %t/libmod.so --target=x86_64-linux-gnu
+// RUN: %clang -nostdlib -fPIC -shared %t/mod.o -o %t/libmod.so --target=x86_64-linux-gnu
 //
 // RUN: cat %t/import.cpp | env LD_LIBRARY_PATH=%t:$LD_LIBRARY_PATH \
 // RUN:     clang-repl -Xcc=-std=c++20 -Xcc=-fmodule-file=M=%t/mod.pcm \


### PR DESCRIPTION
Don't search for unnecessary libs when linking the shared lib. This allows the test to run in chroot environment.