### PR TITLE
[flang] Introducing a method to dynamically and conditionally register dialect interfaces. 

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -67,6 +67,9 @@ bool canLegallyInline(mlir::Operation *op, mlir::Region *reg, bool,
                       mlir::IRMapping &map);
 bool canLegallyInline(mlir::Operation *, mlir::Operation *, bool);
 
+//  register the FIRInlinerInterface to FIROpsDialect
+void addFIRInlinerExtension(mlir::DialectRegistry &registry);
+
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIRDIALECT_H

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -67,7 +67,7 @@ bool canLegallyInline(mlir::Operation *op, mlir::Region *reg, bool,
                       mlir::IRMapping &map);
 bool canLegallyInline(mlir::Operation *, mlir::Operation *, bool);
 
-//  register the FIRInlinerInterface to FIROpsDialect
+// Register the FIRInlinerInterface to FIROpsDialect
 void addFIRInlinerExtension(mlir::DialectRegistry &registry);
 
 } // namespace fir

--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -53,6 +53,13 @@ inline void registerDialects(mlir::DialectRegistry &registry) {
   registry.insert<FLANG_CODEGEN_DIALECT_LIST>();
 }
 
+// Register FIR Extensions
+inline void addFIRExtensions(mlir::DialectRegistry &registry,
+                             bool addFIRInlinerInterface = true) {
+  if (addFIRInlinerInterface)
+    addFIRInlinerExtension(registry);
+}
+
 inline void loadNonCodegenDialects(mlir::MLIRContext &context) {
   mlir::DialectRegistry registry;
   registerNonCodegenDialects(registry);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -786,6 +786,10 @@ void CodeGenAction::generateLLVMIR() {
   llvm::OptimizationLevel level = mapToLevel(opts);
 
   fir::support::loadDialects(*mlirCtx);
+  mlir::DialectRegistry registry;
+  fir::support::registerNonCodegenDialects(registry);
+  fir::support::addFIRExtensions(registry);
+  mlirCtx->appendDialectRegistry(registry);
   fir::support::registerLLVMTranslation(*mlirCtx);
 
   // Set-up the MLIR pass manager

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -69,7 +69,7 @@ fir::FIROpsDialect::FIROpsDialect(mlir::MLIRContext *ctx)
   registerOpExternalInterfaces();
 }
 
-//  register the FIRInlinerInterface to FIROpsDialect
+// Register the FIRInlinerInterface to FIROpsDialect
 void fir::addFIRInlinerExtension(mlir::DialectRegistry &registry) {
   registry.addExtension(
       +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -67,7 +67,14 @@ fir::FIROpsDialect::FIROpsDialect(mlir::MLIRContext *ctx)
 #include "flang/Optimizer/Dialect/FIROps.cpp.inc"
       >();
   registerOpExternalInterfaces();
-  addInterfaces<FIRInlinerInterface>();
+}
+
+//  register the FIRInlinerInterface to FIROpsDialect
+void fir::addFIRInlinerExtension(mlir::DialectRegistry &registry) {
+  registry.addExtension(
+      +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {
+        dialect->addInterface<FIRInlinerInterface>();
+      });
 }
 
 // anchor the class vtable to this compilation unit

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -326,6 +326,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
   // translate to FIR dialect of MLIR
   mlir::DialectRegistry registry;
   fir::support::registerNonCodegenDialects(registry);
+  fir::support::addFIRExtensions(registry);
   mlir::MLIRContext ctx(registry);
   fir::support::loadNonCodegenDialects(ctx);
   auto &defKinds = semanticsContext.defaultKinds();

--- a/flang/tools/fir-opt/fir-opt.cpp
+++ b/flang/tools/fir-opt/fir-opt.cpp
@@ -40,6 +40,7 @@ int main(int argc, char **argv) {
 #endif
   DialectRegistry registry;
   fir::support::registerDialects(registry);
+  fir::support::addFIRExtensions(registry);
   return failed(MlirOptMain(argc, argv, "FIR modular optimizer driver\n",
       registry));
 }

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -90,6 +90,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
   sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
   mlir::DialectRegistry registry;
   fir::support::registerDialects(registry);
+  fir::support::addFIRExtensions(registry);
   mlir::MLIRContext context(registry);
   fir::support::loadDialects(context);
   fir::support::registerLLVMTranslation(context);


### PR DESCRIPTION
This change introduces the `addFIRExtensions` method to dynamically and conditionally register dialect interfaces. As a use case of `addFIRExtensions`, this change moves the static registration of  `FIRInlinerInterface` out of the constructor of `FIROpsDialect` to be dynamically registered while loading the necessary MLIR dialects required by Flang. This registration of `FIRInlinerInterface` is also guarded by a boolean `addFIRInlinerInterface`  which defaults to true.