### PR TITLE
[mlir][EmitC] Drop unused code (NFC)

### DIFF
--- a/mlir/include/mlir/Conversion/SCFToEmitC/SCFToEmitC.h
+++ b/mlir/include/mlir/Conversion/SCFToEmitC/SCFToEmitC.h
@@ -20,10 +20,6 @@ class RewritePatternSet;
 
 /// Collect a set of patterns to convert SCF operations to the EmitC dialect.
 void populateSCFToEmitCConversionPatterns(RewritePatternSet &patterns);
-
-/// Creates a pass to convert SCF operations to the EmitC dialect.
-std::unique_ptr<Pass> createConvertSCFToEmitCPass();
-
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_SCFTOEMITC_SCFTOEMITC_H

--- a/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
+++ b/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
@@ -199,7 +199,3 @@ void SCFToEmitCPass::runOnOperation() {
           applyPartialConversion(getOperation(), target, std::move(patterns))))
     signalPassFailure();
 }
-
-std::unique_ptr<Pass> mlir::createConvertSCFToEmitCPass() {
-  return std::make_unique<SCFToEmitCPass>();
-}


### PR DESCRIPTION
To register the conversion the autogenerated function `registerSCFToEmitC()` calls `createSCFToEmitC()`, which itself is also autogenerated. The removed function, however, isn't used in the upstream codebase.