### PR TITLE
[mlir][spirv] Handle a missing case when inlining spirv.ReturnValue

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -95,7 +95,9 @@ struct SPIRVInlinerInterface : public DialectInlinerInterface {
       OpBuilder(op).create<spirv::BranchOp>(op->getLoc(), newDest);
       op->erase();
     } else if (auto retValOp = dyn_cast<spirv::ReturnValueOp>(op)) {
-      llvm_unreachable("unimplemented spirv.ReturnValue in inliner");
+      OpBuilder(op).create<spirv::BranchOp>(retValOp->getLoc(), newDest,
+                                            retValOp->getOperands());
+      op->erase();
     }
   }
 

--- a/mlir/test/Dialect/SPIRV/Transforms/inlining.mlir
+++ b/mlir/test/Dialect/SPIRV/Transforms/inlining.mlir
@@ -224,5 +224,27 @@ spirv.module Logical GLSL450 {
   spirv.ExecutionMode @inline_into_selection_region "LocalSize", 32, 1, 1
 }
 
+// -----
+
+spirv.module Logical GLSL450 {
+  // CHECK-LABEL: @foo
+  spirv.func @foo(%arg0: i32) -> i32 "None" {
+    // CHECK-NOT: spirv.FunctionCall
+    // CHECK-NEXT: spirv.Constant 1
+    %res = spirv.FunctionCall @bar(%arg0) : (i32) -> i32
+    spirv.ReturnValue %res : i32
+  }
+
+  spirv.func @bar(%arg1: i32) -> i32 "None" attributes {sym_visibility = "private"} {
+    %cst1_i32 = spirv.Constant 1 : i32
+    %0 = spirv.IEqual %arg1, %cst1_i32 : i32
+    spirv.BranchConditional %0, ^bb1(%cst1_i32 : i32), ^bb2
+  ^bb1(%1: i32):
+    spirv.ReturnValue %1 : i32
+  ^bb2:
+    spirv.ReturnValue %cst1_i32 : i32
+  }
+}
+
 // TODO: Add tests for inlining structured control flow into
 // structured control flow.


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/73285.