### PR TITLE
[asan] Disable instrumentation for available_externally global with COFF

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1957,6 +1957,10 @@ bool ModuleAddressSanitizer::shouldInstrumentGlobal(GlobalVariable *G) const {
     // On COFF, don't instrument non-ODR linkages.
     if (G->isInterposable())
       return false;
+    // If the global has AvailableExternally linkage, then it is not in this 
+    // module, which means it does not need to be instrumented.
+    if (G->hasAvailableExternallyLinkage())
+      return false;
   }
 
   // If a comdat is present, it must have a selection kind that implies ODR

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1957,7 +1957,7 @@ bool ModuleAddressSanitizer::shouldInstrumentGlobal(GlobalVariable *G) const {
     // On COFF, don't instrument non-ODR linkages.
     if (G->isInterposable())
       return false;
-    // If the global has AvailableExternally linkage, then it is not in this 
+    // If the global has AvailableExternally linkage, then it is not in this
     // module, which means it does not need to be instrumented.
     if (G->hasAvailableExternallyLinkage())
       return false;

--- a/llvm/test/Instrumentation/AddressSanitizer/do-not-instrument-globals-windows.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/do-not-instrument-globals-windows.ll
@@ -1,7 +1,7 @@
 ; This test checks that we are not instrumenting unnecessary globals
 ; RUN: opt < %s -passes=asan -S | FileCheck %s
 
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"
 
 @v_available_externally = available_externally global i32 zeroinitializer

--- a/llvm/test/Instrumentation/AddressSanitizer/do-not-instrument-globals-windows.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/do-not-instrument-globals-windows.ll
@@ -1,0 +1,10 @@
+; This test checks that we are not instrumenting unnecessary globals
+; RUN: opt < %s -passes=asan -S | FileCheck %s
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+@v_available_externally = available_externally global i32 zeroinitializer
+; CHECK-NOT: {{asan_gen.*v_available_externally}}
+
+; CHECK: @asan.module_ctor


### PR DESCRIPTION
For COFF, available_externally global will be instrumented because of the lack of filtering, and will trigger the Verifier pass assertion and crash the compilation. This patch will filter out the available_externally global for COFF.

For non-COFF, `!G->hasExactDefinition()` in line 1954 will filter out the available_externally globals.

There is a related bug reported in https://bugs.llvm.org/show_bug.cgi?id=47950 / https://github.com/llvm/llvm-project/issues/47294. I tried the reproducer posted on the page and this will fix the problem.

Reproducer:
```
#include <locale>

void grouping_impl() {
  std::use_facet<std::numpunct<char>>(std::locale());
}

// clang -fsanitize=address -D_DLL -std=c++14 -c format.cc
```