### PR TITLE
[CodeGen] Do not include undef registers in the set of used ops

### DIFF
--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -1974,11 +1974,10 @@ static bool hasRegisterDependency(MachineInstr *MI,
       }
       DefedRegsInCopy.push_back(Reg);
 
-      // FIXME: instead of isUse(), readsReg() would be a better fix here,
-      // For example, we can ignore modifications in reg with undef. However,
-      // it's not perfectly clear if skipping the internal read is safe in all
-      // other targets.
-    } else if (MO.isUse()) {
+      // FIXME: It's not perfectly clear if skipping the internal read is safe
+      // in all other targets. If it is, we can replace this entire condition
+      // with MO.readReg().
+    } else if (!MO.isUndef() && MO.isUse()) {
       if (!ModifiedRegUnits.available(Reg)) {
         HasRegDependency = true;
         break;


### PR DESCRIPTION
Undef registers are no-ops, and therefore do not have any dependency associated with them, nor should undef registers be counted as a used op.