### PR TITLE
Fix __isOSVersionAtLeast for Android

### DIFF
--- a/compiler-rt/lib/builtins/os_version_check.c
+++ b/compiler-rt/lib/builtins/os_version_check.c
@@ -316,8 +316,8 @@ int32_t __isOSVersionAtLeast(int32_t Major, int32_t Minor, int32_t Subminor) {
   static pthread_once_t once = PTHREAD_ONCE_INIT;
   pthread_once(&once, readSystemProperties);
 
-  return SdkVersion >= Major ||
-         (IsPreRelease && Major == __ANDROID_API_FUTURE__);
+  // Allow all on pre-release. Note that we still rely on compile-time checks.
+  return SdkVersion >= Major || IsPreRelease;
 }
 
 #else


### PR DESCRIPTION
Allow pre-release APIs on pre-release devices.

The current implementation requires __ANDROID_API_FUTURE__ to use new APIs on pre-release system. This makes it hard to maintain the codebase because it should be switched a concrete version (e.g. __ANDROID_API_X__ on release of X).

Instead, we can just allow pre-release APIs on pre-release system without mandating the major version of __ANDROID_API_FUTURE__.

Note that this doesn't make API guards just no-op in pre-release builds. We can still rely on its compile-time checks and it still works as expected with release builds. Even with pre-release builds, it's the same as before because we would pass __ANDROID_API_FUTURE__ to make the calls anyway.