### PR TITLE
[Clang][Sema] Diagnosis for constexpr constructor not initializing a union member

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -149,9 +149,10 @@ Improvements to Clang's diagnostics
   prints.
 
 - Clang now diagnoses member template declarations with multiple declarators.
+- Clang now diagnoses use of the ``template`` keyword after declarative nested name specifiers.
 
-- Clang now diagnoses use of the ``template`` keyword after declarative nested
-  name specifiers.
+- Clang now diagnoses constexpr constructor for not initializing atleast one member of union
+- Fixes(`#46689 Constexpr constructor not initializing a union member is not diagnosed`)
 
 - The ``-Wshorten-64-to-32`` diagnostic is now grouped under ``-Wimplicit-int-conversion`` instead
    of ``-Wconversion``. Fixes `#69444 <https://github.com/llvm/llvm-project/issues/69444>`_.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -1795,10 +1795,11 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
                                        Stmt *Body,
                                        Sema::CheckConstexprKind Kind);
 
-static bool checkUnionConstructorIntializer(Sema &SemaRef, const FunctionDecl *Dcl,
-                                       const CXXConstructorDecl *Constructor,
-                                       const CXXRecordDecl *RD,
-                                       Sema::CheckConstexprKind Kind);
+static bool
+checkUnionConstructorIntializer(Sema &SemaRef, const FunctionDecl *Dcl,
+                                const CXXConstructorDecl *Constructor,
+                                const CXXRecordDecl *RD,
+                                Sema::CheckConstexprKind Kind);
 
 // Check whether a function declaration satisfies the requirements of a
 // constexpr function definition or a constexpr constructor definition. If so,

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -1795,6 +1795,11 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
                                        Stmt *Body,
                                        Sema::CheckConstexprKind Kind);
 
+static bool checkUnionConstructorIntializer(Sema &SemaRef, const FunctionDecl *Dcl,
+                                       const CXXConstructorDecl *Constructor,
+                                       const CXXRecordDecl *RD,
+                                       Sema::CheckConstexprKind Kind);
+
 // Check whether a function declaration satisfies the requirements of a
 // constexpr function definition or a constexpr constructor definition. If so,
 // return true. If not, produce appropriate diagnostics (unless asked not to by
@@ -2343,17 +2348,9 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
     // - if the class is a union having variant members, exactly one of them
     //   shall be initialized;
     if (RD->isUnion()) {
-      if (Constructor->getNumCtorInitializers() == 0 &&
-          RD->hasVariantMembers()) {
-        if (Kind == Sema::CheckConstexprKind::Diagnose) {
-          SemaRef.Diag(
-              Dcl->getLocation(),
-              SemaRef.getLangOpts().CPlusPlus20
-                  ? diag::warn_cxx17_compat_constexpr_union_ctor_no_init
-                  : diag::ext_constexpr_union_ctor_no_init);
-        } else if (!SemaRef.getLangOpts().CPlusPlus20) {
-          return false;
-        }
+      if (checkUnionConstructorIntializer(SemaRef, Dcl, Constructor, RD,
+                                          Kind)) {
+        return false;
       }
     } else if (!Constructor->isDependentContext() &&
                !Constructor->isDelegatingConstructor()) {
@@ -2392,6 +2389,17 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
           if (!CheckConstexprCtorInitializer(SemaRef, Dcl, I, Inits, Diagnosed,
                                              Kind))
             return false;
+      }
+    } else if (!Constructor->isDelegatingConstructor()) {
+      for (const Decl *Decls : RD->decls()) {
+        if (const auto *Inner = dyn_cast<CXXRecordDecl>(Decls)) {
+          if (Inner->isUnion()) {
+            if (checkUnionConstructorIntializer(SemaRef, Dcl, Constructor,
+                                                Inner, Kind)) {
+              return true;
+            }
+          }
+        }
       }
     }
   } else {
@@ -2471,6 +2479,23 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
   return true;
 }
 
+static bool
+checkUnionConstructorIntializer(Sema &SemaRef, const FunctionDecl *Dcl,
+                                const CXXConstructorDecl *Constructor,
+                                const CXXRecordDecl *RD,
+                                Sema::CheckConstexprKind Kind) {
+  if (Constructor->getNumCtorInitializers() == 0 && RD->hasVariantMembers()) {
+    if (Kind == Sema::CheckConstexprKind::Diagnose) {
+      SemaRef.Diag(Dcl->getLocation(),
+                   SemaRef.getLangOpts().CPlusPlus20
+                       ? diag::warn_cxx17_compat_constexpr_union_ctor_no_init
+                       : diag::ext_constexpr_union_ctor_no_init);
+    } else if (!SemaRef.getLangOpts().CPlusPlus20) {
+      return true;
+    }
+  }
+  return false;
+}
 bool Sema::CheckImmediateEscalatingFunctionDefinition(
     FunctionDecl *FD, const sema::FunctionScopeInfo *FSI) {
   if (!getLangOpts().CPlusPlus20 || !FD->isImmediateEscalating())

--- a/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p4.cpp
+++ b/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p4.cpp
@@ -224,6 +224,9 @@ struct TemplateInit {
   };
   // FIXME: This is ill-formed (no diagnostic required). We should diagnose it.
   constexpr TemplateInit() {} // desired-error {{must initialize all members}}
+#ifndef CXX2A
+  // expected-error@-2 {{constexpr union constructor that does not initialize any member is a C++20 extension}}
+#endif
 };
 template<typename T> struct TemplateInit2 {
   Literal l;

--- a/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p4.cpp
+++ b/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p4.cpp
@@ -222,8 +222,7 @@ struct TemplateInit {
     T g;
     T h;
   };
-  // FIXME: This is ill-formed (no diagnostic required). We should diagnose it.
-  constexpr TemplateInit() {} // desired-error {{must initialize all members}}
+  constexpr TemplateInit() {}
 #ifndef CXX2A
   // expected-error@-2 {{constexpr union constructor that does not initialize any member is a C++20 extension}}
 #endif

--- a/clang/test/SemaCXX/constexpr-union-temp-ctor-cxx.cpp
+++ b/clang/test/SemaCXX/constexpr-union-temp-ctor-cxx.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++14 -verify -fcxx-exceptions -Werror=c++14-extensions -Werror=c++20-extensions %s
+
+template <class> struct C {
+    union {
+      int i;
+    };
+    constexpr C() {} // expected-error {{constexpr union constructor that does not initialize any member is a C++20 extension}}
+};
+constexpr C<int> c;
+
+template <class> class D {
+    union {
+      int i;
+    };
+public:
+    constexpr D() {} // expected-error {{constexpr union constructor that does not initialize any member is a C++20 extension}}
+};
+constexpr D<int> d;
+
+template<typename T>
+struct Foo {
+    union {
+      int i;
+    };
+    constexpr Foo(int a): i(a){}
+};
+constexpr Foo<int> f(5);


### PR DESCRIPTION
For templates, isDependentContext() is true, that's why the previous if check was failing.
Here, we traverse the RD and upon finding a Union declaration we check if at least one member of the union is initialized.
If not, it produces a diagnosis for it.
Fix #46689 