### PR TITLE
[llvm-exegesis] Add branch miss validation counter

### DIFF
--- a/llvm/include/llvm/Target/TargetPfmCounters.td
+++ b/llvm/include/llvm/Target/TargetPfmCounters.td
@@ -42,6 +42,7 @@ def L1ICacheLoadMiss : ValidationEvent<3>;
 def DataTLBLoadMiss : ValidationEvent<4>;
 def DataTLBStoreMiss : ValidationEvent<5>;
 def InstructionTLBLoadMiss : ValidationEvent<6>;
+def BranchPredictionMiss : ValidationEvent<7>;
 
 
 // PfmValidationCounter provides a mapping between the events that are

--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -24,7 +24,8 @@ defvar DefaultIntelPfmValidationCounters = [
   PfmValidationCounter<L1ICacheLoadMiss, "L1-ICACHE-LOAD-MISSES">,
   PfmValidationCounter<DataTLBLoadMiss, "DTLB_LOAD_MISSES:MISS_CAUSES_A_WALK">,
   PfmValidationCounter<DataTLBStoreMiss, "DTLB_STORE_MISSES:MISS_CAUSES_A_WALK">,
-  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB_MISSES:MISS_CAUSES_A_WALK">
+  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB_MISSES:MISS_CAUSES_A_WALK">,
+  PfmValidationCounter<BranchPredictionMiss, "BRANCH-MISSES">
 ];
 
 def PentiumPfmCounters : ProcPfmCounters {
@@ -210,7 +211,8 @@ defvar DefaultAMDPfmValidationCounters = [
   PfmValidationCounter<L1DCacheStoreMiss, "L1-DCACHE-STORE-MISSES">,
   PfmValidationCounter<L1ICacheLoadMiss, "L1-ICACHE-LOAD-MISSES">,
   PfmValidationCounter<DataTLBLoadMiss, "DTLB-LOAD-MISSES">,
-  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB-LOAD-MISSES">
+  PfmValidationCounter<InstructionTLBLoadMiss, "ITLB-LOAD-MISSES">,
+  PfmValidationCounter<BranchPredictionMiss, "BRANCH-MISSES">
 ];
 
 // Set basic counters for AMD cpus that we know libpfm4 supports.

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -209,6 +209,8 @@ const char *validationEventToString(exegesis::ValidationEvent VE) {
     return "data-tlb-store-misses";
   case exegesis::ValidationEvent::InstructionTLBLoadMiss:
     return "instruction-tlb-load-misses";
+  case exegesis::ValidationEvent::BranchPredictionMiss:
+    return "branch-prediction-misses";
   }
   llvm_unreachable("Unhandled exegesis::ValidationEvent enum");
 }
@@ -228,6 +230,8 @@ Expected<exegesis::ValidationEvent> stringToValidationEvent(StringRef Input) {
     return exegesis::ValidationEvent::DataTLBStoreMiss;
   else if (Input == "instruction-tlb-load-misses")
     return exegesis::ValidationEvent::InstructionTLBLoadMiss;
+  else if (Input == "branch-prediction-misses")
+    return exegesis::ValidationEvent::BranchPredictionMiss;
   else
     return make_error<StringError>("Invalid validation event string",
                                    errc::invalid_argument);

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
@@ -39,7 +39,8 @@ enum ValidationEvent {
   L1ICacheLoadMiss,
   DataTLBLoadMiss,
   DataTLBStoreMiss,
-  InstructionTLBLoadMiss
+  InstructionTLBLoadMiss,
+  BranchPredictionMiss
 };
 
 enum class BenchmarkPhaseSelectorE {

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -293,7 +293,9 @@ static cl::list<ValidationEvent> ValidationCounters(
         clEnumValN(ValidationEvent::DataTLBStoreMiss, "data-tlb-store-misses",
                    "Count DTLB store misses"),
         clEnumValN(ValidationEvent::InstructionTLBLoadMiss,
-                   "instruction-tlb-load-misses", "Count ITLB load misses")));
+                   "instruction-tlb-load-misses", "Count ITLB load misses"),
+        clEnumValN(ValidationEvent::BranchPredictionMiss,
+                   "branch-prediction-misses", "Branch prediction misses")));
 
 static ExitOnError ExitOnErr("llvm-exegesis error: ");
 


### PR DESCRIPTION
This patch adds a branch miss validation counter so that it is easy to quantify the number of missed branches when using the loop repetition mode.