### PR TITLE
[dataflow] CXXForRangeStmt should extend flow condition

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -103,9 +103,12 @@ public:
     return {nullptr, false};
   }
 
-  TerminatorVisitorRetTy VisitCXXForRangeStmt(const CXXForRangeStmt *) {
-    // Don't do anything special for CXXForRangeStmt, because the condition
-    // (being implicitly generated) isn't visible from the loop body.
+  TerminatorVisitorRetTy VisitCXXForRangeStmt(const CXXForRangeStmt *S) {
+    // Even though the condition isn't visible from the loop body, analysis
+    // might depend on the implicit implicit statements implied by the loop.
+    auto *Cond = S->getCond();
+    if (Cond != nullptr)
+      return extendFlowCondition(*Cond);
     return {nullptr, false};
   }
 


### PR DESCRIPTION
This is needed in order to correctly assume implicit iterator validity in the iterator checker.