### PR TITLE
[CMake] Turn on LLVM_USE_SPLIT_DWARF by default for Linux Debug build

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -686,8 +686,14 @@ set(LLVM_UBSAN_FLAGS
 set(LLVM_LIB_FUZZING_ENGINE "" CACHE PATH
   "Path to fuzzing library for linking with fuzz targets")
 
-option(LLVM_USE_SPLIT_DWARF
-  "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." OFF)
+# Turn on split-dwarf by default for Linux, take effect on Debug/RelWithDbgInfo builds only.
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    option(LLVM_USE_SPLIT_DWARF
+        "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." ON)
+else()
+    option(LLVM_USE_SPLIT_DWARF
+        "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." OFF)
+endif()
 
 # Define an option controlling whether we should build for 32-bit on 64-bit
 # platforms, where supported.

--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -1186,11 +1186,8 @@ following options with cmake:
    should improve your build time slightly.
 
  * -DLLVM_USE_SPLIT_DWARF
-   Consider setting this to ON if you require a debug build, as this will ease
-   memory pressure on the linker. This will make linking much faster, as the
-   binaries will not contain any of the debug information; however, this will
-   generate the debug information in the form of a DWARF object file (with the
-   extension .dwo). This only applies to host platforms using ELF, such as Linux.
+   Consider setting this to OFF on Linux if you are using old debugger that doesn’t
+   support split dwarf.
 
 .. _links:
 


### PR DESCRIPTION
split-dwarf feature can help reducing compile time and build footprint.
See examples from:
https://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/

RelWithDebInfo build of X86 target shows 15%-37% footprint reduction.

The footprint w and w/o this PR are as below:

Default(BUILD_SHARED_LIBS=OFF):

Compile:
 63G vs. 100G  (37%)

Check-all:
 119G vs. 187G  (37%)

Shared lib (BUILD_SHARED_LIBS=ON):
Compile:
 20G vs. 24G (16%)

Check-all:
 28G vs. 33G (15%)

Debuggability should not be affected.  Should help with memory usage in linker and compile time,
especially incremental build as well.

RFC:  https://discourse.llvm.org/t/rfc-turn-on-llvm-use-split-dwarf-by-default-for-linux-debug-build/76724