### PR TITLE
Fix clang crash when printing highlighted code in diagnostic (after #66514)

### DIFF
--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1349,7 +1349,7 @@ void TextDiagnostic::emitSnippetAndCaret(
   // Prepare source highlighting information for the lines we're about to
   // emit, starting from the first line.
   std::unique_ptr<SmallVector<StyleRange>[]> SourceStyles =
-      highlightLines(BufStart, Lines.first, Lines.second, PP, LangOpts,
+      highlightLines(BufData, Lines.first, Lines.second, PP, LangOpts,
                      DiagOpts->ShowColors, FID, SM);
 
   SmallVector<LineRange> LineRanges =


### PR DESCRIPTION
Implements the fix proposed by Evgeny Eltsin on
https://github.com/llvm/llvm-project/pull/66514#issuecomment-1924039038.

No test case provided, since the bug is extremely sensitive to the preprocessor
state (headers, macros, including the ones defined on command line), and it
turned out to be non-trivial to create an isolated test.
