### PR TITLE
[OpenMP] Fix build breakage (NFC)

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
@@ -69,7 +69,7 @@ cuMemGetAllocationGranularity(size_t *granularity,
 #if (defined(CUDA_VERSION) && (CUDA_VERSION < 11020))
 // Forward declarations of asynchronous memory management functions. This is
 // necessary for older versions of CUDA.
-CUresult cuMemAllocAsync(CUdeviceptr *ptr, size_t, CUstream) { *ptr = nullptr; }
+CUresult cuMemAllocAsync(CUdeviceptr *ptr, size_t, CUstream) { ptr = nullptr; }
 
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {}
 #endif

--- a/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
@@ -69,7 +69,7 @@ cuMemGetAllocationGranularity(size_t *granularity,
 #if (defined(CUDA_VERSION) && (CUDA_VERSION < 11020))
 // Forward declarations of asynchronous memory management functions. This is
 // necessary for older versions of CUDA.
-CUresult cuMemAllocAsync(CUdeviceptr *ptr, size_t, CUstream) { ptr = nullptr; }
+CUresult cuMemAllocAsync(CUdeviceptr *ptr, size_t, CUstream) { *ptr = 0; }
 
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {}
 #endif


### PR DESCRIPTION
Assign `nullptr` to the pointer instead.