### PR TITLE
[WebAssembly] fix `table.grow` type checker 

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -297,6 +297,8 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
       return true;
     if (popType(ErrorLoc, wasm::ValType::I32))
       return true;
+    if (popType(ErrorLoc, Type))
+      return true;
     Stack.push_back(wasm::ValType::I32);
   } else if (Name == "table.fill") {
     if (getTable(Operands[1]->getStartLoc(), Inst, Type))

--- a/llvm/test/MC/WebAssembly/tables.s
+++ b/llvm/test/MC/WebAssembly/tables.s
@@ -71,6 +71,8 @@ table_set:
 
 #      CHECK: table_grow:
 # CHECK-NEXT:	.functype	table_grow (i32) -> (i32)
+# CHECK-NEXT:	i32.const	0
+# CHECK-NEXT:	table.get	foo
 # CHECK-NEXT:	local.get	0
 #      CHECK:	table.grow	foo
 # CHECK-NEXT:	local.get	0
@@ -78,6 +80,8 @@ table_set:
 # CHECK-NEXT:	end_function
 table_grow:
     .functype table_grow (i32) -> (i32)
+    i32.const 0
+    table.get foo
     local.get 0
 
     # ENC: table.grow	foo                     # encoding: [0xfc,0x0f,0x80'A',0x80'A',0x80'A',0x80'A',A]
@@ -145,13 +149,16 @@ table_fill:
 # BIN-NEXT:        Offset:          0x2D
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           0
-# BIN-NEXT:        Offset:          0x39
+# BIN-NEXT:        Offset:          0x38
+# BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
+# BIN-NEXT:        Index:           0
+# BIN-NEXT:        Offset:          0x41
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           2
-# BIN-NEXT:        Offset:          0x49
+# BIN-NEXT:        Offset:          0x51
 # BIN-NEXT:      - Type:            R_WASM_TABLE_NUMBER_LEB
 # BIN-NEXT:        Index:           2
-# BIN-NEXT:        Offset:          0x52
+# BIN-NEXT:        Offset:          0x5A
 # BIN-NEXT:    Functions:
 # BIN-NEXT:      - Index:           0
 # BIN-NEXT:        Locals:          []
@@ -164,7 +171,7 @@ table_fill:
 # BIN-NEXT:        Body:            200020012680808080000B
 # BIN-NEXT:      - Index:           3
 # BIN-NEXT:        Locals:          []
-# BIN-NEXT:        Body:            2000FC0F808080800020006A0B
+# BIN-NEXT:        Body:            41002580808080002000FC0F808080800020006A0B
 # BIN-NEXT:      - Index:           4
 # BIN-NEXT:        Locals:          []
 # BIN-NEXT:        Body:            200041002582808080002001FC1182808080000B

--- a/llvm/test/MC/WebAssembly/type-checker-errors.s
+++ b/llvm/test/MC/WebAssembly/type-checker-errors.s
@@ -216,21 +216,31 @@ table_fill_type_mismatch_3:
   end_function
 
 table_grow_non_exist_table:
-  .functype table_grow_non_exist_table () -> (i32)
-  i32.const 0
+  .functype table_grow_non_exist_table (externref, i32) -> (i32)
+  local.get 0
+  local.get 1
 # CHECK: [[@LINE+1]]:14: error: symbol invalid_table missing .tabletype
   table.grow invalid_table
   end_function
 
-table_grow_wrong_parameter:
-  .functype table_grow_non_exist_table () -> (i32)
-# CHECK: [[@LINE+1]]:3: error: empty stack while popping i32
+table_grow_type_mismatch_1:
+  .functype table_grow_type_mismatch_1 (externref, i32) -> (i32)
+  local.get 1
+# CHECK: [[@LINE+1]]:3: error: empty stack while popping externref
+  table.grow valid_table
+  end_function
+
+table_grow_type_mismatch_2:
+  .functype table_grow_type_mismatch_2 (externref, i32) -> (i32)
+  local.get 0
+# CHECK: [[@LINE+1]]:3: error: popped externref, expected i32
   table.grow valid_table
   end_function
 
 table_grow_wrong_result:
-  .functype table_grow_non_exist_table () -> (f32)
-  i32.const 0
+  .functype table_grow_wrong_result (externref, i32) -> (f32)
+  local.get 0
+  local.get 1
   table.grow valid_table
 # CHECK: [[@LINE+1]]:3: error: popped i32, expected f32
   end_function


### PR DESCRIPTION
table.grow is valid with type `[t i32] -> [i32]`.
Fixes: #79966.