### PR TITLE
[RDF] Skip over NoRegister. NFCI.

### DIFF
--- a/llvm/lib/CodeGen/RDFGraph.cpp
+++ b/llvm/lib/CodeGen/RDFGraph.cpp
@@ -870,7 +870,7 @@ void DataFlowGraph::build(const Config &config) {
     std::set<RegisterId> BaseSet;
     if (BuildCfg.Classes.empty()) {
       // Insert every register.
-      for (unsigned R = 0, E = getPRI().getTRI().getNumRegs(); R != E; ++R)
+      for (unsigned R = 1, E = getPRI().getTRI().getNumRegs(); R != E; ++R)
         BaseSet.insert(R);
     } else {
       for (const TargetRegisterClass *RC : BuildCfg.Classes) {


### PR DESCRIPTION
This just avoids useless work of adding NoRegister to BaseSet, for
consistency with other places that iterate over all physical registers.
