### PR TITLE
[DominanceFrontierBase] Fix doc of compare()'s  return value.

### DIFF
--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -101,8 +101,8 @@ public:
   /// return true;
   bool compareDomSet(DomSetType &DS1, const DomSetType &DS2) const;
 
-  /// compare - Return true if the other dominance frontier base matches
-  /// this dominance frontier base. Otherwise return false.
+  /// compare - Return false if the other dominance frontier base matches
+  /// this dominance frontier base. Otherwise return true.
   bool compare(DominanceFrontierBase &Other) const;
 
   /// print - Convert to human readable form


### PR DESCRIPTION
This is a trivial fix ( I guess it has not been noticed because of no use). Currently, the doc says the function returns `true` if two instances of `DominanceFrontierBase` matches, otherwise `false` is returned. I have checked the implementation

https://github.com/llvm/llvm-project/blob/9308d6688c673606fee1625d777a52539ae72015/llvm/include/llvm/Analysis/DominanceFrontierImpl.h#L71-L94

which examines whether two dominance frontier mappings are equal, and the actual value it returns contradicts the description in the doc.