### PR TITLE
`cppcoreguidelines-macro-usage`: Skip common macros which cannot be converted to `constexpr`

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
@@ -81,6 +81,9 @@ void MacroUsageCheck::warnMacro(const MacroDirective *MD, StringRef MacroName) {
   StringRef Message;
 
   for (const auto &T : MD->getMacroInfo()->tokens()) {
+    if (T.is(tok::hash)) {
+      return;
+    }
     if (T.is(tok::identifier)) {
       StringRef IdentName = T.getIdentifierInfo()->getName();
       if (IdentName == "__FILE__") {

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
@@ -80,6 +80,17 @@ void MacroUsageCheck::warnMacro(const MacroDirective *MD, StringRef MacroName) {
   const MacroInfo *Info = MD->getMacroInfo();
   StringRef Message;
 
+  for (const auto &T : MD->getMacroInfo()->tokens()) {
+    if (T.is(tok::identifier)) {
+      StringRef IdentName = T.getIdentifierInfo()->getName();
+      if (IdentName == "__FILE__") {
+        return;
+      } else if (IdentName == "__LINE__") {
+        return;
+      }
+    }
+  }
+
   if (llvm::all_of(Info->tokens(), std::mem_fn(&Token::isLiteral)))
     Message = "macro '%0' used to declare a constant; consider using a "
               "'constexpr' constant";

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
@@ -43,4 +43,7 @@
 #define DLLEXPORTS __declspec(dllimport)
 #endif
 
+int log(const char* file, unsigned int line, const char* message);
+#define LOG(message) log(__FILE__, __LINE__, (message));
+
 #endif

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
@@ -46,4 +46,7 @@
 int log(const char* file, unsigned int line, const char* message);
 #define LOG(message) log(__FILE__, __LINE__, (message));
 
+#define STRINGIFYIMPL(s) #s
+#define STRINGIFY(s) STRINGIFYIMPL(s)
+
 #endif


### PR DESCRIPTION
With clang-tidy, `cppcoreguidelines-macro-usage` is very hard to enforce without setting regex whitelists.
The reason for this is that many common practices are impossible to do outside of the precompiler.

The two cases here are the use of built-in macros such as `__FILE__` and `__LINE__` and stringification.

**Note to reviewers**:
This is my first contribution to this project so I'm going in a bit blind.
Please let me know of any helper functions I missed such as identifying the builtin macros or stringification.