### PR TITLE
[ADT] Allow std::next to work on BitVector's set_bits_iterator

### DIFF
--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -42,7 +42,7 @@ template <typename BitVectorT> class const_set_bits_iterator_impl {
 
 public:
   using iterator_category = std::forward_iterator_tag;
-  using difference_type   = void;
+  using difference_type   = std::ptrdiff_t;
   using value_type        = int;
   using pointer           = value_type*;
   using reference         = value_type&;

--- a/llvm/unittests/ADT/BitVectorTest.cpp
+++ b/llvm/unittests/ADT/BitVectorTest.cpp
@@ -1143,7 +1143,7 @@ TYPED_TEST(BitVectorTest, EmptyVectorGetData) {
 }
 
 TYPED_TEST(BitVectorTest, Iterators) {
-  TypeParam Singleton(1);
+  TypeParam Singleton(1, true);
   EXPECT_EQ(std::next(Singleton.set_bits_begin()), Singleton.set_bits_end());
 
   TypeParam Filled(10, true);

--- a/llvm/unittests/ADT/BitVectorTest.cpp
+++ b/llvm/unittests/ADT/BitVectorTest.cpp
@@ -1143,6 +1143,9 @@ TYPED_TEST(BitVectorTest, EmptyVectorGetData) {
 }
 
 TYPED_TEST(BitVectorTest, Iterators) {
+  TypeParam Singleton(1);
+  EXPECT_EQ(std::next(Singleton.set_bits_begin()), Singleton.set_bits_end());
+
   TypeParam Filled(10, true);
   EXPECT_NE(Filled.set_bits_begin(), Filled.set_bits_end());
   unsigned Counter = 0;


### PR DESCRIPTION
Without this I would hit errors with libstdc++-12 like:

/usr/include/c++/12/bits/stl_iterator_base_funcs.h:230:5: note: candidate template ignored: substitution failure [with _InputIterator = llvm::const_set_bits_iterator_impl<llvm::BitVector>]: argument may not have 'void' type
    next(_InputIterator __x, typename
    ^
