### PR TITLE
[MachinePipeliner] Fix elements being added while the list is iterated

### DIFF
--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -768,7 +768,6 @@ static void getUnderlyingObjects(const MachineInstr *MI,
       Objs.clear();
       return;
     }
-    Objs.push_back(V);
   }
 }
 


### PR DESCRIPTION
There is no need to add the elements of Objs twice, so the addition is removed.