### PR TITLE
[mlir][EmitC] Add support for external functions

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -498,6 +498,9 @@ def EmitC_FuncOp : EmitC_Op<"func", [
       emitc.return %0 : i32
     }
 
+    // An external function definition:
+    emitc.func private @extern_func(i32)
+                        attributes {specifiers = ["extern"]}
     ```
   }];
   let arguments = (ins SymbolNameAttr:$sym_name,

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -437,9 +437,6 @@ LogicalResult FuncOp::verify() {
     return emitOpError("requires zero or exactly one result, but has ")
            << getNumResults();
 
-  if (isExternal())
-    return emitOpError("does not support empty function bodies");
-
   return success();
 }
 

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -776,15 +776,10 @@ static LogicalResult printFunctionArgs(CppEmitter &emitter,
                                        ArrayRef<Type> arguments) {
   raw_indented_ostream &os = emitter.ostream();
 
-  if (failed(interleaveCommaWithError(
-          arguments, os, [&](Type arg) -> LogicalResult {
-            if (failed(emitter.emitType(functionOp->getLoc(), arg)))
-              return failure();
-            return success();
-          })))
-    return failure();
-
-  return success();
+  return (
+      interleaveCommaWithError(arguments, os, [&](Type arg) -> LogicalResult {
+        return emitter.emitType(functionOp->getLoc(), arg);
+      }));
 }
 
 static LogicalResult printFunctionArgs(CppEmitter &emitter,
@@ -792,16 +787,13 @@ static LogicalResult printFunctionArgs(CppEmitter &emitter,
                                        Region::BlockArgListType arguments) {
   raw_indented_ostream &os = emitter.ostream();
 
-  if (failed(interleaveCommaWithError(
-          arguments, os, [&](BlockArgument arg) -> LogicalResult {
-            if (failed(emitter.emitType(functionOp->getLoc(), arg.getType())))
-              return failure();
-            os << " " << emitter.getOrCreateName(arg);
-            return success();
-          })))
-    return failure();
-
-  return success();
+  return (interleaveCommaWithError(
+      arguments, os, [&](BlockArgument arg) -> LogicalResult {
+        if (failed(emitter.emitType(functionOp->getLoc(), arg.getType())))
+          return failure();
+        os << " " << emitter.getOrCreateName(arg);
+        return success();
+      }));
 }
 
 static LogicalResult printFunctionBody(CppEmitter &emitter,

--- a/mlir/test/Conversion/FuncToEmitC/func-to-emitc.mlir
+++ b/mlir/test/Conversion/FuncToEmitC/func-to-emitc.mlir
@@ -53,3 +53,8 @@ func.func @call(%arg0: i32) -> i32 {
   %0 = call @return_i32(%arg0) : (i32) -> (i32)
   return %0 : i32
 }
+
+// -----
+
+// CHECK-LABEL: emitc.func private @return_i32(i32) -> i32 attributes {specifiers = ["extern"]}
+func.func private @return_i32(%arg0: i32) -> i32

--- a/mlir/test/Dialect/EmitC/invalid_ops.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_ops.mlir
@@ -321,8 +321,3 @@ func.func @return_inside_func.func(%0: i32) -> (i32) {
 
 // expected-error@+1 {{expected non-function type}}
 emitc.func @func_variadic(...)
-
-// -----
-
-// expected-error@+1 {{'emitc.func' op does not support empty function bodies}}
-emitc.func private @empty()

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -30,6 +30,8 @@ emitc.func @call() -> i32 {
   emitc.return %0 : i32
 }
 
+emitc.func private @extern(i32) attributes {specifiers = ["extern"]}
+
 func.func @cast(%arg0: i32) {
   %1 = emitc.cast %arg0: i32 to f32
   return

--- a/mlir/test/Target/Cpp/func.mlir
+++ b/mlir/test/Target/Cpp/func.mlir
@@ -37,3 +37,6 @@ emitc.func @emitc_call() -> i32 {
 // CPP-DECLTOP-NEXT: int32_t [[V0:[^ ]*]];
 // CPP-DECLTOP-NEXT: [[V0:[^ ]*]] = return_i32();
 // CPP-DECLTOP-NEXT: return [[V0:[^ ]*]];
+
+emitc.func private @extern_func(i32) attributes {specifiers = ["extern"]}
+// CPP-DEFAULT: extern void extern_func(int32_t);


### PR DESCRIPTION
This adds a conversion from an externaly defined `func.func`, a `func.func` without function body, to an `emitc.func` with an `extern` specifier.