### PR TITLE
[flang][NFC] Refactor MODULE definitions to not accidentally leak symbols

### DIFF
--- a/flang/module/__cuda_builtins.f90
+++ b/flang/module/__cuda_builtins.f90
@@ -16,4 +16,16 @@ module __CUDA_builtins
     blockIdx => __builtin_blockIdx, &
     gridDim => __builtin_gridDim, &
     warpsize => __builtin_warpsize
+
+  implicit none
+
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  public :: threadIdx, &
+    blockDim, &
+    blockIdx, &
+    gridDim, &
+    warpsize
 end module

--- a/flang/module/__fortran_builtins.f90
+++ b/flang/module/__fortran_builtins.f90
@@ -11,52 +11,60 @@
 ! to USE the standard intrinsic modules in order to access the
 ! standard names of the procedures.
 module __fortran_builtins
+  implicit none
+
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
 
   intrinsic :: __builtin_c_loc
+
   intrinsic :: __builtin_c_f_pointer
+  public :: __builtin_c_f_pointer
+
   intrinsic :: sizeof ! extension
+  public :: sizeof
 
   intrinsic :: selected_int_kind
-  private :: selected_int_kind
-  integer, parameter, private :: int64 = selected_int_kind(18)
+  integer, parameter :: int64 = selected_int_kind(18)
 
-  type, bind(c) :: __builtin_c_ptr
+  type, bind(c), public :: __builtin_c_ptr
     integer(kind=int64), private :: __address
   end type
 
-  type, bind(c) :: __builtin_c_funptr
+  type, bind(c), public :: __builtin_c_funptr
     integer(kind=int64), private :: __address
   end type
 
-  type :: __builtin_event_type
+  type, public :: __builtin_event_type
     integer(kind=int64), private :: __count
   end type
 
-  type :: __builtin_notify_type
+  type, public :: __builtin_notify_type
     integer(kind=int64), private :: __count
   end type
 
-  type :: __builtin_lock_type
+  type, public :: __builtin_lock_type
     integer(kind=int64), private :: __count
   end type
 
-  type :: __builtin_team_type
+  type, public :: __builtin_team_type
     integer(kind=int64), private :: __id
   end type
 
-  integer, parameter :: __builtin_atomic_int_kind = selected_int_kind(18)
-  integer, parameter :: &
+  integer, parameter, public :: __builtin_atomic_int_kind = selected_int_kind(18)
+  integer, parameter, public :: &
     __builtin_atomic_logical_kind = __builtin_atomic_int_kind
 
-  procedure(type(__builtin_c_ptr)) :: __builtin_c_loc
+  procedure(type(__builtin_c_ptr)), public :: __builtin_c_loc
 
-  type :: __builtin_dim3
+  type, public :: __builtin_dim3
     integer :: x=1, y=1, z=1
   end type
-  type(__builtin_dim3) :: &
+  type(__builtin_dim3), public :: &
     __builtin_threadIdx, __builtin_blockDim, __builtin_blockIdx, &
     __builtin_gridDim
-  integer, parameter :: __builtin_warpsize = 32
+  integer, parameter, public :: __builtin_warpsize = 32
 
   intrinsic :: __builtin_fma
   intrinsic :: __builtin_ieee_is_nan, __builtin_ieee_is_negative, &
@@ -71,8 +79,21 @@ module __fortran_builtins
     __builtin_ieee_support_nan, __builtin_ieee_support_sqrt, &
     __builtin_ieee_support_standard, __builtin_ieee_support_subnormal, &
     __builtin_ieee_support_underflow_control
+  public :: __builtin_fma
+  public :: __builtin_ieee_is_nan, __builtin_ieee_is_negative, &
+    __builtin_ieee_is_normal
+  public :: __builtin_ieee_next_after, __builtin_ieee_next_down, &
+    __builtin_ieee_next_up
+  public :: scale ! for ieee_scalb
+  public :: __builtin_ieee_selected_real_kind
+  public :: __builtin_ieee_support_datatype, &
+    __builtin_ieee_support_denormal, __builtin_ieee_support_divide, &
+    __builtin_ieee_support_inf, __builtin_ieee_support_io, &
+    __builtin_ieee_support_nan, __builtin_ieee_support_sqrt, &
+    __builtin_ieee_support_standard, __builtin_ieee_support_subnormal, &
+    __builtin_ieee_support_underflow_control
 
-  type, private :: __force_derived_type_instantiations
+  type :: __force_derived_type_instantiations
     type(__builtin_c_ptr) :: c_ptr
     type(__builtin_c_funptr) :: c_funptr
     type(__builtin_event_type) :: event_type
@@ -81,25 +102,34 @@ module __fortran_builtins
   end type
 
   intrinsic :: __builtin_compiler_options, __builtin_compiler_version
+  public :: __builtin_compiler_options, __builtin_compiler_version
 
   interface operator(==)
     module procedure __builtin_c_ptr_eq
   end interface
+  public :: operator(==)
+
   interface operator(/=)
     module procedure __builtin_c_ptr_eq
   end interface
+  public :: operator(/=)
 
   interface __builtin_c_associated
     module procedure c_associated_c_ptr
     module procedure c_associated_c_funptr
   end interface
