### PR TITLE
[workflows] Close issues used for backports once the PR has been created

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -577,6 +577,10 @@ class ReleaseWorkflow:
 
             pull.as_issue().edit(milestone=self.issue.milestone)
 
+            # Once the pull request has been created, we can close the
+            # issue that was used to request the cherry-pick
+            self.issue.edit(state='closed', state_reason='completed')
+
             try:
                 self.pr_request_review(pull)
             except Exception as e:

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -579,7 +579,7 @@ class ReleaseWorkflow:
 
             # Once the pull request has been created, we can close the
             # issue that was used to request the cherry-pick
-            self.issue.edit(state='closed', state_reason='completed')
+            self.issue.edit(state="closed", state_reason="completed")
 
             try:
                 self.pr_request_review(pull)


### PR DESCRIPTION
This will allow us to track the state of the backport request in the PR, rather than in the issue.  The state updates for PRs can be automated, so this will save us some triage work.