### PR TITLE
[CodeGen][NewPM] Consolidate PASS_NAME and CONSTRUCTOR in MachinePassRegistry.def

### DIFF
--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -14,84 +14,82 @@
 // NOTE: NO INCLUDE GUARD DESIRED!
 
 #ifndef MODULE_ANALYSIS
-#define MODULE_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)
+#define MODULE_ANALYSIS(NAME, CREATE_PASS)
 #endif
-MODULE_ANALYSIS("collector-metadata", CollectorMetadataAnalysis, ())
-MODULE_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis, (PIC))
+MODULE_ANALYSIS("collector-metadata", CollectorMetadataAnalysis())
+MODULE_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
 #undef MODULE_ANALYSIS
 
 #ifndef MODULE_PASS
-#define MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define MODULE_PASS(NAME, CREATE_PASS)
 #endif
-MODULE_PASS("global-merge", GlobalMergePass, (TM, GlobalMergeOptions()))
-MODULE_PASS("jmc-instrumenter", JMCInstrumenterPass, ())
-MODULE_PASS("lower-emutls", LowerEmuTLSPass, ())
-MODULE_PASS("pre-isel-intrinsic-lowering", PreISelIntrinsicLoweringPass, ())
-MODULE_PASS("shadow-stack-gc-lowering", ShadowStackGCLoweringPass, ())
+MODULE_PASS("global-merge", GlobalMergePass(TM, GlobalMergeOptions()))
+MODULE_PASS("jmc-instrumenter", JMCInstrumenterPass())
+MODULE_PASS("lower-emutls", LowerEmuTLSPass())
+MODULE_PASS("pre-isel-intrinsic-lowering", PreISelIntrinsicLoweringPass())
+MODULE_PASS("shadow-stack-gc-lowering", ShadowStackGCLoweringPass())
 #undef MODULE_PASS
 
 #ifndef FUNCTION_ANALYSIS
-#define FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)
+#define FUNCTION_ANALYSIS(NAME, CREATE_PASS)
 #endif
-FUNCTION_ANALYSIS("gc-function", GCFunctionAnalysis, ())
-FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis, (PIC))
-FUNCTION_ANALYSIS("ssp-layout", SSPLayoutAnalysis, ())
-FUNCTION_ANALYSIS("target-ir", TargetIRAnalysis,
-                  (std::move(TM.getTargetIRAnalysis())))
+FUNCTION_ANALYSIS("gc-function", GCFunctionAnalysis())
+FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
+FUNCTION_ANALYSIS("ssp-layout", SSPLayoutAnalysis())
+FUNCTION_ANALYSIS("target-ir", TargetIRAnalysis(std::move(TM.getTargetIRAnalysis())))
 #undef FUNCTION_ANALYSIS
 
 #ifndef FUNCTION_PASS
