### PR TITLE
[ubsan] Support static linking with standalone runtime

### DIFF
--- a/compiler-rt/lib/ubsan/ubsan_signals_standalone.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_signals_standalone.cpp
@@ -66,6 +66,11 @@ void InitializeDeadlySignals() {
     return;
   is_initialized = true;
   InitializeSignalInterceptors();
+#if SANITIZER_INTERCEPT_SIGNAL_AND_SIGACTION
+  // REAL(sigaction_symname) is nullptr in a static link. Bail out.
+  if (!REAL(sigaction_symname))
+    return;
+#endif
   InstallDeadlySignalHandlers(&UBsanOnDeadlySignal);
 }
 

--- a/compiler-rt/test/ubsan/TestCases/Misc/Linux/static-link.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/Linux/static-link.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: ubsan-standalone
 // REQUIRES: target={{x86_64.*}}
-// REQUIRES: librt_has_multf3
 // RUN: %clangxx -fsanitize=bool -static  %s -o %t && UBSAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigfpe=0 %run %t 2>&1 | FileCheck %s
+// RUN: %run %t 2>&1 | FileCheck %s
 #include <signal.h>
 #include <stdio.h>
 


### PR DESCRIPTION
The standalone runtime (not
-fsanitize-minimal-runtime/-fsanitize-trap=undefined) installs some
signal handlers using `real_sigaction`. With static linking
(-static/-static-pie), the called `REAL(sigaction)` is null, leading to
an immediate segfault, which is confusing (#51538).

Fix #51538 by bailing out.

`// REQUIRES: librt_has_multf3` from https://reviews.llvm.org/D109709
actually disabled the test because `librt_has_*` features are only for
`compiler-rt/test/builtins`. The test does not reproduce for me:
libclang_rt.builtins.a or libgcc. Revert the REQUIRES.
