### PR TITLE
[clang] Clang should detect illegal copy constructor with template class as its parameter

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -281,6 +281,8 @@ Bug Fixes to C++ Support
   a requires-clause lie at the same depth as those of the surrounding lambda. This,
   in turn, results in the wrong template argument substitution during constraint checking.
   (`#78524 <https://github.com/llvm/llvm-project/issues/78524>`_)
+- Clang now detects illegal copy constructor with template class as its parameter.
+  Fixes (`#80963 https://github.com/llvm/llvm-project/issues/80963>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -10921,9 +10921,7 @@ void Sema::CheckConstructor(CXXConstructorDecl *Constructor) {
   //   either there are no other parameters or else all other
   //   parameters have default arguments.
   if (!Constructor->isInvalidDecl() &&
-      Constructor->hasOneParamOrDefaultArgs() &&
-      Constructor->getTemplateSpecializationKind() !=
-          TSK_ImplicitInstantiation) {
+      Constructor->hasOneParamOrDefaultArgs()) {
     QualType ParamType = Constructor->getParamDecl(0)->getType();
     QualType ClassTy = Context.getTagDeclType(ClassDecl);
     if (Context.getCanonicalType(ParamType).getUnqualifiedType() == ClassTy) {

--- a/clang/test/SemaCXX/GH81251.cpp
+++ b/clang/test/SemaCXX/GH81251.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+template < class T, class V > struct A
+{
+    A ();
+    A (A &);
+    A (A < V,T >);
+    // expected-error@-1 {{copy constructor must pass its first argument by reference}}
+};
+
+void f ()
+{
+    A <int, int> (A < int, int >());
+    // expected-note@-1 {{in instantiation of template class 'A<int, int>' requested here}}
+    
+    A <int, double> (A < int, double >());
+}


### PR DESCRIPTION
Resolves #80963

As described in the snippet of the issue, `A<T,V>` is correctly detected while it fails to reject in other cases.