### PR TITLE
[Clang] Fix a crash when dumping a pack indexing type.

### DIFF
--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1195,10 +1195,10 @@ void TypePrinter::printDecltypeBefore(const DecltypeType *T, raw_ostream &OS) {
 
 void TypePrinter::printPackIndexingBefore(const PackIndexingType *T,
                                           raw_ostream &OS) {
-  if (T->isInstantiationDependentType())
-    OS << T->getPattern() << "...[" << T->getIndexExpr() << "]";
-  else
+  if (T->hasSelectedType())
     OS << T->getSelectedType();
+  else
+    OS << T->getPattern() << "...[" << T->getIndexExpr() << "]";
   spaceBeforePlaceHolder(OS);
 }
 

--- a/clang/test/AST/ast-dump-pack-indexing-crash.cpp
+++ b/clang/test/AST/ast-dump-pack-indexing-crash.cpp
@@ -13,13 +13,13 @@ void not_pack() {
     Tp...[0] c; // expected-error{{'Tp' does not refer to the name of a parameter pack}}
 }
 
-// CHECK:      -FunctionDecl {{.*}} not_pack 'void ()'
-// CHECK:           |-DeclStmt {{.*}}
-// CHECK:           |-DeclStmt {{.*}}
-// CHECK-NEXT:      | `-VarDecl {{.*}} a 'NotAPack...{{.*}}'
-// CHECK-NEXT:      |-DeclStmt {{.*}}
-// CHECK-NEXT:      | `-VarDecl {{.*}} 'T...{{.*}}'
-// CHECK-NEXT:      `-DeclStmt {{.*}}
-// CHECK-NEXT:        `-VarDecl {{.*}} c 'Tp...{{.*}}'
+// CHECK:      FunctionDecl {{.*}} not_pack 'void ()'
+// CHECK:           DeclStmt {{.*}}
+// CHECK:           DeclStmt {{.*}}
+// CHECK-NEXT:        VarDecl {{.*}} a 'NotAPack...{{.*}}'
+// CHECK-NEXT:      DeclStmt {{.*}}
+// CHECK-NEXT:        VarDecl {{.*}} 'T...{{.*}}'
+// CHECK-NEXT:       DeclStmt {{.*}}
+// CHECK-NEXT:        VarDecl {{.*}} c 'Tp...{{.*}}'
 
 }

--- a/clang/test/AST/ast-dump-pack-indexing-crash.cpp
+++ b/clang/test/AST/ast-dump-pack-indexing-crash.cpp
@@ -15,10 +15,11 @@ void not_pack() {
 
 // CHECK:      -FunctionDecl {{.*}} not_pack 'void ()'
 // CHECK:           |-DeclStmt {{.*}}
-// CHECK:           | `-VarDecl {{.*}} a 'NotAPack...{{.*}}'
 // CHECK:           |-DeclStmt {{.*}}
-// CHECK:           | `-VarDecl {{.*}} 'T...{{.*}}'
-// CHECK:           `-DeclStmt {{.*}}
-// CHECK:             `-VarDecl {{.*}} c 'Tp...{{.*}}'
+// CHECK-NEXT:      | `-VarDecl {{.*}} a 'NotAPack...{{.*}}'
+// CHECK-NEXT:      |-DeclStmt {{.*}}
+// CHECK-NEXT:      | `-VarDecl {{.*}} 'T...{{.*}}'
+// CHECK-NEXT:      `-DeclStmt {{.*}}
+// CHECK-NEXT:        `-VarDecl {{.*}} c 'Tp...{{.*}}'
 
 }

--- a/clang/test/AST/ast-dump-pack-indexing-crash.cpp
+++ b/clang/test/AST/ast-dump-pack-indexing-crash.cpp
@@ -1,0 +1,24 @@
+// RUN: not %clang_cc1 -std=c++2c -ast-dump %s | FileCheck  %s
+
+namespace InvalidPacksShouldNotCrash {
+
+struct NotAPack;
+template <typename T, auto V, template<typename> typename Tp>
+void not_pack() {
+    int i = 0;
+    i...[0]; // expected-error {{i does not refer to the name of a parameter pack}}
+    V...[0]; // expected-error {{V does not refer to the name of a parameter pack}}
+    NotAPack...[0] a; // expected-error{{'NotAPack' does not refer to the name of a parameter pack}}
+    T...[0] b;   // expected-error{{'T' does not refer to the name of a parameter pack}}
+    Tp...[0] c; // expected-error{{'Tp' does not refer to the name of a parameter pack}}
+}
+
+// CHECK:      -FunctionDecl {{.*}} not_pack 'void ()'
+// CHECK:           |-DeclStmt {{.*}}
+// CHECK:           | `-VarDecl {{.*}} a 'NotAPack...{{.*}}'
+// CHECK:           |-DeclStmt {{.*}}
+// CHECK:           | `-VarDecl {{.*}} 'T...{{.*}}'
+// CHECK:           `-DeclStmt {{.*}}
+// CHECK:             `-VarDecl {{.*}} c 'Tp...{{.*}}'
+
+}


### PR DESCRIPTION
Fix a crash caused by incorrect assumptions
Reported here https://github.com/llvm/llvm-project/pull/72644#discussion_r1469525524