### PR TITLE
[workflows] Fix lldb-tests and libclc-tests

### DIFF
--- a/.github/workflows/libclc-tests.yml
+++ b/.github/workflows/libclc-tests.yml
@@ -36,5 +36,4 @@ jobs:
     name: Test libclc
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
-      build_target: ''
       projects: clang;libclc

--- a/.github/workflows/lldb-tests.yml
+++ b/.github/workflows/lldb-tests.yml
@@ -36,5 +36,4 @@ jobs:
     name: Build lldb
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
-      build_target: ''
       projects: clang;lldb

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -22,8 +22,9 @@ on:
   workflow_call:
     inputs:
       build_target:
-        required: true
+        required: false
         type: string
+        default: "all"
 
       projects:
         required: true


### PR DESCRIPTION
This was broken by d25022bb689b9bf48a24c0ae6c29c1d3c2f32823, which caused the workflow to pass an empty string to ninja as the target. The 'all' target is probably not the right target for these tests, but this is what the behavior was before
d25022bb689b9bf48a24c0ae6c29c1d3c2f32823.