-  private :: c_associated_c_ptr, c_associated_c_funptr
+  public :: __builtin_c_associated
+!  private :: c_associated_c_ptr, c_associated_c_funptr
 
-  type(__builtin_c_ptr), parameter :: __builtin_c_null_ptr = __builtin_c_ptr(0)
-  type(__builtin_c_funptr), parameter :: &
+  type(__builtin_c_ptr), parameter, public :: __builtin_c_null_ptr = __builtin_c_ptr(0)
+  type(__builtin_c_funptr), parameter, public :: &
     __builtin_c_null_funptr = __builtin_c_funptr(0)
 
-contains
+  public :: __builtin_c_ptr_eq
+  public :: __builtin_c_ptr_ne
+  public :: __builtin_c_funloc
+
+  contains
 
   elemental logical function __builtin_c_ptr_eq(x, y)
     type(__builtin_c_ptr), intent(in) :: x, y

--- a/flang/module/__fortran_ieee_exceptions.f90
+++ b/flang/module/__fortran_ieee_exceptions.f90
@@ -14,13 +14,18 @@
 include '../include/flang/Runtime/magic-numbers.h'
 
 module __fortran_ieee_exceptions
+  implicit none
 
-  type :: ieee_flag_type ! Fortran 2018, 17.2 & 17.3
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  type, public :: ieee_flag_type ! Fortran 2018, 17.2 & 17.3
     private
     integer(kind=1) :: flag = 0
   end type ieee_flag_type
 
-  type(ieee_flag_type), parameter :: &
+  type(ieee_flag_type), parameter, public :: &
     ieee_invalid = ieee_flag_type(_FORTRAN_RUNTIME_IEEE_INVALID), &
     ieee_overflow = ieee_flag_type(_FORTRAN_RUNTIME_IEEE_OVERFLOW), &
     ieee_divide_by_zero = &
@@ -29,16 +34,16 @@ module __fortran_ieee_exceptions
     ieee_inexact = ieee_flag_type(_FORTRAN_RUNTIME_IEEE_INEXACT), &
     ieee_denorm = ieee_flag_type(_FORTRAN_RUNTIME_IEEE_DENORM) ! extension
 
-  type(ieee_flag_type), parameter :: &
+  type(ieee_flag_type), parameter, public :: &
     ieee_usual(*) = [ ieee_overflow, ieee_divide_by_zero, ieee_invalid ], &
     ieee_all(*) = [ ieee_usual, ieee_underflow, ieee_inexact ]
 
-  type :: ieee_modes_type ! Fortran 2018, 17.7
+  type, public :: ieee_modes_type ! Fortran 2018, 17.7
     private ! opaque fenv.h femode_t data
     integer(kind=4) :: __data(_FORTRAN_RUNTIME_IEEE_FEMODE_T_EXTENT)
   end type ieee_modes_type
 
-  type :: ieee_status_type ! Fortran 2018, 17.7
+  type, public :: ieee_status_type ! Fortran 2018, 17.7
     private ! opaque fenv.h fenv_t data
     integer(kind=4) :: __data(_FORTRAN_RUNTIME_IEEE_FENV_T_EXTENT)
   end type ieee_status_type
@@ -56,6 +61,7 @@ module __fortran_ieee_exceptions
 
 ! Set PRIVATE accessibility for specifics with 1 LOGICAL or REAL argument for
 ! generic G.
+#if 0
 #define PRIVATE_L(G) private :: \
   G##_l1, G##_l2, G##_l4, G##_l8
 #if __x86_64__
@@ -64,6 +70,7 @@ module __fortran_ieee_exceptions
 #else
 #define PRIVATE_R(G) private :: \
   G##_a2, G##_a3, G##_a4, G##_a8, G##_a16
+#endif
 #endif
 
 #define IEEE_GET_FLAG_L(FVKIND) \
@@ -75,7 +82,7 @@ module __fortran_ieee_exceptions
   interface ieee_get_flag
     SPECIFICS_L(IEEE_GET_FLAG_L)
   end interface ieee_get_flag
-  PRIVATE_L(IEEE_GET_FLAG)
+  public :: ieee_get_flag
 #undef IEEE_GET_FLAG_L
 
 #define IEEE_GET_HALTING_MODE_L(HKIND) \
@@ -87,7 +94,7 @@ module __fortran_ieee_exceptions
   interface ieee_get_halting_mode
     SPECIFICS_L(IEEE_GET_HALTING_MODE_L)
   end interface ieee_get_halting_mode
-  PRIVATE_L(IEEE_GET_HALTING_MODE)
+  public :: ieee_get_halting_mode
 #undef IEEE_GET_HALTING_MODE_L
 
   interface ieee_get_modes
@@ -96,6 +103,7 @@ module __fortran_ieee_exceptions
       type(ieee_modes_type), intent(out) :: modes
     end subroutine ieee_get_modes_0
   end interface
+  public :: ieee_get_modes
 
   interface ieee_get_status
     pure subroutine ieee_get_status_0(status)
