### PR TITLE
[lldb][unittest] Use shared once_flag in DiagnosticEventTest

### DIFF
--- a/lldb/unittests/Core/DiagnosticEventTest.cpp
+++ b/lldb/unittests/Core/DiagnosticEventTest.cpp
@@ -11,6 +11,7 @@
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
 #include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DebuggerEvents.h"
 #include "lldb/Host/FileSystem.h"
@@ -26,8 +27,6 @@ using namespace lldb_private::repro;
 static const constexpr std::chrono::seconds TIMEOUT(0);
 static const constexpr size_t DEBUGGERS = 3;
 
-static std::once_flag debugger_initialize_flag;
-
 namespace {
 class DiagnosticEventTest : public ::testing::Test {
 public:
@@ -35,7 +34,7 @@ public:
     FileSystem::Initialize();
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
-    std::call_once(debugger_initialize_flag,
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
                    []() { Debugger::Initialize(nullptr); });
     ArchSpec arch("x86_64-apple-macosx-");
     Platform::SetHostPlatform(


### PR DESCRIPTION
Incorporates the changes from
https://github.com/llvm/llvm-project/pull/80786 to use a once_flag from `TestUtilities` instead of a local flag in order to prevent hitting an assertion that the debugger was initialized again in another test.