### PR TITLE
[mlir][spirv] Linearize ND vectors.

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -229,8 +229,8 @@ struct ConstantCompositeOpPattern final
     if (!srcType || srcType.getNumElements() == 1)
       return failure();
 
-    // arith.constant should only have vector or tenor types.
-    assert((isa<VectorType, RankedTensorType>(srcType)));
+    assert((isa<VectorType, RankedTensorType>(srcType) &&
+            "arith.constant should only have vector or tensor types"));
 
     Type dstType = getTypeConverter()->convertType(srcType);
     if (!dstType)
@@ -250,8 +250,9 @@ struct ConstantCompositeOpPattern final
                                             srcType.getElementType());
         dstElementsAttr = dstElementsAttr.reshape(dstAttrType);
       } else {
-        // TODO: add support for large vectors.
-        return failure();
+        dstAttrType =
+            VectorType::get(srcType.getNumElements(), srcType.getElementType());
+        dstElementsAttr = dstElementsAttr.reshape(dstAttrType);
       }
     }
 

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -330,6 +330,10 @@ convertVectorType(const spirv::TargetEnv &targetEnv,
   if (type.getRank() <= 1 && type.getNumElements() == 1)
     return convertScalarType(targetEnv, options, scalarType, storageClass);
 
+  // Linearize ND vectors
+  if (type.getRank() > 1)
+    type = VectorType::get(type.getNumElements(), scalarType);
+
   if (!spirv::CompositeType::isValid(type)) {
     LLVM_DEBUG(llvm::dbgs()
                << type << " illegal: not a valid composite type\n");

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
@@ -26,9 +26,9 @@ module attributes {
     #spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
 } {
 
-func.func @unsupported_2x2elem_vector(%arg0: vector<2x2xi32>) {
+func.func @unsupported_2x2elem_vector(%arg0: vector<3x5xi32>) {
   // expected-error@+1 {{failed to legalize operation 'arith.muli'}}
-  %2 = arith.muli %arg0, %arg0: vector<2x2xi32>
+  %2 = arith.muli %arg0, %arg0: vector<3x5xi32>
   return
 }
 

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -556,6 +556,8 @@ func.func @constant() {
   %9 = arith.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
   // CHECK: spirv.Constant dense<{{\[}}1, 2, 3, 4, 5, 6]> : tensor<6xi32> : !spirv.array<6 x i32>
   %10 = arith.constant dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
+  // CHECK: spirv.Constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : vector<4xf32>
+  %11 = arith.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : vector<2x2xf32>
   return
 }
 


### PR DESCRIPTION
SPIR-V only supports 1D vectors, try to linearize vector in type converter.

Not sure is this is a right approach or we should have a dedicated vector linearization pass.