### PR TITLE
Don't search for separate debug files for mach-o object files

### DIFF
--- a/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
+++ b/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
@@ -118,7 +118,13 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
     FileSpec dsym_fspec(module_sp->GetSymbolFileFileSpec());
 
     ObjectFileSP dsym_objfile_sp;
-    if (!dsym_fspec) {
+    // On Darwin, we store the debug information either in object files,
+    // using the debug map to tie them to the executable, or in a dSYM.  We
+    // pass through this routine both for binaries and for .o files, but in the
+    // latter case there will never be an external debug file.  So we shouldn't
+    // do all the stats needed to find it.
+    if (!dsym_fspec && module_sp->GetObjectFile()->CalculateType() 
+        != ObjectFile::eTypeObjectFile) {
       // No symbol file was specified in the module, lets try and find one
       // ourselves.
       FileSpec file_spec = obj_file->GetFileSpec();

--- a/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
+++ b/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
@@ -123,8 +123,8 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
     // pass through this routine both for binaries and for .o files, but in the
     // latter case there will never be an external debug file.  So we shouldn't
     // do all the stats needed to find it.
-    if (!dsym_fspec && module_sp->GetObjectFile()->CalculateType() 
-        != ObjectFile::eTypeObjectFile) {
+    if (!dsym_fspec && module_sp->GetObjectFile()->CalculateType() !=
+        ObjectFile::eTypeObjectFile) {
       // No symbol file was specified in the module, lets try and find one
       // ourselves.
       FileSpec file_spec = obj_file->GetFileSpec();


### PR DESCRIPTION
mach-o object files never have separate debug info, and in a big app there can be quite a large number of object files, so even a few stats per object file can slow launches considerably.
This patch avoids this search for Mach-o symbol files of object type.

I don't have a way to test this, the only effect is that you didn't do a bunch of stats that weren't going to do any good anyway.