### PR TITLE
[workflows] Only run code formatter on the main branch

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -1,5 +1,8 @@
 name: "Check code formatting"
 on: pull_request_target
+  branches:
+    - main
+
 permissions:
   pull-requests: write
 


### PR DESCRIPTION
Modifying a cherry-picked patch to fix code formatting issues can be risky, so we don't typically do this.  Therefore, it's not necessary to run this job on the release branches.