### PR TITLE
[libc++] Fix vector<const T>

### DIFF
--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -643,7 +643,7 @@ __uninitialized_allocator_relocate(_Alloc& __alloc, _Tp* __first, _Tp* __last, _
     __guard.__complete();
     std::__allocator_destroy(__alloc, __first, __last);
   } else {
-    __builtin_memcpy(__result, __first, sizeof(_Tp) * (__last - __first));
+    __builtin_memcpy(const_cast<__remove_const_t<_Tp>*>(__result), __first, sizeof(_Tp) * (__last - __first));
   }
 }
 

--- a/libcxx/test/libcxx/containers/sequences/vector/const_T.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/sequences/vector/const_T.compile.pass.cpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Make sure that `vector<const T>` works
+
+#include <vector>
+
+void test() {
+  std::vector<const int> v;
+  v.emplace_back(1);
+  v.push_back(1);
+  v.resize(3);
+}


### PR DESCRIPTION
#80558 introduced code that assumed that the element type of `vector` is never const. This fixes it and adds a test. Eventually we should remove the `allocator<const T>` extension.
