### PR TITLE
[DirectX][NFC] Change all DXIL TableGen tokens to CamelCase

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -7,138 +7,139 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This is a target description file for DXIL operation.
+/// This is a target description file for DXIL operations.
 ///
 //===----------------------------------------------------------------------===//
 
 include "llvm/IR/Intrinsics.td"
 
-class dxil_class<string _name> {
-  string name = _name;
-}
-class dxil_category<string _name> {
-  string name = _name;
+// Abstract representation of the class a DXIL Operation belongs to.
+class DXILOpClass<string name> {
+  string Name = name;
 }
 
-def Unary : dxil_class<"Unary">;
-def Binary : dxil_class<"Binary">;
-def FlattenedThreadIdInGroupClass : dxil_class<"FlattenedThreadIdInGroup">;
-def ThreadIdInGroupClass : dxil_class<"ThreadIdInGroup">;
-def ThreadIdClass : dxil_class<"ThreadId">;
-def GroupIdClass : dxil_class<"GroupId">;
-
-def binary_uint : dxil_category<"Binary uint">;
-def unary_float : dxil_category<"Unary float">;
-def ComputeID : dxil_category<"Compute/Mesh/Amplification shader">;
-
-
-// The parameter description for a DXIL instruction
-class dxil_param<int _pos, string type, string _name, string _doc,
-                 bit _is_const = 0, string _enum_name = "",
-                 int _max_value = 0> {
-  int pos = _pos;           // position in parameter list
-  string llvm_type = type; // llvm type name, $o for overload, $r for resource
-                           // type, $cb for legacy cbuffer, $u4 for u4 struct
-  string name = _name;      // short, unique name
-  string doc = _doc;        // the documentation description of this parameter
-  bit is_const =
-      _is_const; // whether this argument requires a constant value in the IR
-  string enum_name = _enum_name; // the name of the enum type if applicable
-  int max_value =
-      _max_value; // the maximum value for this parameter if applicable
+// Abstract representation of the category a DXIL Operation belongs to
+class DXILOpCategory<string name> {
+  string Name = name;
 }
 
-// A representation for a DXIL instruction
-class dxil_inst<string _name> {
-  string name = _name; // short, unique name
+def UnaryClass : DXILOpClass<"Unary">;
+def BinaryClass : DXILOpClass<"Binary">;
+def FlattenedThreadIdInGroupClass : DXILOpClass<"FlattenedThreadIdInGroup">;
+def ThreadIdInGroupClass : DXILOpClass<"ThreadIdInGroup">;
+def ThreadIdClass : DXILOpClass<"ThreadId">;
+def GroupIdClass : DXILOpClass<"GroupId">;
 
-  string dxil_op = "";       // name of DXIL operation
-  int dxil_opid = 0;         // ID of DXIL operation
-  dxil_class  op_class;      // name of the opcode class
-  dxil_category category;    // classification for this instruction
-  string doc = "";           // the documentation description of this instruction
-  list<dxil_param> ops = []; // the operands that this instruction takes
-  string oload_types = "";   // overload types if applicable
-  string fn_attr = "";       // attribute shorthands: rn=does not access
-                             // memory,ro=only reads from memory,
-  bit is_deriv = 0;          // whether this is some kind of derivative
-  bit is_gradient = 0;       // whether this requires a gradient calculation
-  bit is_feedback = 0;       // whether this is a sampler feedback op
-  bit is_wave = 0; // whether this requires in-wave, cross-lane functionality
-  bit requires_uniform_inputs = 0; // whether this operation requires that all
-                                   // of its inputs are uniform across the wave
-  // Group dxil operation for stats.
-  // Like how many atomic/float/uint/int/... instructions used in the program.
-  list<string> stats_group = [];
+def BinaryUintCategory : DXILOpCategory<"Binary uint">;
+def UnaryFloatCategory : DXILOpCategory<"Unary float">;
+def ComputeIDCategory : DXILOpCategory<"Compute/Mesh/Amplification shader">;
+
+// The parameter description for a DXIL operation
+class DXILOpParameter<int pos, string type, string name, string doc,
+                 bit isConstant = 0, string enumName = "",
+                 int maxValue = 0> {
+  int Pos = pos;               // Position in parameter list
+  string LLVMType = type;      // LLVM type name, $o for overload, $r for resource
+                               // type, $cb for legacy cbuffer, $u4 for u4 struct
+  string Name = name;          // Short, unique parameter name
+  string Doc = doc;            // Description of this parameter
+  bit IsConstant = isConstant; // Whether this parameter requires a constant value in the IR
+  string EnumName = enumName;  // Name of the enum type, if applicable
+  int MaxValue = maxValue;     // Maximum value for this parameter, if applicable
 }
 
-class dxil_op<string name, int code_id, dxil_class code_class, dxil_category op_category, string _doc,
-              string _oload_types, string _fn_attr, list<dxil_param> op_params,
-              list<string> _stats_group = []> : dxil_inst<name> {
-  let dxil_op = name;
-  let dxil_opid = code_id;
-  let doc = _doc;
-  let ops = op_params;
-  let op_class = code_class;
-  let category = op_category;
-  let oload_types = _oload_types;
-  let fn_attr = _fn_attr;
-  let stats_group = _stats_group;
+// A representation for a DXIL operation
+class DXILOperationDesc<string name> {
+  // TODO : Appears redundant. OpName should serve the same purpose
+  string Name = name; // short, unique name
+
+  string OpName = "";         // Name of DXIL operation
+  int OpCode = 0;             // Unique non-negative integer associated with the operation
+  DXILOpClass  OpClass;       // Class of the operation
+  DXILOpCategory OpCategory;  // Category of the operation
+  string Doc = "";            // Description of the operation
+  list<DXILOpParameter> Params = []; // Parameter list of the operation
+  string OverloadTypes = "";  // Overload types, if applicable
+  string Attributes = "";     // Attribute shorthands: rn=does not access
+                              // memory,ro=only reads from memory,
+  bit IsDerivative = 0;       // Whether this is some kind of derivative
+  bit IsGradient = 0;         // Whether this requires a gradient calculation
+  bit IsFeedback = 0;         // Whether this is a sampler feedback operation
+  bit IsWave = 0;             // Whether this requires in-wave, cross-lane functionality
+  bit NeedsUniformInputs = 0; // Whether this operation requires that all
+                              // of its inputs are uniform across the wave
+  // Group DXIL operation for stats - e.g., to accumulate the number of atomic/float/uint/int/...
+  // operations used in the program.
+  list<string> StatsGroup = [];
 }
 
-// The intrinsic which map directly to this dxil op.
-class dxil_map_intrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
+class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory opCategory, string doc,
+              string oloadTypes, string attrs, list<DXILOpParameter> params,
+              list<string> statsGroup = []> : DXILOperationDesc<name> {
+  let OpName = name;
+  let OpCode = opCode;
+  let Doc = doc;
+  let Params = params;
+  let OpClass = opClass;
+  let OpCategory = opCategory;
+  let OverloadTypes = oloadTypes;
+  let Attributes = attrs;
+  let StatsGroup = statsGroup;
+}
 
-def Sin : dxil_op<"Sin", 13, Unary, unary_float, "returns sine(theta) for theta in radians.",
+// LLVM intrinsic that DXIL operation maps to.
+class LLVMIntrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
+
+def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
   "half;float;", "rn",
   [
-    dxil_param<0, "$o", "", "operation result">,
-    dxil_param<1, "i32", "opcode", "DXIL opcode">,
-    dxil_param<2, "$o", "value", "input value">
+    DXILOpParameter<0, "$o", "", "operation result">,
+    DXILOpParameter<1, "i32", "opcode", "DXIL opcode">,
+    DXILOpParameter<2, "$o", "value", "input value">
   ],
   ["floats"]>,
-  dxil_map_intrinsic<int_sin>;
+  LLVMIntrinsic<int_sin>;
 
-def UMax :dxil_op< "UMax", 39,  Binary,  binary_uint, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
+def UMax : DXILOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
     "i16;i32;i64;",  "rn",
   [
-    dxil_param<0,  "$o",  "",  "operation result">,
-    dxil_param<1,  "i32",  "opcode",  "DXIL opcode">,
-    dxil_param<2,  "$o",  "a",  "input value">,
-    dxil_param<3,  "$o",  "b",  "input value">
+    DXILOpParameter<0,  "$o",  "",  "operation result">,
+    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  "$o",  "a",  "input value">,
+    DXILOpParameter<3,  "$o",  "b",  "input value">
   ],
   ["uints"]>,
-  dxil_map_intrinsic<int_umax>;
+  LLVMIntrinsic<int_umax>;
 
-def ThreadId :dxil_op< "ThreadId", 93,  ThreadIdClass, ComputeID, "reads the thread ID", "i32;",  "rn",
+def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", "i32;",  "rn",
   [
-    dxil_param<0,  "i32",  "",  "thread ID component">,
-    dxil_param<1,  "i32",  "opcode",  "DXIL opcode">,
-    dxil_param<2,  "i32",  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  "i32",  "",  "thread ID component">,
+    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
   ]>,
-  dxil_map_intrinsic<int_dx_thread_id>;
+  LLVMIntrinsic<int_dx_thread_id>;
 
-def GroupId :dxil_op< "GroupId", 94,  GroupIdClass, ComputeID, "reads the group ID (SV_GroupID)", "i32;",  "rn",
+def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", "i32;",  "rn",
   [
-    dxil_param<0,  "i32",  "",  "group ID component">,
-    dxil_param<1,  "i32",  "opcode",  "DXIL opcode">,
-    dxil_param<2,  "i32",  "component",  "component to read">
+    DXILOpParameter<0,  "i32",  "",  "group ID component">,
+    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  "i32",  "component",  "component to read">
   ]>,
-  dxil_map_intrinsic<int_dx_group_id>;
+  LLVMIntrinsic<int_dx_group_id>;
 
-def ThreadIdInGroup :dxil_op< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeID,
+def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
   "reads the thread ID within the group (SV_GroupThreadID)", "i32;",  "rn",
   [
-    dxil_param<0,  "i32",  "",  "thread ID in group component">,
-    dxil_param<1,  "i32",  "opcode",  "DXIL opcode">,
-    dxil_param<2,  "i32",  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  "i32",  "",  "thread ID in group component">,
+    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
   ]>,
-  dxil_map_intrinsic<int_dx_thread_id_in_group>;
+  LLVMIntrinsic<int_dx_thread_id_in_group>;
 
-def FlattenedThreadIdInGroup :dxil_op< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeID,
+def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
    "provides a flattened index for a given thread within a given group (SV_GroupIndex)", "i32;",  "rn",
   [
-    dxil_param<0,  "i32",  "",  "result">,
-    dxil_param<1,  "i32",  "opcode",  "DXIL opcode">
+    DXILOpParameter<0,  "i32",  "",  "result">,
+    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">
   ]>,
-  dxil_map_intrinsic<int_dx_flattened_thread_id_in_group>;
+  LLVMIntrinsic<int_dx_flattened_thread_id_in_group>;

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -14,28 +14,28 @@
 include "llvm/IR/Intrinsics.td"
 
 // Abstract representation of the class a DXIL Operation belongs to.
-class DXILOpClass<string name> {
+class DxilOpClass<string name> {
   string Name = name;
 }
 
 // Abstract representation of the category a DXIL Operation belongs to
-class DXILOpCategory<string name> {
+class DxilOpCategory<string name> {
   string Name = name;
 }
 
-def UnaryClass : DXILOpClass<"Unary">;
-def BinaryClass : DXILOpClass<"Binary">;
-def FlattenedThreadIdInGroupClass : DXILOpClass<"FlattenedThreadIdInGroup">;
-def ThreadIdInGroupClass : DXILOpClass<"ThreadIdInGroup">;
-def ThreadIdClass : DXILOpClass<"ThreadId">;
-def GroupIdClass : DXILOpClass<"GroupId">;
+def UnaryClass : DxilOpClass<"Unary">;
+def BinaryClass : DxilOpClass<"Binary">;
+def FlattenedThreadIdInGroupClass : DxilOpClass<"FlattenedThreadIdInGroup">;
+def ThreadIdInGroupClass : DxilOpClass<"ThreadIdInGroup">;
+def ThreadIdClass : DxilOpClass<"ThreadId">;
+def GroupIdClass : DxilOpClass<"GroupId">;
 
-def BinaryUintCategory : DXILOpCategory<"Binary uint">;
-def UnaryFloatCategory : DXILOpCategory<"Unary float">;
-def ComputeIDCategory : DXILOpCategory<"Compute/Mesh/Amplification shader">;
+def BinaryUintCategory : DxilOpCategory<"Binary uint">;
+def UnaryFloatCategory : DxilOpCategory<"Unary float">;
+def ComputeIDCategory : DxilOpCategory<"Compute/Mesh/Amplification shader">;
 
 // The parameter description for a DXIL operation
-class DXILOpParameter<int pos, string type, string name, string doc,
+class DxilOpParameter<int pos, string type, string name, string doc,
                  bit isConstant = 0, string enumName = "",
                  int maxValue = 0> {
   int Pos = pos;               // Position in parameter list
@@ -49,16 +49,16 @@ class DXILOpParameter<int pos, string type, string name, string doc,
 }
 
 // A representation for a DXIL operation
-class DXILOperationDesc<string name> {
+class DxilOperationDesc<string name> {
   // TODO : Appears redundant. OpName should serve the same purpose
   string Name = name; // short, unique name
 
   string OpName = "";         // Name of DXIL operation
   int OpCode = 0;             // Unique non-negative integer associated with the operation
-  DXILOpClass  OpClass;       // Class of the operation
-  DXILOpCategory OpCategory;  // Category of the operation
+  DxilOpClass  OpClass;       // Class of the operation
+  DxilOpCategory OpCategory;  // Category of the operation
   string Doc = "";            // Description of the operation
-  list<DXILOpParameter> Params = []; // Parameter list of the operation
+  list<DxilOpParameter> Params = []; // Parameter list of the operation
   string OverloadTypes = "";  // Overload types, if applicable
   string Attributes = "";     // Attribute shorthands: rn=does not access
                               // memory,ro=only reads from memory,
@@ -73,9 +73,9 @@ class DXILOperationDesc<string name> {
   list<string> StatsGroup = [];
 }
 
-class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory opCategory, string doc,
-              string oloadTypes, string attrs, list<DXILOpParameter> params,
-              list<string> statsGroup = []> : DXILOperationDesc<name> {
+class DxilOperation<string name, int opCode, DxilOpClass opClass, DxilOpCategory opCategory, string doc,
+              string oloadTypes, string attrs, list<DxilOpParameter> params,
+              list<string> statsGroup = []> : DxilOperationDesc<name> {
   let OpName = name;
   let OpCode = opCode;
   let Doc = doc;
@@ -90,56 +90,56 @@ class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory
 // LLVM intrinsic that DXIL operation maps to.
 class LLVMIntrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
 
-def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
+def Sin : DxilOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
   "half;float;", "rn",
   [
-    DXILOpParameter<0, "$o", "", "operation result">,
-    DXILOpParameter<1, "i32", "opcode", "DXIL opcode">,
-    DXILOpParameter<2, "$o", "value", "input value">
+    DxilOpParameter<0, "$o", "", "operation result">,
+    DxilOpParameter<1, "i32", "opcode", "DXIL opcode">,
+    DxilOpParameter<2, "$o", "value", "input value">
   ],
   ["floats"]>,
   LLVMIntrinsic<int_sin>;
 
-def UMax : DXILOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
+def UMax : DxilOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
     "i16;i32;i64;",  "rn",
   [
-    DXILOpParameter<0,  "$o",  "",  "operation result">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "$o",  "a",  "input value">,
-    DXILOpParameter<3,  "$o",  "b",  "input value">
+    DxilOpParameter<0,  "$o",  "",  "operation result">,
+    DxilOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DxilOpParameter<2,  "$o",  "a",  "input value">,
+    DxilOpParameter<3,  "$o",  "b",  "input value">
   ],
   ["uints"]>,
   LLVMIntrinsic<int_umax>;
 
-def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", "i32;",  "rn",
+def ThreadId : DxilOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", "i32;",  "rn",
   [
-    DXILOpParameter<0,  "i32",  "",  "thread ID component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
+    DxilOpParameter<0,  "i32",  "",  "thread ID component">,
+    DxilOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DxilOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id>;
 
-def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", "i32;",  "rn",
+def GroupId : DxilOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", "i32;",  "rn",
   [
-    DXILOpParameter<0,  "i32",  "",  "group ID component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read">
+    DxilOpParameter<0,  "i32",  "",  "group ID component">,
+    DxilOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DxilOpParameter<2,  "i32",  "component",  "component to read">
   ]>,
   LLVMIntrinsic<int_dx_group_id>;
 
-def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
+def ThreadIdInGroup : DxilOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
   "reads the thread ID within the group (SV_GroupThreadID)", "i32;",  "rn",
   [
-    DXILOpParameter<0,  "i32",  "",  "thread ID in group component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
+    DxilOpParameter<0,  "i32",  "",  "thread ID in group component">,
+    DxilOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
+    DxilOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id_in_group>;
 
-def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
+def FlattenedThreadIdInGroup : DxilOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
    "provides a flattened index for a given thread within a given group (SV_GroupIndex)", "i32;",  "rn",
   [
-    DXILOpParameter<0,  "i32",  "",  "result">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">
+    DxilOpParameter<0,  "i32",  "",  "result">,
+    DxilOpParameter<1,  "i32",  "opcode",  "DXIL opcode">
   ]>,
   LLVMIntrinsic<int_dx_flattened_thread_id_in_group>;

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -431,7 +431,7 @@ static void emitDXILOperationTable(std::vector<DXILOperationData> &DXILOps,
 }
 
 static void EmitDXILOperation(RecordKeeper &Records, raw_ostream &OS) {
-  std::vector<Record *> Ops = Records.getAllDerivedDefinitions("DXILOperation");
+  std::vector<Record *> Ops = Records.getAllDerivedDefinitions("DxilOperation");
   OS << "// Generated code, do not edit.\n";
   OS << "\n";
 

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -72,11 +72,11 @@ struct DXILOperationData {
                           // When < 0, should be only 1 overload type.
   SmallVector<StringRef, 4> counters; // counters for this inst.
   DXILOperationData(const Record *R) {
-    Name = R->getValueAsString("name");
-    DXILOp = R->getValueAsString("dxil_op");
-    DXILOpID = R->getValueAsInt("dxil_opid");
-    DXILClass = R->getValueAsDef("op_class")->getValueAsString("name");
-    Category = R->getValueAsDef("category")->getValueAsString("name");
+    Name = R->getValueAsString("Name");
+    DXILOp = R->getValueAsString("OpName");
+    DXILOpID = R->getValueAsInt("OpCode");
+    DXILClass = R->getValueAsDef("OpClass")->getValueAsString("Name");
+    Category = R->getValueAsDef("OpCategory")->getValueAsString("Name");
 
     if (R->getValue("llvm_intrinsic")) {
       auto *IntrinsicDef = R->getValueAsDef("llvm_intrinsic");
@@ -86,9 +86,9 @@ struct DXILOperationData {
       Intrinsic = DefName.substr(4);
     }
 
-    Doc = R->getValueAsString("doc");
+    Doc = R->getValueAsString("Doc");
 
-    ListInit *ParamList = R->getValueAsListInit("ops");
+    ListInit *ParamList = R->getValueAsListInit("Params");
     OverloadParamIndex = -1;
     for (unsigned I = 0; I < ParamList->size(); ++I) {
       Record *Param = ParamList->getElementAsRecord(I);
@@ -97,8 +97,8 @@ struct DXILOperationData {
       if (CurParam.Kind >= ParameterKind::OVERLOAD)
         OverloadParamIndex = I;
     }
-    OverloadTypes = R->getValueAsString("oload_types");
-    FnAttr = R->getValueAsString("fn_attr");
+    OverloadTypes = R->getValueAsString("OverloadTypes");
+    FnAttr = R->getValueAsString("Attributes");
   }
 };
 } // end anonymous namespace
@@ -122,14 +122,14 @@ static ParameterKind parameterTypeNameToKind(StringRef Name) {
 }
 
 DXILParam::DXILParam(const Record *R) {
-  Name = R->getValueAsString("name");
-  Pos = R->getValueAsInt("pos");
-  Kind = parameterTypeNameToKind(R->getValueAsString("llvm_type"));
-  if (R->getValue("doc"))
-    Doc = R->getValueAsString("doc");
-  IsConst = R->getValueAsBit("is_const");
-  EnumName = R->getValueAsString("enum_name");
-  MaxValue = R->getValueAsInt("max_value");
+  Name = R->getValueAsString("Name");
+  Pos = R->getValueAsInt("Pos");
+  Kind = parameterTypeNameToKind(R->getValueAsString("LLVMType"));
+  if (R->getValue("Doc"))
+    Doc = R->getValueAsString("Doc");
+  IsConst = R->getValueAsBit("IsConstant");
+  EnumName = R->getValueAsString("EnumName");
+  MaxValue = R->getValueAsInt("MaxValue");
 }
 
 static std::string parameterKindToString(ParameterKind Kind) {
@@ -431,7 +431,7 @@ static void emitDXILOperationTable(std::vector<DXILOperationData> &DXILOps,
 }
 
 static void EmitDXILOperation(RecordKeeper &Records, raw_ostream &OS) {
-  std::vector<Record *> Ops = Records.getAllDerivedDefinitions("dxil_op");
+  std::vector<Record *> Ops = Records.getAllDerivedDefinitions("DXILOperation");
   OS << "// Generated code, do not edit.\n";
   OS << "\n";
 


### PR DESCRIPTION
These changes are in preparation for potential improvement of DXIL operation description and addition of more DXIL operations to `DXIL.td`.