@@ -103,6 +111,7 @@ module __fortran_ieee_exceptions
       type(ieee_status_type), intent(out) :: status
     end subroutine ieee_get_status_0
   end interface
+  public :: ieee_get_status
 
 #define IEEE_SET_FLAG_L(FVKIND) \
   elemental subroutine ieee_set_flag_l##FVKIND(flag, flag_value); \
@@ -113,7 +122,7 @@ module __fortran_ieee_exceptions
   interface ieee_set_flag
     SPECIFICS_L(IEEE_SET_FLAG_L)
   end interface ieee_set_flag
-  PRIVATE_L(IEEE_SET_FLAG)
+  public :: ieee_set_flag
 #undef IEEE_SET_FLAG_L
 
 #define IEEE_SET_HALTING_MODE_L(HKIND) \
@@ -125,7 +134,7 @@ module __fortran_ieee_exceptions
   interface ieee_set_halting_mode
     SPECIFICS_L(IEEE_SET_HALTING_MODE_L)
   end interface ieee_set_halting_mode
-  PRIVATE_L(IEEE_SET_HALTING_MODE)
+  public :: ieee_set_halting_mode
 #undef IEEE_SET_HALTING_MODE_L
 
   interface ieee_set_modes
@@ -134,6 +143,7 @@ module __fortran_ieee_exceptions
       type(ieee_modes_type), intent(in) :: modes
     end subroutine ieee_set_modes_0
   end interface
+  public :: ieee_set_modes
 
   interface ieee_set_status
     subroutine ieee_set_status_0(status)
@@ -141,6 +151,7 @@ module __fortran_ieee_exceptions
       type(ieee_status_type), intent(in) :: status
     end subroutine ieee_set_status_0
   end interface
+  public :: ieee_set_status
 
 #define IEEE_SUPPORT_FLAG_R(XKIND) \
   pure logical function ieee_support_flag_a##XKIND(flag, x); \
@@ -155,7 +166,7 @@ module __fortran_ieee_exceptions
     end function ieee_support_flag_0
     SPECIFICS_R(IEEE_SUPPORT_FLAG_R)
   end interface ieee_support_flag
-  PRIVATE_R(IEEE_SUPPORT_FLAG)
+  public :: ieee_support_flag
 #undef IEEE_SUPPORT_FLAG_R
 
   interface ieee_support_halting
@@ -164,5 +175,6 @@ module __fortran_ieee_exceptions
       type(ieee_flag_type), intent(in) :: flag
     end function ieee_support_halting_0
   end interface
+  public :: ieee_support_halting
 
 end module __fortran_ieee_exceptions

--- a/flang/module/__fortran_ieee_exceptions.f90
+++ b/flang/module/__fortran_ieee_exceptions.f90
@@ -59,20 +59,6 @@ module __fortran_ieee_exceptions
   G(2) G(3) G(4) G(8) G(16)
 #endif
 
-! Set PRIVATE accessibility for specifics with 1 LOGICAL or REAL argument for
-! generic G.
-#if 0
-#define PRIVATE_L(G) private :: \
-  G##_l1, G##_l2, G##_l4, G##_l8
-#if __x86_64__
-#define PRIVATE_R(G) private :: \
-  G##_a2, G##_a3, G##_a4, G##_a8, G##_a10, G##_a16
-#else
-#define PRIVATE_R(G) private :: \
-  G##_a2, G##_a3, G##_a4, G##_a8, G##_a16
-#endif
-#endif
-
 #define IEEE_GET_FLAG_L(FVKIND) \
   elemental subroutine ieee_get_flag_l##FVKIND(flag, flag_value); \
     import ieee_flag_type; \

--- a/flang/module/__fortran_type_info.f90
+++ b/flang/module/__fortran_type_info.f90
@@ -15,7 +15,10 @@ module __fortran_type_info
 
   use, intrinsic :: __fortran_builtins, &
     only: __builtin_c_ptr, __builtin_c_funptr
+  implicit none
 
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
   private
 
   integer, parameter :: int64 = selected_int_kind(18)

--- a/flang/module/__ppc_types.f90
+++ b/flang/module/__ppc_types.f90
@@ -7,7 +7,12 @@
 !===------------------------------------------------------------------------===!
 
 module __ppc_types
+  implicit none
+
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
   private
+
   ! Definition of derived-types that represent PowerPC vector types.
   type __builtin_ppc_intrinsic_vector(element_category, element_kind)
     integer, kind :: element_category, element_kind

--- a/flang/module/ieee_arithmetic.f90
+++ b/flang/module/ieee_arithmetic.f90
@@ -40,12 +40,60 @@ module ieee_arithmetic
 
   implicit none
 
