### PR TITLE
[SelectionDAG] Use getRegisterType instead of getTypeToTransformTo in ComputePHILiveOutRegInfo.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
@@ -431,7 +431,7 @@ void FunctionLoweringInfo::ComputePHILiveOutRegInfo(const PHINode *PN) {
 
   if (TLI->getNumRegisters(PN->getContext(), IntVT) != 1)
     return;
-  IntVT = TLI->getTypeToTransformTo(PN->getContext(), IntVT);
+  IntVT = TLI->getRegisterType(PN->getContext(), IntVT);
   unsigned BitWidth = IntVT.getSizeInBits();
 
   auto It = ValueMap.find(PN);


### PR DESCRIPTION
Since we used getNumRegisters right before this, I think this is the correct interface we should be using here.

I'm experimenting with making i32 legal on RISC-V 64, but using i64 for the register type between basic blocks. This was one of the first issues I found trying to do that.