### PR TITLE
Fix a crasher when using the public API.

### DIFF
--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1089,9 +1089,9 @@ void SBDebugger::SetSelectedTarget(SBTarget &sb_target) {
   Log *log = GetLog(LLDBLog::API);
 
   TargetSP target_sp(sb_target.GetSP());
-  if (m_opaque_sp) {
+  if (m_opaque_sp && target_sp)
     m_opaque_sp->GetTargetList().SetSelectedTarget(target_sp);
-  }
+
   if (log) {
     SBStream sstr;
     sb_target.GetDescription(sstr, eDescriptionLevelBrief);
@@ -1704,20 +1704,20 @@ SBDebugger::LoadTraceFromFile(SBError &error,
 
 void SBDebugger::RequestInterrupt() {
   LLDB_INSTRUMENT_VA(this);
-  
+
   if (m_opaque_sp)
-    m_opaque_sp->RequestInterrupt();  
+    m_opaque_sp->RequestInterrupt();
 }
 void SBDebugger::CancelInterruptRequest()  {
   LLDB_INSTRUMENT_VA(this);
-  
+
   if (m_opaque_sp)
-    m_opaque_sp->CancelInterruptRequest();  
+    m_opaque_sp->CancelInterruptRequest();
 }
 
 bool SBDebugger::InterruptRequested()   {
   LLDB_INSTRUMENT_VA(this);
-  
+
   if (m_opaque_sp)
     return m_opaque_sp->InterruptRequested();
   return false;

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1089,7 +1089,7 @@ void SBDebugger::SetSelectedTarget(SBTarget &sb_target) {
   Log *log = GetLog(LLDBLog::API);
 
   TargetSP target_sp(sb_target.GetSP());
-  if (m_opaque_sp && target_sp)
+  if (m_opaque_sp)
     m_opaque_sp->GetTargetList().SetSelectedTarget(target_sp);
 
   if (log) {

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1092,7 +1092,6 @@ void SBDebugger::SetSelectedTarget(SBTarget &sb_target) {
   if (m_opaque_sp) {
     m_opaque_sp->GetTargetList().SetSelectedTarget(target_sp);
   }
-
   if (log) {
     SBStream sstr;
     sb_target.GetDescription(sstr, eDescriptionLevelBrief);

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1704,20 +1704,20 @@ SBDebugger::LoadTraceFromFile(SBError &error,
 
 void SBDebugger::RequestInterrupt() {
   LLDB_INSTRUMENT_VA(this);
-
+  
   if (m_opaque_sp)
-    m_opaque_sp->RequestInterrupt();
+    m_opaque_sp->RequestInterrupt();  
 }
 void SBDebugger::CancelInterruptRequest()  {
   LLDB_INSTRUMENT_VA(this);
-
+  
   if (m_opaque_sp)
-    m_opaque_sp->CancelInterruptRequest();
+    m_opaque_sp->CancelInterruptRequest();  
 }
 
 bool SBDebugger::InterruptRequested()   {
   LLDB_INSTRUMENT_VA(this);
-
+  
   if (m_opaque_sp)
     return m_opaque_sp->InterruptRequested();
   return false;

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1089,8 +1089,9 @@ void SBDebugger::SetSelectedTarget(SBTarget &sb_target) {
   Log *log = GetLog(LLDBLog::API);
 
   TargetSP target_sp(sb_target.GetSP());
-  if (m_opaque_sp)
+  if (m_opaque_sp) {
     m_opaque_sp->GetTargetList().SetSelectedTarget(target_sp);
+  }
 
   if (log) {
     SBStream sstr;

--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -568,15 +568,15 @@ bool TargetList::AnyTargetContainsModule(Module &module) {
         m_in_process_target_list.insert(target_sp);
     assert(was_added && "Target pointer was left in the in-process map");
   }
-
+  
   void TargetList::UnregisterInProcessTarget(TargetSP target_sp) {
     std::lock_guard<std::recursive_mutex> guard(m_target_list_mutex);
     [[maybe_unused]] bool was_present =
         m_in_process_target_list.erase(target_sp);
     assert(was_present && "Target pointer being removed was not registered");
   }
-
+  
   bool TargetList::IsTargetInProcess(TargetSP target_sp) {
     std::lock_guard<std::recursive_mutex> guard(m_target_list_mutex);
-    return m_in_process_target_list.count(target_sp) == 1;
+    return m_in_process_target_list.count(target_sp) == 1; 
   }

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -526,3 +526,9 @@ class TargetAPITestCase(TestBase):
                 target.IsLoaded(module),
                 "Running the target should " "have loaded its modules.",
             )
+
+    @no_debug_info_test
+    def test_setting_selected_target_with_invalid_target(self):
+        """Make sure we don't crash when trying to select invalid target."""
+        target = lldb.SBTarget()
+        self.dbg.SetSelectedTarget(target)


### PR DESCRIPTION
A user found a crash when they would do code like: (lldb) script
>>> target = lldb.SBTarget()
>>> lldb.debugger.SetSelectedTarget(target)

We were not checking if the target was valid in SBDebugger::SetSelectedTarget(...).