### PR TITLE
[lldb] DRAFT - Add `Status::Detail` type to hold information from diagnostics

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -10,6 +10,7 @@
 #define LLDB_EXPRESSION_DIAGNOSTICMANAGER_H
 
 #include "lldb/lldb-defines.h"
+#include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -19,20 +20,6 @@
 #include <vector>
 
 namespace lldb_private {
-
-enum DiagnosticOrigin {
-  eDiagnosticOriginUnknown = 0,
-  eDiagnosticOriginLLDB,
-  eDiagnosticOriginClang,
-  eDiagnosticOriginSwift,
-  eDiagnosticOriginLLVM
-};
-
-enum DiagnosticSeverity {
-  eDiagnosticSeverityError,
-  eDiagnosticSeverityWarning,
-  eDiagnosticSeverityRemark
-};
 
 const uint32_t LLDB_INVALID_COMPILER_ID = UINT32_MAX;
 

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -162,6 +162,7 @@ private:
   StreamTee m_err_stream;
 
   lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
+  Status m_error_status;
 
   bool m_did_change_process_state = false;
   bool m_suppress_immediate_output = false;

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -234,6 +234,20 @@ enum LoadDependentFiles {
   eLoadDependentsNo,
 };
 
+enum DiagnosticOrigin {
+  eDiagnosticOriginUnknown = 0,
+  eDiagnosticOriginLLDB,
+  eDiagnosticOriginClang,
+  eDiagnosticOriginSwift,
+  eDiagnosticOriginLLVM
+};
+
+enum DiagnosticSeverity {
+  eDiagnosticSeverityError,
+  eDiagnosticSeverityWarning,
+  eDiagnosticSeverityRemark
+};
+
 inline std::string GetStatDescription(lldb_private::StatisticKind K) {
    switch (K) {
    case StatisticKind::ExpressionSuccessful:

--- a/lldb/source/Expression/UtilityFunction.cpp
+++ b/lldb/source/Expression/UtilityFunction.cpp
@@ -87,25 +87,25 @@ FunctionCaller *UtilityFunction::MakeFunctionCaller(
     return nullptr;
   }
   if (m_caller_up) {
-    DiagnosticManager diagnostics;
+    DiagnosticManager diagnostic_manager;
 
     unsigned num_errors =
-        m_caller_up->CompileFunction(thread_to_use_sp, diagnostics);
+        m_caller_up->CompileFunction(thread_to_use_sp, diagnostic_manager);
     if (num_errors) {
-      error.SetErrorStringWithFormat(
-          "Error compiling %s caller function: \"%s\".",
-          m_function_name.c_str(), diagnostics.GetString().c_str());
+      error.SetErrorStringWithFormat("Error compiling %s caller function:",
+                                     m_function_name.c_str());
+      error.SetErrorDetails(diagnostic_manager);
       m_caller_up.reset();
       return nullptr;
     }
 
-    diagnostics.Clear();
+    diagnostic_manager.Clear();
     ExecutionContext exe_ctx(process_sp);
 
-    if (!m_caller_up->WriteFunctionWrapper(exe_ctx, diagnostics)) {
-      error.SetErrorStringWithFormat(
-          "Error inserting caller function for %s: \"%s\".",
-          m_function_name.c_str(), diagnostics.GetString().c_str());
+    if (!m_caller_up->WriteFunctionWrapper(exe_ctx, diagnostic_manager)) {
+      error.SetErrorStringWithFormat("Error inserting caller function for %s:",
+                                     m_function_name.c_str());
+      error.SetErrorDetails(diagnostic_manager);
       m_caller_up.reset();
       return nullptr;
     }

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -109,8 +109,15 @@ void CommandReturnObject::AppendError(llvm::StringRef in_string) {
 
 void CommandReturnObject::SetError(const Status &error,
                                    const char *fallback_error_cstr) {
-  if (error.Fail())
-    AppendError(error.AsCString(fallback_error_cstr));
+  m_error_status = error;
+  if (m_error_status.Fail()) {
+    std::vector<Status::Detail> details = m_error_status.GetDetails();
+    if (!details.empty()) {
+      for (Status::Detail detail : details)
+        AppendError(detail.GetMessage());
+    } else
+      AppendError(error.AsCString(fallback_error_cstr));
+  }
 }
 
 void CommandReturnObject::SetError(llvm::Error error) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1424,7 +1424,7 @@ lldb_private::Status ClangExpressionParser::PrepareForExecution(
           if (Error Err = dynamic_checkers->Install(install_diags, exe_ctx)) {
             std::string ErrMsg = "couldn't install checkers: " + toString(std::move(Err));
             if (install_diags.Diagnostics().size())
-              ErrMsg = ErrMsg + "\n" + install_diags.GetString().c_str();
+              err.SetErrorDetails(install_diags);
             err.SetErrorString(ErrMsg);
             return err;
           }
@@ -1505,8 +1505,8 @@ lldb_private::Status ClangExpressionParser::RunStaticInitializers(
             exe_ctx, call_static_initializer, options, execution_errors);
 
     if (results != lldb::eExpressionCompleted) {
-      err.SetErrorStringWithFormat("couldn't run static initializer: %s",
-                                   execution_errors.GetString().c_str());
+      err.SetErrorString("couldn't run static initializer: ");
+      err.SetErrorDetails(execution_errors);
       return err;
     }
   }

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -851,9 +851,8 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                                  func_args_addr,
                                                  arguments,
                                                  diagnostics)) {
-    error.SetErrorStringWithFormat(
-        "dlopen error: could not write function arguments: %s",
-        diagnostics.GetString().c_str());
+    error.SetErrorString("dlopen error: could not write function arguments: ");
+    error.SetErrorDetails(diagnostics);
     return LLDB_INVALID_IMAGE_TOKEN;
   }
   
@@ -893,9 +892,9 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   ExpressionResults results = do_dlopen_function->ExecuteFunction(
       exe_ctx, &func_args_addr, options, diagnostics, return_value);
   if (results != eExpressionCompleted) {
-    error.SetErrorStringWithFormat(
-        "dlopen error: failed executing dlopen wrapper function: %s",
-        diagnostics.GetString().c_str());
+    error.SetErrorString(
+        "dlopen error: failed executing dlopen wrapper function: ");
+    error.SetErrorDetails(diagnostics);
     return LLDB_INVALID_IMAGE_TOKEN;
   }
   

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -331,8 +331,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   diagnostics.Clear();
   if (!invocation->WriteFunctionArguments(context, injected_parameters,
                                           parameters, diagnostics)) {
-    error.SetErrorStringWithFormat("LoadLibrary error: unable to write function parameters: %s",
-                                   diagnostics.GetString().c_str());
+    error.SetErrorString(
+        "LoadLibrary error: unable to write function parameters: ");
+    error.SetErrorDetails(diagnostics);
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -372,8 +373,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
       invocation->ExecuteFunction(context, &injected_parameters, options,
                                   diagnostics, value);
   if (result != eExpressionCompleted) {
-    error.SetErrorStringWithFormat("LoadLibrary error: failed to execute LoadLibrary helper: %s",
-                                   diagnostics.GetString().c_str());
+    error.SetErrorString(
+        "LoadLibrary error: failed to execute LoadLibrary helper: ");
+    error.SetErrorDetails(diagnostics);
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 


### PR DESCRIPTION
This is a work in progress that lets `Status` instances separately store multiple messages such as errors, warnings, and/or notes. This approach can help break the anti-pattern where code that creates or modifies a `Status` object has no choice but to merge multiple messages (e.g. errors and warnings) together into one, long string to store all the information in the status object.

By keeping messages separate, the codebase has more opportunities to give developers a richer and more pleasant experiences.  For example, the codebase would have the ability to individually colorize the text of each error, warning, note, etc., as I've done for PR https://github.com/llvm/llvm-project/pull/80938.

Changes:
* + Type `struct Status::Detail` type in `Status.cpp`
* + Member `std::vector<Status::Detail> m_status_details` in `class Status`
	* + Related methods
* + Member `std::vector<Status::Detail> m_status_details` in `class CommandReturnObject`
* Types moved from `DiagnosticManager.h` -> `lldb-private-enumerations.h`
	* `enum DiagnosticOrigin`
	* `enum DiagnosticSeverity`
* The `UserExpression::Evaluate` method:
	* Creates `Status::Detail` for `Diagnostic` in a `DiagnosticManager` instance.
		* And adds it to its `Status &error` parameter.
	* No longer appends the diagnostic manager's string (of its diagnostics) to its `&error` parameter.
* The `CommandReturnObject::SetError` method:
	* Saves a copy of an error (Status).
	* Appends each status detail (diagnostic) into its own separate error messages.
	* This lets `CommandReturnObject` individually colorize each "error:", "warning:", or "note:".
	* Before, only the first entry got the colorization because the remaining entries were just concatenated onto the first entry.