### PR TITLE
[llvm-mca] Account for AcquireAtCycles in llvm-mca

### DIFF
--- a/llvm/include/llvm/MCA/HWEventListener.h
+++ b/llvm/include/llvm/MCA/HWEventListener.h
@@ -63,7 +63,7 @@ public:
 // ResourceRef::second is a bitmask of the referenced sub-unit of the resource.
 using ResourceRef = std::pair<uint64_t, uint64_t>;
 
-using ResourceUse = std::pair<ResourceRef, ReleaseAtCycles>;
+using ResourceUse = std::pair<ResourceRef, NumCyclesUsed>;
 
 class HWInstructionIssuedEvent : public HWInstructionEvent {
 public:

--- a/llvm/include/llvm/MCA/HardwareUnits/ResourceManager.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/ResourceManager.h
@@ -430,7 +430,7 @@ public:
 
   void issueInstruction(
       const InstrDesc &Desc,
-      SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &Pipes);
+      SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Pipes);
 
   void cycleEvent(SmallVectorImpl<ResourceRef> &ResourcesFreed);
 

--- a/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
@@ -136,7 +136,7 @@ class Scheduler : public HardwareUnit {
   /// Issue an instruction without updating the ready queue.
   void issueInstructionImpl(
       InstRef &IR,
-      SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &Pipes);
+      SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Pipes);
 
   // Identify instructions that have finished executing, and remove them from
   // the IssuedSet. References to executed instructions are added to input
@@ -202,7 +202,7 @@ public:
   /// result of this event.
   void issueInstruction(
       InstRef &IR,
-      SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &Used,
+      SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Used,
       SmallVectorImpl<InstRef> &Pending,
       SmallVectorImpl<InstRef> &Ready);
 

--- a/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h
@@ -201,10 +201,8 @@ public:
   /// and a vector of instructions that transitioned to the ready state as a
   /// result of this event.
   void issueInstruction(
-      InstRef &IR,
-      SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Used,
-      SmallVectorImpl<InstRef> &Pending,
-      SmallVectorImpl<InstRef> &Ready);
+      InstRef &IR, SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Used,
+      SmallVectorImpl<InstRef> &Pending, SmallVectorImpl<InstRef> &Ready);
 
   /// Returns true if IR has to be issued immediately, or if IR is a zero
   /// latency instruction.

--- a/llvm/include/llvm/MCA/Support.h
+++ b/llvm/include/llvm/MCA/Support.h
@@ -48,12 +48,12 @@ template <typename T> char InstructionError<T>::ID;
 /// number of resources, are kept separate.  This is used by the
 /// ResourcePressureView to calculate the average resource cycles
 /// per instruction/iteration.
