### PR TITLE
[lldb][progress] Add progress manager class

### DIFF
--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -136,9 +136,6 @@ public:
   static ProgressManager &Instance();
 
 private:
-  /// Manage the class instance internally.
-  static ProgressManager &InstanceImpl();
-
   llvm::StringMap<uint64_t> m_progress_category_map;
   std::mutex m_progress_map_mutex;
 };

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -129,18 +129,15 @@ public:
   ProgressManager();
   ~ProgressManager();
 
-  static void Initialize();
-  static void Terminate();
-  // Control the refcount of the progress report category as needed
+  /// Control the refcount of the progress report category as needed.
   void Increment(std::string category);
   void Decrement(std::string category);
 
-  // Public accessor for the class instance
   static ProgressManager &Instance();
 
 private:
-  // Manage the class instance internally using a std::optional
-  static std::optional<ProgressManager> &InstanceImpl();
+  /// Manage the class instance internally.
+  static ProgressManager &InstanceImpl();
 
   llvm::StringMap<uint64_t> m_progress_category_map;
   std::mutex m_progress_map_mutex;

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-types.h"
+#include "llvm/ADT/StringMap.h"
 #include <atomic>
 #include <mutex>
 #include <optional>
@@ -117,6 +118,32 @@ private:
   /// to ensure that we don't send progress updates after progress has
   /// completed.
   bool m_complete = false;
+};
+
+/// A class used to group progress reports by category. This is done by using a
+/// map that maintains a refcount of each category of progress reports that have
+/// come in. Keeping track of progress reports this way will be done if a
+/// debugger is listening to the eBroadcastBitProgressByCategory broadcast bit.
+class ProgressManager {
+public:
+  ProgressManager();
+  ~ProgressManager();
+
+  static void Initialize();
+  static void Terminate();
+  // Control the refcount of the progress report category as needed
+  void Increment(std::string category);
+  void Decrement(std::string category);
+
+  // Public accessor for the class instance
+  static ProgressManager &Instance();
+
+private:
+  // Manage the class instance internally using a std::optional
+  static std::optional<ProgressManager> &InstanceImpl();
+
+  llvm::StringMap<uint64_t> m_progress_category_map;
+  std::mutex m_progress_map_mutex;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -86,22 +86,18 @@ ProgressManager &ProgressManager::Instance() { return InstanceImpl(); }
 
 void ProgressManager::Increment(std::string title) {
   std::lock_guard<std::mutex> lock(m_progress_map_mutex);
-  auto pair = m_progress_category_map.insert(std::pair(title, 1));
-
-  // If pair.first is not empty after insertion it means that that
-  // category was entered for the first time and should not be incremented.
-  if (!pair.second)
-    ++pair.first->second;
+  m_progress_category_map[title]++;
 }
 
 void ProgressManager::Decrement(std::string title) {
   std::lock_guard<std::mutex> lock(m_progress_map_mutex);
   auto pos = m_progress_category_map.find(title);
 
-  if (pos == m_progress_category_map.end() || pos->second == 0)
+  if (pos == m_progress_category_map.end())
     return;
 
-  // Remove the category from the map if the refcount reaches 0.
-  if (--pos->second == 0)
+  if (pos->second <= 1)
     m_progress_category_map.erase(title);
+  else
+    --pos->second;
 }

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -68,7 +68,11 @@ void Progress::ReportProgress() {
   }
 }
 
-ProgressManager &ProgressManager::InstanceImpl() {
+ProgressManager::ProgressManager() : m_progress_category_map() {}
+
+ProgressManager::~ProgressManager() {}
+
+ProgressManager &ProgressManager::Instance() {
   static std::once_flag g_once_flag;
   static ProgressManager *g_progress_manager = nullptr;
   std::call_once(g_once_flag, []() {
@@ -77,12 +81,6 @@ ProgressManager &ProgressManager::InstanceImpl() {
   });
   return *g_progress_manager;
 }
-
-ProgressManager::ProgressManager() : m_progress_category_map() {}
-
-ProgressManager::~ProgressManager() {}
-
-ProgressManager &ProgressManager::Instance() { return InstanceImpl(); }
 
 void ProgressManager::Increment(std::string title) {
   std::lock_guard<std::mutex> lock(m_progress_map_mutex);


### PR DESCRIPTION
Per discussions from https://github.com/llvm/llvm-project/pull/81026, it was decided that having a class that manages a map of progress reports would be beneficial in order to categorize them. This class is a part of the overall `Progress` class and utilizes a map that keeps a count of how many times a progress report category has been sent. This would be used with the new debugger broadcast bit added in https://github.com/llvm/llvm-project/pull/81169 so that a user listening with that bit will receive grouped progress reports.