### PR TITLE
Remove incorrect forward-declaration of lgamma_r header

### DIFF
--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -97,10 +97,6 @@ public:
   }
 };
 
-#ifndef _LIBCPP_MSVCRT_LIKE
-extern "C" double lgamma_r(double, int*);
-#endif
-
 inline _LIBCPP_HIDE_FROM_ABI double __libcpp_lgamma(double __d) {
 #if defined(_LIBCPP_MSVCRT_LIKE)
   return lgamma(__d);

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -297,6 +297,10 @@ long double    truncl(long double x);
 #    pragma GCC system_header
 #  endif
 
+#  if defined(__APPLE__)
+#    define _REENTRANT
+#  endif
+
 #  if __has_include_next(<math.h>)
 #    include_next <math.h>
 #  endif

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -297,7 +297,10 @@ long double    truncl(long double x);
 #    pragma GCC system_header
 #  endif
 
-#  if defined(__APPLE__)
+// This is required to define functions like lgamma_r on Apple platforms.
+// These functions are not required by the Standard but our implementation
+// uses them.
+#  if defined(__APPLE__) && !defined(_REENTRANT)
 #    define _REENTRANT
 #  endif
 


### PR DESCRIPTION
libc++ declares `lgamma_r` as:

```
extern "C" double lgamma_r(double, int *);
```

while modern glibc uses the following:

```
__MATHCALL (lgamma,_r, (_Mdouble_, int *__signgamp));
```

This causes (I did not digged to the very bottom of it) the following compilation error when compiling with nvcc:

```
libcxx/include/__random/binomial_distribution.h(117): error: linkage specification is incompatible with previous "lgamma_r"
/usr/include/x86_64-linux-gnu/bits/mathcalls.h(271): here
```

Using original declaration solves the issue.