### PR TITLE
[OpenMP] [cmake] In standalone mode, make Python3_EXECUTABLE available

### DIFF
--- a/openmp/cmake/OpenMPTesting.cmake
+++ b/openmp/cmake/OpenMPTesting.cmake
@@ -10,6 +10,8 @@ function(find_standalone_test_dependencies)
     message(WARNING "The check targets will not be available!")
     set(ENABLE_CHECK_TARGETS FALSE PARENT_SCOPE)
     return()
+  else()
+    set(Python3_EXECUTABLE ${Python3_EXECUTABLE} PARENT_SCOPE)
   endif()
 
   # Find executables.


### PR DESCRIPTION
When running the tests, we try to invoke them as
"${Python3_EXECUTABLE} ${OPENMP_LLVM_LIT_EXECUTABLE}", but when running "find_package(Python3)" within the function "find_standalone_test_dependencies", the variable "Python3_EXECUTABLE" only gets set within the function scope.

Tests have worked regardless of this in many cases, where executing the python script directly succeeds. But for consistency, and for working in cases when the python script can't be executed as such, make the Python3_EXECUTABLE variable available as intended.