### PR TITLE
[BOLT] Use new contents when emitting sections with relocations

### DIFF
--- a/bolt/lib/Core/BinarySection.cpp
+++ b/bolt/lib/Core/BinarySection.cpp
@@ -72,7 +72,8 @@ BinarySection::hash(const BinaryData &BD,
 
 void BinarySection::emitAsData(MCStreamer &Streamer,
                                const Twine &SectionName) const {
-  StringRef SectionContents = getContents();
+  StringRef SectionContents =
+      isFinalized() ? getOutputContents() : getContents();
   MCSectionELF *ELFSection =
       BC.Ctx->getELFSection(SectionName, getELFType(), getELFFlags());
 


### PR DESCRIPTION
We can use BinarySection::updateContents() to change section contents. However, if we also add relocations for new contents, then the original data (i.e. not updated) is going to be used. Fix that. A follow-up diff will use the update interface and will include a test case.