### PR TITLE
[WebAssembly] improve getRegForPromotedValue to avoid meanless value copy

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -559,6 +559,8 @@ unsigned WebAssemblyFastISel::getRegForUnsignedValue(const Value *V) {
   Register VReg = getRegForValue(V);
   if (VReg == 0)
     return 0;
+  if (From == To)
+    return VReg;
   return zeroExtend(VReg, V, From, To);
 }
 
@@ -568,6 +570,8 @@ unsigned WebAssemblyFastISel::getRegForSignedValue(const Value *V) {
   Register VReg = getRegForValue(V);
   if (VReg == 0)
     return 0;
+  if (From == To)
+    return VReg;
   return signExtend(VReg, V, From, To);
 }
 

--- a/llvm/test/CodeGen/WebAssembly/suboptimal-compare.ll
+++ b/llvm/test/CodeGen/WebAssembly/suboptimal-compare.ll
@@ -1,0 +1,43 @@
+; RUN: llc < %s -fast-isel -O0 | FileCheck %s
+
+target triple = "wasm32-unknown-unknown"
+
+; CHECK-LABEL: gh_80052:                               # @gh_80052
+; CHECK-NEXT: .functype	gh_80052 (i32) -> (i32)
+; CHECK-NEXT: .local  	i32, i32, i32, i32, i32, i32
+; CHECK:      i32.const	0
+; CHECK-NEXT: local.set	1
+; CHECK-NEXT: local.get	0
+; CHECK-NEXT: local.get	1
+; CHECK-NEXT: i32.eq  
+; CHECK-NEXT: local.set	2
+; CHECK-NEXT: i32.const	1
+; CHECK-NEXT: local.set	3
+; CHECK-NEXT: local.get	2
+; CHECK-NEXT: local.get	3
+; CHECK-NEXT: i32.and 
+; CHECK-NEXT: local.set	4
+; CHECK-NEXT: block   	
+; CHECK-NEXT:   local.get	4
+; CHECK-NEXT:   i32.eqz
+; CHECK-NEXT:   br_if   	0                               # 0: down to label0
+; CHECK:        i32.const	0
+; CHECK-NEXT:   local.set	5
+; CHECK-NEXT:   local.get	5
+; CHECK-NEXT:   return
+; CHECK-NEXT: .LBB0_2:                                # %BB03
+; CHECK-NEXT: end_block                               # label0:
+; CHECK-NEXT: i32.const	1
+; CHECK-NEXT: local.set	6
+; CHECK-NEXT: local.get	6
+; CHECK-NEXT: return
+; CHECK-NEXT: end_function
+define i1 @gh_80052(ptr) {
+BB01:
+    %eq = icmp eq ptr %0, null
+    br i1 %eq, label %BB02, label %BB03
+BB02:
+    ret i1 0
+BB03:
+    ret i1 1
+}

--- a/llvm/test/CodeGen/WebAssembly/suboptimal-compare.ll
+++ b/llvm/test/CodeGen/WebAssembly/suboptimal-compare.ll
@@ -2,8 +2,8 @@
 
 target triple = "wasm32-unknown-unknown"
 
-; CHECK-LABEL: gh_80052:                               # @gh_80052
-; CHECK-NEXT: .functype	gh_80052 (i32) -> (i32)
+; CHECK-LABEL: gh_80053:                               # @gh_80053
+; CHECK-NEXT: .functype	gh_80053 (i32) -> (i32)
 ; CHECK-NEXT: .local  	i32, i32, i32, i32, i32, i32
 ; CHECK:      i32.const	0
 ; CHECK-NEXT: local.set	1
@@ -32,7 +32,7 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: local.get	6
 ; CHECK-NEXT: return
 ; CHECK-NEXT: end_function
-define i1 @gh_80052(ptr) {
+define i1 @gh_80053(ptr) {
 BB01:
     %eq = icmp eq ptr %0, null
     br i1 %eq, label %BB02, label %BB03


### PR DESCRIPTION
When promoted value, it is meaningless to copy value from reg to another reg with the same type.
This PR add additional check for this cases to reduce the code size.
Fixes: #80053.
