### PR TITLE
[lldb][unittest] Add call_once flag to initialize debugger

### DIFF
--- a/lldb/unittests/TestingSupport/TestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/TestUtilities.cpp
@@ -19,6 +19,7 @@ using namespace lldb_private;
 
 extern const char *TestMainArgv0;
 
+std::once_flag TestUtilities::g_debugger_initialize_flag;
 std::string lldb_private::GetInputFilePath(const llvm::Twine &name) {
   llvm::SmallString<128> result = llvm::sys::path::parent_path(TestMainArgv0);
   llvm::sys::fs::make_absolute(result);

--- a/lldb/unittests/TestingSupport/TestUtilities.h
+++ b/lldb/unittests/TestingSupport/TestUtilities.h
@@ -31,6 +31,11 @@
 namespace lldb_private {
 std::string GetInputFilePath(const llvm::Twine &name);
 
+class TestUtilities {
+public:
+  static std::once_flag g_debugger_initialize_flag;
+};
+
 class TestFile {
 public:
   static llvm::Expected<TestFile> fromYaml(llvm::StringRef Yaml);
@@ -51,6 +56,6 @@ private:
 
   std::string Buffer;
 };
-}
+} // namespace lldb_private
 
 #endif


### PR DESCRIPTION
I tried adding a new unit test to the core test
suite (https://github.com/llvm/llvm-project/pull/79533) but it broke the test suite on AArch64 Linux due to hitting an assertion for calling `Debugger::Initialize` more than once. When the unit test suite is invoked as a standalone binary the test suite state is shared, and `Debugger::Initialize` gets called in `DiagnosticEventTest.cpp` before being called in `ProgressReportTest.cpp`.

`DiagnosticEventTest.cpp` uses a call_once flag to initialize the debugger but it's local to that test. This commit adds a once_flag to `TestUtilities` so that `Debugger::Initialize` can be called once by the tests that use it.