### PR TITLE
[Clang][Sema] Do not attempt to instantiate a deleted move constructor

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -7999,7 +7999,8 @@ public:
 
   bool CheckExplicitlyDefaultedSpecialMember(CXXMethodDecl *MD,
                                              CXXSpecialMember CSM,
-                                             SourceLocation DefaultLoc);
+                                             SourceLocation DefaultLoc,
+                                             bool ForDefinition = false);
   void CheckDelayedMemberExceptionSpecs();
 
   bool CheckExplicitlyDefaultedComparison(Scope *S, FunctionDecl *MD,

--- a/clang/test/SemaCXX/cxx0x-defaulted-functions.cpp
+++ b/clang/test/SemaCXX/cxx0x-defaulted-functions.cpp
@@ -286,3 +286,23 @@ struct B {
   auto operator = (RM<B>) -> RV<B> = delete;
 };
 }
+
+namespace GH80869 {
+  struct F {F(F&&)=delete;}; // expected-note {{has been explicitly marked deleted here}}
+
+  template<int=0>
+  struct M {
+    F f; // expected-note {{field 'f' has a deleted move constructor}}
+    M();
+    M(const M&);
+    M(M&&);
+  };
+
+  template<int I>
+  M<I>::M(M&&)=default; // expected-error {{would delete it after its first declaration}}
+
+  M<> f() {
+    M<> m;
+    return m; // expected-note {{in instantiation of}}
+  }
+}


### PR DESCRIPTION
Sema would incorrectly skip diagnosing a malformed use of `= default` on an implcitly deleted move constructor while performing template instantiation, even if we were about to then generate a definition of said move constructor, which caused a crash.

This fixes that by always erroring in that case. However, there are some things to note here
1. This problem did not exist in earlier versions of Clang (e.g. the release branch of Clang 17 diagnoses this correctly with an overload resolution error). 
2. There are some other code paths that seem very similar to this one that that should probably also be investigated (specifically, other special member functions and potentially also defaulted comparison operators; I’ll take a look at adding some tests for those too if need be, but I wanted to document the current state of this here before that).
3. There may be a better place to put this check seeing as the functions that are changed by this do not seem to have been modified compared to the release branch of Clang 17, which also begs the question as to what change actually caused this to break.

This fixes #80869.