### PR TITLE
[ARM][AARCH64][NEON]: Wrong return type of NEON intrinsic  vqrshrunh_n_s16, vqrshruns_n_s32, and vqrshrund_n_s64 in arm_neon.h

### DIFF
--- a/clang/include/clang/Basic/arm_neon.td
+++ b/clang/include/clang/Basic/arm_neon.td
@@ -1354,9 +1354,9 @@ let isScalarNarrowShift = 1 in {
   // Signed/Unsigned Saturating Rounded Shift Right Narrow (Immediate)
   def SCALAR_SQRSHRN_N: SInst<"vqrshrn_n", "(1<)1I", "SsSiSlSUsSUiSUl">;
   // Signed Saturating Shift Right Unsigned Narrow (Immediate)
-  def SCALAR_SQSHRUN_N: SInst<"vqshrun_n", "(1<)1I", "SsSiSl">;
+  def SCALAR_SQSHRUN_N: SInst<"vqshrun_n", "(1<U)1I", "SsSiSl">;
   // Signed Saturating Rounded Shift Right Unsigned Narrow (Immediate)
-  def SCALAR_SQRSHRUN_N: SInst<"vqrshrun_n", "(1<)1I", "SsSiSl">;
+  def SCALAR_SQRSHRUN_N: SInst<"vqrshrun_n", "(1<U)1I", "SsSiSl">;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/clang/test/CodeGen/aarch64-neon-intrinsics.c
+++ b/clang/test/CodeGen/aarch64-neon-intrinsics.c
@@ -14132,8 +14132,8 @@ int32_t test_vqshrund_n_s64(int64_t a) {
 // CHECK:   [[VQRSHRUNH_N_S16:%.*]] = call <8 x i8> @llvm.aarch64.neon.sqrshrun.v8i8(<8 x i16> [[TMP0]], i32 8)
 // CHECK:   [[TMP1:%.*]] = extractelement <8 x i8> [[VQRSHRUNH_N_S16]], i64 0
 // CHECK:   ret i8 [[TMP1]]
-int8_t test_vqrshrunh_n_s16(int16_t a) {
-  return (int8_t)vqrshrunh_n_s16(a, 8);
+uint8_t test_vqrshrunh_n_s16(int16_t a) {
+  return (uint8_t)vqrshrunh_n_s16(a, 8);
 }
 
 // CHECK-LABEL: @test_vqrshruns_n_s32(
@@ -14141,15 +14141,15 @@ int8_t test_vqrshrunh_n_s16(int16_t a) {
 // CHECK:   [[VQRSHRUNS_N_S32:%.*]] = call <4 x i16> @llvm.aarch64.neon.sqrshrun.v4i16(<4 x i32> [[TMP0]], i32 16)
 // CHECK:   [[TMP1:%.*]] = extractelement <4 x i16> [[VQRSHRUNS_N_S32]], i64 0
 // CHECK:   ret i16 [[TMP1]]
-int16_t test_vqrshruns_n_s32(int32_t a) {
-  return (int16_t)vqrshruns_n_s32(a, 16);
+uint16_t test_vqrshruns_n_s32(int32_t a) {
+  return (uint16_t)vqrshruns_n_s32(a, 16);
 }
 
 // CHECK-LABEL: @test_vqrshrund_n_s64(
 // CHECK:   [[VQRSHRUND_N_S64:%.*]] = call i32 @llvm.aarch64.neon.sqrshrun.i32(i64 %a, i32 32)
 // CHECK:   ret i32 [[VQRSHRUND_N_S64]]
-int32_t test_vqrshrund_n_s64(int64_t a) {
-  return (int32_t)vqrshrund_n_s64(a, 32);
+uint32_t test_vqrshrund_n_s64(int64_t a) {
+  return (uint32_t)vqrshrund_n_s64(a, 32);
 }
 
 // CHECK-LABEL: @test_vcvts_n_f32_s32(


### PR DESCRIPTION
* fixes https://github.com/llvm/llvm-project/issues/71751
* changed return types in the table gen file responsible for generation
  of the problematic intrinsics
* this is to ensure that the return type for the functions is the same
  as specified in the Arm Developer Documentation and avoid casting
bugs
(https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrunh_n_s16)
* updated lit tests to reflect the change in return type, worth noting
  that LLVM does not seems to differentiate signed and unsigned ints in
the IR, hence the change in type cannot be checked in IR as far as I am
aware
