### PR TITLE
[hwasan] Call user provided callback function for both fatal and non-…

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_report.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_report.cpp
@@ -40,7 +40,7 @@ class ScopedReport {
  public:
   explicit ScopedReport(bool fatal) : fatal(fatal) {
     Lock lock(&error_message_lock_);
-    error_message_ptr_ = fatal ? &error_message_ : nullptr;
+    error_message_ptr_ = &error_message_;
     ++hwasan_report_count;
   }
 


### PR DESCRIPTION
…fatal error report

This makes the behavior of HWASan matching with ASan: always call user provided callback function for an error report, but only call `SetAbortMessage()` on Android when `flags()->halt_on_error` is true.



