### PR TITLE
[attributes][analyzer] Generalize [[clang::suppress]] to declarations.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2891,6 +2891,13 @@ def Suppress : DeclOrStmtAttr {
   let Spellings = [CXX11<"gsl", "suppress">, Clang<"suppress">];
   let Args = [VariadicStringArgument<"DiagnosticIdentifiers">];
   let Accessors = [Accessor<"isGSL", [CXX11<"gsl", "suppress">]>];
+  // There's no fundamental reason why we can't simply accept all Decls
+  // but let's make a short list so that to avoid supporting something weird
+  // by accident. We can always expand the list later.
+  let Subjects = SubjectList<[
+    Stmt, Var, Field, ObjCProperty, Function, ObjCMethod, Record, ObjCInterface,
+    ObjCImplementation, Namespace, Empty
+  ], ErrorDiag, "variables, functions, structs, interfaces, and namespaces">;
   let Documentation = [SuppressDocs];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5313,6 +5313,29 @@ Putting the attribute on a compound statement suppresses all warnings in scope:
     }
   }
 
+The attribute can also be placed on entire declarations of functions, classes,
+variables, member variables, and so on, to suppress warnings related
+to the declarations themselves. When used this way, the attribute additionally
+suppresses all warnings in the lexical scope of the declaration:
+
+.. code-block:: c++
+
+  class [[clang::suppress]] C {
+    int foo() {
+      int *x = nullptr;
+      ...
+      return *x;  // warnings suppressed in the entire class scope
+    }
+
+    int bar();
+  };
+
+  int C::bar() {
+    int *x = nullptr;
+    ...
+    return *x;  // warning NOT suppressed! - not lexically nested in 'class C{}'
+  }
+
 Some static analysis warnings are accompanied by one or more notes, and the
 line of code against which the warning is emitted isn't necessarily the best
 for suppression purposes. In such cases the tools are allowed to implement

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2960,6 +2960,9 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
         S.mergeHLSLNumThreadsAttr(D, *NT, NT->getX(), NT->getY(), NT->getZ());
   else if (const auto *SA = dyn_cast<HLSLShaderAttr>(Attr))
     NewAttr = S.mergeHLSLShaderAttr(D, *SA, SA->getType());
+  else if (const auto *SupA = dyn_cast<SuppressAttr>(Attr))
+    // Do nothing. Each redeclaration should be suppressed separately.
+    NewAttr = nullptr;
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5245,11 +5245,6 @@ static void handleSuppressAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     // Suppression attribute with GSL spelling requires at least 1 argument.
     if (!AL.checkAtLeastNumArgs(S, 1))
       return;
-  } else if (!isa<VarDecl>(D)) {
-    // Analyzer suppression applies only to variables and statements.
-    S.Diag(AL.getLoc(), diag::err_attribute_wrong_decl_type_str)
-        << AL << 0 << "variables and statements";
-    return;
   }
 
   std::vector<StringRef> DiagnosticIdentifiers;

--- a/clang/lib/StaticAnalyzer/Checkers/ObjCUnusedIVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ObjCUnusedIVarsChecker.cpp
@@ -161,8 +161,8 @@ static void checkObjCUnusedIvar(const ObjCImplementationDecl *D,
 
       PathDiagnosticLocation L =
           PathDiagnosticLocation::create(Ivar, BR.getSourceManager());
-      BR.EmitBasicReport(ID, Checker, "Unused instance variable", "Optimization",
-                         os.str(), L);
+      BR.EmitBasicReport(ID, Checker, "Unused instance variable",
+                         "Optimization", os.str(), L);
     }
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/ObjCUnusedIVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ObjCUnusedIVarsChecker.cpp
@@ -161,7 +161,7 @@ static void checkObjCUnusedIvar(const ObjCImplementationDecl *D,
 
       PathDiagnosticLocation L =
           PathDiagnosticLocation::create(Ivar, BR.getSourceManager());
-      BR.EmitBasicReport(D, Checker, "Unused instance variable", "Optimization",
+      BR.EmitBasicReport(ID, Checker, "Unused instance variable", "Optimization",
                          os.str(), L);
     }
 }

