### PR TITLE
[lldb] Remove unnecessary FormatCache::GetEntry (NFC)

### DIFF
--- a/lldb/include/lldb/DataFormatters/FormatCache.h
+++ b/lldb/include/lldb/DataFormatters/FormatCache.h
@@ -45,14 +45,11 @@ private:
     void Set(lldb::TypeSummaryImplSP);
     void Set(lldb::SyntheticChildrenSP);
   };
-  typedef std::map<ConstString, Entry> CacheMap;
-  CacheMap m_map;
+  std::map<ConstString, Entry> m_entries;
   std::recursive_mutex m_mutex;
 
   uint64_t m_cache_hits = 0;
   uint64_t m_cache_misses = 0;
-
-  Entry &GetEntry(ConstString type);
 
 public:
   FormatCache() = default;

--- a/lldb/source/DataFormatters/FormatCache.cpp
+++ b/lldb/source/DataFormatters/FormatCache.cpp
@@ -51,14 +51,6 @@ void FormatCache::Entry::Set(lldb::SyntheticChildrenSP synthetic_sp) {
   m_synthetic_sp = synthetic_sp;
 }
 
-FormatCache::Entry &FormatCache::GetEntry(ConstString type) {
-  auto i = m_map.find(type), e = m_map.end();
-  if (i != e)
-    return i->second;
-  m_map[type] = FormatCache::Entry();
-  return m_map[type];
-}
-
 namespace lldb_private {
 
 template<> bool FormatCache::Entry::IsCached<lldb::TypeFormatImplSP>() {
@@ -76,7 +68,7 @@ template<> bool FormatCache::Entry::IsCached<lldb::SyntheticChildrenSP>() {
 template <typename ImplSP>
 bool FormatCache::Get(ConstString type, ImplSP &format_impl_sp) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  auto entry = GetEntry(type);
+  auto entry = m_entries[type];
   if (entry.IsCached<ImplSP>()) {
     m_cache_hits++;
     entry.Get(format_impl_sp);
@@ -101,21 +93,21 @@ FormatCache::Get<lldb::SyntheticChildrenSP>(ConstString,
 
 void FormatCache::Set(ConstString type, lldb::TypeFormatImplSP &format_sp) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  GetEntry(type).Set(format_sp);
+  m_entries[type].Set(format_sp);
 }
 
 void FormatCache::Set(ConstString type, lldb::TypeSummaryImplSP &summary_sp) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  GetEntry(type).Set(summary_sp);
+  m_entries[type].Set(summary_sp);
 }
 
 void FormatCache::Set(ConstString type,
                       lldb::SyntheticChildrenSP &synthetic_sp) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  GetEntry(type).Set(synthetic_sp);
+  m_entries[type].Set(synthetic_sp);
 }
 
 void FormatCache::Clear() {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  m_map.clear();
+  m_entries.clear();
 }


### PR DESCRIPTION
The implementation of `FormatCache::Entry &FormatCache::GetEntry(ConstString)` is effectively a duplication of `std::map::operator[]`. This change deletes `GetEntry` and replaces its use with `operator[]`.