### PR TITLE
[clang][dataflow] Add support for `CXXRewrittenBinaryOperator`.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -545,6 +545,10 @@ public:
     VisitCallExpr(S);
   }
 
+  void VisitCXXRewrittenBinaryOperator(const CXXRewrittenBinaryOperator *RBO) {
+    propagateValue(*RBO->getSemanticForm(), *RBO, Env);
+  }
+
   void VisitCXXFunctionalCastExpr(const CXXFunctionalCastExpr *S) {
     if (S->getCastKind() == CK_ConstructorConversion) {
       const Expr *SubExpr = S->getSubExpr();


### PR DESCRIPTION
This occurs in rewritten candidates for binary operators (a C++20 feature).

The patch modifies UncheckedOptionalAccessModelTest to run in C++20 mode (as
well as C++17 mode, as before) and to use rewritten candidates. The modified
test fails without the newly added support for `CXXRewrittenBinaryOperator`.
