### PR TITLE
[RemoveDIs] Don't convert debug-info in bitcode-loading just now

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -8031,14 +8031,6 @@ BitcodeModule::getModuleImpl(LLVMContext &Context, bool MaterializeAll,
       return std::move(Err);
   }
 
-  // If we are operating in a "new debug-info" context, upgrade the debug-info
-  // in the loaded module. This is a transitional approach as we enable "new"
-  // debug-info in LLVM, which will eventually be pushed down into the
-  // autoupgrade path once the bitcode-encoding is finalised. Non-materialised
-  // functions will be upgraded in the materialize method.
-  if (UseNewDbgInfoFormat && !M->IsNewDbgInfoFormat)
-    M->convertToNewDbgValues();
-
   return std::move(M);
 }
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -6632,9 +6632,6 @@ Error BitcodeReader::materialize(GlobalValue *GV) {
   if (Error Err = materializeMetadata())
     return Err;
 
-  bool NewDebugInfoRequested = F->IsNewDbgInfoFormat;
-  F->IsNewDbgInfoFormat = false;
-
   // Move the bit stream to the saved position of the deferred function body.
   if (Error JumpFailed = Stream.JumpToBit(DFII->second))
     return JumpFailed;
@@ -6709,14 +6706,6 @@ Error BitcodeReader::materialize(GlobalValue *GV) {
 
   // Look for functions that rely on old function attribute behavior.
   UpgradeFunctionAttributes(*F);
-
-  // If we've materialized a function set up in "new" debug-info mode, the
-  // contents just loaded will still be in dbg.value mode. Switch to the new
-  // mode now. NB: we can add more complicated logic here in the future to
-  // correctly identify when we do and don't need to autoupgrade.
-  if (NewDebugInfoRequested) {
-    F->convertToNewDbgValues();
-  }
 
   // Bring in any functions that this function forward-referenced via
   // blockaddresses.

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1775,6 +1775,8 @@ IRMover::IRMover(Module &M) : Composite(M) {
 Error IRMover::move(std::unique_ptr<Module> Src,
                     ArrayRef<GlobalValue *> ValuesToLink,
                     LazyCallback AddLazyFor, bool IsPerformingImport) {
+  if (getModule().IsNewDbgInfoFormat)
+    Src->convertToNewDbgValues();
   IRLinker TheIRLinker(Composite, SharedMDs, IdentifiedStructTypes,
                        std::move(Src), ValuesToLink, std::move(AddLazyFor),
                        IsPerformingImport);

--- a/llvm/test/ThinLTO/X86/crash_debuginfo.ll
+++ b/llvm/test/ThinLTO/X86/crash_debuginfo.ll
@@ -4,6 +4,9 @@
 ; RUN: opt -passes=function-import,inline -summary-file %t-index.thinlto.bc %t-dst.bc -o %t.out
 ; RUN: llvm-nm -U %t.out | FileCheck %s --implicit-check-not=_bar
 
+; Ensure we can do the same thing in RemoveDIs mode.
+; RUN: opt -passes=function-import,inline -summary-file %t-index.thinlto.bc %t-dst.bc -o %t.out --try-experimental-debuginfo-iterators
+
 ; Verify that we import bar and inline it. It use to crash importing due to ODR type uniquing
 ; CHECK: _foo
 


### PR DESCRIPTION
We've been building and testing this no-debug-intrinsic work inside of the pass manager for a while, so that optimisation passes get exercised and tested when we turn it on. However, by converting to the non-intrinsic form in the bitcode loader, we accidentally caused all parts of LLVM to potentially see non-intrinsic debug-info.

Seeing how we're trying to turn things on incrementally, it was a mistake to go this far this fast: we can instead just focus on enabling during optimisations for the moment, then all the other parts of LLVM later.

(@OCHyams @SLTozer this is what we've been talking about internally about "drawing the wrong line" through LLVM when staging these changes. Removing these hunks avoids every single tool in the repo having to immediately cope with RemoveDIs debug-info, and we can continue focusing on optimisations only).