### PR TITLE
[LLVM] only add exclude metadata to ELF and COFF only

### DIFF
--- a/flang/test/Driver/embed.f90
+++ b/flang/test/Driver/embed.f90
@@ -3,12 +3,17 @@
 ! RUN lines
 !----------
 ! Embed something that can be easily checked
-! RUN: %flang_fc1 -emit-llvm -o - -fembed-offload-object=%S/Inputs/hello.f90 %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-llvm -o - -fembed-offload-object=%S/Inputs/hello.f90 %s 2>&1 | FileCheck %s \
+! RUN:            --check-prefixes=%if system-linux || system-windows %{CHECK-EXCLUDE%} \
+! RUN:            %else %{CHECK-NOEXC%}
 
 ! RUN: %flang_fc1 -emit-llvm-bc -o %t.bc %s 2>&1
-! RUN: %flang_fc1 -emit-llvm -o - -fembed-offload-object=%S/Inputs/hello.f90 %t.bc 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-llvm -o - -fembed-offload-object=%S/Inputs/hello.f90 %t.bc 2>&1 | FileCheck %s \
+! RUN:            --check-prefixes=%if system-linux || system-windows %{CHECK-EXCLUDE%} \
+! RUN:            %else %{CHECK-NOEXC%}
 
-! CHECK: @[[OBJECT_1:.+]] = private constant [61 x i8] c"program hello\0A  write(*,*), \22Hello world!\22\0Aend program hello\0A", section ".llvm.offloading", align 8, !exclude !0
+! CHECK-NOEXC: @[[OBJECT_1:.+]] = private constant [61 x i8] c"program hello\0A  write(*,*), \22Hello world!\22\0Aend program hello\0A", section ".llvm.offloading", align 8
+! CHECK-EXCLUDE: @[[OBJECT_1:.+]] = private constant [61 x i8] c"program hello\0A  write(*,*), \22Hello world!\22\0Aend program hello\0A", section ".llvm.offloading", align 8, !exclude !0
 ! CHECK: @llvm.compiler.used = appending global [1 x ptr] [ptr @[[OBJECT_1]]], section "llvm.metadata"
 
 

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/ModuleUtils.h"
-#include "llvm/Analysis/VectorUtils.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Analysis/VectorUtils.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
@@ -20,6 +20,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/xxhash.h"
+#include "llvm/TargetParser/Triple.h"
 
 using namespace llvm;
 
@@ -346,7 +347,12 @@ void llvm::embedBufferInModule(Module &M, MemoryBufferRef Buf,
                         MDString::get(Ctx, SectionName)};
 
   MD->addOperand(llvm::MDNode::get(Ctx, MDVals));
-  GV->setMetadata(LLVMContext::MD_exclude, llvm::MDNode::get(Ctx, {}));
+
+  // The exclude metadata node is only supported by ELF and COFF
+  // object file formats.
+  Triple TargetTriple = Triple(M.getTargetTriple());
+  if (TargetTriple.isOSBinFormatELF() || TargetTriple.isOSBinFormatCOFF())
+    GV->setMetadata(LLVMContext::MD_exclude, llvm::MDNode::get(Ctx, {}));
 
   appendToCompilerUsed(M, GV);
 }


### PR DESCRIPTION
As per https://github.com/llvm/llvm-project/blob/9a87c5d440ec16a1116e060829df10bc2a6965ce/llvm/docs/LangRef.rst#L6799 , the `exclude` metadata only targets platforms with COFF and ELF object formats.  Modifying `flang` embed test case to only check for the exclude metadata on windows and linux.