### PR TITLE
[clang-tidy] Remove check-specific HeaderFileExtensions and Implement…

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/DynamicStaticInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/DynamicStaticInitializersCheck.cpp
@@ -27,26 +27,8 @@ AST_MATCHER(clang::VarDecl, hasConstantDeclaration) {
 
 DynamicStaticInitializersCheck::DynamicStaticInitializersCheck(
     StringRef Name, ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void DynamicStaticInitializersCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void DynamicStaticInitializersCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/bugprone/DynamicStaticInitializersCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/DynamicStaticInitializersCheck.h
@@ -15,26 +15,16 @@
 namespace clang::tidy::bugprone {
 
 /// Finds dynamically initialized static variables in header files.
-///
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extensions should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-//
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
 class DynamicStaticInitializersCheck : public ClangTidyCheck {
 public:
   DynamicStaticInitializersCheck(StringRef Name, ClangTidyContext *Context);
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus && !LangOpts.ThreadsafeStatics;
   }
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.cpp
@@ -37,41 +37,9 @@ private:
 
 SuspiciousIncludeCheck::SuspiciousIncludeCheck(StringRef Name,
                                                ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> ImplementationFileExtensionsOption =
-      Options.get("ImplementationFileExtensions");
-  RawStringImplementationFileExtensions =
-      ImplementationFileExtensionsOption.value_or(
-          utils::defaultImplementationFileExtensions());
-  if (ImplementationFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringImplementationFileExtensions,
-                                    ImplementationFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid implementation file extension: '%0'")
-          << RawStringImplementationFileExtensions;
-    }
-  } else
-    ImplementationFileExtensions = Context->getImplementationFileExtensions();
-
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void SuspiciousIncludeCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "ImplementationFileExtensions",
-                RawStringImplementationFileExtensions);
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()),
+      ImplementationFileExtensions(Context->getImplementationFileExtensions()) {
 }
 
 void SuspiciousIncludeCheck::registerPPCallbacks(

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.h
@@ -21,16 +21,6 @@ namespace clang::tidy::bugprone {
 ///     #include "bar.c"    // warning
 ///     #include "baz.h"    // no diagnostic
 ///
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extensions should not contain
-///     "." prefix) ";h;hh;hpp;hxx" by default. For extension-less header
-///     files, using an empty string or leaving an empty string between ";" if
-///     there are other filename extensions.
-///
-///   - `ImplementationFileExtensions`: likewise, a semicolon-separated list of
-///     filename extensions of implementation files. "c;cc;cpp;cxx" by default.
-///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-include.html
 class SuspiciousIncludeCheck : public ClangTidyCheck {
@@ -38,14 +28,9 @@ public:
   SuspiciousIncludeCheck(StringRef Name, ClangTidyContext *Context);
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
   FileExtensionsSet HeaderFileExtensions;
   FileExtensionsSet ImplementationFileExtensions;
-
-private:
-  StringRef RawStringHeaderFileExtensions;
-  StringRef RawStringImplementationFileExtensions;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/google/GlobalNamesInHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/GlobalNamesInHeadersCheck.cpp
@@ -18,26 +18,8 @@ namespace clang::tidy::google::readability {
 
 GlobalNamesInHeadersCheck::GlobalNamesInHeadersCheck(StringRef Name,
                                                      ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void GlobalNamesInHeadersCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void GlobalNamesInHeadersCheck::registerMatchers(
     ast_matchers::MatchFinder *Finder) {

--- a/clang-tools-extra/clang-tidy/google/GlobalNamesInHeadersCheck.h
+++ b/clang-tools-extra/clang-tidy/google/GlobalNamesInHeadersCheck.h
@@ -17,25 +17,15 @@ namespace clang::tidy::google::readability {
 /// Flag global namespace pollution in header files.
 /// Right now it only triggers on using declarations and directives.
 ///
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (the filename extensions should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
-///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html
 class GlobalNamesInHeadersCheck : public ClangTidyCheck {
 public:
   GlobalNamesInHeadersCheck(StringRef Name, ClangTidyContext *Context);
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/clang-tidy/google/UnnamedNamespaceInHeaderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/UnnamedNamespaceInHeaderCheck.cpp
@@ -17,26 +17,8 @@ namespace clang::tidy::google::build {
 
 UnnamedNamespaceInHeaderCheck::UnnamedNamespaceInHeaderCheck(
     StringRef Name, ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void UnnamedNamespaceInHeaderCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void UnnamedNamespaceInHeaderCheck::registerMatchers(
     ast_matchers::MatchFinder *Finder) {

--- a/clang-tools-extra/clang-tidy/google/UnnamedNamespaceInHeaderCheck.h
+++ b/clang-tools-extra/clang-tidy/google/UnnamedNamespaceInHeaderCheck.h
@@ -16,14 +16,6 @@ namespace clang::tidy::google::build {
 
 /// Finds anonymous namespaces in headers.
 ///
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extensions should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
-///
 /// https://google.github.io/styleguide/cppguide.html#Namespaces
 ///
 /// Corresponding cpplint.py check name: 'build/namespaces'.
@@ -36,12 +28,10 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.h
@@ -16,13 +16,6 @@ namespace clang::tidy::llvm_check {
 /// Finds and fixes header guards that do not adhere to LLVM style.
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/llvm/header-guard.html
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extension should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
 class LLVMHeaderGuardCheck : public utils::HeaderGuardCheck {
 public:
   LLVMHeaderGuardCheck(StringRef Name, ClangTidyContext *Context);

--- a/clang-tools-extra/clang-tidy/misc/DefinitionsInHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/DefinitionsInHeadersCheck.cpp
@@ -28,45 +28,16 @@ AST_MATCHER_P(NamedDecl, usesHeaderFileExtension, FileExtensionsSet,
 DefinitionsInHeadersCheck::DefinitionsInHeadersCheck(StringRef Name,
                                                      ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      UseHeaderFileExtension(Options.get("UseHeaderFileExtension", true)) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void DefinitionsInHeadersCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "UseHeaderFileExtension", UseHeaderFileExtension);
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void DefinitionsInHeadersCheck::registerMatchers(MatchFinder *Finder) {
   auto DefinitionMatcher =
       anyOf(functionDecl(isDefinition(), unless(isDeleted())),
             varDecl(isDefinition()));
-  if (UseHeaderFileExtension) {
-    Finder->addMatcher(namedDecl(DefinitionMatcher,
-                                 usesHeaderFileExtension(HeaderFileExtensions))
-                           .bind("name-decl"),
-                       this);
-  } else {
-    Finder->addMatcher(
-        namedDecl(DefinitionMatcher,
-                  anyOf(usesHeaderFileExtension(HeaderFileExtensions),
-                        unless(isExpansionInMainFile())))
-            .bind("name-decl"),
-        this);
-  }
+  Finder->addMatcher(namedDecl(DefinitionMatcher,
+                               usesHeaderFileExtension(HeaderFileExtensions))
+                         .bind("name-decl"),
+                     this);
 }
 
 void DefinitionsInHeadersCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/misc/DefinitionsInHeadersCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/DefinitionsInHeadersCheck.h
@@ -20,12 +20,6 @@ namespace clang::tidy::misc {
 /// The check supports these options:
 ///   - `UseHeaderFileExtension`: Whether to use file extension to distinguish
 ///     header files. True by default.
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extension should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html
@@ -35,13 +29,10 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11;
   }
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  const bool UseHeaderFileExtension;
-  StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -39,21 +39,8 @@ static bool shouldCheckDecl(const Decl *TargetDecl) {
 
 UnusedUsingDeclsCheck::UnusedUsingDeclsCheck(StringRef Name,
                                              ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void UnusedUsingDeclsCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(usingDecl(isExpansionInMainFile()).bind("using"), this);

--- a/clang-tools-extra/clang-tidy/misc/UseAnonymousNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseAnonymousNamespaceCheck.cpp
@@ -31,26 +31,8 @@ AST_MATCHER(VarDecl, isStaticDataMember) { return Node.isStaticDataMember(); }
 
 UseAnonymousNamespaceCheck::UseAnonymousNamespaceCheck(
     StringRef Name, ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {
-  std::optional<StringRef> HeaderFileExtensionsOption =
-      Options.get("HeaderFileExtensions");
-  RawStringHeaderFileExtensions =
-      HeaderFileExtensionsOption.value_or(utils::defaultHeaderFileExtensions());
-  if (HeaderFileExtensionsOption) {
-    if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
-                                    HeaderFileExtensions,
-                                    utils::defaultFileExtensionDelimiters())) {
-      this->configurationDiag("Invalid header file extension: '%0'")
-          << RawStringHeaderFileExtensions;
-    }
-  } else
-    HeaderFileExtensions = Context->getHeaderFileExtensions();
-}
-
-void UseAnonymousNamespaceCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
+    : ClangTidyCheck(Name, Context),
+      HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void UseAnonymousNamespaceCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/misc/UseAnonymousNamespaceCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/UseAnonymousNamespaceCheck.h
@@ -17,14 +17,6 @@ namespace clang::tidy::misc {
 /// Warns when using 'static' functions or variables at global scope, and
 /// suggests moving them to an anonymous namespace.
 ///
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extension should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
-///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html
 class UseAnonymousNamespaceCheck : public ClangTidyCheck {
@@ -33,12 +25,10 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  StringRef RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/clang-tidy/utils/HeaderGuard.cpp
+++ b/clang-tools-extra/clang-tidy/utils/HeaderGuard.cpp
@@ -269,10 +269,6 @@ private:
 };
 } // namespace
 
-void HeaderGuardCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
-}
-
 void HeaderGuardCheck::registerPPCallbacks(const SourceManager &SM,
                                            Preprocessor *PP,
                                            Preprocessor *ModuleExpanderPP) {

--- a/clang-tools-extra/clang-tidy/utils/HeaderGuard.h
+++ b/clang-tools-extra/clang-tidy/utils/HeaderGuard.h
@@ -15,32 +15,12 @@
 namespace clang::tidy::utils {
 
 /// Finds and fixes header guards.
-/// The check supports these options:
-///   - `HeaderFileExtensions`: a semicolon-separated list of filename
-///     extensions of header files (The filename extension should not contain
-///     "." prefix). ";h;hh;hpp;hxx" by default.
-///
-///     For extension-less header files, using an empty string or leaving an
-///     empty string between ";" if there are other filename extensions.
 class HeaderGuardCheck : public ClangTidyCheck {
 public:
   HeaderGuardCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {
-    std::optional<StringRef> HeaderFileExtensionsOption =
-        Options.get("HeaderFileExtensions");
-    RawStringHeaderFileExtensions = HeaderFileExtensionsOption.value_or(
-        utils::defaultHeaderFileExtensions());
-    if (HeaderFileExtensionsOption) {
-      if (!utils::parseFileExtensions(
-              RawStringHeaderFileExtensions, HeaderFileExtensions,
-              utils::defaultFileExtensionDelimiters())) {
-        this->configurationDiag("Invalid header file extension: '%0'")
-            << RawStringHeaderFileExtensions;
-      }
-    } else
-      HeaderFileExtensions = Context->getHeaderFileExtensions();
-  }
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+      : ClangTidyCheck(Name, Context),
+        HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
+
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
 
@@ -65,7 +45,6 @@ public:
                                      StringRef OldGuard = StringRef()) = 0;
 
 private:
-  std::string RawStringHeaderFileExtensions;
   FileExtensionsSet HeaderFileExtensions;
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -106,6 +106,11 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-suspicious-include
+  <clang-tidy/checks/bugprone/suspicious-include>` check by replacing the local
+  options `HeaderFileExtensions` and `ImplementationFileExtensions` by the
+  global options of the same name.
+
 - Cleaned up :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>`
   by removing enforcement of rule `C.48
@@ -113,6 +118,32 @@ Changes in existing checks
   which was deprecated since :program:`clang-tidy` 17. This rule is now covered
   by :doc:`cppcoreguidelines-use-default-member-init
   <clang-tidy/checks/cppcoreguidelines/use-default-member-init>`.
+
+- Improved :doc:`google-build-namespaces
+  <clang-tidy/checks/google/build-namespaces>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
+
+- Improved :doc:`google-global-names-in-headers
+  <clang-tidy/checks/google/global-names-in-headers>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
+
+- Improved :doc:`llvm-header-guard
+  <clang-tidy/checks/llvm/header-guard>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
+
+- Improved :doc:`misc-definitions-in-headers
+  <clang-tidy/checks/misc/definitions-in-headers>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
+  Additionally, the option `UseHeaderFileExtensions` is removed, so that the
+  check uses the `HeaderFileExtensions` option unconditionally.
+
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
+
+- Improved :doc:`misc-use-anonymous-namespace
+  <clang-tidy/checks/misc/misc-use-anonymous-namespace>` check by replacing the local
+  option `HeaderFileExtensions` by the global option of the same name.
 
 - Improved :doc:`modernize-avoid-c-arrays
   <clang-tidy/checks/modernize/avoid-c-arrays>` check by introducing the new

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -142,7 +142,7 @@ Changes in existing checks
   option `HeaderFileExtensions` by the global option of the same name.
 
 - Improved :doc:`misc-use-anonymous-namespace
-  <clang-tidy/checks/misc/misc-use-anonymous-namespace>` check by replacing the local
+  <clang-tidy/checks/misc/use-anonymous-namespace>` check by replacing the local
   option `HeaderFileExtensions` by the global option of the same name.
 
 - Improved :doc:`modernize-avoid-c-arrays

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.rst
@@ -14,27 +14,3 @@ Examples:
   #include "Pterodactyl.h"    // OK, .h files tend not to have definitions.
   #include "Velociraptor.cpp" // Warning, filename is suspicious.
   #include_next <stdio.c>     // Warning, filename is suspicious.
-
-Options
--------
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   Default value: ``";h;hh;hpp;hxx"``
-   A semicolon-separated list of filename extensions of header files (the
-   filename extensions should not contain a "." prefix). For extension-less
-   header files, use an empty string or leave an empty string between ";"
-   if there are other filename extensions.
-
-.. option:: ImplementationFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `ImplementationFileExtensions`.
-
-   Default value: ``"c;cc;cpp;cxx"``
-   Likewise, a semicolon-separated list of filename extensions of
-   implementation files.

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.rst
@@ -11,18 +11,3 @@ Finds anonymous namespaces in headers.
 https://google.github.io/styleguide/cppguide.html#Namespaces
 
 Corresponding cpplint.py check name: `build/namespaces`.
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A comma-separated list of filename extensions of header files (the filename
-   extensions should not include "." prefix). Default is "h,hh,hpp,hxx".
-   For header files without an extension, use an empty string (if there are no
-   other desired extensions) or leave an empty element in the list. E.g.,
-   "h,hh,hpp,hxx," (note the trailing comma).

--- a/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.rst
@@ -8,18 +8,3 @@ Flag global namespace pollution in header files. Right now it only triggers on
 
 The relevant style guide section is
 https://google.github.io/styleguide/cppguide.html#Namespaces.
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A comma-separated list of filename extensions of header files (the filename
-   extensions should not contain "." prefix). Default is "h".
-   For header files without an extension, use an empty string (if there are no
-   other desired extensions) or leave an empty element in the list. E.g.,
-   "h,hh,hpp,hxx," (note the trailing comma).

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.rst
@@ -4,18 +4,3 @@ llvm-header-guard
 =================
 
 Finds and fixes header guards that do not adhere to LLVM style.
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A comma-separated list of filename extensions of header files (the filename
-   extensions should not include "." prefix). Default is "h,hh,hpp,hxx".
-   For header files without an extension, use an empty string (if there are no
-   other desired extensions) or leave an empty element in the list. E.g.,
-   "h,hh,hpp,hxx," (note the trailing comma).

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/definitions-in-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/definitions-in-headers.rst
@@ -92,27 +92,3 @@ When :program:`clang-tidy` is invoked with the `--fix-notes` option, this check
 provides fixes that automatically add the ``inline`` keyword to discovered
 functions. Please note that the addition of the ``inline`` keyword to variables
 is not currently supported by this check.
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A comma-separated list of filename extensions of header files (the filename
-   extensions should not include "." prefix). Default is "h,hh,hpp,hxx".
-   For header files without an extension, use an empty string (if there are no
-   other desired extensions) or leave an empty element in the list. E.g.,
-   "h,hh,hpp,hxx," (note the trailing comma).
-
-.. option:: UseHeaderFileExtension
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. The check will unconditionally use the global option
-   `HeaderFileExtensions`.
-
-   When `true`, the check will use the file extension to distinguish header
-   files. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.rst
@@ -7,7 +7,7 @@ Finds unused ``using`` declarations.
 
 Unused ``using``` declarations in header files will not be diagnosed since these
 using declarations are part of the header's public API. Allowed header file
-extensions can be configured via the `HeaderFileExtensions` option (see below).
+extensions can be configured via the global option `HeaderFileExtensions`.
 
 Example:
 
@@ -16,17 +16,3 @@ Example:
   // main.cpp
   namespace n { class C; }
   using n::C;  // Never actually used.
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A semicolon-separated list of filename extensions of header files (the filename
-   extensions should not include "." prefix). Default is "h,hh,hpp,hxx".
-   For extension-less header files, use an empty string or leave an
-   empty string between "," if there are other filename extensions.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-anonymous-namespace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-anonymous-namespace.rst
@@ -15,7 +15,7 @@ The following uses of ``static`` will *not* be diagnosed:
 
 * Functions or variables in header files, since anonymous namespaces in headers
   is considered an antipattern. Allowed header file extensions can be configured
-  via the `HeaderFileExtensions` option (see below).
+  via the global option `HeaderFileExtensions`.
 * ``const`` or ``constexpr`` variables, since they already have implicit internal
   linkage in C++.
 
@@ -32,19 +32,5 @@ Examples:
     void foo();
     int x;
   } // namespace
-
-Options
--------
-
-.. option:: HeaderFileExtensions
-
-   Note: this option is deprecated, it will be removed in :program:`clang-tidy`
-   version 19. Please use the global configuration option
-   `HeaderFileExtensions`.
-
-   A semicolon-separated list of filename extensions of header files (the filename
-   extensions should not include "." prefix). Default is ";h;hh;hpp;hxx".
-   For extension-less header files, using an empty string or leaving an
-   empty string between ";" if there are other filename extensions.
 
 [1] `Undeprecating static <https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012>`_


### PR DESCRIPTION
…ationFileExtensions

Deprecated since clang-tidy 17. Use the corresponding global options instead.

Fixes #61947