### PR TITLE
FIX : bugprone-too-small-loop-variable - false-negative when const variable is used as loop bound

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -81,12 +81,12 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
 
   // We are interested in only those cases when the loop bound is a variable
   // value (not const, enum, etc.).
-  StatementMatcher LoopBoundMatcher =
-      expr(ignoringParenImpCasts(allOf(hasType(isInteger()),
-                                       unless(integerLiteral()),
-                                       unless(hasType(isConstQualified())),
-                                       unless(hasType(enumType())))))
-          .bind(LoopUpperBoundName);
+ StatementMatcher LoopBoundMatcher =
+       expr(ignoringParenImpCasts(allOf(hasType(isInteger()),
+                                        unless(integerLiteral()),
+                                        unless(allOf(hasType(isConstQualified()), declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(integerLiteral())), isConstexpr(), isConstinit())))))),
+                                        unless(hasType(enumType())))))
+           .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right
   // loop variable.

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -84,8 +84,8 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
   StatementMatcher LoopBoundMatcher =
       expr(ignoringParenImpCasts(allOf(
                hasType(isInteger()), unless(integerLiteral()),
-unless(declRefExpr(to(enumConstantDecl()))),
-unless(allOf(hasType(isConstQualified()),
+              unless(declRefExpr(to(enumConstantDecl()))),
+              unless(allOf(hasType(isConstQualified()),
                     declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(declRefExpr(to(enumConstantDecl())))), isConstexpr(), isConstinit())))))
           .bind(LoopUpperBoundName);
 

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -81,12 +81,16 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
 
   // We are interested in only those cases when the loop bound is a variable
   // value (not const, enum, etc.).
- StatementMatcher LoopBoundMatcher =
-       expr(ignoringParenImpCasts(allOf(hasType(isInteger()),
-                                        unless(integerLiteral()),
-                                        unless(allOf(hasType(isConstQualified()), declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(integerLiteral())), isConstexpr(), isConstinit())))))),
-                                        unless(hasType(enumType())))))
-           .bind(LoopUpperBoundName);
+  StatementMatcher LoopBoundMatcher =
+      expr(ignoringParenImpCasts(allOf(
+               hasType(isInteger()), unless(integerLiteral()),
+               unless(allOf(
+                   hasType(isConstQualified()),
+                   declRefExpr(to(varDecl(anyOf(
+                       hasInitializer(ignoringParenImpCasts(integerLiteral())),
+                       isConstexpr(), isConstinit())))))),
+               unless(hasType(enumType())))))
+          .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right
   // loop variable.

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -86,7 +86,7 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
                hasType(isInteger()), unless(integerLiteral()),
               unless(declRefExpr(to(enumConstantDecl()))),
               unless(allOf(hasType(isConstQualified()),
-                    declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(declRefExpr(to(enumConstantDecl())))), isConstexpr(), isConstinit())))))
+                    declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(declRefExpr(to(enumConstantDecl())))), isConstexpr(), isConstinit())))))))))
           .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -82,11 +82,14 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
   // We are interested in only those cases when the loop bound is a variable
   // value (not const, enum, etc.).
   StatementMatcher LoopBoundMatcher =
