### PR TITLE
[scan-build] Use python3 instead of python in scripts.

### DIFF
--- a/clang/tools/include-mapping/test.py
+++ b/clang/tools/include-mapping/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- test.py -  ---------------------------------------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/clang/tools/scan-view/bin/scan-view
+++ b/clang/tools/scan-view/bin/scan-view
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/clang/tools/scan-view/share/Reporter.py
+++ b/clang/tools/scan-view/share/Reporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Methods for reporting bugs."""

--- a/clang/tools/scan-view/share/startfile.py
+++ b/clang/tools/scan-view/share/startfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Utility for opening a file using the default application in a cross-platform


### PR DESCRIPTION
This was done in some other python files in the following commit:
4c1e487c413810655757ea19d0cf3d4f5c40898e

Without this change these scripts do not run on Debian or Ubuntu systems. See the referenced patch for more information.