### PR TITLE
Allow default arguments to be evaluated like other arguments.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
@@ -91,6 +91,9 @@ public:
 
         const auto *Arg = CE->getArg(ArgIdx);
 
+        if (auto *defaultArg = dyn_cast<CXXDefaultArgExpr>(Arg))
+          Arg = defaultArg->getExpr();
+
         std::pair<const clang::Expr *, bool> ArgOrigin =
             tryToFindPtrOrigin(Arg, true);
 

--- a/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
@@ -1,26 +1,6 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
 
-template <typename T>
-class RefPtr {
-public:
-  RefPtr(T* ptr)
-    : m_ptr(ptr)
-  {
-    if (m_ptr)
-      m_ptr->ref();
-  }
-
-  ~RefPtr()
-  {
-    if (m_ptr)
-      m_ptr->deref();
-  }
-
-  T* get() { return m_ptr; }
-
-private:
-  T* m_ptr;
-};
+#include "mock-types.h"
 
 class Obj {
 public:

--- a/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+
+template <typename T>
+class RefPtr {
+public:
+  RefPtr(T* ptr)
+    : m_ptr(ptr)
+  {
+    if (m_ptr)
+      m_ptr->ref();
+  }
+
+  ~RefPtr()
+  {
+    if (m_ptr)
+      m_ptr->deref();
+  }
+
+  T* get() { return m_ptr; }
+
+private:
+  T* m_ptr;
+};
+
+class Obj {
+public:
+  static Obj* get();
+  static RefPtr<Obj> create();
+  void ref() const;
+  void deref() const;
+};
+
+void someFunction(Obj*, Obj* = nullptr);
+void otherFunction(Obj*, Obj* = Obj::get());
+// expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+void anotherFunction(Obj*, Obj* = Obj::create().get());
+
+void otherFunction() {
+  someFunction(nullptr);
+  someFunction(Obj::get());
+  // expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+  someFunction(Obj::create().get());
+  otherFunction(nullptr);
+  anotherFunction(nullptr);
+}


### PR DESCRIPTION
This PR aligns the evaluation of default arguments with other kinds of arguments by extracting the expressions within them as argument values to be evaluated.