### PR TITLE
[Clang][CodeGen] Mark `__dynamic_cast` as `willreturn`

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1347,9 +1347,10 @@ static llvm::FunctionCallee getItaniumDynamicCastFn(CodeGenFunction &CGF) {
 
   llvm::FunctionType *FTy = llvm::FunctionType::get(Int8PtrTy, Args, false);
 
-  // Mark the function as nounwind readonly.
+  // Mark the function as nounwind willreturn readonly.
   llvm::AttrBuilder FuncAttrs(CGF.getLLVMContext());
   FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
+  FuncAttrs.addAttribute(llvm::Attribute::WillReturn);
   FuncAttrs.addMemoryAttr(llvm::MemoryEffects::readOnly());
   llvm::AttributeList Attrs = llvm::AttributeList::get(
       CGF.getLLVMContext(), llvm::AttributeList::FunctionIndex, FuncAttrs);

--- a/clang/test/CodeGenCXX/dynamic-cast-address-space.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-address-space.cpp
@@ -20,5 +20,5 @@ const B& f(A *a) {
 
 // CHECK: declare ptr @__dynamic_cast(ptr, ptr addrspace(1), ptr addrspace(1), i64) [[NUW_RO:#[0-9]+]]
 
-// CHECK: attributes [[NUW_RO]] = { nounwind memory(read) }
+// CHECK: attributes [[NUW_RO]] = { nounwind willreturn memory(read) }
 // CHECK: attributes [[NR]] = { noreturn }

--- a/clang/test/CodeGenCXX/dynamic-cast-dead.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-dead.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -I%S %s -O3 -triple x86_64-apple-darwin10 -emit-llvm -fcxx-exceptions -fexceptions -std=c++11 -o - | FileCheck %s
+struct A { virtual ~A(); };
+struct B : A { };
+
+void foo(A* a) {
+  // CHECK-NOT: call {{.*}} @__dynamic_cast
+  B* b = dynamic_cast<B*>(a);
+}

--- a/clang/test/CodeGenCXX/dynamic-cast.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast.cpp
@@ -20,5 +20,5 @@ const B& f(A *a) {
 
 // CHECK: declare ptr @__dynamic_cast(ptr, ptr, ptr, i64) [[NUW_RO:#[0-9]+]]
 
-// CHECK: attributes [[NUW_RO]] = { nounwind memory(read) }
+// CHECK: attributes [[NUW_RO]] = { nounwind willreturn memory(read) }
 // CHECK: attributes [[NR]] = { noreturn }


### PR DESCRIPTION
According to the C++ standard, `dynamic_cast` of pointers either returns a pointer (7.6.1.7) or results in undefined behavior (11.9.5). This patch marks `__dynamic_cast` as `willreturn` to remove unused calls.

Fixes #77606.