### PR TITLE
[libc++][doc] Use installed std modules in external projects.

### DIFF
--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -118,8 +118,8 @@ installation of modules and install the modules into ``<install_prefix>``.
   $ cd llvm-project
   $ mkdir build
   $ cmake -G Ninja -S runtimes -B build -DLIBCXX_INSTALL_MODULES=ON -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind"
-  $ ninja --build build -- -j $(nproc)
-  $ ninja --install build --prefix <install_prefix>
+  $ cmake --build build -- -j $(nproc)
+  $ cmake --install build --prefix <install_prefix>
 
 The above ``build`` directory will be referred to as ``<build>`` in the
 rest of these instructions.

--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -393,9 +393,6 @@ Building this project is done with the following steps, assuming the files
              in `LLVM Debian/Ubuntu nightly packages <https://apt.llvm.org>`__ to install
              essential components to build this project.
 
-.. note:: The ``std`` dependencies of ``std.compat`` is not always resolved when
-          building the ``std`` target using multiple jobs.
-
 .. warning:: ``<path-to-compiler>`` should point point to the real binary and
              not to a symlink.
 

--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -222,8 +222,12 @@ Building this project is done with the following steps, assuming the files
 
   $ mkdir build
   $ cmake -G Ninja -S . -B build -DCMAKE_CXX_COMPILER=<path-to-compiler> -DLIBCXX_BUILD=<build>
+  $ ninja -j1 std -C build
   $ ninja -C build
   $ build/main
+
+.. note:: The ``std`` dependencies of ``std.compat`` is not always resolved when
+          building the ``std`` target using multiple jobs.
 
 This is another small sample program that uses the module ``std`` from
 installation directory. It consists of a ``CMakeLists.txt``, an


### PR DESCRIPTION
The original libc++ document about using std modules in external projects is outdated. Loot at #80231 for more details.

This pull request update the document. The new document tells how to use the current installed std modules without toolchains' support.