### PR TITLE
[MLIR][Vector] Implement memory effect for print

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2497,6 +2497,7 @@ def Vector_TransposeOp :
 
 def Vector_PrintOp :
   Vector_Op<"print", [
+    MemoryEffects<[MemWrite]>,
     PredOpTrait<
       "`source` or `punctuation` are not set when printing strings",
       CPred<"!getStringLiteral() || (!getSource() && getPunctuation() == PrintPunctuation::NewLine)">

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-other.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-other.mlir
@@ -38,3 +38,12 @@ func.func @no_side_effects() {
   "test.unregistered_op_foo"(%0) : (memref<5xf32>) -> ()
   return
 }
+
+// -----
+
+// Buffer deallocation should not emit any error here as the operation does not
+// operate on buffer and has known memory effect (write).
+func.func @no_buffer_semantics_with_write_effect(%v0: vector<9x6xf32>) {
+  vector.print %v0 : vector<9x6xf32>
+  return
+}

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-other.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-other.mlir
@@ -42,7 +42,7 @@ func.func @no_side_effects() {
 // -----
 
 // Buffer deallocation should not emit any error here as the operation does not
-// operate on buffer and has known memory effect (write).
+// operate on buffers and has known memory effect (write).
 func.func @no_buffer_semantics_with_write_effect(%v0: vector<9x6xf32>) {
   vector.print %v0 : vector<9x6xf32>
   return


### PR DESCRIPTION
Add write memory effect for the print operation. The exact memory behavior is implemented in other print-like operations such as `transform::PrintOp` or `gpu::printf`.

Providing memory behavior allows using the operation in passes like buffer deallocation instead of emitting an error.