### PR TITLE
[GitHub][workflows] Ask reviewers to merge PRs when author cannot

### DIFF
--- a/.github/workflows/approved-prs.yml
+++ b/.github/workflows/approved-prs.yml
@@ -35,4 +35,4 @@ jobs:
             --token '${{ secrets.GITHUB_TOKEN }}' \
             pr-merge-on-behalf-information \
             --issue-number "${{ github.event.pull_request.number }}" \
-            --author "${{ github.event.pull_request.user.login }}"
+            --author "${{ github.event.review.user.login }}"

--- a/.github/workflows/approved-prs.yml
+++ b/.github/workflows/approved-prs.yml
@@ -1,0 +1,38 @@
+name: "Prompt reviewers to merge PRs on behalf of authors"
+
+permissions:
+  contents: read
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  merge_on_behalf_information_comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >-
+      (github.repository == 'llvm/llvm-project') &&
+      (github.event.review.state == 'APPROVED')
+    steps:
+      - name: Checkout Automation Script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: llvm/utils/git/
+          ref: main
+
+      - name: Setup Automation Script
+        working-directory: ./llvm/utils/git/
+        run: |
+          pip install -r requirements.txt
+
+      - name: Add Merge On Behalf Comment
+        working-directory: ./llvm/utils/git/
+        run: |
+          python3 ./github-automation.py \
+            --token '${{ secrets.GITHUB_TOKEN }}' \
+            pr-merge-on-behalf-information \
+            --issue-number "${{ github.event.pull_request.number }}" \
+            --author "${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/approved-prs.yml
+++ b/.github/workflows/approved-prs.yml
@@ -35,4 +35,5 @@ jobs:
             --token '${{ secrets.GITHUB_TOKEN }}' \
             pr-merge-on-behalf-information \
             --issue-number "${{ github.event.pull_request.number }}" \
-            --author "${{ github.event.review.user.login }}"
+            --author "${{ github.event.pull_request.user.login }}" \
+            --reviewer "${{ github.event.review.user.login }}"

--- a/.github/workflows/approved-prs.yml
+++ b/.github/workflows/approved-prs.yml
@@ -9,7 +9,7 @@ on:
       - submitted
 
 jobs:
-  merge_on_behalf_information_comment:
+  merge-on-behalf-information-comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -301,10 +301,13 @@ If you don't get any reports, no action is required from you. Your changes are w
 class PRMergeOnBehalfInformation:
     COMMENT_TAG = "<!--LLVM MERGE ON BEHALF INFORMATION COMMENT-->\n"
 
-    def __init__(self, token: str, repo: str, pr_number: int, author: str):
+    def __init__(
+        self, token: str, repo: str, pr_number: int, author: str, reviewer: str
+    ):
         self.repo = github.Github(token).get_repo(repo)
         self.pr = self.repo.get_issue(pr_number).as_pull_request()
         self.author = author
+        self.reviewer = reviewer
 
     def run(self) -> bool:
         # Check this first because it only costs 1 API point.
@@ -328,7 +331,7 @@ class PRMergeOnBehalfInformation:
         # This text is using Markdown formatting.
         comment = f"""\
 {self.COMMENT_TAG}
-@{self.author} the PR author does not have permission to merge their own PRs yet. Please merge on their behalf."""
+@{self.reviewer} the PR author does not have permission to merge their own PRs yet. Please merge on their behalf."""
         self.pr.as_issue().create_comment(comment)
         return True
 
@@ -689,6 +692,9 @@ pr_merge_on_behalf_information_parser.add_argument(
     "--issue-number", type=int, required=True
 )
 pr_merge_on_behalf_information_parser.add_argument("--author", type=str, required=True)
+pr_merge_on_behalf_information_parser.add_argument(
+    "--reviewer", type=str, required=True
+)
 
 release_workflow_parser = subparsers.add_parser("release-workflow")
 release_workflow_parser.add_argument(
@@ -745,7 +751,7 @@ elif args.command == "pr-buildbot-information":
     pr_buildbot_information.run()
 elif args.command == "pr-merge-on-behalf-information":
     pr_merge_on_behalf_information = PRMergeOnBehalfInformation(
-        args.token, args.repo, args.issue_number, args.author
+        args.token, args.repo, args.issue_number, args.author, args.reviewer
     )
     pr_merge_on_behalf_information.run()
 elif args.command == "release-workflow":

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -328,10 +328,7 @@ class PRMergeOnBehalfInformation:
         # This text is using Markdown formatting.
         comment = f"""\
 {self.COMMENT_TAG}
