### PR TITLE
[Github] Add git to actions container image

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/library/ubuntu:22.04 as base
-ENV LLVM_SYSROOT=/opt/llvm/
+ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as toolchain
 ENV LLVM_VERSION=17.0.6
@@ -11,7 +11,8 @@ RUN apt-get update && \
     g++ \
     cmake \
     ninja-build \
-    python3
+    python3 \
+    git
 
 RUN wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-$LLVM_VERSION.tar.gz && tar -xf llvmorg-$LLVM_VERSION.tar.gz
 


### PR DESCRIPTION
This patch adds git to the actions container image. This is not necessarily needed for actions/checkout (as it will fallback to downloading a tar archive), but is good to have for that in addition to any future operations that might need git. In addition, the LLVM CMake configuration throws some warnings when Git is not installed.

This patch also removes a slash from LLVM_SYSROOT. This is cosmetic as /opt/llvm//bin (which showed up on $PATH) is equivalent to /opt/llvm/bin, but the latter is canonical.