### PR TITLE
[libc] Add support for C23 binary notation in `sprintf`

### DIFF
--- a/libc/src/stdio/printf_core/converter.cpp
+++ b/libc/src/stdio/printf_core/converter.cpp
@@ -53,6 +53,9 @@ int convert(Writer *writer, const FormatSection &to_conv) {
   case 's':
     return convert_string(writer, to_conv);
   case 'd':
+  case 'b':
+  case 'B':
+    return convert_decimal_binary(writer, to_conv);
   case 'i':
   case 'u':
   case 'o':

--- a/libc/src/stdio/printf_core/converter_atlas.h
+++ b/libc/src/stdio/printf_core/converter_atlas.h
@@ -22,6 +22,9 @@
 // defines convert_int
 #include "src/stdio/printf_core/int_converter.h"
 
+// defines convert_decimal_binary
+#include "src/stdio/printf_core/decimal_binary_converter.h"
+
 #ifndef LIBC_COPT_PRINTF_DISABLE_FLOAT
 // defines convert_float_decimal
 // defines convert_float_dec_exp

--- a/libc/src/stdio/printf_core/decimal_binary_converter.h
+++ b/libc/src/stdio/printf_core/decimal_binary_converter.h
@@ -1,0 +1,8 @@
+//===-- Decimal Binary Converter for printf -----------------------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//

--- a/libc/src/stdio/printf_core/int_converter.h
+++ b/libc/src/stdio/printf_core/int_converter.h
@@ -33,8 +33,9 @@ using HexFmt = IntegerToString<uintmax_t, radix::Hex>;
 using HexFmtUppercase = IntegerToString<uintmax_t, radix::Hex::Uppercase>;
 using OctFmt = IntegerToString<uintmax_t, radix::Oct>;
 using DecFmt = IntegerToString<uintmax_t>;
+using BinFmt = IntegerToString<Bin>
 
-LIBC_INLINE constexpr size_t num_buf_size() {
+    LIBC_INLINE constexpr size_t num_buf_size() {
   constexpr auto max = [](size_t a, size_t b) -> size_t {
     return (a < b) ? b : a;
   };

--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -154,6 +154,10 @@ public:
         WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, int, conv_index);
         break;
       case ('d'):
+      case ('b'):
+      case ('B'):
+        WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, char *, conv_index);
+        break;
       case ('i'):
       case ('o'):
       case ('x'):
@@ -479,6 +483,10 @@ private:
           conv_size = type_desc_from_type<int>();
           break;
         case ('d'):
+        case ('b'):
+        case ('B'):
+          conv_size = type_desc_from_type<void *>();
+          break;
         case ('i'):
         case ('o'):
         case ('x'):


### PR DESCRIPTION
Resolves Issue #80727

Implementation for representation of binary numbers using `b` specifier, similar to other languages.

[Reference](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2612.pdf)