### PR TITLE
[WebAssembly] validate `table.grow` correctly

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -411,7 +411,7 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
     for (unsigned I = II.getNumOperands(); I > II.getNumDefs(); I--) {
       const auto &Op = II.operands()[I - 1];
       if (Op.OperandType == MCOI::OPERAND_REGISTER) {
-        wasm::ValType VT = WebAssembly::regClassToValType(Op.RegClass);
+        auto VT = WebAssembly::regClassToValType(Op.RegClass);
         if (popType(ErrorLoc, VT))
           return true;
       }

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -288,6 +288,16 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
       return true;
     if (popType(ErrorLoc, wasm::ValType::I32))
       return true;
+  } else if (Name == "table.size") {
+    if (getTable(Operands[1]->getStartLoc(), Inst, Type))
+      return true;
+    Stack.push_back(wasm::ValType::I32);
+  } else if (Name == "table.grow") {
+    if (getTable(Operands[1]->getStartLoc(), Inst, Type))
+      return true;
+    if (popType(ErrorLoc, wasm::ValType::I32))
+      return true;
+    Stack.push_back(wasm::ValType::I32);
   } else if (Name == "table.fill") {
     if (getTable(Operands[1]->getStartLoc(), Inst, Type))
       return true;
@@ -401,7 +411,7 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
     for (unsigned I = II.getNumOperands(); I > II.getNumDefs(); I--) {
       const auto &Op = II.operands()[I - 1];
       if (Op.OperandType == MCOI::OPERAND_REGISTER) {
-        auto VT = WebAssembly::regClassToValType(Op.RegClass);
+        wasm::ValType VT = WebAssembly::regClassToValType(Op.RegClass);
         if (popType(ErrorLoc, VT))
           return true;
       }

--- a/llvm/test/MC/WebAssembly/tables.s
+++ b/llvm/test/MC/WebAssembly/tables.s
@@ -71,8 +71,6 @@ table_set:
 
 #      CHECK: table_grow:
 # CHECK-NEXT:	.functype	table_grow (i32) -> (i32)
-# CHECK-NEXT:	i32.const	0
-# CHECK-NEXT:	table.get	foo
 # CHECK-NEXT:	local.get	0
 #      CHECK:	table.grow	foo
 # CHECK-NEXT:	local.get	0
@@ -80,8 +78,6 @@ table_set:
 # CHECK-NEXT:	end_function
 table_grow:
     .functype table_grow (i32) -> (i32)
-    i32.const 0
-    table.get foo
     local.get 0
 
     # ENC: table.grow	foo                     # encoding: [0xfc,0x0f,0x80'A',0x80'A',0x80'A',0x80'A',A]
@@ -149,16 +145,13 @@ table_fill:
 # BIN-NEXT:        Offset:          0x2D
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           0
-# BIN-NEXT:        Offset:          0x38
-# BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
-# BIN-NEXT:        Index:           0
-# BIN-NEXT:        Offset:          0x41
+# BIN-NEXT:        Offset:          0x39
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           2
-# BIN-NEXT:        Offset:          0x51
+# BIN-NEXT:        Offset:          0x49
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           2
-# BIN-NEXT:        Offset:          0x5A
+# BIN-NEXT:        Offset:          0x52
 # BIN-NEXT:    Functions:
 # BIN-NEXT:      - Index:           0
 # BIN-NEXT:        Locals:          []
@@ -171,7 +164,7 @@ table_fill:
 # BIN-NEXT:        Body:            200020012680808080000B
 # BIN-NEXT:      - Index:           3
 # BIN-NEXT:        Locals:          []
-# BIN-NEXT:        Body:            41002580808080002000FC0F808080800020006A0B
+# BIN-NEXT:        Body:            2000FC0F808080800020006A0B
 # BIN-NEXT:      - Index:           4
 # BIN-NEXT:        Locals:          []
 # BIN-NEXT:        Body:            200041002582808080002001FC1182808080000B

--- a/llvm/test/MC/WebAssembly/type-checker-errors.s
+++ b/llvm/test/MC/WebAssembly/type-checker-errors.s
@@ -215,6 +215,26 @@ table_fill_type_mismatch_3:
   table.fill valid_table
   end_function
 
+table_grow_non_exist_table:
+  .functype table_grow_non_exist_table () -> (i32)
+  i32.const 0
+# CHECK: [[@LINE+1]]:14: error: symbol invalid_table missing .tabletype
+  table.grow invalid_table
+  end_function
+
+table_grow_wrong_parameter:
+  .functype table_grow_non_exist_table () -> (i32)
+# CHECK: [[@LINE+1]]:3: error: empty stack while popping i32
+  table.grow valid_table
+  end_function
+
+table_grow_wrong_result:
+  .functype table_grow_non_exist_table () -> (f32)
+  i32.const 0
+  table.grow valid_table
+# CHECK: [[@LINE+1]]:3: error: popped i32, expected f32
+  end_function
+
 drop_empty_stack_while_popping:
   .functype drop_empty_stack_while_popping () -> ()
 # CHECK: :[[@LINE+1]]:3: error: empty stack while popping value


### PR DESCRIPTION
This PR add support in wasm asm type checker to implement checker of `table.grow`
Fixes: #79966.