### PR TITLE
[SystemZ] Implement A, O and R inline assembly format flags

### DIFF
--- a/llvm/test/CodeGen/SystemZ/asm-01.ll
+++ b/llvm/test/CodeGen/SystemZ/asm-01.ll
@@ -59,3 +59,14 @@ define void @f5(i64 %base, i64 %index) {
   call void asm "blah $0", "=*Q" (ptr elementtype(i64) %addr)
   ret void
 }
+
+; Check A, O and R format flags.
+define void @f6(i64 %base) {
+; CHECK-LABEL: f6:
+; CHECK: blah 111,%r2
+; CHECK: br %r14
+  %add = add i64 %base, 111
+  %addr = inttoptr i64 %add to ptr
+  call void asm "blah ${0:O},${0:R}${0:A}", "=*Q" (ptr elementtype(i64) %addr)
+  ret void
+}


### PR DESCRIPTION
Implement the following assembly format flags, which are already
supported by GCC:

	'A': On z14 or higher: If operand is a mem print the alignment
         hint usable with vl/vst prefixed by a comma.
	'O': print only the displacement of a memory reference or address.
	'R': print only the base register of a memory reference or address.

Implement 'A' conservatively, since the memory operand alignment
information is not available for INLINEASM at the moment.