### PR TITLE
{OpenMP][OpenMPIRBuilder]Add ReductionInfoManager

### DIFF
--- a/mlir/test/Target/LLVMIR/openmp-reduction.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-reduction.mlir
@@ -532,7 +532,7 @@ llvm.func @parallel_nested_workshare_reduction(%ub : i64) {
 // CHECK: define internal void @[[OUTLINED]]
 
 // Private reduction variable and its initialization.
-// CHECK: %[[PRIVATE:[0-9]+]] = alloca i32
+// CHECK: %[[PRIVATE:private_redvar]] = alloca i32
 // CHECK: store i32 0, ptr %[[PRIVATE]]
 
 // Loop exit:


### PR DESCRIPTION
Add reduction info manager that will be used to communicate information between distribute and workshare lowerings.
