### PR TITLE
[mlir][ROCDL] Add synchronization primitives (#1077)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -193,15 +193,19 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
 }
 
 def ROCDL_SetPrioOp : ROCDL_IntrOp<"s.setprio", [], [], [], 0>,
-  Arguments<(ins I16:$priority)> {
+  Arguments<(ins I16Attr:$priority)> {
   let results = (outs);
   let assemblyFormat = "$priority attr-dict";
+  string llvmBuilder =
+    "createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_setprio,builder.getInt16(op.getPriority()));";
 }
 
 def ROCDL_SchedBarrier : ROCDL_IntrOp<"sched.barrier", [], [], [], 0>,
-  Arguments<(ins I32:$mask)> {
+  Arguments<(ins I32Attr:$mask)> {
   let results = (outs);
   let assemblyFormat = "$mask attr-dict";
+  string llvmBuilder =
+    "createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_sched_barrier,builder.getInt32(op.getMask()));";
 }
 
 

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -192,6 +192,18 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
   let assemblyFormat = "attr-dict";
 }
 
+def ROCDL_SetPrioOp : ROCDL_IntrOp<"s.setprio", [], [], [], 0>,
+  Arguments<(ins I16:$priority)> {
+  let results = (outs);
+  let assemblyFormat = "$priority attr-dict";
+}
+
+def ROCDL_SchedBarrier : ROCDL_IntrOp<"sched.barrier", [], [], [], 0>,
+  Arguments<(ins I32:$mask)> {
+  let results = (outs);
+  let assemblyFormat = "$mask attr-dict";
+}
+
 
 //===---------------------------------------------------------------------===//
 // Xdlops intrinsics

--- a/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -35,6 +35,18 @@ func.func @rocdl.barrier() {
   llvm.return
 }
 
+func.func @rocdl.sched_barrier() {
+  // CHECK: rocdl.sched.barrier
+  rocdl.sched.barrier 0
+  llvm.return
+}
+
+func.func @rocdl.setprio() {
+  // CHECK: rocdl.s.setprio
+  rocdl.s.setprio 0
+  llvm.return
+}
+
 func.func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32xf32>, %arg3 : i32,
                    %arg4 : vector<16xf32>, %arg5 : vector<4xf32>,

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -91,22 +91,18 @@ llvm.func @rocdl.barrier() {
 }
 
 llvm.func @rocdl.setprio() {
-  %zero = llvm.mlir.constant(0 : i16) : i16
-  %one = llvm.mlir.constant(1 : i16) : i16
   // CHECK: call void @llvm.amdgcn.s.setprio(i16 0)
-  rocdl.s.setprio %zero
+  rocdl.s.setprio 0
   // CHECK-NEXT: call void @llvm.amdgcn.s.setprio(i16 1)
-  rocdl.s.setprio %one
+  rocdl.s.setprio 1
   llvm.return
 }
 
 llvm.func @rocdl.schedbarrier() {
-  %zero = llvm.mlir.constant(0 : i32) : i32
-  %one = llvm.mlir.constant(1 : i32) : i32
   // CHECK: call void @llvm.amdgcn.sched.barrier(i32 0)
-  rocdl.sched.barrier %zero
+  rocdl.sched.barrier 0
   // CHECK-NEXT: call void @llvm.amdgcn.sched.barrier(i32 1)
-  rocdl.sched.barrier %one
+  rocdl.sched.barrier 1
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -90,6 +90,26 @@ llvm.func @rocdl.barrier() {
   llvm.return
 }
 
+llvm.func @rocdl.setprio() {
+  %zero = llvm.mlir.constant(0 : i16) : i16
+  %one = llvm.mlir.constant(1 : i16) : i16
+  // CHECK: call void @llvm.amdgcn.s.setprio(i16 0)
+  rocdl.s.setprio %zero
+  // CHECK-NEXT: call void @llvm.amdgcn.s.setprio(i16 1)
+  rocdl.s.setprio %one
+  llvm.return
+}
+
+llvm.func @rocdl.schedbarrier() {
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %one = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: call void @llvm.amdgcn.sched.barrier(i32 0)
+  rocdl.sched.barrier %zero
+  // CHECK-NEXT: call void @llvm.amdgcn.sched.barrier(i32 1)
+  rocdl.sched.barrier %one
+  llvm.return
+}
+
 llvm.func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32 x f32>, %arg3: i32,
                    %arg4 : vector<16 x f32>, %arg5 : vector<4xf32>,


### PR DESCRIPTION
This PR is adding to MLIR two LLVM intrisics:
- llvm.amdgcn.s.setprio which sets the priority of a wave for the GPU scheduler
- llvm.amdgcn.sched.barrier which sets a software barrier so that the scheduler cannot move instructions around