-@{self.author} you do not have permissions to merge your own PRs yet. Please let us know when you are happy for this to be merged, and one of the reviewers can merge it on your behalf.
-
-(if many approvals are required, please wait until everyone has approved before merging)
-"""
+@{self.author} the PR author does not have permission to merge their own PRs yet. Please merge on their behalf."""
         self.pr.as_issue().create_comment(comment)
         return True
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -298,6 +298,44 @@ If you don't get any reports, no action is required from you. Your changes are w
         return True
 
 
+class PRMergeOnBehalfInformation:
+    COMMENT_TAG = "<!--LLVM MERGE ON BEHALF INFORMATION COMMENT-->\n"
+
+    def __init__(self, token: str, repo: str, pr_number: int, author: str):
+        self.repo = github.Github(token).get_repo(repo)
+        self.pr = self.repo.get_issue(pr_number).as_pull_request()
+        self.author = author
+
+    def run(self) -> bool:
+        # Check this first because it only costs 1 API point.
+        try:
+            if self.repo.get_collaborator_permission(self.author) in ["admin", "write"]:
+                return
+        # There is a UnknownObjectException for this scenario, but this method
+        # does not use it.
+        except github.GithubException as e:
+            # 404 means the author was not found in the collaborator list, so we
+            # know they don't have push permissions. Anything else is a real API
+            # issue, raise it so it is visible.
+            if e.status != 404:
+                raise e
+
+        # A review can be approved more than once, only comment the first time.
+        for comment in self.pr.as_issue().get_comments():
+            if self.COMMENT_TAG in comment.body:
+                return
+
+        # This text is using Markdown formatting.
+        comment = f"""\
+{self.COMMENT_TAG}
+@{self.author} you do not have permissions to merge your own PRs yet. Please let us know when you are happy for this to be merged, and one of the reviewers can merge it on your behalf.
+
+(if many approvals are required, please wait until everyone has approved before merging)
+"""
+        self.pr.as_issue().create_comment(comment)
+        return True
+
+
 def setup_llvmbot_git(git_dir="."):
     """
     Configure the git repo in `git_dir` with the llvmbot account so
@@ -647,6 +685,14 @@ pr_buildbot_information_parser = subparsers.add_parser("pr-buildbot-information"
 pr_buildbot_information_parser.add_argument("--issue-number", type=int, required=True)
 pr_buildbot_information_parser.add_argument("--author", type=str, required=True)
 
+pr_merge_on_behalf_information_parser = subparsers.add_parser(
+    "pr-merge-on-behalf-information"
+)
+pr_merge_on_behalf_information_parser.add_argument(
+    "--issue-number", type=int, required=True
+)
+pr_merge_on_behalf_information_parser.add_argument("--author", type=str, required=True)
+
 release_workflow_parser = subparsers.add_parser("release-workflow")
 release_workflow_parser.add_argument(
     "--llvm-project-dir",
@@ -700,6 +746,11 @@ elif args.command == "pr-buildbot-information":
         args.token, args.repo, args.issue_number, args.author
     )
     pr_buildbot_information.run()
+elif args.command == "pr-merge-on-behalf-information":
+    pr_merge_on_behalf_information = PRMergeOnBehalfInformation(
+        args.token, args.repo, args.issue_number, args.author
+    )
+    pr_merge_on_behalf_information.run()
 elif args.command == "release-workflow":
     release_workflow = ReleaseWorkflow(
         args.token,


### PR DESCRIPTION
This uses https://pygithub.readthedocs.io/en/stable/github_objects/Repository.html?highlight=get_collaborator_permission#github.Repository.Repository.get_collaborator_permission.

Which does https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user and returns the top level "permission" key.

This is less detailed than the user/permissions key but should be fine for this
use case.

When a review is submitted we check:
* If it's an approval.
* Whether we have already left a merge on behalf comment (by looking for a hidden HTML comment).
* Whether the author has permissions to merge their own PR. 

If needed we leave a comment tagging the reviewer. If the reviewer also doesn't have merge permission, then it asks them to find someone else who does.
