### PR TITLE
[DRAFT][clang-format][lld] Run clang-format on lld

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -120,17 +120,33 @@ void SectionChunk::applyRelX64(uint8_t *off, uint16_t type, OutputSection *os,
   case IMAGE_REL_AMD64_ADDR64:
     add64(off, s + imageBase);
     break;
-  case IMAGE_REL_AMD64_ADDR32NB: add32(off, s); break;
-  case IMAGE_REL_AMD64_REL32:    add32(off, s - p - 4); break;
-  case IMAGE_REL_AMD64_REL32_1:  add32(off, s - p - 5); break;
-  case IMAGE_REL_AMD64_REL32_2:  add32(off, s - p - 6); break;
-  case IMAGE_REL_AMD64_REL32_3:  add32(off, s - p - 7); break;
-  case IMAGE_REL_AMD64_REL32_4:  add32(off, s - p - 8); break;
-  case IMAGE_REL_AMD64_REL32_5:  add32(off, s - p - 9); break;
+  case IMAGE_REL_AMD64_ADDR32NB:
+    add32(off, s);
+    break;
+  case IMAGE_REL_AMD64_REL32:
+    add32(off, s - p - 4);
+    break;
+  case IMAGE_REL_AMD64_REL32_1:
+    add32(off, s - p - 5);
+    break;
+  case IMAGE_REL_AMD64_REL32_2:
+    add32(off, s - p - 6);
+    break;
+  case IMAGE_REL_AMD64_REL32_3:
+    add32(off, s - p - 7);
+    break;
+  case IMAGE_REL_AMD64_REL32_4:
+    add32(off, s - p - 8);
+    break;
+  case IMAGE_REL_AMD64_REL32_5:
+    add32(off, s - p - 9);
+    break;
   case IMAGE_REL_AMD64_SECTION:
     applySecIdx(off, os, file->ctx.outputSections.size());
     break;
-  case IMAGE_REL_AMD64_SECREL:   applySecRel(this, off, os, s); break;
+  case IMAGE_REL_AMD64_SECREL:
+    applySecRel(this, off, os, s);
+    break;
   default:
     error("unsupported relocation type 0x" + Twine::utohexstr(type) + " in " +
           toString(file));
@@ -141,16 +157,23 @@ void SectionChunk::applyRelX86(uint8_t *off, uint16_t type, OutputSection *os,
                                uint64_t s, uint64_t p,
                                uint64_t imageBase) const {
   switch (type) {
-  case IMAGE_REL_I386_ABSOLUTE: break;
+  case IMAGE_REL_I386_ABSOLUTE:
+    break;
   case IMAGE_REL_I386_DIR32:
     add32(off, s + imageBase);
     break;
-  case IMAGE_REL_I386_DIR32NB:  add32(off, s); break;
-  case IMAGE_REL_I386_REL32:    add32(off, s - p - 4); break;
+  case IMAGE_REL_I386_DIR32NB:
+    add32(off, s);
+    break;
+  case IMAGE_REL_I386_REL32:
+    add32(off, s - p - 4);
+    break;
   case IMAGE_REL_I386_SECTION:
     applySecIdx(off, os, file->ctx.outputSections.size());
     break;
-  case IMAGE_REL_I386_SECREL:   applySecRel(this, off, os, s); break;
+  case IMAGE_REL_I386_SECREL:
+    applySecRel(this, off, os, s);
+    break;
   default:
     error("unsupported relocation type 0x" + Twine::utohexstr(type) + " in " +
           toString(file));
@@ -158,8 +181,10 @@ void SectionChunk::applyRelX86(uint8_t *off, uint16_t type, OutputSection *os,
 }
 
 static void applyMOV(uint8_t *off, uint16_t v) {
-  write16le(off, (read16le(off) & 0xfbf0) | ((v & 0x800) >> 1) | ((v >> 12) & 0xf));
-  write16le(off + 2, (read16le(off + 2) & 0x8f00) | ((v & 0x700) << 4) | (v & 0xff));
+  write16le(off,
+            (read16le(off) & 0xfbf0) | ((v & 0x800) >> 1) | ((v >> 12) & 0xf));
+  write16le(off + 2,
+            (read16le(off + 2) & 0x8f00) | ((v & 0x700) << 4) | (v & 0xff));
 }
 
 static uint16_t readMOV(uint8_t *off, bool movt) {
@@ -179,7 +204,7 @@ void applyMOV32T(uint8_t *off, uint32_t v) {
   uint16_t immW = readMOV(off, false);    // read MOVW operand
   uint16_t immT = readMOV(off + 4, true); // read MOVT operand
   uint32_t imm = immW | (immT << 16);
-  v += imm;                         // add the immediate offset
+  v += imm;                   // add the immediate offset
   applyMOV(off, v);           // set MOVW operand
   applyMOV(off + 4, v >> 16); // set MOVT operand
 }
@@ -202,7 +227,8 @@ void applyBranch24T(uint8_t *off, int32_t v) {
   uint32_t j2 = ((~v >> 22) & 1) ^ s;
   or16(off, (s << 10) | ((v >> 12) & 0x3ff));
   // Clear out the J1 and J2 bits which may be set.
-  write16le(off + 2, (read16le(off + 2) & 0xd000) | (j1 << 13) | (j2 << 11) | ((v >> 1) & 0x7ff));
+  write16le(off + 2, (read16le(off + 2) & 0xd000) | (j1 << 13) | (j2 << 11) |
+                         ((v >> 1) & 0x7ff));
 }
 
 void SectionChunk::applyRelARM(uint8_t *off, uint16_t type, OutputSection *os,
@@ -216,18 +242,30 @@ void SectionChunk::applyRelARM(uint8_t *off, uint16_t type, OutputSection *os,
   case IMAGE_REL_ARM_ADDR32:
     add32(off, sx + imageBase);
     break;
-  case IMAGE_REL_ARM_ADDR32NB:  add32(off, sx); break;
+  case IMAGE_REL_ARM_ADDR32NB:
+    add32(off, sx);
+    break;
   case IMAGE_REL_ARM_MOV32T:
     applyMOV32T(off, sx + imageBase);
     break;
-  case IMAGE_REL_ARM_BRANCH20T: applyBranch20T(off, sx - p - 4); break;
-  case IMAGE_REL_ARM_BRANCH24T: applyBranch24T(off, sx - p - 4); break;
-  case IMAGE_REL_ARM_BLX23T:    applyBranch24T(off, sx - p - 4); break;
+  case IMAGE_REL_ARM_BRANCH20T:
+    applyBranch20T(off, sx - p - 4);
+    break;
+  case IMAGE_REL_ARM_BRANCH24T:
+    applyBranch24T(off, sx - p - 4);
+    break;
+  case IMAGE_REL_ARM_BLX23T:
+    applyBranch24T(off, sx - p - 4);
+    break;
   case IMAGE_REL_ARM_SECTION:
     applySecIdx(off, os, file->ctx.outputSections.size());
     break;
-  case IMAGE_REL_ARM_SECREL:    applySecRel(this, off, os, s); break;
-  case IMAGE_REL_ARM_REL32:     add32(off, sx - p - 4); break;
+  case IMAGE_REL_ARM_SECREL:
+    applySecRel(this, off, os, s);
+    break;
+  case IMAGE_REL_ARM_REL32:
+    add32(off, sx - p - 4);
+    break;
   default:
     error("unsupported relocation type 0x" + Twine::utohexstr(type) + " in " +
           toString(file));
@@ -326,28 +364,54 @@ void SectionChunk::applyRelARM64(uint8_t *off, uint16_t type, OutputSection *os,
                                  uint64_t s, uint64_t p,
                                  uint64_t imageBase) const {
   switch (type) {
-  case IMAGE_REL_ARM64_PAGEBASE_REL21: applyArm64Addr(off, s, p, 12); break;
-  case IMAGE_REL_ARM64_REL21:          applyArm64Addr(off, s, p, 0); break;
-  case IMAGE_REL_ARM64_PAGEOFFSET_12A: applyArm64Imm(off, s & 0xfff, 0); break;
-  case IMAGE_REL_ARM64_PAGEOFFSET_12L: applyArm64Ldr(off, s & 0xfff); break;
-  case IMAGE_REL_ARM64_BRANCH26:       applyArm64Branch26(off, s - p); break;
-  case IMAGE_REL_ARM64_BRANCH19:       applyArm64Branch19(off, s - p); break;
-  case IMAGE_REL_ARM64_BRANCH14:       applyArm64Branch14(off, s - p); break;
+  case IMAGE_REL_ARM64_PAGEBASE_REL21:
+    applyArm64Addr(off, s, p, 12);
+    break;
+  case IMAGE_REL_ARM64_REL21:
+    applyArm64Addr(off, s, p, 0);
+    break;
+  case IMAGE_REL_ARM64_PAGEOFFSET_12A:
+    applyArm64Imm(off, s & 0xfff, 0);
+    break;
+  case IMAGE_REL_ARM64_PAGEOFFSET_12L:
+    applyArm64Ldr(off, s & 0xfff);
+    break;
+  case IMAGE_REL_ARM64_BRANCH26:
+    applyArm64Branch26(off, s - p);
+    break;
+  case IMAGE_REL_ARM64_BRANCH19:
+    applyArm64Branch19(off, s - p);
+    break;
+  case IMAGE_REL_ARM64_BRANCH14:
+    applyArm64Branch14(off, s - p);
+    break;
   case IMAGE_REL_ARM64_ADDR32:
     add32(off, s + imageBase);
     break;
-  case IMAGE_REL_ARM64_ADDR32NB:       add32(off, s); break;
+  case IMAGE_REL_ARM64_ADDR32NB:
+    add32(off, s);
+    break;
   case IMAGE_REL_ARM64_ADDR64:
     add64(off, s + imageBase);
     break;
-  case IMAGE_REL_ARM64_SECREL:         applySecRel(this, off, os, s); break;
-  case IMAGE_REL_ARM64_SECREL_LOW12A:  applySecRelLow12A(this, off, os, s); break;
-  case IMAGE_REL_ARM64_SECREL_HIGH12A: applySecRelHigh12A(this, off, os, s); break;
-  case IMAGE_REL_ARM64_SECREL_LOW12L:  applySecRelLdr(this, off, os, s); break;
+  case IMAGE_REL_ARM64_SECREL:
+    applySecRel(this, off, os, s);
+    break;
+  case IMAGE_REL_ARM64_SECREL_LOW12A:
+    applySecRelLow12A(this, off, os, s);
+    break;
+  case IMAGE_REL_ARM64_SECREL_HIGH12A:
+    applySecRelHigh12A(this, off, os, s);
+    break;
+  case IMAGE_REL_ARM64_SECREL_LOW12L:
+    applySecRelLdr(this, off, os, s);
+    break;
   case IMAGE_REL_ARM64_SECTION:
     applySecIdx(off, os, file->ctx.outputSections.size());
     break;
-  case IMAGE_REL_ARM64_REL32:          add32(off, s - p - 4); break;
+  case IMAGE_REL_ARM64_REL32:
+    add32(off, s - p - 4);
+    break;
   default:
     error("unsupported relocation type 0x" + Twine::utohexstr(type) + " in " +
           toString(file));
@@ -880,8 +944,7 @@ void RVAFlagTableChunk::writeTo(uint8_t *buf) const {
     ulittle32_t rva;
     uint8_t flag;
   };
-  auto flags =
-      MutableArrayRef(reinterpret_cast<RVAFlag *>(buf), syms.size());
+  auto flags = MutableArrayRef(reinterpret_cast<RVAFlag *>(buf), syms.size());
   for (auto t : zip(syms, flags)) {
     const auto &sym = std::get<0>(t);
     auto &flag = std::get<1>(t);
@@ -1045,13 +1108,9 @@ uint32_t MergeChunk::getOutputCharacteristics() const {
   return IMAGE_SCN_MEM_READ | IMAGE_SCN_CNT_INITIALIZED_DATA;
 }
 
-size_t MergeChunk::getSize() const {
-  return builder.getSize();
-}
+size_t MergeChunk::getSize() const { return builder.getSize(); }
 
-void MergeChunk::writeTo(uint8_t *buf) const {
-  builder.write(buf);
-}
+void MergeChunk::writeTo(uint8_t *buf) const { builder.write(buf); }
 
 // MinGW specific.
 size_t AbsolutePointerChunk::getSize() const { return ctx.config.wordsize; }

--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -279,12 +279,14 @@ public:
   // True if this is a codeview debug info chunk. These will not be laid out in
   // the image. Instead they will end up in the PDB, if one is requested.
   bool isCodeView() const {
-    return getSectionName() == ".debug" || getSectionName().starts_with(".debug$");
+    return getSectionName() == ".debug" ||
+           getSectionName().starts_with(".debug$");
   }
 
   // True if this is a DWARF debug info or exception handling chunk.
   bool isDWARF() const {
-    return getSectionName().starts_with(".debug_") || getSectionName() == ".eh_frame";
+    return getSectionName().starts_with(".debug_") ||
+           getSectionName() == ".eh_frame";
   }
 
   // Allow iteration over the bodies of this chunk's relocated symbols.
@@ -803,6 +805,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<lld::coff::ChunkAndOffset>
     : lld::coff::ChunkAndOffset::DenseMapInfo {};
-}
+} // namespace llvm
 
 #endif

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -24,9 +24,9 @@
 
 namespace lld::coff {
 
+using llvm::StringRef;
 using llvm::COFF::IMAGE_FILE_MACHINE_UNKNOWN;
 using llvm::COFF::WindowsSubsystem;
-using llvm::StringRef;
 class DefinedAbsolute;
 class StringChunk;
 class Symbol;
@@ -52,8 +52,8 @@ enum class EmitKind { Obj, LLVM, ASM };
 
 // Represents an /export option.
 struct Export {
-  StringRef name;       // N in /export:N or /export:E=N
-  StringRef extName;    // E in /export:E=N
+  StringRef name;        // N in /export:N or /export:E=N
+  StringRef extName;     // E in /export:E=N
   StringRef aliasTarget; // GNU specific: N in "alias == N"
   Symbol *sym = nullptr;
   uint16_t ordinal = 0;
@@ -74,25 +74,24 @@ struct Export {
 
   bool operator==(const Export &e) const {
     return (name == e.name && extName == e.extName &&
-            aliasTarget == e.aliasTarget &&
-            ordinal == e.ordinal && noname == e.noname &&
-            data == e.data && isPrivate == e.isPrivate);
+            aliasTarget == e.aliasTarget && ordinal == e.ordinal &&
+            noname == e.noname && data == e.data && isPrivate == e.isPrivate);
   }
 };
 
 enum class DebugType {
-  None  = 0x0,
-  CV    = 0x1,  /// CodeView
-  PData = 0x2,  /// Procedure Data
-  Fixup = 0x4,  /// Relocation Table
+  None = 0x0,
+  CV = 0x1,    /// CodeView
+  PData = 0x2, /// Procedure Data
+  Fixup = 0x4, /// Relocation Table
 };
 
 enum GuardCFLevel {
-  Off     = 0x0,
-  CF      = 0x1, /// Emit gfids tables
+  Off = 0x0,
+  CF = 0x1,      /// Emit gfids tables
   LongJmp = 0x2, /// Emit longjmp tables
-  EHCont  = 0x4, /// Emit ehcont tables
-  All     = 0x7  /// Enable all protections
+  EHCont = 0x4,  /// Emit ehcont tables
+  All = 0x7      /// Enable all protections
 };
 
 enum class ICFLevel {

--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -134,9 +134,7 @@ public:
   explicit NullChunk(size_t n) : size(n) { hasData = false; }
   size_t getSize() const override { return size; }
 
-  void writeTo(uint8_t *buf) const override {
-    memset(buf, 0, size);
-  }
+  void writeTo(uint8_t *buf) const override { memset(buf, 0, size); }
 
 private:
   size_t size;
@@ -200,8 +198,8 @@ public:
 // which then overwrites its jump table slot with the result
 // for subsequent function calls.
 static const uint8_t thunkX64[] = {
-    0x48, 0x8D, 0x05, 0, 0, 0, 0,       // lea     rax, [__imp_<FUNCNAME>]
-    0xE9, 0, 0, 0, 0,                   // jmp     __tailMerge_<lib>
+    0x48, 0x8D, 0x05, 0, 0, 0, 0, // lea     rax, [__imp_<FUNCNAME>]
+    0xE9, 0,    0,    0, 0,       // jmp     __tailMerge_<lib>
 };
 
 static const uint8_t tailMergeX64[] = {
@@ -215,9 +213,9 @@ static const uint8_t tailMergeX64[] = {
     0x66, 0x0F, 0x7F, 0x54, 0x24, 0x20, // movdqa  xmmword ptr [rsp+20h], xmm2
     0x66, 0x0F, 0x7F, 0x5C, 0x24, 0x30, // movdqa  xmmword ptr [rsp+30h], xmm3
     0x48, 0x8B, 0xD0,                   // mov     rdx, rax
-    0x48, 0x8D, 0x0D, 0, 0, 0, 0,       // lea     rcx, [___DELAY_IMPORT_...]
-    0xE8, 0, 0, 0, 0,                   // call    __delayLoadHelper2
-    0x66, 0x0F, 0x6F, 0x04, 0x24,       // movdqa  xmm0, xmmword ptr [rsp]
+    0x48, 0x8D, 0x0D, 0,    0,    0,    0, // lea     rcx, [___DELAY_IMPORT_...]
+    0xE8, 0,    0,    0,    0,             // call    __delayLoadHelper2
+    0x66, 0x0F, 0x6F, 0x04, 0x24,          // movdqa  xmm0, xmmword ptr [rsp]
     0x66, 0x0F, 0x6F, 0x4C, 0x24, 0x10, // movdqa  xmm1, xmmword ptr [rsp+10h]
     0x66, 0x0F, 0x6F, 0x54, 0x24, 0x20, // movdqa  xmm2, xmmword ptr [rsp+20h]
     0x66, 0x0F, 0x6F, 0x5C, 0x24, 0x30, // movdqa  xmm3, xmmword ptr [rsp+30h]
@@ -243,19 +241,21 @@ static const uint8_t tailMergeUnwindInfoX64[] = {
 };
 
 static const uint8_t thunkX86[] = {
-    0xB8, 0, 0, 0, 0,  // mov   eax, offset ___imp__<FUNCNAME>
-    0xE9, 0, 0, 0, 0,  // jmp   __tailMerge_<lib>
+    0xB8, 0, 0, 0, 0, // mov   eax, offset ___imp__<FUNCNAME>
+    0xE9, 0, 0, 0, 0, // jmp   __tailMerge_<lib>
 };
 
 static const uint8_t tailMergeX86[] = {
-    0x51,              // push  ecx
-    0x52,              // push  edx
-    0x50,              // push  eax
-    0x68, 0, 0, 0, 0,  // push  offset ___DELAY_IMPORT_DESCRIPTOR_<DLLNAME>_dll
-    0xE8, 0, 0, 0, 0,  // call  ___delayLoadHelper2@8
-    0x5A,              // pop   edx
-    0x59,              // pop   ecx
-    0xFF, 0xE0,        // jmp   eax
+    0x51, // push  ecx
+    0x52, // push  edx
+    0x50, // push  eax
+    0x68, 0,    0,
+    0,    0, // push  offset ___DELAY_IMPORT_DESCRIPTOR_<DLLNAME>_dll
+    0xE8, 0,    0,
+    0,    0,    // call  ___delayLoadHelper2@8
+    0x5A,       // pop   edx
+    0x59,       // pop   ecx
+    0xFF, 0xE0, // jmp   eax
 };
 
 static const uint8_t thunkARM[] = {

--- a/lld/COFF/DebugTypes.h
+++ b/lld/COFF/DebugTypes.h
@@ -23,7 +23,7 @@ struct GloballyHashedType;
 namespace llvm::pdb {
 class NativeSession;
 class TpiStream;
-}
+} // namespace llvm::pdb
 
 namespace lld::coff {
 

--- a/lld/COFF/DriverUtils.cpp
+++ b/lld/COFF/DriverUtils.cpp
@@ -124,17 +124,18 @@ void LinkerDriver::parseSubsystem(StringRef arg, WindowsSubsystem *sys,
   auto [sysStr, ver] = arg.split(',');
   std::string sysStrLower = sysStr.lower();
   *sys = StringSwitch<WindowsSubsystem>(sysStrLower)
-    .Case("boot_application", IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION)
-    .Case("console", IMAGE_SUBSYSTEM_WINDOWS_CUI)
-    .Case("default", IMAGE_SUBSYSTEM_UNKNOWN)
-    .Case("efi_application", IMAGE_SUBSYSTEM_EFI_APPLICATION)
-    .Case("efi_boot_service_driver", IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER)
-    .Case("efi_rom", IMAGE_SUBSYSTEM_EFI_ROM)
-    .Case("efi_runtime_driver", IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER)
-    .Case("native", IMAGE_SUBSYSTEM_NATIVE)
-    .Case("posix", IMAGE_SUBSYSTEM_POSIX_CUI)
-    .Case("windows", IMAGE_SUBSYSTEM_WINDOWS_GUI)
-    .Default(IMAGE_SUBSYSTEM_UNKNOWN);
+             .Case("boot_application", IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION)
+             .Case("console", IMAGE_SUBSYSTEM_WINDOWS_CUI)
+             .Case("default", IMAGE_SUBSYSTEM_UNKNOWN)
+             .Case("efi_application", IMAGE_SUBSYSTEM_EFI_APPLICATION)
+             .Case("efi_boot_service_driver",
+                   IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER)
+             .Case("efi_rom", IMAGE_SUBSYSTEM_EFI_ROM)
+             .Case("efi_runtime_driver", IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER)
+             .Case("native", IMAGE_SUBSYSTEM_NATIVE)
+             .Case("posix", IMAGE_SUBSYSTEM_POSIX_CUI)
+             .Case("windows", IMAGE_SUBSYSTEM_WINDOWS_GUI)
+             .Default(IMAGE_SUBSYSTEM_UNKNOWN);
   if (*sys == IMAGE_SUBSYSTEM_UNKNOWN && sysStrLower != "default")
     fatal("unknown subsystem: " + sysStr);
   if (!ver.empty())
@@ -384,7 +385,7 @@ public:
 
   std::string path;
 };
-}
+} // namespace
 
 std::string LinkerDriver::createDefaultXml() {
   std::string ret;

--- a/lld/COFF/ICF.cpp
+++ b/lld/COFF/ICF.cpp
@@ -79,7 +79,8 @@ private:
 // of the Visual C++ linker.
 bool ICF::isEligible(SectionChunk *c) {
   // Non-comdat chunks, dead chunks, and writable chunks are not eligible.
-  bool writable = c->getOutputCharacteristics() & llvm::COFF::IMAGE_SCN_MEM_WRITE;
+  bool writable =
+      c->getOutputCharacteristics() & llvm::COFF::IMAGE_SCN_MEM_WRITE;
   if (!c->isCOMDAT() || !c->live || writable)
     return false;
 
@@ -155,8 +156,7 @@ bool ICF::equalsConstant(const SectionChunk *a, const SectionChunk *b) {
 
   // Compare relocations.
   auto eq = [&](const coff_relocation &r1, const coff_relocation &r2) {
-    if (r1.Type != r2.Type ||
-        r1.VirtualAddress != r2.VirtualAddress) {
+    if (r1.Type != r2.Type || r1.VirtualAddress != r2.VirtualAddress) {
       return false;
     }
     Symbol *b1 = a->file->getSymbol(r1.SymbolTableIndex);
@@ -166,7 +166,8 @@ bool ICF::equalsConstant(const SectionChunk *a, const SectionChunk *b) {
     if (auto *d1 = dyn_cast<DefinedRegular>(b1))
       if (auto *d2 = dyn_cast<DefinedRegular>(b2))
         return d1->getValue() == d2->getValue() &&
-               d1->getChunk()->eqClass[cnt % 2] == d2->getChunk()->eqClass[cnt % 2];
+               d1->getChunk()->eqClass[cnt % 2] ==
+                   d2->getChunk()->eqClass[cnt % 2];
     return false;
   };
   if (!std::equal(a->getRelocs().begin(), a->getRelocs().end(),
@@ -191,7 +192,8 @@ bool ICF::equalsVariable(const SectionChunk *a, const SectionChunk *b) {
       return true;
     if (auto *d1 = dyn_cast<DefinedRegular>(b1))
       if (auto *d2 = dyn_cast<DefinedRegular>(b2))
-        return d1->getChunk()->eqClass[cnt % 2] == d2->getChunk()->eqClass[cnt % 2];
+        return d1->getChunk()->eqClass[cnt % 2] ==
+               d2->getChunk()->eqClass[cnt % 2];
     return false;
   };
   return std::equal(a->getRelocs().begin(), a->getRelocs().end(),

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -735,8 +735,8 @@ void ObjFile::initializeFlags() {
             (cs.Flags & CompileSym3Flags::HotPatch) != CompileSym3Flags::None;
       }
       if (sym->kind() == SymbolKind::S_OBJNAME) {
-        auto objName = cantFail(SymbolDeserializer::deserializeAs<ObjNameSym>(
-            sym.get()));
+        auto objName =
+            cantFail(SymbolDeserializer::deserializeAs<ObjNameSym>(sym.get()));
         if (objName.Signature)
           pchSignature = objName.Signature;
       }

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -28,11 +28,11 @@ struct DILineInfo;
 namespace pdb {
 class DbiModuleDescriptorBuilder;
 class NativeSession;
-}
+} // namespace pdb
 namespace lto {
 class InputFile;
 }
-}
+} // namespace llvm
 
 namespace lld {
 class DWARFCache;
@@ -45,10 +45,10 @@ std::vector<MemoryBufferRef> getArchiveMembers(llvm::object::Archive *file);
 using llvm::COFF::IMAGE_FILE_MACHINE_UNKNOWN;
 using llvm::COFF::MachineTypes;
 using llvm::object::Archive;
-using llvm::object::COFFObjectFile;
-using llvm::object::COFFSymbolRef;
 using llvm::object::coff_import_header;
 using llvm::object::coff_section;
+using llvm::object::COFFObjectFile;
+using llvm::object::COFFSymbolRef;
 
 class Chunk;
 class Defined;
@@ -149,9 +149,7 @@ public:
 
   // Returns a Symbol object for the symbolIndex'th symbol in the
   // underlying object file.
-  Symbol *getSymbol(uint32_t symbolIndex) {
-    return symbols[symbolIndex];
-  }
+  Symbol *getSymbol(uint32_t symbolIndex) { return symbols[symbolIndex]; }
 
   // Returns the underlying COFF file.
   COFFObjectFile *getCOFFObj() { return coffObj.get(); }
@@ -216,7 +214,7 @@ public:
                                                 uint32_t sectionIndex);
 
 private:
-  const coff_section* getSection(uint32_t i);
+  const coff_section *getSection(uint32_t i);
   const coff_section *getSection(COFFSymbolRef sym) {
     return getSection(sym.getSectionNumber());
   }

--- a/lld/COFF/LLDMapFile.cpp
+++ b/lld/COFF/LLDMapFile.cpp
@@ -65,9 +65,10 @@ static SymbolMapTy getSectionSyms(ArrayRef<DefinedRegular *> syms) {
   // Sort symbols by address.
   for (auto &it : ret) {
     SmallVectorImpl<DefinedRegular *> &v = it.second;
-    std::stable_sort(v.begin(), v.end(), [](DefinedRegular *a, DefinedRegular *b) {
-      return a->getRVA() < b->getRVA();
-    });
+    std::stable_sort(v.begin(), v.end(),
+                     [](DefinedRegular *a, DefinedRegular *b) {
+                       return a->getRVA() < b->getRVA();
+                     });
   }
   return ret;
 }

--- a/lld/COFF/LLDMapFile.h
+++ b/lld/COFF/LLDMapFile.h
@@ -12,6 +12,6 @@
 namespace lld::coff {
 class COFFLinkerContext;
 void writeLLDMapFile(const COFFLinkerContext &ctx);
-}
+} // namespace lld::coff
 
 #endif

--- a/lld/COFF/LTO.h
+++ b/lld/COFF/LTO.h
@@ -30,7 +30,7 @@
 namespace llvm::lto {
 struct Config;
 class LTO;
-}
+} // namespace llvm::lto
 
 namespace lld::coff {
 
@@ -59,6 +59,6 @@ private:
 
   COFFLinkerContext &ctx;
 };
-}
+} // namespace lld::coff
 
 #endif

--- a/lld/COFF/MapFile.cpp
+++ b/lld/COFF/MapFile.cpp
@@ -18,13 +18,15 @@
 // Symbols list:
 // Address        Publics by Value    Rva + Base          Lib:Object
 // 0001:00001000  main                 0000000140001000    main.obj
-// 0001:00001300  ?__scrt_common_main@@YAHXZ  0000000140001300 libcmt:exe_main.obj
+// 0001:00001300  ?__scrt_common_main@@YAHXZ  0000000140001300
+// libcmt:exe_main.obj
 //
 // entry point at        0001:00000360
 //
 // Static symbols
 //
-// 0000:00000000  __guard_fids__       0000000140000000     libcmt : exe_main.obj
+// 0000:00000000  __guard_fids__       0000000140000000     libcmt :
+// exe_main.obj
 //===----------------------------------------------------------------------===//
 
 #include "MapFile.h"

--- a/lld/COFF/MapFile.h
+++ b/lld/COFF/MapFile.h
@@ -12,6 +12,6 @@
 namespace lld::coff {
 class COFFLinkerContext;
 void writeMapFile(COFFLinkerContext &ctx);
-}
+} // namespace lld::coff
 
 #endif

--- a/lld/COFF/MarkLive.cpp
+++ b/lld/COFF/MarkLive.cpp
@@ -70,4 +70,4 @@ void markLive(COFFLinkerContext &ctx) {
       enqueue(&c);
   }
 }
-}
+} // namespace lld::coff

--- a/lld/COFF/MinGW.cpp
+++ b/lld/COFF/MinGW.cpp
@@ -141,7 +141,8 @@ bool AutoExporter::shouldExport(Defined *sym) const {
   // disallow import symbols.
   if (!isa<DefinedRegular>(sym) && !isa<DefinedCommon>(sym))
     return false;
-  if (excludeSymbols.count(sym->getName()) || manualExcludeSymbols.count(sym->getName()))
+  if (excludeSymbols.count(sym->getName()) ||
+      manualExcludeSymbols.count(sym->getName()))
     return false;
 
   for (StringRef prefix : excludeSymbolPrefixes.keys())
@@ -185,7 +186,8 @@ void lld::coff::writeDefFile(StringRef name,
        << "@" << e.ordinal;
     if (auto *def = dyn_cast_or_null<Defined>(e.sym)) {
       if (def && def->getChunk() &&
-          !(def->getChunk()->getOutputCharacteristics() & IMAGE_SCN_MEM_EXECUTE))
+          !(def->getChunk()->getOutputCharacteristics() &
+            IMAGE_SCN_MEM_EXECUTE))
         os << " DATA";
     }
     os << "\n";

--- a/lld/COFF/PDB.cpp
+++ b/lld/COFF/PDB.cpp
@@ -236,7 +236,7 @@ public:
 
   void finish();
 };
-}
+} // namespace
 
 // Visual Studio's debugger requires absolute paths in various places in the
 // PDB to work without additional configuration:
@@ -379,7 +379,8 @@ void PDBLinker::translateIdSymbols(MutableArrayRef<uint8_t> &recordData,
           CVType funcIdData = tMerger.getIDTable().getType(*ti);
           if (funcIdData.length() >= 8 && (funcIdData.kind() == LF_FUNC_ID ||
                                            funcIdData.kind() == LF_MFUNC_ID)) {
-            newType = *reinterpret_cast<const TypeIndex *>(&funcIdData.data()[8]);
+            newType =
+                *reinterpret_cast<const TypeIndex *>(&funcIdData.data()[8]);
           }
         }
       }
@@ -450,7 +451,8 @@ static bool symbolGoesInModuleStream(const CVSymbol &sym,
   case SymbolKind::S_PROCREF:
   case SymbolKind::S_LPROCREF:
     return false;
-  // S_UDT and S_CONSTANT records go in the module stream if it is not a global record.
+  // S_UDT and S_CONSTANT records go in the module stream if it is not a global
+  // record.
   case SymbolKind::S_UDT:
   case SymbolKind::S_CONSTANT:
     return symbolScopeDepth > 0;
@@ -986,7 +988,8 @@ void DebugSHandler::finish() {
   // subsections. The new checksum table must have the exact same layout and
   // size as the original. Otherwise, the file references in the line and
   // inlinee line tables will be incorrect.
-  auto newChecksums = std::make_unique<DebugChecksumsSubsection>(linker.pdbStrTab);
+  auto newChecksums =
+      std::make_unique<DebugChecksumsSubsection>(linker.pdbStrTab);
   for (const FileChecksumEntry &fc : checksums) {
     SmallString<128> filename =
         exitOnErr(cvStrTab.getString(fc.FileNameOffset));
@@ -1528,7 +1531,7 @@ void PDBLinker::addImportFilesToPDB() {
       continue;
 
     if (!file->thunkLive)
-        continue;
+      continue;
 
     std::string dll = StringRef(file->dllName).lower();
     llvm::pdb::DbiModuleDescriptorBuilder *&mod = dllToModuleDbi[dll];
@@ -1715,12 +1718,11 @@ void PDBLinker::commit(codeview::GUID *guid) {
   // the user can see the output of /time and /summary, which is very helpful
   // when trying to figure out why a PDB file is too large.
   if (Error e = builder.commit(ctx.config.pdbPath, guid)) {
-    e = handleErrors(std::move(e),
-        [](const llvm::msf::MSFError &me) {
-          error(me.message());
-          if (me.isPageOverflow())
-            error("try setting a larger /pdbpagesize");
-        });
+    e = handleErrors(std::move(e), [](const llvm::msf::MSFError &me) {
+      error(me.message());
+      if (me.isPageOverflow())
+        error("try setting a larger /pdbpagesize");
+    });
     checkError(std::move(e));
     error("failed to write PDB file " + Twine(ctx.config.pdbPath));
   }

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -62,7 +62,8 @@ void SymbolTable::addFile(InputFile *file) {
       ctx.objFileInstances.push_back(f);
     } else if (auto *f = dyn_cast<BitcodeFile>(file)) {
       if (ltoCompilationDone) {
-        error("LTO object file " + toString(file) + " linked in after "
+        error("LTO object file " + toString(file) +
+              " linked in after "
               "doing LTO compilation.");
       }
       ctx.bitcodeFileInstances.push_back(f);

--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -25,9 +25,9 @@ namespace lld {
 namespace coff {
 
 using llvm::object::Archive;
-using llvm::object::COFFSymbolRef;
 using llvm::object::coff_import_header;
 using llvm::object::coff_symbol_generic;
+using llvm::object::COFFSymbolRef;
 
 class ArchiveFile;
 class COFFLinkerContext;
@@ -352,8 +352,7 @@ public:
 class DefinedImportData : public Defined {
 public:
   DefinedImportData(StringRef n, ImportFile *f)
-      : Defined(DefinedImportDataKind, n), file(f) {
-  }
+      : Defined(DefinedImportDataKind, n), file(f) {}
 
   static bool classof(const Symbol *s) {
     return s->kind() == DefinedImportDataKind;
@@ -490,7 +489,7 @@ union SymbolUnion {
 };
 
 template <typename T, typename... ArgT>
-void replaceSymbol(Symbol *s, ArgT &&... arg) {
+void replaceSymbol(Symbol *s, ArgT &&...arg) {
   static_assert(std::is_trivially_destructible<T>(),
                 "Symbol types must be trivially destructible");
   static_assert(sizeof(T) <= sizeof(SymbolUnion), "Symbol too small");

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -68,12 +68,11 @@ $ nasm -fbin /tmp/DOSProgram.asm -o /tmp/DOSProgram.bin
 $ xxd -i /tmp/DOSProgram.bin
 */
 static unsigned char dosProgram[] = {
-  0x0e, 0x1f, 0xba, 0x0e, 0x00, 0xb4, 0x09, 0xcd, 0x21, 0xb8, 0x01, 0x4c,
-  0xcd, 0x21, 0x54, 0x68, 0x69, 0x73, 0x20, 0x70, 0x72, 0x6f, 0x67, 0x72,
-  0x61, 0x6d, 0x20, 0x63, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x20, 0x62, 0x65,
-  0x20, 0x72, 0x75, 0x6e, 0x20, 0x69, 0x6e, 0x20, 0x44, 0x4f, 0x53, 0x20,
-  0x6d, 0x6f, 0x64, 0x65, 0x2e, 0x24, 0x00, 0x00
-};
+    0x0e, 0x1f, 0xba, 0x0e, 0x00, 0xb4, 0x09, 0xcd, 0x21, 0xb8, 0x01, 0x4c,
+    0xcd, 0x21, 0x54, 0x68, 0x69, 0x73, 0x20, 0x70, 0x72, 0x6f, 0x67, 0x72,
+    0x61, 0x6d, 0x20, 0x63, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x20, 0x62, 0x65,
+    0x20, 0x72, 0x75, 0x6e, 0x20, 0x69, 0x6e, 0x20, 0x44, 0x4f, 0x53, 0x20,
+    0x6d, 0x6f, 0x64, 0x65, 0x2e, 0x24, 0x00, 0x00};
 static_assert(sizeof(dosProgram) % 8 == 0,
               "DOSProgram size must be multiple of 8");
 
@@ -98,7 +97,7 @@ public:
   void writeTo(uint8_t *b) const override {
     auto *d = reinterpret_cast<debug_directory *>(b);
 
-    for (const std::pair<COFF::DebugType, Chunk *>& record : records) {
+    for (const std::pair<COFF::DebugType, Chunk *> &record : records) {
       Chunk *c = record.second;
       const OutputSection *os = ctx.getOutputSection(c);
       uint64_t offs = os->getFileOff() + (c->getRVA() - os->getRVA());
@@ -245,7 +244,7 @@ private:
                               ArrayRef<SectionChunk *> symIdxChunks,
                               std::vector<Symbol *> &symbols);
   void maybeAddRVATable(SymbolRVASet tableSymbols, StringRef tableSym,
-                        StringRef countSym, bool hasFlag=false);
+                        StringRef countSym, bool hasFlag = false);
   void setSectionPermissions();
   void setECSymbols();
   void writeSections();
@@ -341,9 +340,7 @@ void lld::coff::writeResult(COFFLinkerContext &ctx) {
   Writer(ctx).run();
 }
 
-void OutputSection::addChunk(Chunk *c) {
-  chunks.push_back(c);
-}
+void OutputSection::addChunk(Chunk *c) { chunks.push_back(c); }
 
 void OutputSection::insertChunkAtStart(Chunk *c) {
   chunks.insert(chunks.begin(), c);
@@ -1012,8 +1009,8 @@ void Writer::createSections() {
     if (name.starts_with(".tls"))
       tlsAlignment = std::max(tlsAlignment, c->getAlignment());
 
-    PartialSection *pSec = createPartialSection(name,
-                                                c->getOutputCharacteristics());
+    PartialSection *pSec =
+        createPartialSection(name, c->getOutputCharacteristics());
     pSec->chunks.push_back(c);
   }
 

--- a/lld/Common/ErrorHandler.cpp
+++ b/lld/Common/ErrorHandler.cpp
@@ -172,16 +172,14 @@ std::string ErrorHandler::getLocation(const Twine &msg) {
     return std::string(logName);
 
   static std::regex regexes[] = {
-      std::regex(
-          R"(^undefined (?:\S+ )?symbol:.*\n)"
-          R"(>>> referenced by .+\((\S+):(\d+)\))"),
+      std::regex(R"(^undefined (?:\S+ )?symbol:.*\n)"
+                 R"(>>> referenced by .+\((\S+):(\d+)\))"),
       std::regex(
           R"(^undefined (?:\S+ )?symbol:.*\n>>> referenced by (\S+):(\d+))"),
       std::regex(R"(^undefined symbol:.*\n>>> referenced by (.*):)"),
       std::regex(
           R"(^duplicate symbol: .*\n>>> defined in (\S+)\n>>> defined in.*)"),
-      std::regex(
-          R"(^duplicate symbol: .*\n>>> defined at .+\((\S+):(\d+)\))"),
+      std::regex(R"(^duplicate symbol: .*\n>>> defined at .+\((\S+):(\d+)\))"),
       std::regex(R"(^duplicate symbol: .*\n>>> defined at (\S+):(\d+))"),
       std::regex(
           R"(.*\n>>> defined in .*\n>>> referenced by .+\((\S+):(\d+)\))"),

--- a/lld/ELF/AArch64ErrataFix.cpp
+++ b/lld/ELF/AArch64ErrataFix.cpp
@@ -461,12 +461,11 @@ void AArch64Err843419Patcher::init() {
     llvm::stable_sort(mapSyms, [](const Defined *a, const Defined *b) {
       return a->value < b->value;
     });
-    mapSyms.erase(
-        std::unique(mapSyms.begin(), mapSyms.end(),
-                    [=](const Defined *a, const Defined *b) {
-                      return isCodeMapSymbol(a) == isCodeMapSymbol(b);
-                    }),
-        mapSyms.end());
+    mapSyms.erase(std::unique(mapSyms.begin(), mapSyms.end(),
+                              [=](const Defined *a, const Defined *b) {
+                                return isCodeMapSymbol(a) == isCodeMapSymbol(b);
+                              }),
+                  mapSyms.end());
     // Always start with a Code Mapping Symbol.
     if (!mapSyms.empty() && !isCodeMapSymbol(mapSyms.front()))
       mapSyms.erase(mapSyms.begin());

--- a/lld/ELF/ARMErrataFix.cpp
+++ b/lld/ELF/ARMErrataFix.cpp
@@ -80,7 +80,7 @@ public:
   uint64_t getBranchAddr() const;
 
   static bool classof(const SectionBase *d) {
-    return d->kind() == InputSectionBase::Synthetic && d->name ==".text.patch";
+    return d->kind() == InputSectionBase::Synthetic && d->name == ".text.patch";
   }
 
   // The Section we are patching.

--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -889,7 +889,7 @@ AArch64BtiPac::AArch64BtiPac() {
 }
 
 void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
-  const uint8_t btiData[] = { 0x5f, 0x24, 0x03, 0xd5 }; // bti c
+  const uint8_t btiData[] = {0x5f, 0x24, 0x03, 0xd5}; // bti c
   const uint8_t pltData[] = {
       0xf0, 0x7b, 0xbf, 0xa9, // stp    x16, x30, [sp,#-16]!
       0x10, 0x00, 0x00, 0x90, // adrp   x16, Page(&(.got.plt[2]))
@@ -899,7 +899,7 @@ void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
       0x1f, 0x20, 0x03, 0xd5, // nop
       0x1f, 0x20, 0x03, 0xd5  // nop
   };
-  const uint8_t nopData[] = { 0x1f, 0x20, 0x03, 0xd5 }; // nop
+  const uint8_t nopData[] = {0x1f, 0x20, 0x03, 0xd5}; // nop
 
   uint64_t got = in.gotPlt->getVA();
   uint64_t plt = in.plt->getVA();
@@ -926,21 +926,21 @@ void AArch64BtiPac::writePlt(uint8_t *buf, const Symbol &sym,
                              uint64_t pltEntryAddr) const {
   // The PLT entry is of the form:
   // [btiData] addrInst (pacBr | stdBr) [nopData]
-  const uint8_t btiData[] = { 0x5f, 0x24, 0x03, 0xd5 }; // bti c
+  const uint8_t btiData[] = {0x5f, 0x24, 0x03, 0xd5}; // bti c
   const uint8_t addrInst[] = {
-      0x10, 0x00, 0x00, 0x90,  // adrp x16, Page(&(.got.plt[n]))
-      0x11, 0x02, 0x40, 0xf9,  // ldr  x17, [x16, Offset(&(.got.plt[n]))]
-      0x10, 0x02, 0x00, 0x91   // add  x16, x16, Offset(&(.got.plt[n]))
+      0x10, 0x00, 0x00, 0x90, // adrp x16, Page(&(.got.plt[n]))
+      0x11, 0x02, 0x40, 0xf9, // ldr  x17, [x16, Offset(&(.got.plt[n]))]
+      0x10, 0x02, 0x00, 0x91  // add  x16, x16, Offset(&(.got.plt[n]))
   };
   const uint8_t pacBr[] = {
-      0x9f, 0x21, 0x03, 0xd5,  // autia1716
-      0x20, 0x02, 0x1f, 0xd6   // br   x17
+      0x9f, 0x21, 0x03, 0xd5, // autia1716
+      0x20, 0x02, 0x1f, 0xd6  // br   x17
   };
   const uint8_t stdBr[] = {
-      0x20, 0x02, 0x1f, 0xd6,  // br   x17
-      0x1f, 0x20, 0x03, 0xd5   // nop
+      0x20, 0x02, 0x1f, 0xd6, // br   x17
+      0x1f, 0x20, 0x03, 0xd5  // nop
   };
-  const uint8_t nopData[] = { 0x1f, 0x20, 0x03, 0xd5 }; // nop
+  const uint8_t nopData[] = {0x1f, 0x20, 0x03, 0xd5}; // nop
 
   // NEEDS_COPY indicates a non-ifunc canonical PLT entry whose address may
   // escape to shared objects. isInIplt indicates a non-preemptible ifunc. Its
@@ -1033,7 +1033,7 @@ void lld::elf::createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files) {
   // First, collect all symbols that are marked as tagged, and count how many
   // times they're marked as tagged.
   DenseMap<Symbol *, unsigned> taggedSymbolReferenceCount;
-  for (InputFile* file : files) {
+  for (InputFile *file : files) {
     if (file->kind() != InputFile::ObjKind)
       continue;
     for (InputSectionBase *section : file->getSections()) {
@@ -1056,11 +1056,11 @@ void lld::elf::createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files) {
 
     for (Symbol *symbol : file->getSymbols()) {
       // See `addTaggedSymbolReferences` for more details.
-      if (symbol->type != STT_OBJECT ||
-          symbol->binding == STB_LOCAL)
+      if (symbol->type != STT_OBJECT || symbol->binding == STB_LOCAL)
         continue;
       auto it = taggedSymbolReferenceCount.find(symbol);
-      if (it == taggedSymbolReferenceCount.end()) continue;
+      if (it == taggedSymbolReferenceCount.end())
+        continue;
       unsigned &remainingAllowedTaggedRefs = it->second;
       if (remainingAllowedTaggedRefs == 0) {
         taggedSymbolReferenceCount.erase(it);
@@ -1081,7 +1081,7 @@ void lld::elf::createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files) {
   // uses are tagged.
   for (auto &[symbol, remainingTaggedRefs] : taggedSymbolReferenceCount) {
     assert(remainingTaggedRefs == 0 &&
-            "Symbol is defined as tagged more times than it's used");
+           "Symbol is defined as tagged more times than it's used");
     symbol->setIsTagged(true);
   }
 }

--- a/lld/ELF/Arch/AMDGPU.cpp
+++ b/lld/ELF/Arch/AMDGPU.cpp
@@ -78,8 +78,8 @@ uint32_t AMDGPU::calcEFlagsV4() const {
 
     if (retXnack == EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4 ||
         (retXnack != EF_AMDGPU_FEATURE_XNACK_ANY_V4 &&
-            (getEFlags(f) & EF_AMDGPU_FEATURE_XNACK_V4)
-                != EF_AMDGPU_FEATURE_XNACK_ANY_V4)) {
+         (getEFlags(f) & EF_AMDGPU_FEATURE_XNACK_V4) !=
+             EF_AMDGPU_FEATURE_XNACK_ANY_V4)) {
       if (retXnack != (getEFlags(f) & EF_AMDGPU_FEATURE_XNACK_V4)) {
         error("incompatible xnack: " + toString(f));
         return 0;
@@ -91,8 +91,8 @@ uint32_t AMDGPU::calcEFlagsV4() const {
 
     if (retSramEcc == EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4 ||
         (retSramEcc != EF_AMDGPU_FEATURE_SRAMECC_ANY_V4 &&
-            (getEFlags(f) & EF_AMDGPU_FEATURE_SRAMECC_V4) !=
-                EF_AMDGPU_FEATURE_SRAMECC_ANY_V4)) {
+         (getEFlags(f) & EF_AMDGPU_FEATURE_SRAMECC_V4) !=
+             EF_AMDGPU_FEATURE_SRAMECC_ANY_V4)) {
       if (retSramEcc != (getEFlags(f) & EF_AMDGPU_FEATURE_SRAMECC_V4)) {
         error("incompatible sramecc: " + toString(f));
         return 0;

--- a/lld/ELF/Arch/ARM.cpp
+++ b/lld/ELF/Arch/ARM.cpp
@@ -215,13 +215,13 @@ void ARM::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
 // Long form PLT Header that does not have any restrictions on the displacement
 // of the .plt from the .got.plt.
 static void writePltHeaderLong(uint8_t *buf) {
-  write32(buf + 0, 0xe52de004);   //     str lr, [sp,#-4]!
-  write32(buf + 4, 0xe59fe004);   //     ldr lr, L2
-  write32(buf + 8, 0xe08fe00e);   // L1: add lr, pc, lr
-  write32(buf + 12, 0xe5bef008);  //     ldr pc, [lr, #8]
-  write32(buf + 16, 0x00000000);  // L2: .word   &(.got.plt) - L1 - 8
-  write32(buf + 20, 0xd4d4d4d4);  //     Pad to 32-byte boundary
-  write32(buf + 24, 0xd4d4d4d4);  //     Pad to 32-byte boundary
+  write32(buf + 0, 0xe52de004);  //     str lr, [sp,#-4]!
+  write32(buf + 4, 0xe59fe004);  //     ldr lr, L2
+  write32(buf + 8, 0xe08fe00e);  // L1: add lr, pc, lr
+  write32(buf + 12, 0xe5bef008); //     ldr pc, [lr, #8]
+  write32(buf + 16, 0x00000000); // L2: .word   &(.got.plt) - L1 - 8
+  write32(buf + 20, 0xd4d4d4d4); //     Pad to 32-byte boundary
+  write32(buf + 24, 0xd4d4d4d4); //     Pad to 32-byte boundary
   write32(buf + 28, 0xd4d4d4d4);
   uint64_t gotPlt = in.gotPlt->getVA();
   uint64_t l1 = in.plt->getVA() + 8;
@@ -267,10 +267,10 @@ void ARM::addPltHeaderSymbols(InputSection &isec) const {
 // of the .plt from the .got.plt.
 static void writePltLong(uint8_t *buf, uint64_t gotPltEntryAddr,
                          uint64_t pltEntryAddr) {
-  write32(buf + 0, 0xe59fc004);   //     ldr ip, L2
-  write32(buf + 4, 0xe08cc00f);   // L1: add ip, ip, pc
-  write32(buf + 8, 0xe59cf000);   //     ldr pc, [ip]
-  write32(buf + 12, 0x00000000);  // L2: .word   Offset(&(.got.plt) - L1 - 8
+  write32(buf + 0, 0xe59fc004);  //     ldr ip, L2
+  write32(buf + 4, 0xe08cc00f);  // L1: add ip, ip, pc
+  write32(buf + 8, 0xe59cf000);  //     ldr pc, [ip]
+  write32(buf + 12, 0x00000000); // L2: .word   Offset(&(.got.plt) - L1 - 8
   uint64_t l1 = pltEntryAddr + 4;
   write32(buf + 12, gotPltEntryAddr - l1 - 8);
 }
@@ -308,8 +308,7 @@ void ARM::addPltSymbols(InputSection &isec, uint64_t off) const {
 }
 
 bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                     uint64_t branchAddr, const Symbol &s,
-                     int64_t a) const {
+                     uint64_t branchAddr, const Symbol &s, int64_t a) const {
   // If s is an undefined weak symbol and does not have a PLT entry then it will
   // be resolved as a branch to the next instruction. If it is hidden, its
   // binding has been converted to local, so we just check isUndefined() here. A
@@ -331,7 +330,7 @@ bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
   case R_ARM_CALL: {
     uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA() : s.getVA();
     return !inBranchRange(type, branchAddr, dst + a) ||
-        (!config->armHasBlx && (s.getVA() & 1));
+           (!config->armHasBlx && (s.getVA() & 1));
   }
   case R_ARM_THM_JUMP19:
   case R_ARM_THM_JUMP24:
@@ -343,7 +342,8 @@ bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
   case R_ARM_THM_CALL: {
     uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA() : s.getVA();
     return !inBranchRange(type, branchAddr, dst + a) ||
-        (!config->armHasBlx && (s.getVA() & 1) == 0);;
+           (!config->armHasBlx && (s.getVA() & 1) == 0);
+    ;
   }
   }
   return false;
@@ -514,7 +514,7 @@ static void encodeLdrsGroup(uint8_t *loc, const Relocation &rel, uint64_t val,
   uint32_t imm = getRemAndLZForGroup(group, val).first;
   checkUInt(loc, imm, 8, rel);
   write32(loc, (read32(loc) & 0xff7ff0f0) | opcode | ((imm & 0xf0) << 4) |
-                     (imm & 0xf));
+                   (imm & 0xf));
 }
 
 void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
@@ -559,8 +559,8 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
       // The BLX encoding is 0xfa:H:imm24 where Val = imm24:H:'1'
       checkInt(loc, val, 26, rel);
       write32(loc, 0xfa000000 |                    // opcode
-                         ((val & 2) << 23) |         // H
-                         ((val >> 2) & 0x00ffffff)); // imm24
+                       ((val & 2) << 23) |         // H
+                       ((val >> 2) & 0x00ffffff)); // imm24
       break;
     }
     // BLX (always unconditional) instruction to an ARM Target, select an
@@ -589,14 +589,14 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     // Encoding T3: Val = S:J2:J1:imm6:imm11:0
     checkInt(loc, val, 21, rel);
     write16(loc,
-              (read16(loc) & 0xfbc0) |   // opcode cond
-                  ((val >> 10) & 0x0400) | // S
-                  ((val >> 12) & 0x003f)); // imm6
+            (read16(loc) & 0xfbc0) |     // opcode cond
+                ((val >> 10) & 0x0400) | // S
+                ((val >> 12) & 0x003f)); // imm6
     write16(loc + 2,
-              0x8000 |                    // opcode
-                  ((val >> 8) & 0x0800) | // J2
-                  ((val >> 5) & 0x2000) | // J1
-                  ((val >> 1) & 0x07ff)); // imm11
+            0x8000 |                    // opcode
+                ((val >> 8) & 0x0800) | // J2
+                ((val >> 5) & 0x2000) | // J1
+                ((val >> 1) & 0x07ff)); // imm11
     break;
   case R_ARM_THM_CALL: {
     // R_ARM_THM_CALL is used for BL and BLX instructions, for symbols of type
@@ -625,12 +625,12 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
       // different encoding rules and range due to J1 and J2 always being 1.
       checkInt(loc, val, 23, rel);
       write16(loc,
-                0xf000 |                     // opcode
-                    ((val >> 12) & 0x07ff)); // imm11
+              0xf000 |                     // opcode
+                  ((val >> 12) & 0x07ff)); // imm11
       write16(loc + 2,
-                (read16(loc + 2) & 0xd000) | // opcode
-                    0x2800 |                   // J1 == J2 == 1
-                    ((val >> 1) & 0x07ff));    // imm11
+              (read16(loc + 2) & 0xd000) | // opcode
+                  0x2800 |                 // J1 == J2 == 1
+                  ((val >> 1) & 0x07ff));  // imm11
       break;
     }
   }
@@ -640,26 +640,26 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     // Encoding B  T4, BL T1, BLX T2: Val = S:I1:I2:imm10:imm11:0
     checkInt(loc, val, 25, rel);
     write16(loc,
-              0xf000 |                     // opcode
-                  ((val >> 14) & 0x0400) | // S
-                  ((val >> 12) & 0x03ff)); // imm10
+            0xf000 |                     // opcode
+                ((val >> 14) & 0x0400) | // S
+                ((val >> 12) & 0x03ff)); // imm10
     write16(loc + 2,
-              (read16(loc + 2) & 0xd000) |                  // opcode
-                  (((~(val >> 10)) ^ (val >> 11)) & 0x2000) | // J1
-                  (((~(val >> 11)) ^ (val >> 13)) & 0x0800) | // J2
-                  ((val >> 1) & 0x07ff));                     // imm11
+            (read16(loc + 2) & 0xd000) |                    // opcode
+                (((~(val >> 10)) ^ (val >> 11)) & 0x2000) | // J1
+                (((~(val >> 11)) ^ (val >> 13)) & 0x0800) | // J2
+                ((val >> 1) & 0x07ff));                     // imm11
     break;
   case R_ARM_MOVW_ABS_NC:
   case R_ARM_MOVW_PREL_NC:
   case R_ARM_MOVW_BREL_NC:
     write32(loc, (read32(loc) & ~0x000f0fff) | ((val & 0xf000) << 4) |
-                       (val & 0x0fff));
+                     (val & 0x0fff));
     break;
   case R_ARM_MOVT_ABS:
   case R_ARM_MOVT_PREL:
   case R_ARM_MOVT_BREL:
-    write32(loc, (read32(loc) & ~0x000f0fff) |
-                       (((val >> 16) & 0xf000) << 4) | ((val >> 16) & 0xfff));
+    write32(loc, (read32(loc) & ~0x000f0fff) | (((val >> 16) & 0xf000) << 4) |
+                     ((val >> 16) & 0xfff));
     break;
   case R_ARM_THM_MOVT_ABS:
   case R_ARM_THM_MOVT_PREL:
@@ -672,34 +672,34 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
                 ((val >> 28) & 0x000f)); // imm4
 
     write16(loc + 2,
-              (read16(loc + 2) & 0x8f00) | // opcode
-                  ((val >> 12) & 0x7000) |   // imm3
-                  ((val >> 16) & 0x00ff));   // imm8
+            (read16(loc + 2) & 0x8f00) | // opcode
+                ((val >> 12) & 0x7000) | // imm3
+                ((val >> 16) & 0x00ff)); // imm8
     break;
   case R_ARM_THM_MOVW_ABS_NC:
   case R_ARM_THM_MOVW_PREL_NC:
   case R_ARM_THM_MOVW_BREL_NC:
     // Encoding T3: A = imm4:i:imm3:imm8
     write16(loc,
-              0xf240 |                     // opcode
-                  ((val >> 1) & 0x0400) |  // i
-                  ((val >> 12) & 0x000f)); // imm4
+            0xf240 |                     // opcode
+                ((val >> 1) & 0x0400) |  // i
+                ((val >> 12) & 0x000f)); // imm4
     write16(loc + 2,
-              (read16(loc + 2) & 0x8f00) | // opcode
-                  ((val << 4) & 0x7000) |    // imm3
-                  (val & 0x00ff));           // imm8
+            (read16(loc + 2) & 0x8f00) | // opcode
+                ((val << 4) & 0x7000) |  // imm3
+                (val & 0x00ff));         // imm8
     break;
   case R_ARM_THM_ALU_ABS_G3:
-    write16(loc, (read16(loc) &~ 0x00ff) | ((val >> 24) & 0x00ff));
+    write16(loc, (read16(loc) & ~0x00ff) | ((val >> 24) & 0x00ff));
     break;
   case R_ARM_THM_ALU_ABS_G2_NC:
-    write16(loc, (read16(loc) &~ 0x00ff) | ((val >> 16) & 0x00ff));
+    write16(loc, (read16(loc) & ~0x00ff) | ((val >> 16) & 0x00ff));
     break;
   case R_ARM_THM_ALU_ABS_G1_NC:
-    write16(loc, (read16(loc) &~ 0x00ff) | ((val >> 8) & 0x00ff));
+    write16(loc, (read16(loc) & ~0x00ff) | ((val >> 8) & 0x00ff));
     break;
   case R_ARM_THM_ALU_ABS_G0_NC:
-    write16(loc, (read16(loc) &~ 0x00ff) | (val & 0x00ff));
+    write16(loc, (read16(loc) & ~0x00ff) | (val & 0x00ff));
     break;
   case R_ARM_ALU_PC_G0:
     encodeAluGroup(loc, rel, val, 0, true);
@@ -745,7 +745,7 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     checkUInt(loc, imm, 12, rel);
     write16(loc, (read16(loc) & 0xfb0f) | sub | (imm & 0x800) >> 1);
     write16(loc + 2,
-              (read16(loc + 2) & 0x8f00) | (imm & 0x700) << 4 | (imm & 0xff));
+            (read16(loc + 2) & 0x8f00) | (imm & 0x700) << 4 | (imm & 0xff));
     break;
   }
   case R_ARM_THM_PC8:

--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -198,8 +198,7 @@ static uint32_t findMaskR6(uint32_t insn) {
     if ((0xff000000 & insn) == i.cmpMask)
       return i.relocMask;
 
-  error("unrecognized instruction for 6_X relocation: 0x" +
-        utohexstr(insn));
+  error("unrecognized instruction for 6_X relocation: 0x" + utohexstr(insn));
   return 0;
 }
 
@@ -234,8 +233,7 @@ static uint32_t findMaskR16(uint32_t insn) {
     if ((0xff000000 & insn) == i.cmpMask)
       return i.relocMask;
 
-  error("unrecognized instruction for 16_X type: 0x" +
-        utohexstr(insn));
+  error("unrecognized instruction for 16_X type: 0x" + utohexstr(insn));
   return 0;
 }
 

--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -147,9 +147,7 @@ static uint32_t setK16(uint32_t insn, uint32_t imm) {
   return (insn & 0xfc0003ff) | (extractBits(imm, 15, 0) << 10);
 }
 
-static bool isJirl(uint32_t insn) {
-  return (insn & 0xfc000000) == JIRL;
-}
+static bool isJirl(uint32_t insn) { return (insn & 0xfc000000) == JIRL; }
 
 LoongArch::LoongArch() {
   // The LoongArch ISA itself does not have a limit on page sizes. According to
@@ -313,8 +311,8 @@ void LoongArch::writePltHeader(uint8_t *buf) const {
   //   ld.[wd]   $t3, $t2, %pcrel_lo12(.got.plt)  ; t3 = _dl_runtime_resolve
   //   addi.[wd] $t1, $t1, -pltHeaderSize-12      ; t1 = &.plt[i] - &.plt[0]
   //   addi.[wd] $t0, $t2, %pcrel_lo12(.got.plt)
-  //   srli.[wd] $t1, $t1, (is64?1:2)             ; t1 = &.got.plt[i] - &.got.plt[0]
-  //   ld.[wd]   $t0, $t0, Wordsize               ; t0 = link_map
+  //   srli.[wd] $t1, $t1, (is64?1:2)             ; t1 = &.got.plt[i] -
+  //   &.got.plt[0] ld.[wd]   $t0, $t0, Wordsize               ; t0 = link_map
   //   jr        $t3
   uint32_t offset = in.gotPlt->getVA() - in.plt->getVA();
   uint32_t sub = config->is64 ? SUB_D : SUB_W;
@@ -324,7 +322,8 @@ void LoongArch::writePltHeader(uint8_t *buf) const {
   write32le(buf + 0, insn(PCADDU12I, R_T2, hi20(offset), 0));
   write32le(buf + 4, insn(sub, R_T1, R_T1, R_T3));
   write32le(buf + 8, insn(ld, R_T3, R_T2, lo12(offset)));
-  write32le(buf + 12, insn(addi, R_T1, R_T1, lo12(-target->pltHeaderSize - 12)));
+  write32le(buf + 12,
+            insn(addi, R_T1, R_T1, lo12(-target->pltHeaderSize - 12)));
   write32le(buf + 16, insn(addi, R_T0, R_T2, lo12(offset)));
   write32le(buf + 20, insn(srli, R_T1, R_T1, config->is64 ? 1 : 2));
   write32le(buf + 24, insn(ld, R_T0, R_T0, config->wordsize));
@@ -332,7 +331,7 @@ void LoongArch::writePltHeader(uint8_t *buf) const {
 }
 
 void LoongArch::writePlt(uint8_t *buf, const Symbol &sym,
-                     uint64_t pltEntryAddr) const {
+                         uint64_t pltEntryAddr) const {
   // See the comment in writePltHeader for reason why pcaddu12i is used instead
   // of the pcalau12i that's more commonly seen in the ELF psABI v2.0 days.
   //
@@ -374,7 +373,8 @@ RelExpr LoongArch::getRelExpr(const RelType type, const Symbol &s,
     // work around it for a while, even if a new relocation type may be
     // introduced in the future [2].
     //
-    // [1]: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=9f482b73f41a9a1bbfb173aad0733d1c824c788a
+    // [1]:
+    // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=9f482b73f41a9a1bbfb173aad0733d1c824c788a
     // [2]: https://github.com/loongson/la-abi-specs/pull/3
     return isJirl(read32le(loc)) ? R_PLT : R_ABS;
   case R_LARCH_TLS_DTPREL32:
@@ -475,7 +475,8 @@ RelExpr LoongArch::getRelExpr(const RelType type, const Symbol &s,
   // - relocs that are not used anywhere (R_LARCH_{ADD,SUB}_24 [1], and the
   //   two GNU vtable-related relocs).
   //
-  // [1]: https://web.archive.org/web/20230709064026/https://github.com/loongson/LoongArch-Documentation/issues/51
+  // [1]:
+  // https://web.archive.org/web/20230709064026/https://github.com/loongson/LoongArch-Documentation/issues/51
   default:
     error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +
           ") against symbol " + toString(s));

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -262,13 +262,13 @@ template <class ELFT> void MIPS<ELFT>::writePltHeader(uint8_t *buf) const {
     // Overwrite trap instructions written by Writer::writeTrapInstr.
     memset(buf, 0, pltHeaderSize);
 
-    write16(buf, isMipsR6() ? 0x7860 : 0x7980);  // addiupc v1, (GOTPLT) - .
-    write16(buf + 4, 0xff23);    // lw      $25, 0($3)
-    write16(buf + 8, 0x0535);    // subu16  $2,  $2, $3
-    write16(buf + 10, 0x2525);   // srl16   $2,  $2, 2
-    write16(buf + 12, 0x3302);   // addiu   $24, $2, -2
+    write16(buf, isMipsR6() ? 0x7860 : 0x7980); // addiupc v1, (GOTPLT) - .
+    write16(buf + 4, 0xff23);                   // lw      $25, 0($3)
+    write16(buf + 8, 0x0535);                   // subu16  $2,  $2, $3
+    write16(buf + 10, 0x2525);                  // srl16   $2,  $2, 2
+    write16(buf + 12, 0x3302);                  // addiu   $24, $2, -2
     write16(buf + 14, 0xfffe);
-    write16(buf + 16, 0x0dff);   // move    $15, $31
+    write16(buf + 16, 0x0dff); // move    $15, $31
     if (isMipsR6()) {
       write16(buf + 18, 0x0f83); // move    $28, $3
       write16(buf + 20, 0x472b); // jalrc   $25
@@ -307,7 +307,7 @@ template <class ELFT> void MIPS<ELFT>::writePltHeader(uint8_t *buf) const {
   }
 
   uint32_t jalrInst = config->zHazardplt ? 0x0320fc09 : 0x0320f809;
-  write32(buf + 24, jalrInst); // jalr.hb $25 or jalr $25
+  write32(buf + 24, jalrInst);   // jalr.hb $25 or jalr $25
   write32(buf + 28, 0x2718fffe); // subu  $24, $24, 2
 
   uint64_t gotPlt = in.gotPlt->getVA();
@@ -345,10 +345,10 @@ void MIPS<ELFT>::writePlt(uint8_t *buf, const Symbol &sym,
                                : (config->zHazardplt ? 0x03200408 : 0x03200008);
   uint32_t addInst = ELFT::Is64Bits ? 0x65f80000 : 0x25f80000;
 
-  write32(buf, 0x3c0f0000);     // lui   $15, %hi(.got.plt entry)
-  write32(buf + 4, loadInst);   // l[wd] $25, %lo(.got.plt entry)($15)
-  write32(buf + 8, jrInst);     // jr  $25 / jr.hb $25
-  write32(buf + 12, addInst);   // [d]addiu $24, $15, %lo(.got.plt entry)
+  write32(buf, 0x3c0f0000);   // lui   $15, %hi(.got.plt entry)
+  write32(buf + 4, loadInst); // l[wd] $25, %lo(.got.plt entry)($15)
+  write32(buf + 8, jrInst);   // jr  $25 / jr.hb $25
+  write32(buf + 12, addInst); // [d]addiu $24, $15, %lo(.got.plt entry)
   writeValue(buf, gotPltEntryAddr + 0x8000, 16, 16);
   writeValue(buf + 4, gotPltEntryAddr, 16, 0);
   writeValue(buf + 12, gotPltEntryAddr, 16, 0);
@@ -682,10 +682,10 @@ void MIPS<ELFT>::relocate(uint8_t *loc, const Relocation &rel,
     // offset fits into the 18-bit range.
     if (isInt<18>(val)) {
       switch (read32(loc)) {
-      case 0x0320f809:  // jalr $25 => bal sym
+      case 0x0320f809: // jalr $25 => bal sym
         write32(loc, 0x04110000 | ((val >> 2) & 0xffff));
         break;
-      case 0x03200008:  // jr $25 => b sym
+      case 0x03200008: // jr $25 => b sym
         write32(loc, 0x10000000 | ((val >> 2) & 0xffff));
         break;
       }

--- a/lld/ELF/Arch/PPC.cpp
+++ b/lld/ELF/Arch/PPC.cpp
@@ -117,19 +117,19 @@ void elf::writePPC32GlinkSection(uint8_t *buf, size_t numEntries) {
     if (ha(gotBcl) == ha(gotBcl + 4)) {
       write32(buf + 32, 0x800c0000 | lo(gotBcl)); // lwz r0,r12,GOT+4-1b@l(r12)
       write32(buf + 36,
-              0x818c0000 | lo(gotBcl + 4));       // lwz r12,r12,GOT+8-1b@l(r12)
+              0x818c0000 | lo(gotBcl + 4)); // lwz r12,r12,GOT+8-1b@l(r12)
     } else {
       write32(buf + 32, 0x840c0000 | lo(gotBcl)); // lwzu r0,r12,GOT+4-1b@l(r12)
       write32(buf + 36, 0x818c0000 | 4);          // lwz r12,r12,4(r12)
     }
-    write32(buf + 40, 0x7c0903a6);                // mtctr 0
-    write32(buf + 44, 0x7c0b5a14);                // add r0,11,11
-    write32(buf + 48, 0x7d605a14);                // add r11,0,11
-    write32(buf + 52, 0x4e800420);                // bctr
+    write32(buf + 40, 0x7c0903a6); // mtctr 0
+    write32(buf + 44, 0x7c0b5a14); // add r0,11,11
+    write32(buf + 48, 0x7d605a14); // add r11,0,11
+    write32(buf + 52, 0x4e800420); // bctr
     buf += 56;
   } else {
-    write32(buf + 0, 0x3d800000 | ha(got + 4));   // lis     r12,GOT+4@ha
-    write32(buf + 4, 0x3d6b0000 | ha(-glink));    // addis   r11,r11,-glink@ha
+    write32(buf + 0, 0x3d800000 | ha(got + 4)); // lis     r12,GOT+4@ha
+    write32(buf + 4, 0x3d6b0000 | ha(-glink));  // addis   r11,r11,-glink@ha
     if (ha(got + 4) == ha(got + 8))
       write32(buf + 8, 0x800c0000 | lo(got + 4)); // lwz r0,GOT+4@l(r12)
     else
@@ -140,9 +140,9 @@ void elf::writePPC32GlinkSection(uint8_t *buf, size_t numEntries) {
     if (ha(got + 4) == ha(got + 8))
       write32(buf + 24, 0x818c0000 | lo(got + 8)); // lwz r12,GOT+8@l(r12)
     else
-      write32(buf + 24, 0x818c0000 | 4);          // lwz r12,4(r12)
-    write32(buf + 28, 0x7d605a14);                // add     r11,r0,r11
-    write32(buf + 32, 0x4e800420);                // bctr
+      write32(buf + 24, 0x818c0000 | 4); // lwz r12,4(r12)
+    write32(buf + 28, 0x7d605a14);       // add     r11,r0,r11
+    write32(buf + 32, 0x4e800420);       // bctr
     buf += 36;
   }
 

--- a/lld/ELF/Arch/PPC64.cpp
+++ b/lld/ELF/Arch/PPC64.cpp
@@ -72,11 +72,7 @@ enum DFormOpcd {
   ADDI = 14
 };
 
-enum DSFormOpcd {
-  LD = 58,
-  LWA = 58,
-  STD = 62
-};
+enum DSFormOpcd { LD = 58, LWA = 58, STD = 62 };
 
 constexpr uint32_t NOP = 0x60000000;
 
@@ -361,8 +357,8 @@ getRelaTocSymAndAddend(InputSectionBase *tocSec, uint64_t offset) {
 // instructions:
 //
 //   addis 3, 2, .LC0@toc@ha  # R_PPC64_TOC16_HA
-//   ld    3, .LC0@toc@l(3)   # R_PPC64_TOC16_LO_DS, load the address from a .toc entry
-//   ld/lwa 3, 0(3)           # load the value from the address
+//   ld    3, .LC0@toc@l(3)   # R_PPC64_TOC16_LO_DS, load the address from a
+//   .toc entry ld/lwa 3, 0(3)           # load the value from the address
 //
 //   .section .toc,"aw",@progbits
 //   .LC0: .tc var[TC],var
@@ -1137,9 +1133,9 @@ void PPC64::writeGotHeader(uint8_t *buf) const {
 
 void PPC64::writePltHeader(uint8_t *buf) const {
   // The generic resolver stub goes first.
-  write32(buf +  0, 0x7c0802a6); // mflr r0
-  write32(buf +  4, 0x429f0005); // bcl  20,4*cr7+so,8 <_glink+0x8>
-  write32(buf +  8, 0x7d6802a6); // mflr r11
+  write32(buf + 0, 0x7c0802a6);  // mflr r0
+  write32(buf + 4, 0x429f0005);  // bcl  20,4*cr7+so,8 <_glink+0x8>
+  write32(buf + 8, 0x7d6802a6);  // mflr r11
   write32(buf + 12, 0x7c0803a6); // mtlr r0
   write32(buf + 16, 0x7d8b6050); // subf r12, r11, r12
   write32(buf + 20, 0x380cffcc); // subi r0,r12,52
@@ -1257,7 +1253,7 @@ static bool isTocOptType(RelType type) {
 
 void PPC64::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   RelType type = rel.type;
-  bool shouldTocOptimize =  isTocOptType(type);
+  bool shouldTocOptimize = isTocOptType(type);
   // For dynamic thread pointer relative, toc-relative, and got-indirect
   // relocations, proceed in terms of the corresponding ADDR16 relocation type.
   std::tie(type, val) = toAddr16Rel(type, val);
@@ -1332,8 +1328,7 @@ void PPC64::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
       uint32_t insn = readFromHalf16(loc);
       if (isInstructionUpdateForm(insn))
         error(getErrorLocation(loc) +
-              "can't toc-optimize an update instruction: 0x" +
-              utohexstr(insn));
+              "can't toc-optimize an update instruction: 0x" + utohexstr(insn));
       writeFromHalf16(loc, (insn & 0xffe00000) | 0x00020000 | lo(val));
     } else {
       write16(loc, lo(val));
@@ -1409,8 +1404,8 @@ void PPC64::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     checkInt(loc, val, 34, rel);
 
     uint64_t instr = readPrefixedInstruction(loc) & ~fullMask;
-    writePrefixedInstruction(loc, instr | ((val & si0Mask) << 16) |
-                             (val & si1Mask));
+    writePrefixedInstruction(loc,
+                             instr | ((val & si0Mask) << 16) | (val & si1Mask));
     break;
   }
   // If we encounter a PCREL_OPT relocation that we won't optimize.

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -850,10 +850,12 @@ static bool relax(InputSection &sec) {
       remove = nextLoc - ((loc + align - 1) & -align);
       // If we can't satisfy this alignment, we've found a bad input.
       if (LLVM_UNLIKELY(static_cast<int32_t>(remove) < 0)) {
-        errorOrWarn(getErrorLocation((const uint8_t*)loc) +
+        errorOrWarn(getErrorLocation((const uint8_t *)loc) +
                     "insufficient padding bytes for " + lld::toString(r.type) +
-                    ": " + Twine(r.addend) + " bytes available "
-                    "for requested alignment of " + Twine(align) + " bytes");
+                    ": " + Twine(r.addend) +
+                    " bytes available "
+                    "for requested alignment of " +
+                    Twine(align) + " bytes");
         remove = 0;
       }
       break;

--- a/lld/ELF/Arch/X86.cpp
+++ b/lld/ELF/Arch/X86.cpp
@@ -198,9 +198,9 @@ void X86::writePltHeader(uint8_t *buf) const {
   }
 
   const uint8_t pltData[] = {
-      0xff, 0x35, 0, 0, 0, 0, // pushl (GOTPLT+4)
-      0xff, 0x25, 0, 0, 0, 0, // jmp *(GOTPLT+8)
-      0x90, 0x90, 0x90, 0x90, // nop
+      0xff, 0x35, 0,    0,    0, 0, // pushl (GOTPLT+4)
+      0xff, 0x25, 0,    0,    0, 0, // jmp *(GOTPLT+8)
+      0x90, 0x90, 0x90, 0x90,       // nop
   };
   memcpy(buf, pltData, sizeof(pltData));
   uint32_t gotPlt = in.gotPlt->getVA();

--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -314,7 +314,8 @@ bool X86_64::relaxOnce(int pass) const {
     minVA = std::min(minVA, osec->addr);
     maxVA = std::max(maxVA, osec->addr + osec->size);
   }
-  // If the max VA difference is under 2^31, GOT-generating relocations with a 32-bit range cannot overflow.
+  // If the max VA difference is under 2^31, GOT-generating relocations with a
+  // 32-bit range cannot overflow.
   if (isUInt<31>(maxVA - minVA))
     return false;
 
@@ -423,9 +424,9 @@ void X86_64::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
 
 void X86_64::writePltHeader(uint8_t *buf) const {
   const uint8_t pltData[] = {
-      0xff, 0x35, 0, 0, 0, 0, // pushq GOTPLT+8(%rip)
-      0xff, 0x25, 0, 0, 0, 0, // jmp *GOTPLT+16(%rip)
-      0x0f, 0x1f, 0x40, 0x00, // nop
+      0xff, 0x35, 0,    0,    0, 0, // pushq GOTPLT+8(%rip)
+      0xff, 0x25, 0,    0,    0, 0, // jmp *GOTPLT+16(%rip)
+      0x0f, 0x1f, 0x40, 0x00,       // nop
   };
   memcpy(buf, pltData, sizeof(pltData));
   uint64_t gotPlt = in.gotPlt->getVA();
@@ -438,8 +439,8 @@ void X86_64::writePlt(uint8_t *buf, const Symbol &sym,
                       uint64_t pltEntryAddr) const {
   const uint8_t inst[] = {
       0xff, 0x25, 0, 0, 0, 0, // jmpq *got(%rip)
-      0x68, 0, 0, 0, 0,       // pushq <relocation index>
-      0xe9, 0, 0, 0, 0,       // jmpq plt[0]
+      0x68, 0,    0, 0, 0,    // pushq <relocation index>
+      0xe9, 0,    0, 0, 0,    // jmpq plt[0]
   };
   memcpy(buf, inst, sizeof(inst));
 
@@ -1144,12 +1145,12 @@ void Retpoline::writeGotPlt(uint8_t *buf, const Symbol &s) const {
 
 void Retpoline::writePltHeader(uint8_t *buf) const {
   const uint8_t insn[] = {
-      0xff, 0x35, 0,    0,    0,    0,          // 0:    pushq GOTPLT+8(%rip)
-      0x4c, 0x8b, 0x1d, 0,    0,    0,    0,    // 6:    mov GOTPLT+16(%rip), %r11
-      0xe8, 0x0e, 0x00, 0x00, 0x00,             // d:    callq next
-      0xf3, 0x90,                               // 12: loop: pause
-      0x0f, 0xae, 0xe8,                         // 14:   lfence
-      0xeb, 0xf9,                               // 17:   jmp loop
+      0xff, 0x35, 0,    0,    0,    0,       // 0:    pushq GOTPLT+8(%rip)
+      0x4c, 0x8b, 0x1d, 0,    0,    0,    0, // 6:    mov GOTPLT+16(%rip), %r11
+      0xe8, 0x0e, 0x00, 0x00, 0x00,          // d:    callq next
+      0xf3, 0x90,                            // 12: loop: pause
+      0x0f, 0xae, 0xe8,                      // 14:   lfence
+      0xeb, 0xf9,                            // 17:   jmp loop
       0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, // 19:   int3; .align 16
       0x4c, 0x89, 0x1c, 0x24,                   // 20: next: mov %r11, (%rsp)
       0xc3,                                     // 24:   ret
@@ -1167,12 +1168,12 @@ void Retpoline::writePltHeader(uint8_t *buf) const {
 void Retpoline::writePlt(uint8_t *buf, const Symbol &sym,
                          uint64_t pltEntryAddr) const {
   const uint8_t insn[] = {
-      0x4c, 0x8b, 0x1d, 0, 0, 0, 0, // 0:  mov foo@GOTPLT(%rip), %r11
-      0xe8, 0,    0,    0,    0,    // 7:  callq plt+0x20
-      0xe9, 0,    0,    0,    0,    // c:  jmp plt+0x12
-      0x68, 0,    0,    0,    0,    // 11: pushq <relocation index>
-      0xe9, 0,    0,    0,    0,    // 16: jmp plt+0
-      0xcc, 0xcc, 0xcc, 0xcc, 0xcc, // 1b: int3; padding
+      0x4c, 0x8b, 0x1d, 0,    0,    0, 0, // 0:  mov foo@GOTPLT(%rip), %r11
+      0xe8, 0,    0,    0,    0,          // 7:  callq plt+0x20
+      0xe9, 0,    0,    0,    0,          // c:  jmp plt+0x12
+      0x68, 0,    0,    0,    0,          // 11: pushq <relocation index>
+      0xe9, 0,    0,    0,    0,          // 16: jmp plt+0
+      0xcc, 0xcc, 0xcc, 0xcc, 0xcc,       // 1b: int3; padding
   };
   memcpy(buf, insn, sizeof(insn));
 

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -100,7 +100,7 @@ enum class SeparateSegmentKind { None, Code, Loadable };
 enum class GnuStackKind { None, Exec, NoExec };
 
 // For --lto=
-enum LtoKind : uint8_t {UnifiedThin, UnifiedRegular, Default};
+enum LtoKind : uint8_t { UnifiedThin, UnifiedRegular, Default };
 
 struct SymbolVersion {
   llvm::StringRef name;
@@ -152,7 +152,8 @@ struct Config {
   uint8_t osabi = 0;
   uint32_t andFeatures = 0;
   llvm::CachePruningPolicy thinLTOCachePolicy;
-  llvm::SetVector<llvm::CachedHashString> dependencyFiles; // for --dependency-file
+  llvm::SetVector<llvm::CachedHashString>
+      dependencyFiles; // for --dependency-file
   llvm::StringMap<uint64_t> sectionStartMap;
   llvm::StringRef bfdname;
   llvm::StringRef chroot;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -232,8 +232,8 @@ std::vector<std::pair<MemoryBufferRef, uint64_t>> static getArchiveMembers(
     v.push_back(std::make_pair(mbref, c.getChildOffset()));
   }
   if (err)
-    fatal(mb.getBufferIdentifier() + ": Archive::children failed: " +
-          toString(std::move(err)));
+    fatal(mb.getBufferIdentifier() +
+          ": Archive::children failed: " + toString(std::move(err)));
 
   // Take ownership of memory buffers created for members of thin archives.
   std::vector<std::unique_ptr<MemoryBuffer>> mbs = file->takeThinBuffers();
@@ -1231,7 +1231,8 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasFlag(OPT_optimize_bb_jumps, OPT_no_optimize_bb_jumps, false);
   config->demangle = args.hasFlag(OPT_demangle, OPT_no_demangle, true);
   config->dependencyFile = args.getLastArgValue(OPT_dependency_file);
-  config->dependentLibraries = args.hasFlag(OPT_dependent_libraries, OPT_no_dependent_libraries, true);
+  config->dependentLibraries =
+      args.hasFlag(OPT_dependent_libraries, OPT_no_dependent_libraries, true);
   config->disableVerify = args.hasArg(OPT_disable_verify);
   config->discard = getDiscard(args);
   config->dwoDir = args.getLastArgValue(OPT_plugin_opt_dwo_dir_eq);
@@ -1254,8 +1255,8 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasArg(OPT_shared);
   config->filterList = args::getStrings(args, OPT_filter);
   config->fini = args.getLastArgValue(OPT_fini, "_fini");
-  config->fixCortexA53Errata843419 = args.hasArg(OPT_fix_cortex_a53_843419) &&
-                                     !args.hasArg(OPT_relocatable);
+  config->fixCortexA53Errata843419 =
+      args.hasArg(OPT_fix_cortex_a53_843419) && !args.hasArg(OPT_relocatable);
   config->cmseImplib = args.hasArg(OPT_cmse_implib);
   config->cmseInputLib = args.getLastArgValue(OPT_in_implib);
   config->cmseOutputLib = args.getLastArgValue(OPT_out_implib);
@@ -1341,8 +1342,7 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasFlag(OPT_print_gc_sections, OPT_no_print_gc_sections, false);
   config->printMemoryUsage = args.hasArg(OPT_print_memory_usage);
   config->printArchiveStats = args.getLastArgValue(OPT_print_archive_stats);
-  config->printSymbolOrder =
-      args.getLastArgValue(OPT_print_symbol_order);
+  config->printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);
   config->relax = args.hasFlag(OPT_relax, OPT_no_relax, true);
   config->relaxGP = args.hasFlag(OPT_relax_gp, OPT_no_relax_gp, false);
   config->rpath = getRpath(args);
@@ -1368,7 +1368,8 @@ static void readConfigs(opt::InputArgList &args) {
   config->singleRoRx = !args.hasFlag(OPT_rosegment, OPT_no_rosegment, true);
   config->soName = args.getLastArgValue(OPT_soname);
   config->sortSection = getSortSection(args);
-  config->splitStackAdjustSize = args::getInteger(args, OPT_split_stack_adjust_size, 16384);
+  config->splitStackAdjustSize =
+      args::getInteger(args, OPT_split_stack_adjust_size, 16384);
   config->strip = getStrip(args);
   config->sysroot = args.getLastArgValue(OPT_sysroot);
   config->target1Rel = args.hasFlag(OPT_target1_rel, OPT_target1_abs, false);
@@ -1652,7 +1653,7 @@ static void readConfigs(opt::InputArgList &args) {
         getPackDynRelocs(args);
   }
 
-  if (auto *arg = args.getLastArg(OPT_symbol_ordering_file)){
+  if (auto *arg = args.getLastArg(OPT_symbol_ordering_file)) {
     if (args.hasArg(OPT_call_graph_ordering_file))
       error("--symbol-ordering-file and --call-graph-order-file "
             "may not be used together");
@@ -1892,7 +1893,8 @@ void LinkerDriver::createFiles(opt::InputArgList &args) {
         error("unbalanced --push-state/--pop-state");
         break;
       }
-      std::tie(config->asNeeded, config->isStatic, inWholeArchive) = stack.back();
+      std::tie(config->asNeeded, config->isStatic, inWholeArchive) =
+          stack.back();
       stack.pop_back();
       break;
     }
@@ -2978,11 +2980,13 @@ void LinkerDriver::link(opt::InputArgList &args) {
   if (!config->relocatable)
     ctx.inputSections.push_back(createCommentSection());
 
-  // Split SHF_MERGE and .eh_frame sections into pieces in preparation for garbage collection.
-  invokeELFT(splitSections,);
+  // Split SHF_MERGE and .eh_frame sections into pieces in preparation for
+  // garbage collection.
+  invokeELFT(splitSections, );
 
-  // Garbage collection and removal of shared symbols from unused shared objects.
-  invokeELFT(markLive,);
+  // Garbage collection and removal of shared symbols from unused shared
+  // objects.
+  invokeELFT(markLive, );
 
   // Make copies of any input sections that need to be copied into each
   // partition.
@@ -2995,7 +2999,7 @@ void LinkerDriver::link(opt::InputArgList &args) {
 
   // Create synthesized sections such as .got and .plt. This is called before
   // processSectionCommands() so that they can be placed by SECTIONS commands.
-  invokeELFT(createSyntheticSections,);
+  invokeELFT(createSyntheticSections, );
 
   // Some input sections that are used for exception handling need to be moved
   // into synthetic sections. Do that now so that they aren't assigned to
@@ -3033,10 +3037,11 @@ void LinkerDriver::link(opt::InputArgList &args) {
   }
 
   // Two input sections with different output sections should not be folded.
-  // ICF runs after processSectionCommands() so that we know the output sections.
+  // ICF runs after processSectionCommands() so that we know the output
+  // sections.
   if (config->icf != ICFLevel::None) {
     invokeELFT(findKeepUniqueSections, args);
-    invokeELFT(doIcf,);
+    invokeELFT(doIcf, );
   }
 
   // Read the callgraph now that we know what was gced or icfed
@@ -3044,9 +3049,9 @@ void LinkerDriver::link(opt::InputArgList &args) {
     if (auto *arg = args.getLastArg(OPT_call_graph_ordering_file))
       if (std::optional<MemoryBufferRef> buffer = readFile(arg->getValue()))
         readCallGraph(*buffer);
-    invokeELFT(readCallGraphsFromObjectFiles,);
+    invokeELFT(readCallGraphsFromObjectFiles, );
   }
 
   // Write the result to the file.
-  invokeELFT(writeResult,);
+  invokeELFT(writeResult, );
 }

--- a/lld/ELF/DriverUtils.cpp
+++ b/lld/ELF/DriverUtils.cpp
@@ -229,8 +229,8 @@ std::optional<std::string> elf::findFromSearchPaths(StringRef path) {
   return std::nullopt;
 }
 
-// This is for -l<basename>. We'll look for lib<basename>.so or lib<basename>.a from
-// search paths.
+// This is for -l<basename>. We'll look for lib<basename>.so or lib<basename>.a
+// from search paths.
 std::optional<std::string> elf::searchLibraryBaseName(StringRef name) {
   for (StringRef dir : config->searchPaths) {
     if (!config->isStatic)

--- a/lld/ELF/EhFrame.cpp
+++ b/lld/ELF/EhFrame.cpp
@@ -55,7 +55,7 @@ private:
   InputSectionBase *isec;
   ArrayRef<uint8_t> d;
 };
-}
+} // namespace
 
 // Read a byte and advance D by one byte.
 uint8_t EhReader::readByte() {

--- a/lld/ELF/EhFrame.h
+++ b/lld/ELF/EhFrame.h
@@ -16,6 +16,6 @@ struct EhSectionPiece;
 
 uint8_t getFdeEncoding(EhSectionPiece *p);
 bool hasLSDA(const EhSectionPiece &p);
-}
+} // namespace lld::elf
 
 #endif

--- a/lld/ELF/ICF.cpp
+++ b/lld/ELF/ICF.cpp
@@ -155,7 +155,7 @@ private:
   int current = 0;
   int next = 0;
 };
-}
+} // namespace
 
 // Returns true if section S is subject of ICF.
 static bool isEligible(InputSection *s) {

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1680,9 +1680,10 @@ static uint8_t mapVisibility(GlobalValue::VisibilityTypes gvVisibility) {
   llvm_unreachable("unknown visibility");
 }
 
-static void
-createBitcodeSymbol(Symbol *&sym, const std::vector<bool> &keptComdats,
-                    const lto::InputFile::Symbol &objSym, BitcodeFile &f) {
+static void createBitcodeSymbol(Symbol *&sym,
+                                const std::vector<bool> &keptComdats,
+                                const lto::InputFile::Symbol &objSym,
+                                BitcodeFile &f) {
   uint8_t binding = objSym.isWeak() ? STB_WEAK : STB_GLOBAL;
   uint8_t type = objSym.isTLS() ? STT_TLS : STT_NOTYPE;
   uint8_t visibility = mapVisibility(objSym.getVisibility());

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -189,7 +189,7 @@ public:
   }
   MutableArrayRef<Symbol *> getMutableGlobalSymbols() {
     return llvm::MutableArrayRef(symbols.get() + firstGlobal,
-                                     numSymbols - firstGlobal);
+                                 numSymbols - firstGlobal);
   }
 
   template <typename ELFT> typename ELFT::ShdrRange getELFShdrs() const {

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -73,7 +73,7 @@ InputSectionBase::InputSectionBase(InputFile *file, uint64_t flags,
   // If SHF_COMPRESSED is set, parse the header. The legacy .zdebug format is no
   // longer supported.
   if (flags & SHF_COMPRESSED)
-    invokeELFT(parseCompressedHeader,);
+    invokeELFT(parseCompressedHeader, );
 }
 
 // Drop SHF_GROUP bit unless we are producing a re-linkable object file.
@@ -1131,7 +1131,8 @@ void InputSectionBase::adjustSplitStackFunctionPrologues(uint8_t *buf,
     // conservative.
     if (Defined *d = dyn_cast<Defined>(rel.sym))
       if (InputSection *isec = cast_or_null<InputSection>(d->section))
-        if (!isec || !isec->getFile<ELFT>() || isec->getFile<ELFT>()->splitStack)
+        if (!isec || !isec->getFile<ELFT>() ||
+            isec->getFile<ELFT>()->splitStack)
           continue;
 
     if (enclosingPrologueAttempted(rel.offset, prologues))

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -243,7 +243,6 @@ public:
   template <typename ELFT>
   void adjustSplitStackFunctionPrologues(uint8_t *buf, uint8_t *end);
 
-
   template <typename T> llvm::ArrayRef<T> getDataAs() const {
     size_t s = content().size();
     assert(s % sizeof(T) == 0);
@@ -251,8 +250,7 @@ public:
   }
 
 protected:
-  template <typename ELFT>
-  void parseCompressedHeader();
+  template <typename ELFT> void parseCompressedHeader();
   void decompress() const;
 };
 

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -186,13 +186,13 @@ BitcodeCompiler::BitcodeCompiler() {
         config->thinLTOEmitImportsFiles);
   }
 
-  constexpr llvm::lto::LTO::LTOKind ltoModes[3] =
-    {llvm::lto::LTO::LTOKind::LTOK_UnifiedThin,
-     llvm::lto::LTO::LTOKind::LTOK_UnifiedRegular,
-     llvm::lto::LTO::LTOKind::LTOK_Default};
-  ltoObj = std::make_unique<lto::LTO>(
-      createConfig(), backend, config->ltoPartitions,
-      ltoModes[config->ltoKind]);
+  constexpr llvm::lto::LTO::LTOKind ltoModes[3] = {
+      llvm::lto::LTO::LTOKind::LTOK_UnifiedThin,
+      llvm::lto::LTO::LTOKind::LTOK_UnifiedRegular,
+      llvm::lto::LTO::LTOKind::LTOK_Default};
+  ltoObj =
+      std::make_unique<lto::LTO>(createConfig(), backend, config->ltoPartitions,
+                                 ltoModes[config->ltoKind]);
 
   // Initialize usedStartStop.
   if (ctx.bitcodeFiles.empty())

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -1470,7 +1470,7 @@ SmallVector<size_t, 0> LinkerScript::getPhdrIndices(OutputSection *cmd) {
   return ret;
 }
 
-void LinkerScript::printMemoryUsage(raw_ostream& os) {
+void LinkerScript::printMemoryUsage(raw_ostream &os) {
   auto printSize = [&](uint64_t size) {
     if ((size & 0x3fffffff) == 0)
       os << format_decimal(size >> 30, 10) << " GB";

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -76,7 +76,7 @@ enum SectionsCommandKind {
   AssignmentKind, // . = expr or <sym> = expr
   OutputSectionKind,
   InputSectionKind,
-  ByteKind    // BYTE(expr), SHORT(expr), LONG(expr) or QUAD(expr)
+  ByteKind // BYTE(expr), SHORT(expr), LONG(expr) or QUAD(expr)
 };
 
 struct SectionCommand {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -511,8 +511,7 @@ int64_t RelocationScanner::computeMipsAddend(const RelTy &rel, RelExpr expr,
 }
 
 // Custom error message if Sym is defined in a discarded section.
-template <class ELFT>
-static std::string maybeReportDiscarded(Undefined &sym) {
+template <class ELFT> static std::string maybeReportDiscarded(Undefined &sym) {
   auto *file = dyn_cast_or_null<ObjFile<ELFT>>(sym.file);
   if (!file || !sym.discardedSecIdx)
     return "";
@@ -566,7 +565,7 @@ struct UndefinedDiag {
 
 std::vector<UndefinedDiag> undefs;
 std::mutex relocMutex;
-}
+} // namespace
 
 // Check whether the definition name def is a mangled function name that matches
 // the reference name ref.
@@ -1023,7 +1022,7 @@ bool RelocationScanner::isStaticLinkTimeConstant(RelExpr e, RelType type,
   // We set the final symbols values for linker script defined symbols later.
   // They always can be computed as a link time constant.
   if (sym.scriptDefined)
-      return true;
+    return true;
 
   error("relocation " + toString(type) + " cannot refer to absolute symbol: " +
         toString(sym) + getLocation(*sec, sym, relOff));

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -833,7 +833,8 @@ constexpr std::pair<const char *, unsigned> typeMap[] = {
 // "(TYPE=<value>)".
 // Tok1 and Tok2 are next 2 tokens peeked. See comment for
 // readSectionAddressType below.
-bool ScriptParser::readSectionDirective(OutputSection *cmd, StringRef tok1, StringRef tok2) {
+bool ScriptParser::readSectionDirective(OutputSection *cmd, StringRef tok1,
+                                        StringRef tok2) {
   if (tok1 != "(")
     return false;
   if (tok2 != "NOLOAD" && tok2 != "COPY" && tok2 != "INFO" &&
@@ -1329,10 +1330,10 @@ static std::optional<uint64_t> parseFlag(StringRef tok) {
 // Example: SHF_EXECINSTR & !SHF_WRITE means with flag SHF_EXECINSTR and
 // without flag SHF_WRITE.
 std::pair<uint64_t, uint64_t> ScriptParser::readInputSectionFlags() {
-   uint64_t withFlags = 0;
-   uint64_t withoutFlags = 0;
-   expect("(");
-   while (!errorCount()) {
+  uint64_t withFlags = 0;
+  uint64_t withoutFlags = 0;
+  expect("(");
+  while (!errorCount()) {
     StringRef tok = unquote(next());
     bool without = tok.consume_front("!");
     if (std::optional<uint64_t> flag = parseFlag(tok)) {
@@ -1470,7 +1471,8 @@ Expr ScriptParser::readPrimary() {
     readExpr();
     expect(")");
     script->seenRelroEnd = true;
-    return [=] { return alignToPowerOf2(script->getDot(), config->maxPageSize); };
+    return
+        [=] { return alignToPowerOf2(script->getDot(), config->maxPageSize); };
   }
   if (tok == "DEFINED") {
     StringRef name = unquote(readParenLiteral());

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -288,9 +288,7 @@ public:
   bool needsTocRestore() const { return archSpecificBit; }
   bool isTagged() const { return archSpecificBit; }
   void setNeedsTocRestore(bool v) { archSpecificBit = v; }
-  void setIsTagged(bool v) {
-    archSpecificBit = v;
-  }
+  void setIsTagged(bool v) { archSpecificBit = v; }
 
   // True if this symbol is defined by a symbol assignment or wrapped by --wrap.
   //
@@ -551,7 +549,8 @@ union SymbolUnion {
 template <typename... T> Defined *makeDefined(T &&...args) {
   auto *sym = getSpecificAllocSingleton<SymbolUnion>().Allocate();
   memset(sym, 0, sizeof(Symbol));
-  auto &s = *new (reinterpret_cast<Defined *>(sym)) Defined(std::forward<T>(args)...);
+  auto &s =
+      *new (reinterpret_cast<Defined *>(sym)) Defined(std::forward<T>(args)...);
   return &s;
 }
 

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -318,13 +318,13 @@ void GnuPropertySection::writeTo(uint8_t *buf) {
                                 ? GNU_PROPERTY_AARCH64_FEATURE_1_AND
                                 : GNU_PROPERTY_X86_FEATURE_1_AND;
 
-  write32(buf, 4);                                   // Name size
-  write32(buf + 4, config->is64 ? 16 : 12);          // Content size
-  write32(buf + 8, NT_GNU_PROPERTY_TYPE_0);          // Type
-  memcpy(buf + 12, "GNU", 4);                        // Name string
-  write32(buf + 16, featureAndType);                 // Feature type
-  write32(buf + 20, 4);                              // Feature size
-  write32(buf + 24, config->andFeatures);            // Feature flags
+  write32(buf, 4);                          // Name size
+  write32(buf + 4, config->is64 ? 16 : 12); // Content size
+  write32(buf + 8, NT_GNU_PROPERTY_TYPE_0); // Type
+  memcpy(buf + 12, "GNU", 4);               // Name string
+  write32(buf + 16, featureAndType);        // Feature type
+  write32(buf + 20, 4);                     // Feature size
+  write32(buf + 24, config->andFeatures);   // Feature flags
   if (config->is64)
     write32(buf + 28, 0); // Padding
 }
@@ -336,10 +336,10 @@ BuildIdSection::BuildIdSection()
       hashSize(getHashSize()) {}
 
 void BuildIdSection::writeTo(uint8_t *buf) {
-  write32(buf, 4);                      // Name size
-  write32(buf + 4, hashSize);           // Content size
-  write32(buf + 8, NT_GNU_BUILD_ID);    // Type
-  memcpy(buf + 12, "GNU", 4);           // Name string
+  write32(buf, 4);                   // Name size
+  write32(buf + 4, hashSize);        // Content size
+  write32(buf + 8, NT_GNU_BUILD_ID); // Type
+  memcpy(buf + 12, "GNU", 4);        // Name string
   hashBuf = buf + 16;
 }
 
@@ -428,8 +428,7 @@ void EhFrameSection::addRecords(EhInputSection *sec, ArrayRef<RelTy> rels) {
   }
 }
 
-template <class ELFT>
-void EhFrameSection::addSectionAux(EhInputSection *sec) {
+template <class ELFT> void EhFrameSection::addSectionAux(EhInputSection *sec) {
   if (!sec->isLive())
     return;
   const RelsOrRelas<ELFT> rels = sec->template relsOrRelas<ELFT>();
@@ -860,7 +859,7 @@ void MipsGotSection::build() {
   // to `Local16` list. Preemptible symbol might become non-preemptible
   // one if, for example, it gets a related copy relocation.
   for (FileGot &got : gots) {
-    for (auto &p: got.global)
+    for (auto &p : got.global)
       if (!p.first->isPreemptible)
         got.local16.insert({{p.first, 0}, 0});
     got.global.remove_if([&](const std::pair<Symbol *, size_t> &p) {
@@ -953,15 +952,15 @@ void MipsGotSection::build() {
       p.second.firstIndex = index;
       index += p.second.count;
     }
-    for (auto &p: got.local16)
+    for (auto &p : got.local16)
       p.second = index++;
-    for (auto &p: got.global)
+    for (auto &p : got.global)
       p.second = index++;
-    for (auto &p: got.relocs)
+    for (auto &p : got.relocs)
       p.second = index++;
-    for (auto &p: got.tls)
+    for (auto &p : got.tls)
       p.second = index++;
-    for (auto &p: got.dynTlsSymbols) {
+    for (auto &p : got.dynTlsSymbols) {
       p.second = index;
       index += 2;
     }
@@ -1245,9 +1244,7 @@ void StringTableSection::writeTo(uint8_t *buf) {
 // Returns the number of entries in .gnu.version_d: the number of
 // non-VER_NDX_LOCAL-non-VER_NDX_GLOBAL definitions, plus 1.
 // Note that we don't support vd_cnt > 1 yet.
-static unsigned getVerDefNum() {
-  return namedVersionDefs().size() + 1;
-}
+static unsigned getVerDefNum() { return namedVersionDefs().size() + 1; }
 
 template <class ELFT>
 DynamicSection<ELFT>::DynamicSection()
@@ -1424,8 +1421,8 @@ DynamicSection<ELFT>::computeContents() {
       break;
     case EM_AARCH64:
       if (llvm::find_if(in.relaPlt->relocs, [](const DynamicReloc &r) {
-           return r.type == target->pltRel &&
-                  r.sym->stOther & STO_AARCH64_VARIANT_PCS;
+            return r.type == target->pltRel &&
+                   r.sym->stOther & STO_AARCH64_VARIANT_PCS;
           }) != in.relaPlt->relocs.end())
         addInt(DT_AARCH64_VARIANT_PCS, 0);
       addInSec(DT_PLTGOT, *in.gotPlt);
@@ -1451,7 +1448,8 @@ DynamicSection<ELFT>::computeContents() {
       addInt(DT_AARCH64_PAC_PLT, 0);
 
     if (hasMemtag()) {
-      addInt(DT_AARCH64_MEMTAG_MODE, config->androidMemtagMode == NT_MEMTAG_LEVEL_ASYNC);
+      addInt(DT_AARCH64_MEMTAG_MODE,
+             config->androidMemtagMode == NT_MEMTAG_LEVEL_ASYNC);
       addInt(DT_AARCH64_MEMTAG_HEAP, config->androidMemtagHeap);
       addInt(DT_AARCH64_MEMTAG_STACK, config->androidMemtagStack);
       if (mainPart->memtagGlobalDescriptors->isNeeded()) {
@@ -3449,7 +3447,8 @@ static bool isDuplicateArmExidxSec(InputSection *prev, InputSection *cur) {
   if (cur == nullptr)
     return prevUnwind == 1;
 
-  for (uint32_t offset = 4; offset < (uint32_t)cur->content().size(); offset +=8) {
+  for (uint32_t offset = 4; offset < (uint32_t)cur->content().size();
+       offset += 8) {
     uint32_t curUnwind = read32(cur->content().data() + offset);
     if (isExtabRef(curUnwind) || curUnwind != prevUnwind)
       return false;
@@ -3816,7 +3815,8 @@ size_t PartitionIndexSection::getSize() const {
 
 void PartitionIndexSection::finalizeContents() {
   for (size_t i = 1; i != partitions.size(); ++i)
-    partitions[i].nameStrTab = mainPart->dynStrTab->addString(partitions[i].name);
+    partitions[i].nameStrTab =
+        mainPart->dynStrTab->addString(partitions[i].name);
 }
 
 void PartitionIndexSection::writeTo(uint8_t *buf) {
@@ -3952,7 +3952,8 @@ createMemtagGlobalDescriptors(const SmallVector<const Symbol *, 0> &symbols,
     const uint64_t stepToEncode = ((addr - lastGlobalEnd) / kMemtagGranuleSize)
                                   << kMemtagStepSizeBits;
     if (sizeToEncode < (1 << kMemtagStepSizeBits)) {
-      sectionSize += computeOrWriteULEB128(stepToEncode | sizeToEncode, buf, sectionSize);
+      sectionSize +=
+          computeOrWriteULEB128(stepToEncode | sizeToEncode, buf, sectionSize);
     } else {
       sectionSize += computeOrWriteULEB128(stepToEncode, buf, sectionSize);
       sectionSize += computeOrWriteULEB128(sizeToEncode - 1, buf, sectionSize);

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -349,7 +349,7 @@ private:
   // Try to merge two GOTs. In case of success the `Dst` contains
   // result of merging and the function returns true. In case of
   // overflow the `Dst` is unchanged and the function returns false.
-  bool tryMergeGots(FileGot & dst, FileGot & src, bool isPrimary);
+  bool tryMergeGots(FileGot &dst, FileGot &src, bool isPrimary);
 };
 
 class GotPltSection final : public SyntheticSection {
@@ -910,8 +910,7 @@ public:
 // Elf_Verneed specifies the version requirements for a single DSO, and contains
 // a reference to a linked list of Elf_Vernaux data structures which define the
 // mapping from version identifiers to version names.
-template <class ELFT>
-class VersionNeedSection final : public SyntheticSection {
+template <class ELFT> class VersionNeedSection final : public SyntheticSection {
   using Elf_Verneed = typename ELFT::Verneed;
   using Elf_Vernaux = typename ELFT::Vernaux;
 
@@ -1271,13 +1270,9 @@ public:
   size_t getSize() const override;
   bool updateAllocSize() override;
 
-  void addSymbol(const Symbol &sym) {
-    symbols.push_back(&sym);
-  }
+  void addSymbol(const Symbol &sym) { symbols.push_back(&sym); }
 
-  bool isNeeded() const override {
-    return !symbols.empty();
-  }
+  bool isNeeded() const override { return !symbols.empty(); }
 
 private:
   SmallVector<const Symbol *, 0> symbols;

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -83,8 +83,7 @@ public:
                                                 uint8_t stOther) const;
 
   // Return true if we can reach dst from src with RelType type.
-  virtual bool inBranchRange(RelType type, uint64_t src,
-                             uint64_t dst) const;
+  virtual bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const;
 
   virtual void relocate(uint8_t *loc, const Relocation &rel,
                         uint64_t val) const = 0;

--- a/lld/ELF/Thunks.cpp
+++ b/lld/ELF/Thunks.cpp
@@ -265,8 +265,7 @@ public:
 
 class ThumbV4PILongThunk final : public ThumbThunk {
 public:
-  ThumbV4PILongThunk(Symbol &dest, int64_t addend)
-      : ThumbThunk(dest, addend) {}
+  ThumbV4PILongThunk(Symbol &dest, int64_t addend) : ThumbThunk(dest, addend) {}
 
   uint32_t sizeLong() override { return 20; }
   void writeLong(uint8_t *buf) override;
@@ -355,7 +354,8 @@ public:
   uint32_t size() override { return 16; }
   void writeTo(uint8_t *buf) override;
   void addSymbols(ThunkSection &isec) override;
-  bool isCompatibleWith(const InputSection &isec, const Relocation &rel) const override;
+  bool isCompatibleWith(const InputSection &isec,
+                        const Relocation &rel) const override;
 
 private:
   // Records the call site of the call stub.
@@ -534,10 +534,10 @@ void AArch64Thunk::writeTo(uint8_t *buf) {
 // AArch64 long range Thunks.
 void AArch64ABSLongThunk::writeLong(uint8_t *buf) {
   const uint8_t data[] = {
-    0x50, 0x00, 0x00, 0x58, //     ldr x16, L0
-    0x00, 0x02, 0x1f, 0xd6, //     br  x16
-    0x00, 0x00, 0x00, 0x00, // L0: .xword S
-    0x00, 0x00, 0x00, 0x00,
+      0x50, 0x00, 0x00, 0x58, //     ldr x16, L0
+      0x00, 0x02, 0x1f, 0xd6, //     br  x16
+      0x00, 0x00, 0x00, 0x00, // L0: .xword S
+      0x00, 0x00, 0x00, 0x00,
   };
   uint64_t s = getAArch64ThunkDestVA(destination, addend);
   memcpy(buf, data, sizeof(data));
@@ -663,7 +663,8 @@ bool ThumbThunk::isCompatibleWith(const InputSection &isec,
     return false;
 
   // ARM branch relocations can't use BLX
-  return rel.type != R_ARM_JUMP24 && rel.type != R_ARM_PC24 && rel.type != R_ARM_PLT32;
+  return rel.type != R_ARM_JUMP24 && rel.type != R_ARM_PC24 &&
+         rel.type != R_ARM_PLT32;
 }
 
 void ARMV7ABSLongThunk::writeLong(uint8_t *buf) {
@@ -699,10 +700,10 @@ void ThumbV7ABSLongThunk::addSymbols(ThunkSection &isec) {
 }
 
 void ARMV7PILongThunk::writeLong(uint8_t *buf) {
-  write32(buf + 0, 0xe30fcff0);   // P:  movw ip,:lower16:S - (P + (L1-P) + 8)
-  write32(buf + 4, 0xe340c000);   //     movt ip,:upper16:S - (P + (L1-P) + 8)
-  write32(buf + 8, 0xe08cc00f);   // L1: add  ip, ip, pc
-  write32(buf + 12, 0xe12fff1c);  //     bx   ip
+  write32(buf + 0, 0xe30fcff0);  // P:  movw ip,:lower16:S - (P + (L1-P) + 8)
+  write32(buf + 4, 0xe340c000);  //     movt ip,:upper16:S - (P + (L1-P) + 8)
+  write32(buf + 8, 0xe08cc00f);  // L1: add  ip, ip, pc
+  write32(buf + 12, 0xe12fff1c); //     bx   ip
   uint64_t s = getARMThunkDestVA(destination);
   uint64_t p = getThunkTargetSym()->getVA();
   int64_t offset = s - p - 16;
@@ -717,12 +718,12 @@ void ARMV7PILongThunk::addSymbols(ThunkSection &isec) {
 }
 
 void ThumbV7PILongThunk::writeLong(uint8_t *buf) {
-  write16(buf + 0, 0xf64f);   // P:  movw ip,:lower16:S - (P + (L1-P) + 4)
+  write16(buf + 0, 0xf64f); // P:  movw ip,:lower16:S - (P + (L1-P) + 4)
   write16(buf + 2, 0x7cf4);
-  write16(buf + 4, 0xf2c0);   //     movt ip,:upper16:S - (P + (L1-P) + 4)
+  write16(buf + 4, 0xf2c0); //     movt ip,:upper16:S - (P + (L1-P) + 4)
   write16(buf + 6, 0x0c00);
-  write16(buf + 8, 0x44fc);   // L1: add  ip, pc
-  write16(buf + 10, 0x4760);  //     bx   ip
+  write16(buf + 8, 0x44fc);  // L1: add  ip, pc
+  write16(buf + 10, 0x4760); //     bx   ip
   uint64_t s = getARMThunkDestVA(destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   int64_t offset = s - p - 12;
@@ -741,11 +742,11 @@ void ThumbV6MABSLongThunk::writeLong(uint8_t *buf) {
   // only register we can corrupt is r12 we must instead spill a low register
   // to the stack to use as a scratch register. We push r1 even though we
   // don't need to get some space to use for the return address.
-  write16(buf + 0, 0xb403);   // push {r0, r1} ; Obtain scratch registers
-  write16(buf + 2, 0x4801);   // ldr r0, [pc, #4] ; L1
-  write16(buf + 4, 0x9001);   // str r0, [sp, #4] ; SP + 4 = S
-  write16(buf + 6, 0xbd01);   // pop {r0, pc} ; restore r0 and branch to dest
-  write32(buf + 8, 0x00000000);   // L1: .word S
+  write16(buf + 0, 0xb403);     // push {r0, r1} ; Obtain scratch registers
+  write16(buf + 2, 0x4801);     // ldr r0, [pc, #4] ; L1
+  write16(buf + 4, 0x9001);     // str r0, [sp, #4] ; SP + 4 = S
+  write16(buf + 6, 0xbd01);     // pop {r0, pc} ; restore r0 and branch to dest
+  write32(buf + 8, 0x00000000); // L1: .word S
   uint64_t s = getARMThunkDestVA(destination);
   target->relocateNoSym(buf + 8, R_ARM_ABS32, s);
 }
@@ -790,13 +791,13 @@ void ThumbV6MPILongThunk::writeLong(uint8_t *buf) {
   // Most Thumb instructions cannot access the high registers r8 - r15. As the
   // only register we can corrupt is ip (r12) we must instead spill a low
   // register to the stack to use as a scratch register.
-  write16(buf + 0, 0xb401);   // P:  push {r0}        ; Obtain scratch register
-  write16(buf + 2, 0x4802);   //     ldr r0, [pc, #8] ; L2
-  write16(buf + 4, 0x4684);   //     mov ip, r0       ; high to low register
-  write16(buf + 6, 0xbc01);   //     pop {r0}         ; restore scratch register
-  write16(buf + 8, 0x44e7);   // L1: add pc, ip       ; transfer control
-  write16(buf + 10, 0x46c0);  //     nop              ; pad to 4-byte boundary
-  write32(buf + 12, 0x00000000);  // L2: .word S - (P + (L1 - P) + 4)
+  write16(buf + 0, 0xb401);  // P:  push {r0}        ; Obtain scratch register
+  write16(buf + 2, 0x4802);  //     ldr r0, [pc, #8] ; L2
+  write16(buf + 4, 0x4684);  //     mov ip, r0       ; high to low register
+  write16(buf + 6, 0xbc01);  //     pop {r0}         ; restore scratch register
+  write16(buf + 8, 0x44e7);  // L1: add pc, ip       ; transfer control
+  write16(buf + 10, 0x46c0); //     nop              ; pad to 4-byte boundary
+  write32(buf + 12, 0x00000000); // L2: .word S - (P + (L1 - P) + 4)
   uint64_t s = getARMThunkDestVA(destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 12, R_ARM_REL32, s - p - 12);
@@ -859,8 +860,8 @@ void ThumbV4ABSLongBXThunk::addSymbols(ThunkSection &isec) {
 void ThumbV4ABSLongThunk::writeLong(uint8_t *buf) {
   write16(buf + 0, 0x4778); // bx pc
   write16(buf + 2, 0xe7fd); // b #-6 ; Arm recommended sequence to follow bx pc
-  write32(buf + 4, 0xe59fc000); // ldr r12, [pc] ; L1
-  write32(buf + 8, 0xe12fff1c); // bx r12
+  write32(buf + 4, 0xe59fc000);  // ldr r12, [pc] ; L1
+  write32(buf + 8, 0xe12fff1c);  // bx r12
   write32(buf + 12, 0x00000000); // L1: .word S
   target->relocateNoSym(buf + 12, R_ARM_ABS32, getARMThunkDestVA(destination));
 }
@@ -875,9 +876,9 @@ void ThumbV4ABSLongThunk::addSymbols(ThunkSection &isec) {
 }
 
 void ARMV4PILongBXThunk::writeLong(uint8_t *buf) {
-  write32(buf + 0, 0xe59fc004); // P:  ldr ip, [pc,#4] ; L2
-  write32(buf + 4, 0xe08fc00c);	// L1: add ip, pc, ip
-  write32(buf + 8, 0xe12fff1c);	//     bx ip
+  write32(buf + 0, 0xe59fc004);  // P:  ldr ip, [pc,#4] ; L2
+  write32(buf + 4, 0xe08fc00c);  // L1: add ip, pc, ip
+  write32(buf + 8, 0xe12fff1c);  //     bx ip
   write32(buf + 12, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
   uint64_t s = getARMThunkDestVA(destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
@@ -911,9 +912,10 @@ void ARMV4PILongThunk::addSymbols(ThunkSection &isec) {
 
 void ThumbV4PILongBXThunk::writeLong(uint8_t *buf) {
   write16(buf + 0, 0x4778); // P:  bx pc
-  write16(buf + 2, 0xe7fd); //     b #-6 ; Arm recommended sequence to follow bx pc
-  write32(buf + 4, 0xe59fc000); //     ldr r12, [pc] ; L2
-  write32(buf + 8, 0xe08cf00f); // L1: add pc, r12, pc
+  write16(buf + 2,
+          0xe7fd); //     b #-6 ; Arm recommended sequence to follow bx pc
+  write32(buf + 4, 0xe59fc000);  //     ldr r12, [pc] ; L2
+  write32(buf + 8, 0xe08cf00f);  // L1: add pc, r12, pc
   write32(buf + 12, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
   uint64_t s = getARMThunkDestVA(destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
@@ -931,9 +933,10 @@ void ThumbV4PILongBXThunk::addSymbols(ThunkSection &isec) {
 
 void ThumbV4PILongThunk::writeLong(uint8_t *buf) {
   write16(buf + 0, 0x4778); // P:  bx pc
-  write16(buf + 2, 0xe7fd); //     b #-6 ; Arm recommended sequence to follow bx pc
-  write32(buf + 4, 0xe59fc004); //     ldr ip, [pc,#4] ; L2
-  write32(buf + 8, 0xe08fc00c); // L1: add ip, pc, ip
+  write16(buf + 2,
+          0xe7fd); //     b #-6 ; Arm recommended sequence to follow bx pc
+  write32(buf + 4, 0xe59fc004);  //     ldr ip, [pc,#4] ; L2
+  write32(buf + 8, 0xe08fc00c);  // L1: add ip, pc, ip
   write32(buf + 12, 0xe12fff1c); //     bx ip
   write32(buf + 16, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
   uint64_t s = getARMThunkDestVA(destination);
@@ -964,10 +967,10 @@ void AVRThunk::addSymbols(ThunkSection &isec) {
 // Write MIPS LA25 thunk code to call PIC function from the non-PIC one.
 void MipsThunk::writeTo(uint8_t *buf) {
   uint64_t s = destination.getVA();
-  write32(buf, 0x3c190000); // lui   $25, %hi(func)
+  write32(buf, 0x3c190000);                // lui   $25, %hi(func)
   write32(buf + 4, 0x08000000 | (s >> 2)); // j     func
-  write32(buf + 8, 0x27390000); // addiu $25, $25, %lo(func)
-  write32(buf + 12, 0x00000000); // nop
+  write32(buf + 8, 0x27390000);            // addiu $25, $25, %lo(func)
+  write32(buf + 12, 0x00000000);           // nop
   target->relocateNoSym(buf, R_MIPS_HI16, s);
   target->relocateNoSym(buf + 8, R_MIPS_LO16, s);
 }
@@ -986,10 +989,10 @@ InputSection *MipsThunk::getTargetInputSection() const {
 // to call PIC function from the non-PIC one.
 void MicroMipsThunk::writeTo(uint8_t *buf) {
   uint64_t s = destination.getVA();
-  write16(buf, 0x41b9);       // lui   $25, %hi(func)
-  write16(buf + 4, 0xd400);   // j     func
-  write16(buf + 8, 0x3339);   // addiu $25, $25, %lo(func)
-  write16(buf + 12, 0x0c00);  // nop
+  write16(buf, 0x41b9);      // lui   $25, %hi(func)
+  write16(buf + 4, 0xd400);  // j     func
+  write16(buf + 8, 0x3339);  // addiu $25, $25, %lo(func)
+  write16(buf + 12, 0x0c00); // nop
   target->relocateNoSym(buf, R_MICROMIPS_HI16, s);
   target->relocateNoSym(buf + 4, R_MICROMIPS_26_S1, s);
   target->relocateNoSym(buf + 8, R_MICROMIPS_LO16, s);
@@ -1012,9 +1015,9 @@ InputSection *MicroMipsThunk::getTargetInputSection() const {
 void MicroMipsR6Thunk::writeTo(uint8_t *buf) {
   uint64_t s = destination.getVA();
   uint64_t p = getThunkTargetSym()->getVA();
-  write16(buf, 0x1320);       // lui   $25, %hi(func)
-  write16(buf + 4, 0x3339);   // addiu $25, $25, %lo(func)
-  write16(buf + 8, 0x9400);   // bc    func
+  write16(buf, 0x1320);     // lui   $25, %hi(func)
+  write16(buf + 4, 0x3339); // addiu $25, $25, %lo(func)
+  write16(buf + 8, 0x9400); // bc    func
   target->relocateNoSym(buf, R_MICROMIPS_HI16, s);
   target->relocateNoSym(buf + 4, R_MICROMIPS_LO16, s);
   target->relocateNoSym(buf + 8, R_MICROMIPS_PC26_S1, s - p - 12);
@@ -1110,12 +1113,12 @@ void PPC32LongThunk::writeTo(uint8_t *buf) {
     write32(buf + 20, 0x7c0803a6);           // mtlr r0
     buf += 24;
   } else {
-    write32(buf + 0, 0x3d800000 | ha(d));    // lis r12,d@ha
-    write32(buf + 4, 0x398c0000 | lo(d));    // addi r12,r12,d@l
+    write32(buf + 0, 0x3d800000 | ha(d)); // lis r12,d@ha
+    write32(buf + 4, 0x398c0000 | lo(d)); // addi r12,r12,d@l
     buf += 8;
   }
-  write32(buf + 0, 0x7d8903a6);              // mtctr r12
-  write32(buf + 4, 0x4e800420);              // bctr
+  write32(buf + 0, 0x7d8903a6); // mtctr r12
+  write32(buf + 4, 0x4e800420); // bctr
 }
 
 void elf::writePPC64LoadAndBranch(uint8_t *buf, int64_t offset) {
@@ -1205,12 +1208,12 @@ void PPC64R12SetupStub::writeTo(uint8_t *buf) {
     nextInstOffset = 8;
   } else {
     uint32_t off = offset - 8;
-    write32(buf + 0, 0x7d8802a6);                     // mflr 12
-    write32(buf + 4, 0x429f0005);                     // bcl 20,31,.+4
-    write32(buf + 8, 0x7d6802a6);                     // mflr 11
-    write32(buf + 12, 0x7d8803a6);                    // mtlr 12
+    write32(buf + 0, 0x7d8802a6);  // mflr 12
+    write32(buf + 4, 0x429f0005);  // bcl 20,31,.+4
+    write32(buf + 8, 0x7d6802a6);  // mflr 11
+    write32(buf + 12, 0x7d8803a6); // mtlr 12
     write32(buf + 16,
-            0x3d8b0000 | ((off + 0x8000) >> 16));     // addis 12,11,off@ha
+            0x3d8b0000 | ((off + 0x8000) >> 16)); // addis 12,11,off@ha
     if (gotPlt)
       write32(buf + 20, 0xe98c0000 | (off & 0xffff)); // ld 12, off@l(12)
     else

--- a/lld/ELF/Thunks.h
+++ b/lld/ELF/Thunks.h
@@ -9,8 +9,8 @@
 #ifndef LLD_ELF_THUNKS_H
 #define LLD_ELF_THUNKS_H
 
-#include "llvm/ADT/SmallVector.h"
 #include "Relocations.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace lld::elf {
 class Defined;

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -95,9 +95,7 @@ static bool needsInterpSection() {
          !config->dynamicLinker.empty() && script->needsInterpSection();
 }
 
-template <class ELFT> void elf::writeResult() {
-  Writer<ELFT>().run();
-}
+template <class ELFT> void elf::writeResult() { Writer<ELFT>().run(); }
 
 static void removeEmptyPTLoad(SmallVector<PhdrEntry *, 0> &phdrs) {
   auto it = std::stable_partition(
@@ -517,8 +515,9 @@ template <class ELFT> void elf::createSyntheticSections() {
   add(*in.igotPlt);
   // Add .relro_padding if DATA_SEGMENT_RELRO_END is used; otherwise, add the
   // section in the absence of PHDRS/SECTIONS commands.
-  if (config->zRelro && ((script->phdrsCommands.empty() &&
-        !script->hasSectionsCommand) || script->seenRelroEnd)) {
+  if (config->zRelro &&
+      ((script->phdrsCommands.empty() && !script->hasSectionsCommand) ||
+       script->seenRelroEnd)) {
     in.relroPadding = std::make_unique<RelroPaddingSection>();
     add(*in.relroPadding);
   }
@@ -1071,12 +1070,12 @@ template <class ELFT> void Writer<ELFT>::addRelIpltSymbols() {
   // We'll override Out::elfHeader with In.relaIplt later when we are
   // sure that .rela.plt exists in output.
   ElfSym::relaIpltStart = addOptionalRegular(
-      config->isRela ? "__rela_iplt_start" : "__rel_iplt_start",
-      Out::elfHeader, 0, STV_HIDDEN);
+      config->isRela ? "__rela_iplt_start" : "__rel_iplt_start", Out::elfHeader,
+      0, STV_HIDDEN);
 
-  ElfSym::relaIpltEnd = addOptionalRegular(
-      config->isRela ? "__rela_iplt_end" : "__rel_iplt_end",
-      Out::elfHeader, 0, STV_HIDDEN);
+  ElfSym::relaIpltEnd =
+      addOptionalRegular(config->isRela ? "__rela_iplt_end" : "__rel_iplt_end",
+                         Out::elfHeader, 0, STV_HIDDEN);
 }
 
 // This function generates assignments for predefined symbols (e.g. _end or
@@ -1940,8 +1939,8 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
       ElfSym::riscvGlobalPointer = nullptr;
       if (!config->shared) {
         OutputSection *sec = findSection(".sdata");
-        addOptionalRegular(
-            "__global_pointer$", sec ? sec : Out::elfHeader, 0x800, STV_DEFAULT);
+        addOptionalRegular("__global_pointer$", sec ? sec : Out::elfHeader,
+                           0x800, STV_DEFAULT);
         // Set riscvGlobalPointer to be used by the optional global pointer
         // relaxation.
         if (config->relaxGP) {
@@ -2279,9 +2278,10 @@ template <class ELFT> void Writer<ELFT>::checkExecuteOnly() {
     if (osec->flags & SHF_EXECINSTR)
       for (InputSection *isec : getInputSections(*osec, storage))
         if (!(isec->flags & SHF_EXECINSTR))
-          error("cannot place " + toString(isec) + " into " +
-                toString(osec->name) +
-                ": --execute-only does not support intermingling data and code");
+          error(
+              "cannot place " + toString(isec) + " into " +
+              toString(osec->name) +
+              ": --execute-only does not support intermingling data and code");
 }
 
 // The linker is expected to define SECNAME_start and SECNAME_end
@@ -2638,13 +2638,12 @@ static uint64_t computeFileOffset(OutputSection *os, uint64_t off) {
   // File offsets are not significant for .bss sections other than the first one
   // in a PT_LOAD/PT_TLS. By convention, we keep section offsets monotonically
   // increasing rather than setting to zero.
-  if (os->type == SHT_NOBITS &&
-      (!Out::tlsPhdr || Out::tlsPhdr->firstSec != os))
-     return off;
+  if (os->type == SHT_NOBITS && (!Out::tlsPhdr || Out::tlsPhdr->firstSec != os))
+    return off;
 
   // If the section is not in a PT_LOAD, we just have to align it.
   if (!os->ptLoad)
-     return alignToPowerOf2(off, os->addralign);
+    return alignToPowerOf2(off, os->addralign);
 
   // If two sections share the same PT_LOAD the file offset is calculated
   // using this formula: Off2 = Off1 + (VA2 - VA1).

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -184,11 +184,10 @@ uint64_t TextOutputSection::estimateStubsInRangeVA(size_t callIdx) const {
   uint64_t stubsInRangeVA = isecEnd + maxPotentialThunks * target->thunkSize +
                             in.stubs->getSize() - forwardBranchRange;
   log("thunks = " + std::to_string(thunkMap.size()) +
-      ", potential = " + std::to_string(maxPotentialThunks) +
-      ", stubs = " + std::to_string(in.stubs->getSize()) + ", isecVA = " +
-      utohexstr(isecVA) + ", threshold = " + utohexstr(stubsInRangeVA) +
-      ", isecEnd = " + utohexstr(isecEnd) +
-      ", tail = " + utohexstr(isecEnd - isecVA) +
+      ", potential = " + std::to_string(maxPotentialThunks) + ", stubs = " +
+      std::to_string(in.stubs->getSize()) + ", isecVA = " + utohexstr(isecVA) +
+      ", threshold = " + utohexstr(stubsInRangeVA) + ", isecEnd = " +
+      utohexstr(isecEnd) + ", tail = " + utohexstr(isecEnd - isecVA) +
       ", slop = " + utohexstr(forwardBranchRange - (isecEnd - isecVA)));
   return stubsInRangeVA;
 }

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -321,15 +321,15 @@ static InputFile *addFile(StringRef path, LoadType loadType,
         for (const object::Archive::Child &c : file->getArchive().children(e)) {
           StringRef reason;
           switch (loadType) {
-            case LoadType::LCLinkerOption:
-              reason = "LC_LINKER_OPTION";
-              break;
-            case LoadType::CommandLineForce:
-              reason = "-force_load";
-              break;
-            case LoadType::CommandLine:
-              reason = "-all_load";
-              break;
+          case LoadType::LCLinkerOption:
+            reason = "LC_LINKER_OPTION";
+            break;
+          case LoadType::CommandLineForce:
+            reason = "-force_load";
+            break;
+          case LoadType::CommandLine:
+            reason = "-all_load";
+            break;
           }
           if (Error e = file->fetch(c, reason))
             error(toString(file) + ": " + reason +

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -857,7 +857,7 @@ void ObjFile::parseSymbols(ArrayRef<typename LP::section> sectionHeaders,
     }
     sections[i]->doneSplitting = true;
 
-    auto getSymName = [strtab](const NList& sym) -> StringRef {
+    auto getSymName = [strtab](const NList &sym) -> StringRef {
       return StringRef(strtab + sym.n_strx);
     };
 
@@ -871,7 +871,8 @@ void ObjFile::parseSymbols(ArrayRef<typename LP::section> sectionHeaders,
       // SymbolTable::addDefined() for details.
       if (nList[lhs].n_value == nList[rhs].n_value &&
           nList[lhs].n_type & N_EXT && nList[rhs].n_type & N_EXT)
-        return !(nList[lhs].n_desc & N_WEAK_DEF) && (nList[rhs].n_desc & N_WEAK_DEF);
+        return !(nList[lhs].n_desc & N_WEAK_DEF) &&
+               (nList[rhs].n_desc & N_WEAK_DEF);
       return nList[lhs].n_value < nList[rhs].n_value;
     });
     for (size_t j = 0; j < symbolIndices.size(); ++j) {
@@ -1406,7 +1407,7 @@ void ObjFile::registerEhFrames(Section &ehFrameSection) {
       fatal("found symbol at unexpected offset in __eh_frame");
 
     EhReader reader(this, isec->data, subsec.offset);
-    size_t dataOff = 0; // Offset from the start of the EH frame.
+    size_t dataOff = 0;               // Offset from the start of the EH frame.
     reader.skipValidLength(&dataOff); // readLength() already validated this.
     // cieOffOff is the offset from the start of the EH frame to the cieOff
     // value, which is itself an offset from the current PC to a CIE.
@@ -1675,7 +1676,7 @@ static bool isImplicitlyLinked(StringRef path) {
 }
 
 void DylibFile::loadReexport(StringRef path, DylibFile *umbrella,
-                         const InterfaceFile *currentTopLevelTapi) {
+                             const InterfaceFile *currentTopLevelTapi) {
   DylibFile *reexport = findDylib(path, umbrella, currentTopLevelTapi);
   if (!reexport)
     error(toString(this) + ": unable to locate re-export with install name " +
@@ -2107,8 +2108,8 @@ void DylibFile::handleLDHideSymbol(StringRef name, StringRef originalName) {
     std::tie(minVersion, symbolName) = name.split('$');
     VersionTuple versionTup;
     if (versionTup.tryParse(minVersion)) {
-      warn(toString(this) + ": failed to parse hidden version, symbol `" + originalName +
-           "` ignored.");
+      warn(toString(this) + ": failed to parse hidden version, symbol `" +
+           originalName + "` ignored.");
       return;
     }
     shouldHide = versionTup == config->platformInfo.target.MinDeployment;

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -225,7 +225,7 @@ void ObjcCategoryChecker::parseMethods(const ConcatInputSection *methodsIsec,
     } else {
       assert(mc.kind == MCK_Class);
       const auto *roIsec = mc.isec->getRelocAt(classLayout.roDataOffset)
-                         ->getReferentInputSection();
+                               ->getReferentInputSection();
       nameReloc = roIsec->getRelocAt(roClassLayout.nameOffset);
     }
     StringRef containerName = getReferentString(*nameReloc);

--- a/lld/MachO/Relocations.h
+++ b/lld/MachO/Relocations.h
@@ -119,6 +119,6 @@ InputSection *offsetToInputSection(uint64_t *);
 
 extern const RelocAttrs invalidRelocAttrs;
 
-} // namespace lld::Macho
+} // namespace lld::macho
 
 #endif

--- a/lld/MachO/Symbols.h
+++ b/lld/MachO/Symbols.h
@@ -296,6 +296,7 @@ public:
   }
 
   bool shouldReexport : 1;
+
 private:
   RefState refState : 2;
   const bool weakDef : 1;

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1822,18 +1822,18 @@ ObjCImageInfoSection::parseImageInfo(const InputFile *file) {
 
 static std::string swiftVersionString(uint8_t version) {
   switch (version) {
-    case 1:
-      return "1.0";
-    case 2:
-      return "1.1";
-    case 3:
-      return "2.0";
-    case 4:
-      return "3.0";
-    case 5:
-      return "4.0";
-    default:
-      return ("0x" + Twine::utohexstr(version)).str();
+  case 1:
+    return "1.0";
+  case 2:
+    return "1.1";
+  case 3:
+    return "2.0";
+  case 4:
+    return "3.0";
+  case 5:
+    return "4.0";
+  default:
+    return ("0x" + Twine::utohexstr(version)).str();
   }
 }
 

--- a/lld/include/lld/Common/ErrorHandler.h
+++ b/lld/include/lld/Common/ErrorHandler.h
@@ -78,7 +78,7 @@
 namespace llvm {
 class DiagnosticInfo;
 class raw_ostream;
-}
+} // namespace llvm
 
 namespace lld {
 

--- a/lld/include/lld/Common/LLVM.h
+++ b/lld/include/lld/Common/LLVM.h
@@ -70,12 +70,12 @@ using llvm::isa;
 
 // ADT's.
 using llvm::ArrayRef;
-using llvm::MutableArrayRef;
 using llvm::Error;
 using llvm::ErrorOr;
 using llvm::Expected;
 using llvm::MemoryBuffer;
 using llvm::MemoryBufferRef;
+using llvm::MutableArrayRef;
 using llvm::raw_ostream;
 using llvm::SmallString;
 using llvm::SmallVector;

--- a/lld/include/lld/Common/Memory.h
+++ b/lld/include/lld/Common/Memory.h
@@ -57,7 +57,7 @@ inline llvm::SpecificBumpPtrAllocator<T> &getSpecificAllocSingleton() {
 
 // Creates new instances of T off a (almost) contiguous arena/object pool. The
 // instances are destroyed whenever lldMain() goes out of scope.
-template <typename T, typename... U> T *make(U &&... args) {
+template <typename T, typename... U> T *make(U &&...args) {
   return new (getSpecificAllocSingleton<T>().Allocate())
       T(std::forward<U>(args)...);
 }

--- a/lld/include/lld/Common/Reproduce.h
+++ b/lld/include/lld/Common/Reproduce.h
@@ -14,8 +14,10 @@
 #include "llvm/Support/Error.h"
 
 namespace llvm {
-namespace opt { class Arg; }
+namespace opt {
+class Arg;
 }
+} // namespace llvm
 
 namespace lld {
 
@@ -29,6 +31,6 @@ std::string quote(StringRef s);
 
 // Returns the string form of the given argument.
 std::string toString(const llvm::opt::Arg &arg);
-}
+} // namespace lld
 
 #endif

--- a/lld/include/lld/Common/TargetOptionsCommandFlags.h
+++ b/lld/include/lld/Common/TargetOptionsCommandFlags.h
@@ -23,6 +23,6 @@ std::optional<llvm::Reloc::Model> getRelocModelFromCMModel();
 std::optional<llvm::CodeModel::Model> getCodeModelFromCMModel();
 std::string getCPUStr();
 std::vector<std::string> getMAttrs();
-}
+} // namespace lld
 
 #endif

--- a/lld/include/lld/Common/Version.h
+++ b/lld/include/lld/Common/Version.h
@@ -19,6 +19,6 @@
 namespace lld {
 /// Retrieves a string representing the complete lld version.
 std::string getLLDVersion();
-}
+} // namespace lld
 
 #endif // LLD_VERSION_H

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -484,8 +484,7 @@ static void readConfigs(opt::InputArgList &args) {
   }
 
   if (args.hasArg(OPT_export_memory_with_name)) {
-    config->memoryExport =
-        args.getLastArgValue(OPT_export_memory_with_name);
+    config->memoryExport = args.getLastArgValue(OPT_export_memory_with_name);
   } else if (args.hasArg(OPT_export_memory)) {
     config->memoryExport = memoryName;
   } else {
@@ -639,8 +638,8 @@ static void setConfigs() {
       error("--export-memory is incompatible with --shared");
     }
     if (!config->memoryImport.has_value()) {
-      config->memoryImport =
-          std::pair<llvm::StringRef, llvm::StringRef>(defaultModule, memoryName);
+      config->memoryImport = std::pair<llvm::StringRef, llvm::StringRef>(
+          defaultModule, memoryName);
     }
   }
 
@@ -779,7 +778,7 @@ static void writeWhyExtract() {
 // Equivalent of demote demoteSharedAndLazySymbols() in the ELF linker
 static void demoteLazySymbols() {
   for (Symbol *sym : symtab->symbols()) {
-    if (auto* s = dyn_cast<LazySymbol>(sym)) {
+    if (auto *s = dyn_cast<LazySymbol>(sym)) {
       if (s->signature) {
         LLVM_DEBUG(llvm::dbgs()
                    << "demoting lazy func: " << s->getName() << "\n");
@@ -873,9 +872,8 @@ static void createSyntheticSymbols() {
     WasmSym::tlsAlign = createGlobalVariable("__tls_align", false);
     WasmSym::initTLS = symtab->addSyntheticFunction(
         "__wasm_init_tls", WASM_SYMBOL_VISIBILITY_HIDDEN,
-        make<SyntheticFunction>(
-            is64 ? i64ArgSignature : i32ArgSignature,
-            "__wasm_init_tls"));
+        make<SyntheticFunction>(is64 ? i64ArgSignature : i32ArgSignature,
+                                "__wasm_init_tls"));
   }
 
   if (ctx.isPic ||
@@ -930,15 +928,15 @@ static void processStubLibrariesPreLTO() {
   for (auto &stub_file : ctx.stubFiles) {
     LLVM_DEBUG(llvm::dbgs()
                << "processing stub file: " << stub_file->getName() << "\n");
-    for (auto [name, deps]: stub_file->symbolDependencies) {
-      auto* sym = symtab->find(name);
+    for (auto [name, deps] : stub_file->symbolDependencies) {
+      auto *sym = symtab->find(name);
       // If the symbol is not present at all (yet), or if it is present but
       // undefined, then mark the dependent symbols as used by a regular
       // object so they will be preserved and exported by the LTO process.
       if (!sym || sym->isUndefined()) {
         for (const auto dep : deps) {
-          auto* needed = symtab->find(dep);
-          if (needed ) {
+          auto *needed = symtab->find(dep);
+          if (needed) {
             needed->isUsedInRegularObj = true;
           }
         }
@@ -955,19 +953,20 @@ static void processStubLibraries() {
     for (auto &stub_file : ctx.stubFiles) {
       LLVM_DEBUG(llvm::dbgs()
                  << "processing stub file: " << stub_file->getName() << "\n");
-      for (auto [name, deps]: stub_file->symbolDependencies) {
-        auto* sym = symtab->find(name);
+      for (auto [name, deps] : stub_file->symbolDependencies) {
+        auto *sym = symtab->find(name);
         if (!sym || !sym->isUndefined()) {
           if (sym && sym->traced)
             message(toString(stub_file) + ": stub symbol not needed: " + name);
           else
-            LLVM_DEBUG(llvm::dbgs() << "stub symbol not needed: `" << name << "`\n");
+            LLVM_DEBUG(llvm::dbgs()
+                       << "stub symbol not needed: `" << name << "`\n");
           continue;
         }
         // The first stub library to define a given symbol sets this and
         // definitions in later stub libraries are ignored.
         if (sym->forceImport)
-          continue;  // Already handled
+          continue; // Already handled
         sym->forceImport = true;
         if (sym->traced)
           message(toString(stub_file) + ": importing " + name);
@@ -975,14 +974,13 @@ static void processStubLibraries() {
           LLVM_DEBUG(llvm::dbgs()
                      << toString(stub_file) << ": importing " << name << "\n");
         for (const auto dep : deps) {
-          auto* needed = symtab->find(dep);
+          auto *needed = symtab->find(dep);
           if (!needed) {
             error(toString(stub_file) + ": undefined symbol: " + dep +
                   ". Required by " + toString(*sym));
           } else if (needed->isUndefined()) {
-            error(toString(stub_file) +
-                  ": undefined symbol: " + toString(*needed) +
-                  ". Required by " + toString(*sym));
+            error(toString(stub_file) + ": undefined symbol: " +
+                  toString(*needed) + ". Required by " + toString(*sym));
           } else {
             if (needed->traced)
               message(toString(stub_file) + ": exported " + toString(*needed) +

--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -366,10 +366,9 @@ void InputChunk::generateRelocationCode(raw_ostream &os) const {
                     << " count=" << relocations.size() << "\n");
 
   bool is64 = config->is64.value_or(false);
-  unsigned opcode_ptr_const = is64 ? WASM_OPCODE_I64_CONST
-                                   : WASM_OPCODE_I32_CONST;
-  unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD
-                                 : WASM_OPCODE_I32_ADD;
+  unsigned opcode_ptr_const =
+      is64 ? WASM_OPCODE_I64_CONST : WASM_OPCODE_I32_CONST;
+  unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD : WASM_OPCODE_I32_ADD;
 
   uint64_t tombstone = getTombstone();
   // TODO(sbc): Encode the relocations in the data section and write a loop
@@ -418,7 +417,7 @@ void InputChunk::generateRelocationCode(raw_ostream &os) const {
       }
     } else {
       assert(ctx.isPic);
-      const GlobalSymbol* baseSymbol = WasmSym::memoryBase;
+      const GlobalSymbol *baseSymbol = WasmSym::memoryBase;
       if (rel.Type == R_WASM_TABLE_INDEX_I32 ||
           rel.Type == R_WASM_TABLE_INDEX_I64)
         baseSymbol = WasmSym::tableBase;
@@ -519,17 +518,17 @@ uint64_t InputSection::getTombstoneForSection(StringRef name) {
   // If they occur in DWARF debug symbols, we want to change the pc of the
   // function to -1 to avoid overlapping with a valid range. However for the
   // debug_ranges and debug_loc sections that would conflict with the existing
-  // meaning of -1 so we use -2.  
+  // meaning of -1 so we use -2.
   if (name.equals(".debug_ranges") || name.equals(".debug_loc"))
     return UINT64_C(-2);
   if (name.starts_with(".debug_"))
     return UINT64_C(-1);
-  // If the function occurs in an function attribute section change it to -1 since
-  // 0 is a valid function index.
+  // If the function occurs in an function attribute section change it to -1
+  // since 0 is a valid function index.
   if (name.starts_with("llvm.func_attr."))
     return UINT64_C(-1);
-  // Returning 0 means there is no tombstone value for this section, and relocation
-  // will just use the addend.
+  // Returning 0 means there is no tombstone value for this section, and
+  // relocation will just use the addend.
   return 0;
 }
 

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -135,7 +135,7 @@ int64_t ObjFile::calcNewAddend(const WasmRelocation &reloc) const {
 // Translate from the relocation's index into the final linked output value.
 uint64_t ObjFile::calcNewValue(const WasmRelocation &reloc, uint64_t tombstone,
                                const InputChunk *chunk) const {
-  const Symbol* sym = nullptr;
+  const Symbol *sym = nullptr;
   if (reloc.Type != R_WASM_TYPE_INDEX_LEB) {
     sym = symbols[reloc.Index];
 
@@ -497,7 +497,6 @@ void ObjFile::parse(bool ignoreComdats) {
   typeMap.resize(getWasmObj()->types().size());
   typeIsUsed.resize(getWasmObj()->types().size(), false);
 
-
   // Populate `Segments`.
   for (const WasmSegment &s : wasmObj->dataSegments()) {
     InputChunk *seg;
@@ -819,7 +818,8 @@ void BitcodeFile::parseLazy() {
 
 void BitcodeFile::parse(StringRef symName) {
   if (doneLTO) {
-    error(toString(this) + ": attempt to add bitcode file after LTO (" + symName + ")");
+    error(toString(this) + ": attempt to add bitcode file after LTO (" +
+          symName + ")");
     return;
   }
 

--- a/lld/wasm/LTO.cpp
+++ b/lld/wasm/LTO.cpp
@@ -66,7 +66,7 @@ static std::unique_ptr<lto::LTO> createLTO() {
   lto::ThinBackend backend = lto::createInProcessThinBackend(
       llvm::heavyweight_hardware_concurrency(config->thinLTOJobs));
   return std::make_unique<lto::LTO>(std::move(c), backend,
-                                     config->ltoPartitions);
+                                    config->ltoPartitions);
 }
 
 BitcodeCompiler::BitcodeCompiler() : ltoObj(createLTO()) {}

--- a/lld/wasm/LTO.h
+++ b/lld/wasm/LTO.h
@@ -20,9 +20,9 @@
 #ifndef LLD_WASM_LTO_H
 #define LLD_WASM_LTO_H
 
+#include "Writer.h"
 #include "lld/Common/LLVM.h"
 #include "llvm/ADT/SmallString.h"
-#include "Writer.h"
 #include <memory>
 #include <vector>
 

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -31,7 +31,7 @@ static bool requiresGOTAccess(const Symbol *sym) {
   return true;
 }
 
-static bool allowUndefined(const Symbol* sym) {
+static bool allowUndefined(const Symbol *sym) {
   // Symbols that are explicitly imported are always allowed to be undefined at
   // link time.
   if (sym->isImported())

--- a/lld/wasm/SymbolTable.cpp
+++ b/lld/wasm/SymbolTable.cpp
@@ -100,7 +100,7 @@ Symbol *SymbolTable::find(StringRef name) {
   return symVector[it->second];
 }
 
-void SymbolTable::replace(StringRef name, Symbol* sym) {
+void SymbolTable::replace(StringRef name, Symbol *sym) {
   auto it = symMap.find(CachedHashStringRef(name));
   symVector[it->second] = sym;
 }
@@ -223,8 +223,8 @@ DefinedFunction *SymbolTable::addSyntheticFunction(StringRef name,
   LLVM_DEBUG(dbgs() << "addSyntheticFunction: " << name << "\n");
   assert(!find(name));
   ctx.syntheticFunctions.emplace_back(function);
-  return replaceSymbol<DefinedFunction>(insertName(name).first, name,
-                                        flags, nullptr, function);
+  return replaceSymbol<DefinedFunction>(insertName(name).first, name, flags,
+                                        nullptr, function);
 }
 
 // Adds an optional, linker generated, data symbol.  The symbol will only be
@@ -330,7 +330,8 @@ Symbol *SymbolTable::addDefinedFunction(StringRef name, uint32_t flags,
     // If the new defined function doesn't have signature (i.e. bitcode
     // functions) but the old symbol does, then preserve the old signature
     const WasmSignature *oldSig = s->getSignature();
-    auto* newSym = replaceSymbol<DefinedFunction>(sym, name, flags, file, function);
+    auto *newSym =
+        replaceSymbol<DefinedFunction>(sym, name, flags, file, function);
     if (!newSym->signature)
       newSym->signature = oldSig;
   };
@@ -350,8 +351,9 @@ Symbol *SymbolTable::addDefinedFunction(StringRef name, uint32_t flags,
   if (auto ud = dyn_cast<UndefinedFunction>(existingFunction))
     checkSig = ud->isCalledDirectly;
 
-  if (checkSig && function && !signatureMatches(existingFunction, &function->signature)) {
-    Symbol* variant;
+  if (checkSig && function &&
+      !signatureMatches(existingFunction, &function->signature)) {
+    Symbol *variant;
     if (getFunctionVariant(s, &function->signature, file, &variant))
       // New variant, always replace
       replaceSym(variant);
@@ -786,7 +788,7 @@ bool SymbolTable::addComdat(StringRef name) {
 // The new signature doesn't match.  Create a variant to the symbol with the
 // signature encoded in the name and return that instead.  These symbols are
 // then unified later in handleSymbolVariants.
-bool SymbolTable::getFunctionVariant(Symbol* sym, const WasmSignature *sig,
+bool SymbolTable::getFunctionVariant(Symbol *sym, const WasmSignature *sig,
                                      const InputFile *file, Symbol **out) {
   LLVM_DEBUG(dbgs() << "getFunctionVariant: " << sym->getName() << " -> "
                     << " " << toString(*sig) << "\n");
@@ -798,7 +800,7 @@ bool SymbolTable::getFunctionVariant(Symbol* sym, const WasmSignature *sig,
   if (variants.empty())
     variants.push_back(sym);
 
-  for (Symbol* v : variants) {
+  for (Symbol *v : variants) {
     if (*v->getSignature() == *sig) {
       variant = v;
       break;
@@ -817,7 +819,8 @@ bool SymbolTable::getFunctionVariant(Symbol* sym, const WasmSignature *sig,
     variant->forceExport = false;
     variants.push_back(variant);
   } else {
-    LLVM_DEBUG(dbgs() << "variant already exists: " << toString(*variant) << "\n");
+    LLVM_DEBUG(dbgs() << "variant already exists: " << toString(*variant)
+                      << "\n");
     assert(*variant->getSignature() == *sig);
   }
 
@@ -834,7 +837,7 @@ void SymbolTable::trace(StringRef name) {
 void SymbolTable::wrap(Symbol *sym, Symbol *real, Symbol *wrap) {
   // Swap symbols as instructed by -wrap.
   int &origIdx = symMap[CachedHashStringRef(sym->getName())];
-  int &realIdx= symMap[CachedHashStringRef(real->getName())];
+  int &realIdx = symMap[CachedHashStringRef(real->getName())];
   int &wrapIdx = symMap[CachedHashStringRef(wrap->getName())];
   LLVM_DEBUG(dbgs() << "wrap: " << sym->getName() << "\n");
 
@@ -940,7 +943,7 @@ void SymbolTable::handleSymbolVariants() {
 #ifndef NDEBUG
     LLVM_DEBUG(dbgs() << "symbol with (" << variants.size()
                       << ") variants: " << symName << "\n");
-    for (auto *s: variants) {
+    for (auto *s : variants) {
       auto *f = cast<FunctionSymbol>(s);
       LLVM_DEBUG(dbgs() << " variant: " + f->getName() << " "
                         << toString(*f->signature) << "\n");
@@ -978,4 +981,4 @@ void SymbolTable::handleSymbolVariants() {
   }
 }
 
-} // namespace wasm::lld
+} // namespace lld::wasm

--- a/lld/wasm/SymbolTable.h
+++ b/lld/wasm/SymbolTable.h
@@ -46,7 +46,7 @@ public:
 
   Symbol *find(StringRef name);
 
-  void replace(StringRef name, Symbol* sym);
+  void replace(StringRef name, Symbol *sym);
 
   void trace(StringRef name);
 
@@ -105,7 +105,7 @@ private:
   std::pair<Symbol *, bool> insert(StringRef name, const InputFile *file);
   std::pair<Symbol *, bool> insertName(StringRef name);
 
-  bool getFunctionVariant(Symbol* sym, const WasmSignature *sig,
+  bool getFunctionVariant(Symbol *sym, const WasmSignature *sig,
                           const InputFile *file, Symbol **out);
   InputFunction *replaceWithUnreachable(Symbol *sym, const WasmSignature &sig,
                                         StringRef debugName);

--- a/lld/wasm/Symbols.cpp
+++ b/lld/wasm/Symbols.cpp
@@ -119,7 +119,7 @@ WasmSymbolType Symbol::getWasmType() const {
 }
 
 const WasmSignature *Symbol::getSignature() const {
-  if (auto* f = dyn_cast<FunctionSymbol>(this))
+  if (auto *f = dyn_cast<FunctionSymbol>(this))
     return f->signature;
   if (auto *t = dyn_cast<TagSymbol>(this))
     return t->signature;
@@ -246,9 +246,7 @@ bool Symbol::isExportedExplicit() const {
   return forceExport || flags & WASM_SYMBOL_EXPORTED;
 }
 
-bool Symbol::isNoStrip() const {
-  return flags & WASM_SYMBOL_NO_STRIP;
-}
+bool Symbol::isNoStrip() const { return flags & WASM_SYMBOL_NO_STRIP; }
 
 uint32_t FunctionSymbol::getFunctionIndex() const {
   if (const auto *u = dyn_cast<UndefinedFunction>(this))
@@ -437,7 +435,7 @@ void LazySymbol::setWeak() {
   flags |= (flags & ~WASM_SYMBOL_BINDING_MASK) | WASM_SYMBOL_BINDING_WEAK;
 }
 
-void printTraceSymbolUndefined(StringRef name, const InputFile* file) {
+void printTraceSymbolUndefined(StringRef name, const InputFile *file) {
   message(toString(file) + ": reference to " + name);
 }
 

--- a/lld/wasm/Symbols.h
+++ b/lld/wasm/Symbols.h
@@ -122,7 +122,7 @@ public:
   // or similar.
   bool isNoStrip() const;
 
-  const WasmSignature* getSignature() const;
+  const WasmSignature *getSignature() const;
 
   uint32_t getGOTIndex() const {
     assert(gotIndex != INVALID_INDEX);
@@ -605,7 +605,7 @@ struct WasmSym {
   static DefinedData *definedTableBase;
   // 32-bit copy in wasm64 to work around init expr limitations.
   // These can potentially be removed again once we have
-  // https://github.com/WebAssembly/extended-const 
+  // https://github.com/WebAssembly/extended-const
   static UndefinedGlobal *tableBase32;
   static DefinedData *definedTableBase32;
 
@@ -643,10 +643,10 @@ union SymbolUnion {
 static_assert(sizeof(SymbolUnion) <= 120, "SymbolUnion too large");
 
 void printTraceSymbol(Symbol *sym);
-void printTraceSymbolUndefined(StringRef name, const InputFile* file);
+void printTraceSymbolUndefined(StringRef name, const InputFile *file);
 
 template <typename T, typename... ArgT>
-T *replaceSymbol(Symbol *s, ArgT &&... arg) {
+T *replaceSymbol(Symbol *s, ArgT &&...arg) {
   static_assert(std::is_trivially_destructible<T>(),
                 "Symbol types must be trivially destructible");
   static_assert(sizeof(T) <= sizeof(SymbolUnion), "SymbolUnion too small");

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -417,10 +417,9 @@ void GlobalSection::addInternalGOTEntry(Symbol *sym) {
 void GlobalSection::generateRelocationCode(raw_ostream &os, bool TLS) const {
   assert(!config->extendedConst);
   bool is64 = config->is64.value_or(false);
-  unsigned opcode_ptr_const = is64 ? WASM_OPCODE_I64_CONST
-                                   : WASM_OPCODE_I32_CONST;
-  unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD
-                                 : WASM_OPCODE_I32_ADD;
+  unsigned opcode_ptr_const =
+      is64 ? WASM_OPCODE_I64_CONST : WASM_OPCODE_I32_CONST;
+  unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD : WASM_OPCODE_I32_ADD;
 
   for (const Symbol *sym : internalGotSymbols) {
     if (TLS != sym->isTLS())
@@ -605,7 +604,7 @@ void ElemSection::writeBody() {
   uint32_t tableIndex = config->tableBase;
   for (const FunctionSymbol *sym : indirectFunctions) {
     assert(sym->getTableIndex() == tableIndex);
-    (void) tableIndex;
+    (void)tableIndex;
     writeUleb128(os, sym->getFunctionIndex(), "function index");
     ++tableIndex;
   }
@@ -951,4 +950,4 @@ void BuildIdSection::writeBuildId(llvm::ArrayRef<uint8_t> buf) {
   memcpy(hashPlaceholderPtr, buf.data(), hashSize);
 }
 
-} // namespace wasm::lld
+} // namespace lld::wasm

--- a/lld/wasm/SyntheticSections.h
+++ b/lld/wasm/SyntheticSections.h
@@ -126,7 +126,7 @@ inline bool operator==(const ImportKey<T> &lhs, const ImportKey<T> &rhs) {
          lhs.importName == rhs.importName && lhs.type == rhs.type;
 }
 
-} // namespace wasm::lld
+} // namespace lld::wasm
 
 // `ImportKey<T>` can be used as a key in a `DenseMap` if `T` can be used as a
 // key in a `DenseMap`.
@@ -325,8 +325,7 @@ public:
 
 class ElemSection : public SyntheticSection {
 public:
-  ElemSection()
-      : SyntheticSection(llvm::wasm::WASM_SEC_ELEM) {}
+  ElemSection() : SyntheticSection(llvm::wasm::WASM_SEC_ELEM) {}
   bool isNeeded() const override { return indirectFunctions.size() > 0; };
   void writeBody() override;
   void addEntry(FunctionSymbol *sym);

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -311,7 +311,8 @@ void Writer::writeBuildId() {
 }
 
 static void setGlobalPtr(DefinedGlobal *g, uint64_t memoryPtr) {
-  LLVM_DEBUG(dbgs() << "setGlobalPtr " << g->getName() << " -> " << memoryPtr << "\n");
+  LLVM_DEBUG(dbgs() << "setGlobalPtr " << g->getName() << " -> " << memoryPtr
+                    << "\n");
   g->global->setPointerValue(memoryPtr);
 }
 
@@ -352,7 +353,8 @@ void Writer::layoutMemory() {
     placeStack();
     if (config->globalBase) {
       if (config->globalBase < memoryPtr) {
-        error("--global-base cannot be less than stack size when --stack-first is used");
+        error("--global-base cannot be less than stack size when --stack-first "
+              "is used");
         return;
       }
       memoryPtr = config->globalBase;
@@ -1160,7 +1162,7 @@ void Writer::createSyntheticInitFunctions() {
 
     auto hasTLSRelocs = [](const OutputSegment *segment) {
       if (segment->isTLS())
-        for (const auto* is: segment->inputSegments)
+        for (const auto *is : segment->inputSegments)
           if (is->getRelocations().size())
             return true;
       return false;
@@ -1168,8 +1170,7 @@ void Writer::createSyntheticInitFunctions() {
     if (llvm::any_of(segments, hasTLSRelocs)) {
       WasmSym::applyTLSRelocs = symtab->addSyntheticFunction(
           "__wasm_apply_tls_relocs", WASM_SYMBOL_VISIBILITY_HIDDEN,
-          make<SyntheticFunction>(nullSignature,
-                                  "__wasm_apply_tls_relocs"));
+          make<SyntheticFunction>(nullSignature, "__wasm_apply_tls_relocs"));
       WasmSym::applyTLSRelocs->markLive();
     }
   }
@@ -1337,8 +1338,7 @@ void Writer::createInitMemoryFunction() {
             writePtrConst(os, s->startVA, is64, "destination address");
           }
           writeU8(os, WASM_OPCODE_GLOBAL_SET, "GLOBAL_SET");
-          writeUleb128(os, WasmSym::tlsBase->getGlobalIndex(),
-                       "__tls_base");
+          writeUleb128(os, WasmSym::tlsBase->getGlobalIndex(), "__tls_base");
           if (ctx.isPic) {
             writeU8(os, WASM_OPCODE_LOCAL_GET, "local.tee");
             writeUleb128(os, 1, "local 1");
@@ -1601,7 +1601,8 @@ void Writer::createInitTLSFunction() {
       writeU8(os, WASM_OPCODE_GLOBAL_SET, "global.set");
       writeUleb128(os, WasmSym::tlsBase->getGlobalIndex(), "global index");
 
-      // FIXME(wvo): this local needs to be I64 in wasm64, or we need an extend op.
+      // FIXME(wvo): this local needs to be I64 in wasm64, or we need an extend
+      // op.
       writeU8(os, WASM_OPCODE_LOCAL_GET, "local.get");
       writeUleb128(os, 0, "local index");
 
@@ -1870,4 +1871,4 @@ void Writer::createHeader() {
 
 void writeResult() { Writer().run(); }
 
-} // namespace wasm::lld
+} // namespace lld::wasm

--- a/lld/wasm/WriterUtils.cpp
+++ b/lld/wasm/WriterUtils.cpp
@@ -94,7 +94,7 @@ void writeSleb128(raw_ostream &os, int64_t number, const Twine &msg) {
 }
 
 void writeBytes(raw_ostream &os, const char *bytes, size_t count,
-                      const Twine &msg) {
+                const Twine &msg) {
   debugWrite(os.tell(), msg + " [data[" + Twine(count) + "]]");
   os.write(bytes, count);
 }


### PR DESCRIPTION
Using the same critera as llvm/utils/git/code-format-helper.py, clang-format source files in the lld tree.

This is an example for https://discourse.llvm.org/t/rfc-clang-format-all-the-things/76614 and shows formatting all files, not just the small/medium files.

Instructions and a script to help downstream repos resolve conflicts will be committed separately.