-#define FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
-FUNCTION_PASS("callbr-prepare", CallBrPreparePass, ())
-FUNCTION_PASS("cfguard", CFGuardPass, ())
-FUNCTION_PASS("codegenprepare", CodeGenPreparePass, (TM))
-FUNCTION_PASS("consthoist", ConstantHoistingPass, ())
-FUNCTION_PASS("dwarf-eh-prepare", DwarfEHPreparePass, (TM))
-FUNCTION_PASS("ee-instrument", EntryExitInstrumenterPass, (false))
-FUNCTION_PASS("expand-large-div-rem", ExpandLargeDivRemPass, (TM))
-FUNCTION_PASS("expand-large-fp-convert", ExpandLargeFpConvertPass, (TM))
-FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass, (TM))
-FUNCTION_PASS("expand-reductions", ExpandReductionsPass, ())
-FUNCTION_PASS("expandvp", ExpandVectorPredicationPass, ())
-FUNCTION_PASS("gc-lowering", GCLoweringPass, ())
-FUNCTION_PASS("indirectbr-expand", IndirectBrExpandPass, (TM))
-FUNCTION_PASS("interleaved-access", InterleavedAccessPass, (TM))
-FUNCTION_PASS("interleaved-load-combine", InterleavedLoadCombinePass, (TM))
-FUNCTION_PASS("lower-constant-intrinsics", LowerConstantIntrinsicsPass, ())
-FUNCTION_PASS("lower-invoke", LowerInvokePass, ())
-FUNCTION_PASS("mergeicmps", MergeICmpsPass, ())
-FUNCTION_PASS("partially-inline-libcalls", PartiallyInlineLibCallsPass, ())
-FUNCTION_PASS("post-inline-ee-instrument", EntryExitInstrumenterPass, (true))
-FUNCTION_PASS("replace-with-veclib", ReplaceWithVeclib, ())
-FUNCTION_PASS("safe-stack", SafeStackPass, (TM))
-FUNCTION_PASS("scalarize-masked-mem-intrin", ScalarizeMaskedMemIntrinPass, ())
-FUNCTION_PASS("select-optimize", SelectOptimizePass, (TM))
-FUNCTION_PASS("sjlj-eh-prepare", SjLjEHPreparePass, (TM))
-FUNCTION_PASS("stack-protector", StackProtectorPass, (TM))
-FUNCTION_PASS("tlshoist", TLSVariableHoistPass, ())
-FUNCTION_PASS("unreachableblockelim", UnreachableBlockElimPass, ())
-FUNCTION_PASS("verify", VerifierPass, ())
-FUNCTION_PASS("wasm-eh-prepare", WasmEHPreparePass, ())
-FUNCTION_PASS("win-eh-prepare", WinEHPreparePass, ())
+FUNCTION_PASS("callbr-prepare", CallBrPreparePass())
+FUNCTION_PASS("cfguard", CFGuardPass())
+FUNCTION_PASS("codegenprepare", CodeGenPreparePass(TM))
+FUNCTION_PASS("consthoist", ConstantHoistingPass())
+FUNCTION_PASS("dwarf-eh-prepare", DwarfEHPreparePass(TM))
+FUNCTION_PASS("ee-instrument", EntryExitInstrumenterPass(false))
+FUNCTION_PASS("expand-large-div-rem", ExpandLargeDivRemPass(TM))
+FUNCTION_PASS("expand-large-fp-convert", ExpandLargeFpConvertPass(TM))
+FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass(TM))
+FUNCTION_PASS("expand-reductions", ExpandReductionsPass())
+FUNCTION_PASS("expandvp", ExpandVectorPredicationPass())
+FUNCTION_PASS("gc-lowering", GCLoweringPass())
+FUNCTION_PASS("indirectbr-expand", IndirectBrExpandPass(TM))
+FUNCTION_PASS("interleaved-access", InterleavedAccessPass(TM))
+FUNCTION_PASS("interleaved-load-combine", InterleavedLoadCombinePass(TM))
+FUNCTION_PASS("lower-constant-intrinsics", LowerConstantIntrinsicsPass())
+FUNCTION_PASS("lower-invoke", LowerInvokePass())
+FUNCTION_PASS("mergeicmps", MergeICmpsPass())
+FUNCTION_PASS("partially-inline-libcalls", PartiallyInlineLibCallsPass())
+FUNCTION_PASS("post-inline-ee-instrument", EntryExitInstrumenterPass(true))
+FUNCTION_PASS("replace-with-veclib", ReplaceWithVeclib())
+FUNCTION_PASS("safe-stack", SafeStackPass(TM))
+FUNCTION_PASS("scalarize-masked-mem-intrin", ScalarizeMaskedMemIntrinPass())
+FUNCTION_PASS("select-optimize", SelectOptimizePass(TM))
+FUNCTION_PASS("sjlj-eh-prepare", SjLjEHPreparePass(TM))
+FUNCTION_PASS("stack-protector", StackProtectorPass(TM))
+FUNCTION_PASS("tlshoist", TLSVariableHoistPass())
+FUNCTION_PASS("unreachableblockelim", UnreachableBlockElimPass())
+FUNCTION_PASS("verify", VerifierPass())
+FUNCTION_PASS("wasm-eh-prepare", WasmEHPreparePass())
+FUNCTION_PASS("win-eh-prepare", WinEHPreparePass())
 #undef FUNCTION_PASS
 
 #ifndef LOOP_PASS
