### PR TITLE
[libc++] Add details about string annotations

### DIFF
--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -124,9 +124,9 @@ Improvements and New Features
   ``-DLIBCXX_INSTALL_MODULE_DIR=<path>``. The default location is
   ``${PREFIX}/share/libc++/v1``.
 
-- AddressSanitizer annotations have been added to ``std::basic_string``
-  external buffers (long strings only).
-  Enabled with all allocators by default.
+- AddressSanitizer annotations have been added to ``std::basic_string``.
+  These annotations are enabled for all allocators by default.
+  It's only enable for long string, string using the small buffer optimization are not annotated.
 
 - The libc++ source code has been formatted with ``clang-format``. This
   `discourse thread <https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all>`_

--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -126,7 +126,7 @@ Improvements and New Features
 
 - AddressSanitizer annotations have been added to ``std::basic_string``.
   These annotations are enabled for all allocators by default.
-  It's only enable for long string, string using the small buffer optimization are not annotated.
+  It's only enabled for long strings, strings using the small buffer optimization are not annotated.
 
 - The libc++ source code has been formatted with ``clang-format``. This
   `discourse thread <https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all>`_

--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -124,7 +124,9 @@ Improvements and New Features
   ``-DLIBCXX_INSTALL_MODULE_DIR=<path>``. The default location is
   ``${PREFIX}/share/libc++/v1``.
 
-- AddressSanitizer annotations have been added to ``std::basic_string``.
+- AddressSanitizer annotations have been added to ``std::basic_string``
+  external buffers (long strings only).
+  Enabled with all allocators by default.
 
 - The libc++ source code has been formatted with ``clang-format``. This
   `discourse thread <https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all>`_


### PR DESCRIPTION
This commit adds information that only long strings are annotated, and with all allocators by default.

To read why short string annotations are not turned on yet, read related PR: https://github.com/llvm/llvm-project/pull/79536