### PR TITLE
[llvm][AArch64][TargetParser][NFC] Use parseArchExtension in parseModifier.

### DIFF
--- a/llvm/lib/TargetParser/AArch64TargetParser.cpp
+++ b/llvm/lib/TargetParser/AArch64TargetParser.cpp
@@ -260,24 +260,17 @@ void AArch64::ExtensionSet::addArchDefaults(const ArchInfo &Arch) {
 bool AArch64::ExtensionSet::parseModifier(StringRef Modifier) {
   LLVM_DEBUG(llvm::dbgs() << "parseModifier(" << Modifier << ")\n");
 
-  // Negative modifiers, with the syntax "no<feat>"
-  if (Modifier.starts_with("no")) {
-    StringRef ModifierBase(Modifier.substr(2));
-    for (const auto &AE : Extensions) {
-      if (!AE.NegFeature.empty() && ModifierBase == AE.Name) {
-        disable(AE.ID);
-        return true;
-      }
-    }
-  }
+  bool IsNegated = Modifier.starts_with("no");
+  StringRef ArchExt = IsNegated ? Modifier.drop_front(2) : Modifier;
 
-  // Positive modifiers
-  for (const auto &AE : Extensions) {
-    if (!AE.Feature.empty() && Modifier == AE.Name) {
-      enable(AE.ID);
-      return true;
-    }
+  if (auto AE = parseArchExtension(ArchExt)) {
+    if (AE->Feature.empty() || AE->NegFeature.empty())
+      return false;
+    if (IsNegated)
+      disable(AE->ID);
+    else
+      enable(AE->ID);
+    return true;
   }
-
   return false;
 }


### PR DESCRIPTION
This allows making changes in parseArchExtension to make their way in the command line as well, not only in target attributes.