### PR TITLE
[clang][Sema] Subclass `-Wshorten-64-to-32` under `-Wimplicit-int-conversion`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -153,8 +153,8 @@ Improvements to Clang's diagnostics
 - Clang now diagnoses use of the ``template`` keyword after declarative nested
   name specifiers.
 
-- Added `-Wshorten-64-to-32` diagnostics to enable when
-  `-Wimplicit-int-conversion` is enabled.
+- The ``-Wshorten-64-to-32`` diagnostic is now grouped under ``-Wimplicit-int-conversion`` instead
+   of ``-Wconversion``. Fixes `#69444 <https://github.com/llvm/llvm-project/issues/69444>`_.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -149,7 +149,12 @@ Improvements to Clang's diagnostics
   prints.
 
 - Clang now diagnoses member template declarations with multiple declarators.
-- Clang now diagnoses use of the ``template`` keyword after declarative nested name specifiers.
+
+- Clang now diagnoses use of the ``template`` keyword after declarative nested
+  name specifiers.
+
+- Added `-Wshorten-64-to-32` diagnostics to enable when
+  `-Wimplicit-int-conversion` is enabled.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -108,8 +108,10 @@ def EnumConversion : DiagGroup<"enum-conversion",
                                 EnumCompareConditional]>;
 def ObjCSignedCharBoolImplicitIntConversion :
   DiagGroup<"objc-signed-char-bool-implicit-int-conversion">;
+def Shorten64To32 : DiagGroup<"shorten-64-to-32">;
 def ImplicitIntConversion : DiagGroup<"implicit-int-conversion",
-                                     [ObjCSignedCharBoolImplicitIntConversion]>;
+                                     [Shorten64To32,
+                                      ObjCSignedCharBoolImplicitIntConversion]>;
 def ImplicitConstIntFloatConversion : DiagGroup<"implicit-const-int-float-conversion">;
 def ImplicitIntFloatConversion : DiagGroup<"implicit-int-float-conversion",
  [ImplicitConstIntFloatConversion]>;
@@ -631,7 +633,6 @@ def Shadow : DiagGroup<"shadow", [ShadowFieldInConstructorModified,
 def ShadowAll : DiagGroup<"shadow-all", [Shadow, ShadowFieldInConstructor,
                                          ShadowUncapturedLocal, ShadowField]>;
 
-def Shorten64To32 : DiagGroup<"shorten-64-to-32">;
 def : DiagGroup<"sign-promo">;
 def SignCompare : DiagGroup<"sign-compare">;
 def SwitchDefault  : DiagGroup<"switch-default">;
@@ -942,7 +943,6 @@ def Conversion : DiagGroup<"conversion",
                             EnumConversion,
                             BitFieldEnumConversion,
                             FloatConversion,
-                            Shorten64To32,
                             IntConversion,
                             ImplicitIntConversion,
                             ImplicitFloatConversion,

--- a/clang/test/Sema/conversion-implicit-int-includes-64-to-32.c
+++ b/clang/test/Sema/conversion-implicit-int-includes-64-to-32.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wshorten-64-to-32 -triple x86_64-apple-darwin %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wimplicit-int-conversion -triple x86_64-apple-darwin %s
 
 int test0(long v) {
   return v; // expected-warning {{implicit conversion loses integer precision}}
@@ -17,5 +17,5 @@ int test2(long v) {
 }
 
 char test3(short s) {
-  return s * 2; // no warning.
+  return s * 2; // expected-warning {{implicit conversion loses integer precision: 'int' to 'char'}}
 }


### PR DESCRIPTION
Although "implicit int conversions" is supposed to be a superset containing the more specific "64-to-32" case, previously they were a disjoint set, only enabled in common in the much larger `-Wconversion`.

Closes #69444.

`diagtool tree` diff:

```diff
   -Wconversion
     # ...
     -Wfloat-conversion
       -Wfloat-overflow-conversion
       -Wfloat-zero-conversion
-    -Wshorten-64-to-32
     -Wint-conversion
     -Wimplicit-int-conversion
+      -Wshorten-64-to-32
       -Wobjc-signed-char-bool-implicit-int-conversion
     -Wimplicit-float-conversion
       -Wimplicit-int-float-conversion
         -Wimplicit-const-int-float-conversion
       -Wobjc-signed-char-bool-implicit-float-conversion
     # ...
```