### PR TITLE
[Clang] Fix crash when recovering from an invalid pack indexing type.

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -3854,6 +3854,12 @@ PackIndexingType::computeDependence(QualType Pattern, Expr *IndexExpr,
 
   if (!(IndexD & TypeDependence::UnexpandedPack))
     TD &= ~TypeDependence::UnexpandedPack;
+
+  // If the pattern does not contain an unexpended pack,
+  // the type is still dependent, and invalid
+  if (!Pattern->containsUnexpandedParameterPack())
+    TD |= TypeDependence::Error | TypeDependence::DependentInstantiation;
+
   return TD;
 }
 

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -11,6 +11,21 @@ void not_pack() {
     Tp...[0] c; // expected-error{{'Tp' does not refer to the name of a parameter pack}}
 }
 
+template <typename T, auto V, template<typename> typename Tp>
+void not_pack_arrays() {
+    NotAPack...[0] a[1]; // expected-error{{'NotAPack' does not refer to the name of a parameter pack}}
+    T...[0] b[1];   // expected-error{{'T' does not refer to the name of a parameter pack}}
+    Tp...[0] c[1]; // expected-error{{'Tp' does not refer to the name of a parameter pack}}
+}
+
+template <typename T>
+struct TTP;
+
+void test_errors() {
+    not_pack<int, 0, TTP>();
+    not_pack_arrays<int, 0, TTP>();
+}
+
 namespace invalid_indexes {
 
 int non_constant_index(); // expected-note 2{{declared here}}


### PR DESCRIPTION
If the pattern of a pack indexing type did not contain a pack, we would still construct a pack indexing type (to improve error messages) but we would fail to make the type as dependent, leading to infinite recursion when trying to extract a canonical type.