### PR TITLE
[TableGen] Remove map CodeGenTarget::InstrToIntMap.

### DIFF
--- a/llvm/utils/TableGen/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/CodeGenInstruction.h
@@ -303,6 +303,9 @@ namespace llvm {
     // have been inferred.
     Record *InferredFrom;
 
+    // The enum value assigned by CodeGenTarget::computeInstrsByEnum.
+    mutable unsigned EnumVal;
+
     CodeGenInstruction(Record *R);
 
     /// HasOneImplicitDefWithKnownVT - If the instruction has at least one

--- a/llvm/utils/TableGen/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/CodeGenTarget.cpp
@@ -539,12 +539,10 @@ void CodeGenTarget::ComputeInstrsByEnum() const {
                std::make_tuple(!D2.getValueAsBit("isPseudo"), D2.getName());
       });
 
-  // Build the instruction-to-int map using the same values emitted by
-  // InstrInfoEmitter::emitEnums.
-  assert(InstrToIntMap.empty());
+  // Assign an enum value to each instruction according to the sorted order.
   unsigned Num = 0;
   for (const CodeGenInstruction *Inst : InstrsByEnum)
-    InstrToIntMap[Inst->TheDef] = Num++;
+    Inst->EnumVal = Num++;
 }
 
 

--- a/llvm/utils/TableGen/CodeGenTarget.h
+++ b/llvm/utils/TableGen/CodeGenTarget.h
@@ -17,6 +17,7 @@
 #define LLVM_UTILS_TABLEGEN_CODEGENTARGET_H
 
 #include "CodeGenHwModes.h"
+#include "CodeGenInstruction.h"
 #include "InfoByHwMode.h"
 #include "SDNodeProperties.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -34,7 +35,6 @@ namespace llvm {
 
 class RecordKeeper;
 class Record;
-class CodeGenInstruction;
 class CodeGenRegBank;
 class CodeGenRegister;
 class CodeGenRegisterClass;
@@ -74,7 +74,6 @@ class CodeGenTarget {
 
   mutable StringRef InstNamespace;
   mutable std::vector<const CodeGenInstruction*> InstrsByEnum;
-  mutable DenseMap<const Record *, unsigned> InstrToIntMap;
   mutable unsigned NumPseudoInstructions = 0;
 public:
   CodeGenTarget(RecordKeeper &Records);
@@ -197,9 +196,7 @@ public:
   unsigned getInstrIntValue(const Record *R) const {
     if (InstrsByEnum.empty())
       ComputeInstrsByEnum();
-    auto V = InstrToIntMap.find(R);
-    assert(V != InstrToIntMap.end() && "instr not in InstrToIntMap");
-    return V->second;
+    return getInstruction(R).EnumVal;
   }
 
   typedef ArrayRef<const CodeGenInstruction *>::const_iterator inst_iterator;

--- a/llvm/utils/TableGen/CodeGenTarget.h
+++ b/llvm/utils/TableGen/CodeGenTarget.h
@@ -73,7 +73,7 @@ class CodeGenTarget {
   mutable std::unique_ptr<CodeGenSchedModels> SchedModels;
 
   mutable StringRef InstNamespace;
-  mutable std::vector<const CodeGenInstruction*> InstrsByEnum;
+  mutable std::vector<const CodeGenInstruction *> InstrsByEnum;
   mutable unsigned NumPseudoInstructions = 0;
 public:
   CodeGenTarget(RecordKeeper &Records);


### PR DESCRIPTION
This patch removes CodeGenTarget::InstrToIntMap, using instead a new member CodeGenInstruction::EnumVal to store each enum value. This value is computed and set by CodeGenTarget::computeInstrsByEnum and queried by CodeGenTarget::getInstrIntValue.