### PR TITLE
[RISCV] Only set Zca flag for EF_RISCV_RVC in ELFObjectFileBase::getR…

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
@@ -525,7 +525,8 @@ static RelaxAux initRelaxAux(LinkGraph &G) {
   RelaxAux Aux;
   Aux.Config.IsRV32 = G.getTargetTriple().isRISCV32();
   const auto &Features = G.getFeatures().getFeatures();
-  Aux.Config.HasRVC = llvm::is_contained(Features, "+c");
+  Aux.Config.HasRVC = llvm::is_contained(Features, "+c") ||
+                      llvm::is_contained(Features, "+zca");
 
   for (auto &S : G.sections()) {
     if (!shouldRelax(S))

--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -292,7 +292,7 @@ Expected<SubtargetFeatures> ELFObjectFileBase::getRISCVFeatures() const {
   unsigned PlatformFlags = getPlatformFlags();
 
   if (PlatformFlags & ELF::EF_RISCV_RVC) {
-    Features.AddFeature("c");
+    Features.AddFeature("zca");
   }
 
   RISCVAttributeParser Attributes;

--- a/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_align_rvc.s
+++ b/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_align_rvc.s
@@ -10,6 +10,16 @@
 # RUN:     -slab-allocate 100Kb -slab-address 0x0 -slab-page-size 4096 \
 # RUN:     -check %s %t.rv64
 
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax,+zca %s -o %t.rv32zca
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x0 -slab-page-size 4096 \
+# RUN:     -check %s %t.rv32zca
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax,+zca %s -o %t.rv64zca
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x0 -slab-page-size 4096 \
+# RUN:     -check %s %t.rv64zca
+
     .globl main,align2,align4,align8,align16,align32
     .type  main,@function
 main:

--- a/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_call_boundary.s
+++ b/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_call_boundary.s
@@ -11,6 +11,16 @@
 # RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
 # RUN:     -check %s %t.rv64
 
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax,+zca %s -o %t.rv32zca
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -check %s %t.rv32zca
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax,+zca %s -o %t.rv64zca
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -check %s %t.rv64zca
+
         .globl main
         .type main,@function
 main:

--- a/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_call_rvc.s
+++ b/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_relax_call_rvc.s
@@ -19,6 +19,26 @@
 # RUN:     -debug-only=jitlink -check %s -check-name=jitlink-check-rv64 %t.rv64 \
 # RUN:     2>&1 | FileCheck -check-prefix=CHECK-RV64 %s
 
+# RUN: llvm-mc -triple=riscv32 -mattr=+relax,+zca -filetype=obj -o %t.rv32zca %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -debug-only=jitlink -check %s %t.rv32zca \
+# RUN:    2>&1 | FileCheck %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -debug-only=jitlink -check %s -check-name=jitlink-check-rv32 %t.rv32zca \
+# RUN:     2>&1 | FileCheck -check-prefix=CHECK-RV32 %s
+
+# RUN: llvm-mc -triple=riscv64 -mattr=+relax,+c -filetype=obj -o %t.rv64 %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -debug-only=jitlink -check %s %t.rv64 \
+# RUN:     2>&1 | FileCheck %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 100Kb -slab-address 0x1000 -slab-page-size 4096 \
+# RUN:     -debug-only=jitlink -check %s -check-name=jitlink-check-rv64 %t.rv64 \
+# RUN:     2>&1 | FileCheck -check-prefix=CHECK-RV64 %s
+
         .text
 
 ## Successful relaxation: call -> jal


### PR DESCRIPTION
…ISCVFeatures().

This code appears to be a hack to set the features to include compressed instructions if the ELF EFLAGS flags bit is present, but the ELF attribute for the ISA string is no present or not accurate.

We can't remove the hack because llvm-mc doesn't create ELF attributes by default so a lot of tests fail to disassembler properly. Using clang as the assembler does set the attributes.

This patch changes the hack to only set Zca since that is the minimum implied by the flag. Setting anything else potentially conflicts with the ISA string containing Zcmp or Zcmt.

JITLink also needs to be updated to recognize Zca in addition to C.