### PR TITLE
[LLDB] Add FreeBSD kernel coredump matching check.

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.h
+++ b/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.h
@@ -148,8 +148,9 @@ protected:
 
   static lldb::addr_t FindKernelAtLoadAddress(lldb_private::Process *process);
 
+  template <typename Elf_Ehdr>
   static bool ReadELFHeader(lldb_private::Process *process,
-                            lldb::addr_t address, llvm::ELF::Elf32_Ehdr &header,
+                            lldb::addr_t address, Elf_Ehdr &header,
                             bool *read_error = nullptr);
 
   lldb_private::Process *m_process;

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -795,6 +795,32 @@ bool ObjectFileELF::ParseHeader() {
   return m_header.Parse(m_data, &offset);
 }
 
+UUID ObjectFileELF::GetUUIDByNoteSection() {
+  if (!ParseProgramHeaders())
+    return UUID();
+  for (const ELFProgramHeader &H : m_program_headers) {
+    if (H.p_type == llvm::ELF::PT_NOTE) {
+      const elf_off ph_offset = H.p_offset;
+      const size_t ph_size = H.p_filesz;
+
+      DataExtractor segment_data;
+      if (segment_data.SetData(m_data, ph_offset, ph_size) != ph_size) {
+        // The ELF program header contained incorrect data, probably corefile
+        // is incomplete or corrupted.
+        break;
+      }
+
+      UUID uuid;
+      ArchSpec arch;
+
+      if (RefineModuleDetailsFromNote(segment_data, arch, uuid).Success())
+        return uuid;
+    }
+  }
+
+  return UUID();
+}
+
 UUID ObjectFileELF::GetUUID() {
   // Need to parse the section list to get the UUIDs, so make sure that's been
   // done.
@@ -808,6 +834,9 @@ UUID ObjectFileELF::GetUUID() {
 
       if (!ParseProgramHeaders())
         return UUID();
+
+      if ((m_uuid = GetUUIDByNoteSection()).IsValid())
+        return m_uuid;
 
       core_notes_crc =
           CalculateELFNotesSegmentsCRC32(m_program_headers, m_data);

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -272,6 +272,9 @@ private:
                                      uint32_t &gnu_debuglink_crc,
                                      lldb_private::ArchSpec &arch_spec);
 
+  // Use Note Section to get uuid.
+  lldb_private::UUID GetUUIDByNoteSection();
+
   /// Scans the dynamic section and locates all dependent modules (shared
   /// libraries) populating m_filespec_up.  This method will compute the
   /// dependent module list only once.  Returns the number of dependent


### PR DESCRIPTION
This patch add check for the UUID match between kernel and coredump to prevent developer falsely load kernel with unmatched coredump.
