### PR TITLE
[clang-format] Handle doxygen commands starting with \

### DIFF
--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -449,11 +449,11 @@ const FormatToken &BreakableComment::tokenAt(unsigned LineIndex) const {
 
 static bool mayReflowContent(StringRef Content) {
   Content = Content.trim(Blanks);
-  // Lines starting with '@' commonly have special meaning.
+  // Lines starting with '@' or '\' commonly have special meaning.
   // Lines starting with '-', '-#', '+' or '*' are bulleted/numbered lists.
   bool hasSpecialMeaningPrefix = false;
   for (StringRef Prefix :
-       {"@", "TODO", "FIXME", "XXX", "-# ", "- ", "+ ", "* "}) {
+       {"@", "\\", "TODO", "FIXME", "XXX", "-# ", "- ", "+ ", "* "}) {
     if (Content.starts_with(Prefix)) {
       hasSpecialMeaningPrefix = true;
       break;

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -1909,6 +1909,14 @@ TEST_F(FormatTestComments, ReflowsComments) {
                    "// @param arg",
                    getLLVMStyleWithColumns(20)));
 
+  // Don't reflow lines starting with '\'.
+  EXPECT_EQ("// long long long\n"
+            "// long\n"
+            "// \\param arg",
+            format("// long long long long\n"
+                   "// \\param arg",
+                   getLLVMStyleWithColumns(20)));
+
   // Don't reflow lines starting with 'TODO'.
   EXPECT_EQ("// long long long\n"
             "// long\n"

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -1910,12 +1910,12 @@ TEST_F(FormatTestComments, ReflowsComments) {
                    getLLVMStyleWithColumns(20)));
 
   // Don't reflow lines starting with '\'.
-  EXPECT_EQ("// long long long\n"
-            "// long\n"
-            "// \\param arg",
-            format("// long long long long\n"
-                   "// \\param arg",
-                   getLLVMStyleWithColumns(20)));
+  verifyFormat("// long long long\n"
+               "// long\n"
+               "// \\param arg",
+               "// long long long long\n"
+               "// \\param arg",
+               getLLVMStyleWithColumns(20));
 
   // Don't reflow lines starting with 'TODO'.
   EXPECT_EQ("// long long long\n"


### PR DESCRIPTION
Fixes llvm/llvm-project#63241

Doxygen commands can start with `@` or `\`.