### PR TITLE
[Sema] Warn unused functions for FMV based on the target attribute

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -3538,7 +3538,11 @@ bool FunctionDecl::isTargetMultiVersion() const {
 }
 
 bool FunctionDecl::isTargetMultiVersionDefault() const {
-  return isMultiVersion() && hasAttr<TargetVersionAttr>() &&
+  if (!isMultiVersion())
+    return false;
+  if (hasAttr<TargetAttr>())
+    return getAttr<TargetAttr>()->isDefaultVersion();
+  return hasAttr<TargetVersionAttr>() &&
          getAttr<TargetVersionAttr>()->isDefaultVersion();
 }
 

--- a/clang/test/SemaCXX/attr-target-mv-warn-unused.cpp
+++ b/clang/test/SemaCXX/attr-target-mv-warn-unused.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsyntax-only -verify -Wunused %s
+
+__attribute__((target("sse3")))
+static int not_used_fmv() { return 1; }
+__attribute__((target("avx2")))
+static int not_used_fmv() { return 2; }
+__attribute__((target("default")))
+static int not_used_fmv() { return 0; } // expected-warning {{unused function 'not_used_fmv'}}
+
+__attribute__((target("sse3")))
+static int definitely_used_fmv() { return 1; }
+__attribute__((target("avx2")))
+static int definitely_used_fmv() { return 2; }
+__attribute__((target("default")))
+static int definitely_used_fmv() { return 0; }
+int definite_user() { return definitely_used_fmv(); }


### PR DESCRIPTION
The spurious -Wunused-function warning issue for `target_version` #80227
also applied to `__attribute__((target(...)))` based FMV. #81167 removed
warnings for all `target`-based FMV. This patch restores the warnings
for `__attribute__((target("default")))`.
