### PR TITLE
[libc][NFC] Fix few warnings in tests.

### DIFF
--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -265,7 +265,7 @@ template <typename T> constexpr auto make(Sign sign, FP fp) {
   case FP::QUIET_NAN:
     return T::quiet_nan(sign);
   }
-};
+}
 
 // Tests all properties for all types of float.
 TYPED_TEST(LlvmLibcFPBitsTest, Properties, FPTypes) {

--- a/libc/test/src/sys/socket/linux/bind_test.cpp
+++ b/libc/test/src/sys/socket/linux/bind_test.cpp
@@ -13,7 +13,6 @@
 #include "src/unistd/close.h"
 
 #include "src/errno/libc_errno.h"
-#include "test/UnitTest/LibcTest.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM


### PR DESCRIPTION
```
/usr/local/google/home/lntue/experiment/llvm/llvm-project/libc/test/src/__support/FPUtil/fpbits_test.cpp:268:2: warning: extra ';' outside of a function is incompatible with C++98 [-Wc++98-compat-extra-semi]
};
 ^
1 warning generated.
```

```
In file included from /usr/local/google/home/lntue/experiment/llvm/llvm-project/libc/test/src/sys/socket/linux/bind_test.cpp:17:
/usr/local/google/home/lntue/experiment/llvm/llvm-project/libc/test/UnitTest/Test.h:17:9: warning: 'libc_make_test_file_path' macro redefined [-Wmacro-redefined]
#define libc_make_test_file_path(file_name) (file_name)
        ^
/usr/local/google/home/lntue/experiment/llvm/llvm-project/libc/test/UnitTest/LibcTest.h:20:9: note: previous definition is here
#define libc_make_test_file_path(file_name)                                    \
        ^
1 warning generated.
```