### PR TITLE
[flang][docs] fix stack arrays docs page name

### DIFF
--- a/flang/docs/fstack-arrays.md
+++ b/flang/docs/fstack-arrays.md
@@ -1,4 +1,4 @@
-# -fstack-arrays
+# Stack arrays pass documentation
 ## Problem Description
 In gfortran, `-fstack-arrays` will cause all local arrays, including those of
 unknown size, to be allocated from stack memory. Gfortran enables this flag by

--- a/flang/docs/fstack-arrays.md
+++ b/flang/docs/fstack-arrays.md
@@ -1,4 +1,4 @@
-# Stack arrays pass documentation
+# Stack arrays pass
 ## Problem Description
 In gfortran, `-fstack-arrays` will cause all local arrays, including those of
 unknown size, to be allocated from stack memory. Gfortran enables this flag by


### PR DESCRIPTION
The website renders this `<h1>` as the page title in the index. This patch updates the title to better fit with the names of the other pages. See the index here https://flang.llvm.org/docs/