### PR TITLE
[MemProf][NFC] Compute SHADOW_ENTRY_SIZE from MEM_GRANULARITY and SHA…

### DIFF
--- a/compiler-rt/lib/memprof/memprof_mapping.h
+++ b/compiler-rt/lib/memprof/memprof_mapping.h
@@ -29,8 +29,6 @@ extern uptr kHighMemEnd; // Initialized in __memprof_init.
 
 } // namespace __memprof
 
-#define SHADOW_ENTRY_SIZE 8
-
 // Size of memory block mapped to a single shadow location
 #define MEM_GRANULARITY 64ULL
 
@@ -38,6 +36,8 @@ extern uptr kHighMemEnd; // Initialized in __memprof_init.
 
 #define MEM_TO_SHADOW(mem)                                                     \
   ((((mem) & SHADOW_MASK) >> SHADOW_SCALE) + (SHADOW_OFFSET))
+
+#define SHADOW_ENTRY_SIZE (MEM_GRANULARITY >> SHADOW_SCALE)
 
 #define kLowMemBeg 0
 #define kLowMemEnd (SHADOW_OFFSET ? SHADOW_OFFSET - 1 : 0)


### PR DESCRIPTION
…DOW_SCALE

As MEM_GRANULARITY represents the size of memory block mapped to a single shadow entry, and SHADOW_SCALE represents the scale of shadow mapping, so the single shadow entry size can be computed as (MEM_GRANULARITY >> SHADOW_SCALE).

This patch replaces the hardcoded SHADOW_ENTRY_SIZE with (MEM_GRANULARITY >> SHADOW_SCALE).