-  type :: ieee_class_type
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  ! Explicitly export the symbols from __fortran_builtins
+  public :: ieee_fma
+  public :: ieee_is_nan
+  public :: ieee_is_negative
+  public :: ieee_is_normal
+  public :: ieee_next_after
+  public :: ieee_next_down
+  public :: ieee_next_up
+  public :: ieee_scalb
+  public :: ieee_selected_real_kind
+  public :: ieee_support_datatype
+  public :: ieee_support_denormal
+  public :: ieee_support_divide
+  public :: ieee_support_inf
+  public :: ieee_support_io
+  public :: ieee_support_nan
+  public :: ieee_support_sqrt
+  public :: ieee_support_standard
+  public :: ieee_support_subnormal
+  public :: ieee_support_underflow_control
+
+  ! Explicitly export the symbols from __fortran_ieee_exceptions
+  public :: ieee_flag_type
+  public :: ieee_invalid
+  public :: ieee_overflow
+  public :: ieee_divide_by_zero
+  public :: ieee_underflow
+  public :: ieee_inexact
+  public :: ieee_denorm
+  public :: ieee_usual
+  public :: ieee_all
+  public :: ieee_modes_type
+  public :: ieee_status_type
+  public :: ieee_get_flag
+  public :: ieee_get_halting_mode
+  public :: ieee_get_modes
+  public :: ieee_get_status
+  public :: ieee_set_flag
+  public :: ieee_set_halting_mode
+  public :: ieee_set_modes
+  public :: ieee_set_status
+  public :: ieee_support_flag
+  public :: ieee_support_halting
+
+  type, public :: ieee_class_type
     private
     integer(kind=1) :: which = 0
   end type ieee_class_type
 
-  type(ieee_class_type), parameter :: &
+  type(ieee_class_type), parameter, public :: &
     ieee_signaling_nan = ieee_class_type(_FORTRAN_RUNTIME_IEEE_SIGNALING_NAN), &
     ieee_quiet_nan = ieee_class_type(_FORTRAN_RUNTIME_IEEE_QUIET_NAN), &
     ieee_negative_inf = ieee_class_type(_FORTRAN_RUNTIME_IEEE_NEGATIVE_INF), &
@@ -62,16 +110,16 @@ module ieee_arithmetic
     ieee_positive_inf = ieee_class_type(_FORTRAN_RUNTIME_IEEE_POSITIVE_INF), &
     ieee_other_value = ieee_class_type(_FORTRAN_RUNTIME_IEEE_OTHER_VALUE)
 
-  type(ieee_class_type), parameter :: &
+  type(ieee_class_type), parameter, public :: &
     ieee_negative_denormal = ieee_negative_subnormal, &
     ieee_positive_denormal = ieee_positive_subnormal
 
-  type :: ieee_round_type
+  type, public :: ieee_round_type
     private
     integer(kind=1) :: mode = 0
   end type ieee_round_type
 
-  type(ieee_round_type), parameter :: &
+  type(ieee_round_type), parameter, public :: &
     ieee_to_zero = ieee_round_type(_FORTRAN_RUNTIME_IEEE_TO_ZERO), &
     ieee_nearest = ieee_round_type(_FORTRAN_RUNTIME_IEEE_NEAREST), &
     ieee_up = ieee_round_type(_FORTRAN_RUNTIME_IEEE_UP), &
@@ -89,6 +137,8 @@ module ieee_arithmetic
       type(ieee_round_type), intent(in) :: x, y
     end function ieee_round_eq
   end interface operator(==)
+  public :: operator(==)
+
   interface operator(/=)
     elemental logical function ieee_class_ne(x, y)
       import ieee_class_type
@@ -99,7 +149,7 @@ module ieee_arithmetic
       type(ieee_round_type), intent(in) :: x, y
     end function ieee_round_ne
   end interface operator(/=)
-  private :: ieee_class_eq, ieee_round_eq, ieee_class_ne, ieee_round_ne
+  public :: operator(/=)
 
 ! Define specifics with 1 or 2 INTEGER, LOGICAL, or REAL arguments for
 ! generic G.
@@ -154,58 +204,6 @@ module ieee_arithmetic
   G(16,2) G(16,3) G(16,4) G(16,8) G(16,16)
 #endif
 