-#define LOOP_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define LOOP_PASS(NAME, CREATE_PASS)
 #endif
-LOOP_PASS("loop-reduce", LoopStrengthReducePass, ())
+LOOP_PASS("loop-reduce", LoopStrengthReducePass())
 #undef LOOP_PASS
 
 #ifndef MACHINE_MODULE_PASS
-#define MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define MACHINE_MODULE_PASS(NAME, CREATE_PASS)
 #endif
 #undef MACHINE_MODULE_PASS
 
 #ifndef MACHINE_FUNCTION_ANALYSIS
-#define MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)
 #endif
-MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis,
-                          (PIC))
+MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
 // LiveVariables currently requires pure SSA form.
 // FIXME: Once TwoAddressInstruction pass no longer uses kill flags,
 // LiveVariables can be removed completely, and LiveIntervals can be directly
@@ -123,11 +121,11 @@ MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis,
 #undef MACHINE_FUNCTION_ANALYSIS
 
 #ifndef MACHINE_FUNCTION_PASS
-#define MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
-// MACHINE_FUNCTION_PASS("free-machine-function", FreeMachineFunctionPass, ())
-MACHINE_FUNCTION_PASS("no-op-machine-function", NoOpMachineFunctionPass, ())
-MACHINE_FUNCTION_PASS("print", PrintMIRPass, ())
+// MACHINE_FUNCTION_PASS("free-machine-function", FreeMachineFunctionPass())
+MACHINE_FUNCTION_PASS("no-op-machine-function", NoOpMachineFunctionPass())
+MACHINE_FUNCTION_PASS("print", PrintMIRPass())
 #undef MACHINE_FUNCTION_PASS
 
 // After a pass is converted to new pass manager, its entry should be moved from
@@ -135,130 +133,101 @@ MACHINE_FUNCTION_PASS("print", PrintMIRPass, ())
 // DUMMY_MACHINE_FUNCTION_PASS to MACHINE_FUNCTION_PASS.
 
 #ifndef DUMMY_FUNCTION_PASS
-#define DUMMY_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define DUMMY_FUNCTION_PASS(NAME, PASS_NAME)
 #endif
-DUMMY_FUNCTION_PASS("atomic-expand", AtomicExpandPass, ())
+DUMMY_FUNCTION_PASS("atomic-expand", AtomicExpandPass)
 #undef DUMMY_FUNCTION_PASS
 
 #ifndef DUMMY_MACHINE_MODULE_PASS
-#define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME)
 #endif
-DUMMY_MACHINE_MODULE_PASS("machine-outliner", MachineOutlinerPass, ())
-DUMMY_MACHINE_MODULE_PASS("pseudo-probe-inserter", PseudoProbeInserterPass, ())
-DUMMY_MACHINE_MODULE_PASS("mir-debugify", DebugifyMachineModule, ())
-DUMMY_MACHINE_MODULE_PASS("mir-check-debugify", CheckDebugMachineModulePass, ())
-DUMMY_MACHINE_MODULE_PASS("mir-strip-debug", StripDebugMachineModulePass,
-                          (OnlyDebugified))
+DUMMY_MACHINE_MODULE_PASS("machine-outliner", MachineOutlinerPass)
+DUMMY_MACHINE_MODULE_PASS("pseudo-probe-inserter", PseudoProbeInserterPass)
+DUMMY_MACHINE_MODULE_PASS("mir-debugify", DebugifyMachineModule)
+DUMMY_MACHINE_MODULE_PASS("mir-check-debugify", CheckDebugMachineModulePass)
+DUMMY_MACHINE_MODULE_PASS("mir-strip-debug", StripDebugMachineModulePass)
 #undef DUMMY_MACHINE_MODULE_PASS
 
 #ifndef DUMMY_MACHINE_FUNCTION_PASS
