### PR TITLE
[clang][ARM] Change NEON poly type to be unsigned (#56781)

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3017,7 +3017,7 @@ static unsigned RFT(unsigned t, bool shift = false, bool ForceQuad = false) {
 /// the vector type specified by the NeonTypeFlags.  This is used to check
 /// the pointer arguments for Neon load/store intrinsics.
 static QualType getNeonEltType(NeonTypeFlags Flags, ASTContext &Context,
-                               bool IsPolyUnsigned, bool IsInt64Long) {
+                               bool IsInt64Long) {
   switch (Flags.getEltType()) {
   case NeonTypeFlags::Int8:
     return Flags.isUnsigned() ? Context.UnsignedCharTy : Context.SignedCharTy;
@@ -3032,9 +3032,9 @@ static QualType getNeonEltType(NeonTypeFlags Flags, ASTContext &Context,
       return Flags.isUnsigned() ? Context.UnsignedLongLongTy
                                 : Context.LongLongTy;
   case NeonTypeFlags::Poly8:
-    return IsPolyUnsigned ? Context.UnsignedCharTy : Context.SignedCharTy;
+    return Context.UnsignedCharTy;
   case NeonTypeFlags::Poly16:
-    return IsPolyUnsigned ? Context.UnsignedShortTy : Context.ShortTy;
+    return Context.UnsignedShortTy;
   case NeonTypeFlags::Poly64:
     if (IsInt64Long)
       return Context.UnsignedLongTy;
@@ -3399,13 +3399,8 @@ bool Sema::CheckNeonBuiltinFunctionCall(const TargetInfo &TI,
     ExprResult RHS = DefaultFunctionArrayLvalueConversion(Arg);
     QualType RHSTy = RHS.get()->getType();
 
-    llvm::Triple::ArchType Arch = TI.getTriple().getArch();
-    bool IsPolyUnsigned = Arch == llvm::Triple::aarch64 ||
-                          Arch == llvm::Triple::aarch64_32 ||
-                          Arch == llvm::Triple::aarch64_be;
     bool IsInt64Long = TI.getInt64Type() == TargetInfo::SignedLong;
-    QualType EltTy =
-        getNeonEltType(NeonTypeFlags(TV), Context, IsPolyUnsigned, IsInt64Long);
+    QualType EltTy = getNeonEltType(NeonTypeFlags(TV), Context, IsInt64Long);
     if (HasConstPtr)
       EltTy = EltTy.withConst();
     QualType LHSTy = Context.getPointerType(EltTy);

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8413,24 +8413,11 @@ static bool isPermittedNeonBaseType(QualType &Ty, VectorKind VecKind, Sema &S) {
 
   llvm::Triple Triple = S.Context.getTargetInfo().getTriple();
 
-  // Signed poly is mathematically wrong, but has been baked into some ABIs by
-  // now.
-  bool IsPolyUnsigned = Triple.getArch() == llvm::Triple::aarch64 ||
-                        Triple.getArch() == llvm::Triple::aarch64_32 ||
-                        Triple.getArch() == llvm::Triple::aarch64_be;
   if (VecKind == VectorKind::NeonPoly) {
-    if (IsPolyUnsigned) {
-      // AArch64 polynomial vectors are unsigned.
-      return BTy->getKind() == BuiltinType::UChar ||
-             BTy->getKind() == BuiltinType::UShort ||
-             BTy->getKind() == BuiltinType::ULong ||
-             BTy->getKind() == BuiltinType::ULongLong;
-    } else {
-      // AArch32 polynomial vectors are signed.
-      return BTy->getKind() == BuiltinType::SChar ||
-             BTy->getKind() == BuiltinType::Short ||
-             BTy->getKind() == BuiltinType::LongLong;
-    }
+    return BTy->getKind() == BuiltinType::UChar ||
+           BTy->getKind() == BuiltinType::UShort ||
+           BTy->getKind() == BuiltinType::ULong ||
+           BTy->getKind() == BuiltinType::ULongLong;
   }
 
   // Non-polynomial vector types: the usual suspects are allowed, as well as

--- a/clang/test/CodeGenCXX/mangle-neon-vectors.cpp
+++ b/clang/test/CodeGenCXX/mangle-neon-vectors.cpp
@@ -6,13 +6,8 @@
 typedef float float32_t;
 typedef double float64_t;
 typedef __fp16 float16_t;
-#if defined(__aarch64__)
 typedef unsigned char poly8_t;
 typedef unsigned short poly16_t;
-#else
-typedef signed char poly8_t;
-typedef short poly16_t;
-#endif
 typedef unsigned __INT64_TYPE__ uint64_t;
 
 #if defined(__ARM_FEATURE_BF16)

--- a/clang/test/CodeGenCXX/poly-unsigned.cpp
+++ b/clang/test/CodeGenCXX/poly-unsigned.cpp
@@ -1,22 +1,14 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios -target-feature +neon -ffreestanding -S -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-UNSIGNED-POLY %s
-// RUN: %clang_cc1 -triple arm64-linux-gnu -target-feature +neon -ffreestanding -S -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-UNSIGNED-POLY %s
-// RUN: %clang_cc1 -triple armv7-apple-ios -ffreestanding -target-cpu cortex-a8 -S -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-SIGNED-POLY %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -target-feature +neon -ffreestanding -S -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-linux-gnu -target-feature +neon -ffreestanding -S -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple armv7-apple-ios -ffreestanding -target-cpu cortex-a8 -S -emit-llvm -o - %s | FileCheck %s
 
 // REQUIRES: aarch64-registered-target || arm-registered-target
 
 #include <arm_neon.h>
 
-// Polynomial types really should be universally unsigned, otherwise casting
-// (say) poly8_t "x^7" to poly16_t would change it to "x^15 + x^14 + ... +
-// x^7". Unfortunately 32-bit ARM ended up in a slightly delicate ABI situation
-// so for now it got that wrong.
-
 poly16_t test_poly8(poly8_t pIn) {
-// CHECK-UNSIGNED-POLY: @_Z10test_poly8h
-// CHECK-UNSIGNED-POLY: zext i8 {{.*}} to i16
-
-// CHECK-SIGNED-POLY: @_Z10test_poly8a
-// CHECK-SIGNED-POLY: sext i8 {{.*}} to i16
+// CHECK: @_Z10test_poly8h
+// CHECK: zext i8 {{.*}} to i16
 
   return pIn;
 }

--- a/clang/test/Sema/neon-vector-types.c
+++ b/clang/test/Sema/neon-vector-types.c
@@ -2,8 +2,8 @@
 // RUN: %clang_cc1 %s -triple armv8 -target-feature +neon -fsyntax-only -verify
 
 typedef float float32_t;
-typedef signed char poly8_t;
-typedef short poly16_t;
+typedef unsigned char poly8_t;
+typedef unsigned short poly16_t;
 typedef unsigned __INT64_TYPE__ uint64_t;
 
 // Define some valid Neon types.

--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -1339,7 +1339,7 @@ void Intrinsic::emitBodyAsBuiltinCall() {
       CastToType.makeInteger(8, true);
       Arg = "(" + CastToType.str() + ")" + Arg;
     } else if (CastToType.isVector() && LocalCK == ClassI) {
-      if (CastToType.isInteger())
+      if (CastToType.isInteger() || CastToType.isPoly())
         CastToType.makeSigned();
       Arg = "(" + CastToType.str() + ")" + Arg;
     }
@@ -2380,16 +2380,11 @@ void NeonEmitter::run(raw_ostream &OS) {
 
   OS << "#include <arm_vector_types.h>\n";
 
-  // For now, signedness of polynomial types depends on target
-  OS << "#ifdef __aarch64__\n";
   OS << "typedef uint8_t poly8_t;\n";
   OS << "typedef uint16_t poly16_t;\n";
   OS << "typedef uint64_t poly64_t;\n";
+  OS << "#ifdef __aarch64__\n";
   OS << "typedef __uint128_t poly128_t;\n";
-  OS << "#else\n";
-  OS << "typedef int8_t poly8_t;\n";
-  OS << "typedef int16_t poly16_t;\n";
-  OS << "typedef int64_t poly64_t;\n";
   OS << "#endif\n";
   emitNeonTypeDefs("PcQPcPsQPsPlQPl", OS);
 


### PR DESCRIPTION
This is to be inline with the Arm C Language Specification. (https://github.com/ARM-software/acle/releases/download/r2022Q2/acle-2022Q2.pdf) and with GCC.

This fixes https://github.com/llvm/llvm-project/issues/56781