### PR TITLE
[AArch64] Add FeatureFuseAddSub2RegAndConstOne for Ampere1A

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -1372,6 +1372,7 @@ def TuneAmpere1A : SubtargetFeature<"ampere1a", "ARMProcFamily", "Ampere1A",
                                     FeatureFuseAddress,
                                     FeatureFuseLiterals,
                                     FeatureFuseLiterals,
+                                    FeatureFuseAddSub2RegAndConstOne,
                                     FeatureStorePairSuppress,
                                     FeatureLdpAlignedOnly,
                                     FeatureStpAlignedOnly]>;


### PR DESCRIPTION
Ampere1A introduced the Fusion for A+B+1/A-B-1.
However, the Feature flag to enable that fusion-case never was added to TuneAmpere1A.
This commit corrects that omission.