### PR TITLE
[Github] Add initial version of precommit checks

### DIFF
--- a/.github/workflows/precommit-linux.yaml
+++ b/.github/workflows/precommit-linux.yaml
@@ -1,4 +1,4 @@
-name: "Precommit tests"
+name: "Linux Precommit Tests"
 
 permissions:
   contents: read
@@ -11,9 +11,15 @@ on:
       - '.github/workflows/precommit.yaml'
       - 'llvm/**'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
-  build-llvm:
-    name: "Build and test LLVM"
+  build-llvm-linux:
+    name: "Build and test LLVM (Linux)"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/llvm/ci-ubuntu-22.04:latest
@@ -38,7 +44,7 @@ jobs:
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DLLVM_LIT_ARGS="-v --no-progress-bar" \
-            ./llvm
+            -S ./llvm
       - name: Build LLVM
         run: |
           ninja -C llvm-build llvm-test-depends

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -1,0 +1,47 @@
+name: "Precommit tests"
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/precommit.yaml'
+      - 'llvm/**'
+
+jobs:
+  build-llvm:
+    name: "Build and test LLVM"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/llvm/ci-ubuntu-22.04:latest
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          max-size: 500M
+          variant: sccache
+          key: precommit-linux
+      - name: Configure LLVM
+        run: |
+          cmake -B llvm-build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_LIT_ARGS="-v --no-progress-bar" \
+            ./llvm
+      - name: Build LLVM
+        run: |
+          ninja -C llvm-build llvm-test-depends
+      - name: Check LLVM
+        run: |
+          ninja -C llvm-build check-llvm


### PR DESCRIPTION
This patch adds an initial version of the LLVM precommit checks. These checks should be reasonably performant (full test cycle in ~30 minutes with a fully warm cache, ~80 minutes with a completely cold cache) and should catch regressions within LLVM.

This is mainly intended to test the scalability of the current design and to start eliminating issues before we begin to scale to other subprojects.