### PR TITLE
[lldb] [NFC] Remove min pkt size for compression setting

### DIFF
--- a/lldb/docs/lldb-gdb-remote.txt
+++ b/lldb/docs/lldb-gdb-remote.txt
@@ -1998,16 +1998,12 @@ for this region.
 //  If the debug stub can support compression, it indictes this in the reply of the
 //  "qSupported" packet.  e.g.
 //   LLDB SENDS:    qSupported:xmlRegisters=i386,arm,mips
-//   STUB REPLIES:  qXfer:features:read+;SupportedCompressions=lzfse,zlib-deflate,lz4,lzma;DefaultCompressionMinSize=384
+//   STUB REPLIES:  qXfer:features:read+;SupportedCompressions=lzfse,zlib-deflate,lz4,lzma;
 //
 //  If lldb knows how to use any of these compression algorithms, it can ask that this
-//  compression mode be enabled.  It may optionally change the minimum packet size
-//  where compression is used.  Typically small packets do not benefit from compression,
-//  as well as compression headers -- compression is most beneficial with larger packets.
+//  compression mode be enabled.  
 //
 //  QEnableCompression:type:zlib-deflate;
-//  or
-//  QEnableCompression:type:zlib-deflate;minsize:512;
 //
 //  The debug stub should reply with an uncompressed "OK" packet to indicate that the
 //  request was accepted.  All further packets the stub sends will use this compression.


### PR DESCRIPTION
debugserver will not compress small packets; the overhead of the compression header makes this useful for larger packets.  I default to 384 bytes in debugserver, and added an option for lldb to request a different cutoff.  This option has never been used in lldb in the past nine years, so I don't think there's any point to keeping it around.