### PR TITLE
[Flang] Use specific symbol rather than generic symbol as procInterface to declare procedure pointer.

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5648,7 +5648,9 @@ void DeclarationVisitor::Post(const parser::ProcDecl &x) {
   const auto &name{std::get<parser::Name>(x.t)};
   const Symbol *procInterface{nullptr};
   if (interfaceName_) {
-    procInterface = interfaceName_->symbol;
+    procInterface = interfaceName_->symbol->has<GenericDetails>()
+        ? interfaceName_->symbol->get<GenericDetails>().specific()
+        : interfaceName_->symbol;
   }
   auto attrs{HandleSaveName(name.source, GetAttrs())};
   DerivedTypeDetails *dtDetails{nullptr};


### PR DESCRIPTION
Flang crashes when lowering the type of `p1` with the following code. The problem is when it sets up the `procInterface`, it uses the generic symbol `int`, not the specific `int`. This PR is to correct that.

```
  INTERFACE Int
    integer FUNCTION Int(arg)
      integer :: arg
    END FUNCTION
  END INTERFACE

  integer :: res
  procedure(int), pointer :: p1
  p1 => int
  res = p1(4)
  end
  ```