### PR TITLE
[TableGen][NFC] Replace hardcoded opcode numbering.

### DIFF
--- a/llvm/utils/TableGen/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/GlobalISelMatchTable.cpp
@@ -1399,9 +1399,8 @@ void InstructionOpcodeMatcher::initOpcodeValuesMap(
     const CodeGenTarget &Target) {
   OpcodeValues.clear();
 
-  unsigned OpcodeValue = 0;
   for (const CodeGenInstruction *I : Target.getInstructionsByEnumValue())
-    OpcodeValues[I] = OpcodeValue++;
+    OpcodeValues[I] = Target.getInstrIntValue(I->TheDef);
 }
 
 MatchTableRecord InstructionOpcodeMatcher::getValue() const {

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -1284,8 +1284,9 @@ void InstrInfoEmitter::emitEnums(raw_ostream &OS) {
   OS << "  enum {\n";
   unsigned Num = 0;
   for (const CodeGenInstruction *Inst : Target.getInstructionsByEnumValue())
-    OS << "    " << Inst->TheDef->getName() << "\t= " << Num++ << ",\n";
-  OS << "    INSTRUCTION_LIST_END = " << Num << "\n";
+    OS << "    " << Inst->TheDef->getName()
+       << "\t= " << (Num = Target.getInstrIntValue(Inst->TheDef)) << ",\n";
+  OS << "    INSTRUCTION_LIST_END = " << Num + 1 << "\n";
   OS << "  };\n\n";
   OS << "} // end namespace " << Namespace << "\n";
   OS << "} // end namespace llvm\n";


### PR DESCRIPTION
This patch uses the recently introduced CodeGenTarget::getInstrIntValue to replace hardcoded opcode enum value numbering in a few places.