--- a/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
@@ -82,12 +82,12 @@ public:
     CacheInitializer(ToInit).TraverseDecl(const_cast<Decl *>(D));
   }
 
-  bool VisitVarDecl(VarDecl *VD) {
+  bool VisitDecl(Decl *D) {
     // Bug location could be somewhere in the init value of
     // a freshly declared variable.  Even though it looks like the
     // user applied attribute to a statement, it will apply to a
     // variable declaration, and this is where we check for it.
-    return VisitAttributedNode(VD);
+    return VisitAttributedNode(D);
   }
 
   bool VisitAttributedStmt(AttributedStmt *AS) {
@@ -147,6 +147,20 @@ bool BugSuppression::isSuppressed(const PathDiagnosticLocation &Location,
     // done as well as perform a lot of work we'll never need.
     // Gladly, none of our on-by-default checkers currently need it.
     DeclWithIssue = ACtx.getTranslationUnitDecl();
+  } else {
+    // This is the fast path. However, we should still consider the topmost
+    // declaration that isn't TranslationUnitDecl, because we should respect
+    // attributes on the entire declaration chain.
+    while (true) {
+      // Use the "lexical" parent. Eg., if the attribute is on a class, suppress
+      // warnings in inline methods but not in out-of-line methods.
+      const Decl *Parent =
+          dyn_cast_or_null<Decl>(DeclWithIssue->getLexicalDeclContext());
+      if (Parent == nullptr || isa<TranslationUnitDecl>(Parent))
+        break;
+
+      DeclWithIssue = Parent;
+    }
   }
 
   // While some warnings are attached to AST nodes (mostly path-sensitive

--- a/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor.cpp
@@ -13,7 +13,17 @@ struct DerivedWithVirtualDtor : RefCntblBase {
   virtual ~DerivedWithVirtualDtor() {}
 };
 
+// Confirm that the checker respects [[clang::suppress]]
+struct [[clang::suppress]] SuppressedDerived : RefCntblBase { };
+struct [[clang::suppress]] SuppressedDerivedWithVirtualDtor : RefCntblBase {
+  virtual ~SuppressedDerivedWithVirtualDtor() {}
+};
 
+// FIXME: Support attributes on base specifiers? Currently clang
+// doesn't support such attributes at all, even though it knows
+// how to parse them.
+//
+// struct SuppressedBaseSpecDerived : [[clang::suppress]] RefCntblBase { };
 
 template<class T>
 struct DerivedClassTmpl : T { };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -15,6 +15,11 @@ void raw_ptr() {
   // CHECK-NEXT:{{^     | }}                     ^
   auto foo4 = [=](){ (void) ref_countable; };
   // CHECK: warning: Implicitly captured raw-pointer 'ref_countable' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]
+
+  // Confirm that the checker respects [[clang::suppress]].
+  RefCountable* suppressed_ref_countable = nullptr;
+  [[clang::suppress]] auto foo5 = [suppressed_ref_countable](){};
+  // CHECK-NOT: warning: Captured raw-pointer 'suppressed_ref_countable' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]
 }
 
 void references() {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -60,6 +60,7 @@ class Foo {
     // expected-warning@-1{{Local variable 'baz' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
     auto *baz2 = this->provide_ref_ctnbl();
     // expected-warning@-1{{Local variable 'baz2' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    [[clang::suppress]] auto *baz_suppressed = provide_ref_ctnbl(); // no-warning
   }
 };
 } // namespace auto_keyword

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
@@ -8,6 +8,9 @@ namespace members {
     RefCountable* a = nullptr;
 // expected-warning@-1{{Member variable 'a' in 'members::Foo' is a raw pointer to ref-countable type 'RefCountable'}}
 
+    [[clang::suppress]]
+    RefCountable* a_suppressed = nullptr;
+
   protected:
     RefPtr<RefCountable> b;
 
@@ -25,7 +28,13 @@ namespace members {
   };
 
   void forceTmplToInstantiate(FooTmpl<RefCountable>) {}
+
+  struct [[clang::suppress]] FooSuppressed {
+  private:
+    RefCountable* a = nullptr;
+  };
 }
+
 
 namespace ignore_unions {
   union Foo {

--- a/clang/test/Analysis/ObjCRetSigs.m
+++ b/clang/test/Analysis/ObjCRetSigs.m
@@ -4,10 +4,12 @@ int printf(const char *, ...);
 
 @interface MyBase
 -(long long)length;
+-(long long)suppressedLength;
 @end
 
 @interface MySub : MyBase{}
 -(double)length;
+-(double)suppressedLength;
 @end
 
 @implementation MyBase
@@ -15,10 +17,18 @@ int printf(const char *, ...);
    printf("Called MyBase -length;\n");
    return 3;
 }
+-(long long)suppressedLength{
+   printf("Called MyBase -length;\n");
+   return 3;
+}
 @end
 
 @implementation MySub
 -(double)length{  // expected-warning{{types are incompatible}}
+   printf("Called MySub -length;\n");
+   return 3.3;
+}
+-(double)suppressedLength [[clang::suppress]]{ // no-warning
    printf("Called MySub -length;\n");
    return 3.3;
 }

--- a/clang/test/Analysis/objc_invalidation.m
+++ b/clang/test/Analysis/objc_invalidation.m
@@ -257,6 +257,17 @@ extern void NSLog(NSString *format, ...) __attribute__((format(__NSString__, 1, 
 @implementation MissingInvalidationMethod
 @end
 
+@interface SuppressedMissingInvalidationMethod : Foo <FooBar_Protocol>
+@property (assign) [[clang::suppress]] SuppressedMissingInvalidationMethod *foobar16_warn;
+// FIXME: Suppression should have worked but decl-with-issue is the ivar, not the property.
+#if RUN_IVAR_INVALIDATION
+// expected-warning@-3 {{Property foobar16_warn needs to be invalidated; no invalidation method is defined in the @implementation for SuppressedMissingInvalidationMethod}}
+#endif
+
+@end
+@implementation SuppressedMissingInvalidationMethod
+@end
+
 @interface MissingInvalidationMethod2 : Foo <FooBar_Protocol> {
   Foo *Ivar1;
 #if RUN_IVAR_INVALIDATION
@@ -290,8 +301,10 @@ extern void NSLog(NSString *format, ...) __attribute__((format(__NSString__, 1, 
 @end
 
 @interface InvalidatedInPartial : SomeInvalidationImplementingObject {
-  SomeInvalidationImplementingObject *Ivar1; 
-  SomeInvalidationImplementingObject *Ivar2; 
+  SomeInvalidationImplementingObject *Ivar1;
+  SomeInvalidationImplementingObject *Ivar2;
+  [[clang::suppress]]
+  SomeInvalidationImplementingObject *Ivar3; // no-warning
 }
 -(void)partialInvalidator __attribute__((annotate("objc_instance_variable_invalidator_partial")));
 @end

--- a/clang/test/Analysis/suppression-attr-doc.cpp
+++ b/clang/test/Analysis/suppression-attr-doc.cpp
@@ -52,3 +52,17 @@ int bar2(bool coin_flip) {
   __attribute__((suppress))
   return *result;  // leak warning is suppressed only on this path
 }
+
+class [[clang::suppress]] C {
+  int foo() {
+    int *x = nullptr;
+    return *x;  // warnings suppressed in the entire class
+  }
+
+  int bar();
+};
+
+int C::bar() {
+  int *x = nullptr;
+  return *x;  // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}

--- a/clang/test/Analysis/suppression-attr.cpp
+++ b/clang/test/Analysis/suppression-attr.cpp
@@ -1,0 +1,68 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
+
+namespace [[clang::suppress]]
+suppressed_namespace {
+  int foo() {
+    int *x = 0;
+    return *x;
+  }
+
+  int foo_forward();
+}
+
+int suppressed_namespace::foo_forward() {
+    int *x = 0;
+    return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}
+
+// Another instance of the same namespace.
+namespace suppressed_namespace {
+  int bar() {
+    int *x = 0;
+    return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+  }
+}
+
+void lambda() {
+  [[clang::suppress]] {
+    auto lam = []() {
+      int *x = 0;
+      return *x;
+    };
+  }
+}
+
+class [[clang::suppress]] SuppressedClass {
+  int foo() {
+    int *x = 0;
+    return *x;
+  }
+
+  int bar();
+};
+
+int SuppressedClass::bar() {
+  int *x = 0;
+  return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}
+
+class SuppressedMethodClass {
+  [[clang::suppress]] int foo() {
+    int *x = 0;
+    return *x;
+  }
+
+  [[clang::suppress]] int bar1();
+  int bar2();
+};
+
+int SuppressedMethodClass::bar1() {
+  int *x = 0;
+  return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}
+
+[[clang::suppress]]
+int SuppressedMethodClass::bar2() {
+  int *x = 0;
+  return *x; // no-warning
+}

--- a/clang/test/Analysis/suppression-attr.m
+++ b/clang/test/Analysis/suppression-attr.m
@@ -168,17 +168,15 @@ void malloc_leak_suppression_2_1() {
   *x = 42;
 }
 
-// TODO: reassess when we decide what to do with declaration annotations
-void malloc_leak_suppression_2_2() /* SUPPRESS */ {
+void malloc_leak_suppression_2_2() SUPPRESS {
   int *x = (int *)malloc(sizeof(int));
   *x = 42;
-} // expected-warning{{Potential leak of memory pointed to by 'x'}}
+} // no-warning
 
-// TODO: reassess when we decide what to do with declaration annotations
-/* SUPPRESS */ void malloc_leak_suppression_2_3() {
+SUPPRESS void malloc_leak_suppression_2_3() {
   int *x = (int *)malloc(sizeof(int));
   *x = 42;
-} // expected-warning{{Potential leak of memory pointed to by 'x'}}
+} // no-warning
 
 void malloc_leak_suppression_2_4(int cond) {
   int *x = (int *)malloc(sizeof(int));
@@ -233,20 +231,15 @@ void retain_release_leak__suppression_2(int cond) {
 
 @interface TestSuppress : UIResponder {
 }
-// TODO: reassess when we decide what to do with declaration annotations
-@property(copy) /* SUPPRESS */ NSMutableString *mutableStr;
-// expected-warning@-1 {{Property of mutable type 'NSMutableString' has 'copy' attribute; an immutable object will be stored instead}}
+@property(copy) SUPPRESS NSMutableString *mutableStr; // no-warning
 @end
 @implementation TestSuppress
 
-// TODO: reassess when we decide what to do with declaration annotations
-- (BOOL)resignFirstResponder /* SUPPRESS */ {
+- (BOOL)resignFirstResponder SUPPRESS { // no-warning
   return 0;
-} // expected-warning {{The 'resignFirstResponder' instance method in UIResponder subclass 'TestSuppress' is missing a [super resignFirstResponder] call}}
+}
 
-// TODO: reassess when we decide what to do with declaration annotations
-- (void)methodWhichMayFail:(NSError **)error /* SUPPRESS */ {
-  // expected-warning@-1 {{Method accepting NSError** should have a non-void return value to indicate whether or not an error occurred}}
+- (void)methodWhichMayFail:(NSError **)error SUPPRESS { // no-warning
 }
 @end
 
@@ -269,3 +262,40 @@ void ast_checker_suppress_1() {
   struct ABC *Abc;
   SUPPRESS { Abc = (struct ABC *)&Ab; }
 }
+
+SUPPRESS int suppressed_function() {
+  int *x = 0;
+  return *x; // no-warning
+}
+
+SUPPRESS int suppressed_function_forward();
+int suppressed_function_forward() {
+  int *x = 0;
+  return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}
+
+int suppressed_function_backward();
+SUPPRESS int suppressed_function_backward() {
+  int *x = 0;
+  return *x; // no-warning
+}
+
+SUPPRESS
+@interface SuppressedInterface
+-(int)suppressedMethod;
+-(int)regularMethod SUPPRESS;
+@end
+
+@implementation SuppressedInterface
+-(int)suppressedMethod SUPPRESS {
+  int *x = 0;
+  return *x; // no-warning
+}
+
+// This one is NOT suppressed by the attribute on the forward declaration,
+// and it's also NOT suppressed by the attribute on the entire interface.
+-(int)regularMethod {
+  int *x = 0;
+  return *x; // expected-warning{{Dereference of null pointer (loaded from variable 'x')}}
+}
+@end

--- a/clang/test/Analysis/unused-ivars.m
+++ b/clang/test/Analysis/unused-ivars.m
@@ -44,6 +44,15 @@
 }
 @end
 
+// Confirm that the checker respects [[clang::suppress]].
+@interface TestC {
+@private
+  [[clang::suppress]] int x; // no-warning
+}
+@end
+@implementation TestC @end
+
+
 //===----------------------------------------------------------------------===//
 // Detect that ivar is in use, if used in category in the same file as the
 // implementation.

--- a/clang/test/SemaCXX/attr-suppress.cpp
+++ b/clang/test/SemaCXX/attr-suppress.cpp
@@ -23,18 +23,16 @@ union [[gsl::suppress("type.1")]] U {
   float f;
 };
 
+// This doesn't really suppress anything but why not?
 [[clang::suppress]];
-// expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
 
 namespace N {
 [[clang::suppress("in-a-namespace")]];
-// expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
 } // namespace N
 
 [[clang::suppress]] int global = 42;
 
 [[clang::suppress]] void foo() {
-  // expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
   [[clang::suppress]] int *p;
 
   [[clang::suppress]] int a = 0;           // no-warning
@@ -56,7 +54,11 @@ namespace N {
 }
 
 class [[clang::suppress("type.1")]] V {
-  // expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
   int i;
   float f;
+};
+
+// FIXME: There's no good reason why we shouldn't support this case.
+// But it doesn't look like clang generally supports such attributes yet.
+class W : [[clang::suppress]] public V { // expected-error{{'suppress' attribute cannot be applied to a base specifier}}
 };

--- a/clang/test/SemaObjC/attr-suppress.m
+++ b/clang/test/SemaObjC/attr-suppress.m
@@ -6,8 +6,7 @@
 SUPPRESS1 int global = 42;
 
 SUPPRESS1 void foo() {
-  // expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
-  SUPPRESS1 int *p;
+  SUPPRESS1 int *p; // no-warning
 
   SUPPRESS1 int a = 0; // no-warning
   SUPPRESS2()
@@ -28,23 +27,19 @@ SUPPRESS1 void foo() {
   // GNU-style attributes and C++11 attributes apply to different things when
   // written like this.  GNU  attribute gets attached to the declaration, while
   // C++11 attribute ends up on the type.
-  int SUPPRESS2("r") z;
-  SUPPRESS2(foo)
+  int SUPPRESS2("r") z; // no-warning
+  SUPPRESS2(foo) // no-warning
   float f;
   // expected-error@-2 {{expected string literal as argument of 'suppress' attribute}}
 }
 
-union SUPPRESS2("type.1") U {
-  // expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
+union SUPPRESS2("type.1") U { // no-warning
   int i;
   float f;
 };
 
-SUPPRESS1 @interface Test {
-  // expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
+SUPPRESS1 @interface Test { // no-warning
 }
-@property SUPPRESS2("prop") int *prop;
-// expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
-- (void)bar:(int)x SUPPRESS1;
-// expected-error@-1 {{'suppress' attribute only applies to variables and statements}}
+@property SUPPRESS2("prop") int *prop; // no-warning
+- (void)bar:(int)x SUPPRESS1; // no-warning
 @end


### PR DESCRIPTION
The attribute is now allowed on an assortment of declarations, to suppress warnings related to declarations themselves, or all warnings in the lexical scope of the declaration.

I don't necessarily see a reason to have a list at all, but it does look as if some of those more niche items aren't properly supported by the compiler itself so let's maintain a short safe list for now.

The initial implementation raised a question whether the attribute should apply to lexical declaration context vs. "actual" declaration context. I'm using "lexical" here because it results in less warnings suppressed, which is the conservative behavior: we can always expand it later if we think this is wrong, without breaking any existing code. I also think that this is the correct behavior that we will probably never want to change, given that the user typically desires to keep the suppressions as localized as possible.