### PR TITLE
[llvm][unittests] Put human-readable names on TargetParserTests. NFC

### DIFF
--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -163,15 +163,13 @@ template <typename T> struct ARMCPUTestParams {
     return os;
   }
 
-  static std::function<std::string(const testing::TestParamInfo<ARMCPUTestParams<T>>& Info)>
-  PrintToStringParamName() {
-    return [](const testing::TestParamInfo<ARMCPUTestParams<T>>& Info) {
-      std::string Name = Info.param.CPUName.str();
-      for (char &C : Name)
-        if (!std::isalnum(C))
-          C = '_';
-      return Name;
-    };
+  static std::string
+  PrintToStringParamName(const testing::TestParamInfo<ARMCPUTestParams<T>>& Info) {
+    std::string Name = Info.param.CPUName.str();
+    for (char &C : Name)
+      if (!std::isalnum(C))
+        C = '_';
+    return Name;
   }
 
   StringRef CPUName;
@@ -275,7 +273,7 @@ INSTANTIATE_TEST_SUITE_P(
                                    "7-A"),
         ARMCPUTestParams<uint64_t>("cortex-a8", "armv7-a", "neon",
                                    ARM::AEK_SEC | ARM::AEK_DSP, "7-A")),
-    ARMCPUTestParams<uint64_t>::PrintToStringParamName());
+    ARMCPUTestParams<uint64_t>::PrintToStringParamName);
 
 // gtest in llvm has a limit of 50 test cases when using ::Values so we split
 // them into 2 blocks
@@ -496,7 +494,7 @@ INSTANTIATE_TEST_SUITE_P(
         ARMCPUTestParams<uint64_t>("swift", "armv7s", "neon-vfpv4",
                                    ARM::AEK_HWDIVARM | ARM::AEK_HWDIVTHUMB | ARM::AEK_DSP,
                                    "7-S")),
-    ARMCPUTestParams<uint64_t>::PrintToStringParamName());
+    ARMCPUTestParams<uint64_t>::PrintToStringParamName);
 
 static constexpr unsigned NumARMCPUArchs = 90;
 
@@ -1674,7 +1672,7 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_FP, AArch64::AEK_SIMD, AArch64::AEK_FP16,
                  AArch64::AEK_RAS, AArch64::AEK_LSE, AArch64::AEK_RDM})),
             "8.2-A")),
-    ARMCPUTestParams<AArch64::ExtensionBitset>::PrintToStringParamName());
+    ARMCPUTestParams<AArch64::ExtensionBitset>::PrintToStringParamName);
 
 // Note: number of CPUs includes aliases.
 static constexpr unsigned NumAArch64CPUArchs = 68;

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -163,6 +163,17 @@ template <typename T> struct ARMCPUTestParams {
     return os;
   }
 
+  static std::function<std::string(const testing::TestParamInfo<ARMCPUTestParams<T>>& Info)>
+  PrintToStringParamName() {
+    return [](const testing::TestParamInfo<ARMCPUTestParams<T>>& Info) {
+      std::string Name = Info.param.CPUName.str();
+      for (char &C : Name)
+        if (!std::isalnum(C))
+          C = '_';
+      return Name;
+    };
+  }
+
   StringRef CPUName;
   StringRef ExpectedArch;
   StringRef ExpectedFPU;
@@ -263,7 +274,8 @@ INSTANTIATE_TEST_SUITE_P(
                              ARM::AEK_SEC | ARM::AEK_VIRT | ARM::AEK_DSP,
                                    "7-A"),
         ARMCPUTestParams<uint64_t>("cortex-a8", "armv7-a", "neon",
-                                   ARM::AEK_SEC | ARM::AEK_DSP, "7-A")));
+                                   ARM::AEK_SEC | ARM::AEK_DSP, "7-A")),
+    ARMCPUTestParams<uint64_t>::PrintToStringParamName());
 
 // gtest in llvm has a limit of 50 test cases when using ::Values so we split
 // them into 2 blocks
@@ -483,7 +495,8 @@ INSTANTIATE_TEST_SUITE_P(
         ARMCPUTestParams<uint64_t>("xscale", "xscale", "none", ARM::AEK_NONE, "xscale"),
         ARMCPUTestParams<uint64_t>("swift", "armv7s", "neon-vfpv4",
                                    ARM::AEK_HWDIVARM | ARM::AEK_HWDIVTHUMB | ARM::AEK_DSP,
-                                   "7-S")));
+                                   "7-S")),
+    ARMCPUTestParams<uint64_t>::PrintToStringParamName());
 
 static constexpr unsigned NumARMCPUArchs = 90;
 
@@ -1660,7 +1673,8 @@ INSTANTIATE_TEST_SUITE_P(
                 {AArch64::AEK_CRC, AArch64::AEK_AES, AArch64::AEK_SHA2,
                  AArch64::AEK_FP, AArch64::AEK_SIMD, AArch64::AEK_FP16,
                  AArch64::AEK_RAS, AArch64::AEK_LSE, AArch64::AEK_RDM})),
-            "8.2-A")));
+            "8.2-A")),
+    ARMCPUTestParams<AArch64::ExtensionBitset>::PrintToStringParamName());
 
 // Note: number of CPUs includes aliases.
 static constexpr unsigned NumAArch64CPUArchs = 68;

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -163,6 +163,10 @@ template <typename T> struct ARMCPUTestParams {
     return os;
   }
 
+  /// Print a gtest-compatible facsimile of the CPUName, to make the test's name
+  /// human-readable.
+  ///
+  /// https://github.com/google/googletest/blob/main/docs/advanced.md#specifying-names-for-value-parameterized-test-parameters
   static std::string
   PrintToStringParamName(const testing::TestParamInfo<ARMCPUTestParams<T>>& Info) {
     std::string Name = Info.param.CPUName.str();


### PR DESCRIPTION
Before:
```
[----------] 65 tests from AArch64CPUTests/AArch64CPUTestFixture
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/0
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/0 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/1
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/1 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/2
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/2 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/3
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/3 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/4
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/4 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/5
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/5 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/6
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/6 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/7
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/7 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/8
...
```

After:
```
[----------] 65 tests from AArch64CPUTests/AArch64CPUTestFixture
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a34
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a34 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a35
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a35 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a53
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a53 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a55
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a55 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a510
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a510 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a520
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a520 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a57
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a57 (0 ms)
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65 (0 ms)
...
```

Which improves the experience of finding and running this:
```
$ ./unittests/TargetParser/TargetParserTests --gtest_filter=AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65
Note: Google Test filter = AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from AArch64CPUTests/AArch64CPUTestFixture
[ RUN      ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65
[       OK ] AArch64CPUTests/AArch64CPUTestFixture.testAArch64CPU/cortex_a65 (0 ms)
[----------] 1 test from AArch64CPUTests/AArch64CPUTestFixture (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```