### PR TITLE
[lldb] Support custom LLVM formatting for variables

### DIFF
--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -460,6 +460,15 @@ summary strings, regardless of the format they have applied to their types. To
 do that, you can use %format inside an expression path, as in ${var.x->x%u},
 which would display the value of x as an unsigned integer.
 
+Additionally, custom output can be achieved by using a printf format string
+after the ``%`` marker. When a summary string contains two ``%`` markers, then
+it is using a custom printf format. To illustrate, compare ``${var.byte%x}``
+and ``${var.byte%%x}``. The former uses lldb's hex formatting (``x``), which
+automatically includes a ``0x`` prefix, and also zero pads the value to match
+the size of the type. The latter uses printf formatting (``%x``), and will
+print only the hex value, with no ``0x`` prefix, and no padding. This raw
+control is useful when composing multiple pieces into a larger whole.
+
 You can also use some other special format markers, not available for formats
 themselves, but which carry a special meaning when used in this context:
 

--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -460,14 +460,14 @@ summary strings, regardless of the format they have applied to their types. To
 do that, you can use %format inside an expression path, as in ${var.x->x%u},
 which would display the value of x as an unsigned integer.
 
-Additionally, custom output can be achieved by using a printf format string
-after the ``%`` marker. When a summary string contains two ``%`` markers, then
-it is using a custom printf format. To illustrate, compare ``${var.byte%x}``
-and ``${var.byte%%x}``. The former uses lldb's hex formatting (``x``), which
-automatically includes a ``0x`` prefix, and also zero pads the value to match
-the size of the type. The latter uses printf formatting (``%x``), and will
-print only the hex value, with no ``0x`` prefix, and no padding. This raw
-control is useful when composing multiple pieces into a larger whole.
+Additionally, custom output can be achieved by using an LLVM format string,
+commencing with the ``:`` marker. To illustrate, compare ``${var.byte%x}`` and
+``${var.byte:x-}``. The former uses lldb's builtin hex formatting (``x``),
+which unconditionally inserts a ``0x`` prefix, and also zero pads the value to
+match the size of the type. The latter uses ``llvm::formatv`` formatting
+(``:x-``), and will print only the hex value, with no ``0x`` prefix, and no
+padding. This raw control is useful when composing multiple pieces into a
+larger whole.
 
 You can also use some other special format markers, not available for formats
 themselves, but which carry a special meaning when used in this context:

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -663,13 +663,17 @@ static bool DumpValueWithPrintf(Stream &s, llvm::StringRef format,
   auto type_info = target.GetTypeInfo();
   if (type_info & eTypeIsInteger) {
     if (type_info & eTypeIsSigned) {
-      if (auto integer = target.GetValueAsSigned()) {
-        s.Printf(format.data(), *integer);
+      bool success = false;
+      auto integer = target.GetValueAsSigned(0, &success);
+      if (success) {
+        s.Printf(format.data(), integer);
         return true;
       }
     } else {
-      if (auto integer = target.GetValueAsUnsigned()) {
-        s.Printf(format.data(), *integer);
+      bool success = false;
+      auto integer = target.GetValueAsUnsigned(0, &success);
+      if (success) {
+        s.Printf(format.data(), integer);
         return true;
       }
     }

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -883,8 +883,29 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
   }
 
   if (!is_array_range) {
-    LLDB_LOGF(log,
-              "[Debugger::FormatPrompt] dumping ordinary printable output");
+    if (!entry.printf_format.empty()) {
+      auto type_info = target->GetTypeInfo();
+      if (type_info & eTypeIsInteger) {
+        if (type_info & eTypeIsSigned) {
+          bool success = false;
+          auto integer = target->GetValueAsSigned(0, &success);
+          if (success) {
+            LLDB_LOGF(log, "dumping using printf format");
+            s.Printf(entry.printf_format.c_str(), integer);
+            return true;
+          }
+        } else {
+          bool success = false;
+          auto integer = target->GetValueAsUnsigned(0, &success);
+          if (success) {
+            LLDB_LOGF(log, "dumping using printf format");
+            s.Printf(entry.printf_format.c_str(), integer);
+            return true;
+          }
+        }
+      }
+    }
+    LLDB_LOGF(log, "dumping ordinary printable output");
     return target->DumpPrintableRepresentation(s, val_obj_display,
                                                custom_format);
   } else {

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
@@ -1,0 +1,11 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
+        self.runCmd("type summary add -s '${var.ubyte%%2.2X}${var.sbyte%%2.2X}!' Bytes")
+        self.expect("v bytes", substrs=[" = 1001!"])

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
@@ -7,5 +7,5 @@ class TestCase(TestBase):
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
-        self.runCmd("type summary add -s '${var.ubyte%%2.2X}${var.sbyte%%2.2X}!' Bytes")
+        self.runCmd("type summary add -s '${var.ubyte:x-2}${var.sbyte:x-2}!' Bytes")
         self.expect("v bytes", substrs=[" = 1001!"])

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomPrintfSummary.py
@@ -4,8 +4,15 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
+
+    def test_raw_bytes(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.runCmd("type summary add -s '${var.ubyte:x-2}${var.sbyte:x-2}!' Bytes")
-        self.expect("v bytes", substrs=[" = 1001!"])
+        self.expect("v bytes", substrs=[" = 3001!"])
+
+    def test_bad_format(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
+        self.runCmd("type summary add -s '${var.ubyte:y}!' Bytes")
+        self.expect("v bytes", substrs=[" = '0'!"])

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomSummaryLLVMFormat.py
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomSummaryLLVMFormat.py
@@ -14,5 +14,8 @@ class TestCase(TestBase):
     def test_bad_format(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
-        self.runCmd("type summary add -s '${var.ubyte:y}!' Bytes")
-        self.expect("v bytes", substrs=[" = '0'!"])
+        self.expect(
+            "type summary add -s '${var.ubyte:y}!' Bytes",
+            error=True,
+            substrs=["invalid llvm format"],
+        )

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomSummaryLLVMFormat.py
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/TestCustomSummaryLLVMFormat.py
@@ -4,7 +4,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-
     def test_raw_bytes(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/main.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdio.h>
+
+struct Bytes {
+  uint8_t ubyte;
+  int8_t sbyte;
+};
+
+int main() {
+  struct Bytes bytes = {0x10, 0x01};
+  (void)bytes;
+  printf("break here\n");
+}

--- a/lldb/test/API/functionalities/data-formatter/custom-printf-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/custom-printf-summary/main.c
@@ -7,7 +7,7 @@ struct Bytes {
 };
 
 int main() {
-  struct Bytes bytes = {0x10, 0x01};
+  struct Bytes bytes = {0x30, 0x01};
   (void)bytes;
   printf("break here\n");
 }


### PR DESCRIPTION
Adds support for applying LLVM formatting to variables.

The reason for this is to support cases such as the following.

Let's say you have two separate bytes that you want to print as a combined hex value. Consider the following summary string:

```
${var.byte1%x}${var.byte2%x}
```

The output of this will be: `0x120x34`. That is, a `0x` prefix is unconditionally applied to each byte. This is unlike printf formatting where you must include the `0x` yourself.

Currently, there's no way to do this with summary strings, instead you'll need a summary provider in python or c++.

This change introduces formatting support using LLVM's formatter system. This allows users to achieve the desired custom formatting using:

```
${var.byte1:x-}${var.byte2:x-}
```

Here, each variable is suffixed with `:x-`. This is passed to the LLVM formatter as `{0:x-}`. For integer values, `x` declares the output as hex, and `-` declares that no `0x` prefix is to be used. Further, one could write:

```
${var.byte1:x-2}${var.byte2:x-2}
```

Where the added `2` results in these bytes being written with a minimum of 2 digits.

An alternative considered was to add a new format specifier that would print hex values without the `0x` prefix. The reason that approach was not taken is because in addition to forcing a `0x` prefix, hex values are also forced to use leading zeros. This approach lets the user have full control over formatting.