### PR TITLE
[Coverage][docs] for the main region array there shoudn't be a `numRegionArrays : LEB128` field

### DIFF
--- a/llvm/docs/CoverageMappingFormat.rst
+++ b/llvm/docs/CoverageMappingFormat.rst
@@ -526,7 +526,7 @@ counter that references this expression.
 Mapping Regions
 ---------------
 
-``[numRegionArrays : LEB128, regionsForFile0, regionsForFile1, ...]``
+``[regionsForFile0, regionsForFile1, ...]``
 
 The mapping regions are stored in an array of sub-arrays where every
 region in a particular sub-array has the same file id.


### PR DESCRIPTION
The docs in question are here: https://llvm.org/docs/CoverageMappingFormat.html#mapping-regions

Even in the initial commit this `numRegionArrays : LEB128` field was not there

- In [reader](https://github.com/llvm/llvm-project/commit/a20a5d50ba2a24d045588cc2e47ea3f21b0c5145#diff-90e3ad997e0f62162d8b094250688425e2e875267be0aa6c6ecb00cb97fabaf3R240-R247)
    - The quoted starting line corresponds to `expr1RHS : LEB128` earlier in docs
    - The quoted ending line corresponds to `regionsForFile0` later in docs
- In [writer](https://github.com/llvm/llvm-project/commit/a20a5d50ba2a24d045588cc2e47ea3f21b0c5145#diff-4269d13d9abbaae1e1d175d3c923ca418f9c9a50f88484b10d3d95767b65c70fR137-R146)
    - The quoted starting line corresponds to `expr1RHS : LEB128` earlier in docs
    - The quoted ending line corresponds to `numRegions : LEB128` later in docs
        - Note this variable is for the *sub*-array, not the *main* array
        - The first such variable is written before the loop. If there're more than one sub-arrays, later ones are written within the loop at [this line](https://github.com/llvm/llvm-project/commit/a20a5d50ba2a24d045588cc2e47ea3f21b0c5145#diff-4269d13d9abbaae1e1d175d3c923ca418f9c9a50f88484b10d3d95767b65c70fR153)

More recent code has refactored a bit (mostly in the writer) but the covmap format around this place stays the same: without this `numRegionArrays : LEB128` field
