### PR TITLE
[flang][OpenMP] Accept firstprivate vars in copyprivate

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2429,7 +2429,8 @@ void OmpAttributeVisitor::CheckDataCopyingClause(
       // either 'private' or 'threadprivate' in enclosing context.
       if (!checkSymbol->test(Symbol::Flag::OmpThreadprivate) &&
           !(HasSymbolInEnclosingScope(symbol, currScope()) &&
-              symbol.test(Symbol::Flag::OmpPrivate))) {
+              (symbol.test(Symbol::Flag::OmpPrivate) ||
+                  symbol.test(Symbol::Flag::OmpFirstPrivate)))) {
         context_.Say(name.source,
             "COPYPRIVATE variable '%s' is not PRIVATE or THREADPRIVATE in "
             "outer context"_err_en_US,

--- a/flang/test/Semantics/OpenMP/copyprivate03.f90
+++ b/flang/test/Semantics/OpenMP/copyprivate03.f90
@@ -34,6 +34,13 @@ program omp_copyprivate
   !$omp end parallel
   !$omp end parallel sections
 
+  !The use of FIRSTPRIVATE with COPYPRIVATE is allowed
+  !$omp parallel firstprivate(a)
+  !$omp single
+  a = a + k
+  !$omp end single copyprivate(a)
+  !$omp end parallel
+
   print *, a, b
 
 end program omp_copyprivate


### PR DESCRIPTION
This is patch 1 of 4, to add support for COPYPRIVATE.
Original PR: https://github.com/llvm/llvm-project/pull/73128
