### PR TITLE
[libc][NFC] Fix extraneous namespace on Errno

### DIFF
--- a/libc/src/errno/libc_errno.cpp
+++ b/libc/src/errno/libc_errno.cpp
@@ -46,5 +46,5 @@ LIBC_NAMESPACE::Errno::operator int() { return errno; }
 
 namespace LIBC_NAMESPACE {
 // Define the global `libc_errno` instance.
-LIBC_NAMESPACE::Errno libc_errno;
+Errno libc_errno;
 } // namespace LIBC_NAMESPACE

--- a/libc/src/errno/libc_errno.h
+++ b/libc/src/errno/libc_errno.h
@@ -40,7 +40,7 @@ struct Errno {
   operator int();
 };
 
-extern LIBC_NAMESPACE::Errno libc_errno;
+extern Errno libc_errno;
 
 } // namespace LIBC_NAMESPACE
 


### PR DESCRIPTION
The Errno type doesn't need to be explicitly namespaced now that it's
enclosed in a namespace.
