### PR TITLE
[MemProf] Switch to DenseMap for performance (NFC)

### DIFF
--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -1377,7 +1377,7 @@ private:
 
   // Temporary map while building StackIds list. Clear when index is completely
   // built via releaseTemporaryMemory.
-  std::map<uint64_t, unsigned> StackIdToIndex;
+  DenseMap<uint64_t, unsigned> StackIdToIndex;
 
   // YAML I/O support.
   friend yaml::MappingTraits<ModuleSummaryIndex>;


### PR DESCRIPTION
Some profiling showed that the accesses to this map during bitcode
reading was incurring over 10% of the time in a large thin link. There
is no need for it to be std::map, and I measured around 8.5% time
reduction in the same thin link from switching to DenseMap.
