### PR TITLE
[OpenMP] [test] Skip the -mlong-double-80 test on MSVC ABI

### DIFF
--- a/openmp/runtime/test/atomic/kmp_atomic_float10_max_min.c
+++ b/openmp/runtime/test/atomic/kmp_atomic_float10_max_min.c
@@ -28,7 +28,7 @@ extern long double __kmpc_atomic_float10_min_cpt(ident_t *id_ref, int gtid,
 
 int main() {
   int ret = 0;
-#if KMP_ARCH_X86 || KMP_ARCH_X86_64
+#if (KMP_ARCH_X86 || KMP_ARCH_X86_64) && !defined(_MSC_VER)
   long double s = 012.3456; // small
   long double e = 123.4567; // middle
   long double d = 234.5678; // big
@@ -158,6 +158,6 @@ int main() {
     printf("passed\n");
 #else
   printf("Unsupported architecture, skipping test...\n");
-#endif // KMP_ARCH_X86 || KMP_ARCH_X86_64
+#endif // (KMP_ARCH_X86 || KMP_ARCH_X86_64) && !defined(_MSC_VER)
   return ret;
 }


### PR DESCRIPTION
Within the MSVC ABI, long doubles are the same as regular 64 bit doubles. This test case, which is compiled with -mlong-double-80, cannot work when libomp has been compiled without that flag, as -mlong-double-80 changes the calling convention for the tested functions.