### PR TITLE
[llvm-cov] Keep the detailed error message in CoverageMappingIterator

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
@@ -45,6 +45,7 @@ class CoverageMappingIterator {
   CoverageMappingReader *Reader;
   CoverageMappingRecord Record;
   coveragemap_error ReadErr;
+  std::string ReadErrMsg;
 
   void increment();
 
@@ -80,7 +81,7 @@ public:
   }
   Expected<CoverageMappingRecord &> operator*() {
     if (ReadErr != coveragemap_error::success) {
-      auto E = make_error<CoverageMapError>(ReadErr);
+      auto E = make_error<CoverageMapError>(ReadErr, ReadErrMsg);
       ReadErr = coveragemap_error::success;
       return std::move(E);
     }
@@ -88,7 +89,7 @@ public:
   }
   Expected<CoverageMappingRecord *> operator->() {
     if (ReadErr != coveragemap_error::success) {
-      auto E = make_error<CoverageMapError>(ReadErr);
+      auto E = make_error<CoverageMapError>(ReadErr, ReadErrMsg);
       ReadErr = coveragemap_error::success;
       return std::move(E);
     }

--- a/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
@@ -57,8 +57,10 @@ void CoverageMappingIterator::increment() {
     handleAllErrors(std::move(E), [&](const CoverageMapError &CME) {
       if (CME.get() == coveragemap_error::eof)
         *this = CoverageMappingIterator();
-      else
+      else {
         ReadErr = CME.get();
+        ReadErrMsg = CME.getMessage();
+      }
     });
 }
 

--- a/llvm/test/tools/llvm-cov/warnings.h
+++ b/llvm/test/tools/llvm-cov/warnings.h
@@ -13,4 +13,4 @@
 // FAKE-FUNC-STDERR: Could not read coverage for '{{.*}}'.
 
 // RUN: not llvm-cov report %S/Inputs/malformedRegions.covmapping -instr-profile %S/Inputs/elf_binary_comdat.profdata 2>&1 | FileCheck %s -check-prefix=MALFORMED-REGION
-// MALFORMED-REGION: failed to load coverage: '{{.*}}malformedRegions.covmapping': malformed coverage data
+// MALFORMED-REGION: failed to load coverage: '{{.*}}malformedRegions.covmapping': malformed coverage data: counter mapping region locations are incorrect


### PR DESCRIPTION
Currently errors returned from `CoverageMappingIterator` will have their message part discarded. This commit copies that message when constructing the new `CoverageMapError` object, and let it displayed at the end caller (`llvm-cov`).

Related: #65264