### PR TITLE
[DebugInfo][RemoveDIs] Erase ranges of instructions individually

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -675,7 +675,9 @@ BasicBlock *BasicBlock::splitBasicBlockBefore(iterator I, const Twine &BBName) {
 
 BasicBlock::iterator BasicBlock::erase(BasicBlock::iterator FromIt,
                                        BasicBlock::iterator ToIt) {
-  return InstList.erase(FromIt, ToIt);
+  for (Instruction &I : make_early_inc_range(make_range(FromIt, ToIt)))
+    I.eraseFromParent();
+  return ToIt;
 }
 
 void BasicBlock::replacePhiUsesWith(BasicBlock *Old, BasicBlock *New) {


### PR DESCRIPTION
The BasicBlock::erase method simply removes a range of instructions from the instlist by unlinking them. However, now that we're attaching debug-info directly to instructions, some cleanup is required, so use eraseFromParent on each instruction instead.

This is less efficient, but rare, and seemingly only WASM EH Prepare uses this method of BasicBlock. Detected via a memory leak check in asan.

(asan is always the final boss for whatever I do).