### PR TITLE
[libc][stdbit] fix return types

### DIFF
--- a/libc/include/llvm-libc-macros/stdbit-macros.h
+++ b/libc/include/llvm-libc-macros/stdbit-macros.h
@@ -10,34 +10,34 @@
 #define __LLVM_LIBC_MACROS_STDBIT_MACROS_H
 
 #ifdef __cplusplus
-inline unsigned char stdc_leading_zeros(unsigned char x) {
+inline unsigned stdc_leading_zeros(unsigned char x) {
   return stdc_leading_zeros_uc(x);
 }
-inline unsigned short stdc_leading_zeros(unsigned short x) {
+inline unsigned stdc_leading_zeros(unsigned short x) {
   return stdc_leading_zeros_us(x);
 }
 inline unsigned stdc_leading_zeros(unsigned x) {
   return stdc_leading_zeros_ui(x);
 }
-inline unsigned long stdc_leading_zeros(unsigned long x) {
+inline unsigned stdc_leading_zeros(unsigned long x) {
   return stdc_leading_zeros_ul(x);
 }
-inline unsigned long long stdc_leading_zeros(unsigned long long x) {
+inline unsigned stdc_leading_zeros(unsigned long long x) {
   return stdc_leading_zeros_ull(x);
 }
-inline unsigned char stdc_leading_ones(unsigned char x) {
+inline unsigned stdc_leading_ones(unsigned char x) {
   return stdc_leading_ones_uc(x);
 }
-inline unsigned short stdc_leading_ones(unsigned short x) {
+inline unsigned stdc_leading_ones(unsigned short x) {
   return stdc_leading_ones_us(x);
 }
 inline unsigned stdc_leading_ones(unsigned x) {
   return stdc_leading_ones_ui(x);
 }
-inline unsigned long stdc_leading_ones(unsigned long x) {
+inline unsigned stdc_leading_ones(unsigned long x) {
   return stdc_leading_ones_ul(x);
 }
-inline unsigned long long stdc_leading_ones(unsigned long long x) {
+inline unsigned stdc_leading_ones(unsigned long long x) {
   return stdc_leading_ones_ull(x);
 }
 #else

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -775,16 +775,16 @@ def StdC : StandardSpec<"stdc"> {
       [], // Types
       [], // Enumerations
       [
-          FunctionSpec<"stdc_leading_zeros_uc", RetValSpec<UnsignedCharType>, [ArgSpec<UnsignedCharType>]>,
-          FunctionSpec<"stdc_leading_zeros_us", RetValSpec<UnsignedShortType>, [ArgSpec<UnsignedShortType>]>,
+          FunctionSpec<"stdc_leading_zeros_uc", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedCharType>]>,
+          FunctionSpec<"stdc_leading_zeros_us", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedShortType>]>,
           FunctionSpec<"stdc_leading_zeros_ui", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedIntType>]>,
-          FunctionSpec<"stdc_leading_zeros_ul", RetValSpec<UnsignedLongType>, [ArgSpec<UnsignedLongType>]>,
-          FunctionSpec<"stdc_leading_zeros_ull", RetValSpec<UnsignedLongLongType>, [ArgSpec<UnsignedLongLongType>]>,
-          FunctionSpec<"stdc_leading_ones_uc", RetValSpec<UnsignedCharType>, [ArgSpec<UnsignedCharType>]>,
-          FunctionSpec<"stdc_leading_ones_us", RetValSpec<UnsignedShortType>, [ArgSpec<UnsignedShortType>]>,
+          FunctionSpec<"stdc_leading_zeros_ul", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedLongType>]>,
+          FunctionSpec<"stdc_leading_zeros_ull", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedLongLongType>]>,
+          FunctionSpec<"stdc_leading_ones_uc", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedCharType>]>,
+          FunctionSpec<"stdc_leading_ones_us", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedShortType>]>,
           FunctionSpec<"stdc_leading_ones_ui", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedIntType>]>,
-          FunctionSpec<"stdc_leading_ones_ul", RetValSpec<UnsignedLongType>, [ArgSpec<UnsignedLongType>]>,
-          FunctionSpec<"stdc_leading_ones_ull", RetValSpec<UnsignedLongLongType>, [ArgSpec<UnsignedLongLongType>]>
+          FunctionSpec<"stdc_leading_ones_ul", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedLongType>]>,
+          FunctionSpec<"stdc_leading_ones_ull", RetValSpec<UnsignedIntType>, [ArgSpec<UnsignedLongLongType>]>
       ] // Functions
   >;
 

