### PR TITLE
[workflows] Add a new workflow for testing release branch CI

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -58,6 +58,7 @@ jobs:
   lit-tests:
     name: Lit Tests
     runs-on: ${{ matrix.os }}
+    image: ${{ (runner.os == 'Linux' && ghcr.io/${{ github.repository_owner }}/ci-ubuntu-22.04:latest ) || null }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -58,7 +58,6 @@ jobs:
   lit-tests:
     name: Lit Tests
     runs-on: ${{ matrix.os }}
-    image: ${{ (runner.os == 'Linux' && ghcr.io/${{ github.repository_owner }}/ci-ubuntu-22.04:latest ) || null }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/llvm-project-workflow-tests.yml
+++ b/.github/workflows/llvm-project-workflow-tests.yml
@@ -9,7 +9,6 @@ permissions:
   contents: read
 
 on:
-  pull_request:
     branches:
       - 'main'
     paths:

--- a/.github/workflows/llvm-project-workflow-tests.yml
+++ b/.github/workflows/llvm-project-workflow-tests.yml
@@ -1,0 +1,31 @@
+# This workflow will test the llvm-project-tests workflow in PRs
+# targetting the main branch.  Since this workflow doesn't normally
+# run on main PRs, we need some way to test it to ensure new updates
+# don't break it.
+
+name: LLVM Workflow Test
+
+permissions:
+  contents: read
+
+on:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/llvm-project-tests.yml'
+      - '.github/workflows/llvm-project-workflow-tests.yml'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  llvm-test:
+    if: github.repository_owner == 'llvm'
+    name: Build and Test
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-all
+      projects: clang;lld;libclc;lldb

--- a/.github/workflows/llvm-project-workflow-tests.yml
+++ b/.github/workflows/llvm-project-workflow-tests.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 
 on:
+  pull_request:
     branches:
       - 'main'
     paths:


### PR DESCRIPTION
Since we commit all changes to the release branch CI to main first, we need someway to test that these changes to main don't break the CI.