### PR TITLE
[libc][bazel] disable epoll_pwait2

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3218,12 +3218,14 @@ libc_function(
     ],
 )
 
-libc_function(
-    name = "epoll_pwait2",
-    srcs = ["src/sys/epoll/linux/epoll_pwait2.cpp"],
-    hdrs = ["src/sys/epoll/epoll_pwait2.h"],
-    deps = [
-        ":__support_osutil_syscall",
-        ":errno",
-    ],
-)
+#TODO: Enable once epoll_pwait2 availablilty can be checked first.
+# https://github.com/llvm/llvm-project/issues/80060
+# libc_function(
+#     name = "epoll_pwait2",
+#     srcs = ["src/sys/epoll/linux/epoll_pwait2.cpp"],
+#     hdrs = ["src/sys/epoll/epoll_pwait2.h"],
+#     deps = [
+#         ":__support_osutil_syscall",
+#         ":errno",
+#     ],
+# )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
@@ -26,10 +26,12 @@ libc_test(
     ],
 )
 
-libc_test(
-    name = "epoll_pwait2_test",
-    srcs = ["linux/epoll_pwait2_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_pwait2",
-    ],
-)
+#TODO: Enable once epoll_pwait2 availablilty can be checked first.
+# https://github.com/llvm/llvm-project/issues/80060
+# libc_test(
+#     name = "epoll_pwait2_test",
+#     srcs = ["linux/epoll_pwait2_test.cpp"],
+#     libc_function_deps = [
+#         "//libc:epoll_pwait2",
+#     ],
+# )


### PR DESCRIPTION
Similar to #80051. The epoll_pwait2 syscall isn't available on all
target platforms, and this is causing downstream test failures. This
patch disables it until it can be detected whether or not it is
available.

