### PR TITLE
[Clang][Sema] Fix crash with const qualified member operator new

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -188,6 +188,8 @@ Bug Fixes to C++ Support
   and (`#79745 <https://github.com/llvm/llvm-project/issues/79745>`_)
 - Fix incorrect code generation caused by the object argument of ``static operator()`` and ``static operator[]`` calls not being evaluated.
   Fixes (`#67976 <https://github.com/llvm/llvm-project/issues/67976>`_)
+- Fix crash and diagnostic with const qualified member operator new.
+  Fixes (`#79748 <https://github.com/llvm/llvm-project/issues/79748>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaCXX/function-type-qual.cpp
+++ b/clang/test/SemaCXX/function-type-qual.cpp
@@ -37,3 +37,21 @@ void instantiateArrayDecay() {
   int a[1];
   arrayDecay(a);
 }
+
+namespace GH79748 {
+typedef decltype(sizeof(0)) size_t;
+struct A {
+  void* operator new(size_t bytes) const; //expected-error {{static member function cannot have 'const' qualifier}}
+  void* operator new[](size_t bytes) const; //expected-error {{static member function cannot have 'const' qualifier}}
+
+  void operator delete(void*) const; //expected-error {{static member function cannot have 'const' qualifier}}
+  void operator delete[](void*) const; //expected-error {{static member function cannot have 'const' qualifier}}
+};
+struct B {
+  void* operator new(size_t bytes) volatile; //expected-error {{static member function cannot have 'volatile' qualifier}}
+  void* operator new[](size_t bytes) volatile; //expected-error {{static member function cannot have 'volatile' qualifier}}
+
+  void operator delete(void*) volatile; //expected-error {{static member function cannot have 'volatile' qualifier}}
+  void operator delete[](void*) volatile; //expected-error {{static member function cannot have 'volatile' qualifier}}
+};
+}


### PR DESCRIPTION
We should diagnose a const qualified member operator new but we fail to do so and this leads to crash during debug info generation.

The fix is to diagnose this as ill-formed in the front-end.

Fixes: https://github.com/llvm/llvm-project/issues/79748