### PR TITLE
[mlir] Start moving some builtin type formats to the dialect

### DIFF
--- a/mlir/include/mlir/IR/BuiltinDialect.td
+++ b/mlir/include/mlir/IR/BuiltinDialect.td
@@ -22,7 +22,7 @@ def Builtin_Dialect : Dialect {
   let name = "builtin";
   let cppNamespace = "::mlir";
   let useDefaultAttributePrinterParser = 0;
-  let useDefaultTypePrinterParser = 0;
+  let useDefaultTypePrinterParser = 1;
   let extraClassDeclaration = [{
   private:
     // Register the builtin Attributes.

--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -25,7 +25,8 @@ include "mlir/IR/BuiltinTypeInterfaces.td"
 // Base class for Builtin dialect types.
 class Builtin_Type<string name, string typeMnemonic, list<Trait> traits = [],
                    string baseCppClass = "::mlir::Type">
-    : TypeDef<Builtin_Dialect, name, traits, baseCppClass> {
+    : TypeDef<Builtin_Dialect, name, !listconcat(traits, [PrintTypeQualified]),
+        baseCppClass> {
   let mnemonic = ?;
   let typeName = "builtin." # typeMnemonic;
 }
@@ -62,6 +63,9 @@ def Builtin_Complex : Builtin_Type<"Complex", "complex"> {
   ];
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
+
+  let mnemonic = "complex";
+  let assemblyFormat = "`<` $elementType `>`";
 }
 
 //===----------------------------------------------------------------------===//
@@ -668,6 +672,9 @@ def Builtin_MemRef : Builtin_Type<"MemRef", "memref", [
   }];
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
+
+  let mnemonic = "memref";
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -698,6 +705,8 @@ def Builtin_None : Builtin_Type<"None", "none"> {
   let extraClassDeclaration = [{
     static NoneType get(MLIRContext *context);
   }];
+
+  let mnemonic = "none";
 }
 
 //===----------------------------------------------------------------------===//
@@ -849,6 +858,9 @@ def Builtin_RankedTensor : Builtin_Type<"RankedTensor", "tensor", [
   }];
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
+
+  let mnemonic = "tensor";
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -884,7 +896,7 @@ def Builtin_Tuple : Builtin_Type<"Tuple", "tuple"> {
     tuple<i32, f32, tensor<i1>, i5>
     ```
   }];
-  let parameters = (ins "ArrayRef<Type>":$types);
+  let parameters = (ins OptionalArrayRefParameter<"Type">:$types);
   let builders = [
     TypeBuilder<(ins "TypeRange":$elementTypes), [{
       return $_get($_ctxt, elementTypes);
@@ -916,6 +928,9 @@ def Builtin_Tuple : Builtin_Type<"Tuple", "tuple"> {
       return getTypes()[index];
     }
   }];
+
+  let mnemonic = "tuple";
+  let assemblyFormat = "`<` (`>`) : ($types^ `>`)?";
 }
 
 //===----------------------------------------------------------------------===//
@@ -994,6 +1009,9 @@ def Builtin_UnrankedMemRef : Builtin_Type<"UnrankedMemRef", "unranked_memref", [
   }];
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
+
+  let mnemonic = "memref";
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1043,6 +1061,9 @@ def Builtin_UnrankedTensor : Builtin_Type<"UnrankedTensor", "unranked_tensor", [
   }];
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
+
+  let mnemonic = "tensor";
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -187,6 +187,11 @@ public:
   /// provide a valid type for the attribute.
   virtual void printAttributeWithoutType(Attribute attr);
 
+  /// Print the given attribute without its type if and only if the type is the
+  /// default type for the given attribute.
+  /// E.g. '1 : i64' is printed as just '1'.
+  virtual void printAttributeWithoutDefaultType(Attribute attr);
+
   /// Print the alias for the given attribute, return failure if no alias could
   /// be printed.
   virtual LogicalResult printAlias(Attribute attr);

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -11,6 +11,7 @@
 
 #include "ParserState.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/OpImplementation.h"
 #include <optional>
 
@@ -28,9 +29,14 @@ public:
   using Delimiter = OpAsmParser::Delimiter;
 
   Builder builder;
+  /// Cached instance of the builtin dialect for parsing builtins.
+  Dialect *builtinDialect;
 
   Parser(ParserState &state)
-      : builder(state.config.getContext()), state(state) {}
+      : builder(state.config.getContext()),
+        builtinDialect(
+            builder.getContext()->getLoadedDialect<BuiltinDialect>()),
+        state(state) {}
 
   // Helper methods to get stuff from the parser-global state.
   ParserState &getState() const { return state; }
@@ -192,26 +198,18 @@ public:
   /// Parse an arbitrary type.
   Type parseType();
 
-  /// Parse a complex type.
-  Type parseComplexType();
-
   /// Parse an extended type.
   Type parseExtendedType();
+
+  /// Parse an extended type from the builtin dialect where the '!builtin'
+  /// prefix is missing.
+  Type parseExtendedBuiltinType();
 
   /// Parse a function type.
   Type parseFunctionType();
 
-  /// Parse a memref type.
-  Type parseMemRefType();
-
   /// Parse a non function type.
   Type parseNonFunctionType();
-
-  /// Parse a tensor type.
-  Type parseTensorType();
-
-  /// Parse a tuple type.
-  Type parseTupleType();
 
   /// Parse a vector type.
   VectorType parseVectorType();

--- a/mlir/test/IR/invalid-builtin-types.mlir
+++ b/mlir/test/IR/invalid-builtin-types.mlir
@@ -27,7 +27,7 @@ func.func @illegalunrankedmemrefelementtype(memref<*xtensor<i8>>) -> () // expec
 
 // -----
 // Test no map in memref type.
-func.func @memrefs(memref<2x4xi8, >) // expected-error {{expected list element}}
+func.func @memrefs(memref<2x4xi8, >) // expected-error {{expected attribute}}
 
 // -----
 // Test non-existent map in memref type.
@@ -74,7 +74,7 @@ func.func private @memref_unfinished_strided() -> memref<?x?xf32, strided<>>
 
 // -----
 
-// expected-error @below {{expected a 64-bit signed integer or '?'}}
+// expected-error @below {{unbalanced '[' character in pretty dialect name}}
 func.func private @memref_unfinished_stride_list() -> memref<?x?xf32, strided<[>>
 
 // -----
@@ -94,7 +94,7 @@ func.func private @memref_missing_offset_value() -> memref<?x?xf32, strided<[], 
 
 // -----
 
-// expected-error @below {{expected '>'}}
+// expected-error @below {{unbalanced '<' character in pretty dialect name}}
 func.func private @memref_incorrect_strided_ending() -> memref<?x?xf32, strided<[], offset: 32)>
 
 // -----
@@ -170,12 +170,12 @@ func.func @bad_complex(complex<memref<2x4xi8>>)
 
 // -----
 
-// expected-error @+1 {{expected '<' in complex type}}
+// expected-error @+1 {{expected '<'}}
 func.func @bad_complex(complex memref<2x4xi8>>)
 
 // -----
 
-// expected-error @+1 {{expected '>' in complex type}}
+// expected-error @+1 {{unbalanced '<' character in pretty dialect name}}
 func.func @bad_complex(complex<i32)
 
 // -----

--- a/mlir/test/IR/invalid.mlir
+++ b/mlir/test/IR/invalid.mlir
@@ -419,12 +419,12 @@ func.func @invalid_unknown_type_dialect_name() -> !invalid.dialect<!x@#]!@#>
 
 // -----
 
-// expected-error @+1 {{expected '<' in tuple type}}
+// expected-error @+1 {{expected '<'}}
 func.func @invalid_tuple_missing_less(tuple i32>)
 
 // -----
 
-// expected-error @+1 {{expected '>' in tuple type}}
+// expected-error @+1 {{unbalanced '<' character in pretty dialect name}}
 func.func @invalid_tuple_missing_greater(tuple<i32)
 
 // -----

--- a/mlir/test/IR/qualified-builtin.mlir
+++ b/mlir/test/IR/qualified-builtin.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-opt %s | FileCheck %s
+
+// CHECK-LABEL: @test1
+// CHECK: -> tuple<>
+func.func private @test1() -> !builtin.tuple<>
+
+// CHECK-LABEL: @test2
+// CHECK: -> none
+func.func private @test2() -> !builtin.none
+
+


### PR DESCRIPTION
Most types and attributes in the builtin dialect are parsed and printed using special-purpose printers and parsers for that type. They also use the low-level `Printer` rather than the `AsmPrinter`, making the implementations inconsistent compared to all other dialects in MLIR.

This PR starts moving some builtin types to be parsed using the usual `print` and `parse` methods like all other MLIR dialects. This has the following advantages:
* The implementation now looks like any other dialect's
* It is now possible to use `assemblyFormat` for builtin types and attributes
* The code can be easily moved to other dialects if desired
* Arguably better layering and less code
* As a side-effect, it is now also possible to write `!builtin.<type>` for any types if desired

A future benefit would include being able to print types and attributes in stripped format as well (e.g. `<f32>` vs `complex<f32>`), just like all other dialect types and attributes. This is currently explicitly disabled as it causes a LOT of changes in IR syntax and I believe some ambiguities in the parser.

For the purpose of reviewing and incremental development, this PR only moves `tuple`, `tensor`, `none`, `memref` and `complex`. The plan is to eventually move all attributes and types where the current syntax can be implemented within the dialect.

For backwards compatibility with the existing syntax, the builtin dialect is special-cased in the printer where the `builtin.` prefix is omitted.

Depends on https://github.com/llvm/llvm-project/pull/80420