-! Set PRIVATE accessibility for specifics with 1 or 2 INTEGER, LOGICAL, or REAL
-! arguments for generic G.
-#define PRIVATE_I(G) private :: \
-  G##_i1, G##_i2, G##_i4, G##_i8, G##_i16
-#define PRIVATE_L(G) private :: \
-  G##_l1, G##_l2, G##_l4, G##_l8
-#if __x86_64__
-#define PRIVATE_R(G) private :: \
-  G##_a2, G##_a3, G##_a4, G##_a8, G##_a10, G##_a16
-#else
-#define PRIVATE_R(G) private :: \
-  G##_a2, G##_a3, G##_a4, G##_a8, G##_a16
-#endif
-#define PRIVATE_II(G) private :: \
-  G##_i1_i1, G##_i1_i2, G##_i1_i4, G##_i1_i8, G##_i1_i16, \
-  G##_i2_i1, G##_i2_i2, G##_i2_i4, G##_i2_i8, G##_i2_i16, \
-  G##_i4_i1, G##_i4_i2, G##_i4_i4, G##_i4_i8, G##_i4_i16, \
-  G##_i8_i1, G##_i8_i2, G##_i8_i4, G##_i8_i8, G##_i8_i16, \
-  G##_i16_i1, G##_i16_i2, G##_i16_i4, G##_i16_i8, G##_i16_i16
-#if __x86_64__
-#define PRIVATE_RI(G) private :: \
-  G##_a2_i1, G##_a2_i2, G##_a2_i4, G##_a2_i8, G##_a2_i16, \
-  G##_a3_i1, G##_a3_i2, G##_a3_i4, G##_a3_i8, G##_a3_i16, \
-  G##_a4_i1, G##_a4_i2, G##_a4_i4, G##_a4_i8, G##_a4_i16, \
-  G##_a8_i1, G##_a8_i2, G##_a8_i4, G##_a8_i8, G##_a8_i16, \
-  G##_a10_i1, G##_a10_i2, G##_a10_i4, G##_a10_i8, G##_a10_i16, \
-  G##_a16_i1, G##_a16_i2, G##_a16_i4, G##_a16_i8, G##_a16_i16
-#else
-#define PRIVATE_RI(G) private :: \
-  G##_a2_i1, G##_a2_i2, G##_a2_i4, G##_a2_i8, G##_a2_i16, \
-  G##_a3_i1, G##_a3_i2, G##_a3_i4, G##_a3_i8, G##_a3_i16, \
-  G##_a4_i1, G##_a4_i2, G##_a4_i4, G##_a4_i8, G##_a4_i16, \
-  G##_a8_i1, G##_a8_i2, G##_a8_i4, G##_a8_i8, G##_a8_i16, \
-  G##_a16_i1, G##_a16_i2, G##_a16_i4, G##_a16_i8, G##_a16_i16
-#endif
-#if __x86_64__
-#define PRIVATE_RR(G) private :: \
-  G##_a2_a2, G##_a2_a3, G##_a2_a4, G##_a2_a8, G##_a2_a10, G##_a2_a16, \
-  G##_a3_a2, G##_a3_a3, G##_a3_a4, G##_a3_a8, G##_a3_a10, G##_a3_a16, \
-  G##_a4_a2, G##_a4_a3, G##_a4_a4, G##_a4_a8, G##_a4_a10, G##_a4_a16, \
-  G##_a8_a2, G##_a8_a3, G##_a8_a4, G##_a8_a8, G##_a8_a10, G##_a8_a16, \
-  G##_a10_a2, G##_a10_a3, G##_a10_a4, G##_a10_a8, G##_a10_a10, G##_a10_a16, \
-  G##_a16_a2, G##_a16_a3, G##_a16_a4, G##_a16_a8, G##_a16_a10, G##_a16_a16
-#else
-#define PRIVATE_RR(G) private :: \
-  G##_a2_a2, G##_a2_a3, G##_a2_a4, G##_a2_a8, G##_a2_a16, \
-  G##_a3_a2, G##_a3_a3, G##_a3_a4, G##_a3_a8, G##_a3_a16, \
-  G##_a4_a2, G##_a4_a3, G##_a4_a4, G##_a4_a8, G##_a4_a16, \
-  G##_a8_a2, G##_a8_a3, G##_a8_a4, G##_a8_a8, G##_a8_a16, \
-  G##_a16_a2, G##_a16_a3, G##_a16_a4, G##_a16_a8, G##_a16_a16
-#endif
-
 #define IEEE_CLASS_R(XKIND) \
   elemental type(ieee_class_type) function ieee_class_a##XKIND(x); \
     import ieee_class_type; \
@@ -214,7 +212,7 @@ module ieee_arithmetic
   interface ieee_class
     SPECIFICS_R(IEEE_CLASS_R)
   end interface ieee_class
-  PRIVATE_R(IEEE_CLASS)
+  public :: ieee_class
 #undef IEEE_CLASS_R
 
 #define IEEE_COPY_SIGN_RR(XKIND, YKIND) \
@@ -225,7 +223,7 @@ module ieee_arithmetic
   interface ieee_copy_sign
     SPECIFICS_RR(IEEE_COPY_SIGN_RR)
   end interface ieee_copy_sign
-  PRIVATE_RR(IEEE_COPY_SIGN)
+  public :: ieee_copy_sign
 #undef IEEE_COPY_SIGN_RR
 
 #define IEEE_GET_ROUNDING_MODE_I(RKIND) \
@@ -241,7 +239,7 @@ module ieee_arithmetic
     end subroutine ieee_get_rounding_mode_0
     SPECIFICS_I(IEEE_GET_ROUNDING_MODE_I)
   end interface ieee_get_rounding_mode
-  PRIVATE_I(IEEE_GET_ROUNDING_MODE)
+  public :: ieee_get_rounding_mode
 #undef IEEE_GET_ROUNDING_MODE_I
 
 #define IEEE_GET_UNDERFLOW_MODE_L(GKIND) \
@@ -251,7 +249,7 @@ module ieee_arithmetic
   interface ieee_get_underflow_mode
     SPECIFICS_L(IEEE_GET_UNDERFLOW_MODE_L)
   end interface ieee_get_underflow_mode
-  PRIVATE_L(IEEE_GET_UNDERFLOW_MODE)
+  public ::  ieee_get_underflow_mode
 #undef IEEE_GET_UNDERFLOW_MODE_L
 
 ! When kind argument is present, kind(result) is value(kind), not kind(kind).
