### PR TITLE
[libc] fix stdbit include test when not all entrypoints are available

### DIFF
--- a/libc/test/include/stdbit_test.cpp
+++ b/libc/test/include/stdbit_test.cpp
@@ -8,8 +8,6 @@
 
 #include "test/UnitTest/Test.h"
 
-#include <stdbit.h>
-
 /*
  * The intent of this test is validate that:
  * 1. We provide the definition of the various type generic macros of stdbit.h.
@@ -18,16 +16,24 @@
  * do not contain non-namespaced symbols.
  */
 
-unsigned char stdc_leading_zeros_uc(unsigned char) { return 0xAA; }
-unsigned short stdc_leading_zeros_us(unsigned short) { return 0xAB; }
-unsigned stdc_leading_zeros_ui(unsigned) { return 0xAC; }
-unsigned long stdc_leading_zeros_ul(unsigned long) { return 0xAD; }
-unsigned long long stdc_leading_zeros_ull(unsigned long long) { return 0xAF; }
-unsigned char stdc_leading_ones_uc(unsigned char) { return 0xBA; }
-unsigned short stdc_leading_ones_us(unsigned short) { return 0xBB; }
-unsigned stdc_leading_ones_ui(unsigned) { return 0xBC; }
-unsigned long stdc_leading_ones_ul(unsigned long) { return 0xBD; }
-unsigned long long stdc_leading_ones_ull(unsigned long long) { return 0xBF; }
+/*
+ * Declare these BEFORE including stdbit.h so that this test may still be run
+ * even if a given target doesn't yet have these individual entrypoints enabled.
+ */
+extern "C" {
+unsigned char stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAA; }
+unsigned short stdc_leading_zeros_us(unsigned short) noexcept { return 0xAB; }
+unsigned stdc_leading_zeros_ui(unsigned) noexcept { return 0xAC; }
+unsigned long stdc_leading_zeros_ul(unsigned long) noexcept { return 0xAD; }
+unsigned long long stdc_leading_zeros_ull(unsigned long long) noexcept { return 0xAF; }
+unsigned char stdc_leading_ones_uc(unsigned char) noexcept { return 0xBA; }
+unsigned short stdc_leading_ones_us(unsigned short) noexcept { return 0xBB; }
+unsigned stdc_leading_ones_ui(unsigned) noexcept { return 0xBC; }
+unsigned long stdc_leading_ones_ul(unsigned long) noexcept { return 0xBD; }
+unsigned long long stdc_leading_ones_ull(unsigned long long) noexcept { return 0xBF; }
+}
+
+#include <stdbit.h>
 
 TEST(LlvmLibcStdbitTest, TypeGenericMacroLeadingZeros) {
   EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned char>(0U)),

--- a/libc/test/include/stdbit_test.cpp
+++ b/libc/test/include/stdbit_test.cpp
@@ -10,15 +10,17 @@
 
 /*
  * The intent of this test is validate that:
- * 1. We provide the definition of the various type generic macros of stdbit.h.
+ * 1. We provide the definition of the various type generic macros of stdbit.h
+ * (the macros are transitively included from stdbit-macros.h by stdbit.h).
  * 2. It dispatches to the correct underlying function.
  * Because unit tests build without public packaging, the object files produced
  * do not contain non-namespaced symbols.
  */
 
 /*
- * Declare these BEFORE including stdbit.h so that this test may still be run
- * even if a given target doesn't yet have these individual entrypoints enabled.
+ * Declare these BEFORE including stdbit-macros.h so that this test may still be
+ * run even if a given target doesn't yet have these individual entrypoints
+ * enabled.
  */
 extern "C" {
 unsigned char stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAA; }
@@ -37,7 +39,7 @@ unsigned long long stdc_leading_ones_ull(unsigned long long) noexcept {
 }
 }
 
-#include <stdbit.h>
+#include "include/llvm-libc-macros/stdbit-macros.h"
 
 TEST(LlvmLibcStdbitTest, TypeGenericMacroLeadingZeros) {
   EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned char>(0U)),

--- a/libc/test/include/stdbit_test.cpp
+++ b/libc/test/include/stdbit_test.cpp
@@ -25,12 +25,16 @@ unsigned char stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAA; }
 unsigned short stdc_leading_zeros_us(unsigned short) noexcept { return 0xAB; }
 unsigned stdc_leading_zeros_ui(unsigned) noexcept { return 0xAC; }
 unsigned long stdc_leading_zeros_ul(unsigned long) noexcept { return 0xAD; }
-unsigned long long stdc_leading_zeros_ull(unsigned long long) noexcept { return 0xAF; }
+unsigned long long stdc_leading_zeros_ull(unsigned long long) noexcept {
+  return 0xAF;
+}
 unsigned char stdc_leading_ones_uc(unsigned char) noexcept { return 0xBA; }
 unsigned short stdc_leading_ones_us(unsigned short) noexcept { return 0xBB; }
 unsigned stdc_leading_ones_ui(unsigned) noexcept { return 0xBC; }
 unsigned long stdc_leading_ones_ul(unsigned long) noexcept { return 0xBD; }
-unsigned long long stdc_leading_ones_ull(unsigned long long) noexcept { return 0xBF; }
+unsigned long long stdc_leading_ones_ull(unsigned long long) noexcept {
+  return 0xBF;
+}
 }
 
 #include <stdbit.h>


### PR DESCRIPTION
The intent of the test is to check that:
1. The type generic macros are defined.
2. Those macros dispatch to the correct underlying function.

The issue is that when new functionality is added to our stdbit.h without
rolling out the new entrypoint to all targets, this test breaks because our
generated stdbit.h will not contain declarations for the underlying function.
In that case, we should just declare the underlying functions first before
including our generated stdbit.h which just contains declarations. A definition
is a declaration, but redeclarations must match, hence the additions of
noexcept and extern "C".
