### PR TITLE
[libc] Add `next_toward_inf` fo `FPBits`

### DIFF
--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -31,6 +31,7 @@ add_header_library(
     libc.src.__support.common
     libc.src.__support.CPP.bit
     libc.src.__support.CPP.type_traits
+    libc.src.__support.libc_assert
     libc.src.__support.macros.attributes
     libc.src.__support.macros.properties.float
     libc.src.__support.math_extras

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -13,6 +13,7 @@
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/UInt128.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_assert.h"       // LIBC_ASSERT
 #include "src/__support/macros/attributes.h" // LIBC_INLINE, LIBC_INLINE_VAR
 #include "src/__support/macros/properties/float.h" // LIBC_COMPILER_HAS_FLOAT128
 #include "src/__support/math_extras.h"             // mask_trailing_ones
@@ -268,11 +269,13 @@ protected:
     }
 
     LIBC_INLINE constexpr BiasedExponent &operator++() {
+      LIBC_ASSERT(*this != BiasedExponent(Exponent::INF()));
       ++UP::value;
       return *this;
     }
 
     LIBC_INLINE constexpr BiasedExponent &operator--() {
+      LIBC_ASSERT(*this != BiasedExponent(Exponent::SUBNORMAL()));
       --UP::value;
       return *this;
     }
@@ -568,7 +571,7 @@ public:
       return false;
     return get_implicit_bit();
   }
-  
+
   // Modifiers
   LIBC_INLINE constexpr void next_toward_inf() {
     if (is_finite()) {

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -383,6 +383,7 @@ struct FPRepSem : public FPStorage<fp_type> {
 protected:
   using typename UP::Exponent;
   using typename UP::Significand;
+  using UP::bits;
   using UP::encode;
   using UP::exp_bits;
   using UP::exp_sig_bits;
@@ -448,11 +449,10 @@ public:
   LIBC_INLINE constexpr bool is_normal() const {
     return is_finite() && !is_subnormal();
   }
-
-  // Modifiers
-  LIBC_INLINE constexpr void next_toward_inf() {
+  LIBC_INLINE constexpr RetT next_toward_inf() const {
     if (is_finite())
-      ++UP::bits;
+      return RetT(bits + StorageType(1));
+    return RetT(bits);
   }
 
   // Returns the mantissa with the implicit bit set iff the current
@@ -571,20 +571,19 @@ public:
       return false;
     return get_implicit_bit();
   }
-
-  // Modifiers
-  LIBC_INLINE constexpr void next_toward_inf() {
+  LIBC_INLINE constexpr RetT next_toward_inf() const {
     if (is_finite()) {
       if (exp_sig_bits() == max_normal().uintval()) {
-        bits = inf(sign()).uintval();
+        return inf(sign());
       } else if (exp_sig_bits() == max_subnormal().uintval()) {
-        bits = min_normal(sign()).uintval();
+        return min_normal(sign());
       } else if (sig_bits() == SIG_MASK) {
-        bits = encode(sign(), ++biased_exponent(), Significand::ZERO());
+        return RetT(encode(sign(), ++biased_exponent(), Significand::ZERO()));
       } else {
-        ++bits;
+        return RetT(bits + StorageType(1));
       }
     }
+    return RetT(bits);
   }
 
   LIBC_INLINE constexpr StorageType get_explicit_mantissa() const {
@@ -669,7 +668,6 @@ public:
   using UP::max_subnormal;
   using UP::min_normal;
   using UP::min_subnormal;
-  using UP::next_toward_inf;
   using UP::one;
   using UP::quiet_nan;
   using UP::signaling_nan;
@@ -690,6 +688,7 @@ public:
   using UP::is_signaling_nan;
   using UP::is_subnormal;
   using UP::is_zero;
+  using UP::next_toward_inf;
   using UP::sign;
   LIBC_INLINE constexpr bool is_inf_or_nan() const { return !is_finite(); }
   LIBC_INLINE constexpr bool is_neg() const { return sign().is_neg(); }

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -322,8 +322,7 @@ TYPED_TEST(LlvmLibcFPBitsTest, NextTowardInf, FPTypes) {
   for (Sign sign : all_signs) {
     for (auto tc : TEST_CASES) {
       T val = make<T>(sign, tc.before);
-      val.next_toward_inf();
-      ASSERT_SAME_REP(val, make<T>(sign, tc.after));
+      ASSERT_SAME_REP(val.next_toward_inf(), make<T>(sign, tc.after));
     }
   }
 }

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -306,6 +306,28 @@ TYPED_TEST(LlvmLibcFPBitsTest, Properties, FPTypes) {
   }
 }
 
+#define ASSERT_SAME_REP(A, B) ASSERT_EQ(A.uintval(), B.uintval());
+
+TYPED_TEST(LlvmLibcFPBitsTest, NextTowardInf, FPTypes) {
+  struct {
+    FP before, after;
+  } TEST_CASES[] = {
+      {FP::ZERO, FP::MIN_SUBNORMAL},          //
+      {FP::MAX_SUBNORMAL, FP::MIN_NORMAL},    //
+      {FP::MAX_NORMAL, FP::INF},              //
+      {FP::INF, FP::INF},                     //
+      {FP::QUIET_NAN, FP::QUIET_NAN},         //
+      {FP::SIGNALING_NAN, FP::SIGNALING_NAN}, //
+  };
+  for (Sign sign : all_signs) {
+    for (auto tc : TEST_CASES) {
+      T val = make<T>(sign, tc.before);
+      val.next_toward_inf();
+      ASSERT_SAME_REP(val, make<T>(sign, tc.after));
+    }
+  }
+}
+
 TEST(LlvmLibcFPBitsTest, FloatType) {
   using FloatBits = FPBits<float>;
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -666,6 +666,7 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_bit",
         ":__support_cpp_type_traits",
+        ":__support_libc_assert",
         ":__support_macros_attributes",
         ":__support_macros_properties_float",
         ":__support_math_extras",


### PR DESCRIPTION
It is needed to provide correct rounding when building FPRep from greater precision representations.
