### PR TITLE
[Release] Build default target during Phase 1 and 2 on AIX 

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -528,11 +528,11 @@ function build_llvmCore() {
     LitVerbose="-v"
 
     InstallTarget="install"
-    if [ "$Phase" -lt "3" ]; then
+    # compiler-rt builtins is needed on AIX to have a functional Phase 1 clang.
+    if [ "$Phase" -lt "3" ] && [ "$System" != "AIX" ]; then
       BuildTarget="clang"
       InstallTarget="install-clang install-clang-resource-headers"
-      # compiler-rt builtins is needed on AIX to have a functional Phase 1 clang.
-      if [ "$System" = "AIX" -o "$Phase" != "1" ]; then
+      if [ "$Phase" != "1" ]; then
         BuildTarget="$BuildTarget runtimes"
         InstallTarget="$InstallTarget install-runtimes"
       fi


### PR DESCRIPTION
Commit [`fcae8c`](https://github.com/llvm/llvm-project/pull/72703/commits/fcae8ce77e2256920459fb4cf428a212d6560b68) seems to be skipping the compiler-rt build  during Phase 1 which results in a non-functional Phase 1 clang on AIX