### PR TITLE
[mlir][IR] Do not trigger `notifyOperationInserted` for unlinked ops

### DIFF
--- a/mlir/include/mlir/IR/Builders.h
+++ b/mlir/include/mlir/IR/Builders.h
@@ -530,7 +530,7 @@ public:
     // Fold the operation. If successful erase it, otherwise notify.
     if (succeeded(tryFold(op, results)))
       op->erase();
-    else if (listener)
+    else if (block && listener)
       listener->notifyOperationInserted(op, /*previous=*/{});
   }
 

--- a/mlir/lib/IR/Builders.cpp
+++ b/mlir/lib/IR/Builders.cpp
@@ -408,11 +408,11 @@ AffineMap Builder::getShiftedAffineMap(AffineMap map, int64_t shift) {
 
 /// Insert the given operation at the current insertion point and return it.
 Operation *OpBuilder::insert(Operation *op) {
-  if (block)
+  if (block) {
     block->getOperations().insert(insertPoint, op);
-
-  if (listener)
-    listener->notifyOperationInserted(op, /*previous=*/{});
+    if (listener)
+      listener->notifyOperationInserted(op, /*previous=*/{});
+  }
   return op;
 }
 


### PR DESCRIPTION
This commit changes `OpBuilder::create` and `OpBuilder::createOrFold` such that `notifyOperationInserted` is no longer triggered if no insertion point is set. In such a case, an unlinked operation is created but not inserted, so `notifyOperationInserted` should not be triggered.

Note: Inserting another op into a block that belongs to an unlinked op (e.g., by the builder of the unlinked op) will trigger a notification.