### PR TITLE
[OpenMP] HSA_ENABLE_SDMA visible in libomptarget tests

### DIFF
--- a/openmp/libomptarget/test/lit.cfg
+++ b/openmp/libomptarget/test/lit.cfg
@@ -31,6 +31,9 @@ if 'LIBOMPTARGET_LOCK_MAPPED_HOST_BUFFERS' in os.environ:
 if 'OMP_TARGET_OFFLOAD' in os.environ:
     config.environment['OMP_TARGET_OFFLOAD'] = os.environ['OMP_TARGET_OFFLOAD']
 
+if 'HSA_ENABLE_SDMA' in os.environ:
+    config.environment['HSA_ENABLE_SDMA'] = os.environ['HSA_ENABLE_SDMA']
+
 # set default environment variables for test
 if 'CHECK_OPENMP_ENV' in os.environ:
     test_env = os.environ['CHECK_OPENMP_ENV'].split()


### PR DESCRIPTION
Enable the environment variable inside the test environment. This allows to disable SDMA engine transfers as a potential mitigation of flaky OpenMP offloading tests on AMDGPU.

Motivated by the open ticket https://github.com/ROCm/ROCm/issues/2616 about a missed synchronization signal.