-class ReleaseAtCycles {
+class NumCyclesUsed {
   unsigned Numerator, Denominator;
 
 public:
-  ReleaseAtCycles() : Numerator(0), Denominator(1) {}
-  ReleaseAtCycles(unsigned Cycles, unsigned ResourceUnits = 1)
+  NumCyclesUsed() : Numerator(0), Denominator(1) {}
+  NumCyclesUsed(unsigned Cycles, unsigned ResourceUnits = 1)
       : Numerator(Cycles), Denominator(ResourceUnits) {}
 
   operator double() const {
@@ -67,7 +67,7 @@ public:
   // Add the components of RHS to this instance.  Instead of calculating
   // the final value here, we keep track of the numerator and denominator
   // separately, to reduce floating point error.
-  ReleaseAtCycles &operator+=(const ReleaseAtCycles &RHS);
+  NumCyclesUsed &operator+=(const NumCyclesUsed &RHS);
 };
 
 /// Populates vector Masks with processor resource masks.
@@ -105,7 +105,7 @@ inline unsigned getResourceStateIndex(uint64_t Mask) {
 /// Compute the reciprocal block throughput from a set of processor resource
 /// cycles. The reciprocal block throughput is computed as the MAX between:
 ///  - NumMicroOps / DispatchWidth
-///  - ProcReleaseAtCycles / #ProcResourceUnits  (for every consumed resource).
+///  - ProcNumCyclesUsed / #ProcResourceUnits  (for every consumed resource).
 double computeBlockRThroughput(const MCSchedModel &SM, unsigned DispatchWidth,
                                unsigned NumMicroOps,
                                ArrayRef<unsigned> ProcResourceUsage);

--- a/llvm/lib/MCA/HardwareUnits/ResourceManager.cpp
+++ b/llvm/lib/MCA/HardwareUnits/ResourceManager.cpp
@@ -346,7 +346,7 @@ uint64_t ResourceManager::checkAvailability(const InstrDesc &Desc) const {
 
 void ResourceManager::issueInstruction(
     const InstrDesc &Desc,
-    SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &Pipes) {
+    SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &Pipes) {
   for (const std::pair<uint64_t, ResourceUsage> &R : Desc.Resources) {
     const CycleSegment &CS = R.second.CS;
     if (!CS.size()) {
@@ -354,13 +354,13 @@ void ResourceManager::issueInstruction(
       continue;
     }
 
-    assert(CS.begin() == 0 && "Invalid {Start, End} cycles!");
+    assert(CS.isValid() && "Invalid {Start, End} cycles!");
     if (!R.second.isReserved()) {
       ResourceRef Pipe = selectPipe(R.first);
       use(Pipe);
       BusyResources[Pipe] += CS.size();
-      Pipes.emplace_back(std::pair<ResourceRef, ReleaseAtCycles>(
-          Pipe, ReleaseAtCycles(CS.size())));
+      Pipes.emplace_back(std::pair<ResourceRef, NumCyclesUsed>(
+          Pipe, NumCyclesUsed(CS.size())));
     } else {
       assert((llvm::popcount(R.first) > 1) && "Expected a group!");
       // Mark this group as reserved.

--- a/llvm/lib/MCA/HardwareUnits/Scheduler.cpp
+++ b/llvm/lib/MCA/HardwareUnits/Scheduler.cpp
@@ -69,7 +69,7 @@ Scheduler::Status Scheduler::isAvailable(const InstRef &IR) {
 
 void Scheduler::issueInstructionImpl(
     InstRef &IR,
-    SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &UsedResources) {
+    SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &UsedResources) {
   Instruction *IS = IR.getInstruction();
   const InstrDesc &D = IS->getDesc();
 
@@ -98,7 +98,7 @@ void Scheduler::issueInstructionImpl(
 // Release the buffered resources and issue the instruction.
 void Scheduler::issueInstruction(
     InstRef &IR,
-    SmallVectorImpl<std::pair<ResourceRef, ReleaseAtCycles>> &UsedResources,
+    SmallVectorImpl<std::pair<ResourceRef, NumCyclesUsed>> &UsedResources,
     SmallVectorImpl<InstRef> &PendingInstructions,
     SmallVectorImpl<InstRef> &ReadyInstructions) {
   const Instruction &Inst = *IR.getInstruction();

--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -89,11 +89,11 @@ static void initializeUsedResources(InstrDesc &ID,
       AllInOrderResources &= (PR.BufferSize <= 1);
     }
 
-    CycleSegment RCy(0, PRE->ReleaseAtCycle, false);
+    CycleSegment RCy(PRE->AcquireAtCycle, PRE->ReleaseAtCycle, false);
     Worklist.emplace_back(ResourcePlusCycles(Mask, ResourceUsage(RCy)));
     if (PR.SuperIdx) {
       uint64_t Super = ProcResourceMasks[PR.SuperIdx];
-      SuperResources[Super] += PRE->ReleaseAtCycle;
+      SuperResources[Super] += PRE->ReleaseAtCycle - PRE->AcquireAtCycle;
     }
   }
 

--- a/llvm/lib/MCA/Stages/InstructionTables.cpp
+++ b/llvm/lib/MCA/Stages/InstructionTables.cpp
@@ -38,7 +38,7 @@ Error InstructionTables::execute(InstRef &IR) {
       for (unsigned I = 0, E = NumUnits; I < E; ++I) {
         ResourceRef ResourceUnit = std::make_pair(Index, 1U << I);
         UsedResources.emplace_back(
-            std::make_pair(ResourceUnit, ReleaseAtCycles(Cycles, NumUnits)));
+            std::make_pair(ResourceUnit, NumCyclesUsed(Cycles, NumUnits)));
       }
       continue;
     }
@@ -54,7 +54,7 @@ Error InstructionTables::execute(InstRef &IR) {
         ResourceRef ResourceUnit = std::make_pair(SubUnitIdx, 1U << I2);
         UsedResources.emplace_back(std::make_pair(
             ResourceUnit,
-            ReleaseAtCycles(Cycles, NumUnits * SubUnit.NumUnits)));
+            NumCyclesUsed(Cycles, NumUnits * SubUnit.NumUnits)));
       }
     }
   }

--- a/llvm/lib/MCA/Stages/InstructionTables.cpp
+++ b/llvm/lib/MCA/Stages/InstructionTables.cpp
@@ -53,8 +53,7 @@ Error InstructionTables::execute(InstRef &IR) {
       for (unsigned I2 = 0, E2 = SubUnit.NumUnits; I2 < E2; ++I2) {
         ResourceRef ResourceUnit = std::make_pair(SubUnitIdx, 1U << I2);
         UsedResources.emplace_back(std::make_pair(
-            ResourceUnit,
-            NumCyclesUsed(Cycles, NumUnits * SubUnit.NumUnits)));
+            ResourceUnit, NumCyclesUsed(Cycles, NumUnits * SubUnit.NumUnits)));
       }
     }
   }

--- a/llvm/lib/MCA/Support.cpp
+++ b/llvm/lib/MCA/Support.cpp
@@ -21,7 +21,7 @@ namespace mca {
 
 #define DEBUG_TYPE "llvm-mca"
 
-ReleaseAtCycles &ReleaseAtCycles::operator+=(const ReleaseAtCycles &RHS) {
+NumCyclesUsed &NumCyclesUsed::operator+=(const NumCyclesUsed &RHS) {
   if (Denominator == RHS.Denominator)
     Numerator += RHS.Numerator;
   else {
@@ -92,18 +92,18 @@ double computeBlockRThroughput(const MCSchedModel &SM, unsigned DispatchWidth,
   // The number of available resource units affects the resource pressure
   // distribution, as well as how many blocks can be executed every cycle.
   for (unsigned I = 0, E = SM.getNumProcResourceKinds(); I < E; ++I) {
-    unsigned ReleaseAtCycles = ProcResourceUsage[I];
-    if (!ReleaseAtCycles)
+    unsigned NumCyclesUsed = ProcResourceUsage[I];
+    if (!NumCyclesUsed)
       continue;
 
     const MCProcResourceDesc &MCDesc = *SM.getProcResource(I);
-    double Throughput = static_cast<double>(ReleaseAtCycles) / MCDesc.NumUnits;
+    double Throughput = static_cast<double>(NumCyclesUsed) / MCDesc.NumUnits;
     Max = std::max(Max, Throughput);
   }
 
   // The block reciprocal throughput is computed as the MAX of:
   //  - (NumMicroOps / DispatchWidth)
-  //  - (NumUnits / ReleaseAtCycles)   for every consumed processor resource.
+  //  - (NumUnits / NumCyclesUsed)   for every consumed processor resource.
   return Max;
 }
 

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/reductions.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/reductions.s
@@ -223,13 +223,13 @@ vfredmin.vs  v4, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      206
-# CHECK-NEXT: Total Cycles:      8746
+# CHECK-NEXT: Total Cycles:      8644
 # CHECK-NEXT: Total uOps:        206
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 8743.0
+# CHECK-NEXT: Block RThroughput: 8640.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -459,213 +459,213 @@ vfredmin.vs  v4, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     103.00  -     8743.00 103.00  -     -
+# CHECK-NEXT:  -      -     103.00  -     8640.00 103.00  -     -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     53.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vredand.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vredand.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     36.00  1.00    -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vredor.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vredor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     51.00  1.00    -      -     vredor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     32.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     34.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     53.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     36.00  1.00    -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vredminu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     51.00  1.00    -      -     vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     32.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     34.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     50.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     54.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
 # CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     53.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     36.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vwredsum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     51.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     62.00  1.00    -      -     vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     97.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     96.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     193.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     192.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     385.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     384.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     769.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     768.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1537.00 1.00   -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1536.00 1.00   -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     97.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     96.00  1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     193.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     192.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     385.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     384.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     769.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     768.00 1.00    -      -     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
 # CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfredmax.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfredmax.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfredmax.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     45.00  1.00    -      -     vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     49.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     36.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     40.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     52.00  1.00    -      -     vfredmin.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vfredmin.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     35.00  1.00    -      -     vfredmin.vs	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     51.00  1.00    -      -     vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     41.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     42.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     44.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     48.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     36.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     37.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -     39.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     43.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     51.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     32.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     34.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     38.00  1.00    -      -     vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     47.00  1.00    -      -     vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     46.00  1.00    -      -     vfredmin.vs	v4, v8, v12

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-store.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-store.s
@@ -125,13 +125,13 @@ vlse64.v v1, (a1), a2
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      100
-# CHECK-NEXT: Total Cycles:      4734
+# CHECK-NEXT: Total Cycles:      4678
 # CHECK-NEXT: Total uOps:        100
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 4686.0
+# CHECK-NEXT: Block RThroughput: 4608.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -255,107 +255,107 @@ vlse64.v v1, (a1), a2
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     22.00   -      -     78.00  4686.00  -
+# CHECK-NEXT:  -      -     22.00   -      -     78.00  4608.00  -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   256.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   256.00  -     vlse16.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   513.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   512.00  -     vlse8.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   257.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   256.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   256.00  -     vlse16.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   129.00  -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   128.00  -     vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   33.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   32.00   -     vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   65.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   64.00   -     vlse64.v	v1, (a1), a2

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-x0.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/strided-load-x0.s
@@ -37,13 +37,13 @@ vle64.v v1, (a1)
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      26
-# CHECK-NEXT: Total Cycles:      234
+# CHECK-NEXT: Total Cycles:      211
 # CHECK-NEXT: Total uOps:        26
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.11
-# CHECK-NEXT: IPC:               0.11
-# CHECK-NEXT: Block RThroughput: 229.0
+# CHECK-NEXT: uOps Per Cycle:    0.12
+# CHECK-NEXT: IPC:               0.12
+# CHECK-NEXT: Block RThroughput: 205.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -93,33 +93,33 @@ vle64.v v1, (a1)
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -      -     24.00  229.00  -
+# CHECK-NEXT:  -      -     2.00    -      -     24.00  205.00  -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a1)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a1)
 # CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a1)
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle64.v	v1, (a1)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle32.v	v1, (a1)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle64.v	v1, (a1)

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/vector-integer-arithmetic.s
@@ -755,13 +755,13 @@ vmv.v.v v4, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      707
-# CHECK-NEXT: Total Cycles:      11962
+# CHECK-NEXT: Total Cycles:      11753
 # CHECK-NEXT: Total uOps:        707
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.06
 # CHECK-NEXT: IPC:               0.06
-# CHECK-NEXT: Block RThroughput: 11549.0
+# CHECK-NEXT: Block RThroughput: 11175.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -1492,714 +1492,714 @@ vmv.v.v v4, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     333.00  -     11549.00 374.00  -    -
+# CHECK-NEXT:  -      -     333.00  -     11175.00 374.00  -    -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsub.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsub.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsub.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadd.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vadd.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsubu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwsubu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwsubu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsubu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwadd.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwadd.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwadd.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwadd.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwsub.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwsub.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsub.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwsub.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwaddu.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwaddu.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwaddu.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwsubu.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwsubu.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwsubu.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwsubu.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwadd.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwadd.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwadd.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwadd.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwsub.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwsub.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwsub.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwsub.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf4	v4, v8
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf4	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf2	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf4	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vzext.vf8	v4, v8
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf2	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf4	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vzext.vf8	v4, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsext.vf8	v4, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadc.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadc.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsbc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsbc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsbc.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsbc.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vxor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vxor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vxor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vor.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vor.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vor.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vxor.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vxor.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vxor.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vand.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vand.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vand.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vxor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vxor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vxor.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vxor.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vxor.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vxor.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vand.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vand.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vand.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vand.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vand.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vand.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vor.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vor.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsra.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsra.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsra.vi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsrl.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsrl.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsrl.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsra.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsra.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsra.vi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsll.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsll.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsll.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vsrl.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsrl.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsra.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsra.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsra.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsra.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsra.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsra.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsll.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsll.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vsll.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vsll.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsll.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsll.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmseq.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmseq.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsne.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsne.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsne.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmsne.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsne.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmsne.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsltu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmsltu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsltu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsltu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmslt.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmslt.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmslt.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsleu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmsleu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsleu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmsleu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmsleu.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsle.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmsle.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsle.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsle.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmsle.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmsgtu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmsgtu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmsgtu.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmsgt.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsgt.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmsgt.vi	v4, v8, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmin.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmax.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmax.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmin.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmax.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmax.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vminu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vminu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmin.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmin.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmax.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmax.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vminu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vminu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmin.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmin.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmax.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmax.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vminu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vminu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmin.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmin.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmin.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhsu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmul.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmul.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulhsu.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulhsu.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmul.vv	v4, v8, v12
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmul.vx	v4, v8, a0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     30.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     60.00  1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     120.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     480.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     960.00 1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1920.00 1.00   -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     30.00  1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     60.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     120.00 1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     480.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     960.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     112.00 1.00    -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     225.00 1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     224.00 1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     449.00 1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     448.00 1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     896.00 1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     229.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     228.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     457.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     456.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     912.00 1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vnmsub.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vnmsub.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsub.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsub.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmacc.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmacc.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmacc.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmacc.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vv	v4, v12, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmaccsu.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmaccus.vx	v4, a0, v8
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmv.v.v	v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     5.00   1.00    -      -     vmv.v.x	v4, a0
+# CHECK-NEXT:  -      -      -      -     4.00   1.00    -      -     vmv.v.x	v4, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vmv.v.i	v4, 0
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vmv.v.i	v4, 0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmv.v.v	v4, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vmv.v.v	v4, v12

--- a/llvm/test/tools/llvm-mca/RISCV/different-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/different-lmul-instruments.s
@@ -16,7 +16,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 20.0
+# CHECK-NEXT: Block RThroughput: 18.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -44,14 +44,14 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     18.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/different-sew-instruments.s
@@ -11,13 +11,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      359
+# CHECK-NEXT: Total Cycles:      358
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 356.0
+# CHECK-NEXT: Block RThroughput: 354.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -45,14 +45,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     356.00 2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     354.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/disable-im.s
+++ b/llvm/test/tools/llvm-mca/RISCV/disable-im.s
@@ -13,13 +13,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      6
-# CHECK-NEXT: Total Cycles:      42
+# CHECK-NEXT: Total Cycles:      40
 # CHECK-NEXT: Total uOps:        6
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.14
-# CHECK-NEXT: IPC:               0.14
-# CHECK-NEXT: Block RThroughput: 51.0
+# CHECK-NEXT: uOps Per Cycle:    0.15
+# CHECK-NEXT: IPC:               0.15
+# CHECK-NEXT: Block RThroughput: 48.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -49,27 +49,27 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     51.00  3.00    -      -
+# CHECK-NEXT:  -      -     3.00    -     48.00  3.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
-# CHECK-NEXT: Index     0123456789          0123456789          01
+# CHECK-NEXT: Index     0123456789          0123456789
 
-# CHECK:      [0,0]     DeeE .    .    .    .    .    .    .    ..   vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .    .    .    ..   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .    .    .    ..   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,3]     .    .    .    .    DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,4]     .    .    .    .    .DeeE.    .    .    ..   vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT: [0,5]     .    .    .    .    .    .    .    . DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeE .    .    .    .    .    .    .   .   vsetvli	zero, a0, e8, m2, tu, mu
+# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .    .    .   .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .    .    .   .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,3]     .    .    .    .   DeeeE .    .    .   .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,4]     .    .    .    .    DeeE .    .    .   .   vsetvli	zero, a0, e8, m8, tu, mu
+# CHECK-NEXT: [0,5]     .    .    .    .    .    .    .    DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/fractional-lmul-data.s
@@ -11,13 +11,13 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      91
+# CHECK-NEXT: Total Cycles:      90
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.04
 # CHECK-NEXT: IPC:               0.04
-# CHECK-NEXT: Block RThroughput: 88.0
+# CHECK-NEXT: Block RThroughput: 86.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -45,11 +45,11 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     88.00  2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     86.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     56.00  1.00    -      -     vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     30.00  1.00    -      -     vdiv.vv	v12, v12, v12

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-at-start.s
@@ -13,7 +13,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 3.0
+# CHECK-NEXT: Block RThroughput: 2.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -39,12 +39,12 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     2.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-middle.s
@@ -8,13 +8,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      22
+# CHECK-NEXT: Total Cycles:      21
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.14
 # CHECK-NEXT: IPC:               0.14
-# CHECK-NEXT: Block RThroughput: 19.0
+# CHECK-NEXT: Block RThroughput: 17.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -41,21 +41,21 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     19.00  2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     17.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          01
+# CHECK-NEXT: Index     0123456789          0
 
-# CHECK:      [0,0]     DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,1]     .DeeE.    .    .    ..   vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT: [0,2]     .    .    .    . DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeeE.    .    .    .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,1]     .DeeE.    .    .    .   vsetvli	zero, a0, e8, mf8, tu, mu
+# CHECK-NEXT: [0,2]     .    .    .    .DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-in-region.s
@@ -17,7 +17,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 3.0
+# CHECK-NEXT: Block RThroughput: 2.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -43,12 +43,12 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     2.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/lmul-instrument-straddles-region.s
@@ -18,7 +18,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.25
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 3.0
+# CHECK-NEXT: Block RThroughput: 2.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -44,12 +44,12 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     3.00   1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     2.00   1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     01234567

--- a/llvm/test/tools/llvm-mca/RISCV/multiple-same-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/multiple-same-lmul-instruments.s
@@ -15,13 +15,13 @@ vsub.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      8
-# CHECK-NEXT: Total Cycles:      29
+# CHECK-NEXT: Total Cycles:      28
 # CHECK-NEXT: Total uOps:        8
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.28
-# CHECK-NEXT: IPC:               0.28
-# CHECK-NEXT: Block RThroughput: 27.0
+# CHECK-NEXT: uOps Per Cycle:    0.29
+# CHECK-NEXT: IPC:               0.29
+# CHECK-NEXT: Block RThroughput: 22.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -53,31 +53,31 @@ vsub.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     27.00  5.00    -      -
+# CHECK-NEXT:  -      -     3.00    -     22.00  5.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vsub.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vsub.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vadd.vv	v12, v12, v12
-# CHECK-NEXT:  -      -      -      -     9.00   1.00    -      -     vsub.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     8.00   1.00    -      -     vsub.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          012345678
+# CHECK-NEXT: Index     0123456789          01234567
 
-# CHECK:      [0,0]     DeeE .    .    .    .    .  .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    .  .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    .  .   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,3]     .    . DeeeE   .    .    .  .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,4]     .    .    .DeeeE    .    .  .   vsub.vv	v12, v12, v12
-# CHECK-NEXT: [0,5]     .    .    . DeeE    .    .  .   vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT: [0,6]     .    .    .    DeeeE.    .  .   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,7]     .    .    .    .    .   DeeeE   vsub.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeE .    .    .    .    . .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,1]     .  DeeeE  .    .    .    . .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,2]     .   DeeE  .    .    .    . .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,3]     .    . DeeeE   .    .    . .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,4]     .    .    .DeeeE    .    . .   vsub.vv	v12, v12, v12
+# CHECK-NEXT: [0,5]     .    .    . DeeE    .    . .   vsetvli	zero, a0, e8, m4, tu, mu
+# CHECK-NEXT: [0,6]     .    .    .    DeeeE.    . .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,7]     .    .    .    .    .  DeeeE   vsub.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/multiple-same-sew-instruments.s
@@ -16,13 +16,13 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      8
-# CHECK-NEXT: Total Cycles:      574
+# CHECK-NEXT: Total Cycles:      570
 # CHECK-NEXT: Total uOps:        8
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 571.0
+# CHECK-NEXT: Block RThroughput: 566.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -54,18 +54,18 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     571.00 5.00    -      -
+# CHECK-NEXT:  -      -     3.00    -     566.00 5.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     112.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     112.00 1.00    -      -     vdivu.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/needs-sew-but-only-lmul.s
@@ -10,13 +10,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      485
+# CHECK-NEXT: Total Cycles:      484
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 482.0
+# CHECK-NEXT: Block RThroughput: 480.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -43,13 +43,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     482.00 2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     480.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/no-vsetvli-to-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/no-vsetvli-to-start.s
@@ -7,13 +7,13 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      22
+# CHECK-NEXT: Total Cycles:      21
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.14
 # CHECK-NEXT: IPC:               0.14
-# CHECK-NEXT: Block RThroughput: 20.0
+# CHECK-NEXT: Block RThroughput: 18.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -40,21 +40,21 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     20.00  2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     18.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
-# CHECK-NEXT: Index     0123456789          01
+# CHECK-NEXT: Index     0123456789          0
 
-# CHECK:      [0,0]     DeeeE.    .    .    ..   vadd.vv	v12, v12, v12
-# CHECK-NEXT: [0,1]     .DeeE.    .    .    ..   vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT: [0,2]     .    .    .    . DeeeE   vadd.vv	v12, v12, v12
+# CHECK:      [0,0]     DeeeE.    .    .    .   vadd.vv	v12, v12, v12
+# CHECK-NEXT: [0,1]     .DeeE.    .    .    .   vsetvli	zero, a0, e8, m1, tu, mu
+# CHECK-NEXT: [0,2]     .    .    .    .DeeeE   vadd.vv	v12, v12, v12
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-at-start.s
@@ -14,7 +14,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 241.0
+# CHECK-NEXT: Block RThroughput: 240.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -40,12 +40,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     241.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     240.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-middle.s
@@ -13,13 +13,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      2834
+# CHECK-NEXT: Total Cycles:      2833
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 2834.0
+# CHECK-NEXT: Block RThroughput: 2832.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -46,13 +46,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2834.00 2.00   -      -
+# CHECK-NEXT:  -      -     1.00    -     2832.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1920.00 1.00   -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     912.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-in-region.s
@@ -18,7 +18,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 115.0
+# CHECK-NEXT: Block RThroughput: 114.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -44,12 +44,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     114.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/sew-instrument-straddles-region.s
@@ -19,7 +19,7 @@ vdiv.vv v8, v8, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 115.0
+# CHECK-NEXT: Block RThroughput: 114.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -45,12 +45,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     114.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     114.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/vle-vse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vle-vse.s
@@ -413,13 +413,13 @@ vsm.v    v1, (a0)
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      400
-# CHECK-NEXT: Total Cycles:      1133
+# CHECK-NEXT: Total Cycles:      1059
 # CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.35
-# CHECK-NEXT: IPC:               0.35
-# CHECK-NEXT: Block RThroughput: 524.0
+# CHECK-NEXT: uOps Per Cycle:    0.38
+# CHECK-NEXT: IPC:               0.38
+# CHECK-NEXT: Block RThroughput: 424.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -843,407 +843,407 @@ vsm.v    v1, (a0)
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     200.00  -      -     200.00 524.00 524.00
+# CHECK-NEXT:  -      -     200.00  -      -     200.00 424.00 424.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00   1.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   5.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   4.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   9.00    -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   8.00    -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   17.00   -     vle64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   16.00   -     vle64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse8.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse8.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse16.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse16.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     1.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse32.v	v1, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse32.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse32.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     5.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     4.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     9.00   vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     8.00   vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     17.00  vse64.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     16.00  vse64.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00   3.00    -     vlm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00   2.00    -     vlm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -     1.00    -     3.00   vsm.v	v1, (a0)
+# CHECK-NEXT:  -      -      -      -      -     1.00    -     2.00   vsm.v	v1, (a0)

--- a/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-instrument.s
@@ -14,7 +14,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 20.0
+# CHECK-NEXT: Block RThroughput: 18.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -42,14 +42,14 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     18.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetivli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1141
+# CHECK-NEXT: Total Cycles:      1140
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1138.0
+# CHECK-NEXT: Block RThroughput: 1136.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -42,14 +42,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     1136.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     896.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-instrument.s
@@ -14,7 +14,7 @@ vadd.vv v12, v12, v12
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
-# CHECK-NEXT: Block RThroughput: 20.0
+# CHECK-NEXT: Block RThroughput: 18.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -42,14 +42,14 @@ vadd.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     20.00  2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     18.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vadd.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vadd.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     16.00  1.00    -      -     vadd.vv	v12, v12, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01

--- a/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/vsetvli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1141
+# CHECK-NEXT: Total Cycles:      1140
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1138.0
+# CHECK-NEXT: Block RThroughput: 1136.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -42,14 +42,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     1136.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     240.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     896.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
+++ b/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
@@ -611,9 +611,9 @@ void BottleneckAnalysis::printBottleneckHints(raw_ostream &OS) const {
     ArrayRef<unsigned> Distribution = Tracker.getResourcePressureDistribution();
     const MCSchedModel &SM = getSubTargetInfo().getSchedModel();
     for (unsigned I = 0, E = Distribution.size(); I < E; ++I) {
-      unsigned ReleaseAtCycles = Distribution[I];
-      if (ReleaseAtCycles) {
-        double Frequency = (double)ReleaseAtCycles * 100 / TotalCycles;
+      unsigned NumCyclesUsed = Distribution[I];
+      if (NumCyclesUsed) {
+        double Frequency = (double)NumCyclesUsed * 100 / TotalCycles;
         const MCProcResourceDesc &PRDesc = *SM.getProcResource(I);
         OS << "\n  - " << PRDesc.Name << "  [ "
            << format("%.2f", floor((Frequency * 100) + 0.5) / 100) << "% ]";

--- a/llvm/tools/llvm-mca/Views/ResourcePressureView.cpp
+++ b/llvm/tools/llvm-mca/Views/ResourcePressureView.cpp
@@ -54,7 +54,7 @@ void ResourcePressureView::onEvent(const HWInstructionEvent &Event) {
   const auto &IssueEvent = static_cast<const HWInstructionIssuedEvent &>(Event);
   ArrayRef<llvm::MCInst> Source = getSource();
   const unsigned SourceIdx = Event.IR.getSourceIndex() % Source.size();
-  for (const std::pair<ResourceRef, ReleaseAtCycles> &Use :
+  for (const std::pair<ResourceRef, NumCyclesUsed> &Use :
        IssueEvent.UsedResources) {
     const ResourceRef &RR = Use.first;
     assert(Resource2VecIndex.contains(RR.first));
@@ -181,7 +181,7 @@ json::Value ResourcePressureView::toJSON() const {
   ArrayRef<llvm::MCInst> Source = getSource();
   const unsigned Executions = LastInstructionIdx / Source.size() + 1;
   for (const auto &R : enumerate(ResourceUsage)) {
-    const ReleaseAtCycles &RU = R.value();
+    const NumCyclesUsed &RU = R.value();
     if (RU.getNumerator() == 0)
       continue;
     unsigned InstructionIndex = R.index() / NumResourceUnits;

--- a/llvm/tools/llvm-mca/Views/ResourcePressureView.h
+++ b/llvm/tools/llvm-mca/Views/ResourcePressureView.h
@@ -78,7 +78,7 @@ class ResourcePressureView : public InstructionView {
   llvm::DenseMap<unsigned, unsigned> Resource2VecIndex;
 
   // Table of resources used by instructions.
-  std::vector<ReleaseAtCycles> ResourceUsage;
+  std::vector<NumCyclesUsed> ResourceUsage;
   unsigned NumResourceUnits;
 
   void printResourcePressurePerIter(llvm::raw_ostream &OS) const;


### PR DESCRIPTION
In the past, there was a variable named ResourceCycles which modeled how long a resource was consumed. Then a variable named AcquireAtCycles was added and allowed the scheduler to specify how many cycles after issuing the instruction the resource was acquired. Relatively to the issue cycle, the resource was consumed from that AcquireAtCycle until the cycle ResourceCycles.

We decided ResourceCycles should be renamed ReleaseAtCycle, and the number of cycles a resource was consumed is ReleaseAtCycle - AcquireAtCycle. This renaming happened globally, but only the scheduler was updated to account for AcquireAtCycle.

This patch accounts for the total number of cycles to be calculated as ReleaseAtCycle - AcquireAtCycle in llvm-mca. This patch renames the class ReleaseAtCycles to NumCyclesUsed since that better describes what that class now models.