### PR TITLE
[Libomptarget] Remove unused 'SupportsEmptyImages' API function

### DIFF
--- a/openmp/libomptarget/include/Shared/PluginAPI.h
+++ b/openmp/libomptarget/include/Shared/PluginAPI.h
@@ -40,11 +40,6 @@ int32_t __tgt_rtl_is_valid_binary(__tgt_device_image *Image);
 // function to move data from source device to destination device directly.
 int32_t __tgt_rtl_is_data_exchangable(int32_t SrcDevId, int32_t DstDevId);
 
-// Return an integer other than zero if the plugin can handle images which do
-// not contain target regions and global variables (but can contain other
-// functions)
-int32_t __tgt_rtl_supports_empty_images();
-
 // Initialize the requires flags for the device.
 int64_t __tgt_rtl_init_requires(int64_t RequiresFlags);
 

--- a/openmp/libomptarget/include/Shared/PluginAPI.inc
+++ b/openmp/libomptarget/include/Shared/PluginAPI.inc
@@ -33,7 +33,6 @@ PLUGIN_API_HANDLE(launch_kernel, true);
 PLUGIN_API_HANDLE(init_requires, false);
 PLUGIN_API_HANDLE(synchronize, false);
 PLUGIN_API_HANDLE(query_async, false);
-PLUGIN_API_HANDLE(supports_empty_images, false);
 PLUGIN_API_HANDLE(set_info_flag, false);
 PLUGIN_API_HANDLE(print_device_info, false);
 PLUGIN_API_HANDLE(create_event, false);

--- a/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/PluginInterface.h
@@ -1048,9 +1048,6 @@ struct GenericPluginTy {
   /// we could not move this function into GenericDeviceTy.
   virtual Expected<bool> isELFCompatible(StringRef Image) const = 0;
 
-  /// Indicate whether the plugin supports empty images.
-  virtual bool supportsEmptyImages() const { return false; }
-
 protected:
   /// Indicate whether a device id is valid.
   bool isValidDeviceId(int32_t DeviceId) const {

--- a/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1620,10 +1620,6 @@ int32_t __tgt_rtl_is_valid_binary(__tgt_device_image *Image) {
   }
 }
 
-int32_t __tgt_rtl_supports_empty_images() {
-  return Plugin::get().supportsEmptyImages();
-}
-
 int32_t __tgt_rtl_init_device(int32_t DeviceId) {
   auto Err = Plugin::get().initDevice(DeviceId);
   if (Err) {

--- a/openmp/libomptarget/src/omptarget.cpp
+++ b/openmp/libomptarget/src/omptarget.cpp
@@ -140,16 +140,13 @@ static int initLibrary(DeviceTy &Device) {
    */
   int32_t DeviceId = Device.DeviceID;
   int Rc = OFFLOAD_SUCCESS;
-  bool SupportsEmptyImages = Device.RTL->supports_empty_images &&
-                             Device.RTL->supports_empty_images() > 0;
   {
     std::lock_guard<decltype(PM->TrlTblMtx)> LG(PM->TrlTblMtx);
     for (auto *HostEntriesBegin : PM->HostEntriesBeginRegistrationOrder) {
       TranslationTable *TransTable =
           &PM->HostEntriesBeginToTransTable[HostEntriesBegin];
       if (TransTable->HostTable.EntriesBegin ==
-              TransTable->HostTable.EntriesEnd &&
-          !SupportsEmptyImages) {
+          TransTable->HostTable.EntriesEnd) {
         // No host entry so no need to proceed
         continue;
       }


### PR DESCRIPTION
Summary:
This function is always false in the current implementation and is not
even considered required. Just remove it and if someone needs it in the
future they can add it back in. This is done to simplify the interface
prior to other changes
