### PR TITLE
Document use of `skip-precommit-approval` label for non-review pull requests

### DIFF
--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -104,9 +104,9 @@ needs an explicit approval before it is committed. Do not assume silent
 approval, or solicit objections to a patch with a deadline.
 
 .. note::
-   If you are using a Pull Request to get precommit CI results, but not
-   because it needs a precommit review, apply the `skip-precommit-approval
-   <https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
+   If you are using a Pull Request for purposes other than review
+   (eg: precommit CI results, convenient web-based reverts, etc)
+   `skip-precommit-approval<https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
    label to the PR.
 
 Acknowledge All Reviewer Feedback

--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -103,6 +103,12 @@ ready to be committed. Specifically, once a patch is sent out for review, it
 needs an explicit approval before it is committed. Do not assume silent
 approval, or solicit objections to a patch with a deadline.
 
+.. note::
+   If you are using a Pull Request to get precommit CI results, but not
+   because it needs a precommit review, apply the `skip-precommit-approval
+   <https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
+   label to the PR.
+
 Acknowledge All Reviewer Feedback
 ---------------------------------
 

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -30,6 +30,12 @@ describes the typical workflow of creating a Pull Request and getting it reviewe
 and accepted. This is meant as an overview of the GitHub workflow, for complete
 documentation refer to `GitHub's documentation <https://docs.github.com/pull-requests>`_.
 
+.. note::
+   If you are using a Pull Request to get precommit CI results, but not
+   because it needs a precommit review, apply the `skip-precommit-approval
+   <https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
+   label to the PR.
+
 GitHub Tools
 ------------
 You can interact with GitHub in several ways: via git command line tools,

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -31,9 +31,9 @@ and accepted. This is meant as an overview of the GitHub workflow, for complete
 documentation refer to `GitHub's documentation <https://docs.github.com/pull-requests>`_.
 
 .. note::
-   If you are using a Pull Request to get precommit CI results, but not
-   because it needs a precommit review, apply the `skip-precommit-approval
-   <https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
+   If you are using a Pull Request for purposes other than review
+   (eg: precommit CI results, convenient web-based reverts, etc)
+   `skip-precommit-approval<https://github.com/llvm/llvm-project/labels?q=skip-precommit-approval>`
    label to the PR.
 
 GitHub Tools


### PR DESCRIPTION
Derived from this discussion: https://discourse.llvm.org/t/prs-without-approvals-muddy-the-waters/76656
