### PR TITLE
[libc++][hardening] Check that `_LIBCPP_HARDENING_MODE_DEFAULT` is defined

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -325,6 +325,11 @@
 // clang-format on
 
 #  ifndef _LIBCPP_HARDENING_MODE
+
+#    ifndef _LIBCPP_HARDENING_MODE_DEFAULT
+#      error _LIBCPP_HARDENING_MODE_DEFAULT is not defined.
+#    endif
+
 #    define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_DEFAULT
 #  endif
 

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -327,7 +327,8 @@
 #  ifndef _LIBCPP_HARDENING_MODE
 
 #    ifndef _LIBCPP_HARDENING_MODE_DEFAULT
-#      error _LIBCPP_HARDENING_MODE_DEFAULT is not defined.
+#      error _LIBCPP_HARDENING_MODE_DEFAULT is not defined. This definition should be set at configuration time in the \
+`__config_site` header, please make sure your installation of libc++ is not broken.
 #    endif
 
 #    define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_DEFAULT


### PR DESCRIPTION
If the `_LIBCPP_HARDENING_MODE_DEFAULT` macro is not defined, `_LIBCPP_HARDENING_MODE` will be considered defined but fail the check for a valid hardening mode, resulting in a slightly less understandable error (that error is really meant more to prevent users from passing incorrect values such as `0` or `1` directly rather than catching configuration issues).