-#define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)
+#define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME)
 #endif
-DUMMY_MACHINE_FUNCTION_PASS("bbsections-prepare", BasicBlockSectionsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("bbsections-profile-reader",
-                            BasicBlockSectionsProfileReaderPass, (Buf))
-DUMMY_MACHINE_FUNCTION_PASS("block-placement", MachineBlockPlacementPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("block-placement-stats",
-                            MachineBlockPlacementStatsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("branch-folder", BranchFolderPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("break-false-deps", BreakFalseDepsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("cfguard-longjmp", CFGuardLongjmpPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("cfi-fixup", CFIFixupPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("cfi-instr-inserter", CFIInstrInserterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("dead-mi-elimination",
-                            DeadMachineInstructionElimPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("detect-dead-lanes", DetectDeadLanesPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("dot-machine-cfg", MachineCFGPrinter, ())
-DUMMY_MACHINE_FUNCTION_PASS("early-ifcvt", EarlyIfConverterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("early-machinelicm", EarlyMachineLICMPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("early-tailduplication", EarlyTailDuplicatePass, ())
-DUMMY_MACHINE_FUNCTION_PASS("fentry-insert", FEntryInserterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("finalize-isel", FinalizeISelPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("fixup-statepoint-caller-saved",
-                            FixupStatepointCallerSavedPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("fs-profile-loader", MIRProfileLoaderNewPass,
-                            (File, ProfileFile, P, FS))
-DUMMY_MACHINE_FUNCTION_PASS("funclet-layout", FuncletLayoutPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("gc-empty-basic-blocks", GCEmptyBasicBlocksPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("implicit-null-checks", ImplicitNullChecksPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("instruction-select", InstructionSelectPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("irtranslator", IRTranslatorPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("kcfi", MachineKCFIPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("legalizer", LegalizerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("livedebugvalues", LiveDebugValuesPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("liveintervals", LiveIntervalsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("localstackalloc", LocalStackSlotPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("lrshrink", LiveRangeShrinkPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-combiner", MachineCombinerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-cp", MachineCopyPropagationPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-cse", MachineCSEPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-function-splitter",
-                            MachineFunctionSplitterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-latecleanup", MachineLateInstrsCleanupPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-sanmd", MachineSanitizerBinaryMetadata, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-scheduler", MachineSchedulerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-sink", MachineSinkingPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machine-uniformity",
-                            MachineUniformityInfoWrapperPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machineinstr-printer", MachineFunctionPrinterPass,
-                            (OS, Banner))
-DUMMY_MACHINE_FUNCTION_PASS("machinelicm", MachineLICMPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machineverifier", MachineVerifierPass, (Banner))
-DUMMY_MACHINE_FUNCTION_PASS("mirfs-discriminators", MIRAddFSDiscriminatorsPass,
-                            (P))
-DUMMY_MACHINE_FUNCTION_PASS("opt-phis", OptimizePHIsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("patchable-function", PatchableFunctionPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("peephole-opt", PeepholeOptimizerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("phi-node-elimination", PHIEliminationPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("post-RA-sched", PostRASchedulerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("postmisched", PostMachineSchedulerPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("postra-machine-sink", PostRAMachineSinkingPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("postrapseudos", ExpandPostRAPseudosPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("print-machine-cycles", MachineCycleInfoPrinterPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("print-machine-uniformity",
-                            MachineUniformityInfoPrinterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("processimpdefs", ProcessImplicitDefsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("prologepilog", PrologEpilogInserterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("prologepilog-code", PrologEpilogCodeInserterPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("ra-basic", RABasicPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("ra-fast", RAFastPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("ra-greedy", RAGreedyPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("ra-pbqp", RAPBQPPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("reg-usage-collector", RegUsageInfoCollectorPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("reg-usage-propagation",
-                            RegUsageInfoPropagationPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("regalloc", RegAllocPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("regallocscoringpass", RegAllocScoringPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("regbankselect", RegBankSelectPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("removeredundantdebugvalues",
-                            RemoveRedundantDebugValuesPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("rename-independent-subregs",
-                            RenameIndependentSubregsPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("reset-machine-function", ResetMachineFunctionPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("shrink-wrap", ShrinkWrapPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("simple-register-coalescing", RegisterCoalescerPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("stack-coloring", StackColoringPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("stack-frame-layout", StackFrameLayoutAnalysisPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("stack-slot-coloring", StackSlotColoringPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("stackmap-liveness", StackMapLivenessPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("tailduplication", TailDuplicatePass, ())
-DUMMY_MACHINE_FUNCTION_PASS("twoaddressinstruction", TwoAddressInstructionPass,
-                            ())
-DUMMY_MACHINE_FUNCTION_PASS("unpack-mi-bundles", UnpackMachineBundlesPass,
-                            (Ftor))
-DUMMY_MACHINE_FUNCTION_PASS("virtregrewriter", VirtRegRewriterPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("xray-instrumentation", XRayInstrumentationPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("bbsections-prepare", BasicBlockSectionsPass)
+DUMMY_MACHINE_FUNCTION_PASS("bbsections-profile-reader", BasicBlockSectionsProfileReaderPass)
+DUMMY_MACHINE_FUNCTION_PASS("block-placement", MachineBlockPlacementPass)
+DUMMY_MACHINE_FUNCTION_PASS("block-placement-stats", MachineBlockPlacementStatsPass)
+DUMMY_MACHINE_FUNCTION_PASS("branch-folder", BranchFolderPass)
+DUMMY_MACHINE_FUNCTION_PASS("break-false-deps", BreakFalseDepsPass)
+DUMMY_MACHINE_FUNCTION_PASS("cfguard-longjmp", CFGuardLongjmpPass)
+DUMMY_MACHINE_FUNCTION_PASS("cfi-fixup", CFIFixupPass)
+DUMMY_MACHINE_FUNCTION_PASS("cfi-instr-inserter", CFIInstrInserterPass)
+DUMMY_MACHINE_FUNCTION_PASS("dead-mi-elimination", DeadMachineInstructionElimPass)
+DUMMY_MACHINE_FUNCTION_PASS("detect-dead-lanes", DetectDeadLanesPass)
+DUMMY_MACHINE_FUNCTION_PASS("dot-machine-cfg", MachineCFGPrinter)
+DUMMY_MACHINE_FUNCTION_PASS("early-ifcvt", EarlyIfConverterPass)
+DUMMY_MACHINE_FUNCTION_PASS("early-machinelicm", EarlyMachineLICMPass)
+DUMMY_MACHINE_FUNCTION_PASS("early-tailduplication", EarlyTailDuplicatePass)
+DUMMY_MACHINE_FUNCTION_PASS("fentry-insert", FEntryInserterPass)
+DUMMY_MACHINE_FUNCTION_PASS("finalize-isel", FinalizeISelPass)
+DUMMY_MACHINE_FUNCTION_PASS("fixup-statepoint-caller-saved", FixupStatepointCallerSavedPass)
+DUMMY_MACHINE_FUNCTION_PASS("fs-profile-loader", MIRProfileLoaderNewPass)
+DUMMY_MACHINE_FUNCTION_PASS("funclet-layout", FuncletLayoutPass)
+DUMMY_MACHINE_FUNCTION_PASS("gc-empty-basic-blocks", GCEmptyBasicBlocksPass)
+DUMMY_MACHINE_FUNCTION_PASS("implicit-null-checks", ImplicitNullChecksPass)
+DUMMY_MACHINE_FUNCTION_PASS("instruction-select", InstructionSelectPass)
+DUMMY_MACHINE_FUNCTION_PASS("irtranslator", IRTranslatorPass)
+DUMMY_MACHINE_FUNCTION_PASS("kcfi", MachineKCFIPass)
+DUMMY_MACHINE_FUNCTION_PASS("legalizer", LegalizerPass)
+DUMMY_MACHINE_FUNCTION_PASS("livedebugvalues", LiveDebugValuesPass)
+DUMMY_MACHINE_FUNCTION_PASS("liveintervals", LiveIntervalsPass)
+DUMMY_MACHINE_FUNCTION_PASS("localstackalloc", LocalStackSlotPass)
+DUMMY_MACHINE_FUNCTION_PASS("lrshrink", LiveRangeShrinkPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-combiner", MachineCombinerPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-cp", MachineCopyPropagationPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-cse", MachineCSEPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-function-splitter", MachineFunctionSplitterPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-latecleanup", MachineLateInstrsCleanupPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-sanmd", MachineSanitizerBinaryMetadata)
+DUMMY_MACHINE_FUNCTION_PASS("machine-scheduler", MachineSchedulerPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-sink", MachineSinkingPass)
+DUMMY_MACHINE_FUNCTION_PASS("machine-uniformity", MachineUniformityInfoWrapperPass)
+DUMMY_MACHINE_FUNCTION_PASS("machineinstr-printer", MachineFunctionPrinterPass)
+DUMMY_MACHINE_FUNCTION_PASS("machinelicm", MachineLICMPass)
+DUMMY_MACHINE_FUNCTION_PASS("machineverifier", MachineVerifierPass)
+DUMMY_MACHINE_FUNCTION_PASS("mirfs-discriminators", MIRAddFSDiscriminatorsPass)
+DUMMY_MACHINE_FUNCTION_PASS("opt-phis", OptimizePHIsPass)
+DUMMY_MACHINE_FUNCTION_PASS("patchable-function", PatchableFunctionPass)
+DUMMY_MACHINE_FUNCTION_PASS("peephole-opt", PeepholeOptimizerPass)
+DUMMY_MACHINE_FUNCTION_PASS("phi-node-elimination", PHIEliminationPass)
+DUMMY_MACHINE_FUNCTION_PASS("post-RA-sched", PostRASchedulerPass)
+DUMMY_MACHINE_FUNCTION_PASS("postmisched", PostMachineSchedulerPass)
+DUMMY_MACHINE_FUNCTION_PASS("postra-machine-sink", PostRAMachineSinkingPass)
+DUMMY_MACHINE_FUNCTION_PASS("postrapseudos", ExpandPostRAPseudosPass)
+DUMMY_MACHINE_FUNCTION_PASS("print-machine-cycles", MachineCycleInfoPrinterPass)
+DUMMY_MACHINE_FUNCTION_PASS("print-machine-uniformity", MachineUniformityInfoPrinterPass)
+DUMMY_MACHINE_FUNCTION_PASS("processimpdefs", ProcessImplicitDefsPass)
+DUMMY_MACHINE_FUNCTION_PASS("prologepilog", PrologEpilogInserterPass)
+DUMMY_MACHINE_FUNCTION_PASS("prologepilog-code", PrologEpilogCodeInserterPass)
+DUMMY_MACHINE_FUNCTION_PASS("ra-basic", RABasicPass)
+DUMMY_MACHINE_FUNCTION_PASS("ra-fast", RAFastPass)
+DUMMY_MACHINE_FUNCTION_PASS("ra-greedy", RAGreedyPass)
+DUMMY_MACHINE_FUNCTION_PASS("ra-pbqp", RAPBQPPass)
+DUMMY_MACHINE_FUNCTION_PASS("reg-usage-collector", RegUsageInfoCollectorPass)
+DUMMY_MACHINE_FUNCTION_PASS("reg-usage-propagation", RegUsageInfoPropagationPass)
+DUMMY_MACHINE_FUNCTION_PASS("regalloc", RegAllocPass)
+DUMMY_MACHINE_FUNCTION_PASS("regallocscoringpass", RegAllocScoringPass)
+DUMMY_MACHINE_FUNCTION_PASS("regbankselect", RegBankSelectPass)
+DUMMY_MACHINE_FUNCTION_PASS("removeredundantdebugvalues", RemoveRedundantDebugValuesPass)
+DUMMY_MACHINE_FUNCTION_PASS("rename-independent-subregs", RenameIndependentSubregsPass)
+DUMMY_MACHINE_FUNCTION_PASS("reset-machine-function", ResetMachineFunctionPass)
+DUMMY_MACHINE_FUNCTION_PASS("shrink-wrap", ShrinkWrapPass)
+DUMMY_MACHINE_FUNCTION_PASS("simple-register-coalescing", RegisterCoalescerPass)
+DUMMY_MACHINE_FUNCTION_PASS("stack-coloring", StackColoringPass)
+DUMMY_MACHINE_FUNCTION_PASS("stack-frame-layout", StackFrameLayoutAnalysisPass)
+DUMMY_MACHINE_FUNCTION_PASS("stack-slot-coloring", StackSlotColoringPass)
+DUMMY_MACHINE_FUNCTION_PASS("stackmap-liveness", StackMapLivenessPass)
+DUMMY_MACHINE_FUNCTION_PASS("tailduplication", TailDuplicatePass)
+DUMMY_MACHINE_FUNCTION_PASS("twoaddressinstruction", TwoAddressInstructionPass)
+DUMMY_MACHINE_FUNCTION_PASS("unpack-mi-bundles", UnpackMachineBundlesPass)
+DUMMY_MACHINE_FUNCTION_PASS("virtregrewriter", VirtRegRewriterPass)
+DUMMY_MACHINE_FUNCTION_PASS("xray-instrumentation", XRayInstrumentationPass)
 #undef DUMMY_MACHINE_FUNCTION_PASS
-
-#ifndef DUMMY_MACHINE_FUNCTION_ANALYSIS
-#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)
-#endif
-DUMMY_MACHINE_FUNCTION_ANALYSIS("gc-analysis", GCMachineCodeAnalysisPass, ())
-#undef DUMMY_MACHINE_FUNCTION_ANALYSIS

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -465,11 +465,6 @@ public:
                                    inconvertibleErrorCode());
   }
 
-  virtual std::pair<StringRef, bool> getPassNameFromLegacyName(StringRef) {
-    llvm_unreachable(
-        "getPassNameFromLegacyName parseMIRPipeline is not overridden");
-  }
-
   /// Add passes to the specified pass manager to get machine code emitted with
   /// the MCJIT. This method returns true if machine code is not supported. It
   /// fills the MCContext Ctx pointer which can be used to build custom

--- a/llvm/lib/Passes/CodeGenPassBuilder.cpp
+++ b/llvm/lib/Passes/CodeGenPassBuilder.cpp
@@ -16,7 +16,7 @@
 using namespace llvm;
 
 namespace llvm {
-#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
+#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                     \
   AnalysisKey PASS_NAME::Key;
 #include "llvm/Passes/MachinePassRegistry.def"
 } // namespace llvm

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -398,10 +398,10 @@ PassBuilder::PassBuilder(TargetMachine *TM, PipelineTuningOptions PTO,
   PIC->addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
 #include "PassRegistry.def"
 
-#define MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  PIC->addClassToPassName(PASS_NAME::name(), NAME);
-#define MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)                    \
-  PIC->addClassToPassName(PASS_NAME::name(), NAME);
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                           \
+  PIC->addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)                               \
+  PIC->addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
 #include "llvm/Passes/MachinePassRegistry.def"
   }
 }
@@ -441,8 +441,8 @@ void PassBuilder::registerFunctionAnalyses(FunctionAnalysisManager &FAM) {
 void PassBuilder::registerMachineFunctionAnalyses(
     MachineFunctionAnalysisManager &MFAM) {
 
-#define MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  MFAM.registerPass([&] { return PASS_NAME(); });
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                           \
+  MFAM.registerPass([&] { return CREATE_PASS; });
 #include "llvm/Passes/MachinePassRegistry.def"
 
   for (auto &C : MachineFunctionAnalysisRegistrationCallbacks)
@@ -1860,14 +1860,14 @@ Error PassBuilder::parseMachinePass(MachineFunctionPassManager &MFPM,
     return make_error<StringError>("invalid pipeline",
                                    inconvertibleErrorCode());
 
-#define MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)                      \
+#define MACHINE_MODULE_PASS(NAME, CREATE_PASS)                                 \
   if (Name == NAME) {                                                          \
-    MFPM.addPass(PASS_NAME());                                                 \
+    MFPM.addPass(CREATE_PASS);                                                 \
     return Error::success();                                                   \
   }
-#define MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)                    \
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)                               \
   if (Name == NAME) {                                                          \
-    MFPM.addPass(PASS_NAME());                                                 \
+    MFPM.addPass(CREATE_PASS);                                                 \
     return Error::success();                                                   \
   }
 #include "llvm/Passes/MachinePassRegistry.def"
@@ -2179,18 +2179,15 @@ void PassBuilder::printPassNames(raw_ostream &OS) {
 #include "PassRegistry.def"
 
   OS << "Machine module passes (WIP):\n";
-#define MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)                      \
-  printPassName(NAME, OS);
+#define MACHINE_MODULE_PASS(NAME, CREATE_PASS) printPassName(NAME, OS);
 #include "llvm/Passes/MachinePassRegistry.def"
 
   OS << "Machine function passes (WIP):\n";
-#define MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)                    \
-  printPassName(NAME, OS);
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS) printPassName(NAME, OS);
 #include "llvm/Passes/MachinePassRegistry.def"
 
   OS << "Machine function analyses (WIP):\n";
-#define MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)                \
-  printPassName(NAME, OS);
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS) printPassName(NAME, OS);
 #include "llvm/Passes/MachinePassRegistry.def"
 }
 

--- a/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
+++ b/llvm/unittests/MIR/PassBuilderCallbacksTest.cpp
@@ -434,6 +434,12 @@ TEST_F(MachineFunctionCallbacksTest, InstrumentedPasses) {
       runBeforeNonSkippedPass(HasNameRegex("MockPassHandle"), HasName("test")))
       .InSequence(PISequence);
   EXPECT_CALL(CallbacksHandle,
+              runBeforeAnalysis(HasNameRegex("MockAnalysisHandle"), _))
+      .InSequence(PISequence);
+  EXPECT_CALL(CallbacksHandle,
+              runAfterAnalysis(HasNameRegex("MockAnalysisHandle"), _))
+      .InSequence(PISequence);
+  EXPECT_CALL(CallbacksHandle,
               runAfterPass(HasNameRegex("MockPassHandle"), HasName("test"), _))
       .InSequence(PISequence);
 


### PR DESCRIPTION
This matches the optimization pipeline's PassRegistry.def.

I ran into a bug where CONSTRUCTOR wasn't always being used (in PassBuilder::registerMachineFunctionAnalyses()).

Make DUMMY_* just accept a pass name, there's no point in having proper constructors if the generated dummy class has a templated constructor accepting arbitrary arguments.

Remove unused getPassNameFromLegacyName() as it was using this but for no purpose.

Remove DUMMY_MACHINE_FUNCTION_ANALYSIS, we can just add those as we port them.

This for some reason exposed missing mock calls in existing unittests.