@@ -273,8 +271,7 @@ module ieee_arithmetic
     SPECIFICS_R(IEEE_INT_R)
     SPECIFICS_RI(IEEE_INT_RI)
   end interface ieee_int
-  PRIVATE_R(IEEE_INT)
-  PRIVATE_RI(IEEE_INT)
+  public :: ieee_int
 #undef IEEE_INT_R
 #undef IEEE_INT_RI
 
@@ -285,7 +282,7 @@ module ieee_arithmetic
   interface ieee_is_finite
     SPECIFICS_R(IEEE_IS_FINITE_R)
   end interface ieee_is_finite
-  PRIVATE_R(IEEE_IS_FINITE)
+  public :: ieee_is_finite
 #undef IEEE_IS_FINITE_R
 
 #define IEEE_LOGB_R(XKIND) \
@@ -295,7 +292,7 @@ module ieee_arithmetic
   interface ieee_logb
     SPECIFICS_R(IEEE_LOGB_R)
   end interface ieee_logb
-  PRIVATE_R(IEEE_LOGB)
+  public :: ieee_logb
 #undef IEEE_LOGB_R
 
 #define IEEE_MAX_R(XKIND) \
@@ -305,7 +302,7 @@ module ieee_arithmetic
   interface ieee_max
     SPECIFICS_R(IEEE_MAX_R)
   end interface ieee_max
-  PRIVATE_R(IEEE_MAX)
+  public :: ieee_max
 #undef IEEE_MAX_R
 
 #define IEEE_MAX_MAG_R(XKIND) \
@@ -315,7 +312,7 @@ module ieee_arithmetic
   interface ieee_max_mag
     SPECIFICS_R(IEEE_MAX_MAG_R)
   end interface ieee_max_mag
-  PRIVATE_R(IEEE_MAX_MAG)
+  public :: ieee_max_mag
 #undef IEEE_MAX_MAG_R
 
 #define IEEE_MAX_NUM_R(XKIND) \
@@ -325,7 +322,7 @@ module ieee_arithmetic
   interface ieee_max_num
     SPECIFICS_R(IEEE_MAX_NUM_R)
   end interface ieee_max_num
-  PRIVATE_R(IEEE_MAX_NUM)
+  public :: ieee_max_num
 #undef IEEE_MAX_NUM_R
 
 #define IEEE_MAX_NUM_MAG_R(XKIND) \
@@ -335,7 +332,7 @@ module ieee_arithmetic
   interface ieee_max_num_mag
     SPECIFICS_R(IEEE_MAX_NUM_MAG_R)
   end interface ieee_max_num_mag
-  PRIVATE_R(IEEE_MAX_NUM_MAG)
+  public :: ieee_max_num_mag
 #undef IEEE_MAX_NUM_MAG_R
 
 #define IEEE_MIN_R(XKIND) \
@@ -345,7 +342,7 @@ module ieee_arithmetic
   interface ieee_min
     SPECIFICS_R(IEEE_MIN_R)
   end interface ieee_min
-  PRIVATE_R(IEEE_MIN)
+  public :: ieee_min
 #undef IEEE_MIN_R
 
 #define IEEE_MIN_MAG_R(XKIND) \
@@ -355,7 +352,7 @@ module ieee_arithmetic
   interface ieee_min_mag
     SPECIFICS_R(IEEE_MIN_MAG_R)
   end interface ieee_min_mag
-  PRIVATE_R(IEEE_MIN_MAG)
+  public :: ieee_min_mag
 #undef IEEE_MIN_MAG_R
 
 #define IEEE_MIN_NUM_R(XKIND) \
@@ -365,7 +362,7 @@ module ieee_arithmetic
   interface ieee_min_num
     SPECIFICS_R(IEEE_MIN_NUM_R)
   end interface ieee_min_num
-  PRIVATE_R(IEEE_MIN_NUM)
+  public :: ieee_min_num
 #undef IEEE_MIN_NUM_R
 
 #define IEEE_MIN_NUM_MAG_R(XKIND) \
@@ -375,7 +372,7 @@ module ieee_arithmetic
   interface ieee_min_num_mag
     SPECIFICS_R(IEEE_MIN_NUM_MAG_R)
   end interface ieee_min_num_mag
-  PRIVATE_R(IEEE_MIN_NUM_MAG)
+  public ::ieee_min_num_mag
 #undef IEEE_MIN_NUM_MAG_R
 
 #define IEEE_QUIET_EQ_R(AKIND) \
@@ -385,7 +382,7 @@ module ieee_arithmetic
   interface ieee_quiet_eq
     SPECIFICS_R(IEEE_QUIET_EQ_R)
   end interface ieee_quiet_eq
-  PRIVATE_R(IEEE_QUIET_EQ)
+  public :: ieee_quiet_eq
 #undef IEEE_QUIET_EQ_R
 
 #define IEEE_QUIET_GE_R(AKIND) \
@@ -395,7 +392,7 @@ module ieee_arithmetic
   interface ieee_quiet_ge
     SPECIFICS_R(IEEE_QUIET_GE_R)
   end interface ieee_quiet_ge
