### PR TITLE
[flang] ensure parent component are first in runtime type info

### DIFF
--- a/flang/lib/Semantics/runtime-type-info.cpp
+++ b/flang/lib/Semantics/runtime-type-info.cpp
@@ -555,10 +555,11 @@ const Symbol *RuntimeTableBuilder::DescribeType(Scope &dtScope) {
           },
           symbol.details());
     }
-    // Sort the data component symbols by offset before emitting them
+    // Sort the data component symbols by offset before emitting them, placing
+    // the parent component first if any.
     std::sort(dataComponentSymbols.begin(), dataComponentSymbols.end(),
         [](const Symbol *x, const Symbol *y) {
-          return x->offset() < y->offset();
+          return x->test(Symbol::Flag::ParentComp) || x->offset() < y->offset();
         });
     std::vector<evaluate::StructureConstructor> dataComponents;
     for (const Symbol *symbol : dataComponentSymbols) {

--- a/flang/test/Semantics/typeinfo10.f90
+++ b/flang/test/Semantics/typeinfo10.f90
@@ -1,0 +1,14 @@
+!RUN: bbc --dump-symbols %s | FileCheck %s
+!RUN: %flang_fc1 -fdebug-dump-symbols %s | FileCheck %s
+
+! Test that empty parent types are still set first in the
+! runtime info global array describing components.
+module empty_parent
+ type :: z
+ end type
+
+ type, extends(z) :: t
+  integer :: a
+ end type
+end module
+! CHECK: .c.t, SAVE{{.*}}.n.z{{.*}}n.a


### PR DESCRIPTION
Static info generated to describe derived types contain an array listing the components of some derived type.

The parent component must be first for the runtime to properly works. The current sort was only relying on the offset, but if the parent is an empty type, this did not work properly because its offset did not compare smaller than the first component and the parent was not added first