### PR TITLE
[X86] [iamcu] Fix wrong alignment value for attr (aligned) with -miamcu

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -672,6 +672,7 @@ public:
   MCUX86_32TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : X86_32TargetInfo(Triple, Opts) {
     LongDoubleWidth = 64;
+    DefaultAlignForAttributeAligned = 32;
     LongDoubleFormat = &llvm::APFloat::IEEEdouble();
     resetDataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:32-"
                     "f64:32-f128:32-n8:16:32-a:0:32-S32");

--- a/clang/test/Sema/attr-aligned.c
+++ b/clang/test/Sema/attr-aligned.c
@@ -1,10 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin9 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple i586-intel-elfiamcu -fsyntax-only -verify %s
 
 int x __attribute__((aligned(3))); // expected-error {{requested alignment is not a power of 2}}
 int y __attribute__((aligned(1ull << 33))); // expected-error {{requested alignment must be 4294967296 bytes or smaller}}
 int y __attribute__((aligned(1ull << 32)));
-// GH50534
-int z __attribute__((aligned((__int128_t)0x1234567890abcde0ULL << 64))); // expected-error {{requested alignment must be 4294967296 bytes or smaller}}
 
 // PR26444
 int y __attribute__((aligned(1 << 29)));
@@ -12,7 +11,14 @@ int y __attribute__((aligned(1 << 28)));
 
 // PR3254
 short g0[3] __attribute__((aligned));
+#ifdef __iamcu
+short g0_chk[__alignof__(g0) == 4 ? 1 : -1];
+#else
 short g0_chk[__alignof__(g0) == 16 ? 1 : -1];
+
+// GH50534
+int z __attribute__((aligned((__int128_t)0x1234567890abcde0ULL << 64))); // expected-error {{requested alignment must be 4294967296 bytes or smaller}}
+#endif
 
 typedef char ueber_aligned_char __attribute__((aligned(8)));
 


### PR DESCRIPTION
attribute ((aligned)) should be 4 for -miamcu.

relate: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66818