### PR TITLE
[Support] Introduce formatv variant of createStringError

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -22,6 +22,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdint>
@@ -1259,6 +1260,15 @@ template <typename... Ts>
 inline Error createStringError(std::errc EC, char const *Fmt,
                                const Ts &... Vals) {
   return createStringError(std::make_error_code(EC), Fmt, Vals...);
+}
+
+template <typename... Ts>
+inline Error createStringErrorV(std::error_code EC, const char *Fmt,
+                                const Ts &...Vals) {
+  std::string Buffer;
+  raw_string_ostream Stream(Buffer);
+  Stream << formatv(Fmt, Vals...);
+  return make_error<StringError>(Stream.str(), EC);
 }
 
 /// This class wraps a filename and another Error.

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -472,6 +472,23 @@ TEST(Error, createStringError) {
     << "Failed to convert createStringError() result to error_code.";
 }
 
+TEST(Error, createStringErrorV) {
+  static llvm::StringRef Bar("bar");
+  static const std::error_code EC = errc::invalid_argument;
+  std::string Msg;
+  raw_string_ostream S(Msg);
+  logAllUnhandledErrors(createStringErrorV(EC, "foo{0}{1}{2:x}", Bar, 1, 0xff),
+                        S);
+  EXPECT_EQ(S.str(), "foobar10xff\n")
+      << "Unexpected createStringErrorV() log result";
+
+  S.flush();
+  Msg.clear();
+  auto Res = errorToErrorCode(createStringErrorV(EC, "foo{0}", Bar));
+  EXPECT_EQ(Res, EC)
+      << "Failed to convert createStringErrorV() result to error_code.";
+}
+
 // Test that the ExitOnError utility works as expected.
 TEST(ErrorDeathTest, ExitOnError) {
   ExitOnError ExitOnErr;


### PR DESCRIPTION
Many times I have found myself wanting to create a StringError with the ability to interpolate a StringRef into the error string. This can be achieved with:

StringRef Foo("...");
auto Err = createStringError(..., "Something went wrong: %s", Foo.str().c_str());

However, this requires us to construct a temporary std::string (which may perform a memory allocation if large enough).

I propose a new variant of `createStringError` called `createStringErrorV` which uses `formatv` under the hood. This allows the above example to become:

StringRef Foo("...");
auto Err = createStringErrorV(..., "Something went wrong: {0}", Foo);