### PR TITLE
[GitHub][workflows] Ask reviewers to merge new contributor's PRs

### DIFF
--- a/.github/workflows/approved-prs.yml
+++ b/.github/workflows/approved-prs.yml
@@ -1,0 +1,47 @@
+name: "Prompt reviewers to merge PRs on behalf of new contributors."
+
+permissions:
+  contents: read
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  merge_on_behalf_information_comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # If this PR was approved, and is authored by a new contributor. New
+    # contributor statuses don't work as expected, so we check that it is not
+    # any other status instead.
+    # (see https://github.com/orgs/community/discussions/78038)
+    if: >-
+      (github.repository == 'llvm/llvm-project') &&
+      (github.event.review.state == 'APPROVED') &&
+      (github.event.pull_request.author_association != 'COLLABORATOR') &&
+      (github.event.pull_request.author_association != 'CONTRIBUTOR') &&
+      (github.event.pull_request.author_association != 'MANNEQUIN') &&
+      (github.event.pull_request.author_association != 'MEMBER') &&
+      (github.event.pull_request.author_association != 'OWNER')
+    steps:
+      - name: Checkout Automation Script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: llvm/utils/git/
+          ref: main
+
+      - name: Setup Automation Script
+        working-directory: ./llvm/utils/git/
+        run: |
+          pip install -r requirements.txt
+
+      - name: Add Merge On Behalf Information Comment
+        working-directory: ./llvm/utils/git/
+        run: |
+          python3 ./github-automation.py \
+            --token '${{ secrets.GITHUB_TOKEN }}' \
+            pr-merge-on-behalf-information \
+            --issue-number "${{ github.event.pull_request.number }}" \
+            --author "${{ github.event.pull_request.user.login }}"


### PR DESCRIPTION
As suggested on an RFC for previous changes in this area - https://discourse.llvm.org/t/rfc-fyi-pull-request-greetings-for-new-contributors/75458/12.

This is based on GitHub's example for this use case: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved

When a review is submitted we check:
* If it's an approval.
* Whether it's on a PR from a new contributor (using the same logic as `new-prs.yml`).

Then if we haven't already left a comment, add one to tell the author that they can have the PR merged by a reviewer. PRs can get multiple approvals, so we'll look for another magic HTML comment to tell if we've already done this.

The comment doesn't ask the reviewers to merge it right away, just on the chance that the author still had things to do. As we don't have a norm of merging as soon as there is an approval, so doing that without asking might be surprising.

It also notes that if we need multiple approvals to wait for those. Though in that situation I don't think GitHub will enable the merge button until they've all approved anyway.

In future we can make this check more clever, perhaps by using a GitHub API to check all users and see if they have permissions. It's limited to new contributor PRs for now since we know for sure they won't have permissions.

With this change, new contributor PRs will get:
* A welcome comment on submission.
* This merge on behalf comment on first approval.
* A post merge comment about what to expect from the build bots.