### PR TITLE
[Flang] Support passing a function that returns procedure pointer as actual corresponding to a procedure dummy.

### DIFF
--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -924,8 +924,7 @@ static PreparedDummyArgument preparePresentUserCallActualArgument(
   if (hlfir::isFortranProcedureValue(dummyType)) {
     // Procedure pointer or function returns procedure pointer actual to
     // procedure dummy.
-    if (actual.isProcedurePointer() ||
-        actual.getType().isa<fir::BoxProcType>()) {
+    if (actual.isProcedurePointer()) {
       actual = hlfir::derefPointersAndAllocatables(loc, builder, actual);
       return PreparedDummyArgument{actual, /*cleanups=*/{}};
     }
@@ -933,7 +932,11 @@ static PreparedDummyArgument preparePresentUserCallActualArgument(
     assert(actual.isProcedure());
     // Do nothing if this is a procedure argument. It is already a
     // fir.boxproc/fir.tuple<fir.boxproc, len> as it should.
-    if (actual.getType() != dummyType)
+    if (!actual.getType().isa<fir::BoxProcType>() &&
+        actual.getType() != dummyType)
+      // The actual argument may be a procedure that returns character (a
+      // fir.tuple<fir.boxproc, len>) while the dummy is not. Extract the tuple
+      // in that case.
       actual = fixProcedureDummyMismatch(loc, builder, actual, dummyType);
     return PreparedDummyArgument{actual, /*cleanups=*/{}};
   }

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -922,8 +922,10 @@ static PreparedDummyArgument preparePresentUserCallActualArgument(
   // Handle procedure arguments (procedure pointers should go through
   // prepareProcedurePointerActualArgument).
   if (hlfir::isFortranProcedureValue(dummyType)) {
-    // Procedure pointer actual to procedure dummy.
-    if (actual.isProcedurePointer()) {
+    // Procedure pointer or function returns procedure pointer actual to
+    // procedure dummy.
+    if (actual.isProcedurePointer() ||
+        actual.getType().isa<fir::BoxProcType>()) {
       actual = hlfir::derefPointersAndAllocatables(loc, builder, actual);
       return PreparedDummyArgument{actual, /*cleanups=*/{}};
     }


### PR DESCRIPTION
Flang crashes with the following case. The problem is we missed the case when passing a reference to a function that returns a procedure pointer as actual that corresponds to a procedure dummy. This PR is to fix that.

```
  PROGRAM main
  IMPLICIT NONE
  INTERFACE
    FUNCTION IntF(Arg)
      integer :: Arg, IntF
    END FUNCTION
  END INTERFACE

  INTERFACE
    FUNCTION RetPtr(Arg)
      IMPORT
      PROCEDURE(IntF) :: Arg
      PROCEDURE(IntF), POINTER :: RetPtr
    END FUNCTION
  END INTERFACE

  CALL ModSub(RetPtr(IntF))
  contains
    SUBROUTINE ModSub(Fun1)
    PROCEDURE(IntF) :: Fun1
    END SUBROUTINE
  END
  ```