### PR TITLE
[RISCV] sifive-p670 uses SiFive7SchedModel

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -245,7 +245,7 @@ def SIFIVE_P450 : RISCVProcessorModel<"sifive-p450", SiFiveP400Model,
                                        TuneLUIADDIFusion,
                                        TuneAUIPCADDIFusion]>;
 
-def SIFIVE_P670 : RISCVProcessorModel<"sifive-p670", NoSchedModel,
+def SIFIVE_P670 : RISCVProcessorModel<"sifive-p670", SiFive7Model,
                                       [Feature64Bit,
                                        FeatureStdExtZifencei,
                                        FeatureStdExtM,


### PR DESCRIPTION
I collected numbers that show that the SiFive7SchedModel was better than using NoSchedModel.

The sifive-p670 is not a SiFive7 processor, however we have a P600SchedModel in our downstream that has not been updated since before SchedWriteRes accounted for LMUL & SEW. I collected numbers that show that the SiFive7SchedModel outpreformed this old model as well.

We intend to add the P600SchedModel in the future, once it has been revamped and causes sifive-p670 to outpreform in comparison to the SiFive7NModel.