### PR TITLE
Revert "[X86][clang] Lift _BitInt() supported max width."

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -239,6 +239,8 @@ AMDGPU Support
 X86 Support
 ^^^^^^^^^^^
 
+- Revert _BitInt() supported max width increase, which does not work properly.
+
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -507,9 +507,6 @@ public:
   ArrayRef<Builtin::Info> getTargetBuiltins() const override;
 
   bool hasBitIntType() const override { return true; }
-  size_t getMaxBitIntWidth() const override {
-    return llvm::IntegerType::MAX_INT_BITS;
-  }
 };
 
 class LLVM_LIBRARY_VISIBILITY NetBSDI386TargetInfo
@@ -820,9 +817,6 @@ public:
   ArrayRef<Builtin::Info> getTargetBuiltins() const override;
 
   bool hasBitIntType() const override { return true; }
-  size_t getMaxBitIntWidth() const override {
-    return llvm::IntegerType::MAX_INT_BITS;
-  }
 };
 
 // x86-64 Windows target

--- a/clang/test/Analysis/bitint-no-crash.c
+++ b/clang/test/Analysis/bitint-no-crash.c
@@ -1,10 +1,9 @@
  // RUN: %clang_analyze_cc1 -analyzer-checker=core \
  // RUN:   -analyzer-checker=debug.ExprInspection \
- // RUN:   -triple x86_64-pc-linux-gnu \
+ // RUN:   -fexperimental-max-bitint-width=256 \
  // RUN:   -verify %s
 
-// Don't crash when using _BitInt(). Pin to the x86_64 triple for now,
-// since not all architectures support _BitInt()
+// Don't crash when using _BitInt().
 // expected-no-diagnostics
 _BitInt(256) a;
 _BitInt(129) b;

--- a/clang/test/CodeGen/ext-int-cc.c
+++ b/clang/test/CodeGen/ext-int-cc.c
@@ -131,10 +131,10 @@ void ParamPassing3(_BitInt(15) a, _BitInt(31) b) {}
 // are negated. This will give an error when a target does support larger
 // _BitInt widths to alert us to enable the test.
 void ParamPassing4(_BitInt(129) a) {}
-// LIN64: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
-// WIN64: define dso_local void @ParamPassing4(ptr %{{.+}})
-// LIN32: define{{.*}} void @ParamPassing4(ptr %{{.+}})
-// WIN32: define dso_local void @ParamPassing4(ptr %{{.+}})
+// LIN64-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
+// WIN64-NOT: define dso_local void @ParamPassing4(ptr %{{.+}})
+// LIN32-NOT: define{{.*}} void @ParamPassing4(ptr %{{.+}})
+// WIN32-NOT: define dso_local void @ParamPassing4(ptr %{{.+}})
 // NACL-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
 // NVPTX64-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
 // NVPTX-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
@@ -290,10 +290,10 @@ _BitInt(128) ReturnPassing4(void){}
 
 #if __BITINT_MAXWIDTH__ > 128
 _BitInt(129) ReturnPassing5(void){}
-// LIN64: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
-// WIN64: define dso_local void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
-// LIN32: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
-// WIN32: define dso_local void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// LIN64-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// WIN64-NOT: define dso_local void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// LIN32-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// WIN32-NOT: define dso_local void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
 // NACL-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
 // NVPTX64-NOT: define{{.*}} i129 @ReturnPassing5(
 // NVPTX-NOT: define{{.*}} i129 @ReturnPassing5(


### PR DESCRIPTION
This reverts commit def720726b73e0d7ab139376ab3ea955f25f4d89.

As noted in #60925 and in D86310, with the current implementation of `_BitInt` in Clang, we can have either a correct `__int128` implementation, or a correct `_BitInt(128)` implementation, but not both: having a correct `__int128` implementation results in a mostly-working `_BitInt(65-128)` type, but internal compiler errors and seriously wrong code for `_BitInt(129+)`. The currently specified ABI is not implementable on top of LLVM's integer types, and attempts to get the ABI changed to something we can implement have resulted in nothing, so I think the safest thing to do at this time is to make sure Clang reports this as an error in exactly the same way that it does for all other architectures. I think it was simply too soon to lift that restriction.

cc @FreddyLeaf 