### PR TITLE
Mark llvm/test/CodeGen/WebAssembly/immediates.ll as passing on MIPS

### DIFF
--- a/llvm/test/CodeGen/WebAssembly/immediates.ll
+++ b/llvm/test/CodeGen/WebAssembly/immediates.ll
@@ -1,11 +1,5 @@
 ; RUN: llc < %s -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-keep-registers | FileCheck %s
 
-; Usually MIPS hosts uses a legacy (non IEEE 754-2008) encoding for NaNs.
-; Tests like `nan_f32` failed in attempt to compare hard-coded IEEE 754-2008
-; NaN value and a legacy NaN value provided by a system.
-; FIXME: This should be based on host not target, but there's no "system-mips" feature.
-; XFAIL: target={{(mips|mipsel|mips64|mips64el)-.*}}
-
 ; Test that basic immediates assemble as expected.
 
 target triple = "wasm32-unknown-unknown"


### PR DESCRIPTION
Fixes #80533