### PR TITLE
Fix an implicit cast to a base ref counted class generates a false positive.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -84,6 +84,7 @@ std::optional<bool> isRefCountable(const CXXRecordDecl* R)
   if (AnyInconclusiveBase)
     return std::nullopt;
 
+  Paths.clear();
   const auto hasPublicDerefInBase =
       [&AnyInconclusiveBase](const CXXBaseSpecifier *Base, CXXBasePath &) {
         auto hasDerefInBase = clang::hasPublicMethodInBase(Base, "deref");

--- a/clang/test/Analysis/Checkers/WebKit/implicit-cast-to-base-class-with-deref-in-superclass.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/implicit-cast-to-base-class-with-deref-in-superclass.cpp
@@ -1,28 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
 // expected-no-diagnostics
 
-template<typename T>
-class Ref {
-public:
-    ~Ref()
-    {
-        if (auto* ptr = m_ptr)
-            ptr->deref();
-        m_ptr = nullptr;
-    }
-
-    Ref(T& object)
-        : m_ptr(&object)
-    {
-        object.ref();
-    }
-
-    operator T&() const { return *m_ptr; }
-    bool operator!() const { return !*m_ptr; }
-
-private:
-    T* m_ptr;
-};
+#include "mock-types.h"
 
 class Base {
 public:

--- a/clang/test/Analysis/Checkers/WebKit/implicit-cast-to-base-class-with-deref-in-superclass.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/implicit-cast-to-base-class-with-deref-in-superclass.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+// expected-no-diagnostics
+
+template<typename T>
+class Ref {
+public:
+    ~Ref()
+    {
+        if (auto* ptr = m_ptr)
+            ptr->deref();
+        m_ptr = nullptr;
+    }
+
+    Ref(T& object)
+        : m_ptr(&object)
+    {
+        object.ref();
+    }
+
+    operator T&() const { return *m_ptr; }
+    bool operator!() const { return !*m_ptr; }
+
+private:
+    T* m_ptr;
+};
+
+class Base {
+public:
+    virtual ~Base();
+    void ref() const;
+    void deref() const;
+};
+
+class Event : public Base {
+protected:
+    explicit Event();
+};
+
+class SubEvent : public Event {
+public:
+    static Ref<SubEvent> create();
+private:
+    SubEvent() = default;
+};
+
+void someFunction(Base&);
+
+static void test()
+{
+    someFunction(SubEvent::create());
+}


### PR DESCRIPTION
The bug was caused by isRefCountable erroneously returning false for a class with both ref() and deref() functions defined because we were not resetting the base paths results between looking for "ref()" and "deref()"