-  PRIVATE_R(IEEE_QUIET_GE)
+  public :: ieee_quiet_ge
 #undef IEEE_QUIET_GE_R
 
 #define IEEE_QUIET_GT_R(AKIND) \
@@ -405,7 +402,7 @@ module ieee_arithmetic
   interface ieee_quiet_gt
     SPECIFICS_R(IEEE_QUIET_GT_R)
   end interface ieee_quiet_gt
-  PRIVATE_R(IEEE_QUIET_GT)
+  public :: ieee_quiet_gt
 #undef IEEE_QUIET_GT_R
 
 #define IEEE_QUIET_LE_R(AKIND) \
@@ -415,7 +412,7 @@ module ieee_arithmetic
   interface ieee_quiet_le
     SPECIFICS_R(IEEE_QUIET_LE_R)
   end interface ieee_quiet_le
-  PRIVATE_R(IEEE_QUIET_LE)
+  public :: ieee_quiet_le
 #undef IEEE_QUIET_LE_R
 
 #define IEEE_QUIET_LT_R(AKIND) \
@@ -425,7 +422,7 @@ module ieee_arithmetic
   interface ieee_quiet_lt
     SPECIFICS_R(IEEE_QUIET_LT_R)
   end interface ieee_quiet_lt
-  PRIVATE_R(IEEE_QUIET_LT)
+  public :: ieee_quiet_lt
 #undef IEEE_QUIET_LT_R
 
 #define IEEE_QUIET_NE_R(AKIND) \
@@ -435,7 +432,7 @@ module ieee_arithmetic
   interface ieee_quiet_ne
     SPECIFICS_R(IEEE_QUIET_NE_R)
   end interface ieee_quiet_ne
-  PRIVATE_R(IEEE_QUIET_NE)
+  public :: ieee_quiet_ne
 #undef IEEE_QUIET_NE_R
 
 ! When kind argument is present, kind(result) is value(kind), not kind(kind).
@@ -464,10 +461,7 @@ module ieee_arithmetic
     SPECIFICS_II(IEEE_REAL_II)
     SPECIFICS_RI(IEEE_REAL_RI)
   end interface ieee_real
-  PRIVATE_I(IEEE_REAL)
-  PRIVATE_R(IEEE_REAL)
-  PRIVATE_II(IEEE_REAL)
-  PRIVATE_RI(IEEE_REAL)
+  public :: ieee_real
 #undef IEEE_REAL_I
 #undef IEEE_REAL_R
 #undef IEEE_REAL_II
@@ -481,7 +475,7 @@ module ieee_arithmetic
   interface ieee_rem
     SPECIFICS_RR(IEEE_REM_RR)
   end interface ieee_rem
-  PRIVATE_RR(IEEE_REM)
+  public :: ieee_rem
 #undef IEEE_REM_RR
 
 #define IEEE_RINT_R(XKIND) \
@@ -493,7 +487,7 @@ module ieee_arithmetic
   interface ieee_rint
     SPECIFICS_R(IEEE_RINT_R)
   end interface ieee_rint
-  PRIVATE_R(IEEE_RINT)
+  public :: ieee_rint
 #undef IEEE_RINT_R
 
 #define IEEE_SET_ROUNDING_MODE_I(RKIND) \
@@ -509,7 +503,7 @@ module ieee_arithmetic
     end subroutine ieee_set_rounding_mode_0
     SPECIFICS_I(IEEE_SET_ROUNDING_MODE_I)
   end interface ieee_set_rounding_mode
-  PRIVATE_I(IEEE_SET_ROUNDING_MODE)
+  public :: ieee_set_rounding_mode
 #undef IEEE_SET_ROUNDING_MODE_I
 
 #define IEEE_SET_UNDERFLOW_MODE_L(GKIND) \
@@ -519,7 +513,7 @@ module ieee_arithmetic
   interface ieee_set_underflow_mode
     SPECIFICS_L(IEEE_SET_UNDERFLOW_MODE_L)
   end interface ieee_set_underflow_mode
-  PRIVATE_L(IEEE_SET_UNDERFLOW_MODE)
+  public :: ieee_set_underflow_mode
 #undef IEEE_SET_UNDERFLOW_MODE_L
 
 #define IEEE_SIGNALING_EQ_R(AKIND) \
@@ -529,7 +523,7 @@ module ieee_arithmetic
   interface ieee_signaling_eq
     SPECIFICS_R(IEEE_SIGNALING_EQ_R)
   end interface ieee_signaling_eq
-  PRIVATE_R(IEEE_SIGNALING_EQ)
+  public :: ieee_signaling_eq
 #undef IEEE_SIGNALING_EQ_R
 
 #define IEEE_SIGNALING_GE_R(AKIND) \
@@ -539,7 +533,7 @@ module ieee_arithmetic
   interface ieee_signaling_ge
     SPECIFICS_R(IEEE_SIGNALING_GE_R)
   end interface ieee_signaling_ge
-  PRIVATE_R(IEEE_SIGNALING_GE)
+  public :: ieee_signaling_ge
 #undef IEEE_SIGNALING_GE_R
 
 #define IEEE_SIGNALING_GT_R(AKIND) \
