### PR TITLE
[llvm-nm][WebAssembly] Print function symbol sizes

### DIFF
--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -98,8 +98,6 @@ public:
     return Info.Flags & wasm::WASM_SYMBOL_VISIBILITY_MASK;
   }
 
-  uint32_t getSize() const;
-
   void print(raw_ostream &Out) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -98,6 +98,8 @@ public:
     return Info.Flags & wasm::WASM_SYMBOL_VISIBILITY_MASK;
   }
 
+  uint32_t getSize() const;
+
   void print(raw_ostream &Out) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -179,6 +181,7 @@ public:
   Expected<SymbolRef::Type> getSymbolType(DataRefImpl Symb) const override;
   Expected<section_iterator> getSymbolSection(DataRefImpl Symb) const override;
   uint32_t getSymbolSectionId(SymbolRef Sym) const;
+  uint32_t getSymbolSize(SymbolRef Sym) const;
 
   // Overrides from SectionRef.
   void moveSectionNext(DataRefImpl &Sec) const override;

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -1934,7 +1934,7 @@ uint32_t WasmObjectFile::getSymbolSectionIdImpl(const WasmSymbol &Sym) const {
 
 uint32_t WasmObjectFile::getSymbolSize(SymbolRef Symb) const {
   const WasmSymbol &Sym = getWasmSymbol(Symb);
-  if(!Sym.isDefined())
+  if (!Sym.isDefined())
     return 0;
   if (Sym.isTypeData())
     return Sym.Info.DataRef.Size;

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -1932,6 +1932,20 @@ uint32_t WasmObjectFile::getSymbolSectionIdImpl(const WasmSymbol &Sym) const {
   }
 }
 
+uint32_t WasmObjectFile::getSymbolSize(SymbolRef Symb) const {
+  const WasmSymbol &Sym = getWasmSymbol(Symb);
+  if(!Sym.isDefined())
+    return 0;
+  if (Sym.isTypeData())
+    return Sym.Info.DataRef.Size;
+  if (Sym.isTypeFunction())
+    return functions()[Sym.Info.ElementIndex - getNumImportedFunctions()].Size;
+  // Currently symbol size is only tracked for data segments and functions. In
+  // principle we could also track size (e.g. binary size) for tables, globals
+  // and element segments etc too.
+  return 0;
+}
+
 void WasmObjectFile::moveSectionNext(DataRefImpl &Sec) const { Sec.d.a++; }
 
 Expected<StringRef> WasmObjectFile::getSectionName(DataRefImpl Sec) const {

--- a/llvm/test/MC/WebAssembly/alias-offset.s
+++ b/llvm/test/MC/WebAssembly/alias-offset.s
@@ -12,10 +12,10 @@ sym_a:
 .set sym_b, sym_a + 4
 
 # CHECK-LABEL: SYMBOL TABLE:
-# CHECK-NEXT: 00000000 l     O DATA foo
-# CHECK-NEXT: 00000004 l     O DATA sym_a
-# CHECK-NEXT: 00000008 l     O DATA sym_b
-# CHECK-NEXT: 00000001 l     F CODE main
+# CHECK-NEXT: 00000000 l     O DATA 00000004 foo
+# CHECK-NEXT: 00000004 l     O DATA 00000008 sym_a
+# CHECK-NEXT: 00000008 l     O DATA 00000004 sym_b
+# CHECK-NEXT: 00000001 l     F CODE 00000012 main
 
   .text
   .section    .text,"",@

--- a/llvm/test/MC/WebAssembly/alias.s
+++ b/llvm/test/MC/WebAssembly/alias.s
@@ -10,6 +10,6 @@ sym_a:
 
 .set sym_b, sym_a
 
-# CHECK: 00000000 l     O DATA foo
-# CHECK: 00000004 l     O DATA sym_a
-# CHECK: 00000004 l     O DATA sym_b
+# CHECK: 00000000 l     O DATA 00000004 foo
+# CHECK: 00000004 l     O DATA 00000004 sym_a
+# CHECK: 00000004 l     O DATA 00000004 sym_b

--- a/llvm/test/Object/wasm-linked-namesec-with-linkingsec.yaml
+++ b/llvm/test/Object/wasm-linked-namesec-with-linkingsec.yaml
@@ -2,7 +2,7 @@
 # RUN: llvm-nm -P %t.wasm | FileCheck %s
 #
 # Test that names from the linking section override those from the name section
-# CHECK:  foo T 1 0
+# CHECK:  foo T 1 3
 # CHECK-NOT: my_func_local_name
 
 --- !WASM

--- a/llvm/test/Object/wasm-linked-symbol-table.yaml
+++ b/llvm/test/Object/wasm-linked-symbol-table.yaml
@@ -2,9 +2,9 @@
 # RUN: llvm-objdump -t %t.wasm | FileCheck %s
 #
 # CHECK:      SYMBOL TABLE:
-# CHECK-NEXT: 0000009f g F CODE my_func_export
-# CHECK-NEXT: 0000002a g O DATA my_global_export
-# CHECK-NEXT: 00000000 g   TABLE my_table_export
+# CHECK-NEXT: 0000009f g F CODE 00000003 my_func_export
+# CHECK-NEXT: 0000002a g O DATA 00000000 my_global_export
+# CHECK-NEXT: 00000000 g   TABLE 00000000 my_table_export
 
 --- !WASM
 FileHeader:

--- a/llvm/test/tools/llvm-nm/wasm/linked.yaml
+++ b/llvm/test/tools/llvm-nm/wasm/linked.yaml
@@ -1,9 +1,14 @@
 # RUN: yaml2obj %s -o %t.wasm
 # RUN: llvm-nm %t.wasm | FileCheck %s
+# RUN: llvm-nm -P %t.wasm | FileCheck %s --check-prefix=POSIX
 
 # CHECK: 0000009f T my_func_export
 # CHECK-NEXT: 0000002a D my_global_export
 # CHECK-NEXT: 00000000 D my_table_export
+
+# POSIX: my_func_export T 9f 3
+# POSIX-NEXT: my_global_export D 2a 0
+# POSIX-NEXT: my_table_export D 0 0
 
 --- !WASM
 FileHeader:

--- a/llvm/test/tools/llvm-nm/wasm/print-size.test
+++ b/llvm/test/tools/llvm-nm/wasm/print-size.test
@@ -43,4 +43,4 @@ Sections:
         Size:            32
 
 # CHECK: 00000000 00000020 D a_data_symbol
-# CHECK: 00000001 00000000 T a_func
+# CHECK: 00000001 0000000d T a_func

--- a/llvm/test/tools/llvm-objdump/wasm/dylink-symbol-table.yaml
+++ b/llvm/test/tools/llvm-objdump/wasm/dylink-symbol-table.yaml
@@ -2,8 +2,8 @@
 # RUN: llvm-objdump -t %t.so | FileCheck %s
 #
 # CHECK:      SYMBOL TABLE:
-# CHECK-NEXT: 00000001 g F CODE my_func_export
-# CHECK-NEXT: 0000002a g O DATA my_global_export
+# CHECK-NEXT: 00000001 g F CODE 00000003 my_func_export
+# CHECK-NEXT: 0000002a g O DATA 00000000 my_global_export
 
 --- !WASM
 FileHeader:

--- a/llvm/test/tools/llvm-objdump/wasm/linked-symbol-table-namesec.yaml
+++ b/llvm/test/tools/llvm-objdump/wasm/linked-symbol-table-namesec.yaml
@@ -2,12 +2,12 @@
 # RUN: llvm-objdump -t %t.wasm | FileCheck %s
 #
 # CHECK:      SYMBOL TABLE:
-# CHECK-NEXT: 00000000   F *UND* my_func_import_name
-# CHECK-NEXT: 00000083 g F CODE my_func_export_name
-# CHECK-NEXT: 00000086 l F CODE my_func_local_name
-# CHECK-NEXT: 00000000    *UND* my_global_import_name
-# CHECK-NEXT: 00000001 g  GLOBAL my_global_export_name
-# CHECK-NEXT: 00000000 l O DATA my_datasegment_name
+# CHECK-NEXT: 00000000   F *UND* 00000000 my_func_import_name
+# CHECK-NEXT: 00000083 g F CODE 00000003 my_func_export_name
+# CHECK-NEXT: 00000086 l F CODE 00000003 my_func_local_name
+# CHECK-NEXT: 00000000    *UND* 00000000 my_global_import_name
+# CHECK-NEXT: 00000001 g  GLOBAL 00000000 my_global_export_name
+# CHECK-NEXT: 00000000 l O DATA 00000004 my_datasegment_name
 
 --- !WASM
 FileHeader:

--- a/llvm/test/tools/llvm-objdump/wasm/symbol-table.test
+++ b/llvm/test/tools/llvm-objdump/wasm/symbol-table.test
@@ -1,9 +1,9 @@
 RUN: llvm-objdump -t %p/Inputs/trivial.obj.wasm | FileCheck %s
 
 CHECK:      SYMBOL TABLE:
-CHECK-NEXT: 00000001 g     F CODE	main
-CHECK-NEXT: 00000000 l     O DATA	.L.str
-CHECK-NEXT: 00000000       F *UND*	puts
-CHECK-NEXT: 00000019 l     F CODE	.LSomeOtherFunction_bitcast
-CHECK-NEXT: 00000000       F *UND*	SomeOtherFunction
-CHECK-NEXT: 00000010 g     O DATA	var
+CHECK-NEXT: 00000001 g     F CODE	00000018	main
+CHECK-NEXT: 00000000 l     O DATA	0000000d	.L.str
+CHECK-NEXT: 00000000       F *UND*	00000000	puts
+CHECK-NEXT: 00000019 l     F CODE	0000000b	.LSomeOtherFunction_bitcast
+CHECK-NEXT: 00000000       F *UND*	00000000	SomeOtherFunction
+CHECK-NEXT: 00000010 g     O DATA	00000004	var

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1854,16 +1854,8 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
               dyn_cast<const XCOFFObjectFile>(&Obj))
         S.Size = XCOFFObj->getSymbolSize(Sym.getRawDataRefImpl());
 
-      if (const WasmObjectFile *WasmObj = dyn_cast<WasmObjectFile>(&Obj)) {
-        const WasmSymbol &WasmSym = WasmObj->getWasmSymbol(Sym);
-        if (WasmSym.isTypeData() && !WasmSym.isUndefined())
-          S.Size = WasmSym.Info.DataRef.Size;
-        else if (WasmSym.isTypeFunction() && !WasmSym.isUndefined())
-          S.Size = WasmObj
-                       ->functions()[WasmSym.Info.ElementIndex -
-                                     WasmObj->getNumImportedFunctions()]
-                       .Size;
-      }
+      if (const WasmObjectFile *WasmObj = dyn_cast<WasmObjectFile>(&Obj))
+        S.Size = WasmObj->getSymbolSize(Sym);
 
       if (PrintAddress && isa<ObjectFile>(Obj)) {
         SymbolRef SymRef(Sym);

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1858,7 +1858,7 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
         const WasmSymbol &WasmSym = WasmObj->getWasmSymbol(Sym);
         if (WasmSym.isTypeData() && !WasmSym.isUndefined())
           S.Size = WasmSym.Info.DataRef.Size;
-        if (WasmSym.isTypeFunction() && !WasmSym.isUndefined())
+        else if (WasmSym.isTypeFunction() && !WasmSym.isUndefined())
           S.Size = WasmObj
                        ->functions()[WasmSym.Info.ElementIndex -
                                      WasmObj->getNumImportedFunctions()]

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1858,6 +1858,11 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
         const WasmSymbol &WasmSym = WasmObj->getWasmSymbol(Sym);
         if (WasmSym.isTypeData() && !WasmSym.isUndefined())
           S.Size = WasmSym.Info.DataRef.Size;
+        if (WasmSym.isTypeFunction() && !WasmSym.isUndefined())
+          S.Size = WasmObj
+                       ->functions()[WasmSym.Info.ElementIndex -
+                                     WasmObj->getNumImportedFunctions()]
+                       .Size;
       }
 
       if (PrintAddress && isa<ObjectFile>(Obj)) {

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2948,7 +2948,8 @@ void Dumper::printSymbol(const SymbolRef &Symbol,
   else if (O.isELF())
     outs() << '\t' << format(Fmt, ELFSymbolRef(Symbol).getSize());
   else if (O.isWasm())
-    outs() << '\t' << format(Fmt, cast<WasmObjectFile>(O).getSymbolSize(Symbol));
+    outs() << '\t'
+           << format(Fmt, cast<WasmObjectFile>(O).getSymbolSize(Symbol));
 
   if (O.isELF()) {
     if (!SymbolVersions.empty()) {

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2947,6 +2947,8 @@ void Dumper::printSymbol(const SymbolRef &Symbol,
                               Symbol.getRawDataRefImpl()));
   else if (O.isELF())
     outs() << '\t' << format(Fmt, ELFSymbolRef(Symbol).getSize());
+  else if (O.isWasm())
+    outs() << '\t' << format(Fmt, cast<WasmObjectFile>(O).getSymbolSize(Symbol));
 
   if (O.isELF()) {
     if (!SymbolVersions.empty()) {


### PR DESCRIPTION
nm already prints sizes for data symbols. Do that for function symbols too,
and update objdump to also print size information.

Implements item 3 from https://github.com/llvm/llvm-project/issues/76107