--- a/libc/src/stdbit/stdc_leading_ones_uc.cpp
+++ b/libc/src/stdbit/stdc_leading_ones_uc.cpp
@@ -13,8 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned char, stdc_leading_ones_uc, (unsigned char value)) {
-  return static_cast<unsigned char>(cpp::countl_one(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_ones_uc, (unsigned char value)) {
+  return static_cast<unsigned>(cpp::countl_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_ones_uc.h
+++ b/libc/src/stdbit/stdc_leading_ones_uc.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned char stdc_leading_ones_uc(unsigned char value);
+unsigned stdc_leading_ones_uc(unsigned char value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_ones_ul.cpp
+++ b/libc/src/stdbit/stdc_leading_ones_ul.cpp
@@ -13,8 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned long, stdc_leading_ones_ul, (unsigned long value)) {
-  return static_cast<unsigned long>(cpp::countl_one(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_ones_ul, (unsigned long value)) {
+  return static_cast<unsigned>(cpp::countl_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_ones_ul.h
+++ b/libc/src/stdbit/stdc_leading_ones_ul.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned long stdc_leading_ones_ul(unsigned long value);
+unsigned stdc_leading_ones_ul(unsigned long value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_ones_ull.cpp
+++ b/libc/src/stdbit/stdc_leading_ones_ull.cpp
@@ -13,9 +13,9 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned long long, stdc_leading_ones_ull,
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_ones_ull,
                    (unsigned long long value)) {
-  return static_cast<unsigned long long>(cpp::countl_one(value));
+  return static_cast<unsigned>(cpp::countl_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_ones_ull.h
+++ b/libc/src/stdbit/stdc_leading_ones_ull.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned long long stdc_leading_ones_ull(unsigned long long value);
+unsigned stdc_leading_ones_ull(unsigned long long value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_ones_us.cpp
+++ b/libc/src/stdbit/stdc_leading_ones_us.cpp
@@ -13,9 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned short, stdc_leading_ones_us,
-                   (unsigned short value)) {
-  return static_cast<unsigned short>(cpp::countl_one(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_ones_us, (unsigned short value)) {
+  return static_cast<unsigned>(cpp::countl_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_ones_us.h
+++ b/libc/src/stdbit/stdc_leading_ones_us.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned short stdc_leading_ones_us(unsigned short value);
+unsigned stdc_leading_ones_us(unsigned short value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_zeros_uc.cpp
+++ b/libc/src/stdbit/stdc_leading_zeros_uc.cpp
@@ -13,9 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned char, stdc_leading_zeros_uc,
-                   (unsigned char value)) {
-  return static_cast<unsigned char>(cpp::countl_zero(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_uc, (unsigned char value)) {
+  return static_cast<unsigned>(cpp::countl_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_zeros_uc.h
+++ b/libc/src/stdbit/stdc_leading_zeros_uc.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned char stdc_leading_zeros_uc(unsigned char value);
+unsigned stdc_leading_zeros_uc(unsigned char value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_zeros_ul.cpp
+++ b/libc/src/stdbit/stdc_leading_zeros_ul.cpp
@@ -13,9 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned long, stdc_leading_zeros_ul,
-                   (unsigned long value)) {
-  return static_cast<unsigned long>(cpp::countl_zero(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_ul, (unsigned long value)) {
+  return static_cast<unsigned>(cpp::countl_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_zeros_ul.h
+++ b/libc/src/stdbit/stdc_leading_zeros_ul.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned long stdc_leading_zeros_ul(unsigned long value);
+unsigned stdc_leading_zeros_ul(unsigned long value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_zeros_ull.cpp
+++ b/libc/src/stdbit/stdc_leading_zeros_ull.cpp
@@ -13,9 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned long long, stdc_leading_zeros_ull,
-                   (unsigned long long value)) {
-  return static_cast<unsigned long long>(cpp::countl_zero(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_ull, (unsigned long long value)) {
+  return static_cast<unsigned>(cpp::countl_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_zeros_ull.cpp
+++ b/libc/src/stdbit/stdc_leading_zeros_ull.cpp
@@ -13,7 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_ull, (unsigned long long value)) {
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_ull,
+                   (unsigned long long value)) {
   return static_cast<unsigned>(cpp::countl_zero(value));
 }
 

--- a/libc/src/stdbit/stdc_leading_zeros_ull.h
+++ b/libc/src/stdbit/stdc_leading_zeros_ull.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned long long stdc_leading_zeros_ull(unsigned long long value);
+unsigned stdc_leading_zeros_ull(unsigned long long value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/stdc_leading_zeros_us.cpp
+++ b/libc/src/stdbit/stdc_leading_zeros_us.cpp
@@ -13,9 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(unsigned short, stdc_leading_zeros_us,
-                   (unsigned short value)) {
-  return static_cast<unsigned short>(cpp::countl_zero(value));
+LLVM_LIBC_FUNCTION(unsigned, stdc_leading_zeros_us, (unsigned short value)) {
+  return static_cast<unsigned>(cpp::countl_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_leading_zeros_us.h
+++ b/libc/src/stdbit/stdc_leading_zeros_us.h
@@ -11,7 +11,7 @@
 
 namespace LIBC_NAMESPACE {
 
-unsigned short stdc_leading_zeros_us(unsigned short value);
+unsigned stdc_leading_zeros_us(unsigned short value);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/test/include/stdbit_test.cpp
+++ b/libc/test/include/stdbit_test.cpp
@@ -23,40 +23,34 @@
  * enabled.
  */
 extern "C" {
-unsigned char stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAA; }
-unsigned short stdc_leading_zeros_us(unsigned short) noexcept { return 0xAB; }
-unsigned stdc_leading_zeros_ui(unsigned) noexcept { return 0xAC; }
-unsigned long stdc_leading_zeros_ul(unsigned long) noexcept { return 0xAD; }
-unsigned long long stdc_leading_zeros_ull(unsigned long long) noexcept {
-  return 0xAF;
+unsigned stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAAU; }
+unsigned stdc_leading_zeros_us(unsigned short) noexcept { return 0xABU; }
+unsigned stdc_leading_zeros_ui(unsigned) noexcept { return 0xACU; }
+unsigned stdc_leading_zeros_ul(unsigned long) noexcept { return 0xADU; }
+unsigned stdc_leading_zeros_ull(unsigned long long) noexcept { return 0xAFU;
 }
-unsigned char stdc_leading_ones_uc(unsigned char) noexcept { return 0xBA; }
-unsigned short stdc_leading_ones_us(unsigned short) noexcept { return 0xBB; }
-unsigned stdc_leading_ones_ui(unsigned) noexcept { return 0xBC; }
-unsigned long stdc_leading_ones_ul(unsigned long) noexcept { return 0xBD; }
-unsigned long long stdc_leading_ones_ull(unsigned long long) noexcept {
-  return 0xBF;
+unsigned stdc_leading_ones_uc(unsigned char) noexcept { return 0xBAU; }
+unsigned stdc_leading_ones_us(unsigned short) noexcept { return 0xBBU; }
+unsigned stdc_leading_ones_ui(unsigned) noexcept { return 0xBCU; }
+unsigned stdc_leading_ones_ul(unsigned long) noexcept { return 0xBDU; }
+unsigned stdc_leading_ones_ull(unsigned long long) noexcept { return 0xBFU;
 }
 }
 
 #include "include/llvm-libc-macros/stdbit-macros.h"
 
 TEST(LlvmLibcStdbitTest, TypeGenericMacroLeadingZeros) {
-  EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned char>(0U)),
-            static_cast<unsigned char>(0xAA));
-  EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned short>(0U)),
-            static_cast<unsigned short>(0xAB));
-  EXPECT_EQ(stdc_leading_zeros(0U), static_cast<unsigned>(0xAC));
-  EXPECT_EQ(stdc_leading_zeros(0UL), static_cast<unsigned long>(0xAD));
-  EXPECT_EQ(stdc_leading_zeros(0ULL), static_cast<unsigned long long>(0xAF));
+  EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned char>(0U)), 0xAAU);
+  EXPECT_EQ(stdc_leading_zeros(static_cast<unsigned short>(0U)), 0xABU);
+  EXPECT_EQ(stdc_leading_zeros(0U), 0xACU);
+  EXPECT_EQ(stdc_leading_zeros(0UL), 0xADU);
+  EXPECT_EQ(stdc_leading_zeros(0ULL), 0xAFU);
 }
 
 TEST(LlvmLibcStdbitTest, TypeGenericMacroLeadingOnes) {
-  EXPECT_EQ(stdc_leading_ones(static_cast<unsigned char>(0U)),
-            static_cast<unsigned char>(0xBA));
-  EXPECT_EQ(stdc_leading_ones(static_cast<unsigned short>(0U)),
-            static_cast<unsigned short>(0xBB));
-  EXPECT_EQ(stdc_leading_ones(0U), static_cast<unsigned>(0xBC));
-  EXPECT_EQ(stdc_leading_ones(0UL), static_cast<unsigned long>(0xBD));
-  EXPECT_EQ(stdc_leading_ones(0ULL), static_cast<unsigned long long>(0xBF));
+  EXPECT_EQ(stdc_leading_ones(static_cast<unsigned char>(0U)), 0xBAU);
+  EXPECT_EQ(stdc_leading_ones(static_cast<unsigned short>(0U)), 0xBBU);
+  EXPECT_EQ(stdc_leading_ones(0U), 0xBCU);
+  EXPECT_EQ(stdc_leading_ones(0UL), 0xBDU);
+  EXPECT_EQ(stdc_leading_ones(0ULL), 0xBFU);
 }

--- a/libc/test/include/stdbit_test.cpp
+++ b/libc/test/include/stdbit_test.cpp
@@ -27,14 +27,12 @@ unsigned stdc_leading_zeros_uc(unsigned char) noexcept { return 0xAAU; }
 unsigned stdc_leading_zeros_us(unsigned short) noexcept { return 0xABU; }
 unsigned stdc_leading_zeros_ui(unsigned) noexcept { return 0xACU; }
 unsigned stdc_leading_zeros_ul(unsigned long) noexcept { return 0xADU; }
-unsigned stdc_leading_zeros_ull(unsigned long long) noexcept { return 0xAFU;
-}
+unsigned stdc_leading_zeros_ull(unsigned long long) noexcept { return 0xAFU; }
 unsigned stdc_leading_ones_uc(unsigned char) noexcept { return 0xBAU; }
 unsigned stdc_leading_ones_us(unsigned short) noexcept { return 0xBBU; }
 unsigned stdc_leading_ones_ui(unsigned) noexcept { return 0xBCU; }
 unsigned stdc_leading_ones_ul(unsigned long) noexcept { return 0xBDU; }
-unsigned stdc_leading_ones_ull(unsigned long long) noexcept { return 0xBFU;
-}
+unsigned stdc_leading_ones_ull(unsigned long long) noexcept { return 0xBFU; }
 }
 
 #include "include/llvm-libc-macros/stdbit-macros.h"

--- a/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
@@ -11,10 +11,12 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUcTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(UCHAR_MAX), static_cast<unsigned>(UCHAR_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(UCHAR_MAX),
+            static_cast<unsigned>(UCHAR_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(~(1U << i)), UCHAR_WIDTH - i - 1U);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(~(1U << i)),
+              UCHAR_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
@@ -11,12 +11,10 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUcTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(UCHAR_MAX),
-            static_cast<unsigned char>(UCHAR_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(UCHAR_MAX), static_cast<unsigned>(UCHAR_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(~(1U << i)),
-              static_cast<unsigned char>(UCHAR_WIDTH - i - 1));
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(~(1U << i)), UCHAR_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ui_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ui_test.cpp
@@ -11,10 +11,12 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUiTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(UINT_MAX), static_cast<unsigned>(UINT_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(UINT_MAX),
+            static_cast<unsigned>(UINT_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUiTest, ZeroHot) {
   for (unsigned i = 0U; i != UINT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(~(1U << i)), UINT_WIDTH - i - 1U);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(~(1U << i)),
+              UINT_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ui_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ui_test.cpp
@@ -11,12 +11,10 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUiTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(UINT_MAX),
-            static_cast<unsigned>(UINT_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(UINT_MAX), static_cast<unsigned>(UINT_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUiTest, ZeroHot) {
   for (unsigned i = 0U; i != UINT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(~(1U << i)),
-              static_cast<unsigned>(UINT_WIDTH - i - 1));
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ui(~(1U << i)), UINT_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ul_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ul_test.cpp
@@ -11,12 +11,10 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUlTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(ULONG_MAX),
-            static_cast<unsigned long>(ULONG_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(ULONG_MAX), static_cast<unsigned>(ULONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUlTest, ZeroHot) {
   for (unsigned i = 0U; i != ULONG_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(~(1UL << i)),
-              static_cast<unsigned long>(ULONG_WIDTH - i - 1));
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(~(1UL << i)), ULONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ul_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ul_test.cpp
@@ -11,10 +11,12 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUlTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(ULONG_MAX), static_cast<unsigned>(ULONG_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(ULONG_MAX),
+            static_cast<unsigned>(ULONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUlTest, ZeroHot) {
   for (unsigned i = 0U; i != ULONG_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(~(1UL << i)), ULONG_WIDTH - i - 1U);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ul(~(1UL << i)),
+              ULONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ull_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ull_test.cpp
@@ -11,12 +11,10 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUllTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(ULLONG_MAX),
-            static_cast<unsigned long long>(ULLONG_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(ULLONG_MAX), static_cast<unsigned>(ULLONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUllTest, ZeroHot) {
   for (unsigned i = 0U; i != ULLONG_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(~(1ULL << i)),
-              static_cast<unsigned long long>(ULLONG_WIDTH - i - 1));
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(~(1ULL << i)), ULLONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_ull_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_ull_test.cpp
@@ -11,10 +11,12 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingOnesUllTest, All) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(ULLONG_MAX), static_cast<unsigned>(ULLONG_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(ULLONG_MAX),
+            static_cast<unsigned>(ULLONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUllTest, ZeroHot) {
   for (unsigned i = 0U; i != ULLONG_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(~(1ULL << i)), ULLONG_WIDTH - i - 1U);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_ull(~(1ULL << i)),
+              ULLONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_us_test.cpp
@@ -12,11 +12,11 @@
 
 TEST(LlvmLibcStdcLeadingOnesUsTest, All) {
   EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_us(USHRT_MAX),
-            static_cast<unsigned short>(USHRT_WIDTH));
+            static_cast<unsigned>(USHRT_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingOnesUsTest, ZeroHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_us(~(1U << i)),
-              static_cast<unsigned short>(USHRT_WIDTH - i - 1));
+              USHRT_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
@@ -11,7 +11,8 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingZerosUcTest, Zero) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(0U), static_cast<unsigned>(UCHAR_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(0U),
+            static_cast<unsigned>(UCHAR_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUcTest, OneHot) {

--- a/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
@@ -11,12 +11,11 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStdcLeadingZerosUcTest, Zero) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(0U),
-            static_cast<unsigned char>(UCHAR_WIDTH));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(0U), static_cast<unsigned>(UCHAR_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(1U << i),
-              static_cast<unsigned char>(UCHAR_WIDTH - i - 1));
+              UCHAR_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_ul_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_ul_test.cpp
@@ -13,11 +13,11 @@
 
 TEST(LlvmLibcStdcLeadingZerosUlTest, Zero) {
   EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ul(0UL),
-            static_cast<unsigned long>(ULONG_WIDTH));
+            static_cast<unsigned>(ULONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUlTest, OneHot) {
   for (unsigned i = 0U; i != ULONG_WIDTH; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ul(1UL << i),
-              static_cast<unsigned long>(ULONG_WIDTH - i - 1));
+              ULONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_ull_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_ull_test.cpp
@@ -13,11 +13,11 @@
 
 TEST(LlvmLibcStdcLeadingZerosUllTest, Zero) {
   EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ull(0ULL),
-            static_cast<unsigned long long>(ULLONG_WIDTH));
+            static_cast<unsigned>(ULLONG_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUllTest, OneHot) {
   for (unsigned i = 0U; i != ULLONG_WIDTH; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ull(1ULL << i),
-              static_cast<unsigned long long>(ULLONG_WIDTH - i - 1));
+              ULLONG_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_us_test.cpp
@@ -12,11 +12,11 @@
 
 TEST(LlvmLibcStdcLeadingZerosUsTest, Zero) {
   EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_us(0U),
-            static_cast<unsigned short>(USHRT_WIDTH));
+            static_cast<unsigned>(USHRT_WIDTH));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_us(1U << i),
-              static_cast<unsigned short>(USHRT_WIDTH - i - 1));
+              USHRT_WIDTH - i - 1U);
 }


### PR DESCRIPTION
All of the functions I've previously implemented return an unsigned int; not
the parameter type.
