### PR TITLE
[readtapi] Ensure universal dylibs record the same input path location across slices

### DIFF
--- a/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
+++ b/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
@@ -408,6 +408,7 @@ Expected<Records> DylibReader::readFile(MemoryBufferRef Buffer,
         Results.emplace_back(std::make_shared<RecordsSlice>(RecordsSlice({T})));
         if (auto Err = load(&Obj, *Results.back(), Opt, Arch))
           return std::move(Err);
+        Results.back()->getBinaryAttrs().Path = Buffer.getBufferIdentifier();
       }
       break;
     }

--- a/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
+++ b/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
@@ -199,6 +199,7 @@ static void stubifyImpl(std::unique_ptr<InterfaceFile> IF, Context &Ctx) {
   // TODO: Add inlining and magic merge support.
   if (Ctx.OutStream == nullptr) {
     std::error_code EC;
+    assert(!IF->getPath().empty() && "Unknown output location");
     SmallString<PATH_MAX> OutputLoc = IF->getPath();
     replace_extension(OutputLoc, ".tbd");
     Ctx.OutStream = std::make_unique<llvm::raw_fd_stream>(OutputLoc, EC);


### PR DESCRIPTION
resolves: https://github.com/llvm/llvm-project/issues/80868