### PR TITLE
[Clang][Sema] Implement proposed resolution for CWG2847

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2982,6 +2982,9 @@ def err_trailing_requires_clause_on_deduction_guide : Error<
   "deduction guide cannot have a requires clause">;
 def err_constrained_non_templated_function
     : Error<"non-templated function cannot have a requires clause">;
+def err_non_temp_spec_requires_clause : Error<
+  "%select{explicit|friend}0 specialization cannot have a trailing requires clause "
+  "unless it declares a function template">;
 def err_reference_to_function_with_unsatisfied_constraints : Error<
   "invalid reference to function %0: constraints not satisfied">;
 def err_requires_expr_local_parameter_default_argument : Error<

--- a/clang/test/CXX/drs/dr28xx.cpp
+++ b/clang/test/CXX/drs/dr28xx.cpp
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -std=c++98 -verify=expected %s
+// RUN: %clang_cc1 -std=c++11 -verify=expected %s
+// RUN: %clang_cc1 -std=c++14 -verify=expected %s
+// RUN: %clang_cc1 -std=c++17 -verify=expected %s
+// RUN: %clang_cc1 -std=c++20 -verify=expected,since-cxx20 %s
+// RUN: %clang_cc1 -std=c++23 -verify=expected,since-cxx20,since-cxx23 %s
+// RUN: %clang_cc1 -std=c++2c -verify=expected,since-cxx20,since-cxx23,since-cxx26 %s
+
+#if __cplusplus < 202002L
+// expected-no-diagnostics
+#endif
+
+namespace dr2847 { // dr2847: 19
+
+#if __cplusplus >= 202002L
+
+template<typename>
+void i();
+
+struct A {
+  template<typename>
+  void f() requires true;
+
+  template<>
+  void f<int>() requires true;
+  // since-cxx20-error@-1 {{explicit specialization cannot have a trailing requires clause unless it declares a function template}}
+
+  friend void i<int>() requires true;
+  // since-cxx20-error@-1 {{friend specialization cannot have a trailing requires clause unless it declares a function template}}
+};
+
+template<typename>
+struct B {
+  void f() requires true;
+
+  template<typename>
+  void g() requires true;
+
+  template<typename>
+  void h() requires true;
+
+  template<>
+  void h<int>() requires true;
+  // since-cxx20-error@-1 {{explicit specialization cannot have a trailing requires clause unless it declares a function template}}
+
+  friend void i<int>() requires true;
+  // since-cxx20-error@-1 {{friend specialization cannot have a trailing requires clause unless it declares a function template}}
+};
+
+template<>
+void B<int>::f() requires true;
+// since-cxx20-error@-1 {{explicit specialization cannot have a trailing requires clause unless it declares a function template}}
+
+template<>
+template<typename T>
+void B<int>::g() requires true;
+
+#endif
+
+} // namespace dr2847


### PR DESCRIPTION
Per the approved resolution for [CWG2847](https://cplusplus.github.io/CWG/issues/2847.html), [temp.expl.spec] p8 will state:
> An explicit specialization shall not have a trailing _requires-clause_ unless it declares a function template.

We already implement this _partially_ insofar that a diagnostic is issued upon instantiation of `A<int>` in the following example:
```cpp
template<typename>
struct A
{
    template<typename>
    void f();

    template<>
    void f<int>() requires true; // error: non-templated function cannot have a requires clause
};
template struct A<int>;  // note: in instantiation of template class 'A<int>' requested here
```

This patch adds a bespoke diagnostic for such declarations, and moves the point of diagnosis for non-templated functions with trailing requires-clauses from `CheckFunctionDeclaration` to `ActOnFunctionDeclarator` (there is no point in diagnosing this during instantiation since we already have all the necessary information when parsing the declaration).