### PR TITLE
[Clang][Sema] Diagnose declarative nested-name-specifiers naming alias templates

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -211,6 +211,8 @@ Improvements to Clang's diagnostics
 
 - Clang now diagnoses extraneous template parameter lists as a language extension.
 
+- Clang now diagnoses declarative nested name specifiers that name alias templates.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8255,6 +8255,9 @@ def err_not_tag_in_scope : Error<
 def ext_template_after_declarative_nns : ExtWarn<
     "'template' cannot be used after a declarative nested name specifier">,
     InGroup<DiagGroup<"template-in-declaration-name">>;
+def ext_alias_template_in_declarative_nns : ExtWarn<
+  "a declarative nested name specifier cannot name an alias template">,
+  InGroup<DiagGroup<"alias-template-in-declaration-name">>;
 
 def err_no_typeid_with_fno_rtti : Error<
   "use of typeid requires -frtti">;

--- a/clang/test/CXX/expr/expr.prim/expr.prim.id/expr.prim.id.qual/p3.cpp
+++ b/clang/test/CXX/expr/expr.prim/expr.prim.id/expr.prim.id.qual/p3.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -verify %s
+
+template<typename T>
+struct A {
+  void f();
+};
+
+template<typename T>
+using B = A<T>;
+
+template<typename T>
+void B<T>::f() { } // expected-warning {{a declarative nested name specifier cannot name an alias template}}
+
+template<>
+void B<int>::f() { } // ok, template argument list of simple-template-id doesn't involve template parameters
+
+namespace N {
+
+  template<typename T>
+  struct D {
+    void f();
+  };
+
+  template<typename T>
+  using E = D<T>;
+}
+
+template<typename T>
+void N::E<T>::f() { } // expected-warning {{a declarative nested name specifier cannot name an alias template}}

--- a/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p1.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p1.cpp
@@ -26,5 +26,5 @@ namespace Example2 {
     void g();
   };
   template<class T> using B = A<T>;
-  template<class T> void B<T>::g() {} // ok.
+  template<class T> void B<T>::g() {} // // expected-warning {{a declarative nested name specifier cannot name an alias template}}
 }


### PR DESCRIPTION
According to [[expr.prim.id.qual] p3](http://eel.is/c++draft/expr.prim.id.qual#3):
> The _nested-name-specifier_ `​::` nominates the global namespace. A _nested-name-specifier_ with a _computed-type-specifier_ nominates the type denoted by the _computed-type-specifier_, which shall be a class or enumeration type. **If a _nested-name-specifier_ `N` is declarative and has a _simple-template-id_ with a template argument list `A` that involves a template parameter, let `T` be the template nominated by `N` without `A`. `T` shall be a class template.**

Meaning, the out-of-line definition of `A::f` in the following example is ill-formed:
```cpp
template<typename T>
struct A 
{ 
    void f(); 
};

template<typename T>
using B = A<T>;

template<typename T>
void B<T>::f() { } // error: a declarative nested name specifier cannot name an alias template
```

This patch diagnoses such cases as an extension (in group `alias-template-in-declaration-name`).
