### PR TITLE
[Flang][bbc] Prevent bbc -emit-fir command invoking all passes twice

### DIFF
--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -256,6 +256,22 @@ createTargetMachine(llvm::StringRef targetTriple, std::string &error) {
                                      /*Reloc::Model=*/std::nullopt)};
 }
 
+/// Build and execute the OpenMPFIRPassPipeline with its own instance
+/// of the pass manager, allowing it to be invoked as soon as it's
+/// required without impacting the main pass pipeline that may be invoked
+/// more than once for verification.
+static mlir::LogicalResult runOpenMPPasses(mlir::ModuleOp mlirModule) {
+  mlir::PassManager pm(mlirModule->getName(),
+                       mlir::OpPassManager::Nesting::Implicit);
+  fir::createOpenMPFIRPassPipeline(pm, enableOpenMPDevice);
+  (void)mlir::applyPassManagerCLOptions(pm);
+  if (mlir::failed(pm.run(mlirModule))) {
+    llvm::errs() << "FATAL: failed to correctly apply OpenMP pass pipeline";
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
 //===----------------------------------------------------------------------===//
 // Translate Fortran input to FIR, a dialect of MLIR.
 //===----------------------------------------------------------------------===//
@@ -368,14 +384,16 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
                            "could not open output file ")
            << outputName;
 
+  // WARNING: This pipeline must be run immediately after the lowering to
+  // ensure that the FIR is correct with respect to OpenMP operations/
+  // attributes.
+  if (enableOpenMP)
+    if (mlir::failed(runOpenMPPasses(mlirModule)))
+      return mlir::failure();
+
   // Otherwise run the default passes.
   mlir::PassManager pm(mlirModule->getName(),
                        mlir::OpPassManager::Nesting::Implicit);
-  if (enableOpenMP)
-    // WARNING: This pipeline must be run immediately after the lowering to
-    // ensure that the FIR is correct with respect to OpenMP operations/
-    // attributes.
-    fir::createOpenMPFIRPassPipeline(pm, enableOpenMPDevice);
   pm.enableVerifier(/*verifyPasses=*/true);
   (void)mlir::applyPassManagerCLOptions(pm);
   if (passPipeline.hasAnyOccurrences()) {

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -389,18 +389,14 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     // --emit-fir: Build the IR, verify it, and dump the IR if the IR passes
     // verification. Use --dump-module-on-failure to dump invalid IR.
     pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
-    if (mlir::failed(pm.run(mlirModule))) {
-      llvm::errs() << "FATAL: verification of lowering to FIR failed";
-      return mlir::failure();
-    }
 
-    if (emitFIR && useHLFIR) {
-      // lower HLFIR to FIR
+    // Add HLFIR to FIR lowering pass
+    if (emitFIR && useHLFIR)
       fir::createHLFIRToFIRPassPipeline(pm, llvm::OptimizationLevel::O2);
-      if (mlir::failed(pm.run(mlirModule))) {
-        llvm::errs() << "FATAL: lowering from HLFIR to FIR failed";
-        return mlir::failure();
-      }
+
+    if (mlir::failed(pm.run(mlirModule))) {
+      llvm::errs() << "FATAL: verification of FIR or HLFIR module failed";
+      return mlir::failure();
     }
 
     printModule(mlirModule, out);

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -389,14 +389,18 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     // --emit-fir: Build the IR, verify it, and dump the IR if the IR passes
     // verification. Use --dump-module-on-failure to dump invalid IR.
     pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
-
-    // Add HLFIR to FIR lowering pass
-    if (emitFIR && useHLFIR)
-      fir::createHLFIRToFIRPassPipeline(pm, llvm::OptimizationLevel::O2);
-
     if (mlir::failed(pm.run(mlirModule))) {
-      llvm::errs() << "FATAL: verification of FIR or HLFIR module failed";
+      llvm::errs() << "FATAL: verification of lowering to FIR failed";
       return mlir::failure();
+    }
+
+    if (emitFIR && useHLFIR) {
+      // lower HLFIR to FIR
+      fir::createHLFIRToFIRPassPipeline(pm, llvm::OptimizationLevel::O2);
+      if (mlir::failed(pm.run(mlirModule))) {
+        llvm::errs() << "FATAL: lowering from HLFIR to FIR failed";
+        return mlir::failure();
+      }
     }
 
     printModule(mlirModule, out);


### PR DESCRIPTION
Currently when the bbc tool is invoked with the emit-fir command the pass pipeline will be invoked twice causing passes added to the pass manager to run twice on the input IR.

This change seeks to prevent that from occuring by only invoking the pass managers run command once and situationally adding the HLFIR to FIR pass pipeline in the same scenario as before.