-      expr(ignoringParenImpCasts(allOf(
-               hasType(isInteger()), unless(integerLiteral()),
-              unless(declRefExpr(to(enumConstantDecl()))),
-              unless(allOf(hasType(isConstQualified()),
-                    declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(declRefExpr(to(enumConstantDecl())))), isConstexpr(), isConstinit())))))))))
+      expr(ignoringParenImpCasts(
+               allOf(hasType(isInteger()), unless(integerLiteral()),
+                     unless(declRefExpr(to(enumConstantDecl()))),
+                     unless(allOf(hasType(isConstQualified()),
+                                  declRefExpr(to(varDecl(anyOf(
+                                      hasInitializer(ignoringParenImpCasts(
+                                          declRefExpr(to(enumConstantDecl())))),
+                                      isConstexpr(), isConstinit())))))))))
           .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -84,12 +84,9 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
   StatementMatcher LoopBoundMatcher =
       expr(ignoringParenImpCasts(allOf(
                hasType(isInteger()), unless(integerLiteral()),
-               unless(allOf(
-                   hasType(isConstQualified()),
-                   declRefExpr(to(varDecl(anyOf(
-                       hasInitializer(ignoringParenImpCasts(integerLiteral())),
-                       isConstexpr(), isConstinit())))))),
-               unless(hasType(enumType())))))
+unless(declRefExpr(to(enumConstantDecl()))),
+unless(allOf(hasType(isConstQualified()),
+                    declRefExpr(to(varDecl(anyOf(hasInitializer(ignoringParenImpCasts(declRefExpr(to(enumConstantDecl())))), isConstexpr(), isConstinit())))))
           .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right

--- a/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TooSmallLoopVariableCheck.cpp
@@ -82,14 +82,14 @@ void TooSmallLoopVariableCheck::registerMatchers(MatchFinder *Finder) {
   // We are interested in only those cases when the loop bound is a variable
   // value (not const, enum, etc.).
   StatementMatcher LoopBoundMatcher =
-      expr(ignoringParenImpCasts(
-               allOf(hasType(isInteger()), unless(integerLiteral()),
-                     unless(declRefExpr(to(enumConstantDecl()))),
-                     unless(allOf(hasType(isConstQualified()),
-                                  declRefExpr(to(varDecl(anyOf(
-                                      hasInitializer(ignoringParenImpCasts(
-                                          declRefExpr(to(enumConstantDecl())))),
-                                      isConstexpr(), isConstinit())))))))))
+      expr(ignoringParenImpCasts(allOf(
+               hasType(isInteger()), unless(integerLiteral()),
+               unless(allOf(
+                   hasType(isConstQualified()),
+                   declRefExpr(to(varDecl(anyOf(
+                       hasInitializer(ignoringParenImpCasts(integerLiteral())),
+                       isConstexpr(), isConstinit())))))),
+               unless(hasType(enumType())))))
           .bind(LoopUpperBoundName);
 
   // We use the loop increment expression only to make sure we found the right

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -118,8 +118,8 @@ Changes in existing checks
   global options of the same name.
 
 - Improved :doc:`bugprone-too-small-loop-variable
-  <clang-tidy/checks/bugprone/too-small-loop-variable>` check by correctly 
-  implementing the check for const loop variable initialized with a function declaration.
+  <clang-tidy/checks/bugprone/too-small-loop-variable>` support by correctly 
+  implementing the check for const loop boundary.
 
 - Cleaned up :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>`

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -169,6 +169,9 @@ Miscellaneous
   option is specified. Now ``clang-apply-replacements`` applies formatting only with
   the option.
 
+- Fixed incorrect implementation of ``too-small-loop-variable`` check when a const loop
+  variable is initialized with a function declaration.
+
 Improvements to include-fixer
 -----------------------------
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -158,7 +158,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-too-small-loop-variable
   <clang-tidy/checks/bugprone/too-small-loop-variable>` check by correctly 
-  implementing the check for const loop variables with a function declaration.
+  implementing the check for const loop variable initialized with a function declaration.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -117,6 +117,10 @@ Changes in existing checks
   options `HeaderFileExtensions` and `ImplementationFileExtensions` by the
   global options of the same name.
 
+- Improved :doc:`bugprone-too-small-loop-variable
+  <clang-tidy/checks/bugprone/too-small-loop-variable>` check by correctly 
+  implementing the check for const loop variable initialized with a function declaration.
+
 - Cleaned up :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>`
   by removing enforcement of rule `C.48
@@ -155,10 +159,6 @@ Changes in existing checks
   <clang-tidy/checks/modernize/avoid-c-arrays>` check by introducing the new
   `AllowStringArrays` option, enabling the exclusion of array types with deduced
   length initialized from string literals.
-
-- Improved :doc:`bugprone-too-small-loop-variable
-  <clang-tidy/checks/bugprone/too-small-loop-variable>` check by correctly 
-  implementing the check for const loop variable initialized with a function declaration.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -156,6 +156,10 @@ Changes in existing checks
   `AllowStringArrays` option, enabling the exclusion of array types with deduced
   length initialized from string literals.
 
+- Improved :doc:`bugprone-too-small-loop-variable
+  <clang-tidy/checks/bugprone/too-small-loop-variable>` check by correctly 
+  implementing the check for const loop variables with a function declaration.
+
 Removed checks
 ^^^^^^^^^^^^^^
 
@@ -168,9 +172,6 @@ Miscellaneous
 - Fixed incorrect formatting in ``clang-apply-repalcements`` when no ``--format``
   option is specified. Now ``clang-apply-replacements`` applies formatting only with
   the option.
-
-- Fixed incorrect implementation of ``too-small-loop-variable`` check when a const loop
-  variable is initialized with a function declaration.
 
 Improvements to include-fixer
 -----------------------------

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
@@ -28,7 +28,9 @@ In a real use case size means a container's size which depends on the user input
 This algorithm works for a small amount of objects, but will lead to freeze for
 a larger user input.
 
-It's recommended to enable the compiler warning -Wtautological-constant-out-of-range-compare as well, since check does not inspect compile-time constant loop boundaries to avoid overlaps with the warning.
+It's recommended to enable the compiler warning
+`-Wtautological-constant-out-of-range-compare` as well, since check does not
+inspect compile-time constant loop boundaries to avoid overlaps with the warning.
 
 .. option:: MagnitudeBitsUpperLimit
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
@@ -44,3 +44,5 @@ a larger user input.
     for (unsigned i = 0; i < size; ++i) {} // no warning with MagnitudeBitsUpperLimit = 31 on a system where unsigned is 32-bit
     for (int i = 0; i < size; ++i) {} // warning with MagnitudeBitsUpperLimit = 31 on a system where int is 32-bit
   }
+
+``-Wtautological-constant-out-of-range-compare`` compiler warning should also be used.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
@@ -28,6 +28,8 @@ In a real use case size means a container's size which depends on the user input
 This algorithm works for a small amount of objects, but will lead to freeze for
 a larger user input.
 
+It's recommended to enable the compiler warning -Wtautological-constant-out-of-range-compare as well, since check does not inspect compile-time constant loop boundaries to avoid overlaps with the warning.
+
 .. option:: MagnitudeBitsUpperLimit
 
   Upper limit for the magnitude bits of the loop variable. If it's set the check
@@ -44,5 +46,3 @@ a larger user input.
     for (unsigned i = 0; i < size; ++i) {} // no warning with MagnitudeBitsUpperLimit = 31 on a system where unsigned is 32-bit
     for (int i = 0; i < size; ++i) {} // warning with MagnitudeBitsUpperLimit = 31 on a system where int is 32-bit
   }
-
-``-Wtautological-constant-out-of-range-compare`` compiler warning should also be used.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/too-small-loop-variable.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/too-small-loop-variable.cpp
@@ -93,6 +93,18 @@ void voidBadForLoopWithMacroBound() {
   }
 }
 
+unsigned int getVal() {
+    return 300;
+}
+
+// The iteration's upper bound has a function declaration.
+void voidBadForLoop8() {
+  const unsigned int l = getVal();
+  for (unsigned char i = 0; i < l; ++i) {
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: loop variable has narrower type 'unsigned char' than iteration's upper bound 'const unsigned int' [bugprone-too-small-loop-variable]
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Correct loops: we should not warn here.
 


### PR DESCRIPTION
Fixes: #79580

**PR SUMMARY**: Changed LibASTMatcher to give an appropriate warning when a const loop bound is initialized with a function declaration. 