### PR TITLE
[Clang][Sema] fix crash in codegen stage when an lambda expression declared in an unevaluated context

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -260,16 +260,13 @@ Bug Fixes to C++ Support
   or non-constant more accurately. Previously, only a subset of the initializer
   elements were considered, misclassifying some initializers as constant. Fixes
   some of (`#80510 <https://github.com/llvm/llvm-project/issues/80510>`).
-<<<<<<< HEAD
 - Clang now ignores top-level cv-qualifiers on function parameters in template partial orderings.
   (`#75404 <https://github.com/llvm/llvm-project/issues/75404>`_)
 - No longer reject valid use of the ``_Alignas`` specifier when declaring a
   local variable, which is supported as a C11 extension in C++. Previously, it
   was only accepted at namespace scope but not at local function scope.
-=======
 - Fix a crash in codegen when lambdas declared in an unevaluated context.
   Fixes (`#76674 <https://github.com/llvm/llvm-project/issues/76674>`_)
->>>>>>> 5430d0709c2a ([Clang][Sema] fix crash in codegen stage when an lambda expression declared in an unevaluated context)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -260,11 +260,16 @@ Bug Fixes to C++ Support
   or non-constant more accurately. Previously, only a subset of the initializer
   elements were considered, misclassifying some initializers as constant. Fixes
   some of (`#80510 <https://github.com/llvm/llvm-project/issues/80510>`).
+<<<<<<< HEAD
 - Clang now ignores top-level cv-qualifiers on function parameters in template partial orderings.
   (`#75404 <https://github.com/llvm/llvm-project/issues/75404>`_)
 - No longer reject valid use of the ``_Alignas`` specifier when declaring a
   local variable, which is supported as a C11 extension in C++. Previously, it
   was only accepted at namespace scope but not at local function scope.
+=======
+- Fix a crash in codegen when lambdas declared in an unevaluated context.
+  Fixes (`#76674 <https://github.com/llvm/llvm-project/issues/76674>`_)
+>>>>>>> 5430d0709c2a ([Clang][Sema] fix crash in codegen stage when an lambda expression declared in an unevaluated context)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/CodeGen/PR76674.cpp
+++ b/clang/test/CodeGen/PR76674.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -std=c++20 -emit-llvm -o - %s
+// expected-no-diagnostics
+
+template <class>
+struct A {
+    template <class U>
+    using Func = decltype([] {return U{};});
+};
+
+A<int>::Func<int> f{};
+int i{f()};


### PR DESCRIPTION
Try to fix [issue](https://github.com/llvm/llvm-project/issues/76674)
When transform a lambda expression which is declared in an unevaluated context, `isInstantiationDependentType()` and `isVariablyModifiedType()` both return false and lead to skip transforming the lambda expression. On the other hand, `AlreadyTransformed` also skip transformation in this case. Add the condition to check whether it's in decltype makes it work.