### PR TITLE
Thread safety analysis: provide printSCFG definition.

### DIFF
--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
@@ -528,6 +528,7 @@ private:
 };
 
 // Dump an SCFG to llvm::errs().
+// The implementation is not stable, and used for debugging only.
 void printSCFG(CFGWalker &Walker);
 
 } // namespace threadSafety

--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
@@ -527,9 +527,10 @@ private:
   BlockInfo *CurrentBlockInfo = nullptr;
 };
 
+#ifndef NDEBUG
 // Dump an SCFG to llvm::errs().
-// The implementation is not stable, and used for debugging only.
 void printSCFG(CFGWalker &Walker);
+#endif // NDEBUG
 
 } // namespace threadSafety
 } // namespace clang

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -995,7 +995,6 @@ void SExprBuilder::exitCFG(const CFGBlock *Last) {
   IncompleteArgs.clear();
 }
 
-/*
 namespace {
 
 class TILPrinter :
@@ -1016,4 +1015,3 @@ void printSCFG(CFGWalker &Walker) {
 
 } // namespace threadSafety
 } // namespace clang
-*/

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -995,6 +995,7 @@ void SExprBuilder::exitCFG(const CFGBlock *Last) {
   IncompleteArgs.clear();
 }
 
+#ifndef NDEBUG
 namespace {
 
 class TILPrinter :
@@ -1015,3 +1016,4 @@ void printSCFG(CFGWalker &Walker) {
 
 } // namespace threadSafety
 } // namespace clang
+#endif // NDEBUG


### PR DESCRIPTION
I called this function when investigating the issue (https://github.com/llvm/llvm-project/issues/78131), and I was surprised to see the definition is commented out.

I think it makes sense to provide the definition even though the implementation is not stable.