@@ -549,7 +543,7 @@ module ieee_arithmetic
   interface ieee_signaling_gt
     SPECIFICS_R(IEEE_SIGNALING_GT_R)
   end interface ieee_signaling_gt
-  PRIVATE_R(IEEE_SIGNALING_GT)
+  public :: ieee_signaling_gt
 #undef IEEE_SIGNALING_GT_R
 
 #define IEEE_SIGNALING_LE_R(AKIND) \
@@ -559,7 +553,7 @@ module ieee_arithmetic
   interface ieee_signaling_le
     SPECIFICS_R(IEEE_SIGNALING_LE_R)
   end interface ieee_signaling_le
-  PRIVATE_R(IEEE_SIGNALING_LE)
+  public :: ieee_signaling_le
 #undef IEEE_SIGNALING_LE_R
 
 #define IEEE_SIGNALING_LT_R(AKIND) \
@@ -569,7 +563,7 @@ module ieee_arithmetic
   interface ieee_signaling_lt
     SPECIFICS_R(IEEE_SIGNALING_LT_R)
   end interface ieee_signaling_lt
-  PRIVATE_R(IEEE_SIGNALING_LT)
+  public :: ieee_signaling_lt
 #undef IEEE_SIGNALING_LT_R
 
 #define IEEE_SIGNALING_NE_R(AKIND) \
@@ -579,7 +573,7 @@ module ieee_arithmetic
   interface ieee_signaling_ne
     SPECIFICS_R(IEEE_SIGNALING_NE_R)
   end interface ieee_signaling_ne
-  PRIVATE_R(IEEE_SIGNALING_NE)
+  public :: ieee_signaling_ne
 #undef IEEE_SIGNALING_NE_R
 
 #define IEEE_SIGNBIT_R(XKIND) \
@@ -589,7 +583,7 @@ module ieee_arithmetic
   interface ieee_signbit
     SPECIFICS_R(IEEE_SIGNBIT_R)
   end interface ieee_signbit
-  PRIVATE_R(IEEE_SIGNBIT)
+  public :: ieee_signbit
 #undef IEEE_SIGNBIT_R
 
 #define IEEE_SUPPORT_ROUNDING_R(XKIND) \
@@ -605,18 +599,18 @@ module ieee_arithmetic
     end function ieee_support_rounding_0
     SPECIFICS_R(IEEE_SUPPORT_ROUNDING_R)
   end interface ieee_support_rounding
-  PRIVATE_R(IEEE_SUPPORT_ROUNDING)
+  public :: ieee_support_rounding
 #undef IEEE_SUPPORT_ROUNDING_R
 
 #define IEEE_UNORDERED_RR(XKIND, YKIND) \
- elemental logical function ieee_unordered_a##XKIND##_a##YKIND(x, y); \
+  elemental logical function ieee_unordered_a##XKIND##_a##YKIND(x, y); \
     real(XKIND), intent(in) :: x; \
     real(YKIND), intent(in) :: y; \
   end function ieee_unordered_a##XKIND##_a##YKIND;
   interface ieee_unordered
     SPECIFICS_RR(IEEE_UNORDERED_RR)
   end interface ieee_unordered
-  PRIVATE_RR(IEEE_UNORDERED)
+  public :: ieee_unordered
 #undef IEEE_UNORDERED_RR
 
 #define IEEE_VALUE_R(XKIND) \
@@ -628,7 +622,7 @@ module ieee_arithmetic
   interface ieee_value
     SPECIFICS_R(IEEE_VALUE_R)
   end interface ieee_value
-  PRIVATE_R(IEEE_VALUE)
+  public :: ieee_value
 #undef IEEE_VALUE_R
 
 end module ieee_arithmetic

--- a/flang/module/ieee_exceptions.f90
+++ b/flang/module/ieee_exceptions.f90
@@ -8,4 +8,9 @@
 
 module ieee_exceptions
   use __fortran_ieee_exceptions
+
+  implicit none
+
+  ! Because this MODULE simply re-exports an internal MODULE file,
+  ! we do not use PRIVATE in here.
 end module ieee_exceptions

--- a/flang/module/ieee_features.f90
+++ b/flang/module/ieee_features.f90
@@ -9,13 +9,18 @@
 ! See Fortran 2018, clause 17.2
 
 module ieee_features
+  implicit none
 
-  type :: ieee_features_type
+  ! Set PRIVATE by default to explicitly only export what is meant
+  ! to be exported by this MODULE.
+  private
+
+  type, public :: ieee_features_type
     private
     integer(kind=1) :: feature = 0
   end type ieee_features_type
 
-  type(ieee_features_type), parameter :: &
+  type(ieee_features_type), parameter, public :: &
     ieee_datatype = ieee_features_type(1), &
     ieee_denormal = ieee_features_type(2), &
     ieee_divide = ieee_features_type(3), &


### PR DESCRIPTION
This PR continues the work started with PR #79006, by setting visibility in MODULES to PRIVATE by default and explicitly exporting only the desired symbols.  `omp_lib` needs more work, as it should maybe be compiled from `omp_lib.f90` in `openmp/runtime/src/incluce/omp_lib.f90.var` instead of simply using an INCLUDE for `omp_lib.h`