### PR TITLE
[Clang][Sema] Fix missing warning when comparing mismatched enums in …

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -161,6 +161,9 @@ Improvements to Clang's time-trace
 
 Bug Fixes in This Version
 -------------------------
+- Fixed missing warnings when comparing mismatched enumeration constants
+  in C (`#29217 <https://github.com/llvm/llvm-project/issues/29217>`).
+
 - Clang now accepts elaborated-type-specifiers that explicitly specialize
   a member class template for an implicit instantiation of a class template.
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -40,26 +40,26 @@
 #include <optional>
 
 namespace clang {
-  class APValue;
-  class ASTContext;
-  class BlockDecl;
-  class CXXBaseSpecifier;
-  class CXXMemberCallExpr;
-  class CXXOperatorCallExpr;
-  class CastExpr;
-  class Decl;
-  class IdentifierInfo;
-  class MaterializeTemporaryExpr;
-  class NamedDecl;
-  class ObjCPropertyRefExpr;
-  class OpaqueValueExpr;
-  class ParmVarDecl;
-  class StringLiteral;
-  class TargetInfo;
-  class ValueDecl;
+class APValue;
+class ASTContext;
+class BlockDecl;
+class CXXBaseSpecifier;
+class CXXMemberCallExpr;
+class CXXOperatorCallExpr;
+class CastExpr;
+class Decl;
+class IdentifierInfo;
+class MaterializeTemporaryExpr;
+class NamedDecl;
+class ObjCPropertyRefExpr;
+class OpaqueValueExpr;
+class ParmVarDecl;
+class StringLiteral;
+class TargetInfo;
+class ValueDecl;
 
 /// A simple array of base specifiers.
-typedef SmallVector<CXXBaseSpecifier*, 4> CXXCastPath;
+typedef SmallVector<CXXBaseSpecifier *, 4> CXXCastPath;
 
 /// An adjustment to be made to the temporary created when emitting a
 /// reference binding, which accesses a particular subobject of that temporary.
@@ -88,7 +88,7 @@ struct SubobjectAdjustment {
 
   SubobjectAdjustment(const CastExpr *BasePath,
                       const CXXRecordDecl *DerivedClass)
-    : Kind(DerivedToBaseAdjustment) {
+      : Kind(DerivedToBaseAdjustment) {
     DerivedToBase.BasePath = BasePath;
     DerivedToBase.DerivedClass = DerivedClass;
   }
@@ -98,7 +98,7 @@ struct SubobjectAdjustment {
   }
 
   SubobjectAdjustment(const MemberPointerType *MPT, Expr *RHS)
-    : Kind(MemberPointerAdjustment) {
+      : Kind(MemberPointerAdjustment) {
     this->Ptr.MPT = MPT;
     this->Ptr.RHS = RHS;
   }
@@ -112,10 +112,10 @@ class Expr : public ValueStmt {
 
 public:
   Expr() = delete;
-  Expr(const Expr&) = delete;
+  Expr(const Expr &) = delete;
   Expr(Expr &&) = delete;
-  Expr &operator=(const Expr&) = delete;
-  Expr &operator=(Expr&&) = delete;
+  Expr &operator=(const Expr &) = delete;
+  Expr &operator=(Expr &&) = delete;
 
 protected:
   Expr(StmtClass SC, QualType T, ExprValueKind VK, ExprObjectKind OK)
@@ -128,7 +128,7 @@ protected:
   }
 
   /// Construct an empty expression.
-  explicit Expr(StmtClass SC, EmptyShell) : ValueStmt(SC) { }
+  explicit Expr(StmtClass SC, EmptyShell) : ValueStmt(SC) {}
 
   /// Each concrete expr subclass is expected to compute its dependence and call
   /// this in the constructor.
@@ -152,6 +152,12 @@ public:
 
     TR = t;
   }
+
+  /// If this expression is an enumeration constant, return the
+  /// enumeration type under which said constant was declared.
+  /// Otherwise return the expression's type.
+  /// Note this effectively circumvents the weak typing of C's enum constants
+  QualType getEnumCoercedType(const ASTContext &Ctx) const;
 
   ExprDependence getDependence() const {
     return static_cast<ExprDependence>(ExprBits.Dependent);
@@ -294,7 +300,7 @@ public:
     MLV_IncompleteVoidType,
     MLV_DuplicateVectorComponents,
     MLV_InvalidExpression,
-    MLV_LValueCast,           // Specialized form of MLV_InvalidExpression.
+    MLV_LValueCast, // Specialized form of MLV_InvalidExpression.
     MLV_IncompleteType,
     MLV_ConstQualified,
     MLV_ConstQualifiedField,
@@ -327,25 +333,26 @@ public:
     enum Kinds {
       CL_LValue,
       CL_XValue,
-      CL_Function, // Functions cannot be lvalues in C.
-      CL_Void, // Void cannot be an lvalue in C.
+      CL_Function,        // Functions cannot be lvalues in C.
+      CL_Void,            // Void cannot be an lvalue in C.
       CL_AddressableVoid, // Void expression whose address can be taken in C.
       CL_DuplicateVectorComponents, // A vector shuffle with dupes.
       CL_MemberFunction, // An expression referring to a member function
       CL_SubObjCPropertySetting,
-      CL_ClassTemporary, // A temporary of class type, or subobject thereof.
-      CL_ArrayTemporary, // A temporary of array type.
+      CL_ClassTemporary,    // A temporary of class type, or subobject thereof.
+      CL_ArrayTemporary,    // A temporary of array type.
       CL_ObjCMessageRValue, // ObjC message is an rvalue
-      CL_PRValue // A prvalue for any other reason, of any other type
+      CL_PRValue            // A prvalue for any other reason, of any other type
     };
     /// The results of modification testing.
     enum ModifiableType {
       CM_Untested, // testModifiable was false.
       CM_Modifiable,
-      CM_RValue, // Not modifiable because it's an rvalue
-      CM_Function, // Not modifiable because it's a function; C++ only
+      CM_RValue,     // Not modifiable because it's an rvalue
+      CM_Function,   // Not modifiable because it's a function; C++ only
       CM_LValueCast, // Same as CM_RValue, but indicates GCC cast-as-lvalue ext
-      CM_NoSetterProperty,// Implicit assignment to ObjC property without setter
+      CM_NoSetterProperty, // Implicit assignment to ObjC property without
+                           // setter
       CM_ConstQualified,
       CM_ConstQualifiedField,
       CM_ConstAddrSpace,
@@ -360,8 +367,7 @@ public:
     unsigned short Modifiable;
 
     explicit Classification(Kinds k, ModifiableType m)
-      : Kind(k), Modifiable(m)
-    {}
+        : Kind(k), Modifiable(m) {}
 
   public:
     Classification() {}
@@ -382,7 +388,6 @@ public:
     static Classification makeSimpleLValue() {
       return Classification(CL_LValue, CM_Modifiable);
     }
-
   };
   /// Classify - Classify this expression according to the C++11
   ///        expression taxonomy.
@@ -408,7 +413,8 @@ public:
   /// expression is modifiable (C99 6.3.2.1p1).
   /// \param Loc A source location that might be filled with a relevant location
   ///            if the expression is not modifiable.
-  Classification ClassifyModifiable(ASTContext &Ctx, SourceLocation &Loc) const{
+  Classification ClassifyModifiable(ASTContext &Ctx,
+                                    SourceLocation &Loc) const {
     return ClassifyImpl(Ctx, &Loc);
   }
 
@@ -421,9 +427,9 @@ public:
   static ExprValueKind getValueKindForType(QualType T) {
     if (const ReferenceType *RT = T->getAs<ReferenceType>())
       return (isa<LValueReferenceType>(RT)
-                ? VK_LValue
-                : (RT->getPointeeType()->isFunctionType()
-                     ? VK_LValue : VK_XValue));
+                  ? VK_LValue
+                  : (RT->getPointeeType()->isFunctionType() ? VK_LValue
+                                                            : VK_XValue));
     return VK_PRValue;
   }
 
@@ -454,7 +460,6 @@ private:
   Classification ClassifyImpl(ASTContext &Ctx, SourceLocation *Loc) const;
 
 public:
-
   /// Returns true if this expression is a gl-value that
   /// potentially refers to a bit-field.
   ///
@@ -472,12 +477,19 @@ public:
   FieldDecl *getSourceBitField();
 
   const FieldDecl *getSourceBitField() const {
-    return const_cast<Expr*>(this)->getSourceBitField();
+    return const_cast<Expr *>(this)->getSourceBitField();
+  }
+
+  /// If this expression refers to an enum constant, retrieve its declaration
+  EnumConstantDecl *getEnumConstantDecl();
+
+  const EnumConstantDecl *getEnumConstantDecl() const {
+    return const_cast<Expr *>(this)->getEnumConstantDecl();
   }
 
   Decl *getReferencedDeclOfCallee();
   const Decl *getReferencedDeclOfCallee() const {
-    return const_cast<Expr*>(this)->getReferencedDeclOfCallee();
+    return const_cast<Expr *>(this)->getReferencedDeclOfCallee();
   }
 
   /// If this expression is an l-value for an Objective C
@@ -500,9 +512,7 @@ public:
   bool refersToGlobalRegisterVar() const;
 
   /// Returns whether this expression has a placeholder type.
-  bool hasPlaceholderType() const {
-    return getType()->isPlaceholderType();
-  }
+  bool hasPlaceholderType() const { return getType()->isPlaceholderType(); }
 
   /// Returns whether this expression has a specific placeholder type.
   bool hasPlaceholderType(BuiltinType::Kind K) const {
@@ -562,19 +572,18 @@ public:
   /// might be usable in a constant expression in C++11, if it were marked
   /// constexpr. Return false if the function can never produce a constant
   /// expression, along with diagnostics describing why not.
-  static bool isPotentialConstantExpr(const FunctionDecl *FD,
-                                      SmallVectorImpl<
-                                        PartialDiagnosticAt> &Diags);
+  static bool
+  isPotentialConstantExpr(const FunctionDecl *FD,
+                          SmallVectorImpl<PartialDiagnosticAt> &Diags);
 
   /// isPotentialConstantExprUnevaluated - Return true if this expression might
   /// be usable in a constant expression in C++11 in an unevaluated context, if
   /// it were in function FD marked constexpr. Return false if the function can
   /// never produce a constant expression, along with diagnostics describing
   /// why not.
-  static bool isPotentialConstantExprUnevaluated(Expr *E,
-                                                 const FunctionDecl *FD,
-                                                 SmallVectorImpl<
-                                                   PartialDiagnosticAt> &Diags);
+  static bool isPotentialConstantExprUnevaluated(
+      Expr *E, const FunctionDecl *FD,
+      SmallVectorImpl<PartialDiagnosticAt> &Diags);
 
   /// isConstantInitializer - Returns true if this expression can be emitted to
   /// IR as a constant, and thus can be used as a constant initializer in C.
@@ -620,9 +629,7 @@ public:
 
     // hasSideEffects - Return true if the evaluated expression has
     // side effects.
-    bool hasSideEffects() const {
-      return HasSideEffects;
-    }
+    bool hasSideEffects() const { return HasSideEffects; }
   };
 
   /// EvalResult is a struct with detailed info about an evaluated expression.
@@ -729,7 +736,7 @@ public:
   /// constant.
   bool EvaluateWithSubstitution(APValue &Value, ASTContext &Ctx,
                                 const FunctionDecl *Callee,
-                                ArrayRef<const Expr*> Args,
+                                ArrayRef<const Expr *> Args,
                                 const Expr *This = nullptr) const;
 
   enum class ConstantExprKind {
@@ -815,9 +822,9 @@ public:
   /// isNullPointerConstant - C99 6.3.2.3p3 - Test if this reduces down to
   /// a Null pointer constant. The return value can further distinguish the
   /// kind of NULL pointer constant that was detected.
-  NullPointerConstantKind isNullPointerConstant(
-      ASTContext &Ctx,
-      NullPointerConstantValueDependence NPC) const;
+  NullPointerConstantKind
+  isNullPointerConstant(ASTContext &Ctx,
+                        NullPointerConstantValueDependence NPC) const;
 
   /// isOBJCGCCandidate - Return true if this expression may be used in a read/
   /// write barrier.
@@ -1003,7 +1010,7 @@ public:
   /// Checks that the two Expr's will refer to the same value as a comparison
   /// operand.  The caller must ensure that the values referenced by the Expr's
   /// are not modified between E1 and E2 or the result my be invalid.
-  static bool isSameComparisonOperand(const Expr* E1, const Expr* E2);
+  static bool isSameComparisonOperand(const Expr *E1, const Expr *E2);
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() >= firstExprConstant &&
@@ -1025,16 +1032,16 @@ using ConstantExprKind = Expr::ConstantExprKind;
 /// FullExpr - Represents a "full-expression" node.
 class FullExpr : public Expr {
 protected:
- Stmt *SubExpr;
+  Stmt *SubExpr;
 
- FullExpr(StmtClass SC, Expr *subexpr)
-     : Expr(SC, subexpr->getType(), subexpr->getValueKind(),
-            subexpr->getObjectKind()),
-       SubExpr(subexpr) {
-   setDependence(computeDependence(this));
- }
-  FullExpr(StmtClass SC, EmptyShell Empty)
-    : Expr(SC, Empty) {}
+  FullExpr(StmtClass SC, Expr *subexpr)
+      : Expr(SC, subexpr->getType(), subexpr->getValueKind(),
+             subexpr->getObjectKind()),
+        SubExpr(subexpr) {
+    setDependence(computeDependence(this));
+  }
+  FullExpr(StmtClass SC, EmptyShell Empty) : Expr(SC, Empty) {}
+
 public:
   const Expr *getSubExpr() const { return cast<Expr>(SubExpr); }
   Expr *getSubExpr() { return cast<Expr>(SubExpr); }
@@ -1137,7 +1144,7 @@ public:
   APValue getAPValueResult() const;
   llvm::APSInt getResultAsAPSInt() const;
   // Iterators
-  child_range children() { return child_range(&SubExpr, &SubExpr+1); }
+  child_range children() { return child_range(&SubExpr, &SubExpr + 1); }
   const_child_range children() const {
     return const_child_range(&SubExpr, &SubExpr + 1);
   }
@@ -1171,7 +1178,7 @@ public:
   static const OpaqueValueExpr *findInCopyConstruct(const Expr *expr);
 
   explicit OpaqueValueExpr(EmptyShell Empty)
-    : Expr(OpaqueValueExprClass, Empty) {}
+      : Expr(OpaqueValueExprClass, Empty) {}
 
   /// Retrieve the location of this expression.
   SourceLocation getLocation() const { return OpaqueValueExprBits.Loc; }
@@ -1483,7 +1490,7 @@ class IntegerLiteral : public Expr, public APIntStorage {
 
   /// Construct an empty integer literal.
   explicit IntegerLiteral(EmptyShell Empty)
-    : Expr(IntegerLiteralClass, Empty) { }
+      : Expr(IntegerLiteralClass, Empty) {}
 
 public:
   // type should be IntTy, LongTy, LongLongTy, UnsignedIntTy, UnsignedLongTy,
@@ -1529,7 +1536,7 @@ class FixedPointLiteral : public Expr, public APIntStorage {
   explicit FixedPointLiteral(EmptyShell Empty)
       : Expr(FixedPointLiteralClass, Empty) {}
 
- public:
+public:
   FixedPointLiteral(const ASTContext &C, const llvm::APInt &V, QualType type,
                     SourceLocation l, unsigned Scale);
 
@@ -1573,6 +1580,7 @@ enum class CharacterLiteralKind { Ascii, Wide, UTF8, UTF16, UTF32 };
 class CharacterLiteral : public Expr {
   unsigned Value;
   SourceLocation Loc;
+
 public:
   // type should be IntTy
   CharacterLiteral(unsigned value, CharacterLiteralKind kind, QualType type,
@@ -1584,7 +1592,7 @@ public:
   }
 
   /// Construct an empty character literal.
-  CharacterLiteral(EmptyShell Empty) : Expr(CharacterLiteralClass, Empty) { }
+  CharacterLiteral(EmptyShell Empty) : Expr(CharacterLiteralClass, Empty) {}
 
   SourceLocation getLocation() const { return Loc; }
   CharacterLiteralKind getKind() const {
@@ -1698,6 +1706,7 @@ public:
 ///
 class ImaginaryLiteral : public Expr {
   Stmt *Val;
+
 public:
   ImaginaryLiteral(Expr *val, QualType Ty)
       : Expr(ImaginaryLiteralClass, Ty, VK_PRValue, OK_Ordinary), Val(val) {
@@ -1706,7 +1715,7 @@ public:
 
   /// Build an empty imaginary literal.
   explicit ImaginaryLiteral(EmptyShell Empty)
-    : Expr(ImaginaryLiteralClass, Empty) { }
+      : Expr(ImaginaryLiteralClass, Empty) {}
 
   const Expr *getSubExpr() const { return cast<Expr>(Val); }
   Expr *getSubExpr() { return cast<Expr>(Val); }
@@ -1722,7 +1731,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Val, &Val+1); }
+  child_range children() { return child_range(&Val, &Val + 1); }
   const_child_range children() const {
     return const_child_range(&Val, &Val + 1);
   }
@@ -1875,7 +1884,9 @@ public:
   bool isUTF8() const { return getKind() == StringLiteralKind::UTF8; }
   bool isUTF16() const { return getKind() == StringLiteralKind::UTF16; }
   bool isUTF32() const { return getKind() == StringLiteralKind::UTF32; }
-  bool isUnevaluated() const { return getKind() == StringLiteralKind::Unevaluated; }
+  bool isUnevaluated() const {
+    return getKind() == StringLiteralKind::Unevaluated;
+  }
   bool isPascal() const { return StringLiteralBits.IsPascal; }
 
   bool containsNonAscii() const {
@@ -2105,6 +2116,7 @@ public:
 class ParenExpr : public Expr {
   SourceLocation L, R;
   Stmt *Val;
+
 public:
   ParenExpr(SourceLocation l, SourceLocation r, Expr *val)
       : Expr(ParenExprClass, val->getType(), val->getValueKind(),
@@ -2114,8 +2126,7 @@ public:
   }
 
   /// Construct an empty parenthesized expression.
-  explicit ParenExpr(EmptyShell Empty)
-    : Expr(ParenExprClass, Empty) { }
+  explicit ParenExpr(EmptyShell Empty) : Expr(ParenExprClass, Empty) {}
 
   const Expr *getSubExpr() const { return cast<Expr>(Val); }
   Expr *getSubExpr() { return cast<Expr>(Val); }
@@ -2137,7 +2148,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Val, &Val+1); }
+  child_range children() { return child_range(&Val, &Val + 1); }
   const_child_range children() const {
     return const_child_range(&Val, &Val + 1);
   }
@@ -2234,9 +2245,7 @@ public:
   }
 
   /// isPrefix - Return true if this is a prefix operation, like --x.
-  static bool isPrefix(Opcode Op) {
-    return Op == UO_PreInc || Op == UO_PreDec;
-  }
+  static bool isPrefix(Opcode Op) { return Op == UO_PreInc || Op == UO_PreDec; }
 
   bool isPrefix() const { return isPrefix(getOpcode()); }
   bool isPostfix() const { return isPostfix(getOpcode()); }
@@ -2244,16 +2253,12 @@ public:
   static bool isIncrementOp(Opcode Op) {
     return Op == UO_PreInc || Op == UO_PostInc;
   }
-  bool isIncrementOp() const {
-    return isIncrementOp(getOpcode());
-  }
+  bool isIncrementOp() const { return isIncrementOp(getOpcode()); }
 
   static bool isDecrementOp(Opcode Op) {
     return Op == UO_PreDec || Op == UO_PostDec;
   }
-  bool isDecrementOp() const {
-    return isDecrementOp(getOpcode());
-  }
+  bool isDecrementOp() const { return isDecrementOp(getOpcode()); }
 
   static bool isIncrementDecrementOp(Opcode Op) { return Op <= UO_PreDec; }
   bool isIncrementDecrementOp() const {
@@ -2290,7 +2295,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Val, &Val+1); }
+  child_range children() { return child_range(&Val, &Val + 1); }
   const_child_range children() const {
     return const_child_range(&Val, &Val + 1);
   }
@@ -2450,24 +2455,22 @@ class OffsetOfExpr final
     return NumComps;
   }
 
-  OffsetOfExpr(const ASTContext &C, QualType type,
-               SourceLocation OperatorLoc, TypeSourceInfo *tsi,
-               ArrayRef<OffsetOfNode> comps, ArrayRef<Expr*> exprs,
-               SourceLocation RParenLoc);
+  OffsetOfExpr(const ASTContext &C, QualType type, SourceLocation OperatorLoc,
+               TypeSourceInfo *tsi, ArrayRef<OffsetOfNode> comps,
+               ArrayRef<Expr *> exprs, SourceLocation RParenLoc);
 
   explicit OffsetOfExpr(unsigned numComps, unsigned numExprs)
-    : Expr(OffsetOfExprClass, EmptyShell()),
-      TSInfo(nullptr), NumComps(numComps), NumExprs(numExprs) {}
+      : Expr(OffsetOfExprClass, EmptyShell()), TSInfo(nullptr),
+        NumComps(numComps), NumExprs(numExprs) {}
 
 public:
-
   static OffsetOfExpr *Create(const ASTContext &C, QualType type,
                               SourceLocation OperatorLoc, TypeSourceInfo *tsi,
                               ArrayRef<OffsetOfNode> comps,
-                              ArrayRef<Expr*> exprs, SourceLocation RParenLoc);
+                              ArrayRef<Expr *> exprs, SourceLocation RParenLoc);
 
-  static OffsetOfExpr *CreateEmpty(const ASTContext &C,
-                                   unsigned NumComps, unsigned NumExprs);
+  static OffsetOfExpr *CreateEmpty(const ASTContext &C, unsigned NumComps,
+                                   unsigned NumExprs);
 
   /// getOperatorLoc - Return the location of the operator.
   SourceLocation getOperatorLoc() const { return OperatorLoc; }
@@ -2477,12 +2480,8 @@ public:
   SourceLocation getRParenLoc() const { return RParenLoc; }
   void setRParenLoc(SourceLocation R) { RParenLoc = R; }
 
-  TypeSourceInfo *getTypeSourceInfo() const {
-    return TSInfo;
-  }
-  void setTypeSourceInfo(TypeSourceInfo *tsi) {
-    TSInfo = tsi;
-  }
+  TypeSourceInfo *getTypeSourceInfo() const { return TSInfo; }
+  void setTypeSourceInfo(TypeSourceInfo *tsi) { TSInfo = tsi; }
 
   const OffsetOfNode &getComponent(unsigned Idx) const {
     assert(Idx < NumComps && "Subscript out of range");
@@ -2494,11 +2493,9 @@ public:
     getTrailingObjects<OffsetOfNode>()[Idx] = ON;
   }
 
-  unsigned getNumComponents() const {
-    return NumComps;
-  }
+  unsigned getNumComponents() const { return NumComps; }
 
-  Expr* getIndexExpr(unsigned Idx) {
+  Expr *getIndexExpr(unsigned Idx) {
     assert(Idx < NumExprs && "Subscript out of range");
     return getTrailingObjects<Expr *>()[Idx];
   }
@@ -2508,14 +2505,12 @@ public:
     return getTrailingObjects<Expr *>()[Idx];
   }
 
-  void setIndexExpr(unsigned Idx, Expr* E) {
+  void setIndexExpr(unsigned Idx, Expr *E) {
     assert(Idx < NumComps && "Subscript out of range");
     getTrailingObjects<Expr *>()[Idx] = E;
   }
 
-  unsigned getNumExpressions() const {
-    return NumExprs;
-  }
+  unsigned getNumExpressions() const { return NumExprs; }
 
   SourceLocation getBeginLoc() const LLVM_READONLY { return OperatorLoc; }
   SourceLocation getEndLoc() const LLVM_READONLY { return RParenLoc; }
@@ -2570,7 +2565,7 @@ public:
 
   /// Construct an empty sizeof/alignof expression.
   explicit UnaryExprOrTypeTraitExpr(EmptyShell Empty)
-    : Expr(UnaryExprOrTypeTraitExprClass, Empty) { }
+      : Expr(UnaryExprOrTypeTraitExprClass, Empty) {}
 
   UnaryExprOrTypeTrait getKind() const {
     return static_cast<UnaryExprOrTypeTrait>(UnaryExprOrTypeTraitExprBits.Kind);
@@ -2583,19 +2578,17 @@ public:
   }
 
   bool isArgumentType() const { return UnaryExprOrTypeTraitExprBits.IsType; }
-  QualType getArgumentType() const {
-    return getArgumentTypeInfo()->getType();
-  }
+  QualType getArgumentType() const { return getArgumentTypeInfo()->getType(); }
   TypeSourceInfo *getArgumentTypeInfo() const {
     assert(isArgumentType() && "calling getArgumentType() when arg is expr");
     return Argument.Ty;
   }
   Expr *getArgumentExpr() {
     assert(!isArgumentType() && "calling getArgumentExpr() when arg is type");
-    return static_cast<Expr*>(Argument.Ex);
+    return static_cast<Expr *>(Argument.Ex);
   }
   const Expr *getArgumentExpr() const {
-    return const_cast<UnaryExprOrTypeTraitExpr*>(this)->getArgumentExpr();
+    return const_cast<UnaryExprOrTypeTraitExpr *>(this)->getArgumentExpr();
   }
 
   void setArgument(Expr *E) {
@@ -2654,7 +2647,7 @@ public:
 
   /// Create an empty array subscript expression.
   explicit ArraySubscriptExpr(EmptyShell Shell)
-    : Expr(ArraySubscriptExprClass, Shell) { }
+      : Expr(ArraySubscriptExprClass, Shell) {}
 
   /// An array access can be written A[4] or 4[A] (both are equivalent).
   /// - getBase() and getIdx() always present the normalized view: A[4].
@@ -2701,7 +2694,7 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[0]+END_EXPR);
+    return child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
   }
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
@@ -3200,15 +3193,13 @@ class MemberExpr final
       : Expr(MemberExprClass, Empty), Base(), MemberDecl() {}
 
 public:
-  static MemberExpr *Create(const ASTContext &C, Expr *Base, bool IsArrow,
-                            SourceLocation OperatorLoc,
-                            NestedNameSpecifierLoc QualifierLoc,
-                            SourceLocation TemplateKWLoc, ValueDecl *MemberDecl,
-                            DeclAccessPair FoundDecl,
-                            DeclarationNameInfo MemberNameInfo,
-                            const TemplateArgumentListInfo *TemplateArgs,
-                            QualType T, ExprValueKind VK, ExprObjectKind OK,
-                            NonOdrUseReason NOUR);
+  static MemberExpr *
+  Create(const ASTContext &C, Expr *Base, bool IsArrow,
+         SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
+         SourceLocation TemplateKWLoc, ValueDecl *MemberDecl,
+         DeclAccessPair FoundDecl, DeclarationNameInfo MemberNameInfo,
+         const TemplateArgumentListInfo *TemplateArgs, QualType T,
+         ExprValueKind VK, ExprObjectKind OK, NonOdrUseReason NOUR);
 
   /// Create an implicit MemberExpr, with no location, qualifier, template
   /// arguments, and so on. Suitable only for non-static member access.
@@ -3329,8 +3320,8 @@ public:
 
   /// Retrieve the member declaration name info.
   DeclarationNameInfo getMemberNameInfo() const {
-    return DeclarationNameInfo(MemberDecl->getDeclName(),
-                               MemberLoc, MemberDNLoc);
+    return DeclarationNameInfo(MemberDecl->getDeclName(), MemberLoc,
+                               MemberDNLoc);
   }
 
   SourceLocation getOperatorLoc() const { return MemberExprBits.OperatorLoc; }
@@ -3384,7 +3375,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Base, &Base+1); }
+  child_range children() { return child_range(&Base, &Base + 1); }
   const_child_range children() const {
     return const_child_range(&Base, &Base + 1);
   }
@@ -3403,6 +3394,7 @@ class CompoundLiteralExpr : public Expr {
   /// The int part of the pair stores whether this expr is file scope.
   llvm::PointerIntPair<TypeSourceInfo *, 1, bool> TInfoAndScope;
   Stmt *Init;
+
 public:
   CompoundLiteralExpr(SourceLocation lparenloc, TypeSourceInfo *tinfo,
                       QualType T, ExprValueKind VK, Expr *init, bool fileScope)
@@ -3413,7 +3405,7 @@ public:
 
   /// Construct an empty compound literal.
   explicit CompoundLiteralExpr(EmptyShell Empty)
-    : Expr(CompoundLiteralExprClass, Empty) { }
+      : Expr(CompoundLiteralExprClass, Empty) {}
 
   const Expr *getInitializer() const { return cast<Expr>(Init); }
   Expr *getInitializer() { return cast<Expr>(Init); }
@@ -3452,7 +3444,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Init, &Init+1); }
+  child_range children() { return child_range(&Init, &Init + 1); }
   const_child_range children() const {
     return const_child_range(&Init, &Init + 1);
   }
@@ -3467,8 +3459,8 @@ class CastExpr : public Expr {
 
   bool CastConsistency() const;
 
-  const CXXBaseSpecifier * const *path_buffer() const {
-    return const_cast<CastExpr*>(this)->path_buffer();
+  const CXXBaseSpecifier *const *path_buffer() const {
+    return const_cast<CastExpr *>(this)->path_buffer();
   }
   CXXBaseSpecifier **path_buffer();
 
@@ -3506,7 +3498,7 @@ protected:
   }
 
 public:
-  CastKind getCastKind() const { return (CastKind) CastExprBits.Kind; }
+  CastKind getCastKind() const { return (CastKind)CastExprBits.Kind; }
   void setCastKind(CastKind K) { CastExprBits.Kind = K; }
 
   static const char *getCastKindName(CastKind CK);
@@ -3595,7 +3587,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Op, &Op+1); }
+  child_range children() { return child_range(&Op, &Op + 1); }
   const_child_range children() const { return const_child_range(&Op, &Op + 1); }
 };
 
@@ -3727,8 +3719,8 @@ public:
   QualType getTypeAsWritten() const { return TInfo->getType(); }
 
   static bool classof(const Stmt *T) {
-     return T->getStmtClass() >= firstExplicitCastExprConstant &&
-            T->getStmtClass() <= lastExplicitCastExprConstant;
+    return T->getStmtClass() >= firstExplicitCastExprConstant &&
+           T->getStmtClass() <= lastExplicitCastExprConstant;
   }
 };
 
@@ -3892,7 +3884,9 @@ public:
     return Opc >= BO_Mul && Opc <= BO_Rem;
   }
   bool isMultiplicativeOp() const { return isMultiplicativeOp(getOpcode()); }
-  static bool isAdditiveOp(Opcode Opc) { return Opc == BO_Add || Opc==BO_Sub; }
+  static bool isAdditiveOp(Opcode Opc) {
+    return Opc == BO_Add || Opc == BO_Sub;
+  }
   bool isAdditiveOp() const { return isAdditiveOp(getOpcode()); }
   static bool isShiftOp(Opcode Opc) { return Opc == BO_Shl || Opc == BO_Shr; }
   bool isShiftOp() const { return isShiftOp(getOpcode()); }
@@ -3900,13 +3894,17 @@ public:
   static bool isBitwiseOp(Opcode Opc) { return Opc >= BO_And && Opc <= BO_Or; }
   bool isBitwiseOp() const { return isBitwiseOp(getOpcode()); }
 
-  static bool isRelationalOp(Opcode Opc) { return Opc >= BO_LT && Opc<=BO_GE; }
+  static bool isRelationalOp(Opcode Opc) {
+    return Opc >= BO_LT && Opc <= BO_GE;
+  }
   bool isRelationalOp() const { return isRelationalOp(getOpcode()); }
 
   static bool isEqualityOp(Opcode Opc) { return Opc == BO_EQ || Opc == BO_NE; }
   bool isEqualityOp() const { return isEqualityOp(getOpcode()); }
 
-  static bool isComparisonOp(Opcode Opc) { return Opc >= BO_Cmp && Opc<=BO_NE; }
+  static bool isComparisonOp(Opcode Opc) {
+    return Opc >= BO_Cmp && Opc <= BO_NE;
+  }
   bool isComparisonOp() const { return isComparisonOp(getOpcode()); }
 
   static bool isCommaOp(Opcode Opc) { return Opc == BO_Comma; }
@@ -3916,12 +3914,18 @@ public:
     switch (Opc) {
     default:
       llvm_unreachable("Not a comparison operator.");
-    case BO_LT: return BO_GE;
-    case BO_GT: return BO_LE;
-    case BO_LE: return BO_GT;
-    case BO_GE: return BO_LT;
-    case BO_EQ: return BO_NE;
-    case BO_NE: return BO_EQ;
+    case BO_LT:
+      return BO_GE;
+    case BO_GT:
+      return BO_LE;
+    case BO_LE:
+      return BO_GT;
+    case BO_GE:
+      return BO_LT;
+    case BO_EQ:
+      return BO_NE;
+    case BO_NE:
+      return BO_EQ;
     }
   }
 
@@ -3929,17 +3933,23 @@ public:
     switch (Opc) {
     default:
       llvm_unreachable("Not a comparison operator.");
-    case BO_LT: return BO_GT;
-    case BO_GT: return BO_LT;
-    case BO_LE: return BO_GE;
-    case BO_GE: return BO_LE;
+    case BO_LT:
+      return BO_GT;
+    case BO_GT:
+      return BO_LT;
+    case BO_LE:
+      return BO_GE;
+    case BO_GE:
+      return BO_LE;
     case BO_EQ:
     case BO_NE:
       return Opc;
     }
   }
 
-  static bool isLogicalOp(Opcode Opc) { return Opc == BO_LAnd || Opc==BO_LOr; }
+  static bool isLogicalOp(Opcode Opc) {
+    return Opc == BO_LAnd || Opc == BO_LOr;
+  }
   bool isLogicalOp() const { return isLogicalOp(getOpcode()); }
 
   static bool isAssignmentOp(Opcode Opc) {
@@ -3964,9 +3974,7 @@ public:
   static bool isShiftAssignOp(Opcode Opc) {
     return Opc == BO_ShlAssign || Opc == BO_ShrAssign;
   }
-  bool isShiftAssignOp() const {
-    return isShiftAssignOp(getOpcode());
-  }
+  bool isShiftAssignOp() const { return isShiftAssignOp(getOpcode()); }
 
   /// Return true if a binary operator using the specified opcode and operands
   /// would match the 'p = (i8*)nullptr + n' idiom for casting a pointer-sized
@@ -3982,7 +3990,7 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[0]+END_EXPR);
+    return child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
   }
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
@@ -4119,7 +4127,7 @@ protected:
       : Expr(SC, T, VK, OK), QuestionLoc(qloc), ColonLoc(cloc) {}
 
   AbstractConditionalOperator(StmtClass SC, EmptyShell Empty)
-    : Expr(SC, Empty) { }
+      : Expr(SC, Empty) {}
 
 public:
   /// getCond - Return the expression representing the condition for
@@ -4148,9 +4156,10 @@ public:
 /// middle" extension is a BinaryConditionalOperator.
 class ConditionalOperator : public AbstractConditionalOperator {
   enum { COND, LHS, RHS, END_EXPR };
-  Stmt* SubExprs[END_EXPR]; // Left/Middle/Right hand sides.
+  Stmt *SubExprs[END_EXPR]; // Left/Middle/Right hand sides.
 
   friend class ASTStmtReader;
+
 public:
   ConditionalOperator(Expr *cond, SourceLocation QLoc, Expr *lhs,
                       SourceLocation CLoc, Expr *rhs, QualType t,
@@ -4165,7 +4174,7 @@ public:
 
   /// Build an empty conditional operator.
   explicit ConditionalOperator(EmptyShell Empty)
-    : AbstractConditionalOperator(ConditionalOperatorClass, Empty) { }
+      : AbstractConditionalOperator(ConditionalOperatorClass, Empty) {}
 
   /// getCond - Return the expression representing the condition for
   ///   the ?: operator.
@@ -4196,7 +4205,7 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[0]+END_EXPR);
+    return child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
   }
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
@@ -4220,6 +4229,7 @@ class BinaryConditionalOperator : public AbstractConditionalOperator {
   OpaqueValueExpr *OpaqueValue;
 
   friend class ASTStmtReader;
+
 public:
   BinaryConditionalOperator(Expr *common, OpaqueValueExpr *opaqueValue,
                             Expr *cond, Expr *lhs, Expr *rhs,
@@ -4238,7 +4248,7 @@ public:
 
   /// Build an empty conditional operator.
   explicit BinaryConditionalOperator(EmptyShell Empty)
-    : AbstractConditionalOperator(BinaryConditionalOperatorClass, Empty) { }
+      : AbstractConditionalOperator(BinaryConditionalOperatorClass, Empty) {}
 
   /// getCommon - Return the common expression, written to the
   ///   left of the condition.  The opaque value will be bound to the
@@ -4255,16 +4265,12 @@ public:
   /// getTrueExpr - Return the subexpression which will be
   ///   evaluated if the condition evaluates to true;  this is defined
   ///   in terms of the opaque value.
-  Expr *getTrueExpr() const {
-    return cast<Expr>(SubExprs[LHS]);
-  }
+  Expr *getTrueExpr() const { return cast<Expr>(SubExprs[LHS]); }
 
   /// getFalseExpr - Return the subexpression which will be
   ///   evaluated if the condnition evaluates to false; this is
   ///   defined in terms of the opaque value.
-  Expr *getFalseExpr() const {
-    return cast<Expr>(SubExprs[RHS]);
-  }
+  Expr *getFalseExpr() const { return cast<Expr>(SubExprs[RHS]); }
 
   SourceLocation getBeginLoc() const LLVM_READONLY {
     return getCommon()->getBeginLoc();
@@ -4308,6 +4314,7 @@ inline Expr *AbstractConditionalOperator::getFalseExpr() const {
 class AddrLabelExpr : public Expr {
   SourceLocation AmpAmpLoc, LabelLoc;
   LabelDecl *Label;
+
 public:
   AddrLabelExpr(SourceLocation AALoc, SourceLocation LLoc, LabelDecl *L,
                 QualType t)
@@ -4317,8 +4324,7 @@ public:
   }
 
   /// Build an empty address of a label expression.
-  explicit AddrLabelExpr(EmptyShell Empty)
-    : Expr(AddrLabelExprClass, Empty) { }
+  explicit AddrLabelExpr(EmptyShell Empty) : Expr(AddrLabelExprClass, Empty) {}
 
   SourceLocation getAmpAmpLoc() const { return AmpAmpLoc; }
   void setAmpAmpLoc(SourceLocation L) { AmpAmpLoc = L; }
@@ -4353,6 +4359,7 @@ public:
 class StmtExpr : public Expr {
   Stmt *SubStmt;
   SourceLocation LParenLoc, RParenLoc;
+
 public:
   StmtExpr(CompoundStmt *SubStmt, QualType T, SourceLocation LParenLoc,
            SourceLocation RParenLoc, unsigned TemplateDepth)
@@ -4365,7 +4372,7 @@ public:
   }
 
   /// Build an empty statement expression.
-  explicit StmtExpr(EmptyShell Empty) : Expr(StmtExprClass, Empty) { }
+  explicit StmtExpr(EmptyShell Empty) : Expr(StmtExprClass, Empty) {}
 
   CompoundStmt *getSubStmt() { return cast<CompoundStmt>(SubStmt); }
   const CompoundStmt *getSubStmt() const { return cast<CompoundStmt>(SubStmt); }
@@ -4386,7 +4393,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&SubStmt, &SubStmt+1); }
+  child_range children() { return child_range(&SubStmt, &SubStmt + 1); }
   const_child_range children() const {
     return const_child_range(&SubStmt, &SubStmt + 1);
   }
@@ -4409,12 +4416,12 @@ class ShuffleVectorExpr : public Expr {
   unsigned NumExprs;
 
 public:
-  ShuffleVectorExpr(const ASTContext &C, ArrayRef<Expr*> args, QualType Type,
+  ShuffleVectorExpr(const ASTContext &C, ArrayRef<Expr *> args, QualType Type,
                     SourceLocation BLoc, SourceLocation RP);
 
   /// Build an empty vector-shuffle expression.
   explicit ShuffleVectorExpr(EmptyShell Empty)
-    : Expr(ShuffleVectorExprClass, Empty), SubExprs(nullptr) { }
+      : Expr(ShuffleVectorExprClass, Empty), SubExprs(nullptr) {}
 
   SourceLocation getBuiltinLoc() const { return BuiltinLoc; }
   void setBuiltinLoc(SourceLocation L) { BuiltinLoc = L; }
@@ -4451,12 +4458,12 @@ public:
 
   llvm::APSInt getShuffleMaskIdx(const ASTContext &Ctx, unsigned N) const {
     assert((N < NumExprs - 2) && "Shuffle idx out of range!");
-    return getExpr(N+2)->EvaluateKnownConstInt(Ctx);
+    return getExpr(N + 2)->EvaluateKnownConstInt(Ctx);
   }
 
   // Iterators
   child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[0]+NumExprs);
+    return child_range(&SubExprs[0], &SubExprs[0] + NumExprs);
   }
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[0] + NumExprs);
@@ -4474,7 +4481,8 @@ private:
 
   friend class ASTReader;
   friend class ASTStmtReader;
-  explicit ConvertVectorExpr(EmptyShell Empty) : Expr(ConvertVectorExprClass, Empty) {}
+  explicit ConvertVectorExpr(EmptyShell Empty)
+      : Expr(ConvertVectorExprClass, Empty) {}
 
 public:
   ConvertVectorExpr(Expr *SrcExpr, TypeSourceInfo *TI, QualType DstType,
@@ -4489,12 +4497,8 @@ public:
   Expr *getSrcExpr() const { return cast<Expr>(SrcExpr); }
 
   /// getTypeSourceInfo - Return the destination type.
-  TypeSourceInfo *getTypeSourceInfo() const {
-    return TInfo;
-  }
-  void setTypeSourceInfo(TypeSourceInfo *ti) {
-    TInfo = ti;
-  }
+  TypeSourceInfo *getTypeSourceInfo() const { return TInfo; }
+  void setTypeSourceInfo(TypeSourceInfo *ti) { TInfo = ti; }
 
   /// getBuiltinLoc - Return the location of the __builtin_convertvector token.
   SourceLocation getBuiltinLoc() const { return BuiltinLoc; }
@@ -4510,7 +4514,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&SrcExpr, &SrcExpr+1); }
+  child_range children() { return child_range(&SrcExpr, &SrcExpr + 1); }
   const_child_range children() const {
     return const_child_range(&SrcExpr, &SrcExpr + 1);
   }
@@ -4527,9 +4531,10 @@ public:
 ///   sub-expression.
 class ChooseExpr : public Expr {
   enum { COND, LHS, RHS, END_EXPR };
-  Stmt* SubExprs[END_EXPR]; // Left/Middle/Right hand sides.
+  Stmt *SubExprs[END_EXPR]; // Left/Middle/Right hand sides.
   SourceLocation BuiltinLoc, RParenLoc;
   bool CondIsTrue;
+
 public:
   ChooseExpr(SourceLocation BLoc, Expr *cond, Expr *lhs, Expr *rhs, QualType t,
              ExprValueKind VK, ExprObjectKind OK, SourceLocation RP,
@@ -4544,7 +4549,7 @@ public:
   }
 
   /// Build an empty __builtin_choose_expr.
-  explicit ChooseExpr(EmptyShell Empty) : Expr(ChooseExprClass, Empty) { }
+  explicit ChooseExpr(EmptyShell Empty) : Expr(ChooseExprClass, Empty) {}
 
   /// isConditionTrue - Return whether the condition is true (i.e. not
   /// equal to zero).
@@ -4587,7 +4592,7 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[0]+END_EXPR);
+    return child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
   }
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[0] + END_EXPR);
@@ -4611,7 +4616,7 @@ public:
   }
 
   /// Build an empty GNU __null expression.
-  explicit GNUNullExpr(EmptyShell Empty) : Expr(GNUNullExprClass, Empty) { }
+  explicit GNUNullExpr(EmptyShell Empty) : Expr(GNUNullExprClass, Empty) {}
 
   /// getTokenLocation - The location of the __null token.
   SourceLocation getTokenLocation() const { return TokenLoc; }
@@ -4638,6 +4643,7 @@ class VAArgExpr : public Expr {
   Stmt *Val;
   llvm::PointerIntPair<TypeSourceInfo *, 1, bool> TInfo;
   SourceLocation BuiltinLoc, RParenLoc;
+
 public:
   VAArgExpr(SourceLocation BLoc, Expr *e, TypeSourceInfo *TInfo,
             SourceLocation RPLoc, QualType t, bool IsMS)
@@ -4675,7 +4681,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Val, &Val+1); }
+  child_range children() { return child_range(&Val, &Val + 1); }
   const_child_range children() const {
     return const_child_range(&Val, &Val + 1);
   }
@@ -4838,11 +4844,11 @@ class InitListExpr : public Expr {
 
 public:
   InitListExpr(const ASTContext &C, SourceLocation lbraceloc,
-               ArrayRef<Expr*> initExprs, SourceLocation rbraceloc);
+               ArrayRef<Expr *> initExprs, SourceLocation rbraceloc);
 
   /// Build an empty initializer list.
   explicit InitListExpr(EmptyShell Empty)
-    : Expr(InitListExprClass, Empty), AltForm(nullptr, true) { }
+      : Expr(InitListExprClass, Empty), AltForm(nullptr, true) {}
 
   unsigned getNumInits() const { return InitExprs.size(); }
 
@@ -4850,8 +4856,8 @@ public:
   Expr **getInits() { return reinterpret_cast<Expr **>(InitExprs.data()); }
 
   /// Retrieve the set of initializers.
-  Expr * const *getInits() const {
-    return reinterpret_cast<Expr * const *>(InitExprs.data());
+  Expr *const *getInits() const {
+    return reinterpret_cast<Expr *const *>(InitExprs.data());
   }
 
   ArrayRef<Expr *> inits() { return llvm::ArrayRef(getInits(), getNumInits()); }
@@ -4940,10 +4946,9 @@ public:
     return const_cast<InitListExpr *>(this)->getInitializedFieldInUnion();
   }
   void setInitializedFieldInUnion(FieldDecl *FD) {
-    assert((FD == nullptr
-            || getInitializedFieldInUnion() == nullptr
-            || getInitializedFieldInUnion() == FD)
-           && "Only one field of a union may be initialized at a time!");
+    assert((FD == nullptr || getInitializedFieldInUnion() == nullptr ||
+            getInitializedFieldInUnion() == FD) &&
+           "Only one field of a union may be initialized at a time!");
     ArrayFillerOrUnionFieldInit = FD;
   }
 
@@ -4951,9 +4956,7 @@ public:
   // locations). Implicit InitListExpr's are created by the semantic analyzer.
   // FIXME: This is wrong; InitListExprs created by semantic analysis have
   // valid source locations too!
-  bool isExplicit() const {
-    return LBraceLoc.isValid() && RBraceLoc.isValid();
-  }
+  bool isExplicit() const { return LBraceLoc.isValid() && RBraceLoc.isValid(); }
 
   /// Is this an initializer for an array of characters, initialized by a string
   /// literal or an @encode?
@@ -5092,8 +5095,8 @@ private:
                      ArrayRef<Expr *> IndexExprs, Expr *Init);
 
   explicit DesignatedInitExpr(unsigned NumSubExprs)
-    : Expr(DesignatedInitExprClass, EmptyShell()),
-      NumDesignators(0), NumSubExprs(NumSubExprs), Designators(nullptr) { }
+      : Expr(DesignatedInitExprClass, EmptyShell()), NumDesignators(0),
+        NumSubExprs(NumSubExprs), Designators(nullptr) {}
 
 public:
   /// Represents a single C99 designator.
@@ -5145,8 +5148,7 @@ public:
                                  SourceLocation RBracketLoc)
           : Index(Index), LBracketLoc(LBracketLoc), RBracketLoc(RBracketLoc) {}
 
-      ArrayOrRangeDesignatorInfo(unsigned Index,
-                                 SourceLocation LBracketLoc,
+      ArrayOrRangeDesignatorInfo(unsigned Index, SourceLocation LBracketLoc,
                                  SourceLocation EllipsisLoc,
                                  SourceLocation RBracketLoc)
           : Index(Index), LBracketLoc(LBracketLoc), EllipsisLoc(EllipsisLoc),
@@ -5223,8 +5225,8 @@ public:
                                             SourceLocation LBracketLoc,
                                             SourceLocation RBracketLoc) {
       Designator D(ArrayDesignator);
-      new (&D.ArrayOrRangeInfo) ArrayOrRangeDesignatorInfo(Index, LBracketLoc,
-                                                           RBracketLoc);
+      new (&D.ArrayOrRangeInfo)
+          ArrayOrRangeDesignatorInfo(Index, LBracketLoc, RBracketLoc);
       return D;
     }
 
@@ -5234,9 +5236,8 @@ public:
                                                  SourceLocation EllipsisLoc,
                                                  SourceLocation RBracketLoc) {
       Designator D(ArrayRangeDesignator);
-      new (&D.ArrayOrRangeInfo) ArrayOrRangeDesignatorInfo(Index, LBracketLoc,
-                                                           EllipsisLoc,
-                                                           RBracketLoc);
+      new (&D.ArrayOrRangeInfo) ArrayOrRangeDesignatorInfo(
+          Index, LBracketLoc, EllipsisLoc, RBracketLoc);
       return D;
     }
 
@@ -5281,7 +5282,7 @@ public:
 
   static DesignatedInitExpr *Create(const ASTContext &C,
                                     llvm::ArrayRef<Designator> Designators,
-                                    ArrayRef<Expr*> IndexExprs,
+                                    ArrayRef<Expr *> IndexExprs,
                                     SourceLocation EqualOrColonLoc,
                                     bool GNUSyntax, Expr *Init);
 
@@ -5328,12 +5329,10 @@ public:
 
   /// Retrieve the initializer value.
   Expr *getInit() const {
-    return cast<Expr>(*const_cast<DesignatedInitExpr*>(this)->child_begin());
+    return cast<Expr>(*const_cast<DesignatedInitExpr *>(this)->child_begin());
   }
 
-  void setInit(Expr *init) {
-    *child_begin() = init;
-  }
+  void setInit(Expr *init) { *child_begin() = init; }
 
   /// Retrieve the total number of subexpressions in this
   /// designated initializer expression, including the actual
@@ -5371,7 +5370,7 @@ public:
     return child_range(begin, begin + NumSubExprs);
   }
   const_child_range children() const {
-    Stmt * const *begin = getTrailingObjects<Stmt *>();
+    Stmt *const *begin = getTrailingObjects<Stmt *>();
     return const_child_range(begin, begin + NumSubExprs);
   }
 
@@ -5394,8 +5393,7 @@ public:
     setDependence(computeDependence(this));
   }
 
-  explicit NoInitExpr(EmptyShell Empty)
-    : Expr(NoInitExprClass, Empty) { }
+  explicit NoInitExpr(EmptyShell Empty) : Expr(NoInitExprClass, Empty) {}
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == NoInitExprClass;
@@ -5434,7 +5432,7 @@ public:
                            Expr *baseExprs, SourceLocation rBraceLoc);
 
   explicit DesignatedInitUpdateExpr(EmptyShell Empty)
-    : Expr(DesignatedInitUpdateExprClass, Empty) { }
+      : Expr(DesignatedInitUpdateExprClass, Empty) {}
 
   SourceLocation getBeginLoc() const LLVM_READONLY;
   SourceLocation getEndLoc() const LLVM_READONLY;
@@ -5516,9 +5514,7 @@ public:
     return getCommonExpr()->getEndLoc();
   }
 
-  child_range children() {
-    return child_range(SubExprs, SubExprs + 2);
-  }
+  child_range children() { return child_range(SubExprs, SubExprs + 2); }
   const_child_range children() const {
     return const_child_range(SubExprs, SubExprs + 2);
   }
@@ -5576,7 +5572,7 @@ public:
 
   /// Construct an empty implicit value initialization.
   explicit ImplicitValueInitExpr(EmptyShell Empty)
-    : Expr(ImplicitValueInitExprClass, Empty) { }
+      : Expr(ImplicitValueInitExprClass, Empty) {}
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == ImplicitValueInitExprClass;
@@ -5705,9 +5701,7 @@ class GenericSelectionExpr final
   unsigned ResultIndex : 15; // NB: ResultDependentIndex is tied to this width.
   LLVM_PREFERRED_TYPE(bool)
   unsigned IsExprPredicate : 1;
-  enum : unsigned {
-    ResultDependentIndex = 0x7FFF
-  };
+  enum : unsigned { ResultDependentIndex = 0x7FFF };
 
   unsigned getIndexOfControllingExpression() const {
     // If controlled by an expression, the first offset into the Stmt *
@@ -5722,7 +5716,7 @@ class GenericSelectionExpr final
     // If controlled by a type, the first offset into the TypeSourceInfo *
     // trailing array is the controlling type, the associated types follow this.
     assert(isTypePredicate() && "Asking for the controlling type of a "
-                                 "selection expr predicated by an expression");
+                                "selection expr predicated by an expression");
     return 0;
   }
 
@@ -5739,7 +5733,6 @@ class GenericSelectionExpr final
     // TypeSourceInfo * in the trailing array.
     return (int)isTypePredicate();
   }
-
 
   /// The location of the "default" and of the right parenthesis.
   SourceLocation DefaultLoc, RParenLoc;
@@ -5819,7 +5812,7 @@ class GenericSelectionExpr final
         std::conditional_t<Const, const Stmt *const *, Stmt **>;
     using TSIPtrPtrTy = std::conditional_t<Const, const TypeSourceInfo *const *,
                                            TypeSourceInfo **>;
-    StmtPtrPtrTy E; // = nullptr; FIXME: Once support for gcc 4.8 is dropped.
+    StmtPtrPtrTy E;  // = nullptr; FIXME: Once support for gcc 4.8 is dropped.
     TSIPtrPtrTy TSI; // Kept in sync with E.
     unsigned Offset = 0, SelectedOffset = 0;
     AssociationIteratorTy(StmtPtrPtrTy E, TSIPtrPtrTy TSI, unsigned Offset,
@@ -5970,7 +5963,7 @@ public:
   TypeSourceInfo *getControllingType() {
     return getTrailingObjects<TypeSourceInfo *>()[getIndexOfControllingType()];
   }
-  const TypeSourceInfo* getControllingType() const {
+  const TypeSourceInfo *getControllingType() const {
     return getTrailingObjects<TypeSourceInfo *>()[getIndexOfControllingType()];
   }
 
@@ -6084,6 +6077,7 @@ class ExtVectorElementExpr : public Expr {
   Stmt *Base;
   IdentifierInfo *Accessor;
   SourceLocation AccessorLoc;
+
 public:
   ExtVectorElementExpr(QualType ty, ExprValueKind VK, Expr *base,
                        IdentifierInfo &accessor, SourceLocation loc)
@@ -6095,7 +6089,7 @@ public:
 
   /// Build an empty vector element expression.
   explicit ExtVectorElementExpr(EmptyShell Empty)
-    : Expr(ExtVectorElementExprClass, Empty) { }
+      : Expr(ExtVectorElementExprClass, Empty) {}
 
   const Expr *getBase() const { return cast<Expr>(Base); }
   Expr *getBase() { return cast<Expr>(Base); }
@@ -6132,7 +6126,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Base, &Base+1); }
+  child_range children() { return child_range(&Base, &Base + 1); }
   const_child_range children() const {
     return const_child_range(&Base, &Base + 1);
   }
@@ -6143,6 +6137,7 @@ public:
 class BlockExpr : public Expr {
 protected:
   BlockDecl *TheBlock;
+
 public:
   BlockExpr(BlockDecl *BD, QualType ty)
       : Expr(BlockExprClass, ty, VK_PRValue, OK_Ordinary), TheBlock(BD) {
@@ -6150,7 +6145,7 @@ public:
   }
 
   /// Build an empty block expression.
-  explicit BlockExpr(EmptyShell Empty) : Expr(BlockExprClass, Empty) { }
+  explicit BlockExpr(EmptyShell Empty) : Expr(BlockExprClass, Empty) {}
 
   const BlockDecl *getBlockDecl() const { return TheBlock; }
   BlockDecl *getBlockDecl() { return TheBlock; }
@@ -6236,7 +6231,7 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&SrcExpr, &SrcExpr+1); }
+  child_range children() { return child_range(&SrcExpr, &SrcExpr + 1); }
   const_child_range children() const {
     return const_child_range(&SrcExpr, &SrcExpr + 1);
   }
@@ -6285,19 +6280,16 @@ class PseudoObjectExpr final
   // Note also that ASTStmtWriter assumes this encoding.
 
   Expr **getSubExprsBuffer() { return getTrailingObjects<Expr *>(); }
-  const Expr * const *getSubExprsBuffer() const {
+  const Expr *const *getSubExprsBuffer() const {
     return getTrailingObjects<Expr *>();
   }
 
-  PseudoObjectExpr(QualType type, ExprValueKind VK,
-                   Expr *syntactic, ArrayRef<Expr*> semantic,
-                   unsigned resultIndex);
+  PseudoObjectExpr(QualType type, ExprValueKind VK, Expr *syntactic,
+                   ArrayRef<Expr *> semantic, unsigned resultIndex);
 
   PseudoObjectExpr(EmptyShell shell, unsigned numSemanticExprs);
 
-  unsigned getNumSubExprs() const {
-    return PseudoObjectExprBits.NumSubExprs;
-  }
+  unsigned getNumSubExprs() const { return PseudoObjectExprBits.NumSubExprs; }
 
 public:
   /// NoResult - A value for the result index indicating that there is
@@ -6305,7 +6297,7 @@ public:
   enum : unsigned { NoResult = ~0U };
 
   static PseudoObjectExpr *Create(const ASTContext &Context, Expr *syntactic,
-                                  ArrayRef<Expr*> semantic,
+                                  ArrayRef<Expr *> semantic,
                                   unsigned resultIndex);
 
   static PseudoObjectExpr *Create(const ASTContext &Context, EmptyShell shell,
@@ -6320,7 +6312,8 @@ public:
   /// Return the index of the result-bearing expression into the semantics
   /// expressions, or PseudoObjectExpr::NoResult if there is none.
   unsigned getResultExprIndex() const {
-    if (PseudoObjectExprBits.ResultIndex == 0) return NoResult;
+    if (PseudoObjectExprBits.ResultIndex == 0)
+      return NoResult;
     return PseudoObjectExprBits.ResultIndex - 1;
   }
 
@@ -6331,16 +6324,14 @@ public:
     return getSubExprsBuffer()[PseudoObjectExprBits.ResultIndex];
   }
   const Expr *getResultExpr() const {
-    return const_cast<PseudoObjectExpr*>(this)->getResultExpr();
+    return const_cast<PseudoObjectExpr *>(this)->getResultExpr();
   }
 
   unsigned getNumSemanticExprs() const { return getNumSubExprs() - 1; }
 
-  typedef Expr * const *semantics_iterator;
-  typedef const Expr * const *const_semantics_iterator;
-  semantics_iterator semantics_begin() {
-    return getSubExprsBuffer() + 1;
-  }
+  typedef Expr *const *semantics_iterator;
+  typedef const Expr *const *const_semantics_iterator;
+  semantics_iterator semantics_begin() { return getSubExprsBuffer() + 1; }
   const_semantics_iterator semantics_begin() const {
     return getSubExprsBuffer() + 1;
   }
@@ -6351,10 +6342,10 @@ public:
     return getSubExprsBuffer() + getNumSubExprs();
   }
 
-  ArrayRef<Expr*> semantics() {
+  ArrayRef<Expr *> semantics() {
     return ArrayRef(semantics_begin(), semantics_end());
   }
-  ArrayRef<const Expr*> semantics() const {
+  ArrayRef<const Expr *> semantics() const {
     return ArrayRef(semantics_begin(), semantics_end());
   }
 
@@ -6363,7 +6354,7 @@ public:
     return getSubExprsBuffer()[index + 1];
   }
   const Expr *getSemanticExpr(unsigned index) const {
-    return const_cast<PseudoObjectExpr*>(this)->getSemanticExpr(index);
+    return const_cast<PseudoObjectExpr *>(this)->getSemanticExpr(index);
   }
 
   SourceLocation getExprLoc() const LLVM_READONLY {
@@ -6408,7 +6399,7 @@ class AtomicExpr : public Expr {
 public:
   enum AtomicOp {
 #define BUILTIN(ID, TYPE, ATTRS)
-#define ATOMIC_BUILTIN(ID, TYPE, ATTRS) AO ## ID,
+#define ATOMIC_BUILTIN(ID, TYPE, ATTRS) AO##ID,
 #include "clang/Basic/Builtins.inc"
     // Avoid trailing comma
     BI_First = 0
@@ -6425,8 +6416,9 @@ private:
   AtomicOp Op;
 
   friend class ASTStmtReader;
+
 public:
-  AtomicExpr(SourceLocation BLoc, ArrayRef<Expr*> args, QualType t,
+  AtomicExpr(SourceLocation BLoc, ArrayRef<Expr *> args, QualType t,
              AtomicOp op, SourceLocation RP);
 
   /// Determine the number of arguments the specified atomic builtin
@@ -6434,14 +6426,10 @@ public:
   static unsigned getNumSubExprs(AtomicOp Op);
 
   /// Build an empty AtomicExpr.
-  explicit AtomicExpr(EmptyShell Empty) : Expr(AtomicExprClass, Empty) { }
+  explicit AtomicExpr(EmptyShell Empty) : Expr(AtomicExprClass, Empty) {}
 
-  Expr *getPtr() const {
-    return cast<Expr>(SubExprs[PTR]);
-  }
-  Expr *getOrder() const {
-    return cast<Expr>(SubExprs[ORDER]);
-  }
+  Expr *getPtr() const { return cast<Expr>(SubExprs[PTR]); }
+  Expr *getOrder() const { return cast<Expr>(SubExprs[ORDER]); }
   Expr *getScope() const {
     assert(getScopeModel() && "No scope");
     return cast<Expr>(SubExprs[NumSubExprs - 1]);
@@ -6482,8 +6470,8 @@ public:
   unsigned getNumSubExprs() const { return NumSubExprs; }
 
   Expr **getSubExprs() { return reinterpret_cast<Expr **>(SubExprs); }
-  const Expr * const *getSubExprs() const {
-    return reinterpret_cast<Expr * const *>(SubExprs);
+  const Expr *const *getSubExprs() const {
+    return reinterpret_cast<Expr *const *>(SubExprs);
   }
 
   bool isVolatile() const {
@@ -6520,7 +6508,7 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(SubExprs, SubExprs+NumSubExprs);
+    return child_range(SubExprs, SubExprs + NumSubExprs);
   }
   const_child_range children() const {
     return const_child_range(SubExprs, SubExprs + NumSubExprs);
@@ -6577,7 +6565,6 @@ public:
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == TypoExprClass;
   }
-
 };
 
 /// Frontend produces RecoveryExprs on semantic errors that prevent creating

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -371,35 +371,37 @@ static bool SemaBuiltinOverflow(Sema &S, CallExpr *TheCall,
     return true;
 
   std::pair<unsigned, const char *> Builtins[] = {
-    { Builtin::BI__builtin_add_overflow, "ckd_add" },
-    { Builtin::BI__builtin_sub_overflow, "ckd_sub" },
-    { Builtin::BI__builtin_mul_overflow, "ckd_mul" },
+      {Builtin::BI__builtin_add_overflow, "ckd_add"},
+      {Builtin::BI__builtin_sub_overflow, "ckd_sub"},
+      {Builtin::BI__builtin_mul_overflow, "ckd_mul"},
   };
 
-  bool CkdOperation = llvm::any_of(Builtins, [&](const std::pair<unsigned,
-    const char *> &P) {
-    return BuiltinID == P.first && TheCall->getExprLoc().isMacroID() &&
-         Lexer::getImmediateMacroName(TheCall->getExprLoc(),
-         S.getSourceManager(), S.getLangOpts()) == P.second;
-  });
+  bool CkdOperation =
+      llvm::any_of(Builtins, [&](const std::pair<unsigned, const char *> &P) {
+        return BuiltinID == P.first && TheCall->getExprLoc().isMacroID() &&
+               Lexer::getImmediateMacroName(TheCall->getExprLoc(),
+                                            S.getSourceManager(),
+                                            S.getLangOpts()) == P.second;
+      });
 
   auto ValidCkdIntType = [](QualType QT) {
     // A valid checked integer type is an integer type other than a plain char,
     // bool, a bit-precise type, or an enumeration type.
     if (const auto *BT = QT.getCanonicalType()->getAs<BuiltinType>())
       return (BT->getKind() >= BuiltinType::Short &&
-           BT->getKind() <= BuiltinType::Int128) || (
-           BT->getKind() >= BuiltinType::UShort &&
-           BT->getKind() <= BuiltinType::UInt128) ||
-           BT->getKind() == BuiltinType::UChar ||
-           BT->getKind() == BuiltinType::SChar;
+              BT->getKind() <= BuiltinType::Int128) ||
+             (BT->getKind() >= BuiltinType::UShort &&
+              BT->getKind() <= BuiltinType::UInt128) ||
+             BT->getKind() == BuiltinType::UChar ||
+             BT->getKind() == BuiltinType::SChar;
     return false;
   };
 
   // First two arguments should be integers.
   for (unsigned I = 0; I < 2; ++I) {
     ExprResult Arg = S.DefaultFunctionArrayLvalueConversion(TheCall->getArg(I));
-    if (Arg.isInvalid()) return true;
+    if (Arg.isInvalid())
+      return true;
     TheCall->setArg(I, Arg.get());
 
     QualType Ty = Arg.get()->getType();
@@ -416,18 +418,18 @@ static bool SemaBuiltinOverflow(Sema &S, CallExpr *TheCall,
   // the other qualifiers aren't possible.
   {
     ExprResult Arg = S.DefaultFunctionArrayLvalueConversion(TheCall->getArg(2));
-    if (Arg.isInvalid()) return true;
+    if (Arg.isInvalid())
+      return true;
     TheCall->setArg(2, Arg.get());
 
     QualType Ty = Arg.get()->getType();
     const auto *PtrTy = Ty->getAs<PointerType>();
-    if (!PtrTy ||
-        !PtrTy->getPointeeType()->isIntegerType() ||
+    if (!PtrTy || !PtrTy->getPointeeType()->isIntegerType() ||
         (!ValidCkdIntType(PtrTy->getPointeeType()) && CkdOperation) ||
         PtrTy->getPointeeType().isConstQualified()) {
       S.Diag(Arg.get()->getBeginLoc(),
              diag::err_overflow_builtin_must_be_ptr_int)
-        << CkdOperation << Ty << Arg.get()->getSourceRange();
+          << CkdOperation << Ty << Arg.get()->getSourceRange();
       return true;
     }
   }
@@ -545,7 +547,8 @@ struct BuiltinDumpStructGenerator {
     }
 
     analyze_printf::PrintfSpecifier Specifier;
-    if (Specifier.fixType(T, S.getLangOpts(), S.Context, /*IsObjCLiteral=*/false)) {
+    if (Specifier.fixType(T, S.getLangOpts(), S.Context,
+                          /*IsObjCLiteral=*/false)) {
       // We were able to guess how to format this.
       if (Specifier.getConversionSpecifier().getKind() ==
           analyze_printf::PrintfConversionSpecifier::sArg) {
@@ -806,7 +809,7 @@ static bool SemaBuiltinCallWithStaticChain(Sema &S, CallExpr *BuiltinCall) {
   }
 
   QualType ReturnTy = CE->getCallReturnType(S.Context);
-  QualType ArgTys[2] = { ReturnTy, ChainResult.get()->getType() };
+  QualType ArgTys[2] = {ReturnTy, ChainResult.get()->getType()};
   QualType BuiltinTy = S.Context.getFunctionType(
       ReturnTy, ArgTys, FunctionProtoType::ExtProtoInfo());
   QualType BuiltinPtrTy = S.Context.getPointerType(BuiltinTy);
@@ -1551,7 +1554,7 @@ static bool checkOpenCLEnqueueLocalSizeArgs(Sema &S, CallExpr *TheCall,
   bool IllegalParams = false;
   for (unsigned I = Start; I <= End; ++I)
     IllegalParams |= checkOpenCLEnqueueIntType(S, TheCall->getArg(I),
-                                              S.Context.getSizeType());
+                                               S.Context.getSizeType());
   return IllegalParams;
 }
 
@@ -1656,7 +1659,8 @@ static bool SemaOpenCLBuiltinEnqueueKernel(Sema &S, CallExpr *TheCall) {
     // we have a block type, check the prototype
     const BlockPointerType *BPT =
         cast<BlockPointerType>(Arg3->getType().getCanonicalType());
-    if (BPT->getPointeeType()->castAs<FunctionProtoType>()->getNumParams() > 0) {
+    if (BPT->getPointeeType()->castAs<FunctionProtoType>()->getNumParams() >
+        0) {
       S.Diag(Arg3->getBeginLoc(),
              diag::err_opencl_enqueue_kernel_blocks_no_args);
       return true;
@@ -1727,7 +1731,7 @@ static bool SemaOpenCLBuiltinEnqueueKernel(Sema &S, CallExpr *TheCall) {
 
 /// Returns OpenCL access qual.
 static OpenCLAccessAttr *getOpenCLArgAccess(const Decl *D) {
-    return D->getAttr<OpenCLAccessAttr>();
+  return D->getAttr<OpenCLAccessAttr>();
 }
 
 /// Returns true if pipe element type is different from the pointer.
@@ -1936,8 +1940,8 @@ static bool SemaOpenCLBuiltinToAddr(Sema &S, unsigned BuiltinID,
     return true;
 
   auto RT = Call->getArg(0)->getType();
-  if (!RT->isPointerType() || RT->getPointeeType()
-      .getAddressSpace() == LangAS::opencl_constant) {
+  if (!RT->isPointerType() ||
+      RT->getPointeeType().getAddressSpace() == LangAS::opencl_constant) {
     S.Diag(Call->getBeginLoc(), diag::err_opencl_builtin_to_addr_invalid_arg)
         << Call->getArg(0) << Call->getDirectCallee() << Call->getSourceRange();
     return true;
@@ -1965,8 +1969,8 @@ static bool SemaOpenCLBuiltinToAddr(Sema &S, unsigned BuiltinID,
   default:
     llvm_unreachable("Invalid builtin function");
   }
-  Call->setType(S.Context.getPointerType(S.Context.getQualifiedType(
-      RT.getUnqualifiedType(), Qual)));
+  Call->setType(S.Context.getPointerType(
+      S.Context.getQualifiedType(RT.getUnqualifiedType(), Qual)));
 
   return false;
 }
@@ -2185,9 +2189,9 @@ static bool SemaBuiltinCpu(Sema &S, const TargetInfo &TI, CallExpr *TheCall,
   return false;
 }
 
-ExprResult
-Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
-                               CallExpr *TheCall) {
+ExprResult Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl,
+                                          unsigned BuiltinID,
+                                          CallExpr *TheCall) {
   ExprResult TheCallResult(TheCall);
 
   // Find out if any arguments are required to be integer constant expressions.
@@ -2195,12 +2199,13 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   ASTContext::GetBuiltinTypeError Error;
   Context.GetBuiltinType(BuiltinID, Error, &ICEArguments);
   if (Error != ASTContext::GE_None)
-    ICEArguments = 0;  // Don't diagnose previously diagnosed errors.
+    ICEArguments = 0; // Don't diagnose previously diagnosed errors.
 
   // If any arguments are required to be ICE's, check and diagnose.
   for (unsigned ArgNo = 0; ICEArguments != 0; ++ArgNo) {
     // Skip arguments not required to be ICE's.
-    if ((ICEArguments & (1 << ArgNo)) == 0) continue;
+    if ((ICEArguments & (1 << ArgNo)) == 0)
+      continue;
 
     llvm::APSInt Result;
     // If we don't have enough arguments, continue so we can issue better
@@ -2371,7 +2376,8 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       return ExprError();
     break;
   case Builtin::BI__builtin_classify_type:
-    if (checkArgCount(*this, TheCall, 1)) return true;
+    if (checkArgCount(*this, TheCall, 1))
+      return true;
     TheCall->setType(Context.IntTy);
     break;
   case Builtin::BI__builtin_complex:
@@ -2379,9 +2385,11 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       return ExprError();
     break;
   case Builtin::BI__builtin_constant_p: {
-    if (checkArgCount(*this, TheCall, 1)) return true;
+    if (checkArgCount(*this, TheCall, 1))
+      return true;
     ExprResult Arg = DefaultFunctionArrayLvalueConversion(TheCall->getArg(0));
-    if (Arg.isInvalid()) return true;
+    if (Arg.isInvalid())
+      return true;
     TheCall->setArg(0, Arg.get());
     TheCall->setType(Context.IntTy);
     break;
@@ -2523,8 +2531,8 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     break;
   }
 #define BUILTIN(ID, TYPE, ATTRS)
-#define ATOMIC_BUILTIN(ID, TYPE, ATTRS) \
-  case Builtin::BI##ID: \
+#define ATOMIC_BUILTIN(ID, TYPE, ATTRS)                                        \
+  case Builtin::BI##ID:                                                        \
     return SemaAtomicOpsOverloaded(TheCallResult, AtomicExpr::AO##ID);
 #include "clang/Basic/Builtins.inc"
   case Builtin::BI__annotation:
@@ -2921,7 +2929,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     const auto *TyA = Arg->getType()->getAs<VectorType>();
     if (!TyA || !TyA->getElementType()->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1  << /* vector of integers */ 6 << Arg->getType();
+          << 1 << /* vector of integers */ 6 << Arg->getType();
       return ExprError();
     }
     TheCall->setType(TyA->getElementType());
@@ -3373,14 +3381,14 @@ bool Sema::CheckNeonBuiltinFunctionCall(const TargetInfo &TI,
   bool HasConstPtr = false;
   switch (BuiltinID) {
 #define GET_NEON_OVERLOAD_CHECK
-#include "clang/Basic/arm_neon.inc"
 #include "clang/Basic/arm_fp16.inc"
+#include "clang/Basic/arm_neon.inc"
 #undef GET_NEON_OVERLOAD_CHECK
   }
 
   // For NEON intrinsics which are overloaded on vector element type, validate
   // the immediate which specifies which variant to emit.
-  unsigned ImmArg = TheCall->getNumArgs()-1;
+  unsigned ImmArg = TheCall->getNumArgs() - 1;
   if (mask) {
     if (SemaBuiltinConstantArg(TheCall, ImmArg, Result))
       return true;
@@ -3424,10 +3432,10 @@ bool Sema::CheckNeonBuiltinFunctionCall(const TargetInfo &TI,
   switch (BuiltinID) {
   default:
     return false;
-  #define GET_NEON_IMMEDIATE_CHECK
-  #include "clang/Basic/arm_neon.inc"
-  #include "clang/Basic/arm_fp16.inc"
-  #undef GET_NEON_IMMEDIATE_CHECK
+#define GET_NEON_IMMEDIATE_CHECK
+#include "clang/Basic/arm_fp16.inc"
+#include "clang/Basic/arm_neon.inc"
+#undef GET_NEON_IMMEDIATE_CHECK
   }
 
   return SemaBuiltinConstantArgRange(TheCall, i, l, u + l);
@@ -3437,7 +3445,7 @@ bool Sema::CheckMVEBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
   switch (BuiltinID) {
   default:
     return false;
-  #include "clang/Basic/arm_mve_builtin_sema.inc"
+#include "clang/Basic/arm_mve_builtin_sema.inc"
   }
 }
 
@@ -3495,7 +3503,8 @@ bool Sema::CheckARMBuiltinExclusiveCall(unsigned BuiltinID, CallExpr *TheCall,
                  BuiltinID == AArch64::BI__builtin_arm_ldrex ||
                  BuiltinID == AArch64::BI__builtin_arm_ldaex;
 
-  DeclRefExpr *DRE =cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
+  DeclRefExpr *DRE =
+      cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
 
   // Ensure that we have the proper number of arguments.
   if (checkArgCount(*this, TheCall, IsLdrex ? 1 : 2))
@@ -3605,7 +3614,7 @@ bool Sema::CheckARMBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
 
   if (BuiltinID == ARM::BI__builtin_arm_prefetch) {
     return SemaBuiltinConstantArgRange(TheCall, 1, 0, 1) ||
-      SemaBuiltinConstantArgRange(TheCall, 2, 0, 1);
+           SemaBuiltinConstantArgRange(TheCall, 2, 0, 1);
   }
 
   if (BuiltinID == ARM::BI__builtin_arm_rsr64 ||
@@ -3629,7 +3638,8 @@ bool Sema::CheckARMBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   // range check them here.
   // FIXME: VFP Intrinsics should error if VFP not present.
   switch (BuiltinID) {
-  default: return false;
+  default:
+    return false;
   case ARM::BI__builtin_arm_ssat:
     return SemaBuiltinConstantArgRange(TheCall, 1, 1, 32);
   case ARM::BI__builtin_arm_usat:
@@ -3735,11 +3745,18 @@ bool Sema::CheckAArch64BuiltinFunctionCall(const TargetInfo &TI,
   // range check them here.
   unsigned i = 0, l = 0, u = 0;
   switch (BuiltinID) {
-  default: return false;
+  default:
+    return false;
   case AArch64::BI__builtin_arm_dmb:
   case AArch64::BI__builtin_arm_dsb:
-  case AArch64::BI__builtin_arm_isb: l = 0; u = 15; break;
-  case AArch64::BI__builtin_arm_tcancel: l = 0; u = 65535; break;
+  case AArch64::BI__builtin_arm_isb:
+    l = 0;
+    u = 15;
+    break;
+  case AArch64::BI__builtin_arm_tcancel:
+    l = 0;
+    u = 65535;
+    break;
   }
 
   return SemaBuiltinConstantArgRange(TheCall, i, l, u + l);
@@ -3829,8 +3846,7 @@ static bool isValidBPFPreserveEnumValueArg(Expr *Arg) {
   return llvm::is_contained(ET->getDecl()->enumerators(), Enumerator);
 }
 
-bool Sema::CheckBPFBuiltinFunctionCall(unsigned BuiltinID,
-                                       CallExpr *TheCall) {
+bool Sema::CheckBPFBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
   assert((BuiltinID == BPF::BI__builtin_preserve_field_info ||
           BuiltinID == BPF::BI__builtin_btf_type_id ||
           BuiltinID == BPF::BI__builtin_preserve_type_info ||
@@ -3906,223 +3922,209 @@ bool Sema::CheckHexagonBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   };
 
   static BuiltinInfo Infos[] = {
-    { Hexagon::BI__builtin_circ_ldd,                  {{ 3, true,  4,  3 }} },
-    { Hexagon::BI__builtin_circ_ldw,                  {{ 3, true,  4,  2 }} },
-    { Hexagon::BI__builtin_circ_ldh,                  {{ 3, true,  4,  1 }} },
-    { Hexagon::BI__builtin_circ_lduh,                 {{ 3, true,  4,  1 }} },
-    { Hexagon::BI__builtin_circ_ldb,                  {{ 3, true,  4,  0 }} },
-    { Hexagon::BI__builtin_circ_ldub,                 {{ 3, true,  4,  0 }} },
-    { Hexagon::BI__builtin_circ_std,                  {{ 3, true,  4,  3 }} },
-    { Hexagon::BI__builtin_circ_stw,                  {{ 3, true,  4,  2 }} },
-    { Hexagon::BI__builtin_circ_sth,                  {{ 3, true,  4,  1 }} },
-    { Hexagon::BI__builtin_circ_sthhi,                {{ 3, true,  4,  1 }} },
-    { Hexagon::BI__builtin_circ_stb,                  {{ 3, true,  4,  0 }} },
+      {Hexagon::BI__builtin_circ_ldd, {{3, true, 4, 3}}},
+      {Hexagon::BI__builtin_circ_ldw, {{3, true, 4, 2}}},
+      {Hexagon::BI__builtin_circ_ldh, {{3, true, 4, 1}}},
+      {Hexagon::BI__builtin_circ_lduh, {{3, true, 4, 1}}},
+      {Hexagon::BI__builtin_circ_ldb, {{3, true, 4, 0}}},
+      {Hexagon::BI__builtin_circ_ldub, {{3, true, 4, 0}}},
+      {Hexagon::BI__builtin_circ_std, {{3, true, 4, 3}}},
+      {Hexagon::BI__builtin_circ_stw, {{3, true, 4, 2}}},
+      {Hexagon::BI__builtin_circ_sth, {{3, true, 4, 1}}},
+      {Hexagon::BI__builtin_circ_sthhi, {{3, true, 4, 1}}},
+      {Hexagon::BI__builtin_circ_stb, {{3, true, 4, 0}}},
 
-    { Hexagon::BI__builtin_HEXAGON_L2_loadrub_pci,    {{ 1, true,  4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_L2_loadrb_pci,     {{ 1, true,  4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_L2_loadruh_pci,    {{ 1, true,  4,  1 }} },
-    { Hexagon::BI__builtin_HEXAGON_L2_loadrh_pci,     {{ 1, true,  4,  1 }} },
-    { Hexagon::BI__builtin_HEXAGON_L2_loadri_pci,     {{ 1, true,  4,  2 }} },
-    { Hexagon::BI__builtin_HEXAGON_L2_loadrd_pci,     {{ 1, true,  4,  3 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_storerb_pci,    {{ 1, true,  4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_storerh_pci,    {{ 1, true,  4,  1 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_storerf_pci,    {{ 1, true,  4,  1 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_storeri_pci,    {{ 1, true,  4,  2 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_storerd_pci,    {{ 1, true,  4,  3 }} },
+      {Hexagon::BI__builtin_HEXAGON_L2_loadrub_pci, {{1, true, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_L2_loadrb_pci, {{1, true, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_L2_loadruh_pci, {{1, true, 4, 1}}},
+      {Hexagon::BI__builtin_HEXAGON_L2_loadrh_pci, {{1, true, 4, 1}}},
+      {Hexagon::BI__builtin_HEXAGON_L2_loadri_pci, {{1, true, 4, 2}}},
+      {Hexagon::BI__builtin_HEXAGON_L2_loadrd_pci, {{1, true, 4, 3}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_storerb_pci, {{1, true, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_storerh_pci, {{1, true, 4, 1}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_storerf_pci, {{1, true, 4, 1}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_storeri_pci, {{1, true, 4, 2}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_storerd_pci, {{1, true, 4, 3}}},
 
-    { Hexagon::BI__builtin_HEXAGON_A2_combineii,      {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A2_tfrih,          {{ 1, false, 16, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A2_tfril,          {{ 1, false, 16, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A2_tfrpi,          {{ 0, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_bitspliti,      {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_cmpbeqi,        {{ 1, false, 8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_cmpbgti,        {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_cround_ri,      {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_round_ri,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_round_ri_sat,   {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpbeqi,       {{ 1, false, 8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpbgti,       {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpbgtui,      {{ 1, false, 7,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpheqi,       {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmphgti,       {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmphgtui,      {{ 1, false, 7,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpweqi,       {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpwgti,       {{ 1, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_A4_vcmpwgtui,      {{ 1, false, 7,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_C2_bitsclri,       {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_C2_muxii,          {{ 2, true,  8,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_C4_nbitsclri,      {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_dfclass,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_dfimm_n,        {{ 0, false, 10, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_dfimm_p,        {{ 0, false, 10, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_sfclass,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_sfimm_n,        {{ 0, false, 10, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_F2_sfimm_p,        {{ 0, false, 10, 0 }} },
-    { Hexagon::BI__builtin_HEXAGON_M4_mpyri_addi,     {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_M4_mpyri_addr_u2,  {{ 1, false, 6,  2 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_addasl_rrri,    {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_acc,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_and,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p,        {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_nac,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_or,     {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_xacc,   {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_acc,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_and,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_nac,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_or,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_sat,    {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_xacc,   {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_vh,       {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asl_i_vw,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_acc,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_and,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p,        {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_nac,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_or,     {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_rnd_goodsyntax,
-                                                      {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_rnd,    {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_acc,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_and,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_nac,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_or,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_rnd_goodsyntax,
-                                                      {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_rnd,    {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_svw_trun, {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_vh,       {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_asr_i_vw,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_clrbit_i,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_extractu,       {{ 1, false, 5,  0 },
-                                                       { 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_extractup,      {{ 1, false, 6,  0 },
-                                                       { 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_insert,         {{ 2, false, 5,  0 },
-                                                       { 3, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_insertp,        {{ 2, false, 6,  0 },
-                                                       { 3, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_acc,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_and,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p,        {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_nac,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_or,     {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_xacc,   {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_acc,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_and,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_nac,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_or,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_xacc,   {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_vh,       {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_lsr_i_vw,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_setbit_i,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_tableidxb_goodsyntax,
-                                                      {{ 2, false, 4,  0 },
-                                                       { 3, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_tableidxd_goodsyntax,
-                                                      {{ 2, false, 4,  0 },
-                                                       { 3, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_tableidxh_goodsyntax,
-                                                      {{ 2, false, 4,  0 },
-                                                       { 3, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_tableidxw_goodsyntax,
-                                                      {{ 2, false, 4,  0 },
-                                                       { 3, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_togglebit_i,    {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_tstbit_i,       {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_valignib,       {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S2_vspliceib,      {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_addi_asl_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_addi_lsr_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_andi_asl_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_andi_lsr_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_clbaddi,        {{ 1, true , 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_clbpaddi,       {{ 1, true,  6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_extract,        {{ 1, false, 5,  0 },
-                                                       { 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_extractp,       {{ 1, false, 6,  0 },
-                                                       { 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_lsli,           {{ 0, true,  6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_ntstbit_i,      {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_ori_asl_ri,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_ori_lsr_ri,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_subi_asl_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_subi_lsr_ri,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_vrcrotate_acc,  {{ 3, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S4_vrcrotate,      {{ 2, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S5_asrhub_rnd_sat_goodsyntax,
-                                                      {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S5_asrhub_sat,     {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S5_vasrhrnd_goodsyntax,
-                                                      {{ 1, false, 4,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p,        {{ 1, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_acc,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_and,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_nac,    {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_or,     {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_xacc,   {{ 2, false, 6,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r,        {{ 1, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_acc,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_and,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_nac,    {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_or,     {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_xacc,   {{ 2, false, 5,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_valignbi,       {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_valignbi_128B,  {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlalignbi,      {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlalignbi_128B, {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi,      {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_128B, {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_acc,  {{ 3, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_acc_128B,
-                                                      {{ 3, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi,       {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_128B,  {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_acc,   {{ 3, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_acc_128B,
-                                                      {{ 3, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrsadubi,       {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_128B,  {{ 2, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_acc,   {{ 3, false, 1,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_acc_128B,
-                                                      {{ 3, false, 1,  0 }} },
+      {Hexagon::BI__builtin_HEXAGON_A2_combineii, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A2_tfrih, {{1, false, 16, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A2_tfril, {{1, false, 16, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A2_tfrpi, {{0, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_bitspliti, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_cmpbeqi, {{1, false, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_cmpbgti, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_cround_ri, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_round_ri, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_round_ri_sat, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpbeqi, {{1, false, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpbgti, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpbgtui, {{1, false, 7, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpheqi, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmphgti, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmphgtui, {{1, false, 7, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpweqi, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpwgti, {{1, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_A4_vcmpwgtui, {{1, false, 7, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_C2_bitsclri, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_C2_muxii, {{2, true, 8, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_C4_nbitsclri, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_dfclass, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_dfimm_n, {{0, false, 10, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_dfimm_p, {{0, false, 10, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_sfclass, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_sfimm_n, {{0, false, 10, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_F2_sfimm_p, {{0, false, 10, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_M4_mpyri_addi, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_M4_mpyri_addr_u2, {{1, false, 6, 2}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_addasl_rrri, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_acc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_and, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_nac, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_or, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_p_xacc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_acc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_and, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_nac, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_or, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_sat, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_r_xacc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_vh, {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asl_i_vw, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_acc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_and, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_nac, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_or, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_rnd_goodsyntax,
+       {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_p_rnd, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_acc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_and, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_nac, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_or, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_rnd_goodsyntax,
+       {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_r_rnd, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_svw_trun, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_vh, {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_asr_i_vw, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_clrbit_i, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_extractu,
+       {{1, false, 5, 0}, {2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_extractup,
+       {{1, false, 6, 0}, {2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_insert,
+       {{2, false, 5, 0}, {3, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_insertp,
+       {{2, false, 6, 0}, {3, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_acc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_and, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_nac, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_or, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_p_xacc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_acc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_and, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_nac, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_or, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_r_xacc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_vh, {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_lsr_i_vw, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_setbit_i, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_tableidxb_goodsyntax,
+       {{2, false, 4, 0}, {3, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_tableidxd_goodsyntax,
+       {{2, false, 4, 0}, {3, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_tableidxh_goodsyntax,
+       {{2, false, 4, 0}, {3, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_tableidxw_goodsyntax,
+       {{2, false, 4, 0}, {3, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_togglebit_i, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_tstbit_i, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_valignib, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S2_vspliceib, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_addi_asl_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_addi_lsr_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_andi_asl_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_andi_lsr_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_clbaddi, {{1, true, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_clbpaddi, {{1, true, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_extract,
+       {{1, false, 5, 0}, {2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_extractp,
+       {{1, false, 6, 0}, {2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_lsli, {{0, true, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_ntstbit_i, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_ori_asl_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_ori_lsr_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_subi_asl_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_subi_lsr_ri, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_vrcrotate_acc, {{3, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S4_vrcrotate, {{2, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S5_asrhub_rnd_sat_goodsyntax,
+       {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S5_asrhub_sat, {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S5_vasrhrnd_goodsyntax, {{1, false, 4, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p, {{1, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_acc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_and, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_nac, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_or, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_p_xacc, {{2, false, 6, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r, {{1, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_acc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_and, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_nac, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_or, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_S6_rol_i_r_xacc, {{2, false, 5, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_valignbi, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_valignbi_128B, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlalignbi, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlalignbi_128B, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_128B, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_acc, {{3, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpybusi_acc_128B, {{3, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_128B, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_acc, {{3, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrmpyubi_acc_128B, {{3, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrsadubi, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_128B, {{2, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_acc, {{3, false, 1, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vrsadubi_acc_128B, {{3, false, 1, 0}}},
 
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10,    {{ 2, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_128B,
-                                                      {{ 2, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_vxx,
-                                                      {{ 3, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_vxx_128B,
-                                                      {{ 3, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10,    {{ 2, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_128B,
-                                                      {{ 2, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_vxx,
-                                                      {{ 3, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_vxx_128B,
-                                                      {{ 3, false, 2,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvvbi,       {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvvbi_128B,  {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvvb_oracci, {{ 3, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvvb_oracci_128B,
-                                                      {{ 3, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvwhi,       {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvwhi_128B,  {{ 2, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvwh_oracci, {{ 3, false, 3,  0 }} },
-    { Hexagon::BI__builtin_HEXAGON_V6_vlutvwh_oracci_128B,
-                                                      {{ 3, false, 3,  0 }} },
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10, {{2, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_128B, {{2, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_vxx, {{3, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyhubs10_vxx_128B,
+       {{3, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10, {{2, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_128B, {{2, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_vxx, {{3, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_v6mpyvubs10_vxx_128B,
+       {{3, false, 2, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvvbi, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvvbi_128B, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvvb_oracci, {{3, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvvb_oracci_128B, {{3, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvwhi, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvwhi_128B, {{2, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvwh_oracci, {{3, false, 3, 0}}},
+      {Hexagon::BI__builtin_HEXAGON_V6_vlutvwh_oracci_128B, {{3, false, 3, 0}}},
   };
 
   // Use a dynamically initialized static to sort the table exactly once on
   // first run.
   static const bool SortOnce =
       (llvm::sort(Infos,
-                 [](const BuiltinInfo &LHS, const BuiltinInfo &RHS) {
-                   return LHS.BuiltinID < RHS.BuiltinID;
-                 }),
+                  [](const BuiltinInfo &LHS, const BuiltinInfo &RHS) {
+                    return LHS.BuiltinID < RHS.BuiltinID;
+                  }),
        true);
   (void)SortOnce;
 
@@ -4694,14 +4696,43 @@ bool Sema::CheckMipsBuiltinCpu(const TargetInfo &TI, unsigned BuiltinID,
 bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   unsigned i = 0, l = 0, u = 0, m = 0;
   switch (BuiltinID) {
-  default: return false;
-  case Mips::BI__builtin_mips_wrdsp: i = 1; l = 0; u = 63; break;
-  case Mips::BI__builtin_mips_rddsp: i = 0; l = 0; u = 63; break;
-  case Mips::BI__builtin_mips_append: i = 2; l = 0; u = 31; break;
-  case Mips::BI__builtin_mips_balign: i = 2; l = 0; u = 3; break;
-  case Mips::BI__builtin_mips_precr_sra_ph_w: i = 2; l = 0; u = 31; break;
-  case Mips::BI__builtin_mips_precr_sra_r_ph_w: i = 2; l = 0; u = 31; break;
-  case Mips::BI__builtin_mips_prepend: i = 2; l = 0; u = 31; break;
+  default:
+    return false;
+  case Mips::BI__builtin_mips_wrdsp:
+    i = 1;
+    l = 0;
+    u = 63;
+    break;
+  case Mips::BI__builtin_mips_rddsp:
+    i = 0;
+    l = 0;
+    u = 63;
+    break;
+  case Mips::BI__builtin_mips_append:
+    i = 2;
+    l = 0;
+    u = 31;
+    break;
+  case Mips::BI__builtin_mips_balign:
+    i = 2;
+    l = 0;
+    u = 3;
+    break;
+  case Mips::BI__builtin_mips_precr_sra_ph_w:
+    i = 2;
+    l = 0;
+    u = 31;
+    break;
+  case Mips::BI__builtin_mips_precr_sra_r_ph_w:
+    i = 2;
+    l = 0;
+    u = 31;
+    break;
+  case Mips::BI__builtin_mips_prepend:
+    i = 2;
+    l = 0;
+    u = 31;
+    break;
   // MSA intrinsics. Instructions (which the intrinsics maps to) which use the
   // df/m field.
   // These intrinsics take an unsigned 3 bit immediate.
@@ -4714,9 +4745,17 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_srai_b:
   case Mips::BI__builtin_msa_srari_b:
   case Mips::BI__builtin_msa_srli_b:
-  case Mips::BI__builtin_msa_srlri_b: i = 1; l = 0; u = 7; break;
+  case Mips::BI__builtin_msa_srlri_b:
+    i = 1;
+    l = 0;
+    u = 7;
+    break;
   case Mips::BI__builtin_msa_binsli_b:
-  case Mips::BI__builtin_msa_binsri_b: i = 2; l = 0; u = 7; break;
+  case Mips::BI__builtin_msa_binsri_b:
+    i = 2;
+    l = 0;
+    u = 7;
+    break;
   // These intrinsics take an unsigned 4 bit immediate.
   case Mips::BI__builtin_msa_bclri_h:
   case Mips::BI__builtin_msa_bnegi_h:
@@ -4727,14 +4766,26 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_srai_h:
   case Mips::BI__builtin_msa_srari_h:
   case Mips::BI__builtin_msa_srli_h:
-  case Mips::BI__builtin_msa_srlri_h: i = 1; l = 0; u = 15; break;
+  case Mips::BI__builtin_msa_srlri_h:
+    i = 1;
+    l = 0;
+    u = 15;
+    break;
   case Mips::BI__builtin_msa_binsli_h:
-  case Mips::BI__builtin_msa_binsri_h: i = 2; l = 0; u = 15; break;
+  case Mips::BI__builtin_msa_binsri_h:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
   // These intrinsics take an unsigned 5 bit immediate.
   // The first block of intrinsics actually have an unsigned 5 bit field,
   // not a df/n field.
   case Mips::BI__builtin_msa_cfcmsa:
-  case Mips::BI__builtin_msa_ctcmsa: i = 0; l = 0; u = 31; break;
+  case Mips::BI__builtin_msa_ctcmsa:
+    i = 0;
+    l = 0;
+    u = 31;
+    break;
   case Mips::BI__builtin_msa_clei_u_b:
   case Mips::BI__builtin_msa_clei_u_h:
   case Mips::BI__builtin_msa_clei_u_w:
@@ -4768,9 +4819,17 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_subvi_b:
   case Mips::BI__builtin_msa_subvi_h:
   case Mips::BI__builtin_msa_subvi_w:
-  case Mips::BI__builtin_msa_subvi_d: i = 1; l = 0; u = 31; break;
+  case Mips::BI__builtin_msa_subvi_d:
+    i = 1;
+    l = 0;
+    u = 31;
+    break;
   case Mips::BI__builtin_msa_binsli_w:
-  case Mips::BI__builtin_msa_binsri_w: i = 2; l = 0; u = 31; break;
+  case Mips::BI__builtin_msa_binsri_w:
+    i = 2;
+    l = 0;
+    u = 31;
+    break;
   // These intrinsics take an unsigned 6 bit immediate.
   case Mips::BI__builtin_msa_bclri_d:
   case Mips::BI__builtin_msa_bnegi_d:
@@ -4781,9 +4840,17 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_srai_d:
   case Mips::BI__builtin_msa_srari_d:
   case Mips::BI__builtin_msa_srli_d:
-  case Mips::BI__builtin_msa_srlri_d: i = 1; l = 0; u = 63; break;
+  case Mips::BI__builtin_msa_srlri_d:
+    i = 1;
+    l = 0;
+    u = 63;
+    break;
   case Mips::BI__builtin_msa_binsli_d:
-  case Mips::BI__builtin_msa_binsri_d: i = 2; l = 0; u = 63; break;
+  case Mips::BI__builtin_msa_binsri_d:
+    i = 2;
+    l = 0;
+    u = 63;
+    break;
   // These intrinsics take a signed 5 bit immediate.
   case Mips::BI__builtin_msa_ceqi_b:
   case Mips::BI__builtin_msa_ceqi_h:
@@ -4804,7 +4871,11 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_mini_s_b:
   case Mips::BI__builtin_msa_mini_s_h:
   case Mips::BI__builtin_msa_mini_s_w:
-  case Mips::BI__builtin_msa_mini_s_d: i = 1; l = -16; u = 15; break;
+  case Mips::BI__builtin_msa_mini_s_d:
+    i = 1;
+    l = -16;
+    u = 15;
+    break;
   // These intrinsics take an unsigned 8 bit immediate.
   case Mips::BI__builtin_msa_andi_b:
   case Mips::BI__builtin_msa_nori_b:
@@ -4812,53 +4883,161 @@ bool Sema::CheckMipsBuiltinArgument(unsigned BuiltinID, CallExpr *TheCall) {
   case Mips::BI__builtin_msa_shf_b:
   case Mips::BI__builtin_msa_shf_h:
   case Mips::BI__builtin_msa_shf_w:
-  case Mips::BI__builtin_msa_xori_b: i = 1; l = 0; u = 255; break;
+  case Mips::BI__builtin_msa_xori_b:
+    i = 1;
+    l = 0;
+    u = 255;
+    break;
   case Mips::BI__builtin_msa_bseli_b:
   case Mips::BI__builtin_msa_bmnzi_b:
-  case Mips::BI__builtin_msa_bmzi_b: i = 2; l = 0; u = 255; break;
+  case Mips::BI__builtin_msa_bmzi_b:
+    i = 2;
+    l = 0;
+    u = 255;
+    break;
   // df/n format
   // These intrinsics take an unsigned 4 bit immediate.
   case Mips::BI__builtin_msa_copy_s_b:
   case Mips::BI__builtin_msa_copy_u_b:
   case Mips::BI__builtin_msa_insve_b:
-  case Mips::BI__builtin_msa_splati_b: i = 1; l = 0; u = 15; break;
-  case Mips::BI__builtin_msa_sldi_b: i = 2; l = 0; u = 15; break;
+  case Mips::BI__builtin_msa_splati_b:
+    i = 1;
+    l = 0;
+    u = 15;
+    break;
+  case Mips::BI__builtin_msa_sldi_b:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
   // These intrinsics take an unsigned 3 bit immediate.
   case Mips::BI__builtin_msa_copy_s_h:
   case Mips::BI__builtin_msa_copy_u_h:
   case Mips::BI__builtin_msa_insve_h:
-  case Mips::BI__builtin_msa_splati_h: i = 1; l = 0; u = 7; break;
-  case Mips::BI__builtin_msa_sldi_h: i = 2; l = 0; u = 7; break;
+  case Mips::BI__builtin_msa_splati_h:
+    i = 1;
+    l = 0;
+    u = 7;
+    break;
+  case Mips::BI__builtin_msa_sldi_h:
+    i = 2;
+    l = 0;
+    u = 7;
+    break;
   // These intrinsics take an unsigned 2 bit immediate.
   case Mips::BI__builtin_msa_copy_s_w:
   case Mips::BI__builtin_msa_copy_u_w:
   case Mips::BI__builtin_msa_insve_w:
-  case Mips::BI__builtin_msa_splati_w: i = 1; l = 0; u = 3; break;
-  case Mips::BI__builtin_msa_sldi_w: i = 2; l = 0; u = 3; break;
+  case Mips::BI__builtin_msa_splati_w:
+    i = 1;
+    l = 0;
+    u = 3;
+    break;
+  case Mips::BI__builtin_msa_sldi_w:
+    i = 2;
+    l = 0;
+    u = 3;
+    break;
   // These intrinsics take an unsigned 1 bit immediate.
   case Mips::BI__builtin_msa_copy_s_d:
   case Mips::BI__builtin_msa_copy_u_d:
   case Mips::BI__builtin_msa_insve_d:
-  case Mips::BI__builtin_msa_splati_d: i = 1; l = 0; u = 1; break;
-  case Mips::BI__builtin_msa_sldi_d: i = 2; l = 0; u = 1; break;
+  case Mips::BI__builtin_msa_splati_d:
+    i = 1;
+    l = 0;
+    u = 1;
+    break;
+  case Mips::BI__builtin_msa_sldi_d:
+    i = 2;
+    l = 0;
+    u = 1;
+    break;
   // Memory offsets and immediate loads.
   // These intrinsics take a signed 10 bit immediate.
-  case Mips::BI__builtin_msa_ldi_b: i = 0; l = -128; u = 255; break;
+  case Mips::BI__builtin_msa_ldi_b:
+    i = 0;
+    l = -128;
+    u = 255;
+    break;
   case Mips::BI__builtin_msa_ldi_h:
   case Mips::BI__builtin_msa_ldi_w:
-  case Mips::BI__builtin_msa_ldi_d: i = 0; l = -512; u = 511; break;
-  case Mips::BI__builtin_msa_ld_b: i = 1; l = -512; u = 511; m = 1; break;
-  case Mips::BI__builtin_msa_ld_h: i = 1; l = -1024; u = 1022; m = 2; break;
-  case Mips::BI__builtin_msa_ld_w: i = 1; l = -2048; u = 2044; m = 4; break;
-  case Mips::BI__builtin_msa_ld_d: i = 1; l = -4096; u = 4088; m = 8; break;
-  case Mips::BI__builtin_msa_ldr_d: i = 1; l = -4096; u = 4088; m = 8; break;
-  case Mips::BI__builtin_msa_ldr_w: i = 1; l = -2048; u = 2044; m = 4; break;
-  case Mips::BI__builtin_msa_st_b: i = 2; l = -512; u = 511; m = 1; break;
-  case Mips::BI__builtin_msa_st_h: i = 2; l = -1024; u = 1022; m = 2; break;
-  case Mips::BI__builtin_msa_st_w: i = 2; l = -2048; u = 2044; m = 4; break;
-  case Mips::BI__builtin_msa_st_d: i = 2; l = -4096; u = 4088; m = 8; break;
-  case Mips::BI__builtin_msa_str_d: i = 2; l = -4096; u = 4088; m = 8; break;
-  case Mips::BI__builtin_msa_str_w: i = 2; l = -2048; u = 2044; m = 4; break;
+  case Mips::BI__builtin_msa_ldi_d:
+    i = 0;
+    l = -512;
+    u = 511;
+    break;
+  case Mips::BI__builtin_msa_ld_b:
+    i = 1;
+    l = -512;
+    u = 511;
+    m = 1;
+    break;
+  case Mips::BI__builtin_msa_ld_h:
+    i = 1;
+    l = -1024;
+    u = 1022;
+    m = 2;
+    break;
+  case Mips::BI__builtin_msa_ld_w:
+    i = 1;
+    l = -2048;
+    u = 2044;
+    m = 4;
+    break;
+  case Mips::BI__builtin_msa_ld_d:
+    i = 1;
+    l = -4096;
+    u = 4088;
+    m = 8;
+    break;
+  case Mips::BI__builtin_msa_ldr_d:
+    i = 1;
+    l = -4096;
+    u = 4088;
+    m = 8;
+    break;
+  case Mips::BI__builtin_msa_ldr_w:
+    i = 1;
+    l = -2048;
+    u = 2044;
+    m = 4;
+    break;
+  case Mips::BI__builtin_msa_st_b:
+    i = 2;
+    l = -512;
+    u = 511;
+    m = 1;
+    break;
+  case Mips::BI__builtin_msa_st_h:
+    i = 2;
+    l = -1024;
+    u = 1022;
+    m = 2;
+    break;
+  case Mips::BI__builtin_msa_st_w:
+    i = 2;
+    l = -2048;
+    u = 2044;
+    m = 4;
+    break;
+  case Mips::BI__builtin_msa_st_d:
+    i = 2;
+    l = -4096;
+    u = 4088;
+    m = 8;
+    break;
+  case Mips::BI__builtin_msa_str_d:
+    i = 2;
+    l = -4096;
+    u = 4088;
+    m = 8;
+    break;
+  case Mips::BI__builtin_msa_str_w:
+    i = 2;
+    l = -2048;
+    u = 2044;
+    m = 4;
+    break;
   }
 
   if (!m)
@@ -4897,10 +5076,13 @@ static QualType DecodePPCMMATypeFromStr(ASTContext &Context, const char *&Str,
     Str = End;
     QualType Type;
     switch (size) {
-  #define PPC_VECTOR_TYPE(typeName, Id, size) \
-    case size: Type = Context.Id##Ty; break;
-  #include "clang/Basic/PPCTypes.def"
-    default: llvm_unreachable("Invalid PowerPC MMA vector type");
+#define PPC_VECTOR_TYPE(typeName, Id, size)                                    \
+  case size:                                                                   \
+    Type = Context.Id##Ty;                                                     \
+    break;
+#include "clang/Basic/PPCTypes.def"
+    default:
+      llvm_unreachable("Invalid PowerPC MMA vector type");
     }
     bool CheckVectorArgs = false;
     while (!CheckVectorArgs) {
@@ -4995,7 +5177,8 @@ bool Sema::CheckPPCBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
            << TheCall->getSourceRange();
 
   switch (BuiltinID) {
-  default: return false;
+  default:
+    return false;
   case PPC::BI__builtin_altivec_crypto_vshasigmaw:
   case PPC::BI__builtin_altivec_crypto_vshasigmad:
     return SemaBuiltinConstantArgRange(TheCall, 1, 0, 1) ||
@@ -5037,15 +5220,15 @@ bool Sema::CheckPPCBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case PPC::BI__builtin_unpack_vector_int128:
     return SemaBuiltinConstantArgRange(TheCall, 1, 0, 1);
   case PPC::BI__builtin_altivec_vgnb:
-     return SemaBuiltinConstantArgRange(TheCall, 1, 2, 7);
+    return SemaBuiltinConstantArgRange(TheCall, 1, 2, 7);
   case PPC::BI__builtin_vsx_xxeval:
-     return SemaBuiltinConstantArgRange(TheCall, 3, 0, 255);
+    return SemaBuiltinConstantArgRange(TheCall, 3, 0, 255);
   case PPC::BI__builtin_altivec_vsldbi:
-     return SemaBuiltinConstantArgRange(TheCall, 2, 0, 7);
+    return SemaBuiltinConstantArgRange(TheCall, 2, 0, 7);
   case PPC::BI__builtin_altivec_vsrdbi:
-     return SemaBuiltinConstantArgRange(TheCall, 2, 0, 7);
+    return SemaBuiltinConstantArgRange(TheCall, 2, 0, 7);
   case PPC::BI__builtin_vsx_xxpermx:
-     return SemaBuiltinConstantArgRange(TheCall, 3, 0, 7);
+    return SemaBuiltinConstantArgRange(TheCall, 3, 0, 7);
   case PPC::BI__builtin_ppc_tw:
   case PPC::BI__builtin_ppc_tdw:
     return SemaBuiltinConstantArgRange(TheCall, 2, 1, 31);
@@ -5133,7 +5316,7 @@ bool Sema::CheckPPCBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
                << TheCall->getArg(I)->getType() << ArgType << 1 << 0 << 0;
     return false;
   }
-#define CUSTOM_BUILTIN(Name, Intr, Types, Acc, Feature)                                 \
+#define CUSTOM_BUILTIN(Name, Intr, Types, Acc, Feature)                        \
   case PPC::BI__builtin_##Name:                                                \
     return SemaBuiltinPPCMMACall(TheCall, BuiltinID, Types);
 #include "clang/Basic/BuiltinsPPC.def"
@@ -5151,7 +5334,7 @@ bool Sema::CheckPPCMMAType(QualType Type, SourceLocation TypeLoc) {
 #define PPC_VECTOR_TYPE(Name, Id, Size) || CoreType == Context.Id##Ty
   if (false
 #include "clang/Basic/PPCTypes.def"
-     ) {
+  ) {
     Diag(TypeLoc, diag::err_ppc_invalid_use_mma_type);
     return true;
   }
@@ -5263,7 +5446,8 @@ static bool CheckInvalidVLENandLMUL(const TargetInfo &TI, CallExpr *TheCall,
   std::string RequiredExt = "zvl" + std::to_string(MinRequiredVLEN) + "b";
   if (!TI.hasFeature(RequiredExt))
     return S.Diag(TheCall->getBeginLoc(),
-        diag::err_riscv_type_requires_extension) << Type << RequiredExt;
+                  diag::err_riscv_type_requires_extension)
+           << Type << RequiredExt;
 
   return false;
 }
@@ -5314,8 +5498,7 @@ bool Sema::CheckRISCVBuiltinFunctionCall(const TargetInfo &TI,
       // Error message
       FeatureMissing = true;
       Diag(TheCall->getBeginLoc(), diag::err_riscv_builtin_requires_extension)
-          << IsExtension
-          << TheCall->getSourceRange() << StringRef(FeatureStrs);
+          << IsExtension << TheCall->getSourceRange() << StringRef(FeatureStrs);
     }
   }
 
@@ -6145,12 +6328,21 @@ bool Sema::CheckSystemZBuiltinFunctionCall(unsigned BuiltinID,
   // range check them here.
   unsigned i = 0, l = 0, u = 0;
   switch (BuiltinID) {
-  default: return false;
-  case SystemZ::BI__builtin_s390_lcbb: i = 1; l = 0; u = 15; break;
+  default:
+    return false;
+  case SystemZ::BI__builtin_s390_lcbb:
+    i = 1;
+    l = 0;
+    u = 15;
+    break;
   case SystemZ::BI__builtin_s390_verimb:
   case SystemZ::BI__builtin_s390_verimh:
   case SystemZ::BI__builtin_s390_verimf:
-  case SystemZ::BI__builtin_s390_verimg: i = 3; l = 0; u = 255; break;
+  case SystemZ::BI__builtin_s390_verimg:
+    i = 3;
+    l = 0;
+    u = 255;
+    break;
   case SystemZ::BI__builtin_s390_vfaeb:
   case SystemZ::BI__builtin_s390_vfaeh:
   case SystemZ::BI__builtin_s390_vfaef:
@@ -6162,16 +6354,36 @@ bool Sema::CheckSystemZBuiltinFunctionCall(unsigned BuiltinID,
   case SystemZ::BI__builtin_s390_vfaezf:
   case SystemZ::BI__builtin_s390_vfaezbs:
   case SystemZ::BI__builtin_s390_vfaezhs:
-  case SystemZ::BI__builtin_s390_vfaezfs: i = 2; l = 0; u = 15; break;
+  case SystemZ::BI__builtin_s390_vfaezfs:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
   case SystemZ::BI__builtin_s390_vfisb:
   case SystemZ::BI__builtin_s390_vfidb:
     return SemaBuiltinConstantArgRange(TheCall, 1, 0, 15) ||
            SemaBuiltinConstantArgRange(TheCall, 2, 0, 15);
   case SystemZ::BI__builtin_s390_vftcisb:
-  case SystemZ::BI__builtin_s390_vftcidb: i = 1; l = 0; u = 4095; break;
-  case SystemZ::BI__builtin_s390_vlbb: i = 1; l = 0; u = 15; break;
-  case SystemZ::BI__builtin_s390_vpdi: i = 2; l = 0; u = 15; break;
-  case SystemZ::BI__builtin_s390_vsldb: i = 2; l = 0; u = 15; break;
+  case SystemZ::BI__builtin_s390_vftcidb:
+    i = 1;
+    l = 0;
+    u = 4095;
+    break;
+  case SystemZ::BI__builtin_s390_vlbb:
+    i = 1;
+    l = 0;
+    u = 15;
+    break;
+  case SystemZ::BI__builtin_s390_vpdi:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
+  case SystemZ::BI__builtin_s390_vsldb:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
   case SystemZ::BI__builtin_s390_vstrcb:
   case SystemZ::BI__builtin_s390_vstrch:
   case SystemZ::BI__builtin_s390_vstrcf:
@@ -6183,19 +6395,47 @@ bool Sema::CheckSystemZBuiltinFunctionCall(unsigned BuiltinID,
   case SystemZ::BI__builtin_s390_vstrcfs:
   case SystemZ::BI__builtin_s390_vstrczbs:
   case SystemZ::BI__builtin_s390_vstrczhs:
-  case SystemZ::BI__builtin_s390_vstrczfs: i = 3; l = 0; u = 15; break;
-  case SystemZ::BI__builtin_s390_vmslg: i = 3; l = 0; u = 15; break;
+  case SystemZ::BI__builtin_s390_vstrczfs:
+    i = 3;
+    l = 0;
+    u = 15;
+    break;
+  case SystemZ::BI__builtin_s390_vmslg:
+    i = 3;
+    l = 0;
+    u = 15;
+    break;
   case SystemZ::BI__builtin_s390_vfminsb:
   case SystemZ::BI__builtin_s390_vfmaxsb:
   case SystemZ::BI__builtin_s390_vfmindb:
-  case SystemZ::BI__builtin_s390_vfmaxdb: i = 2; l = 0; u = 15; break;
-  case SystemZ::BI__builtin_s390_vsld: i = 2; l = 0; u = 7; break;
-  case SystemZ::BI__builtin_s390_vsrd: i = 2; l = 0; u = 7; break;
+  case SystemZ::BI__builtin_s390_vfmaxdb:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
+  case SystemZ::BI__builtin_s390_vsld:
+    i = 2;
+    l = 0;
+    u = 7;
+    break;
+  case SystemZ::BI__builtin_s390_vsrd:
+    i = 2;
+    l = 0;
+    u = 7;
+    break;
   case SystemZ::BI__builtin_s390_vclfnhs:
   case SystemZ::BI__builtin_s390_vclfnls:
   case SystemZ::BI__builtin_s390_vcfn:
-  case SystemZ::BI__builtin_s390_vcnf: i = 1; l = 0; u = 15; break;
-  case SystemZ::BI__builtin_s390_vcrnfs: i = 2; l = 0; u = 15; break;
+  case SystemZ::BI__builtin_s390_vcnf:
+    i = 1;
+    l = 0;
+    u = 15;
+    break;
+  case SystemZ::BI__builtin_s390_vcrnfs:
+    i = 2;
+    l = 0;
+    u = 15;
+    break;
   }
   return SemaBuiltinConstantArgRange(TheCall, i, l, u);
 }
@@ -6557,9 +6797,8 @@ bool Sema::CheckX86BuiltinRoundingOrSAE(unsigned BuiltinID, CallExpr *TheCall) {
   // is set. If the intrinsic has rounding control(bits 1:0), make sure its only
   // combined with ROUND_NO_EXC. If the intrinsic does not have rounding
   // control, allow ROUND_NO_EXC and ROUND_CUR_DIRECTION together.
-  if (Result == 4/*ROUND_CUR_DIRECTION*/ ||
-      Result == 8/*ROUND_NO_EXC*/ ||
-      (!HasRC && Result == 12/*ROUND_CUR_DIRECTION|ROUND_NO_EXC*/) ||
+  if (Result == 4 /*ROUND_CUR_DIRECTION*/ || Result == 8 /*ROUND_NO_EXC*/ ||
+      (!HasRC && Result == 12 /*ROUND_CUR_DIRECTION|ROUND_NO_EXC*/) ||
       (HasRC && Result.getZExtValue() >= 8 && Result.getZExtValue() <= 11))
     return false;
 
@@ -6783,7 +7022,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_extracti64x2_256_mask:
   case X86::BI__builtin_ia32_extractf32x4_256_mask:
   case X86::BI__builtin_ia32_extracti32x4_256_mask:
-    i = 1; l = 0; u = 1;
+    i = 1;
+    l = 0;
+    u = 1;
     break;
   case X86::BI__builtin_ia32_vec_set_v2di:
   case X86::BI__builtin_ia32_vinsertf128_pd256:
@@ -6798,7 +7039,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_inserti64x2_256:
   case X86::BI__builtin_ia32_insertf32x4_256:
   case X86::BI__builtin_ia32_inserti32x4_256:
-    i = 2; l = 0; u = 1;
+    i = 2;
+    l = 0;
+    u = 1;
     break;
   case X86::BI__builtin_ia32_vpermilpd:
   case X86::BI__builtin_ia32_vec_ext_v4hi:
@@ -6809,12 +7052,16 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_extracti32x4_mask:
   case X86::BI__builtin_ia32_extractf64x2_512_mask:
   case X86::BI__builtin_ia32_extracti64x2_512_mask:
-    i = 1; l = 0; u = 3;
+    i = 1;
+    l = 0;
+    u = 3;
     break;
   case X86::BI_mm_prefetch:
   case X86::BI__builtin_ia32_vec_ext_v8hi:
   case X86::BI__builtin_ia32_vec_ext_v8si:
-    i = 1; l = 0; u = 7;
+    i = 1;
+    l = 0;
+    u = 7;
     break;
   case X86::BI__builtin_ia32_sha1rnds4:
   case X86::BI__builtin_ia32_blendpd:
@@ -6830,13 +7077,17 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_inserti64x2_512:
   case X86::BI__builtin_ia32_insertf32x4:
   case X86::BI__builtin_ia32_inserti32x4:
-    i = 2; l = 0; u = 3;
+    i = 2;
+    l = 0;
+    u = 3;
     break;
   case X86::BI__builtin_ia32_vpermil2pd:
   case X86::BI__builtin_ia32_vpermil2pd256:
   case X86::BI__builtin_ia32_vpermil2ps:
   case X86::BI__builtin_ia32_vpermil2ps256:
-    i = 3; l = 0; u = 3;
+    i = 3;
+    l = 0;
+    u = 3;
     break;
   case X86::BI__builtin_ia32_cmpb128_mask:
   case X86::BI__builtin_ia32_cmpw128_mask:
@@ -6872,7 +7123,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_vpcomq:
   case X86::BI__builtin_ia32_vec_set_v8hi:
   case X86::BI__builtin_ia32_vec_set_v8si:
-    i = 2; l = 0; u = 7;
+    i = 2;
+    l = 0;
+    u = 7;
     break;
   case X86::BI__builtin_ia32_vpermilpd256:
   case X86::BI__builtin_ia32_roundps:
@@ -6890,7 +7143,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_getmantph512_mask:
   case X86::BI__builtin_ia32_vec_ext_v16qi:
   case X86::BI__builtin_ia32_vec_ext_v16hi:
-    i = 1; l = 0; u = 15;
+    i = 1;
+    l = 0;
+    u = 15;
     break;
   case X86::BI__builtin_ia32_pblendd128:
   case X86::BI__builtin_ia32_blendps:
@@ -6909,10 +7164,14 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_getmantsh_round_mask:
   case X86::BI__builtin_ia32_vec_set_v16qi:
   case X86::BI__builtin_ia32_vec_set_v16hi:
-    i = 2; l = 0; u = 15;
+    i = 2;
+    l = 0;
+    u = 15;
     break;
   case X86::BI__builtin_ia32_vec_ext_v32qi:
-    i = 1; l = 0; u = 31;
+    i = 1;
+    l = 0;
+    u = 31;
     break;
   case X86::BI__builtin_ia32_cmpps:
   case X86::BI__builtin_ia32_cmpss:
@@ -6929,7 +7188,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_cmpsd_mask:
   case X86::BI__builtin_ia32_cmpss_mask:
   case X86::BI__builtin_ia32_vec_set_v32qi:
-    i = 2; l = 0; u = 31;
+    i = 2;
+    l = 0;
+    u = 31;
     break;
   case X86::BI__builtin_ia32_permdf256:
   case X86::BI__builtin_ia32_permdi256:
@@ -7007,7 +7268,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_kshiftrihi:
   case X86::BI__builtin_ia32_kshiftrisi:
   case X86::BI__builtin_ia32_kshiftridi:
-    i = 1; l = 0; u = 255;
+    i = 1;
+    l = 0;
+    u = 255;
     break;
   case X86::BI__builtin_ia32_vperm2f128_pd256:
   case X86::BI__builtin_ia32_vperm2f128_ps256:
@@ -7057,7 +7320,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_vpshrdw128:
   case X86::BI__builtin_ia32_vpshrdw256:
   case X86::BI__builtin_ia32_vpshrdw512:
-    i = 2; l = 0; u = 255;
+    i = 2;
+    l = 0;
+    u = 255;
     break;
   case X86::BI__builtin_ia32_fixupimmpd512_mask:
   case X86::BI__builtin_ia32_fixupimmpd512_maskz:
@@ -7088,7 +7353,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_pternlogq256_mask:
   case X86::BI__builtin_ia32_pternlogq256_maskz:
   case X86::BI__builtin_ia32_vsm3rnds2:
-    i = 3; l = 0; u = 255;
+    i = 3;
+    l = 0;
+    u = 255;
     break;
   case X86::BI__builtin_ia32_gatherpfdpd:
   case X86::BI__builtin_ia32_gatherpfdps:
@@ -7098,7 +7365,9 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_scatterpfdps:
   case X86::BI__builtin_ia32_scatterpfqpd:
   case X86::BI__builtin_ia32_scatterpfqps:
-    i = 4; l = 2; u = 3;
+    i = 4;
+    l = 2;
+    u = 3;
     break;
   case X86::BI__builtin_ia32_reducesd_mask:
   case X86::BI__builtin_ia32_reducess_mask:
@@ -7106,11 +7375,15 @@ bool Sema::CheckX86BuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case X86::BI__builtin_ia32_rndscaless_round_mask:
   case X86::BI__builtin_ia32_rndscalesh_round_mask:
   case X86::BI__builtin_ia32_reducesh_mask:
-    i = 4; l = 0; u = 255;
+    i = 4;
+    l = 0;
+    u = 255;
     break;
   case X86::BI__builtin_ia32_cmpccxadd32:
   case X86::BI__builtin_ia32_cmpccxadd64:
-    i = 3; l = 0; u = 15;
+    i = 3;
+    l = 0;
+    u = 15;
     break;
   }
 
@@ -7141,7 +7414,7 @@ bool Sema::getFormatStringInfo(const FormatAttr *Format, bool IsCXXMember,
   // of member functions is counted. However, it doesn't appear in our own
   // lists, so decrement format_idx in that case.
   if (IsCXXMember) {
-    if(FSI->FormatIdx == 0)
+    if (FSI->FormatIdx == 0)
       return false;
     --FSI->FormatIdx;
     if (FSI->FirstDataArg != 0)
@@ -7164,21 +7437,18 @@ static bool CheckNonNullExpr(Sema &S, const Expr *Expr) {
   // considered null for the purposes of the nonnull attribute.
   if (const RecordType *UT = Expr->getType()->getAsUnionType()) {
     if (UT->getDecl()->hasAttr<TransparentUnionAttr>())
-      if (const CompoundLiteralExpr *CLE =
-          dyn_cast<CompoundLiteralExpr>(Expr))
+      if (const CompoundLiteralExpr *CLE = dyn_cast<CompoundLiteralExpr>(Expr))
         if (const InitListExpr *ILE =
-            dyn_cast<InitListExpr>(CLE->getInitializer()))
+                dyn_cast<InitListExpr>(CLE->getInitializer()))
           Expr = ILE->getInit(0);
   }
 
   bool Result;
   return (!Expr->isValueDependent() &&
-          Expr->EvaluateAsBooleanCondition(Result, S.Context) &&
-          !Result);
+          Expr->EvaluateAsBooleanCondition(Result, S.Context) && !Result);
 }
 
-static void CheckNonNullArgument(Sema &S,
-                                 const Expr *ArgExpr,
+static void CheckNonNullArgument(Sema &S, const Expr *ArgExpr,
                                  SourceLocation CallSiteLoc) {
   if (CheckNonNullExpr(S, ArgExpr))
     S.DiagRuntimeBehavior(CallSiteLoc, ArgExpr,
@@ -7198,19 +7468,17 @@ bool Sema::GetFormatNSStringIdx(const FormatAttr *Format, unsigned &Idx) {
 
 /// Diagnose use of %s directive in an NSString which is being passed
 /// as formatting string to formatting method.
-static void
-DiagnoseCStringFormatDirectiveInCFAPI(Sema &S,
-                                        const NamedDecl *FDecl,
-                                        Expr **Args,
-                                        unsigned NumArgs) {
+static void DiagnoseCStringFormatDirectiveInCFAPI(Sema &S,
+                                                  const NamedDecl *FDecl,
+                                                  Expr **Args,
+                                                  unsigned NumArgs) {
   unsigned Idx = 0;
   bool Format = false;
   ObjCStringFormatFamily SFFamily = FDecl->getObjCFStringFormattingFamily();
   if (SFFamily == ObjCStringFormatFamily::SFF_CFString) {
     Idx = 2;
     Format = true;
-  }
-  else
+  } else
     for (const auto *I : FDecl->specific_attrs<FormatAttr>()) {
       if (S.GetFormatNSStringIdx(I, Idx)) {
         Format = true;
@@ -7224,7 +7492,7 @@ DiagnoseCStringFormatDirectiveInCFAPI(Sema &S,
     FormatExpr = CSCE->getSubExpr();
   const StringLiteral *FormatString;
   if (const ObjCStringLiteral *OSL =
-      dyn_cast<ObjCStringLiteral>(FormatExpr->IgnoreParenImpCasts()))
+          dyn_cast<ObjCStringLiteral>(FormatExpr->IgnoreParenImpCasts()))
     FormatString = OSL->getString();
   else
     FormatString = dyn_cast<StringLiteral>(FormatExpr->IgnoreParenImpCasts());
@@ -7232,9 +7500,9 @@ DiagnoseCStringFormatDirectiveInCFAPI(Sema &S,
     return;
   if (S.FormatStringHasSArg(FormatString)) {
     S.Diag(FormatExpr->getExprLoc(), diag::warn_objc_cdirective_format_string)
-      << "%s" << 1 << 1;
+        << "%s" << 1 << 1;
     S.Diag(FDecl->getLocation(), diag::note_entity_declared_at)
-      << FDecl->getDeclName();
+        << FDecl->getDeclName();
   }
 }
 
@@ -7246,8 +7514,7 @@ static bool isNonNullType(QualType type) {
   return false;
 }
 
-static void CheckNonNullArguments(Sema &S,
-                                  const NamedDecl *FDecl,
+static void CheckNonNullArguments(Sema &S, const NamedDecl *FDecl,
                                   const FunctionProtoType *Proto,
                                   ArrayRef<const Expr *> Args,
                                   SourceLocation CallSiteLoc) {
@@ -7283,14 +7550,14 @@ static void CheckNonNullArguments(Sema &S,
   if (FDecl && (isa<FunctionDecl>(FDecl) || isa<ObjCMethodDecl>(FDecl))) {
     // Handle the nonnull attribute on the parameters of the
     // function/method.
-    ArrayRef<ParmVarDecl*> parms;
+    ArrayRef<ParmVarDecl *> parms;
     if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(FDecl))
       parms = FD->parameters();
     else
       parms = cast<ObjCMethodDecl>(FDecl)->parameters();
 
     unsigned ParamIndex = 0;
-    for (ArrayRef<ParmVarDecl*>::iterator I = parms.begin(), E = parms.end();
+    for (ArrayRef<ParmVarDecl *>::iterator I = parms.begin(), E = parms.end();
          I != E; ++I, ++ParamIndex) {
       const ParmVarDecl *PVD = *I;
       if (PVD->hasAttr<NonNullAttr>() || isNonNullType(PVD->getType())) {
@@ -7444,11 +7711,11 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
   if (CallType != VariadicDoesNotApply &&
       (!FD || FD->getBuiltinID() != Builtin::BI__noop)) {
     unsigned NumParams = Proto ? Proto->getNumParams()
-                       : FDecl && isa<FunctionDecl>(FDecl)
-                           ? cast<FunctionDecl>(FDecl)->getNumParams()
-                       : FDecl && isa<ObjCMethodDecl>(FDecl)
-                           ? cast<ObjCMethodDecl>(FDecl)->param_size()
-                       : 0;
+                         : FDecl && isa<FunctionDecl>(FDecl)
+                             ? cast<FunctionDecl>(FDecl)->getNumParams()
+                         : FDecl && isa<ObjCMethodDecl>(FDecl)
+                             ? cast<ObjCMethodDecl>(FDecl)->param_size()
+                             : 0;
 
     for (unsigned ArgIdx = NumParams; ArgIdx < Args.size(); ++ArgIdx) {
       // Args[ArgIdx] can be null in malformed code.
@@ -7597,13 +7864,13 @@ void Sema::CheckConstructorCall(FunctionDecl *FDecl, QualType ThisType,
 /// and safety properties not strictly enforced by the C type system.
 bool Sema::CheckFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
                              const FunctionProtoType *Proto) {
-  bool IsMemberOperatorCall = isa<CXXOperatorCallExpr>(TheCall) &&
-                              isa<CXXMethodDecl>(FDecl);
-  bool IsMemberFunction = isa<CXXMemberCallExpr>(TheCall) ||
-                          IsMemberOperatorCall;
-  VariadicCallType CallType = getVariadicCallType(FDecl, Proto,
-                                                  TheCall->getCallee());
-  Expr** Args = TheCall->getArgs();
+  bool IsMemberOperatorCall =
+      isa<CXXOperatorCallExpr>(TheCall) && isa<CXXMethodDecl>(FDecl);
+  bool IsMemberFunction =
+      isa<CXXMemberCallExpr>(TheCall) || IsMemberOperatorCall;
+  VariadicCallType CallType =
+      getVariadicCallType(FDecl, Proto, TheCall->getCallee());
+  Expr **Args = TheCall->getArgs();
   unsigned NumArgs = TheCall->getNumArgs();
 
   Expr *ImplicitThis = nullptr;
@@ -7727,8 +7994,8 @@ bool Sema::CheckPointerCall(NamedDecl *NDecl, CallExpr *TheCall,
 /// Checks function calls when a FunctionDecl or a NamedDecl is not available,
 /// such as function pointers returned from functions.
 bool Sema::CheckOtherCall(CallExpr *TheCall, const FunctionProtoType *Proto) {
-  VariadicCallType CallType = getVariadicCallType(/*FDecl=*/nullptr, Proto,
-                                                  TheCall->getCallee());
+  VariadicCallType CallType =
+      getVariadicCallType(/*FDecl=*/nullptr, Proto, TheCall->getCallee());
   checkCall(/*FDecl=*/nullptr, Proto, /*ThisArg=*/nullptr,
             llvm::ArrayRef(TheCall->getArgs(), TheCall->getNumArgs()),
             /*IsMemberFunction=*/false, TheCall->getRParenLoc(),
@@ -7776,7 +8043,8 @@ static bool isValidOrderingForOp(int64_t Ordering, AtomicExpr::AtomicOp Op) {
 ExprResult Sema::SemaAtomicOpsOverloaded(ExprResult TheCallResult,
                                          AtomicExpr::AtomicOp Op) {
   CallExpr *TheCall = cast<CallExpr>(TheCallResult.get());
-  DeclRefExpr *DRE =cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
+  DeclRefExpr *DRE =
+      cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
   MultiExprArg Args{TheCall->getArgs(), TheCall->getNumArgs()};
   return BuildAtomicExpr({TheCall->getBeginLoc(), TheCall->getEndLoc()},
                          DRE->getSourceRange(), TheCall->getRParenLoc(), Args,
@@ -7820,8 +8088,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
   } Form = Init;
 
   const unsigned NumForm = GNUCmpXchg + 1;
-  const unsigned NumArgs[] = { 2, 2, 3, 3, 3, 3, 4, 5, 6 };
-  const unsigned NumVals[] = { 1, 0, 1, 1, 1, 1, 2, 2, 3 };
+  const unsigned NumArgs[] = {2, 2, 3, 3, 3, 3, 4, 5, 6};
+  const unsigned NumVals[] = {1, 0, 1, 1, 1, 1, 2, 2, 3};
   // where:
   //   C is an appropriate type,
   //   A is volatile _Atomic(C) for __c11 builtins and is C for GNU builtins,
@@ -7829,9 +8097,9 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
   //   M is C if C is an integer, and ptrdiff_t if C is a pointer, and
   //   the int parameters are for orderings.
 
-  static_assert(sizeof(NumArgs)/sizeof(NumArgs[0]) == NumForm
-      && sizeof(NumVals)/sizeof(NumVals[0]) == NumForm,
-      "need to update code for modified forms");
+  static_assert(sizeof(NumArgs) / sizeof(NumArgs[0]) == NumForm &&
+                    sizeof(NumVals) / sizeof(NumVals[0]) == NumForm,
+                "need to update code for modified forms");
   static_assert(AtomicExpr::AO__atomic_add_fetch == 0 &&
                     AtomicExpr::AO__atomic_xor_fetch + 1 ==
                         AtomicExpr::AO__c11_atomic_compare_exchange_strong,
@@ -8018,7 +8286,7 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
 
   // For a __c11 builtin, this should be a pointer to an _Atomic type.
   QualType AtomTy = pointerType->getPointeeType(); // 'A'
-  QualType ValType = AtomTy; // 'C'
+  QualType ValType = AtomTy;                       // 'C'
   if (IsC11) {
     if (!AtomTy->isAtomicType()) {
       Diag(ExprRange.getBegin(), diag::err_atomic_op_needs_atomic)
@@ -8117,8 +8385,7 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
   ValType.removeLocalVolatile();
   ValType.removeLocalConst();
   QualType ResultType = ValType;
-  if (Form == Copy || Form == LoadCopy || Form == GNUXchg ||
-      Form == Init)
+  if (Form == Copy || Form == LoadCopy || Form == GNUXchg || Form == Init)
     ResultType = Context.VoidTy;
   else if (Form == C11CmpXchg || Form == GNUCmpXchg)
     ResultType = Context.BoolTy;
@@ -8242,7 +8509,7 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
   }
 
   // Permute the arguments into a 'consistent' order.
-  SmallVector<Expr*, 5> SubExprs;
+  SmallVector<Expr *, 5> SubExprs;
   SubExprs.push_back(Ptr);
   switch (Form) {
   case Init:
@@ -8356,7 +8623,7 @@ static bool checkBuiltinArgument(Sema &S, CallExpr *E, unsigned ArgIndex) {
 
   ParmVarDecl *Param = Fn->getParamDecl(ArgIndex);
   InitializedEntity Entity =
-    InitializedEntity::InitializeParameter(S.Context, Param);
+      InitializedEntity::InitializeParameter(S.Context, Param);
 
   ExprResult Arg = E->getArg(ArgIndex);
   Arg = S.PerformCopyInitialization(Entity, SourceLocation(), Arg);
@@ -8403,8 +8670,7 @@ bool Sema::BuiltinWasmRefNullFunc(CallExpr *TheCall) {
 ///
 /// This function goes through and does final semantic checking for these
 /// builtins, as well as generating any warnings.
-ExprResult
-Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
+ExprResult Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
   CallExpr *TheCall = static_cast<CallExpr *>(TheCallResult.get());
   Expr *Callee = TheCall->getCallee();
   DeclRefExpr *DRE = cast<DeclRefExpr>(Callee->IgnoreParenCasts());
@@ -8475,41 +8741,52 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
   // We need to figure out which concrete builtin this maps onto.  For example,
   // __sync_fetch_and_add with a 2 byte object turns into
   // __sync_fetch_and_add_2.
-#define BUILTIN_ROW(x) \
-  { Builtin::BI##x##_1, Builtin::BI##x##_2, Builtin::BI##x##_4, \
-    Builtin::BI##x##_8, Builtin::BI##x##_16 }
+#define BUILTIN_ROW(x)                                                         \
+  {                                                                            \
+    Builtin::BI##x##_1, Builtin::BI##x##_2, Builtin::BI##x##_4,                \
+        Builtin::BI##x##_8, Builtin::BI##x##_16                                \
+  }
 
   static const unsigned BuiltinIndices[][5] = {
-    BUILTIN_ROW(__sync_fetch_and_add),
-    BUILTIN_ROW(__sync_fetch_and_sub),
-    BUILTIN_ROW(__sync_fetch_and_or),
-    BUILTIN_ROW(__sync_fetch_and_and),
-    BUILTIN_ROW(__sync_fetch_and_xor),
-    BUILTIN_ROW(__sync_fetch_and_nand),
+      BUILTIN_ROW(__sync_fetch_and_add),
+      BUILTIN_ROW(__sync_fetch_and_sub),
+      BUILTIN_ROW(__sync_fetch_and_or),
+      BUILTIN_ROW(__sync_fetch_and_and),
+      BUILTIN_ROW(__sync_fetch_and_xor),
+      BUILTIN_ROW(__sync_fetch_and_nand),
 
-    BUILTIN_ROW(__sync_add_and_fetch),
-    BUILTIN_ROW(__sync_sub_and_fetch),
-    BUILTIN_ROW(__sync_and_and_fetch),
-    BUILTIN_ROW(__sync_or_and_fetch),
-    BUILTIN_ROW(__sync_xor_and_fetch),
-    BUILTIN_ROW(__sync_nand_and_fetch),
+      BUILTIN_ROW(__sync_add_and_fetch),
+      BUILTIN_ROW(__sync_sub_and_fetch),
+      BUILTIN_ROW(__sync_and_and_fetch),
+      BUILTIN_ROW(__sync_or_and_fetch),
+      BUILTIN_ROW(__sync_xor_and_fetch),
+      BUILTIN_ROW(__sync_nand_and_fetch),
 
-    BUILTIN_ROW(__sync_val_compare_and_swap),
-    BUILTIN_ROW(__sync_bool_compare_and_swap),
-    BUILTIN_ROW(__sync_lock_test_and_set),
-    BUILTIN_ROW(__sync_lock_release),
-    BUILTIN_ROW(__sync_swap)
-  };
+      BUILTIN_ROW(__sync_val_compare_and_swap),
+      BUILTIN_ROW(__sync_bool_compare_and_swap),
+      BUILTIN_ROW(__sync_lock_test_and_set),
+      BUILTIN_ROW(__sync_lock_release),
+      BUILTIN_ROW(__sync_swap)};
 #undef BUILTIN_ROW
 
   // Determine the index of the size.
   unsigned SizeIndex;
   switch (Context.getTypeSizeInChars(ValType).getQuantity()) {
-  case 1: SizeIndex = 0; break;
-  case 2: SizeIndex = 1; break;
-  case 4: SizeIndex = 2; break;
-  case 8: SizeIndex = 3; break;
-  case 16: SizeIndex = 4; break;
+  case 1:
+    SizeIndex = 0;
+    break;
+  case 2:
+    SizeIndex = 1;
+    break;
+  case 4:
+    SizeIndex = 2;
+    break;
+  case 8:
+    SizeIndex = 3;
+    break;
+  case 16:
+    SizeIndex = 4;
+    break;
   default:
     Diag(DRE->getBeginLoc(), diag::err_atomic_builtin_pointer_size)
         << FirstArg->getType() << FirstArg->getSourceRange();
@@ -8524,7 +8801,8 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
   unsigned BuiltinIndex, NumFixed = 1;
   bool WarnAboutSemanticsChange = false;
   switch (BuiltinID) {
-  default: llvm_unreachable("Unknown overloaded atomic builtin!");
+  default:
+    llvm_unreachable("Unknown overloaded atomic builtin!");
   case Builtin::BI__sync_fetch_and_add:
   case Builtin::BI__sync_fetch_and_add_1:
   case Builtin::BI__sync_fetch_and_add_2:
@@ -8688,7 +8966,7 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
 
   // Now that we know how many fixed arguments we expect, first check that we
   // have at least that many.
-  if (TheCall->getNumArgs() < 1+NumFixed) {
+  if (TheCall->getNumArgs() < 1 + NumFixed) {
     Diag(TheCall->getEndLoc(), diag::err_typecheck_call_too_few_args_at_least)
         << 0 << 1 + NumFixed << TheCall->getNumArgs() << /*is non object*/ 0
         << Callee->getSourceRange();
@@ -8725,13 +9003,13 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
   // deduce the types of the rest of the arguments accordingly.  Walk
   // the remaining arguments, converting them to the deduced value type.
   for (unsigned i = 0; i != NumFixed; ++i) {
-    ExprResult Arg = TheCall->getArg(i+1);
+    ExprResult Arg = TheCall->getArg(i + 1);
 
     // GCC does an implicit conversion to the pointer or integer ValType.  This
     // can fail in some cases (1i -> int**), check for this error case now.
     // Initialize the argument.
-    InitializedEntity Entity = InitializedEntity::InitializeParameter(Context,
-                                                   ValType, /*consume*/ false);
+    InitializedEntity Entity = InitializedEntity::InitializeParameter(
+        Context, ValType, /*consume*/ false);
     Arg = PerformCopyInitialization(Entity, SourceLocation(), Arg);
     if (Arg.isInvalid())
       return ExprError();
@@ -8742,7 +9020,7 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
     // pass in 42.  The 42 gets converted to char.  This is even more strange
     // for things like 45.123 -> char, etc.
     // FIXME: Do this check.
-    TheCall->setArg(i+1, Arg.get());
+    TheCall->setArg(i + 1, Arg.get());
   }
 
   // Create a new DeclRefExpr to refer to the new decl.
@@ -8754,8 +9032,8 @@ Sema::SemaBuiltinAtomicOverloaded(ExprResult TheCallResult) {
   // Set the callee in the CallExpr.
   // FIXME: This loses syntactic information.
   QualType CalleePtrTy = Context.getPointerType(NewBuiltinDecl->getType());
-  ExprResult PromotedCall = ImpCastExprToType(NewDRE, CalleePtrTy,
-                                              CK_BuiltinFnToFnPtr);
+  ExprResult PromotedCall =
+      ImpCastExprToType(NewDRE, CalleePtrTy, CK_BuiltinFnToFnPtr);
   TheCall->setCallee(PromotedCall.get());
 
   // Change the result type of the call to match the original value type. This
@@ -8927,8 +9205,7 @@ static bool checkVAStartABI(Sema &S, unsigned BuiltinID, Expr *Fn) {
       // On x64 Windows, don't allow this in System V ABI functions.
       // (Yes, that means there's no corresponding way to support variadic
       // System V ABI functions on Windows.)
-      if ((IsWindows && CC == CC_X86_64SysV) ||
-          (!IsWindows && CC == CC_Win64))
+      if ((IsWindows && CC == CC_X86_64SysV) || (!IsWindows && CC == CC_Win64))
         return S.Diag(Fn->getBeginLoc(),
                       diag::err_va_start_used_in_wrong_abi_function)
                << !IsWindows;
@@ -8941,8 +9218,9 @@ static bool checkVAStartABI(Sema &S, unsigned BuiltinID, Expr *Fn) {
   return false;
 }
 
-static bool checkVAStartIsInVariadicFunction(Sema &S, Expr *Fn,
-                                             ParmVarDecl **LastParam = nullptr) {
+static bool
+checkVAStartIsInVariadicFunction(Sema &S, Expr *Fn,
+                                 ParmVarDecl **LastParam = nullptr) {
   // Determine whether the current function, block, or obj-c method is variadic
   // and get its parameter list.
   bool IsVariadic = false;
@@ -9047,8 +9325,10 @@ bool Sema::SemaBuiltinVAStart(unsigned BuiltinID, CallExpr *TheCall) {
                       Context.typesAreCompatible(ED->getPromotionType(), Type));
            }()) {
     unsigned Reason = 0;
-    if (Type->isReferenceType())  Reason = 1;
-    else if (IsCRegister)         Reason = 2;
+    if (Type->isReferenceType())
+      Reason = 1;
+    else if (IsCRegister)
+      Reason = 2;
     Diag(Arg->getBeginLoc(), diag::warn_va_start_type_is_undefined) << Reason;
     Diag(ParamLoc, diag::note_parameter_type) << Type;
   }
@@ -9286,8 +9566,8 @@ bool Sema::SemaBuiltinComplex(CallExpr *TheCall) {
   if (!Context.hasSameType(Real->getType(), Imag->getType())) {
     return Diag(Real->getBeginLoc(),
                 diag::err_typecheck_call_different_arg_types)
-           << Real->getType() << Imag->getType()
-           << Real->getSourceRange() << Imag->getSourceRange();
+           << Real->getType() << Imag->getType() << Real->getSourceRange()
+           << Imag->getSourceRange();
   }
 
   // We don't allow _Complex _Float16 nor _Complex __fp16 as type specifiers;
@@ -9429,7 +9709,7 @@ ExprResult Sema::SemaBuiltinShuffleVector(CallExpr *TheCall) {
                        << TheCall->getArg(i)->getSourceRange());
   }
 
-  SmallVector<Expr*, 32> exprs;
+  SmallVector<Expr *, 32> exprs;
 
   for (unsigned i = 0, e = TheCall->getNumArgs(); i != e; i++) {
     exprs.push_back(TheCall->getArg(i));
@@ -9451,21 +9731,19 @@ ExprResult Sema::SemaConvertVectorExpr(Expr *E, TypeSourceInfo *TInfo,
   QualType SrcTy = E->getType();
 
   if (!SrcTy->isVectorType() && !SrcTy->isDependentType())
-    return ExprError(Diag(BuiltinLoc,
-                          diag::err_convertvector_non_vector)
+    return ExprError(Diag(BuiltinLoc, diag::err_convertvector_non_vector)
                      << E->getSourceRange());
   if (!DstTy->isVectorType() && !DstTy->isDependentType())
     return ExprError(Diag(BuiltinLoc, diag::err_builtin_non_vector_type)
-                     << "second"
-                     << "__builtin_convertvector");
+                     << "second" << "__builtin_convertvector");
 
   if (!SrcTy->isDependentType() && !DstTy->isDependentType()) {
     unsigned SrcElts = SrcTy->castAs<VectorType>()->getNumElements();
     unsigned DstElts = DstTy->castAs<VectorType>()->getNumElements();
     if (SrcElts != DstElts)
-      return ExprError(Diag(BuiltinLoc,
-                            diag::err_convertvector_incompatible_vector)
-                       << E->getSourceRange());
+      return ExprError(
+          Diag(BuiltinLoc, diag::err_convertvector_incompatible_vector)
+          << E->getSourceRange());
   }
 
   return new (Context)
@@ -9521,7 +9799,8 @@ bool Sema::SemaBuiltinArithmeticFence(CallExpr *TheCall) {
 // has side effects.
 bool Sema::SemaBuiltinAssume(CallExpr *TheCall) {
   Expr *Arg = TheCall->getArg(0);
-  if (Arg->isInstantiationDependent()) return false;
+  if (Arg->isInstantiationDependent())
+    return false;
 
   if (Arg->HasSideEffects(Context))
     Diag(Arg->getBeginLoc(), diag::warn_assume_side_effects)
@@ -9575,8 +9854,7 @@ bool Sema::SemaBuiltinAssumeAligned(CallExpr *TheCall) {
   Expr *FirstArg = TheCall->getArg(0);
 
   {
-    ExprResult FirstArgResult =
-        DefaultFunctionArrayLvalueConversion(FirstArg);
+    ExprResult FirstArgResult = DefaultFunctionArrayLvalueConversion(FirstArg);
     if (checkBuiltinArgument(*this, TheCall, 0))
       return true;
     /// In-place updation of FirstArg by checkBuiltinArgument is ignored.
@@ -9696,10 +9974,12 @@ bool Sema::SemaBuiltinOSLogFormat(CallExpr *TheCall) {
 bool Sema::SemaBuiltinConstantArg(CallExpr *TheCall, int ArgNum,
                                   llvm::APSInt &Result) {
   Expr *Arg = TheCall->getArg(ArgNum);
-  DeclRefExpr *DRE =cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
+  DeclRefExpr *DRE =
+      cast<DeclRefExpr>(TheCall->getCallee()->IgnoreParenCasts());
   FunctionDecl *FDecl = cast<FunctionDecl>(DRE->getDecl());
 
-  if (Arg->isTypeDependent() || Arg->isValueDependent()) return false;
+  if (Arg->isTypeDependent() || Arg->isValueDependent())
+    return false;
 
   std::optional<llvm::APSInt> R;
   if (!(R = Arg->getIntegerConstantExpr(Context)))
@@ -9711,8 +9991,8 @@ bool Sema::SemaBuiltinConstantArg(CallExpr *TheCall, int ArgNum,
 
 /// SemaBuiltinConstantArgRange - Handle a check if argument ArgNum of CallExpr
 /// TheCall is a constant expression in the range [Low, High].
-bool Sema::SemaBuiltinConstantArgRange(CallExpr *TheCall, int ArgNum,
-                                       int Low, int High, bool RangeIsError) {
+bool Sema::SemaBuiltinConstantArgRange(CallExpr *TheCall, int ArgNum, int Low,
+                                       int High, bool RangeIsError) {
   if (isConstantEvaluatedContext())
     return false;
   llvm::APSInt Result;
@@ -9742,8 +10022,8 @@ bool Sema::SemaBuiltinConstantArgRange(CallExpr *TheCall, int ArgNum,
   return false;
 }
 
-/// SemaBuiltinConstantArgMultiple - Handle a check if argument ArgNum of CallExpr
-/// TheCall is a constant expression is a multiple of Num..
+/// SemaBuiltinConstantArgMultiple - Handle a check if argument ArgNum of
+/// CallExpr TheCall is a constant expression is a multiple of Num..
 bool Sema::SemaBuiltinConstantArgMultiple(CallExpr *TheCall, int ArgNum,
                                           unsigned Num) {
   llvm::APSInt Result;
@@ -9870,7 +10150,8 @@ bool Sema::SemaBuiltinConstantArgShiftedByteOrXXFF(CallExpr *TheCall,
 }
 
 /// SemaBuiltinARMMemoryTaggingCall - Handle calls of memory tagging extensions
-bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall) {
+bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID,
+                                           CallExpr *TheCall) {
   if (BuiltinID == AArch64::BI__builtin_arm_irg) {
     if (checkArgCount(*this, TheCall, 2))
       return true;
@@ -9883,7 +10164,7 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType FirstArgType = FirstArg.get()->getType();
     if (!FirstArgType->isAnyPointerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_pointer)
-               << "first" << FirstArgType << Arg0->getSourceRange();
+             << "first" << FirstArgType << Arg0->getSourceRange();
     TheCall->setArg(0, FirstArg.get());
 
     ExprResult SecArg = DefaultLvalueConversion(Arg1);
@@ -9892,7 +10173,7 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType SecArgType = SecArg.get()->getType();
     if (!SecArgType->isIntegerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_integer)
-               << "second" << SecArgType << Arg1->getSourceRange();
+             << "second" << SecArgType << Arg1->getSourceRange();
 
     // Derive the return type from the pointer argument.
     TheCall->setType(FirstArgType);
@@ -9910,7 +10191,7 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType FirstArgType = FirstArg.get()->getType();
     if (!FirstArgType->isAnyPointerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_pointer)
-               << "first" << FirstArgType << Arg0->getSourceRange();
+             << "first" << FirstArgType << Arg0->getSourceRange();
     TheCall->setArg(0, FirstArg.get());
 
     // Derive the return type from the pointer argument.
@@ -9932,12 +10213,12 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType FirstArgType = FirstArg.get()->getType();
     if (!FirstArgType->isAnyPointerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_pointer)
-               << "first" << FirstArgType << Arg0->getSourceRange();
+             << "first" << FirstArgType << Arg0->getSourceRange();
 
     QualType SecArgType = Arg1->getType();
     if (!SecArgType->isIntegerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_integer)
-               << "second" << SecArgType << Arg1->getSourceRange();
+             << "second" << SecArgType << Arg1->getSourceRange();
     TheCall->setType(Context.IntTy);
     return false;
   }
@@ -9954,7 +10235,7 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType FirstArgType = FirstArg.get()->getType();
     if (!FirstArgType->isAnyPointerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_must_be_pointer)
-               << "first" << FirstArgType << Arg0->getSourceRange();
+             << "first" << FirstArgType << Arg0->getSourceRange();
     TheCall->setArg(0, FirstArg.get());
 
     // Derive the return type from the pointer argument.
@@ -9976,18 +10257,19 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
     QualType ArgTypeA = ArgExprA.get()->getType();
     QualType ArgTypeB = ArgExprB.get()->getType();
 
-    auto isNull = [&] (Expr *E) -> bool {
-      return E->isNullPointerConstant(
-                        Context, Expr::NPC_ValueDependentIsNotNull); };
+    auto isNull = [&](Expr *E) -> bool {
+      return E->isNullPointerConstant(Context,
+                                      Expr::NPC_ValueDependentIsNotNull);
+    };
 
     // argument should be either a pointer or null
     if (!ArgTypeA->isAnyPointerType() && !isNull(ArgA))
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_null_or_pointer)
-        << "first" << ArgTypeA << ArgA->getSourceRange();
+             << "first" << ArgTypeA << ArgA->getSourceRange();
 
     if (!ArgTypeB->isAnyPointerType() && !isNull(ArgB))
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_arg_null_or_pointer)
-        << "second" << ArgTypeB << ArgB->getSourceRange();
+             << "second" << ArgTypeB << ArgB->getSourceRange();
 
     // Ensure Pointee types are compatible
     if (ArgTypeA->isAnyPointerType() && !isNull(ArgA) &&
@@ -9995,18 +10277,19 @@ bool Sema::SemaBuiltinARMMemoryTaggingCall(unsigned BuiltinID, CallExpr *TheCall
       QualType pointeeA = ArgTypeA->getPointeeType();
       QualType pointeeB = ArgTypeB->getPointeeType();
       if (!Context.typesAreCompatible(
-             Context.getCanonicalType(pointeeA).getUnqualifiedType(),
-             Context.getCanonicalType(pointeeB).getUnqualifiedType())) {
-        return Diag(TheCall->getBeginLoc(), diag::err_typecheck_sub_ptr_compatible)
-          << ArgTypeA <<  ArgTypeB << ArgA->getSourceRange()
-          << ArgB->getSourceRange();
+              Context.getCanonicalType(pointeeA).getUnqualifiedType(),
+              Context.getCanonicalType(pointeeB).getUnqualifiedType())) {
+        return Diag(TheCall->getBeginLoc(),
+                    diag::err_typecheck_sub_ptr_compatible)
+               << ArgTypeA << ArgTypeB << ArgA->getSourceRange()
+               << ArgB->getSourceRange();
       }
     }
 
     // at least one argument should be pointer type
     if (!ArgTypeA->isAnyPointerType() && !ArgTypeB->isAnyPointerType())
       return Diag(TheCall->getBeginLoc(), diag::err_memtag_any2arg_pointer)
-        <<  ArgTypeA << ArgTypeB << ArgA->getSourceRange();
+             << ArgTypeA << ArgTypeB << ArgA->getSourceRange();
 
     if (isNull(ArgA)) // adopt type of the other pointer
       ArgExprA = ImpCastExprToType(ArgExprA.get(), ArgTypeB, CK_NullToPointer);
@@ -10095,7 +10378,7 @@ bool Sema::SemaBuiltinARMSpecialReg(unsigned BuiltinID, CallExpr *TheCall,
     else
       Ranges.append({15, 7, 15});
 
-    for (unsigned i=0; i<Fields.size(); ++i) {
+    for (unsigned i = 0; i < Fields.size(); ++i) {
       int IntField;
       ValidString &= !Fields[i].getAsInteger(10, IntField);
       ValidString &= (IntField >= 0 && IntField <= Ranges[i]);
@@ -10119,17 +10402,17 @@ bool Sema::SemaBuiltinARMSpecialReg(unsigned BuiltinID, CallExpr *TheCall,
     // These are the named PSTATE accesses using "MSR (immediate)" instructions,
     // along with the upper limit on the immediates allowed.
     auto MaxLimit = llvm::StringSwitch<std::optional<unsigned>>(Reg)
-      .CaseLower("spsel", 15)
-      .CaseLower("daifclr", 15)
-      .CaseLower("daifset", 15)
-      .CaseLower("pan", 15)
-      .CaseLower("uao", 15)
-      .CaseLower("dit", 15)
-      .CaseLower("ssbs", 15)
-      .CaseLower("tco", 15)
-      .CaseLower("allint", 1)
-      .CaseLower("pm", 1)
-      .Default(std::nullopt);
+                        .CaseLower("spsel", 15)
+                        .CaseLower("daifclr", 15)
+                        .CaseLower("daifset", 15)
+                        .CaseLower("pan", 15)
+                        .CaseLower("uao", 15)
+                        .CaseLower("dit", 15)
+                        .CaseLower("ssbs", 15)
+                        .CaseLower("tco", 15)
+                        .CaseLower("allint", 1)
+                        .CaseLower("pm", 1)
+                        .Default(std::nullopt);
 
     // If this is not a named PSTATE, just continue without validating, as this
     // will be lowered to an "MSR (register)" instruction directly
@@ -10215,7 +10498,7 @@ bool Sema::SemaBuiltinPPCMMACall(CallExpr *TheCall, unsigned BuiltinID,
   // number of arguments in TheCall and if it is not the case, to display a
   // better error message.
   while (*TypeStr != '\0') {
-    (void) DecodePPCMMATypeFromStr(Context, TypeStr, Mask);
+    (void)DecodePPCMMATypeFromStr(Context, TypeStr, Mask);
     ArgNum++;
   }
   if (checkArgCount(*this, TheCall, ArgNum))
@@ -10266,9 +10549,7 @@ class UncoveredArgHandler {
 public:
   UncoveredArgHandler() = default;
 
-  bool hasUncoveredArg() const {
-    return (FirstUncoveredArg >= 0);
-  }
+  bool hasUncoveredArg() const { return (FirstUncoveredArg >= 0); }
 
   unsigned getUncoveredArg() const {
     assert(hasUncoveredArg() && "no uncovered argument");
@@ -10312,8 +10593,7 @@ enum StringLiteralCheckType {
 } // namespace
 
 static void sumOffsets(llvm::APSInt &Offset, llvm::APSInt Addend,
-                                     BinaryOperatorKind BinOpKind,
-                                     bool AddendIsRight) {
+                       BinaryOperatorKind BinOpKind, bool AddendIsRight) {
   unsigned BitWidth = Offset.getBitWidth();
   unsigned AddendBitWidth = Addend.getBitWidth();
   // There might be negative interim results.
@@ -10361,13 +10641,11 @@ class FormatStringLiteral {
   const StringLiteral *FExpr;
   int64_t Offset;
 
- public:
+public:
   FormatStringLiteral(const StringLiteral *fexpr, int64_t Offset = 0)
       : FExpr(fexpr), Offset(Offset) {}
 
-  StringRef getString() const {
-    return FExpr->getString().drop_front(Offset);
-  }
+  StringRef getString() const { return FExpr->getString().drop_front(Offset); }
 
   unsigned getByteLength() const {
     return FExpr->getByteLength() - getCharByteWidth() * Offset;
@@ -10387,10 +10665,11 @@ class FormatStringLiteral {
   bool isUTF32() const { return FExpr->isUTF32(); }
   bool isPascal() const { return FExpr->isPascal(); }
 
-  SourceLocation getLocationOfByte(
-      unsigned ByteNo, const SourceManager &SM, const LangOptions &Features,
-      const TargetInfo &Target, unsigned *StartToken = nullptr,
-      unsigned *StartTokenByteOffset = nullptr) const {
+  SourceLocation
+  getLocationOfByte(unsigned ByteNo, const SourceManager &SM,
+                    const LangOptions &Features, const TargetInfo &Target,
+                    unsigned *StartToken = nullptr,
+                    unsigned *StartTokenByteOffset = nullptr) const {
     return FExpr->getLocationOfByte(ByteNo + Offset, SM, Features, Target,
                                     StartToken, StartTokenByteOffset);
   }
@@ -10458,8 +10737,7 @@ tryAgain:
   case Stmt::ConditionalOperatorClass: {
     // The expression is a literal if both sub-expressions were, and it was
     // completely checked only if both sub-expressions were checked.
-    const AbstractConditionalOperator *C =
-        cast<AbstractConditionalOperator>(E);
+    const AbstractConditionalOperator *C = cast<AbstractConditionalOperator>(E);
 
     // Determine whether it is necessary to check both sub-expressions, for
     // example, because the condition expression is a constant that can be
@@ -10635,7 +10913,8 @@ tryAgain:
   case Stmt::CallExprClass:
   case Stmt::CXXMemberCallExprClass: {
     const CallExpr *CE = cast<CallExpr>(E);
-    if (const NamedDecl *ND = dyn_cast_or_null<NamedDecl>(CE->getCalleeDecl())) {
+    if (const NamedDecl *ND =
+            dyn_cast_or_null<NamedDecl>(CE->getCalleeDecl())) {
       bool IsFirst = true;
       StringLiteralCheckType CommonResult;
       for (const auto *FA : ND->specific_attrs<FormatArgAttr>()) {
@@ -10863,7 +11142,7 @@ bool Sema::CheckFormatArguments(ArrayRef<const Expr *> Args,
   if (UncoveredArg.hasUncoveredArg()) {
     unsigned ArgIdx = UncoveredArg.getUncoveredArg() + firstDataArg;
     assert(ArgIdx < Args.size() && "ArgIdx outside bounds");
-    UncoveredArg.Diagnose(*this, /*IsFunctionCall*/true, Args[ArgIdx]);
+    UncoveredArg.Diagnose(*this, /*IsFunctionCall*/ true, Args[ArgIdx]);
   }
 
   if (CT != SLCT_NotALiteral)
@@ -10887,7 +11166,7 @@ bool Sema::CheckFormatArguments(ArrayRef<const Expr *> Args,
   // warn only with -Wformat-nonliteral.
   if (Args.size() == firstDataArg) {
     Diag(FormatLoc, diag::warn_format_nonliteral_noargs)
-      << OrigFormatExpr->getSourceRange();
+        << OrigFormatExpr->getSourceRange();
     switch (Type) {
     default:
       break;
@@ -10895,16 +11174,16 @@ bool Sema::CheckFormatArguments(ArrayRef<const Expr *> Args,
     case FST_FreeBSDKPrintf:
     case FST_Printf:
       Diag(FormatLoc, diag::note_format_security_fixit)
-        << FixItHint::CreateInsertion(FormatLoc, "\"%s\", ");
+          << FixItHint::CreateInsertion(FormatLoc, "\"%s\", ");
       break;
     case FST_NSString:
       Diag(FormatLoc, diag::note_format_security_fixit)
-        << FixItHint::CreateInsertion(FormatLoc, "@\"%@\", ");
+          << FixItHint::CreateInsertion(FormatLoc, "@\"%@\", ");
       break;
     }
   } else {
     Diag(FormatLoc, diag::warn_format_nonliteral)
-      << OrigFormatExpr->getSourceRange();
+        << OrigFormatExpr->getSourceRange();
   }
   return false;
 }
@@ -10956,23 +11235,21 @@ public:
                                  unsigned specifierLen) override;
 
   void HandleInvalidLengthModifier(
-                           const analyze_format_string::FormatSpecifier &FS,
-                           const analyze_format_string::ConversionSpecifier &CS,
-                           const char *startSpecifier, unsigned specifierLen,
-                           unsigned DiagID);
+      const analyze_format_string::FormatSpecifier &FS,
+      const analyze_format_string::ConversionSpecifier &CS,
+      const char *startSpecifier, unsigned specifierLen, unsigned DiagID);
 
   void HandleNonStandardLengthModifier(
-                    const analyze_format_string::FormatSpecifier &FS,
-                    const char *startSpecifier, unsigned specifierLen);
+      const analyze_format_string::FormatSpecifier &FS,
+      const char *startSpecifier, unsigned specifierLen);
 
   void HandleNonStandardConversionSpecifier(
-                    const analyze_format_string::ConversionSpecifier &CS,
-                    const char *startSpecifier, unsigned specifierLen);
+      const analyze_format_string::ConversionSpecifier &CS,
+      const char *startSpecifier, unsigned specifierLen);
 
   void HandlePosition(const char *startPos, unsigned posLen) override;
 
-  void HandleInvalidPosition(const char *startSpecifier,
-                             unsigned specifierLen,
+  void HandleInvalidPosition(const char *startSpecifier, unsigned specifierLen,
                              analyze_format_string::PositionContext p) override;
 
   void HandleZeroPosition(const char *startPos, unsigned posLen) override;
@@ -11020,10 +11297,11 @@ SourceRange CheckFormatHandler::getFormatStringRange() {
   return OrigFormatExpr->getSourceRange();
 }
 
-CharSourceRange CheckFormatHandler::
-getSpecifierRange(const char *startSpecifier, unsigned specifierLen) {
+CharSourceRange
+CheckFormatHandler::getSpecifierRange(const char *startSpecifier,
+                                      unsigned specifierLen) {
   SourceLocation Start = getLocationOfByte(startSpecifier);
-  SourceLocation End   = getLocationOfByte(startSpecifier + specifierLen - 1);
+  SourceLocation End = getLocationOfByte(startSpecifier + specifierLen - 1);
 
   // Advance the end SourceLocation by one due to half-open ranges.
   End = End.getLocWithOffset(1);
@@ -11037,10 +11315,10 @@ SourceLocation CheckFormatHandler::getLocationOfByte(const char *x) {
 }
 
 void CheckFormatHandler::HandleIncompleteSpecifier(const char *startSpecifier,
-                                                   unsigned specifierLen){
+                                                   unsigned specifierLen) {
   EmitFormatDiagnostic(S.PDiag(diag::warn_printf_incomplete_specifier),
                        getLocationOfByte(startSpecifier),
-                       /*IsStringLocation*/true,
+                       /*IsStringLocation*/ true,
                        getSpecifierRange(startSpecifier, specifierLen));
 }
 
@@ -11058,12 +11336,12 @@ void CheckFormatHandler::HandleInvalidLengthModifier(
   if (FixedLM) {
     EmitFormatDiagnostic(S.PDiag(DiagID) << LM.toString() << CS.toString(),
                          getLocationOfByte(LM.getStart()),
-                         /*IsStringLocation*/true,
+                         /*IsStringLocation*/ true,
                          getSpecifierRange(startSpecifier, specifierLen));
 
     S.Diag(getLocationOfByte(LM.getStart()), diag::note_format_fix_specifier)
-      << FixedLM->toString()
-      << FixItHint::CreateReplacement(LMRange, FixedLM->toString());
+        << FixedLM->toString()
+        << FixItHint::CreateReplacement(LMRange, FixedLM->toString());
 
   } else {
     FixItHint Hint;
@@ -11072,9 +11350,8 @@ void CheckFormatHandler::HandleInvalidLengthModifier(
 
     EmitFormatDiagnostic(S.PDiag(DiagID) << LM.toString() << CS.toString(),
                          getLocationOfByte(LM.getStart()),
-                         /*IsStringLocation*/true,
-                         getSpecifierRange(startSpecifier, specifierLen),
-                         Hint);
+                         /*IsStringLocation*/ true,
+                         getSpecifierRange(startSpecifier, specifierLen), Hint);
   }
 }
 
@@ -11090,20 +11367,20 @@ void CheckFormatHandler::HandleNonStandardLengthModifier(
   std::optional<LengthModifier> FixedLM = FS.getCorrectedLengthModifier();
   if (FixedLM) {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard)
-                           << LM.toString() << 0,
+                             << LM.toString() << 0,
                          getLocationOfByte(LM.getStart()),
-                         /*IsStringLocation*/true,
+                         /*IsStringLocation*/ true,
                          getSpecifierRange(startSpecifier, specifierLen));
 
     S.Diag(getLocationOfByte(LM.getStart()), diag::note_format_fix_specifier)
-      << FixedLM->toString()
-      << FixItHint::CreateReplacement(LMRange, FixedLM->toString());
+        << FixedLM->toString()
+        << FixItHint::CreateReplacement(LMRange, FixedLM->toString());
 
   } else {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard)
-                           << LM.toString() << 0,
+                             << LM.toString() << 0,
                          getLocationOfByte(LM.getStart()),
-                         /*IsStringLocation*/true,
+                         /*IsStringLocation*/ true,
                          getSpecifierRange(startSpecifier, specifierLen));
   }
 }
@@ -11117,30 +11394,29 @@ void CheckFormatHandler::HandleNonStandardConversionSpecifier(
   std::optional<ConversionSpecifier> FixedCS = CS.getStandardSpecifier();
   if (FixedCS) {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard)
-                          << CS.toString() << /*conversion specifier*/1,
+                             << CS.toString() << /*conversion specifier*/ 1,
                          getLocationOfByte(CS.getStart()),
-                         /*IsStringLocation*/true,
+                         /*IsStringLocation*/ true,
                          getSpecifierRange(startSpecifier, specifierLen));
 
     CharSourceRange CSRange = getSpecifierRange(CS.getStart(), CS.getLength());
     S.Diag(getLocationOfByte(CS.getStart()), diag::note_format_fix_specifier)
-      << FixedCS->toString()
-      << FixItHint::CreateReplacement(CSRange, FixedCS->toString());
+        << FixedCS->toString()
+        << FixItHint::CreateReplacement(CSRange, FixedCS->toString());
   } else {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard)
-                          << CS.toString() << /*conversion specifier*/1,
+                             << CS.toString() << /*conversion specifier*/ 1,
                          getLocationOfByte(CS.getStart()),
-                         /*IsStringLocation*/true,
+                         /*IsStringLocation*/ true,
                          getSpecifierRange(startSpecifier, specifierLen));
   }
 }
 
-void CheckFormatHandler::HandlePosition(const char *startPos,
-                                        unsigned posLen) {
+void CheckFormatHandler::HandlePosition(const char *startPos, unsigned posLen) {
   EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard_positional_arg),
-                               getLocationOfByte(startPos),
-                               /*IsStringLocation*/true,
-                               getSpecifierRange(startPos, posLen));
+                       getLocationOfByte(startPos),
+                       /*IsStringLocation*/ true,
+                       getSpecifierRange(startPos, posLen));
 }
 
 void CheckFormatHandler::HandleInvalidPosition(
@@ -11155,18 +11431,18 @@ void CheckFormatHandler::HandleInvalidPosition(
 void CheckFormatHandler::HandleZeroPosition(const char *startPos,
                                             unsigned posLen) {
   EmitFormatDiagnostic(S.PDiag(diag::warn_format_zero_positional_specifier),
-                               getLocationOfByte(startPos),
-                               /*IsStringLocation*/true,
-                               getSpecifierRange(startPos, posLen));
+                       getLocationOfByte(startPos),
+                       /*IsStringLocation*/ true,
+                       getSpecifierRange(startPos, posLen));
 }
 
 void CheckFormatHandler::HandleNullChar(const char *nullCharacter) {
   if (!isa<ObjCStringLiteral>(OrigFormatExpr)) {
     // The presence of a null character is likely an error.
     EmitFormatDiagnostic(
-      S.PDiag(diag::warn_printf_format_string_contains_null_char),
-      getLocationOfByte(nullCharacter), /*IsStringLocation*/true,
-      getFormatStringRange());
+        S.PDiag(diag::warn_printf_format_string_contains_null_char),
+        getLocationOfByte(nullCharacter), /*IsStringLocation*/ true,
+        getFormatStringRange());
   }
 }
 
@@ -11194,8 +11470,7 @@ void CheckFormatHandler::DoneProcessing() {
 
 void UncoveredArgHandler::Diagnose(Sema &S, bool IsFunctionCall,
                                    const Expr *ArgExpr) {
-  assert(hasUncoveredArg() && !DiagnosticExprs.empty() &&
-         "Invalid state");
+  assert(hasUncoveredArg() && !DiagnosticExprs.empty() && "Invalid state");
 
   if (!ArgExpr)
     return;
@@ -11210,25 +11485,19 @@ void UncoveredArgHandler::Diagnose(Sema &S, bool IsFunctionCall,
     PDiag << E->getSourceRange();
 
   CheckFormatHandler::EmitFormatDiagnostic(
-                                  S, IsFunctionCall, DiagnosticExprs[0],
-                                  PDiag, Loc, /*IsStringLocation*/false,
-                                  DiagnosticExprs[0]->getSourceRange());
+      S, IsFunctionCall, DiagnosticExprs[0], PDiag, Loc,
+      /*IsStringLocation*/ false, DiagnosticExprs[0]->getSourceRange());
 }
 
-bool
-CheckFormatHandler::HandleInvalidConversionSpecifier(unsigned argIndex,
-                                                     SourceLocation Loc,
-                                                     const char *startSpec,
-                                                     unsigned specifierLen,
-                                                     const char *csStart,
-                                                     unsigned csLen) {
+bool CheckFormatHandler::HandleInvalidConversionSpecifier(
+    unsigned argIndex, SourceLocation Loc, const char *startSpec,
+    unsigned specifierLen, const char *csStart, unsigned csLen) {
   bool keepGoing = true;
   if (argIndex < NumDataArgs) {
     // Consider the argument coverered, even though the specifier doesn't
     // make sense.
     CoveredArgs.set(argIndex);
-  }
-  else {
+  } else {
     // If argIndex exceeds the number of data arguments we
     // don't issue a warning because that is just a cascade of warnings (and
     // they may have intended '%%' anyway). We don't want to continue processing
@@ -11246,8 +11515,7 @@ CheckFormatHandler::HandleInvalidConversionSpecifier(unsigned argIndex,
   if (!llvm::sys::locale::isPrint(*csStart)) {
     llvm::UTF32 CodePoint;
     const llvm::UTF8 **B = reinterpret_cast<const llvm::UTF8 **>(&csStart);
-    const llvm::UTF8 *E =
-        reinterpret_cast<const llvm::UTF8 *>(csStart + csLen);
+    const llvm::UTF8 *E = reinterpret_cast<const llvm::UTF8 *>(csStart + csLen);
     llvm::ConversionResult Result =
         llvm::convertUTF8Sequence(B, E, &CodePoint, llvm::strictConversion);
 
@@ -11274,29 +11542,27 @@ CheckFormatHandler::HandleInvalidConversionSpecifier(unsigned argIndex,
   return keepGoing;
 }
 
-void
-CheckFormatHandler::HandlePositionalNonpositionalArgs(SourceLocation Loc,
-                                                      const char *startSpec,
-                                                      unsigned specifierLen) {
+void CheckFormatHandler::HandlePositionalNonpositionalArgs(
+    SourceLocation Loc, const char *startSpec, unsigned specifierLen) {
   EmitFormatDiagnostic(
-    S.PDiag(diag::warn_format_mix_positional_nonpositional_args),
-    Loc, /*isStringLoc*/true, getSpecifierRange(startSpec, specifierLen));
+      S.PDiag(diag::warn_format_mix_positional_nonpositional_args), Loc,
+      /*isStringLoc*/ true, getSpecifierRange(startSpec, specifierLen));
 }
 
-bool
-CheckFormatHandler::CheckNumArgs(
-  const analyze_format_string::FormatSpecifier &FS,
-  const analyze_format_string::ConversionSpecifier &CS,
-  const char *startSpecifier, unsigned specifierLen, unsigned argIndex) {
+bool CheckFormatHandler::CheckNumArgs(
+    const analyze_format_string::FormatSpecifier &FS,
+    const analyze_format_string::ConversionSpecifier &CS,
+    const char *startSpecifier, unsigned specifierLen, unsigned argIndex) {
 
   if (argIndex >= NumDataArgs) {
-    PartialDiagnostic PDiag = FS.usesPositionalArg()
-      ? (S.PDiag(diag::warn_printf_positional_arg_exceeds_data_args)
-           << (argIndex+1) << NumDataArgs)
-      : S.PDiag(diag::warn_printf_insufficient_data_args);
-    EmitFormatDiagnostic(
-      PDiag, getLocationOfByte(CS.getStart()), /*IsStringLocation*/true,
-      getSpecifierRange(startSpecifier, specifierLen));
+    PartialDiagnostic PDiag =
+        FS.usesPositionalArg()
+            ? (S.PDiag(diag::warn_printf_positional_arg_exceeds_data_args)
+               << (argIndex + 1) << NumDataArgs)
+            : S.PDiag(diag::warn_printf_insufficient_data_args);
+    EmitFormatDiagnostic(PDiag, getLocationOfByte(CS.getStart()),
+                         /*IsStringLocation*/ true,
+                         getSpecifierRange(startSpecifier, specifierLen));
 
     // Since more arguments than conversion tokens are given, by extension
     // all arguments are covered, so mark this as so.
@@ -11306,14 +11572,14 @@ CheckFormatHandler::CheckNumArgs(
   return true;
 }
 
-template<typename Range>
+template <typename Range>
 void CheckFormatHandler::EmitFormatDiagnostic(PartialDiagnostic PDiag,
                                               SourceLocation Loc,
                                               bool IsStringLocation,
                                               Range StringRange,
                                               ArrayRef<FixItHint> FixIt) {
-  EmitFormatDiagnostic(S, inFunctionCall, Args[FormatIdx], PDiag,
-                       Loc, IsStringLocation, StringRange, FixIt);
+  EmitFormatDiagnostic(S, inFunctionCall, Args[FormatIdx], PDiag, Loc,
+                       IsStringLocation, StringRange, FixIt);
 }
 
 /// If the format string is not within the function call, emit a note
@@ -11354,18 +11620,19 @@ void CheckFormatHandler::EmitFormatDiagnostic(
     D << FixIt;
   } else {
     S.Diag(IsStringLocation ? ArgumentExpr->getExprLoc() : Loc, PDiag)
-      << ArgumentExpr->getSourceRange();
+        << ArgumentExpr->getSourceRange();
 
     const Sema::SemaDiagnosticBuilder &Note =
-      S.Diag(IsStringLocation ? Loc : StringRange.getBegin(),
-             diag::note_format_string_defined);
+        S.Diag(IsStringLocation ? Loc : StringRange.getBegin(),
+               diag::note_format_string_defined);
 
     Note << StringRange;
     Note << FixIt;
   }
 }
 
-//===--- CHECK: Printf format string checking ------------------------------===//
+//===--- CHECK: Printf format string checking
+//------------------------------===//
 
 namespace {
 
@@ -11394,9 +11661,8 @@ public:
   }
 
   bool HandleInvalidPrintfConversionSpecifier(
-                                      const analyze_printf::PrintfSpecifier &FS,
-                                      const char *startSpecifier,
-                                      unsigned specifierLen) override;
+      const analyze_printf::PrintfSpecifier &FS, const char *startSpecifier,
+      unsigned specifierLen) override;
 
   void handleInvalidMaskType(StringRef MaskType) override;
 
@@ -11404,16 +11670,16 @@ public:
                              const char *startSpecifier, unsigned specifierLen,
                              const TargetInfo &Target) override;
   bool checkFormatExpr(const analyze_printf::PrintfSpecifier &FS,
-                       const char *StartSpecifier,
-                       unsigned SpecifierLen,
+                       const char *StartSpecifier, unsigned SpecifierLen,
                        const Expr *E);
 
-  bool HandleAmount(const analyze_format_string::OptionalAmount &Amt, unsigned k,
-                    const char *startSpecifier, unsigned specifierLen);
+  bool HandleAmount(const analyze_format_string::OptionalAmount &Amt,
+                    unsigned k, const char *startSpecifier,
+                    unsigned specifierLen);
   void HandleInvalidAmount(const analyze_printf::PrintfSpecifier &FS,
                            const analyze_printf::OptionalAmount &Amt,
-                           unsigned type,
-                           const char *startSpecifier, unsigned specifierLen);
+                           unsigned type, const char *startSpecifier,
+                           unsigned specifierLen);
   void HandleFlag(const analyze_printf::PrintfSpecifier &FS,
                   const analyze_printf::OptionalFlag &flag,
                   const char *startSpecifier, unsigned specifierLen);
@@ -11421,34 +11687,31 @@ public:
                          const analyze_printf::OptionalFlag &ignoredFlag,
                          const analyze_printf::OptionalFlag &flag,
                          const char *startSpecifier, unsigned specifierLen);
-  bool checkForCStrMembers(const analyze_printf::ArgType &AT,
-                           const Expr *E);
+  bool checkForCStrMembers(const analyze_printf::ArgType &AT, const Expr *E);
 
   void HandleEmptyObjCModifierFlag(const char *startFlag,
                                    unsigned flagLen) override;
 
   void HandleInvalidObjCModifierFlag(const char *startFlag,
-                                            unsigned flagLen) override;
+                                     unsigned flagLen) override;
 
-  void HandleObjCFlagsWithNonObjCConversion(const char *flagsStart,
-                                           const char *flagsEnd,
-                                           const char *conversionPosition)
-                                             override;
+  void
+  HandleObjCFlagsWithNonObjCConversion(const char *flagsStart,
+                                       const char *flagsEnd,
+                                       const char *conversionPosition) override;
 };
 
 } // namespace
 
 bool CheckPrintfHandler::HandleInvalidPrintfConversionSpecifier(
-                                      const analyze_printf::PrintfSpecifier &FS,
-                                      const char *startSpecifier,
-                                      unsigned specifierLen) {
+    const analyze_printf::PrintfSpecifier &FS, const char *startSpecifier,
+    unsigned specifierLen) {
   const analyze_printf::PrintfConversionSpecifier &CS =
-    FS.getConversionSpecifier();
+      FS.getConversionSpecifier();
 
-  return HandleInvalidConversionSpecifier(FS.getArgIndex(),
-                                          getLocationOfByte(CS.getStart()),
-                                          startSpecifier, specifierLen,
-                                          CS.getStart(), CS.getLength());
+  return HandleInvalidConversionSpecifier(
+      FS.getArgIndex(), getLocationOfByte(CS.getStart()), startSpecifier,
+      specifierLen, CS.getStart(), CS.getLength());
 }
 
 void CheckPrintfHandler::handleInvalidMaskType(StringRef MaskType) {
@@ -11488,10 +11751,10 @@ bool CheckPrintfHandler::HandleAmount(
 
       if (!AT.matchesType(S.Context, T)) {
         EmitFormatDiagnostic(S.PDiag(diag::warn_printf_asterisk_wrong_type)
-                               << k << AT.getRepresentativeTypeName(S.Context)
-                               << T << Arg->getSourceRange(),
+                                 << k << AT.getRepresentativeTypeName(S.Context)
+                                 << T << Arg->getSourceRange(),
                              getLocationOfByte(Amt.getStart()),
-                             /*IsStringLocation*/true,
+                             /*IsStringLocation*/ true,
                              getSpecifierRange(startSpecifier, specifierLen));
         // Don't do any more checking.  We will just emit
         // spurious errors.
@@ -11503,26 +11766,23 @@ bool CheckPrintfHandler::HandleAmount(
 }
 
 void CheckPrintfHandler::HandleInvalidAmount(
-                                      const analyze_printf::PrintfSpecifier &FS,
-                                      const analyze_printf::OptionalAmount &Amt,
-                                      unsigned type,
-                                      const char *startSpecifier,
-                                      unsigned specifierLen) {
+    const analyze_printf::PrintfSpecifier &FS,
+    const analyze_printf::OptionalAmount &Amt, unsigned type,
+    const char *startSpecifier, unsigned specifierLen) {
   const analyze_printf::PrintfConversionSpecifier &CS =
-    FS.getConversionSpecifier();
+      FS.getConversionSpecifier();
 
   FixItHint fixit =
-    Amt.getHowSpecified() == analyze_printf::OptionalAmount::Constant
-      ? FixItHint::CreateRemoval(getSpecifierRange(Amt.getStart(),
-                                 Amt.getConstantLength()))
-      : FixItHint();
+      Amt.getHowSpecified() == analyze_printf::OptionalAmount::Constant
+          ? FixItHint::CreateRemoval(
+                getSpecifierRange(Amt.getStart(), Amt.getConstantLength()))
+          : FixItHint();
 
   EmitFormatDiagnostic(S.PDiag(diag::warn_printf_nonsensical_optional_amount)
-                         << type << CS.toString(),
+                           << type << CS.toString(),
                        getLocationOfByte(Amt.getStart()),
-                       /*IsStringLocation*/true,
-                       getSpecifierRange(startSpecifier, specifierLen),
-                       fixit);
+                       /*IsStringLocation*/ true,
+                       getSpecifierRange(startSpecifier, specifierLen), fixit);
 }
 
 void CheckPrintfHandler::HandleFlag(const analyze_printf::PrintfSpecifier &FS,
@@ -11531,39 +11791,37 @@ void CheckPrintfHandler::HandleFlag(const analyze_printf::PrintfSpecifier &FS,
                                     unsigned specifierLen) {
   // Warn about pointless flag with a fixit removal.
   const analyze_printf::PrintfConversionSpecifier &CS =
-    FS.getConversionSpecifier();
-  EmitFormatDiagnostic(S.PDiag(diag::warn_printf_nonsensical_flag)
-                         << flag.toString() << CS.toString(),
-                       getLocationOfByte(flag.getPosition()),
-                       /*IsStringLocation*/true,
-                       getSpecifierRange(startSpecifier, specifierLen),
-                       FixItHint::CreateRemoval(
-                         getSpecifierRange(flag.getPosition(), 1)));
+      FS.getConversionSpecifier();
+  EmitFormatDiagnostic(
+      S.PDiag(diag::warn_printf_nonsensical_flag)
+          << flag.toString() << CS.toString(),
+      getLocationOfByte(flag.getPosition()),
+      /*IsStringLocation*/ true,
+      getSpecifierRange(startSpecifier, specifierLen),
+      FixItHint::CreateRemoval(getSpecifierRange(flag.getPosition(), 1)));
 }
 
 void CheckPrintfHandler::HandleIgnoredFlag(
-                                const analyze_printf::PrintfSpecifier &FS,
-                                const analyze_printf::OptionalFlag &ignoredFlag,
-                                const analyze_printf::OptionalFlag &flag,
-                                const char *startSpecifier,
-                                unsigned specifierLen) {
+    const analyze_printf::PrintfSpecifier &FS,
+    const analyze_printf::OptionalFlag &ignoredFlag,
+    const analyze_printf::OptionalFlag &flag, const char *startSpecifier,
+    unsigned specifierLen) {
   // Warn about ignored flag with a fixit removal.
   EmitFormatDiagnostic(S.PDiag(diag::warn_printf_ignored_flag)
-                         << ignoredFlag.toString() << flag.toString(),
+                           << ignoredFlag.toString() << flag.toString(),
                        getLocationOfByte(ignoredFlag.getPosition()),
-                       /*IsStringLocation*/true,
+                       /*IsStringLocation*/ true,
                        getSpecifierRange(startSpecifier, specifierLen),
                        FixItHint::CreateRemoval(
-                         getSpecifierRange(ignoredFlag.getPosition(), 1)));
+                           getSpecifierRange(ignoredFlag.getPosition(), 1)));
 }
 
 void CheckPrintfHandler::HandleEmptyObjCModifierFlag(const char *startFlag,
                                                      unsigned flagLen) {
   // Warn about an empty flag.
-  EmitFormatDiagnostic(S.PDiag(diag::warn_printf_empty_objc_flag),
-                       getLocationOfByte(startFlag),
-                       /*IsStringLocation*/true,
-                       getSpecifierRange(startFlag, flagLen));
+  EmitFormatDiagnostic(
+      S.PDiag(diag::warn_printf_empty_objc_flag), getLocationOfByte(startFlag),
+      /*IsStringLocation*/ true, getSpecifierRange(startFlag, flagLen));
 }
 
 void CheckPrintfHandler::HandleInvalidObjCModifierFlag(const char *startFlag,
@@ -11572,30 +11830,31 @@ void CheckPrintfHandler::HandleInvalidObjCModifierFlag(const char *startFlag,
   auto Range = getSpecifierRange(startFlag, flagLen);
   StringRef flag(startFlag, flagLen);
   EmitFormatDiagnostic(S.PDiag(diag::warn_printf_invalid_objc_flag) << flag,
-                      getLocationOfByte(startFlag),
-                      /*IsStringLocation*/true,
-                      Range, FixItHint::CreateRemoval(Range));
+                       getLocationOfByte(startFlag),
+                       /*IsStringLocation*/ true, Range,
+                       FixItHint::CreateRemoval(Range));
 }
 
 void CheckPrintfHandler::HandleObjCFlagsWithNonObjCConversion(
-    const char *flagsStart, const char *flagsEnd, const char *conversionPosition) {
-    // Warn about using '[...]' without a '@' conversion.
-    auto Range = getSpecifierRange(flagsStart, flagsEnd - flagsStart + 1);
-    auto diag = diag::warn_printf_ObjCflags_without_ObjCConversion;
-    EmitFormatDiagnostic(S.PDiag(diag) << StringRef(conversionPosition, 1),
-                         getLocationOfByte(conversionPosition),
-                         /*IsStringLocation*/true,
-                         Range, FixItHint::CreateRemoval(Range));
+    const char *flagsStart, const char *flagsEnd,
+    const char *conversionPosition) {
+  // Warn about using '[...]' without a '@' conversion.
+  auto Range = getSpecifierRange(flagsStart, flagsEnd - flagsStart + 1);
+  auto diag = diag::warn_printf_ObjCflags_without_ObjCConversion;
+  EmitFormatDiagnostic(S.PDiag(diag) << StringRef(conversionPosition, 1),
+                       getLocationOfByte(conversionPosition),
+                       /*IsStringLocation*/ true, Range,
+                       FixItHint::CreateRemoval(Range));
 }
 
 // Determines if the specified is a C++ class or struct containing
 // a member with the specified name and kind (e.g. a CXXMethodDecl named
 // "c_str()").
-template<typename MemberKind>
-static llvm::SmallPtrSet<MemberKind*, 1>
+template <typename MemberKind>
+static llvm::SmallPtrSet<MemberKind *, 1>
 CXXRecordMembersNamed(StringRef Name, Sema &S, QualType Ty) {
   const RecordType *RT = Ty->getAs<RecordType>();
-  llvm::SmallPtrSet<MemberKind*, 1> Results;
+  llvm::SmallPtrSet<MemberKind *, 1> Results;
 
   if (!RT)
     return Results;
@@ -11627,8 +11886,8 @@ bool Sema::hasCStrMethod(const Expr *E) {
 
   MethodSet Results =
       CXXRecordMembersNamed<CXXMethodDecl>("c_str", *this, E->getType());
-  for (MethodSet::iterator MI = Results.begin(), ME = Results.end();
-       MI != ME; ++MI)
+  for (MethodSet::iterator MI = Results.begin(), ME = Results.end(); MI != ME;
+       ++MI)
     if ((*MI)->getMinRequiredArguments() == 0)
       return true;
   return false;
@@ -11637,15 +11896,15 @@ bool Sema::hasCStrMethod(const Expr *E) {
 // Check if a (w)string was passed when a (w)char* was needed, and offer a
 // better diagnostic if so. AT is assumed to be valid.
 // Returns true when a c_str() conversion method is found.
-bool CheckPrintfHandler::checkForCStrMembers(
-    const analyze_printf::ArgType &AT, const Expr *E) {
+bool CheckPrintfHandler::checkForCStrMembers(const analyze_printf::ArgType &AT,
+                                             const Expr *E) {
   using MethodSet = llvm::SmallPtrSet<CXXMethodDecl *, 1>;
 
   MethodSet Results =
       CXXRecordMembersNamed<CXXMethodDecl>("c_str", S, E->getType());
 
-  for (MethodSet::iterator MI = Results.begin(), ME = Results.end();
-       MI != ME; ++MI) {
+  for (MethodSet::iterator MI = Results.begin(), ME = Results.end(); MI != ME;
+       ++MI) {
     const CXXMethodDecl *Method = *MI;
     if (Method->getMinRequiredArguments() == 0 &&
         AT.matchesType(S.Context, Method->getReturnType())) {
@@ -11670,10 +11929,9 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
 
   if (FS.consumesDataArgument()) {
     if (atFirstArg) {
-        atFirstArg = false;
-        usesPositionalArgs = FS.usesPositionalArg();
-    }
-    else if (usesPositionalArgs != FS.usesPositionalArg()) {
+      atFirstArg = false;
+      usesPositionalArgs = FS.usesPositionalArg();
+    } else if (usesPositionalArgs != FS.usesPositionalArg()) {
       HandlePositionalNonpositionalArgs(getLocationOfByte(CS.getStart()),
                                         startSpecifier, specifierLen);
       return false;
@@ -11682,13 +11940,13 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
 
   // First check if the field width, precision, and conversion specifier
   // have matching data arguments.
-  if (!HandleAmount(FS.getFieldWidth(), /* field width */ 0,
-                    startSpecifier, specifierLen)) {
+  if (!HandleAmount(FS.getFieldWidth(), /* field width */ 0, startSpecifier,
+                    specifierLen)) {
     return false;
   }
 
-  if (!HandleAmount(FS.getPrecision(), /* precision */ 1,
-                    startSpecifier, specifierLen)) {
+  if (!HandleAmount(FS.getPrecision(), /* precision */ 1, startSpecifier,
+                    specifierLen)) {
     return false;
   }
 
@@ -11720,8 +11978,9 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
     // Type check the first argument (int for %b, pointer for %D)
     const Expr *Ex = getDataArg(argIndex);
     const analyze_printf::ArgType &AT =
-      (CS.getKind() == ConversionSpecifier::FreeBSDbArg) ?
-        ArgType(S.Context.IntTy) : ArgType::CPointerTy;
+        (CS.getKind() == ConversionSpecifier::FreeBSDbArg)
+            ? ArgType(S.Context.IntTy)
+            : ArgType::CPointerTy;
     if (AT.isValid() && !AT.matchesType(S.Context, Ex->getType()))
       EmitFormatDiagnostic(
           S.PDiag(diag::warn_format_conversion_argument_type_mismatch)
@@ -11741,7 +12000,7 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
           Ex->getBeginLoc(), /*IsStringLocation*/ false,
           getSpecifierRange(startSpecifier, specifierLen));
 
-     return true;
+    return true;
   }
 
   // Check for using an Objective-C specific conversion specifier
@@ -11806,13 +12065,13 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
   // Check for invalid use of field width
   if (!FS.hasValidFieldWidth()) {
     HandleInvalidAmount(FS, FS.getFieldWidth(), /* field width */ 0,
-        startSpecifier, specifierLen);
+                        startSpecifier, specifierLen);
   }
 
   // Check for invalid use of precision
   if (!FS.hasValidPrecision()) {
     HandleInvalidAmount(FS, FS.getPrecision(), /* precision */ 1,
-        startSpecifier, specifierLen);
+                        startSpecifier, specifierLen);
   }
 
   // Precision is mandatory for %P specifier.
@@ -11841,10 +12100,10 @@ bool CheckPrintfHandler::HandlePrintfSpecifier(
   // Check that flags are not ignored by another flag
   if (FS.hasSpacePrefix() && FS.hasPlusPrefix()) // ' ' ignored by '+'
     HandleIgnoredFlag(FS, FS.hasSpacePrefix(), FS.hasPlusPrefix(),
-        startSpecifier, specifierLen);
+                      startSpecifier, specifierLen);
   if (FS.hasLeadingZeros() && FS.isLeftJustified()) // '0' ignored by '-'
     HandleIgnoredFlag(FS, FS.hasLeadingZeros(), FS.isLeftJustified(),
-            startSpecifier, specifierLen);
+                      startSpecifier, specifierLen);
 
   // Check the length modifier is valid with the given conversion specifier.
   if (!FS.hasValidLengthModifier(S.getASTContext().getTargetInfo(),
@@ -11911,20 +12170,19 @@ static bool requiresParensToAddCast(const Expr *E) {
 }
 
 static std::pair<QualType, StringRef>
-shouldNotPrintDirectly(const ASTContext &Context,
-                       QualType IntendedTy,
+shouldNotPrintDirectly(const ASTContext &Context, QualType IntendedTy,
                        const Expr *E) {
   // Use a 'while' to peel off layers of typedefs.
   QualType TyTy = IntendedTy;
   while (const TypedefType *UserTy = TyTy->getAs<TypedefType>()) {
     StringRef Name = UserTy->getDecl()->getName();
     QualType CastTy = llvm::StringSwitch<QualType>(Name)
-      .Case("CFIndex", Context.getNSIntegerType())
-      .Case("NSInteger", Context.getNSIntegerType())
-      .Case("NSUInteger", Context.getNSUIntegerType())
-      .Case("SInt32", Context.IntTy)
-      .Case("UInt32", Context.UnsignedIntTy)
-      .Default(QualType());
+                          .Case("CFIndex", Context.getNSIntegerType())
+                          .Case("NSInteger", Context.getNSIntegerType())
+                          .Case("NSUInteger", Context.getNSUIntegerType())
+                          .Case("SInt32", Context.IntTy)
+                          .Case("UInt32", Context.UnsignedIntTy)
+                          .Default(QualType());
 
     if (!CastTy.isNull())
       return std::make_pair(CastTy, Name);
@@ -11934,8 +12192,7 @@ shouldNotPrintDirectly(const ASTContext &Context,
 
   // Strip parens if necessary.
   if (const ParenExpr *PE = dyn_cast<ParenExpr>(E))
-    return shouldNotPrintDirectly(Context,
-                                  PE->getSubExpr()->getType(),
+    return shouldNotPrintDirectly(Context, PE->getSubExpr()->getType(),
                                   PE->getSubExpr());
 
   // If this is a conditional expression, then its result type is constructed
@@ -11946,14 +12203,10 @@ shouldNotPrintDirectly(const ASTContext &Context,
     QualType TrueTy, FalseTy;
     StringRef TrueName, FalseName;
 
-    std::tie(TrueTy, TrueName) =
-      shouldNotPrintDirectly(Context,
-                             CO->getTrueExpr()->getType(),
-                             CO->getTrueExpr());
-    std::tie(FalseTy, FalseName) =
-      shouldNotPrintDirectly(Context,
-                             CO->getFalseExpr()->getType(),
-                             CO->getFalseExpr());
+    std::tie(TrueTy, TrueName) = shouldNotPrintDirectly(
+        Context, CO->getTrueExpr()->getType(), CO->getTrueExpr());
+    std::tie(FalseTy, FalseName) = shouldNotPrintDirectly(
+        Context, CO->getFalseExpr()->getType(), CO->getFalseExpr());
 
     if (TrueTy == FalseTy)
       return std::make_pair(TrueTy, TrueName);
@@ -11969,8 +12222,8 @@ shouldNotPrintDirectly(const ASTContext &Context,
 /// Return true if \p ICE is an implicit argument promotion of an arithmetic
 /// type. Bit-field 'promotions' from a higher ranked type to a lower ranked
 /// type do not count.
-static bool
-isArithmeticArgumentPromotion(Sema &S, const ImplicitCastExpr *ICE) {
+static bool isArithmeticArgumentPromotion(Sema &S,
+                                          const ImplicitCastExpr *ICE) {
   QualType From = ICE->getSubExpr()->getType();
   QualType To = ICE->getType();
   // It's an integer promotion if the destination type is the promoted
@@ -11990,11 +12243,9 @@ isArithmeticArgumentPromotion(Sema &S, const ImplicitCastExpr *ICE) {
          S.Context.getFloatingTypeOrder(From, To) < 0;
 }
 
-bool
-CheckPrintfHandler::checkFormatExpr(const analyze_printf::PrintfSpecifier &FS,
-                                    const char *StartSpecifier,
-                                    unsigned SpecifierLen,
-                                    const Expr *E) {
+bool CheckPrintfHandler::checkFormatExpr(
+    const analyze_printf::PrintfSpecifier &FS, const char *StartSpecifier,
+    unsigned SpecifierLen, const Expr *E) {
   using namespace analyze_format_string;
   using namespace analyze_printf;
 
@@ -12140,10 +12391,12 @@ CheckPrintfHandler::checkFormatExpr(const analyze_printf::PrintfSpecifier &FS,
 
   // Special-case some of Darwin's platform-independence types by suggesting
   // casts to primitive types that are known to be large enough.
-  bool ShouldNotPrintDirectly = false; StringRef CastTyName;
+  bool ShouldNotPrintDirectly = false;
+  StringRef CastTyName;
   if (S.Context.getTargetInfo().getTriple().isOSDarwin()) {
     QualType CastTy;
-    std::tie(CastTy, CastTyName) = shouldNotPrintDirectly(S.Context, IntendedTy, E);
+    std::tie(CastTy, CastTyName) =
+        shouldNotPrintDirectly(S.Context, IntendedTy, E);
     if (!CastTy.isNull()) {
       // %zi/%zu and %td/%tu are OK to use for NSInteger/NSUInteger of type int
       // (long in ASTContext). Only complain to pedants or when they're the
@@ -12211,7 +12464,7 @@ CheckPrintfHandler::checkFormatExpr(const analyze_printf::PrintfSpecifier &FS,
       IntendedTy.print(CastFix, S.Context.getPrintingPolicy());
       CastFix << (S.LangOpts.CPlusPlus ? ">" : ")");
 
-      SmallVector<FixItHint,4> Hints;
+      SmallVector<FixItHint, 4> Hints;
       if (AT.matchesType(S.Context, IntendedTy) != ArgType::Match ||
           ShouldNotPrintDirectly)
         Hints.push_back(FixItHint::CreateReplacement(SpecRange, os.str()));
@@ -12268,8 +12521,8 @@ CheckPrintfHandler::checkFormatExpr(const analyze_printf::PrintfSpecifier &FS,
       }
     }
   } else {
-    const CharSourceRange &CSR = getSpecifierRange(StartSpecifier,
-                                                   SpecifierLen);
+    const CharSourceRange &CSR =
+        getSpecifierRange(StartSpecifier, SpecifierLen);
     // Since the warning for passing non-POD types to variadic functions
     // was deferred until now, we emit a warning for non-POD
     // arguments here.
@@ -12378,10 +12631,10 @@ public:
                             const char *startSpecifier,
                             unsigned specifierLen) override;
 
-  bool HandleInvalidScanfConversionSpecifier(
-          const analyze_scanf::ScanfSpecifier &FS,
-          const char *startSpecifier,
-          unsigned specifierLen) override;
+  bool
+  HandleInvalidScanfConversionSpecifier(const analyze_scanf::ScanfSpecifier &FS,
+                                        const char *startSpecifier,
+                                        unsigned specifierLen) override;
 
   void HandleIncompleteScanList(const char *start, const char *end) override;
 };
@@ -12391,27 +12644,24 @@ public:
 void CheckScanfHandler::HandleIncompleteScanList(const char *start,
                                                  const char *end) {
   EmitFormatDiagnostic(S.PDiag(diag::warn_scanf_scanlist_incomplete),
-                       getLocationOfByte(end), /*IsStringLocation*/true,
+                       getLocationOfByte(end), /*IsStringLocation*/ true,
                        getSpecifierRange(start, end - start));
 }
 
 bool CheckScanfHandler::HandleInvalidScanfConversionSpecifier(
-                                        const analyze_scanf::ScanfSpecifier &FS,
-                                        const char *startSpecifier,
-                                        unsigned specifierLen) {
+    const analyze_scanf::ScanfSpecifier &FS, const char *startSpecifier,
+    unsigned specifierLen) {
   const analyze_scanf::ScanfConversionSpecifier &CS =
-    FS.getConversionSpecifier();
+      FS.getConversionSpecifier();
 
-  return HandleInvalidConversionSpecifier(FS.getArgIndex(),
-                                          getLocationOfByte(CS.getStart()),
-                                          startSpecifier, specifierLen,
-                                          CS.getStart(), CS.getLength());
+  return HandleInvalidConversionSpecifier(
+      FS.getArgIndex(), getLocationOfByte(CS.getStart()), startSpecifier,
+      specifierLen, CS.getStart(), CS.getLength());
 }
 
 bool CheckScanfHandler::HandleScanfSpecifier(
-                                       const analyze_scanf::ScanfSpecifier &FS,
-                                       const char *startSpecifier,
-                                       unsigned specifierLen) {
+    const analyze_scanf::ScanfSpecifier &FS, const char *startSpecifier,
+    unsigned specifierLen) {
   using namespace analyze_scanf;
   using namespace analyze_format_string;
 
@@ -12423,8 +12673,7 @@ bool CheckScanfHandler::HandleScanfSpecifier(
     if (atFirstArg) {
       atFirstArg = false;
       usesPositionalArgs = FS.usesPositionalArg();
-    }
-    else if (usesPositionalArgs != FS.usesPositionalArg()) {
+    } else if (usesPositionalArgs != FS.usesPositionalArg()) {
       HandlePositionalNonpositionalArgs(getLocationOfByte(CS.getStart()),
                                         startSpecifier, specifierLen);
       return false;
@@ -12435,11 +12684,11 @@ bool CheckScanfHandler::HandleScanfSpecifier(
   const OptionalAmount &Amt = FS.getFieldWidth();
   if (Amt.getHowSpecified() == OptionalAmount::Constant) {
     if (Amt.getConstantAmount() == 0) {
-      const CharSourceRange &R = getSpecifierRange(Amt.getStart(),
-                                                   Amt.getConstantLength());
+      const CharSourceRange &R =
+          getSpecifierRange(Amt.getStart(), Amt.getConstantLength());
       EmitFormatDiagnostic(S.PDiag(diag::warn_scanf_nonzero_width),
                            getLocationOfByte(Amt.getStart()),
-                           /*IsStringLocation*/true, R,
+                           /*IsStringLocation*/ true, R,
                            FixItHint::CreateRemoval(R));
     }
   }
@@ -12453,9 +12702,9 @@ bool CheckScanfHandler::HandleScanfSpecifier(
   // Consume the argument.
   unsigned argIndex = FS.getArgIndex();
   if (argIndex < NumDataArgs) {
-      // The check to see if the argIndex is valid will come later.
-      // We set the bit here because we may exit early from this
-      // function if we encounter some other error.
+    // The check to see if the argIndex is valid will come later.
+    // We set the bit here because we may exit early from this
+    // function if we encounter some other error.
     CoveredArgs.set(argIndex);
   }
 
@@ -12552,7 +12801,7 @@ static void CheckFormatString(
   const char *Str = StrRef.data();
   // Account for cases where the string literal is truncated in a declaration.
   const ConstantArrayType *T =
-    S.Context.getAsConstantArrayType(FExpr->getType());
+      S.Context.getAsConstantArrayType(FExpr->getType());
   assert(T && "String literal not of constant array type!");
   size_t TypeSize = T->getSize().getZExtValue();
   size_t StrLen = std::min(std::max(TypeSize, size_t(1)) - 1, StrRef.size());
@@ -12616,9 +12865,8 @@ bool Sema::FormatStringHasSArg(const StringLiteral *FExpr) {
   assert(T && "String literal not of constant array type!");
   size_t TypeSize = T->getSize().getZExtValue();
   size_t StrLen = std::min(std::max(TypeSize, size_t(1)) - 1, StrRef.size());
-  return analyze_format_string::ParseFormatStringHasSArg(Str, Str + StrLen,
-                                                         getLangOpts(),
-                                                         Context.getTargetInfo());
+  return analyze_format_string::ParseFormatStringHasSArg(
+      Str, Str + StrLen, getLangOpts(), Context.getTargetInfo());
 }
 
 //===--- CHECK: Warn on use of wrong absolute value function. -------------===//
@@ -12666,7 +12914,7 @@ static unsigned getLargerAbsoluteValueFunction(unsigned AbsFunction) {
     return 0;
 
   case Builtin::BIcabsf:
-   return Builtin::BIcabs;
+    return Builtin::BIcabs;
   case Builtin::BIcabs:
     return Builtin::BIcabsl;
   case Builtin::BIcabsl:
@@ -12716,11 +12964,7 @@ static unsigned getBestAbsFunction(ASTContext &Context, QualType ArgType,
   return BestKind;
 }
 
-enum AbsoluteValueKind {
-  AVK_Integer,
-  AVK_Floating,
-  AVK_Complex
-};
+enum AbsoluteValueKind { AVK_Integer, AVK_Floating, AVK_Complex };
 
 static AbsoluteValueKind getAbsoluteValueKind(QualType T) {
   if (T->isIntegralOrEnumerationType())
@@ -12910,8 +13154,8 @@ static void emitReplacement(Sema &S, SourceLocation Loc, SourceRange Range,
   if (!EmitHeaderHint)
     return;
 
-  S.Diag(Loc, diag::note_include_header_or_declare) << HeaderName
-                                                    << FunctionName;
+  S.Diag(Loc, diag::note_include_header_or_declare)
+      << HeaderName << FunctionName;
 }
 
 template <std::size_t StrLen>
@@ -13026,32 +13270,44 @@ void Sema::CheckAbsoluteValueFunction(const CallExpr *Call,
 //===--- CHECK: Warn on use of std::max and unsigned zero. r---------------===//
 void Sema::CheckMaxUnsignedZero(const CallExpr *Call,
                                 const FunctionDecl *FDecl) {
-  if (!Call || !FDecl) return;
+  if (!Call || !FDecl)
+    return;
 
   // Ignore template specializations and macros.
-  if (inTemplateInstantiation()) return;
-  if (Call->getExprLoc().isMacroID()) return;
+  if (inTemplateInstantiation())
+    return;
+  if (Call->getExprLoc().isMacroID())
+    return;
 
   // Only care about the one template argument, two function parameter std::max
-  if (Call->getNumArgs() != 2) return;
-  if (!IsStdFunction(FDecl, "max")) return;
-  const auto * ArgList = FDecl->getTemplateSpecializationArgs();
-  if (!ArgList) return;
-  if (ArgList->size() != 1) return;
+  if (Call->getNumArgs() != 2)
+    return;
+  if (!IsStdFunction(FDecl, "max"))
+    return;
+  const auto *ArgList = FDecl->getTemplateSpecializationArgs();
+  if (!ArgList)
+    return;
+  if (ArgList->size() != 1)
+    return;
 
   // Check that template type argument is unsigned integer.
-  const auto& TA = ArgList->get(0);
-  if (TA.getKind() != TemplateArgument::Type) return;
+  const auto &TA = ArgList->get(0);
+  if (TA.getKind() != TemplateArgument::Type)
+    return;
   QualType ArgType = TA.getAsType();
-  if (!ArgType->isUnsignedIntegerType()) return;
+  if (!ArgType->isUnsignedIntegerType())
+    return;
 
   // See if either argument is a literal zero.
-  auto IsLiteralZeroArg = [](const Expr* E) -> bool {
+  auto IsLiteralZeroArg = [](const Expr *E) -> bool {
     const auto *MTE = dyn_cast<MaterializeTemporaryExpr>(E);
-    if (!MTE) return false;
+    if (!MTE)
+      return false;
     const auto *Num = dyn_cast<IntegerLiteral>(MTE->getSubExpr());
-    if (!Num) return false;
-    if (Num->getValue() != 0) return false;
+    if (!Num)
+      return false;
+    if (Num->getValue() != 0)
+      return false;
     return true;
   };
 
@@ -13061,7 +13317,8 @@ void Sema::CheckMaxUnsignedZero(const CallExpr *Call,
   const bool IsSecondArgZero = IsLiteralZeroArg(SecondArg);
 
   // Only warn when exactly one argument is zero.
-  if (IsFirstArgZero == IsSecondArgZero) return;
+  if (IsFirstArgZero == IsSecondArgZero)
+    return;
 
   SourceRange FirstRange = FirstArg->getSourceRange();
   SourceRange SecondRange = SecondArg->getSourceRange();
@@ -13082,8 +13339,8 @@ void Sema::CheckMaxUnsignedZero(const CallExpr *Call,
   }
 
   Diag(Call->getExprLoc(), diag::note_remove_max_call)
-        << FixItHint::CreateRemoval(Call->getCallee()->getSourceRange())
-        << FixItHint::CreateRemoval(RemovalRange);
+      << FixItHint::CreateRemoval(Call->getCallee()->getSourceRange())
+      << FixItHint::CreateRemoval(RemovalRange);
 }
 
 //===--- CHECK: Standard memory functions ---------------------------------===//
@@ -13264,7 +13521,7 @@ struct SearchNonTrivialToCopyField
   Sema &S;
 };
 
-}
+} // namespace
 
 /// Detect if \c SizeofExpr is likely to calculate the sizeof an object.
 static bool doesExprLikelyComputeSize(const Expr *SizeofExpr) {
@@ -13308,7 +13565,7 @@ static void CheckMemaccessSize(Sema &S, unsigned BId, const CallExpr *Call) {
     return;
 
   const Expr *SizeArg =
-    Call->getArg(BId == Builtin::BImemset ? 2 : 1)->IgnoreImpCasts();
+      Call->getArg(BId == Builtin::BImemset ? 2 : 1)->IgnoreImpCasts();
 
   auto isLiteralZero = [](const Expr *E) {
     return (isa<IntegerLiteral>(E) &&
@@ -13342,8 +13599,7 @@ static void CheckMemaccessSize(Sema &S, unsigned BId, const CallExpr *Call) {
   // If the second argument to a memset is a sizeof expression and the third
   // isn't, this is also likely an error. This should catch
   // 'memset(buf, sizeof(buf), 0xff)'.
-  if (BId == Builtin::BImemset &&
-      doesExprLikelyComputeSize(Call->getArg(1)) &&
+  if (BId == Builtin::BImemset && doesExprLikelyComputeSize(Call->getArg(1)) &&
       !doesExprLikelyComputeSize(Call->getArg(2))) {
     SourceLocation DiagLoc = Call->getArg(1)->getExprLoc();
     S.Diag(DiagLoc, diag::warn_suspicious_sizeof_memset) << 1;
@@ -13359,8 +13615,7 @@ static void CheckMemaccessSize(Sema &S, unsigned BId, const CallExpr *Call) {
 /// function calls.
 ///
 /// \param Call The call expression to diagnose.
-void Sema::CheckMemaccessArguments(const CallExpr *Call,
-                                   unsigned BId,
+void Sema::CheckMemaccessArguments(const CallExpr *Call, unsigned BId,
                                    IdentifierInfo *FnName) {
   assert(BId != 0);
 
@@ -13372,7 +13627,9 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
     return;
 
   unsigned LastArg = (BId == Builtin::BImemset || BId == Builtin::BIbzero ||
-                      BId == Builtin::BIstrndup ? 1 : 2);
+                              BId == Builtin::BIstrndup
+                          ? 1
+                          : 2);
   unsigned LenArg =
       (BId == Builtin::BIbzero || BId == Builtin::BIstrndup ? 1 : 2);
   const Expr *LenExpr = Call->getArg(LenArg)->IgnoreParenImpCasts();
@@ -13448,22 +13705,19 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
             ReadableName = Lexer::getImmediateMacroName(SL, SM, LangOpts);
             SL = SM.getSpellingLoc(SL);
             DSR = SourceRange(SM.getSpellingLoc(DSR.getBegin()),
-                             SM.getSpellingLoc(DSR.getEnd()));
+                              SM.getSpellingLoc(DSR.getEnd()));
             SSR = SourceRange(SM.getSpellingLoc(SSR.getBegin()),
-                             SM.getSpellingLoc(SSR.getEnd()));
+                              SM.getSpellingLoc(SSR.getEnd()));
           }
 
           DiagRuntimeBehavior(SL, SizeOfArg,
                               PDiag(diag::warn_sizeof_pointer_expr_memaccess)
-                                << ReadableName
-                                << PointeeTy
-                                << DestTy
-                                << DSR
-                                << SSR);
-          DiagRuntimeBehavior(SL, SizeOfArg,
-                         PDiag(diag::warn_sizeof_pointer_expr_memaccess_note)
-                                << ActionIdx
-                                << SSR);
+                                  << ReadableName << PointeeTy << DestTy << DSR
+                                  << SSR);
+          DiagRuntimeBehavior(
+              SL, SizeOfArg,
+              PDiag(diag::warn_sizeof_pointer_expr_memaccess_note)
+                  << ActionIdx << SSR);
 
           break;
         }
@@ -13477,9 +13731,9 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
             Context.typesAreCompatible(SizeOfArgTy, DestTy)) {
           DiagRuntimeBehavior(LenExpr->getExprLoc(), Dest,
                               PDiag(diag::warn_sizeof_pointer_type_memaccess)
-                                << FnName << SizeOfArgTy << ArgIdx
-                                << PointeeTy << Dest->getSourceRange()
-                                << LenExpr->getSourceRange());
+                                  << FnName << SizeOfArgTy << ArgIdx
+                                  << PointeeTy << Dest->getSourceRange()
+                                  << LenExpr->getSourceRange());
           break;
         }
       }
@@ -13502,7 +13756,7 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
       if (ArgIdx != 0 || IsCmp) {
         if (BId == Builtin::BImemcpy)
           OperationType = 1;
-        else if(BId == Builtin::BImemmove)
+        else if (BId == Builtin::BImemmove)
           OperationType = 2;
         else if (IsCmp)
           OperationType = 3;
@@ -13514,12 +13768,11 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
                               << IsContained << ContainedRD << OperationType
                               << Call->getCallee()->getSourceRange());
     } else if (PointeeTy.hasNonTrivialObjCLifetime() &&
-             BId != Builtin::BImemset)
-      DiagRuntimeBehavior(
-        Dest->getExprLoc(), Dest,
-        PDiag(diag::warn_arc_object_memaccess)
-          << ArgIdx << FnName << PointeeTy
-          << Call->getCallee()->getSourceRange());
+               BId != Builtin::BImemset)
+      DiagRuntimeBehavior(Dest->getExprLoc(), Dest,
+                          PDiag(diag::warn_arc_object_memaccess)
+                              << ArgIdx << FnName << PointeeTy
+                              << Call->getCallee()->getSourceRange());
     else if (const auto *RT = PointeeTy->getAs<RecordType>()) {
       if ((BId == Builtin::BImemset || BId == Builtin::BIbzero) &&
           RT->getDecl()->isNonTrivialToPrimitiveDefaultInitialize()) {
@@ -13540,9 +13793,9 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
       continue;
 
     DiagRuntimeBehavior(
-      Dest->getExprLoc(), Dest,
-      PDiag(diag::note_bad_memaccess_silence)
-        << FixItHint::CreateInsertion(ArgRange.getBegin(), "(void*)"));
+        Dest->getExprLoc(), Dest,
+        PDiag(diag::note_bad_memaccess_silence)
+            << FixItHint::CreateInsertion(ArgRange.getBegin(), "(void*)"));
     break;
   }
 }
@@ -13554,7 +13807,7 @@ static const Expr *ignoreLiteralAdditions(const Expr *Ex, ASTContext &Ctx) {
   Ex = Ex->IgnoreParenCasts();
 
   while (true) {
-    const BinaryOperator * BO = dyn_cast<BinaryOperator>(Ex);
+    const BinaryOperator *BO = dyn_cast<BinaryOperator>(Ex);
     if (!BO || !BO->isAdditiveOp())
       break;
 
@@ -13675,8 +13928,7 @@ static const Expr *getStrlenExprArg(const Expr *E) {
 // Warn on anti-patterns as the 'size' argument to strncat.
 // The correct size argument should look like following:
 //   strncat(dst, src, sizeof(dst) - strlen(dest) - 1);
-void Sema::CheckStrncatArguments(const CallExpr *CE,
-                                 IdentifierInfo *FnName) {
+void Sema::CheckStrncatArguments(const CallExpr *CE, IdentifierInfo *FnName) {
   // Don't crash if the user has the wrong number of arguments.
   if (CE->getNumArgs() < 3)
     return;
@@ -13729,8 +13981,8 @@ void Sema::CheckStrncatArguments(const CallExpr *CE,
 
   // Check if the destination is an array (rather than a pointer to an array).
   QualType DstTy = DstArg->getType();
-  bool isKnownSizeArray = isConstantSizeArrayWithMoreThanOneElement(DstTy,
-                                                                    Context);
+  bool isKnownSizeArray =
+      isConstantSizeArrayWithMoreThanOneElement(DstTy, Context);
   if (!isKnownSizeArray) {
     if (PatternType == 1)
       Diag(SL, diag::warn_strncat_wrong_size) << SR;
@@ -13754,7 +14006,7 @@ void Sema::CheckStrncatArguments(const CallExpr *CE,
   OS << ") - 1";
 
   Diag(SL, diag::note_strncat_wrong_size)
-    << FixItHint::CreateReplacement(SR, OS.str());
+      << FixItHint::CreateReplacement(SR, OS.str());
 }
 
 namespace {
@@ -13871,18 +14123,15 @@ void Sema::CheckFreeArguments(const CallExpr *E) {
     return CheckFreeArgumentsCast(*this, CalleeName, Cast);
 }
 
-void
-Sema::CheckReturnValExpr(Expr *RetValExp, QualType lhsType,
-                         SourceLocation ReturnLoc,
-                         bool isObjCMethod,
-                         const AttrVec *Attrs,
-                         const FunctionDecl *FD) {
+void Sema::CheckReturnValExpr(Expr *RetValExp, QualType lhsType,
+                              SourceLocation ReturnLoc, bool isObjCMethod,
+                              const AttrVec *Attrs, const FunctionDecl *FD) {
   // Check if the return value is null but should not be.
   if (((Attrs && hasSpecificAttr<ReturnsNonNullAttr>(*Attrs)) ||
        (!isObjCMethod && isNonNullType(lhsType))) &&
       CheckNonNullExpr(*this, RetValExp))
     Diag(ReturnLoc, diag::warn_null_ret)
-      << (isObjCMethod ? 1 : 0) << RetValExp->getSourceRange();
+        << (isObjCMethod ? 1 : 0) << RetValExp->getSourceRange();
 
   // C++11 [basic.stc.dynamic.allocation]p4:
   //   If an allocation function declared with a non-throwing
@@ -13892,12 +14141,12 @@ Sema::CheckReturnValExpr(Expr *RetValExp, QualType lhsType,
   if (FD) {
     OverloadedOperatorKind Op = FD->getOverloadedOperator();
     if (Op == OO_New || Op == OO_Array_New) {
-      const FunctionProtoType *Proto
-        = FD->getType()->castAs<FunctionProtoType>();
-      if (!Proto->isNothrow(/*ResultIfDependent*/true) &&
+      const FunctionProtoType *Proto =
+          FD->getType()->castAs<FunctionProtoType>();
+      if (!Proto->isNothrow(/*ResultIfDependent*/ true) &&
           CheckNonNullExpr(*this, RetValExp))
         Diag(ReturnLoc, diag::warn_operator_new_returns_null)
-          << FD << getLangOpts().CPlusPlus11;
+            << FD << getLangOpts().CPlusPlus11;
     }
   }
 
@@ -13948,8 +14197,8 @@ void Sema::CheckFloatComparison(SourceLocation Loc, Expr *LHS, Expr *RHS,
   }
 
   // Match a more general floating-point equality comparison (-Wfloat-equal).
-  Expr* LeftExprSansParen = LHS->IgnoreParenImpCasts();
-  Expr* RightExprSansParen = RHS->IgnoreParenImpCasts();
+  Expr *LeftExprSansParen = LHS->IgnoreParenImpCasts();
+  Expr *RightExprSansParen = RHS->IgnoreParenImpCasts();
 
   // Special case: check for x == x (which is OK).
   // Do not emit warnings for such cases.
@@ -13963,26 +14212,26 @@ void Sema::CheckFloatComparison(SourceLocation Loc, Expr *LHS, Expr *RHS,
   //  is a heuristic: often comparison against such literals are used to
   //  detect if a value in a variable has not changed.  This clearly can
   //  lead to false negatives.
-  if (FloatingLiteral* FLL = dyn_cast<FloatingLiteral>(LeftExprSansParen)) {
+  if (FloatingLiteral *FLL = dyn_cast<FloatingLiteral>(LeftExprSansParen)) {
     if (FLL->isExact())
       return;
-  } else
-    if (FloatingLiteral* FLR = dyn_cast<FloatingLiteral>(RightExprSansParen))
-      if (FLR->isExact())
-        return;
+  } else if (FloatingLiteral *FLR =
+                 dyn_cast<FloatingLiteral>(RightExprSansParen))
+    if (FLR->isExact())
+      return;
 
   // Check for comparisons with builtin types.
-  if (CallExpr* CL = dyn_cast<CallExpr>(LeftExprSansParen))
+  if (CallExpr *CL = dyn_cast<CallExpr>(LeftExprSansParen))
     if (CL->getBuiltinCallee())
       return;
 
-  if (CallExpr* CR = dyn_cast<CallExpr>(RightExprSansParen))
+  if (CallExpr *CR = dyn_cast<CallExpr>(RightExprSansParen))
     if (CR->getBuiltinCallee())
       return;
 
   // Emit the diagnostic.
   Diag(Loc, diag::warn_floatingpoint_eq)
-    << LHS->getSourceRange() << RHS->getSourceRange();
+      << LHS->getSourceRange() << RHS->getSourceRange();
 }
 
 //===--- CHECK: Integer mixed-sign comparisons (-Wsign-compare) --------===//
@@ -14006,19 +14255,15 @@ struct IntRange {
       : Width(Width), NonNegative(NonNegative) {}
 
   /// Number of bits excluding the sign bit.
-  unsigned valueBits() const {
-    return NonNegative ? Width : Width - 1;
-  }
+  unsigned valueBits() const { return NonNegative ? Width : Width - 1; }
 
   /// Returns the range of the bool type.
-  static IntRange forBoolType() {
-    return IntRange(1, true);
-  }
+  static IntRange forBoolType() { return IntRange(1, true); }
 
   /// Returns the range of an opaque value of the given integral type.
   static IntRange forValueOfType(ASTContext &C, QualType T) {
     return forValueOfCanonicalType(C,
-                          T->getCanonicalTypeInternal().getTypePtr());
+                                   T->getCanonicalTypeInternal().getTypePtr());
   }
 
   /// Returns the range of an opaque value of a canonical integral type.
@@ -14050,10 +14295,10 @@ struct IntRange {
       unsigned NumNegative = Enum->getNumNegativeBits();
 
       if (NumNegative == 0)
-        return IntRange(NumPositive, true/*NonNegative*/);
+        return IntRange(NumPositive, true /*NonNegative*/);
       else
         return IntRange(std::max(NumPositive + 1, NumNegative),
-                        false/*NonNegative*/);
+                        false /*NonNegative*/);
     }
 
     if (const auto *EIT = dyn_cast<BitIntType>(T))
@@ -14264,13 +14509,15 @@ static IntRange GetExprRange(ASTContext &C, const Expr *E, unsigned MaxWidth,
     // GetExprRange requires an integer expression, but a throw expression
     // results in a void type.
     Expr *E = CO->getTrueExpr();
-    IntRange L = E->getType()->isVoidType()
-                     ? IntRange{0, true}
-                     : GetExprRange(C, E, MaxWidth, InConstantContext, Approximate);
+    IntRange L =
+        E->getType()->isVoidType()
+            ? IntRange{0, true}
+            : GetExprRange(C, E, MaxWidth, InConstantContext, Approximate);
     E = CO->getFalseExpr();
-    IntRange R = E->getType()->isVoidType()
-                     ? IntRange{0, true}
-                     : GetExprRange(C, E, MaxWidth, InConstantContext, Approximate);
+    IntRange R =
+        E->getType()->isVoidType()
+            ? IntRange{0, true}
+            : GetExprRange(C, E, MaxWidth, InConstantContext, Approximate);
     return IntRange::join(L, R);
   }
 
@@ -14326,8 +14573,8 @@ static IntRange GetExprRange(ASTContext &C, const Expr *E, unsigned MaxWidth,
     case BO_Shl:
       // ...except that we want to treat '1 << (blah)' as logically
       // positive.  It's an important idiom.
-      if (IntegerLiteral *I
-            = dyn_cast<IntegerLiteral>(BO->getLHS()->IgnoreParenCasts())) {
+      if (IntegerLiteral *I =
+              dyn_cast<IntegerLiteral>(BO->getLHS()->IgnoreParenCasts())) {
         if (I->getValue() == 1) {
           IntRange R = IntRange::forValueOfType(C, GetExprType(E));
           return IntRange(R.Width, /*NonNegative*/ true);
@@ -14509,8 +14756,7 @@ static void AnalyzeImplicitConversions(Sema &S, Expr *E, SourceLocation CC,
 
 static bool IsEnumConstOrFromMacro(Sema &S, Expr *E) {
   // Suppress cases where we are comparing against an enum constant.
-  if (const DeclRefExpr *DR =
-      dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts()))
+  if (const DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts()))
     if (isa<EnumConstantDecl>(DR->getDecl()))
       return true;
 
@@ -14521,8 +14767,8 @@ static bool IsEnumConstOrFromMacro(Sema &S, Expr *E) {
   if (BeginLoc.isMacroID()) {
     StringRef MacroName = Lexer::getImmediateMacroName(
         BeginLoc, S.getSourceManager(), S.getLangOpts());
-    return MacroName != "YES" && MacroName != "NO" &&
-           MacroName != "true" && MacroName != "false";
+    return MacroName != "YES" && MacroName != "NO" && MacroName != "true" &&
+           MacroName != "false";
   }
 
   return false;
@@ -14599,21 +14845,30 @@ struct PromotedRange {
            Value.isUnsigned() == PromotedMin.isUnsigned());
     if (!isContiguous()) {
       assert(Value.isUnsigned() && "discontiguous range for signed compare");
-      if (Value.isMinValue()) return Min;
-      if (Value.isMaxValue()) return Max;
-      if (Value >= PromotedMin) return InRange;
-      if (Value <= PromotedMax) return InRange;
+      if (Value.isMinValue())
+        return Min;
+      if (Value.isMaxValue())
+        return Max;
+      if (Value >= PromotedMin)
+        return InRange;
+      if (Value <= PromotedMax)
+        return InRange;
       return InHole;
     }
 
     switch (llvm::APSInt::compareValues(Value, PromotedMin)) {
-    case -1: return Less;
-    case 0: return PromotedMin == PromotedMax ? OnlyValue : Min;
+    case -1:
+      return Less;
+    case 0:
+      return PromotedMin == PromotedMax ? OnlyValue : Min;
     case 1:
       switch (llvm::APSInt::compareValues(Value, PromotedMax)) {
-      case -1: return InRange;
-      case 0: return Max;
-      case 1: return Greater;
+      case -1:
+        return InRange;
+      case 0:
+        return Max;
+      case 1:
+        return Greater;
       }
     }
 
@@ -14624,11 +14879,15 @@ struct PromotedRange {
   constantValue(BinaryOperatorKind Op, ComparisonResult R, bool ConstantOnRHS) {
     if (Op == BO_Cmp) {
       ComparisonResult LTFlag = LT, GTFlag = GT;
-      if (ConstantOnRHS) std::swap(LTFlag, GTFlag);
+      if (ConstantOnRHS)
+        std::swap(LTFlag, GTFlag);
 
-      if (R & EQ) return StringRef("'std::strong_ordering::equal'");
-      if (R & LTFlag) return StringRef("'std::strong_ordering::less'");
-      if (R & GTFlag) return StringRef("'std::strong_ordering::greater'");
+      if (R & EQ)
+        return StringRef("'std::strong_ordering::equal'");
+      if (R & LTFlag)
+        return StringRef("'std::strong_ordering::less'");
+      if (R & GTFlag)
+        return StringRef("'std::strong_ordering::greater'");
       return std::nullopt;
     }
 
@@ -14657,13 +14916,12 @@ struct PromotedRange {
     return std::nullopt;
   }
 };
-}
+} // namespace
 
 static bool HasEnumType(Expr *E) {
   // Strip off implicit integral promotions.
   while (ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(E)) {
-    if (ICE->getCastKind() != CK_IntegralCast &&
-        ICE->getCastKind() != CK_NoOp)
+    if (ICE->getCastKind() != CK_IntegralCast && ICE->getCastKind() != CK_NoOp)
       break;
     E = ICE->getSubExpr();
   }
@@ -14674,11 +14932,7 @@ static bool HasEnumType(Expr *E) {
 static int classifyConstantValue(Expr *Constant) {
   // The values of this enumeration are used in the diagnostics
   // diag::warn_out_of_range_compare and diag::warn_tautological_bool_compare.
-  enum ConstantValueKind {
-    Miscellaneous = 0,
-    LiteralTrue,
-    LiteralFalse
-  };
+  enum ConstantValueKind { Miscellaneous = 0, LiteralTrue, LiteralFalse };
   if (auto *BL = dyn_cast<CXXBoolLiteralExpr>(Constant))
     return BL->getValue() ? ConstantValueKind::LiteralTrue
                           : ConstantValueKind::LiteralFalse;
@@ -14786,7 +15040,7 @@ static bool CheckTautologicalComparison(Sema &S, BinaryOperator *E,
   if (ED) {
     OS << '\'' << *ED << "' (" << Value << ")";
   } else if (auto *BL = dyn_cast<ObjCBoolLiteralExpr>(
-               Constant->IgnoreParenImpCasts())) {
+                 Constant->IgnoreParenImpCasts())) {
     OS << (BL->getValue() ? "YES" : "NO");
   } else {
     OS << Value;
@@ -14825,8 +15079,8 @@ static bool CheckTautologicalComparison(Sema &S, BinaryOperator *E,
         (isKnownToHaveUnsignedValue(OriginalOther) && Value == 0)
             ? (HasEnumType(OriginalOther)
                    ? diag::warn_unsigned_enum_always_true_comparison
-                   : IsCharTy ? diag::warn_unsigned_char_always_true_comparison
-                              : diag::warn_unsigned_always_true_comparison)
+               : IsCharTy ? diag::warn_unsigned_char_always_true_comparison
+                          : diag::warn_unsigned_always_true_comparison)
             : diag::warn_tautological_constant_compare;
 
     S.Diag(E->getOperatorLoc(), Diag)
@@ -14973,7 +15227,7 @@ static bool AnalyzeBitFieldAssignment(Sema &S, FieldDecl *Bitfield, Expr *Init,
   // White-list bool bitfields.
   QualType BitfieldType = Bitfield->getType();
   if (BitfieldType->isBooleanType())
-     return false;
+    return false;
 
   if (BitfieldType->isEnumeralType()) {
     EnumDecl *BitfieldEnumDecl = BitfieldType->castAs<EnumType>()->getDecl();
@@ -14991,8 +15245,7 @@ static bool AnalyzeBitFieldAssignment(Sema &S, FieldDecl *Bitfield, Expr *Init,
 
   // Ignore value- or type-dependent expressions.
   if (Bitfield->getBitWidth()->isValueDependent() ||
-      Bitfield->getBitWidth()->isTypeDependent() ||
-      Init->isValueDependent() ||
+      Bitfield->getBitWidth()->isTypeDependent() || Init->isValueDependent() ||
       Init->isTypeDependent())
     return false;
 
@@ -15137,19 +15390,19 @@ static void DiagnoseImpCast(Sema &S, Expr *E, QualType SourceType, QualType T,
     return;
   }
   S.Diag(E->getExprLoc(), diag)
-    << SourceType << T << E->getSourceRange() << SourceRange(CContext);
+      << SourceType << T << E->getSourceRange() << SourceRange(CContext);
 }
 
 /// Diagnose an implicit cast;  purely a helper for CheckImplicitConversion.
 static void DiagnoseImpCast(Sema &S, Expr *E, QualType T,
-                            SourceLocation CContext,
-                            unsigned diag, bool pruneControlFlow = false) {
+                            SourceLocation CContext, unsigned diag,
+                            bool pruneControlFlow = false) {
   DiagnoseImpCast(S, E, E->getType(), T, CContext, diag, pruneControlFlow);
 }
 
 static bool isObjCSignedCharBool(Sema &S, QualType Ty) {
   return Ty->isSpecificBuiltinType(BuiltinType::SChar) &&
-      S.getLangOpts().ObjC && S.NSAPIObj->isObjCBOOLType(Ty);
+         S.getLangOpts().ObjC && S.NSAPIObj->isObjCBOOLType(Ty);
 }
 
 static void adornObjCBoolConversionDiagWithTernaryFixit(
@@ -15184,7 +15437,7 @@ static void DiagnoseFloatingImpCast(Sema &S, Expr *E, QualType T,
 
   llvm::APFloat Value(0.0);
   bool IsConstant =
-    E->EvaluateAsFloat(Value, S.Context, Expr::SE_AllowSideEffects);
+      E->EvaluateAsFloat(Value, S.Context, Expr::SE_AllowSideEffects);
   if (!IsConstant) {
     if (isObjCSignedCharBool(S, T)) {
       return adornObjCBoolConversionDiagWithTernaryFixit(
@@ -15193,8 +15446,8 @@ static void DiagnoseFloatingImpCast(Sema &S, Expr *E, QualType T,
               << E->getType());
     }
 
-    return DiagnoseImpCast(S, E, T, CContext,
-                           diag::warn_impcast_float_integer, PruneWarnings);
+    return DiagnoseImpCast(S, E, T, CContext, diag::warn_impcast_float_integer,
+                           PruneWarnings);
   }
 
   bool isExact = false;
@@ -15222,7 +15475,8 @@ static void DiagnoseFloatingImpCast(Sema &S, Expr *E, QualType T,
   }
 
   if (Result == llvm::APFloat::opOK && isExact) {
-    if (IsLiteral) return;
+    if (IsLiteral)
+      return;
     return DiagnoseImpCast(S, E, T, CContext, diag::warn_impcast_float_integer,
                            PruneWarnings);
   }
@@ -15241,7 +15495,7 @@ static void DiagnoseFloatingImpCast(Sema &S, Expr *E, QualType T,
     // Warn on floating point literal to integer.
     DiagID = diag::warn_impcast_literal_float_to_integer;
   } else if (IntegerValue == 0) {
-    if (Value.isZero()) {  // Skip -0.0 to 0 conversion.
+    if (Value.isZero()) { // Skip -0.0 to 0 conversion.
       return DiagnoseImpCast(S, E, T, CContext,
                              diag::warn_impcast_float_integer, PruneWarnings);
     }
@@ -15253,7 +15507,7 @@ static void DiagnoseFloatingImpCast(Sema &S, Expr *E, QualType T,
         return DiagnoseImpCast(S, E, T, CContext,
                                diag::warn_impcast_float_integer, PruneWarnings);
       }
-    } else {  // IntegerValue.isSigned()
+    } else { // IntegerValue.isSigned()
       if (!IntegerValue.isMaxSignedValue() &&
           !IntegerValue.isMinSignedValue()) {
         return DiagnoseImpCast(S, E, T, CContext,
@@ -15302,7 +15556,8 @@ static void AnalyzeCompoundAssignment(Sema &S, BinaryOperator *E) {
                         ->getAs<BuiltinType>();
 
   // The below checks assume source is floating point.
-  if (!ResultBT || !RBT || !RBT->isFloatingPoint()) return;
+  if (!ResultBT || !RBT || !RBT->isFloatingPoint())
+    return;
 
   // If source is floating point but target is an integer.
   if (ResultBT->isInteger())
@@ -15323,7 +15578,8 @@ static void AnalyzeCompoundAssignment(Sema &S, BinaryOperator *E) {
 
 static std::string PrettyPrintInRange(const llvm::APSInt &Value,
                                       IntRange Range) {
-  if (!Range.Width) return "0";
+  if (!Range.Width)
+    return "0";
 
   llvm::APSInt ValueInRange = Value;
   ValueInRange.setIsSigned(!Range.NonNegative);
@@ -15338,12 +15594,12 @@ static bool IsImplicitBoolFloatConversion(Sema &S, Expr *Ex, bool ToBool) {
   Expr *InnerE = Ex->IgnoreParenImpCasts();
   const Type *Target = S.Context.getCanonicalType(Ex->getType()).getTypePtr();
   const Type *Source =
-    S.Context.getCanonicalType(InnerE->getType()).getTypePtr();
+      S.Context.getCanonicalType(InnerE->getType()).getTypePtr();
   if (Target->isDependentType())
     return false;
 
   const BuiltinType *FloatCandidateBT =
-    dyn_cast<BuiltinType>(ToBool ? Source : Target);
+      dyn_cast<BuiltinType>(ToBool ? Source : Target);
   const Type *BoolCandidateType = ToBool ? Target : Source;
 
   return (BoolCandidateType->isSpecificBuiltinType(BuiltinType::Bool) &&
@@ -15358,14 +15614,13 @@ static void CheckImplicitArgumentConversions(Sema &S, CallExpr *TheCall,
     if (!IsImplicitBoolFloatConversion(S, CurrA, true))
       continue;
 
-    bool IsSwapped = ((i > 0) &&
-        IsImplicitBoolFloatConversion(S, TheCall->getArg(i - 1), false));
-    IsSwapped |= ((i < (NumArgs - 1)) &&
-        IsImplicitBoolFloatConversion(S, TheCall->getArg(i + 1), false));
+    bool IsSwapped = ((i > 0) && IsImplicitBoolFloatConversion(
+                                     S, TheCall->getArg(i - 1), false));
+    IsSwapped |= ((i < (NumArgs - 1)) && IsImplicitBoolFloatConversion(
+                                             S, TheCall->getArg(i + 1), false));
     if (IsSwapped) {
       // Warn on this floating-point to bool conversion.
-      DiagnoseImpCast(S, CurrA->IgnoreParenImpCasts(),
-                      CurrA->getType(), CC,
+      DiagnoseImpCast(S, CurrA->IgnoreParenImpCasts(), CurrA->getType(), CC,
                       diag::warn_impcast_floating_point_to_bool);
     }
   }
@@ -15442,10 +15697,8 @@ static void checkObjCCollectionLiteralElement(Sema &S,
   QualType ElementType = Element->getType();
   ExprResult ElementResult(Element);
   if (ElementType->getAs<ObjCObjectPointerType>() &&
-      S.CheckSingleAssignmentConstraints(TargetElementType,
-                                         ElementResult,
-                                         false, false)
-        != Sema::Compatible) {
+      S.CheckSingleAssignmentConstraints(TargetElementType, ElementResult,
+                                         false, false) != Sema::Compatible) {
     S.Diag(Element->getBeginLoc(), diag::warn_objc_collection_literal_element)
         << ElementType << ElementKind << TargetElementType
         << Element->getSourceRange();
@@ -15469,8 +15722,8 @@ static void checkObjCArrayLiteral(Sema &S, QualType TargetType,
     return;
 
   if (TargetObjCPtr->isUnspecialized() ||
-      TargetObjCPtr->getInterfaceDecl()->getCanonicalDecl()
-        != S.NSArrayDecl->getCanonicalDecl())
+      TargetObjCPtr->getInterfaceDecl()->getCanonicalDecl() !=
+          S.NSArrayDecl->getCanonicalDecl())
     return;
 
   auto TypeArgs = TargetObjCPtr->getTypeArgs();
@@ -15480,8 +15733,7 @@ static void checkObjCArrayLiteral(Sema &S, QualType TargetType,
   QualType TargetElementType = TypeArgs[0];
   for (unsigned I = 0, N = ArrayLiteral->getNumElements(); I != N; ++I) {
     checkObjCCollectionLiteralElement(S, TargetElementType,
-                                      ArrayLiteral->getElement(I),
-                                      0);
+                                      ArrayLiteral->getElement(I), 0);
   }
 }
 
@@ -15498,8 +15750,8 @@ checkObjCDictionaryLiteral(Sema &S, QualType TargetType,
     return;
 
   if (TargetObjCPtr->isUnspecialized() ||
-      TargetObjCPtr->getInterfaceDecl()->getCanonicalDecl()
-        != S.NSDictionaryDecl->getCanonicalDecl())
+      TargetObjCPtr->getInterfaceDecl()->getCanonicalDecl() !=
+          S.NSDictionaryDecl->getCanonicalDecl())
     return;
 
   auto TypeArgs = TargetObjCPtr->getTypeArgs();
@@ -15594,12 +15846,15 @@ static void CheckImplicitConversion(Sema &S, Expr *E, QualType T,
                                     SourceLocation CC,
                                     bool *ICContext = nullptr,
                                     bool IsListInit = false) {
-  if (E->isTypeDependent() || E->isValueDependent()) return;
+  if (E->isTypeDependent() || E->isValueDependent())
+    return;
 
   const Type *Source = S.Context.getCanonicalType(E->getType()).getTypePtr();
   const Type *Target = S.Context.getCanonicalType(T).getTypePtr();
-  if (Source == Target) return;
-  if (Target->isDependentType()) return;
+  if (Source == Target)
+    return;
+  if (Target->isDependentType())
+    return;
 
   // If the conversion context location is invalid don't complain. We also
   // don't want to emit a warning if the issue occurs from the expansion of
@@ -15747,9 +16002,10 @@ static void CheckImplicitConversion(Sema &S, Expr *E, QualType T,
         Expr::EvalResult result;
         if (E->EvaluateAsRValue(result, S.Context)) {
           // Value might be a float, a float vector, or a float complex.
-          if (IsSameFloatAfterCast(result.Val,
-                   S.Context.getFloatTypeSemantics(QualType(TargetBT, 0)),
-                   S.Context.getFloatTypeSemantics(QualType(SourceBT, 0))))
+          if (IsSameFloatAfterCast(
+                  result.Val,
+                  S.Context.getFloatTypeSemantics(QualType(TargetBT, 0)),
+                  S.Context.getFloatTypeSemantics(QualType(SourceBT, 0))))
             return;
         }
 
@@ -16050,15 +16306,8 @@ static void CheckImplicitConversion(Sema &S, Expr *E, QualType T,
   // Diagnose conversions between different enumeration types.
   // In C, we pretend that the type of an EnumConstantDecl is its enumeration
   // type, to give us better diagnostics.
-  QualType SourceType = E->getType();
-  if (!S.getLangOpts().CPlusPlus) {
-    if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E))
-      if (EnumConstantDecl *ECD = dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
-        EnumDecl *Enum = cast<EnumDecl>(ECD->getDeclContext());
-        SourceType = S.Context.getTypeDeclType(Enum);
-        Source = S.Context.getCanonicalType(SourceType).getTypePtr();
-      }
-  }
+  QualType SourceType = E->getEnumCoercedType(S.Context);
+  Source = S.Context.getCanonicalType(SourceType).getTypePtr();
 
   if (const EnumType *SourceEnum = Source->getAs<EnumType>())
     if (const EnumType *TargetEnum = Target->getAs<EnumType>())
@@ -16108,7 +16357,8 @@ static void CheckConditionalOperator(Sema &S, AbstractConditionalOperator *E,
 
   // If -Wconversion would have warned about either of the candidates
   // for a signedness conversion to the context type...
-  if (!Suspicious) return;
+  if (!Suspicious)
+    return;
 
   // ...but it's currently ignored...
   if (!S.Diags.isIgnored(diag::warn_impcast_integer_sign_conditional, CC))
@@ -16116,11 +16366,12 @@ static void CheckConditionalOperator(Sema &S, AbstractConditionalOperator *E,
 
   // ...then check whether it would have warned about either of the
   // candidates for a signedness conversion to the condition type.
-  if (E->getType() == T) return;
+  if (E->getType() == T)
+    return;
 
   Suspicious = false;
-  CheckImplicitConversion(S, TrueExpr->IgnoreParenImpCasts(),
-                          E->getType(), CC, &Suspicious);
+  CheckImplicitConversion(S, TrueExpr->IgnoreParenImpCasts(), E->getType(), CC,
+                          &Suspicious);
   if (!Suspicious)
     CheckImplicitConversion(S, E->getFalseExpr()->IgnoreParenImpCasts(),
                             E->getType(), CC, &Suspicious);
@@ -16145,7 +16396,7 @@ struct AnalyzeImplicitConversionsWorkItem {
   SourceLocation CC;
   bool IsListInit;
 };
-}
+} // namespace
 
 /// Data recursive variant of AnalyzeImplicitConversions. Subexpressions
 /// that should be visited are added to WorkList.
@@ -16251,10 +16502,12 @@ static void AnalyzeImplicitConversions(
   // we don't really need to recurse into them, because any internal
   // expressions should have been analyzed already when they were
   // built into statements.
-  if (isa<StmtExpr>(E)) return;
+  if (isa<StmtExpr>(E))
+    return;
 
   // Don't descend into unevaluated contexts.
-  if (isa<UnaryExprOrTypeTraitExpr>(E)) return;
+  if (isa<UnaryExprOrTypeTraitExpr>(E))
+    return;
 
   // Now just recurse over the expression's children.
   CC = E->getExprLoc();
@@ -16305,7 +16558,7 @@ static void AnalyzeImplicitConversions(
 /// implicit conversions in the given expression.  There are a couple
 /// of competing diagnostics here, -Wconversion and -Wsign-compare.
 static void AnalyzeImplicitConversions(Sema &S, Expr *OrigE, SourceLocation CC,
-                                       bool IsListInit/*= false*/) {
+                                       bool IsListInit /*= false*/) {
   llvm::SmallVector<AnalyzeImplicitConversionsWorkItem, 16> WorkList;
   WorkList.push_back({OrigE, CC, IsListInit});
   while (!WorkList.empty())
@@ -16418,8 +16671,8 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
     unsigned DiagID = IsCompare
                           ? diag::warn_address_of_reference_null_compare
                           : diag::warn_address_of_reference_bool_conversion;
-    PartialDiagnostic PD = PDiag(DiagID) << E->getSourceRange() << Range
-                                         << IsEqual;
+    PartialDiagnostic PD = PDiag(DiagID)
+                           << E->getSourceRange() << Range << IsEqual;
     if (CheckForReference(*this, E, PD)) {
       return;
     }
@@ -16432,8 +16685,8 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
     E->printPretty(S, nullptr, getPrintingPolicy());
     unsigned DiagID = IsCompare ? diag::warn_nonnull_expr_compare
                                 : diag::warn_cast_nonnull_to_bool;
-    Diag(E->getExprLoc(), DiagID) << IsParam << S.str()
-      << E->getSourceRange() << Range << IsEqual;
+    Diag(E->getExprLoc(), DiagID)
+        << IsParam << S.str() << E->getSourceRange() << Range << IsEqual;
     Diag(NonnullAttr->getLocation(), diag::note_declared_nonnull) << IsParam;
   };
 
@@ -16460,7 +16713,7 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
     return;
 
   // Check for parameter decl with nonnull attribute
-  if (const auto* PV = dyn_cast<ParmVarDecl>(D)) {
+  if (const auto *PV = dyn_cast<ParmVarDecl>(D)) {
     if (getCurFunction() &&
         !getCurFunction()->ModifiedNonNullParams.count(PV)) {
       if (const Attr *A = PV->getAttr<NonNullAttr>()) {
@@ -16478,8 +16731,8 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
 
         for (const auto *NonNull : FD->specific_attrs<NonNullAttr>()) {
           if (!NonNull->args_size()) {
-              ComplainAboutNonnullParamOrCall(NonNull);
-              return;
+            ComplainAboutNonnullParamOrCall(NonNull);
+            return;
           }
 
           for (const ParamIdx &ArgNo : NonNull->args()) {
@@ -16513,11 +16766,7 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
 
   unsigned DiagID = IsCompare ? diag::warn_null_pointer_compare
                               : diag::warn_impcast_pointer_to_bool;
-  enum {
-    AddressOf,
-    FunctionPointer,
-    ArrayPointer
-  } DiagType;
+  enum { AddressOf, FunctionPointer, ArrayPointer } DiagType;
   if (IsAddressOf)
     DiagType = AddressOf;
   else if (IsFunction)
@@ -16526,8 +16775,8 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
     DiagType = ArrayPointer;
   else
     llvm_unreachable("Could not determine diagnostic.");
-  Diag(E->getExprLoc(), DiagID) << DiagType << S.str() << E->getSourceRange()
-                                << Range << IsEqual;
+  Diag(E->getExprLoc(), DiagID)
+      << DiagType << S.str() << E->getSourceRange() << Range << IsEqual;
 
   if (!IsFunction)
     return;
@@ -16597,9 +16846,9 @@ void Sema::CheckBoolLikeConversion(Expr *E, SourceLocation CC) {
   ::CheckBoolLikeConversion(*this, E, CC);
 }
 
-/// Diagnose when expression is an integer constant expression and its evaluation
-/// results in integer overflow
-void Sema::CheckForIntOverflow (const Expr *E) {
+/// Diagnose when expression is an integer constant expression and its
+/// evaluation results in integer overflow
+void Sema::CheckForIntOverflow(const Expr *E) {
   // Use a work list to deal with nested struct initializers.
   SmallVector<const Expr *, 2> Exprs(1, E);
 
@@ -16628,8 +16877,7 @@ void Sema::CheckForIntOverflow (const Expr *E) {
       Exprs.push_back(Array->getIdx());
     else if (const auto *Compound = dyn_cast<CompoundLiteralExpr>(E))
       Exprs.push_back(Compound->getInitializer());
-    else if (const auto *New = dyn_cast<CXXNewExpr>(E);
-             New && New->isArray()) {
+    else if (const auto *New = dyn_cast<CXXNewExpr>(E); New && New->isArray()) {
       if (auto ArraySize = New->getArraySize())
         Exprs.push_back(*ArraySize);
     }
@@ -16682,9 +16930,7 @@ class SequenceChecker : public ConstEvaluatedExprVisitor<SequenceChecker> {
     }
 
     /// Merge a sequence of operations into its parent.
-    void merge(Seq S) {
-      Values[S.Index].Merged = true;
-    }
+    void merge(Seq S) { Values[S.Index].Merged = true; }
 
     /// Determine whether two operations are unsequenced. This operation
     /// is asymmetric: \p Cur should be the more recent sequence, and \p Old
@@ -16775,7 +17021,7 @@ class SequenceChecker : public ConstEvaluatedExprVisitor<SequenceChecker> {
   /// UK_ModAsValue.
   struct SequencedSubexpression {
     SequencedSubexpression(SequenceChecker &Self)
-      : Self(Self), OldModAsSideEffect(Self.ModAsSideEffect) {
+        : Self(Self), OldModAsSideEffect(Self.ModAsSideEffect) {
       Self.ModAsSideEffect = &ModAsSideEffect;
     }
 
@@ -17530,9 +17776,8 @@ void Sema::CheckCompletedExpr(Expr *E, SourceLocation CheckLoc,
 }
 
 void Sema::CheckBitFieldInitialization(SourceLocation InitLoc,
-                                       FieldDecl *BitField,
-                                       Expr *Init) {
-  (void) AnalyzeBitFieldAssignment(*this, BitField, Init, InitLoc);
+                                       FieldDecl *BitField, Expr *Init) {
+  (void)AnalyzeBitFieldAssignment(*this, BitField, Init, InitLoc);
 }
 
 static void diagnoseArrayStarInParamType(Sema &S, QualType PType,
@@ -17914,39 +18159,44 @@ void Sema::CheckCastAlign(Expr *Op, QualType T, SourceRange TRange) {
 
   // Require that the destination be a pointer type.
   const PointerType *DestPtr = T->getAs<PointerType>();
-  if (!DestPtr) return;
+  if (!DestPtr)
+    return;
 
   // If the destination has alignment 1, we're done.
   QualType DestPointee = DestPtr->getPointeeType();
-  if (DestPointee->isIncompleteType()) return;
+  if (DestPointee->isIncompleteType())
+    return;
   CharUnits DestAlign = Context.getTypeAlignInChars(DestPointee);
-  if (DestAlign.isOne()) return;
+  if (DestAlign.isOne())
+    return;
 
   // Require that the source be a pointer type.
   const PointerType *SrcPtr = Op->getType()->getAs<PointerType>();
-  if (!SrcPtr) return;
+  if (!SrcPtr)
+    return;
   QualType SrcPointee = SrcPtr->getPointeeType();
 
   // Explicitly allow casts from cv void*.  We already implicitly
   // allowed casts to cv void*, since they have alignment 1.
   // Also allow casts involving incomplete types, which implicitly
   // includes 'void'.
-  if (SrcPointee->isIncompleteType()) return;
+  if (SrcPointee->isIncompleteType())
+    return;
 
   CharUnits SrcAlign = getPresumedAlignmentOfPointer(Op, *this);
 
-  if (SrcAlign >= DestAlign) return;
+  if (SrcAlign >= DestAlign)
+    return;
 
   Diag(TRange.getBegin(), diag::warn_cast_align)
-    << Op->getType() << T
-    << static_cast<unsigned>(SrcAlign.getQuantity())
-    << static_cast<unsigned>(DestAlign.getQuantity())
-    << TRange << Op->getSourceRange();
+      << Op->getType() << T << static_cast<unsigned>(SrcAlign.getQuantity())
+      << static_cast<unsigned>(DestAlign.getQuantity()) << TRange
+      << Op->getSourceRange();
 }
 
 void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
-                            const ArraySubscriptExpr *ASE,
-                            bool AllowOnePastEnd, bool IndexNegated) {
+                            const ArraySubscriptExpr *ASE, bool AllowOnePastEnd,
+                            bool IndexNegated) {
   // Already diagnosed by the constant evaluator.
   if (isConstantEvaluatedContext())
     return;
@@ -17961,8 +18211,8 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
   const ConstantArrayType *ArrayTy =
       Context.getAsConstantArrayType(BaseExpr->getType());
 
-  LangOptions::StrictFlexArraysLevelKind
-    StrictFlexArraysLevel = getLangOpts().getStrictFlexArraysLevel();
+  LangOptions::StrictFlexArraysLevelKind StrictFlexArraysLevel =
+      getLangOpts().getStrictFlexArraysLevel();
 
   const Type *BaseType =
       ArrayTy == nullptr ? nullptr : ArrayTy->getElementType().getTypePtr();
@@ -18102,8 +18352,8 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     // ']' location) and the index expression are both from macro expansions
     // within a system header.
     if (ASE) {
-      SourceLocation RBracketLoc = SourceMgr.getSpellingLoc(
-          ASE->getRBracketLoc());
+      SourceLocation RBracketLoc =
+          SourceMgr.getSpellingLoc(ASE->getRBracketLoc());
       if (SourceMgr.isInSystemHeader(RBracketLoc)) {
         SourceLocation IndexLoc =
             SourceMgr.getSpellingLoc(IndexExpr->getBeginLoc());
@@ -18125,7 +18375,8 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     unsigned DiagID = diag::warn_array_index_precedes_bounds;
     if (!ASE) {
       DiagID = diag::warn_ptr_arith_precedes_bounds;
-      if (index.isNegative()) index = -index;
+      if (index.isNegative())
+        index = -index;
     }
 
     DiagRuntimeBehavior(BaseExpr->getBeginLoc(), BaseExpr,
@@ -18152,56 +18403,55 @@ void Sema::CheckArrayAccess(const Expr *expr) {
   while (expr) {
     expr = expr->IgnoreParenImpCasts();
     switch (expr->getStmtClass()) {
-      case Stmt::ArraySubscriptExprClass: {
-        const ArraySubscriptExpr *ASE = cast<ArraySubscriptExpr>(expr);
-        CheckArrayAccess(ASE->getBase(), ASE->getIdx(), ASE,
-                         AllowOnePastEnd > 0);
-        expr = ASE->getBase();
+    case Stmt::ArraySubscriptExprClass: {
+      const ArraySubscriptExpr *ASE = cast<ArraySubscriptExpr>(expr);
+      CheckArrayAccess(ASE->getBase(), ASE->getIdx(), ASE, AllowOnePastEnd > 0);
+      expr = ASE->getBase();
+      break;
+    }
+    case Stmt::MemberExprClass: {
+      expr = cast<MemberExpr>(expr)->getBase();
+      break;
+    }
+    case Stmt::OMPArraySectionExprClass: {
+      const OMPArraySectionExpr *ASE = cast<OMPArraySectionExpr>(expr);
+      if (ASE->getLowerBound())
+        CheckArrayAccess(ASE->getBase(), ASE->getLowerBound(),
+                         /*ASE=*/nullptr, AllowOnePastEnd > 0);
+      return;
+    }
+    case Stmt::UnaryOperatorClass: {
+      // Only unwrap the * and & unary operators
+      const UnaryOperator *UO = cast<UnaryOperator>(expr);
+      expr = UO->getSubExpr();
+      switch (UO->getOpcode()) {
+      case UO_AddrOf:
+        AllowOnePastEnd++;
         break;
-      }
-      case Stmt::MemberExprClass: {
-        expr = cast<MemberExpr>(expr)->getBase();
+      case UO_Deref:
+        AllowOnePastEnd--;
         break;
-      }
-      case Stmt::OMPArraySectionExprClass: {
-        const OMPArraySectionExpr *ASE = cast<OMPArraySectionExpr>(expr);
-        if (ASE->getLowerBound())
-          CheckArrayAccess(ASE->getBase(), ASE->getLowerBound(),
-                           /*ASE=*/nullptr, AllowOnePastEnd > 0);
-        return;
-      }
-      case Stmt::UnaryOperatorClass: {
-        // Only unwrap the * and & unary operators
-        const UnaryOperator *UO = cast<UnaryOperator>(expr);
-        expr = UO->getSubExpr();
-        switch (UO->getOpcode()) {
-          case UO_AddrOf:
-            AllowOnePastEnd++;
-            break;
-          case UO_Deref:
-            AllowOnePastEnd--;
-            break;
-          default:
-            return;
-        }
-        break;
-      }
-      case Stmt::ConditionalOperatorClass: {
-        const ConditionalOperator *cond = cast<ConditionalOperator>(expr);
-        if (const Expr *lhs = cond->getLHS())
-          CheckArrayAccess(lhs);
-        if (const Expr *rhs = cond->getRHS())
-          CheckArrayAccess(rhs);
-        return;
-      }
-      case Stmt::CXXOperatorCallExprClass: {
-        const auto *OCE = cast<CXXOperatorCallExpr>(expr);
-        for (const auto *Arg : OCE->arguments())
-          CheckArrayAccess(Arg);
-        return;
-      }
       default:
         return;
+      }
+      break;
+    }
+    case Stmt::ConditionalOperatorClass: {
+      const ConditionalOperator *cond = cast<ConditionalOperator>(expr);
+      if (const Expr *lhs = cond->getLHS())
+        CheckArrayAccess(lhs);
+      if (const Expr *rhs = cond->getRHS())
+        CheckArrayAccess(rhs);
+      return;
+    }
+    case Stmt::CXXOperatorCallExprClass: {
+      const auto *OCE = cast<CXXOperatorCallExpr>(expr);
+      for (const auto *Arg : OCE->arguments())
+        CheckArrayAccess(Arg);
+      return;
+    }
+    default:
+      return;
     }
   }
 }
@@ -18267,19 +18517,22 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
       if (!findRetainCycleOwner(S, ref->getBase(), owner))
         return false;
 
-      if (ref->isFreeIvar()) owner.setLocsFrom(ref);
+      if (ref->isFreeIvar())
+        owner.setLocsFrom(ref);
       owner.Indirect = true;
       return true;
     }
 
     if (DeclRefExpr *ref = dyn_cast<DeclRefExpr>(e)) {
       VarDecl *var = dyn_cast<VarDecl>(ref->getDecl());
-      if (!var) return false;
+      if (!var)
+        return false;
       return considerVariable(var, ref, owner);
     }
 
     if (MemberExpr *member = dyn_cast<MemberExpr>(e)) {
-      if (member->isArrow()) return false;
+      if (member->isArrow())
+        return false;
 
       // Don't count this as an indirect ownership.
       e = member->getBase();
@@ -18288,17 +18541,18 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
 
     if (PseudoObjectExpr *pseudo = dyn_cast<PseudoObjectExpr>(e)) {
       // Only pay attention to pseudo-objects on property references.
-      ObjCPropertyRefExpr *pre
-        = dyn_cast<ObjCPropertyRefExpr>(pseudo->getSyntacticForm()
-                                              ->IgnoreParens());
-      if (!pre) return false;
-      if (pre->isImplicitProperty()) return false;
+      ObjCPropertyRefExpr *pre = dyn_cast<ObjCPropertyRefExpr>(
+          pseudo->getSyntacticForm()->IgnoreParens());
+      if (!pre)
+        return false;
+      if (pre->isImplicitProperty())
+        return false;
       ObjCPropertyDecl *property = pre->getExplicitProperty();
       if (!property->isRetaining() &&
           !(property->getPropertyIvarDecl() &&
-            property->getPropertyIvarDecl()->getType()
-              .getObjCLifetime() == Qualifiers::OCL_Strong))
-          return false;
+            property->getPropertyIvarDecl()->getType().getObjCLifetime() ==
+                Qualifiers::OCL_Strong))
+        return false;
 
       owner.Indirect = true;
       if (pre->isSuperReceiver()) {
@@ -18309,8 +18563,8 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
         owner.Range = pre->getSourceRange();
         return true;
       }
-      e = const_cast<Expr*>(cast<OpaqueValueExpr>(pre->getBase())
-                              ->getSourceExpr());
+      e = const_cast<Expr *>(
+          cast<OpaqueValueExpr>(pre->getBase())->getSourceExpr());
       continue;
     }
 
@@ -18322,56 +18576,57 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
 
 namespace {
 
-  struct FindCaptureVisitor : EvaluatedExprVisitor<FindCaptureVisitor> {
-    VarDecl *Variable;
-    Expr *Capturer = nullptr;
-    bool VarWillBeReased = false;
+struct FindCaptureVisitor : EvaluatedExprVisitor<FindCaptureVisitor> {
+  VarDecl *Variable;
+  Expr *Capturer = nullptr;
+  bool VarWillBeReased = false;
 
-    FindCaptureVisitor(ASTContext &Context, VarDecl *variable)
-        : EvaluatedExprVisitor<FindCaptureVisitor>(Context),
-          Variable(variable) {}
+  FindCaptureVisitor(ASTContext &Context, VarDecl *variable)
+      : EvaluatedExprVisitor<FindCaptureVisitor>(Context), Variable(variable) {}
 
-    void VisitDeclRefExpr(DeclRefExpr *ref) {
-      if (ref->getDecl() == Variable && !Capturer)
-        Capturer = ref;
-    }
+  void VisitDeclRefExpr(DeclRefExpr *ref) {
+    if (ref->getDecl() == Variable && !Capturer)
+      Capturer = ref;
+  }
 
-    void VisitObjCIvarRefExpr(ObjCIvarRefExpr *ref) {
-      if (Capturer) return;
-      Visit(ref->getBase());
-      if (Capturer && ref->isFreeIvar())
-        Capturer = ref;
-    }
+  void VisitObjCIvarRefExpr(ObjCIvarRefExpr *ref) {
+    if (Capturer)
+      return;
+    Visit(ref->getBase());
+    if (Capturer && ref->isFreeIvar())
+      Capturer = ref;
+  }
 
-    void VisitBlockExpr(BlockExpr *block) {
-      // Look inside nested blocks
-      if (block->getBlockDecl()->capturesVariable(Variable))
-        Visit(block->getBlockDecl()->getBody());
-    }
+  void VisitBlockExpr(BlockExpr *block) {
+    // Look inside nested blocks
+    if (block->getBlockDecl()->capturesVariable(Variable))
+      Visit(block->getBlockDecl()->getBody());
+  }
 
-    void VisitOpaqueValueExpr(OpaqueValueExpr *OVE) {
-      if (Capturer) return;
-      if (OVE->getSourceExpr())
-        Visit(OVE->getSourceExpr());
-    }
+  void VisitOpaqueValueExpr(OpaqueValueExpr *OVE) {
+    if (Capturer)
+      return;
+    if (OVE->getSourceExpr())
+      Visit(OVE->getSourceExpr());
+  }
 
-    void VisitBinaryOperator(BinaryOperator *BinOp) {
-      if (!Variable || VarWillBeReased || BinOp->getOpcode() != BO_Assign)
+  void VisitBinaryOperator(BinaryOperator *BinOp) {
+    if (!Variable || VarWillBeReased || BinOp->getOpcode() != BO_Assign)
+      return;
+    Expr *LHS = BinOp->getLHS();
+    if (const DeclRefExpr *DRE = dyn_cast_or_null<DeclRefExpr>(LHS)) {
+      if (DRE->getDecl() != Variable)
         return;
-      Expr *LHS = BinOp->getLHS();
-      if (const DeclRefExpr *DRE = dyn_cast_or_null<DeclRefExpr>(LHS)) {
-        if (DRE->getDecl() != Variable)
-          return;
-        if (Expr *RHS = BinOp->getRHS()) {
-          RHS = RHS->IgnoreParenCasts();
-          std::optional<llvm::APSInt> Value;
-          VarWillBeReased =
-              (RHS && (Value = RHS->getIntegerConstantExpr(Context)) &&
-               *Value == 0);
-        }
+      if (Expr *RHS = BinOp->getRHS()) {
+        RHS = RHS->IgnoreParenCasts();
+        std::optional<llvm::APSInt> Value;
+        VarWillBeReased =
+            (RHS && (Value = RHS->getIntegerConstantExpr(Context)) &&
+             *Value == 0);
       }
     }
-  };
+  }
+};
 
 } // namespace
 
@@ -18418,15 +18673,16 @@ static void diagnoseRetainCycle(Sema &S, Expr *capturer,
   assert(owner.Variable && owner.Loc.isValid());
 
   S.Diag(capturer->getExprLoc(), diag::warn_arc_retain_cycle)
-    << owner.Variable << capturer->getSourceRange();
+      << owner.Variable << capturer->getSourceRange();
   S.Diag(owner.Loc, diag::note_arc_retain_cycle_owner)
-    << owner.Indirect << owner.Range;
+      << owner.Indirect << owner.Range;
 }
 
 /// Check for a keyword selector that starts with the word 'add' or
 /// 'set'.
 static bool isSetterLikeSelector(Selector sel) {
-  if (sel.isUnarySelector()) return false;
+  if (sel.isUnarySelector())
+    return false;
 
   StringRef str = sel.getNameForSlot(0);
   str = str.ltrim('_');
@@ -18440,15 +18696,15 @@ static bool isSetterLikeSelector(Selector sel) {
   } else
     return false;
 
-  if (str.empty()) return true;
+  if (str.empty())
+    return true;
   return !isLowercase(str.front());
 }
 
 static std::optional<int>
 GetNSMutableArrayArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
   bool IsMutableArray = S.NSAPIObj->isSubclassOfNSClass(
-                                                Message->getReceiverInterface(),
-                                                NSAPI::ClassId_NSMutableArray);
+      Message->getReceiverInterface(), NSAPI::ClassId_NSMutableArray);
   if (!IsMutableArray) {
     return std::nullopt;
   }
@@ -18464,15 +18720,15 @@ GetNSMutableArrayArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
   NSAPI::NSArrayMethodKind MK = *MKOpt;
 
   switch (MK) {
-    case NSAPI::NSMutableArr_addObject:
-    case NSAPI::NSMutableArr_insertObjectAtIndex:
-    case NSAPI::NSMutableArr_setObjectAtIndexedSubscript:
-      return 0;
-    case NSAPI::NSMutableArr_replaceObjectAtIndex:
-      return 1;
+  case NSAPI::NSMutableArr_addObject:
+  case NSAPI::NSMutableArr_insertObjectAtIndex:
+  case NSAPI::NSMutableArr_setObjectAtIndexedSubscript:
+    return 0;
+  case NSAPI::NSMutableArr_replaceObjectAtIndex:
+    return 1;
 
-    default:
-      return std::nullopt;
+  default:
+    return std::nullopt;
   }
 
   return std::nullopt;
@@ -18481,8 +18737,7 @@ GetNSMutableArrayArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
 static std::optional<int>
 GetNSMutableDictionaryArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
   bool IsMutableDictionary = S.NSAPIObj->isSubclassOfNSClass(
-                                            Message->getReceiverInterface(),
-                                            NSAPI::ClassId_NSMutableDictionary);
+      Message->getReceiverInterface(), NSAPI::ClassId_NSMutableDictionary);
   if (!IsMutableDictionary) {
     return std::nullopt;
   }
@@ -18498,13 +18753,13 @@ GetNSMutableDictionaryArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
   NSAPI::NSDictionaryMethodKind MK = *MKOpt;
 
   switch (MK) {
-    case NSAPI::NSMutableDict_setObjectForKey:
-    case NSAPI::NSMutableDict_setValueForKey:
-    case NSAPI::NSMutableDict_setObjectForKeyedSubscript:
-      return 0;
+  case NSAPI::NSMutableDict_setObjectForKey:
+  case NSAPI::NSMutableDict_setValueForKey:
+  case NSAPI::NSMutableDict_setObjectForKeyedSubscript:
+    return 0;
 
-    default:
-      return std::nullopt;
+  default:
+    return std::nullopt;
   }
 
   return std::nullopt;
@@ -18513,12 +18768,10 @@ GetNSMutableDictionaryArgumentIndex(Sema &S, ObjCMessageExpr *Message) {
 static std::optional<int> GetNSSetArgumentIndex(Sema &S,
                                                 ObjCMessageExpr *Message) {
   bool IsMutableSet = S.NSAPIObj->isSubclassOfNSClass(
-                                                Message->getReceiverInterface(),
-                                                NSAPI::ClassId_NSMutableSet);
+      Message->getReceiverInterface(), NSAPI::ClassId_NSMutableSet);
 
   bool IsMutableOrderedSet = S.NSAPIObj->isSubclassOfNSClass(
-                                            Message->getReceiverInterface(),
-                                            NSAPI::ClassId_NSMutableOrderedSet);
+      Message->getReceiverInterface(), NSAPI::ClassId_NSMutableOrderedSet);
   if (!IsMutableSet && !IsMutableOrderedSet) {
     return std::nullopt;
   }
@@ -18534,13 +18787,13 @@ static std::optional<int> GetNSSetArgumentIndex(Sema &S,
   NSAPI::NSSetMethodKind MK = *MKOpt;
 
   switch (MK) {
-    case NSAPI::NSMutableSet_addObject:
-    case NSAPI::NSOrderedSet_setObjectAtIndex:
-    case NSAPI::NSOrderedSet_setObjectAtIndexedSubscript:
-    case NSAPI::NSOrderedSet_insertObjectAtIndex:
-      return 0;
-    case NSAPI::NSOrderedSet_replaceObjectAtIndexWithObject:
-      return 1;
+  case NSAPI::NSMutableSet_addObject:
+  case NSAPI::NSOrderedSet_setObjectAtIndex:
+  case NSAPI::NSOrderedSet_setObjectAtIndexedSubscript:
+  case NSAPI::NSOrderedSet_insertObjectAtIndex:
+    return 0;
+  case NSAPI::NSOrderedSet_replaceObjectAtIndexWithObject:
+    return 1;
   }
 
   return std::nullopt;
@@ -18571,7 +18824,7 @@ void Sema::CheckObjCCircularContainer(ObjCMessageExpr *Message) {
       if (ArgRE->isObjCSelfExpr()) {
         Diag(Message->getSourceRange().getBegin(),
              diag::warn_objc_circular_container)
-          << ArgRE->getDecl() << StringRef("'super'");
+            << ArgRE->getDecl() << StringRef("'super'");
       }
     }
   } else {
@@ -18587,11 +18840,11 @@ void Sema::CheckObjCCircularContainer(ObjCMessageExpr *Message) {
           ValueDecl *Decl = ReceiverRE->getDecl();
           Diag(Message->getSourceRange().getBegin(),
                diag::warn_objc_circular_container)
-            << Decl << Decl;
+              << Decl << Decl;
           if (!ArgRE->isObjCSelfExpr()) {
             Diag(Decl->getLocation(),
                  diag::note_objc_circular_container_declared_here)
-              << Decl;
+                << Decl;
           }
         }
       }
@@ -18601,10 +18854,10 @@ void Sema::CheckObjCCircularContainer(ObjCMessageExpr *Message) {
           ObjCIvarDecl *Decl = IvarRE->getDecl();
           Diag(Message->getSourceRange().getBegin(),
                diag::warn_objc_circular_container)
-            << Decl << Decl;
+              << Decl << Decl;
           Diag(Decl->getLocation(),
                diag::note_objc_circular_container_declared_here)
-            << Decl;
+              << Decl;
         }
       }
     }
@@ -18665,8 +18918,8 @@ void Sema::checkRetainCycles(VarDecl *Var, Expr *Init) {
     diagnoseRetainCycle(*this, Capturer, Owner);
 }
 
-static bool checkUnsafeAssignLiteral(Sema &S, SourceLocation Loc,
-                                     Expr *RHS, bool isProperty) {
+static bool checkUnsafeAssignLiteral(Sema &S, SourceLocation Loc, Expr *RHS,
+                                     bool isProperty) {
   // Check if RHS is an Objective-C object literal, which also can get
   // immediately zapped in a weak reference.  Note that we explicitly
   // allow ObjCStringLiterals, since those are designed to never really die.
@@ -18679,23 +18932,20 @@ static bool checkUnsafeAssignLiteral(Sema &S, SourceLocation Loc,
     return false;
 
   S.Diag(Loc, diag::warn_arc_literal_assign)
-    << (unsigned) Kind
-    << (isProperty ? 0 : 1)
-    << RHS->getSourceRange();
+      << (unsigned)Kind << (isProperty ? 0 : 1) << RHS->getSourceRange();
 
   return true;
 }
 
 static bool checkUnsafeAssignObject(Sema &S, SourceLocation Loc,
-                                    Qualifiers::ObjCLifetime LT,
-                                    Expr *RHS, bool isProperty) {
+                                    Qualifiers::ObjCLifetime LT, Expr *RHS,
+                                    bool isProperty) {
   // Strip off any implicit cast added to get to the one ARC-specific.
   while (ImplicitCastExpr *cast = dyn_cast<ImplicitCastExpr>(RHS)) {
     if (cast->getCastKind() == CK_ARCConsumeObject) {
       S.Diag(Loc, diag::warn_arc_retained_assign)
-        << (LT == Qualifiers::OCL_ExplicitNone)
-        << (isProperty ? 0 : 1)
-        << RHS->getSourceRange();
+          << (LT == Qualifiers::OCL_ExplicitNone) << (isProperty ? 0 : 1)
+          << RHS->getSourceRange();
       return true;
     }
     RHS = cast->getSubExpr();
@@ -18708,8 +18958,7 @@ static bool checkUnsafeAssignObject(Sema &S, SourceLocation Loc,
   return false;
 }
 
-bool Sema::checkUnsafeAssigns(SourceLocation Loc,
-                              QualType LHS, Expr *RHS) {
+bool Sema::checkUnsafeAssigns(SourceLocation Loc, QualType LHS, Expr *RHS) {
   Qualifiers::ObjCLifetime LT = LHS.getObjCLifetime();
 
   if (LT != Qualifiers::OCL_Weak && LT != Qualifiers::OCL_ExplicitNone)
@@ -18721,13 +18970,11 @@ bool Sema::checkUnsafeAssigns(SourceLocation Loc,
   return false;
 }
 
-void Sema::checkUnsafeExprAssigns(SourceLocation Loc,
-                              Expr *LHS, Expr *RHS) {
+void Sema::checkUnsafeExprAssigns(SourceLocation Loc, Expr *LHS, Expr *RHS) {
   QualType LHSType;
   // PropertyRef on LHS type need be directly obtained from
   // its declaration as it has a PseudoType.
-  ObjCPropertyRefExpr *PRE
-    = dyn_cast<ObjCPropertyRefExpr>(LHS->IgnoreParens());
+  ObjCPropertyRefExpr *PRE = dyn_cast<ObjCPropertyRefExpr>(LHS->IgnoreParens());
   if (PRE && !PRE->isImplicitProperty()) {
     const ObjCPropertyDecl *PD = PRE->getExplicitProperty();
     if (PD)
@@ -18771,7 +19018,7 @@ void Sema::checkUnsafeExprAssigns(SourceLocation Loc,
       while (ImplicitCastExpr *cast = dyn_cast<ImplicitCastExpr>(RHS)) {
         if (cast->getCastKind() == CK_ARCConsumeObject) {
           Diag(Loc, diag::warn_arc_retained_property_assign)
-          << RHS->getSourceRange();
+              << RHS->getSourceRange();
           return;
         }
         RHS = cast->getSubExpr();
@@ -18798,14 +19045,14 @@ static bool ShouldDiagnoseEmptyStmtBody(const SourceManager &SourceMgr,
 
   // Get line numbers of statement and body.
   bool StmtLineInvalid;
-  unsigned StmtLine = SourceMgr.getPresumedLineNumber(StmtLoc,
-                                                      &StmtLineInvalid);
+  unsigned StmtLine =
+      SourceMgr.getPresumedLineNumber(StmtLoc, &StmtLineInvalid);
   if (StmtLineInvalid)
     return false;
 
   bool BodyLineInvalid;
-  unsigned BodyLine = SourceMgr.getSpellingLineNumber(Body->getSemiLoc(),
-                                                      &BodyLineInvalid);
+  unsigned BodyLine =
+      SourceMgr.getSpellingLineNumber(Body->getSemiLoc(), &BodyLineInvalid);
   if (BodyLineInvalid)
     return false;
 
@@ -18816,8 +19063,7 @@ static bool ShouldDiagnoseEmptyStmtBody(const SourceManager &SourceMgr,
   return true;
 }
 
-void Sema::DiagnoseEmptyStmtBody(SourceLocation StmtLoc,
-                                 const Stmt *Body,
+void Sema::DiagnoseEmptyStmtBody(SourceLocation StmtLoc, const Stmt *Body,
                                  unsigned DiagID) {
   // Since this is a syntactic check, don't emit diagnostic for template
   // instantiations, this just adds noise.
@@ -18837,8 +19083,7 @@ void Sema::DiagnoseEmptyStmtBody(SourceLocation StmtLoc,
   Diag(NBody->getSemiLoc(), diag::note_empty_body_on_separate_line);
 }
 
-void Sema::DiagnoseEmptyLoopBody(const Stmt *S,
-                                 const Stmt *PossibleBody) {
+void Sema::DiagnoseEmptyLoopBody(const Stmt *S, const Stmt *PossibleBody) {
   assert(!CurrentInstantiationScope); // Ensured by caller
 
   SourceLocation StmtLoc;
@@ -18907,7 +19152,7 @@ void Sema::DiagnoseEmptyLoopBody(const Stmt *S,
 
 /// DiagnoseSelfMove - Emits a warning if a value is moved to itself.
 void Sema::DiagnoseSelfMove(const Expr *LHSExpr, const Expr *RHSExpr,
-                             SourceLocation OpLoc) {
+                            SourceLocation OpLoc) {
   if (Diags.isIgnored(diag::warn_sizeof_pointer_expr_memaccess, OpLoc))
     return;
 
@@ -19044,12 +19289,10 @@ static bool isLayoutCompatibleStruct(ASTContext &C, RecordDecl *RD1,
       return false;
 
     // Check the base classes.
-    for (CXXRecordDecl::base_class_const_iterator
-               Base1 = D1CXX->bases_begin(),
-           BaseEnd1 = D1CXX->bases_end(),
-              Base2 = D2CXX->bases_begin();
-         Base1 != BaseEnd1;
-         ++Base1, ++Base2) {
+    for (CXXRecordDecl::base_class_const_iterator Base1 = D1CXX->bases_begin(),
+                                                  BaseEnd1 = D1CXX->bases_end(),
+                                                  Base2 = D2CXX->bases_begin();
+         Base1 != BaseEnd1; ++Base1, ++Base2) {
       if (!isLayoutCompatible(C, Base1->getType(), Base2->getType()))
         return false;
     }
@@ -19064,7 +19307,7 @@ static bool isLayoutCompatibleStruct(ASTContext &C, RecordDecl *RD1,
                              Field2End = RD2->field_end(),
                              Field1 = RD1->field_begin(),
                              Field1End = RD1->field_end();
-  for ( ; Field1 != Field1End && Field2 != Field2End; ++Field1, ++Field2) {
+  for (; Field1 != Field1End && Field2 != Field2End; ++Field1, ++Field2) {
     if (!isLayoutCompatible(C, *Field1, *Field2))
       return false;
   }
@@ -19083,14 +19326,13 @@ static bool isLayoutCompatibleUnion(ASTContext &C, RecordDecl *RD1,
     UnmatchedFields.insert(Field2);
 
   for (auto *Field1 : RD1->fields()) {
-    llvm::SmallPtrSet<FieldDecl *, 8>::iterator
-        I = UnmatchedFields.begin(),
-        E = UnmatchedFields.end();
+    llvm::SmallPtrSet<FieldDecl *, 8>::iterator I = UnmatchedFields.begin(),
+                                                E = UnmatchedFields.end();
 
-    for ( ; I != E; ++I) {
+    for (; I != E; ++I) {
       if (isLayoutCompatible(C, Field1, *I)) {
         bool Result = UnmatchedFields.erase(*I);
-        (void) Result;
+        (void)Result;
         assert(Result);
         break;
       }
@@ -19134,15 +19376,13 @@ static bool isLayoutCompatible(ASTContext &C, QualType T1, QualType T2) {
     return false;
 
   if (TC1 == Type::Enum) {
-    return isLayoutCompatible(C,
-                              cast<EnumType>(T1)->getDecl(),
+    return isLayoutCompatible(C, cast<EnumType>(T1)->getDecl(),
                               cast<EnumType>(T2)->getDecl());
   } else if (TC1 == Type::Record) {
     if (!T1->isStandardLayoutType() || !T2->isStandardLayoutType())
       return false;
 
-    return isLayoutCompatible(C,
-                              cast<RecordType>(T1)->getDecl(),
+    return isLayoutCompatible(C, cast<RecordType>(T1)->getDecl(),
                               cast<RecordType>(T2)->getDecl());
   }
 
@@ -19165,7 +19405,7 @@ static bool isLayoutCompatible(ASTContext &C, QualType T1, QualType T2) {
 static bool FindTypeTagExpr(const Expr *TypeExpr, const ASTContext &Ctx,
                             const ValueDecl **VD, uint64_t *MagicValue,
                             bool isConstantEvaluated) {
-  while(true) {
+  while (true) {
     if (!TypeExpr)
       return false;
 
@@ -19277,8 +19517,7 @@ static bool GetMatchingCType(
   if (!MagicValues)
     return false;
 
-  llvm::DenseMap<Sema::TypeTagMagicValue,
-                 Sema::TypeTagData>::const_iterator I =
+  llvm::DenseMap<Sema::TypeTagMagicValue, Sema::TypeTagData>::const_iterator I =
       MagicValues->find(std::make_pair(ArgumentKind, MagicValue));
   if (I == MagicValues->end())
     return false;
@@ -19289,8 +19528,7 @@ static bool GetMatchingCType(
 
 void Sema::RegisterTypeTagForDatatype(const IdentifierInfo *ArgumentKind,
                                       uint64_t MagicValue, QualType Type,
-                                      bool LayoutCompatible,
-                                      bool MustBeNull) {
+                                      bool LayoutCompatible, bool MustBeNull) {
   if (!TypeTagForDatatypeMagicValues)
     TypeTagForDatatypeMagicValues.reset(
         new llvm::DenseMap<TypeTagMagicValue, TypeTagData>);
@@ -19312,8 +19550,8 @@ static bool IsSameCharType(QualType T1, QualType T2) {
   BuiltinType::Kind T1Kind = BT1->getKind();
   BuiltinType::Kind T2Kind = BT2->getKind();
 
-  return (T1Kind == BuiltinType::SChar  && T2Kind == BuiltinType::Char_S) ||
-         (T1Kind == BuiltinType::UChar  && T2Kind == BuiltinType::Char_U) ||
+  return (T1Kind == BuiltinType::SChar && T2Kind == BuiltinType::Char_S) ||
+         (T1Kind == BuiltinType::UChar && T2Kind == BuiltinType::Char_U) ||
          (T1Kind == BuiltinType::Char_U && T2Kind == BuiltinType::UChar) ||
          (T1Kind == BuiltinType::Char_S && T2Kind == BuiltinType::SChar);
 }
@@ -19340,7 +19578,7 @@ void Sema::CheckArgumentWithTypeTag(const ArgumentWithTypeTagAttr *Attr,
     if (FoundWrongKind)
       Diag(TypeTagExpr->getExprLoc(),
            diag::warn_type_tag_for_datatype_wrong_kind)
-        << TypeTagExpr->getSourceRange();
+          << TypeTagExpr->getSourceRange();
     return;
   }
 
@@ -19367,12 +19605,11 @@ void Sema::CheckArgumentWithTypeTag(const ArgumentWithTypeTagAttr *Attr,
 
   if (TypeInfo.MustBeNull) {
     // Type tag with matching void type requires a null pointer.
-    if (!ArgumentExpr->isNullPointerConstant(Context,
-                                             Expr::NPC_ValueDependentIsNotNull)) {
+    if (!ArgumentExpr->isNullPointerConstant(
+            Context, Expr::NPC_ValueDependentIsNotNull)) {
       Diag(ArgumentExpr->getExprLoc(),
            diag::warn_type_safety_null_pointer_required)
-          << ArgumentKind->getName()
-          << ArgumentExpr->getSourceRange()
+          << ArgumentKind->getName() << ArgumentExpr->getSourceRange()
           << TypeTagExpr->getSourceRange();
     }
     return;
@@ -19396,19 +19633,16 @@ void Sema::CheckArgumentWithTypeTag(const ArgumentWithTypeTagAttr *Attr,
                                            RequiredType->getPointeeType())) ||
           (!IsPointerAttr && IsSameCharType(ArgumentType, RequiredType)))
         mismatch = false;
-  } else
-    if (IsPointerAttr)
-      mismatch = !isLayoutCompatible(Context,
-                                     ArgumentType->getPointeeType(),
-                                     RequiredType->getPointeeType());
-    else
-      mismatch = !isLayoutCompatible(Context, ArgumentType, RequiredType);
+  } else if (IsPointerAttr)
+    mismatch = !isLayoutCompatible(Context, ArgumentType->getPointeeType(),
+                                   RequiredType->getPointeeType());
+  else
+    mismatch = !isLayoutCompatible(Context, ArgumentType, RequiredType);
 
   if (mismatch)
     Diag(ArgumentExpr->getExprLoc(), diag::warn_type_safety_type_mismatch)
-        << ArgumentType << ArgumentKind
-        << TypeInfo.LayoutCompatible << RequiredType
-        << ArgumentExpr->getSourceRange()
+        << ArgumentType << ArgumentKind << TypeInfo.LayoutCompatible
+        << RequiredType << ArgumentExpr->getSourceRange()
         << TypeTagExpr->getSourceRange();
 }
 
@@ -19501,7 +19735,7 @@ void Sema::RefersToMemberWithReducedAlignment(
   // For now, just disregard these cases. This is left for future
   // improvement.
   if (!DRE && !isa<CXXThisExpr>(TopBase))
-      return;
+    return;
 
   // Alignment expected by the whole expression.
   CharUnits ExpectedAlignment = Context.getTypeAlignInChars(E->getType());
@@ -19668,7 +19902,8 @@ bool Sema::SemaBuiltinNonDeterministicValue(CallExpr *TheCall) {
   QualType TyArg = Arg.get()->getType();
 
   if (!TyArg->isBuiltinType() && !TyArg->isVectorType())
-    return Diag(TheCall->getArg(0)->getBeginLoc(), diag::err_builtin_invalid_arg_type)
+    return Diag(TheCall->getArg(0)->getBeginLoc(),
+                diag::err_builtin_invalid_arg_type)
            << 1 << /*vector, integer or floating point ty*/ 0 << TyArg;
 
   TheCall->setType(TyArg);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -133,7 +133,7 @@ void Sema::NoteDeletedFunction(FunctionDecl *Decl) {
     return NoteDeletedInheritingConstructor(Ctor);
 
   Diag(Decl->getLocation(), diag::note_availability_specified_here)
-    << Decl << 1;
+      << Decl << 1;
 }
 
 /// Determine whether a FunctionDecl was ever declared with an
@@ -190,7 +190,7 @@ static void diagnoseUseOfInternalDeclInInlineFunction(Sema &S,
 
   S.Diag(Loc, DowngradeWarning ? diag::ext_internal_in_extern_inline_quiet
                                : diag::ext_internal_in_extern_inline)
-    << /*IsVar=*/!UsedFn << D;
+      << /*IsVar=*/!UsedFn << D;
 
   S.MaybeSuggestAddingStaticToDecl(Current);
 
@@ -205,7 +205,7 @@ void Sema::MaybeSuggestAddingStaticToDecl(const FunctionDecl *Cur) {
   if (!hasAnyExplicitStorageClass(First)) {
     SourceLocation DeclBegin = First->getSourceRange().getBegin();
     Diag(DeclBegin, diag::note_convert_inline_to_static)
-      << Cur << FixItHint::CreateInsertion(DeclBegin, "static ");
+        << Cur << FixItHint::CreateInsertion(DeclBegin, "static ");
   }
 }
 
@@ -255,10 +255,10 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
   if (ParsingInitForAutoVars.count(D)) {
     if (isa<BindingDecl>(D)) {
       Diag(Loc, diag::err_binding_cannot_appear_in_own_initializer)
-        << D->getDeclName();
+          << D->getDeclName();
     } else {
       Diag(Loc, diag::err_auto_variable_cannot_appear_in_own_initializer)
-        << D->getDeclName() << cast<VarDecl>(D)->getType();
+          << D->getDeclName() << cast<VarDecl>(D)->getType();
     }
     return true;
   }
@@ -293,8 +293,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
         // constraint expression, for example)
         return true;
       if (!Satisfaction.IsSatisfied) {
-        Diag(Loc,
-             diag::err_reference_to_function_with_unsatisfied_constraints)
+        Diag(Loc, diag::err_reference_to_function_with_unsatisfied_constraints)
             << D;
         DiagnoseUnsatisfiedConstraint(Satisfaction);
         return true;
@@ -309,7 +308,6 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
 
     if (getLangOpts().CUDA && !CheckCUDACall(Loc, FD))
       return true;
-
   }
 
   if (auto *MD = dyn_cast<CXXMethodDecl>(D)) {
@@ -319,12 +317,12 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
           cast<CXXConstructorDecl>(MD)->isDefaultConstructor()) ||
          MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())) {
       Diag(Loc, diag::warn_cxx17_compat_lambda_def_ctor_assign)
-        << !isa<CXXConstructorDecl>(MD);
+          << !isa<CXXConstructorDecl>(MD);
     }
   }
 
-  auto getReferencedObjCProp = [](const NamedDecl *D) ->
-                                      const ObjCPropertyDecl * {
+  auto getReferencedObjCProp =
+      [](const NamedDecl *D) -> const ObjCPropertyDecl * {
     if (const auto *MD = dyn_cast<ObjCMethodDecl>(D))
       return MD->findPropertyDecl();
     return nullptr;
@@ -333,7 +331,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
     if (diagnoseArgIndependentDiagnoseIfAttrs(ObjCPDecl, Loc))
       return true;
   } else if (diagnoseArgIndependentDiagnoseIfAttrs(D, Loc)) {
-      return true;
+    return true;
   }
 
   // [OpenMP 4.0], 2.15 declare reduction Directive, Restrictions
@@ -522,7 +520,8 @@ ExprResult Sema::DefaultFunctionArrayConversion(Expr *E, bool Diagnose) {
   // Handle any placeholder expressions which made it here.
   if (E->hasPlaceholderType()) {
     ExprResult result = CheckPlaceholderExpr(E);
-    if (result.isInvalid()) return ExprError();
+    if (result.isInvalid())
+      return ExprError();
     E = result.get();
   }
 
@@ -536,7 +535,8 @@ ExprResult Sema::DefaultFunctionArrayConversion(Expr *E, bool Diagnose) {
           return ExprError();
 
     E = ImpCastExprToType(E, Context.getPointerType(Ty),
-                          CK_FunctionToPointerDecay).get();
+                          CK_FunctionToPointerDecay)
+            .get();
   } else if (Ty->isArrayType()) {
     // In C90 mode, arrays only promote to pointers if the array expression is
     // an lvalue.  The relevant legalese is C90 6.2.2.1p3: "an lvalue that has
@@ -586,8 +586,7 @@ static void CheckForNullPointerDereference(Sema &S, Expr *E) {
 }
 
 static void DiagnoseDirectIsaAccess(Sema &S, const ObjCIvarRefExpr *OIRE,
-                                    SourceLocation AssignLoc,
-                                    const Expr* RHS) {
+                                    SourceLocation AssignLoc, const Expr *RHS) {
   const ObjCIvarDecl *IV = OIRE->getDecl();
   if (!IV)
     return;
@@ -605,13 +604,12 @@ static void DiagnoseDirectIsaAccess(Sema &S, const ObjCIvarRefExpr *OIRE,
     if (ObjCInterfaceDecl *IDecl = OTy->getInterface()) {
       ObjCInterfaceDecl *ClassDeclared = nullptr;
       ObjCIvarDecl *IV = IDecl->lookupInstanceVariable(Member, ClassDeclared);
-      if (!ClassDeclared->getSuperClass()
-          && (*ClassDeclared->ivar_begin()) == IV) {
+      if (!ClassDeclared->getSuperClass() &&
+          (*ClassDeclared->ivar_begin()) == IV) {
         if (RHS) {
-          NamedDecl *ObjectSetClass =
-            S.LookupSingleName(S.TUScope,
-                               &S.Context.Idents.get("object_setClass"),
-                               SourceLocation(), S.LookupOrdinaryName);
+          NamedDecl *ObjectSetClass = S.LookupSingleName(
+              S.TUScope, &S.Context.Idents.get("object_setClass"),
+              SourceLocation(), S.LookupOrdinaryName);
           if (ObjectSetClass) {
             SourceLocation RHSLocEnd = S.getLocForEndOfToken(RHS->getEndLoc());
             S.Diag(OIRE->getExprLoc(), diag::warn_objc_isa_assign)
@@ -620,14 +618,12 @@ static void DiagnoseDirectIsaAccess(Sema &S, const ObjCIvarRefExpr *OIRE,
                 << FixItHint::CreateReplacement(
                        SourceRange(OIRE->getOpLoc(), AssignLoc), ",")
                 << FixItHint::CreateInsertion(RHSLocEnd, ")");
-          }
-          else
+          } else
             S.Diag(OIRE->getLocation(), diag::warn_objc_isa_assign);
         } else {
-          NamedDecl *ObjectGetClass =
-            S.LookupSingleName(S.TUScope,
-                               &S.Context.Idents.get("object_getClass"),
-                               SourceLocation(), S.LookupOrdinaryName);
+          NamedDecl *ObjectGetClass = S.LookupSingleName(
+              S.TUScope, &S.Context.Idents.get("object_getClass"),
+              SourceLocation(), S.LookupOrdinaryName);
           if (ObjectGetClass)
             S.Diag(OIRE->getExprLoc(), diag::warn_objc_isa_use)
                 << FixItHint::CreateInsertion(OIRE->getBeginLoc(),
@@ -646,14 +642,16 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
   // Handle any placeholder expressions which made it here.
   if (E->hasPlaceholderType()) {
     ExprResult result = CheckPlaceholderExpr(E);
-    if (result.isInvalid()) return ExprError();
+    if (result.isInvalid())
+      return ExprError();
     E = result.get();
   }
 
   // C++ [conv.lval]p1:
   //   A glvalue of a non-function, non-array type T can be
   //   converted to a prvalue.
-  if (!E->isGLValue()) return E;
+  if (!E->isGLValue())
+    return E;
 
   QualType T = E->getType();
   assert(!T.isNull() && "r-value conversion on typeless expression?");
@@ -664,10 +662,8 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
 
   // We don't want to throw lvalue-to-rvalue casts on top of
   // expressions of certain types in C++.
-  if (getLangOpts().CPlusPlus &&
-      (E->getType() == Context.OverloadTy ||
-       T->isDependentType() ||
-       T->isRecordType()))
+  if (getLangOpts().CPlusPlus && (E->getType() == Context.OverloadTy ||
+                                  T->isDependentType() || T->isRecordType()))
     return E;
 
   // The C standard is actually really unclear on this point, and
@@ -682,16 +678,15 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
   if (getLangOpts().OpenCL &&
       !getOpenCLOptions().isAvailableOption("cl_khr_fp16", getLangOpts()) &&
       T->isHalfType()) {
-    Diag(E->getExprLoc(), diag::err_opencl_half_load_store)
-      << 0 << T;
+    Diag(E->getExprLoc(), diag::err_opencl_half_load_store) << 0 << T;
     return ExprError();
   }
 
   CheckForNullPointerDereference(*this, E);
   if (const ObjCIsaExpr *OISA = dyn_cast<ObjCIsaExpr>(E->IgnoreParenCasts())) {
-    NamedDecl *ObjectGetClass = LookupSingleName(TUScope,
-                                     &Context.Idents.get("object_getClass"),
-                                     SourceLocation(), LookupOrdinaryName);
+    NamedDecl *ObjectGetClass =
+        LookupSingleName(TUScope, &Context.Idents.get("object_getClass"),
+                         SourceLocation(), LookupOrdinaryName);
     if (ObjectGetClass)
       Diag(E->getExprLoc(), diag::warn_objc_isa_use)
           << FixItHint::CreateInsertion(OISA->getBeginLoc(), "object_getClass(")
@@ -699,10 +694,9 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
                  SourceRange(OISA->getOpLoc(), OISA->getIsaMemberLoc()), ")");
     else
       Diag(E->getExprLoc(), diag::warn_objc_isa_use);
-  }
-  else if (const ObjCIvarRefExpr *OIRE =
-            dyn_cast<ObjCIvarRefExpr>(E->IgnoreParenCasts()))
-    DiagnoseDirectIsaAccess(*this, OIRE, SourceLocation(), /* Expr*/nullptr);
+  } else if (const ObjCIvarRefExpr *OIRE =
+                 dyn_cast<ObjCIvarRefExpr>(E->IgnoreParenCasts()))
+    DiagnoseDirectIsaAccess(*this, OIRE, SourceLocation(), /* Expr*/ nullptr);
 
   // C++ [conv.lval]p1:
   //   [...] If T is a non-class type, the type of the prvalue is the
@@ -726,8 +720,8 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
     return Res;
   E = Res.get();
 
-  // Loading a __weak object implicitly retains the value, so we need a cleanup to
-  // balance that.
+  // Loading a __weak object implicitly retains the value, so we need a cleanup
+  // to balance that.
   if (E->getType().getObjCLifetime() == Qualifiers::OCL_Weak)
     Cleanup.setExprNeedsCleanups(true);
 
@@ -921,8 +915,8 @@ ExprResult Sema::DefaultArgumentPromotion(Expr *E) {
   // potentially potentially evaluated contexts.
   if (getLangOpts().CPlusPlus && E->isGLValue() && !isUnevaluatedContext()) {
     ExprResult Temp = PerformCopyInitialization(
-                       InitializedEntity::InitializeTemporary(E->getType()),
-                                                E->getExprLoc(), E);
+        InitializedEntity::InitializeTemporary(E->getType()), E->getExprLoc(),
+        E);
     if (Temp.isInvalid())
       return ExprError();
     E = Temp.get();
@@ -1045,7 +1039,7 @@ ExprResult Sema::DefaultVariadicArgumentPromotion(Expr *E, VariadicCallType CT,
          (FDecl && FDecl->hasAttr<CFAuditedTransferAttr>()))) {
       E = stripARCUnbridgedCast(E);
 
-    // Otherwise, do normal placeholder checking.
+      // Otherwise, do normal placeholder checking.
     } else {
       ExprResult ExprRes = CheckPlaceholderExpr(E);
       if (ExprRes.isInvalid())
@@ -1109,13 +1103,15 @@ static bool handleIntegerToComplexFloatConversion(Sema &S, ExprResult &IntExpr,
                                                   QualType IntTy,
                                                   QualType ComplexTy,
                                                   bool SkipCast) {
-  if (IntTy->isComplexType() || IntTy->isRealFloatingType()) return true;
-  if (SkipCast) return false;
+  if (IntTy->isComplexType() || IntTy->isRealFloatingType())
+    return true;
+  if (SkipCast)
+    return false;
   if (IntTy->isIntegerType()) {
     QualType fpTy = ComplexTy->castAs<ComplexType>()->getElementType();
     IntExpr = S.ImpCastExprToType(IntExpr.get(), fpTy, CK_IntegralToFloating);
-    IntExpr = S.ImpCastExprToType(IntExpr.get(), ComplexTy,
-                                  CK_FloatingRealToComplex);
+    IntExpr =
+        S.ImpCastExprToType(IntExpr.get(), ComplexTy, CK_FloatingRealToComplex);
   } else {
     assert(IntTy->isComplexIntegerType());
     IntExpr = S.ImpCastExprToType(IntExpr.get(), ComplexTy,
@@ -1188,8 +1184,8 @@ static QualType handleIntToFloatConversion(Sema &S, ExprResult &FloatExpr,
   if (IntTy->isIntegerType()) {
     if (ConvertInt)
       // Convert intExpr to the lhs floating point type.
-      IntExpr = S.ImpCastExprToType(IntExpr.get(), FloatTy,
-                                    CK_IntegralToFloating);
+      IntExpr =
+          S.ImpCastExprToType(IntExpr.get(), FloatTy, CK_IntegralToFloating);
     return FloatTy;
   }
 
@@ -1204,17 +1200,17 @@ static QualType handleIntToFloatConversion(Sema &S, ExprResult &FloatExpr,
 
   // float -> _Complex float
   if (ConvertFloat)
-    FloatExpr = S.ImpCastExprToType(FloatExpr.get(), result,
-                                    CK_FloatingRealToComplex);
+    FloatExpr =
+        S.ImpCastExprToType(FloatExpr.get(), result, CK_FloatingRealToComplex);
 
   return result;
 }
 
 /// Handle arithmethic conversion with floating point types.  Helper
 /// function of UsualArithmeticConversions()
-static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
-                                      ExprResult &RHS, QualType LHSType,
-                                      QualType RHSType, bool IsCompAssign) {
+static QualType handleFloatConversion(Sema &S, ExprResult &LHS, ExprResult &RHS,
+                                      QualType LHSType, QualType RHSType,
+                                      bool IsCompAssign) {
   bool LHSFloat = LHSType->isRealFloatingType();
   bool RHSFloat = RHSType->isRealFloatingType();
 
@@ -1251,11 +1247,11 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
 
     return handleIntToFloatConversion(S, LHS, RHS, LHSType, RHSType,
                                       /*ConvertFloat=*/!IsCompAssign,
-                                      /*ConvertInt=*/ true);
+                                      /*ConvertInt=*/true);
   }
   assert(RHSFloat);
   return handleIntToFloatConversion(S, RHS, LHS, RHSType, LHSType,
-                                    /*ConvertFloat=*/ true,
+                                    /*ConvertFloat=*/true,
                                     /*ConvertInt=*/!IsCompAssign);
 }
 
@@ -1300,7 +1296,7 @@ ExprResult doComplexIntegralCast(Sema &S, Expr *op, QualType toType) {
   return S.ImpCastExprToType(op, S.Context.getComplexType(toType),
                              CK_IntegralComplexCast);
 }
-}
+} // namespace
 
 /// Handle integer arithmetic conversions.  Helper function of
 /// UsualArithmeticConversions()
@@ -1345,7 +1341,7 @@ static QualType handleIntegerConversion(Sema &S, ExprResult &LHS,
     // on most 32-bit systems).  Use the unsigned type corresponding
     // to the signed type.
     QualType result =
-      S.Context.getCorrespondingUnsignedType(LHSSigned ? LHSType : RHSType);
+        S.Context.getCorrespondingUnsignedType(LHSSigned ? LHSType : RHSType);
     RHS = (*doRHSCast)(S, RHS.get(), result);
     if (!IsCompAssign)
       LHS = (*doLHSCast)(S, LHS.get(), result);
@@ -1366,8 +1362,8 @@ static QualType handleComplexIntConversion(Sema &S, ExprResult &LHS,
     QualType LHSEltType = LHSComplexInt->getElementType();
     QualType RHSEltType = RHSComplexInt->getElementType();
     QualType ScalarType =
-      handleIntegerConversion<doComplexIntegralCast, doComplexIntegralCast>
-        (S, LHS, RHS, LHSEltType, RHSEltType, IsCompAssign);
+        handleIntegerConversion<doComplexIntegralCast, doComplexIntegralCast>(
+            S, LHS, RHS, LHSEltType, RHSEltType, IsCompAssign);
 
     return S.Context.getComplexType(ScalarType);
   }
@@ -1375,11 +1371,10 @@ static QualType handleComplexIntConversion(Sema &S, ExprResult &LHS,
   if (LHSComplexInt) {
     QualType LHSEltType = LHSComplexInt->getElementType();
     QualType ScalarType =
-      handleIntegerConversion<doComplexIntegralCast, doIntegralCast>
-        (S, LHS, RHS, LHSEltType, RHSType, IsCompAssign);
+        handleIntegerConversion<doComplexIntegralCast, doIntegralCast>(
+            S, LHS, RHS, LHSEltType, RHSType, IsCompAssign);
     QualType ComplexType = S.Context.getComplexType(ScalarType);
-    RHS = S.ImpCastExprToType(RHS.get(), ComplexType,
-                              CK_IntegralRealToComplex);
+    RHS = S.ImpCastExprToType(RHS.get(), ComplexType, CK_IntegralRealToComplex);
 
     return ComplexType;
   }
@@ -1388,13 +1383,12 @@ static QualType handleComplexIntConversion(Sema &S, ExprResult &LHS,
 
   QualType RHSEltType = RHSComplexInt->getElementType();
   QualType ScalarType =
-    handleIntegerConversion<doIntegralCast, doComplexIntegralCast>
-      (S, LHS, RHS, LHSType, RHSEltType, IsCompAssign);
+      handleIntegerConversion<doIntegralCast, doComplexIntegralCast>(
+          S, LHS, RHS, LHSType, RHSEltType, IsCompAssign);
   QualType ComplexType = S.Context.getComplexType(ScalarType);
 
   if (!IsCompAssign)
-    LHS = S.ImpCastExprToType(LHS.get(), ComplexType,
-                              CK_IntegralRealToComplex);
+    LHS = S.ImpCastExprToType(LHS.get(), ComplexType, CK_IntegralRealToComplex);
   return ComplexType;
 }
 
@@ -1497,7 +1491,8 @@ static void checkEnumArithmeticConversions(Sema &S, Expr *LHS, Expr *RHS,
   //
   // Warn on this in all language modes. Produce a deprecation warning in C++20.
   // Eventually we will presumably reject these cases (in C++23 onwards?).
-  QualType L = LHS->getType(), R = RHS->getType();
+  QualType L = LHS->getEnumCoercedType(S.Context),
+           R = RHS->getEnumCoercedType(S.Context);
   bool LEnum = L->isUnscopedEnumerationType(),
        REnum = R->isUnscopedEnumerationType();
   bool IsCompAssign = ACK == Sema::ACK_CompAssign;
@@ -1523,8 +1518,8 @@ static void checkEnumArithmeticConversions(Sema &S, Expr *LHS, Expr *RHS,
       // user cares about this, but this situation is still deprecated in
       // C++2a. Use a different warning group.
       DiagID = S.getLangOpts().CPlusPlus20
-                    ? diag::warn_arith_conv_mixed_anon_enum_types_cxx20
-                    : diag::warn_arith_conv_mixed_anon_enum_types;
+                   ? diag::warn_arith_conv_mixed_anon_enum_types_cxx20
+                   : diag::warn_arith_conv_mixed_anon_enum_types;
     } else if (ACK == Sema::ACK_Conditional) {
       // Conditional expressions are separated out because they have
       // historically had a different warning flag.
@@ -1624,14 +1619,13 @@ QualType Sema::UsualArithmeticConversions(ExprResult &LHS, ExprResult &RHS,
     return handleFixedPointConversion(*this, LHSType, RHSType);
 
   // Finally, we have two differing integer types.
-  return handleIntegerConversion<doIntegralCast, doIntegralCast>
-           (*this, LHS, RHS, LHSType, RHSType, ACK == ACK_CompAssign);
+  return handleIntegerConversion<doIntegralCast, doIntegralCast>(
+      *this, LHS, RHS, LHSType, RHSType, ACK == ACK_CompAssign);
 }
 
 //===----------------------------------------------------------------------===//
 //  Semantic Analysis for various Expression Types
 //===----------------------------------------------------------------------===//
-
 
 ExprResult Sema::ActOnGenericSelectionExpr(
     SourceLocation KeyLoc, SourceLocation DefaultLoc, SourceLocation RParenLoc,
@@ -1640,10 +1634,10 @@ ExprResult Sema::ActOnGenericSelectionExpr(
   unsigned NumAssocs = ArgTypes.size();
   assert(NumAssocs == ArgExprs.size());
 
-  TypeSourceInfo **Types = new TypeSourceInfo*[NumAssocs];
+  TypeSourceInfo **Types = new TypeSourceInfo *[NumAssocs];
   for (unsigned i = 0; i < NumAssocs; ++i) {
     if (ArgTypes[i])
-      (void) GetTypeFromParser(ArgTypes[i], &Types[i]);
+      (void)GetTypeFromParser(ArgTypes[i], &Types[i]);
     else
       Types[i] = nullptr;
   }
@@ -1661,7 +1655,7 @@ ExprResult Sema::ActOnGenericSelectionExpr(
   ExprResult ER = CreateGenericSelectionExpr(
       KeyLoc, DefaultLoc, RParenLoc, PredicateIsExpr, ControllingExprOrType,
       llvm::ArrayRef(Types, NumAssocs), ArgExprs);
-  delete [] Types;
+  delete[] Types;
   return ER;
 }
 
@@ -1773,26 +1767,23 @@ ExprResult Sema::CreateGenericSelectionExpr(
 
         if (D != 0) {
           Diag(Types[i]->getTypeLoc().getBeginLoc(), D)
-            << Types[i]->getTypeLoc().getSourceRange()
-            << Types[i]->getType();
+              << Types[i]->getTypeLoc().getSourceRange() << Types[i]->getType();
           TypeErrorFound = true;
         }
 
         // C11 6.5.1.1p2 "No two generic associations in the same generic
         // selection shall specify compatible types."
-        for (unsigned j = i+1; j < NumAssocs; ++j)
+        for (unsigned j = i + 1; j < NumAssocs; ++j)
           if (Types[j] && !Types[j]->getType()->isDependentType() &&
               Context.typesAreCompatible(Types[i]->getType(),
                                          Types[j]->getType())) {
             Diag(Types[j]->getTypeLoc().getBeginLoc(),
                  diag::err_assoc_compatible_types)
-              << Types[j]->getTypeLoc().getSourceRange()
-              << Types[j]->getType()
-              << Types[i]->getType();
-            Diag(Types[i]->getTypeLoc().getBeginLoc(),
-                 diag::note_compat_assoc)
-              << Types[i]->getTypeLoc().getSourceRange()
-              << Types[i]->getType();
+                << Types[j]->getTypeLoc().getSourceRange()
+                << Types[j]->getType() << Types[i]->getType();
+            Diag(Types[i]->getTypeLoc().getBeginLoc(), diag::note_compat_assoc)
+                << Types[i]->getTypeLoc().getSourceRange()
+                << Types[i]->getType();
             TypeErrorFound = true;
           }
       }
@@ -1858,10 +1849,8 @@ ExprResult Sema::CreateGenericSelectionExpr(
     Diag(SR.getBegin(), diag::err_generic_sel_multi_match)
         << SR << P.second << (unsigned)CompatIndices.size();
     for (unsigned I : CompatIndices) {
-      Diag(Types[I]->getTypeLoc().getBeginLoc(),
-           diag::note_compat_assoc)
-        << Types[I]->getTypeLoc().getSourceRange()
-        << Types[I]->getType();
+      Diag(Types[I]->getTypeLoc().getBeginLoc(), diag::note_compat_assoc)
+          << Types[I]->getTypeLoc().getSourceRange() << Types[I]->getType();
     }
     return ExprError();
   }
@@ -1881,8 +1870,7 @@ ExprResult Sema::CreateGenericSelectionExpr(
   // then the result expression of the generic selection is the expression
   // in that generic association. Otherwise, the result expression of the
   // generic selection is the expression in the default generic association."
-  unsigned ResultIndex =
-    CompatIndices.size() ? CompatIndices[0] : DefaultIndex;
+  unsigned ResultIndex = CompatIndices.size() ? CompatIndices[0] : DefaultIndex;
 
   if (ControllingExpr) {
     return GenericSelectionExpr::Create(
@@ -1937,7 +1925,7 @@ static SourceLocation getUDSuffixLoc(Sema &S, SourceLocation TokLoc,
 static ExprResult BuildCookedLiteralOperatorCall(Sema &S, Scope *Scope,
                                                  IdentifierInfo *UDSuffix,
                                                  SourceLocation UDSuffixLoc,
-                                                 ArrayRef<Expr*> Args,
+                                                 ArrayRef<Expr *> Args,
                                                  SourceLocation LitEndLoc) {
   assert(Args.size() <= 2 && "too many arguments for literal operator");
 
@@ -1949,7 +1937,7 @@ static ExprResult BuildCookedLiteralOperatorCall(Sema &S, Scope *Scope,
   }
 
   DeclarationName OpName =
-    S.Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
+      S.Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
   DeclarationNameInfo OpNameInfo(OpName, UDSuffixLoc);
   OpNameInfo.setCXXLiteralOperatorNameLoc(UDSuffixLoc);
 
@@ -2047,8 +2035,8 @@ Sema::ExpandFunctionLocalPredefinedMacros(ArrayRef<Token> Toks) {
 /// multiple tokens.  However, the common case is that StringToks points to one
 /// string.
 ///
-ExprResult
-Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
+ExprResult Sema::ActOnStringLiteral(ArrayRef<Token> StringToks,
+                                    Scope *UDLScope) {
   assert(!StringToks.empty() && "Must have at least one string!");
 
   // StringToks needs backing storage as it doesn't hold array elements itself
@@ -2112,18 +2100,17 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
       Context.getStringLiteralArrayType(CharTy, Literal.GetNumStringChars());
 
   // Pass &StringTokLocs[0], StringTokLocs.size() to factory!
-  StringLiteral *Lit = StringLiteral::Create(Context, Literal.GetString(),
-                                             Kind, Literal.Pascal, StrTy,
-                                             &StringTokLocs[0],
-                                             StringTokLocs.size());
+  StringLiteral *Lit =
+      StringLiteral::Create(Context, Literal.GetString(), Kind, Literal.Pascal,
+                            StrTy, &StringTokLocs[0], StringTokLocs.size());
   if (Literal.getUDSuffix().empty())
     return Lit;
 
   // We're building a user-defined literal.
   IdentifierInfo *UDSuffix = &Context.Idents.get(Literal.getUDSuffix());
   SourceLocation UDSuffixLoc =
-    getUDSuffixLoc(*this, StringTokLocs[Literal.getUDSuffixToken()],
-                   Literal.getUDSuffixOffset());
+      getUDSuffixLoc(*this, StringTokLocs[Literal.getUDSuffixToken()],
+                     Literal.getUDSuffixOffset());
 
   // Make sure we're allowed user-defined literals here.
   if (!UDLScope)
@@ -2134,13 +2121,11 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
   QualType SizeType = Context.getSizeType();
 
   DeclarationName OpName =
-    Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
+      Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
   DeclarationNameInfo OpNameInfo(OpName, UDSuffixLoc);
   OpNameInfo.setCXXLiteralOperatorNameLoc(UDSuffixLoc);
 
-  QualType ArgTy[] = {
-    Context.getArrayDecayedType(StrTy), SizeType
-  };
+  QualType ArgTy[] = {Context.getArrayDecayedType(StrTy), SizeType};
 
   LookupResult R(*this, OpName, UDSuffixLoc, LookupOrdinaryName);
   switch (LookupLiteralOperator(UDLScope, R, ArgTy,
@@ -2150,9 +2135,9 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
 
   case LOLR_Cooked: {
     llvm::APInt Len(Context.getIntWidth(SizeType), Literal.GetNumStringChars());
-    IntegerLiteral *LenArg = IntegerLiteral::Create(Context, Len, SizeType,
-                                                    StringTokLocs[0]);
-    Expr *Args[] = { Lit, LenArg };
+    IntegerLiteral *LenArg =
+        IntegerLiteral::Create(Context, Len, SizeType, StringTokLocs[0]);
+    Expr *Args[] = {Lit, LenArg};
 
     return BuildLiteralOperatorCall(R, OpNameInfo, Args, StringTokLocs.back());
   }
@@ -2174,7 +2159,8 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
     llvm::APSInt Value(CharBits, CharIsUnsigned);
 
     TemplateArgument TypeArg(CharTy);
-    TemplateArgumentLocInfo TypeArgInfo(Context.getTrivialTypeSourceInfo(CharTy));
+    TemplateArgumentLocInfo TypeArgInfo(
+        Context.getTrivialTypeSourceInfo(CharTy));
     ExplicitArgs.addArgument(TemplateArgumentLoc(TypeArg, TypeArgInfo));
 
     for (unsigned I = 0, N = Lit->getLength(); I != N; ++I) {
@@ -2195,10 +2181,9 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
   llvm_unreachable("unexpected literal operator lookup result");
 }
 
-DeclRefExpr *
-Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
-                       SourceLocation Loc,
-                       const CXXScopeSpec *SS) {
+DeclRefExpr *Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
+                                    SourceLocation Loc,
+                                    const CXXScopeSpec *SS) {
   DeclarationNameInfo NameInfo(D->getDeclName(), Loc);
   return BuildDeclRefExpr(D, Ty, VK, NameInfo, SS);
 }
@@ -2340,11 +2325,10 @@ Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
 /// This actually loses a lot of source location information for
 /// non-standard name kinds; we should consider preserving that in
 /// some way.
-void
-Sema::DecomposeUnqualifiedId(const UnqualifiedId &Id,
-                             TemplateArgumentListInfo &Buffer,
-                             DeclarationNameInfo &NameInfo,
-                             const TemplateArgumentListInfo *&TemplateArgs) {
+void Sema::DecomposeUnqualifiedId(
+    const UnqualifiedId &Id, TemplateArgumentListInfo &Buffer,
+    DeclarationNameInfo &NameInfo,
+    const TemplateArgumentListInfo *&TemplateArgs) {
   if (Id.getKind() == UnqualifiedIdKind::IK_TemplateId) {
     Buffer.setLAngleLoc(Id.TemplateId->LAngleLoc);
     Buffer.setRAngleLoc(Id.TemplateId->RAngleLoc);
@@ -2373,8 +2357,8 @@ static void emitEmptyLookupTypoDiagnostic(
     // Emit a special diagnostic for failed member lookups.
     // FIXME: computing the declaration context might fail here (?)
     if (Ctx)
-      SemaRef.Diag(TypoLoc, diag::err_no_member) << Typo << Ctx
-                                                 << SS.getRange();
+      SemaRef.Diag(TypoLoc, diag::err_no_member)
+          << Typo << Ctx << SS.getRange();
     else
       SemaRef.Diag(TypoLoc, DiagnosticID) << Typo;
     return;
@@ -2390,9 +2374,10 @@ static void emitEmptyLookupTypoDiagnostic(
     SemaRef.diagnoseTypo(TC, SemaRef.PDiag(DiagnosticSuggestID) << Typo,
                          SemaRef.PDiag(NoteID));
   else
-    SemaRef.diagnoseTypo(TC, SemaRef.PDiag(diag::err_no_member_suggest)
-                                 << Typo << Ctx << DroppedSpecifier
-                                 << SS.getRange(),
+    SemaRef.diagnoseTypo(TC,
+                         SemaRef.PDiag(diag::err_no_member_suggest)
+                             << Typo << Ctx << DroppedSpecifier
+                             << SS.getRange(),
                          SemaRef.PDiag(NoteID));
 }
 
@@ -2550,15 +2535,14 @@ bool Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
                                  OverloadCandidateSet::CSK_Normal);
         OverloadCandidateSet::iterator Best;
         for (NamedDecl *CD : Corrected) {
-          if (FunctionTemplateDecl *FTD =
-                   dyn_cast<FunctionTemplateDecl>(CD))
-            AddTemplateOverloadCandidate(
-                FTD, DeclAccessPair::make(FTD, AS_none), ExplicitTemplateArgs,
-                Args, OCS);
+          if (FunctionTemplateDecl *FTD = dyn_cast<FunctionTemplateDecl>(CD))
+            AddTemplateOverloadCandidate(FTD,
+                                         DeclAccessPair::make(FTD, AS_none),
+                                         ExplicitTemplateArgs, Args, OCS);
           else if (FunctionDecl *FD = dyn_cast<FunctionDecl>(CD))
             if (!ExplicitTemplateArgs || ExplicitTemplateArgs->size() == 0)
-              AddOverloadCandidate(FD, DeclAccessPair::make(FD, AS_none),
-                                   Args, OCS);
+              AddOverloadCandidate(FD, DeclAccessPair::make(FD, AS_none), Args,
+                                   OCS);
         }
         switch (OCS.BestViableFunction(*this, R.getNameLoc(), Best)) {
         case OR_Success:
@@ -2579,8 +2563,8 @@ bool Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
           Record = Ty->getAsCXXRecordDecl();
         }
         if (!Record)
-          Record = cast<CXXRecordDecl>(
-              ND->getDeclContext()->getRedeclContext());
+          Record =
+              cast<CXXRecordDecl>(ND->getDeclContext()->getRedeclContext());
         R.setNamingClass(Record);
       }
 
@@ -2609,9 +2593,10 @@ bool Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
         diagnoseTypo(Corrected, PDiag(diagnostic_suggest) << Name,
                      PDiag(NoteID), AcceptableWithRecovery);
       else
-        diagnoseTypo(Corrected, PDiag(diag::err_no_member_suggest)
-                                  << Name << computeDeclContext(SS, false)
-                                  << DroppedSpecifier << SS.getRange(),
+        diagnoseTypo(Corrected,
+                     PDiag(diag::err_no_member_suggest)
+                         << Name << computeDeclContext(SS, false)
+                         << DroppedSpecifier << SS.getRange(),
                      PDiag(NoteID), AcceptableWithRecovery);
 
       // Tell the callee whether to try to recover.
@@ -2624,8 +2609,7 @@ bool Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
   // FIXME: computing the declaration context might fail here (?)
   if (!SS.isEmpty()) {
     Diag(R.getNameLoc(), diag::err_no_member)
-      << Name << computeDeclContext(SS, false)
-      << SS.getRange();
+        << Name << computeDeclContext(SS, false) << SS.getRange();
     return true;
   }
 
@@ -2681,12 +2665,13 @@ recoverFromMSUnqualifiedLookup(Sema &S, ASTContext &Context,
       TemplateArgs);
 }
 
-ExprResult
-Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
-                        SourceLocation TemplateKWLoc, UnqualifiedId &Id,
-                        bool HasTrailingLParen, bool IsAddressOfOperand,
-                        CorrectionCandidateCallback *CCC,
-                        bool IsInlineAsmIdentifier, Token *KeywordReplacement) {
+ExprResult Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
+                                   SourceLocation TemplateKWLoc,
+                                   UnqualifiedId &Id, bool HasTrailingLParen,
+                                   bool IsAddressOfOperand,
+                                   CorrectionCandidateCallback *CCC,
+                                   bool IsInlineAsmIdentifier,
+                                   Token *KeywordReplacement) {
   assert(!(IsAddressOfOperand && HasTrailingLParen) &&
          "cannot be direct & operand and have a trailing lparen");
   if (SS.isInvalid())
@@ -2789,7 +2774,8 @@ Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
   if (R.empty() && HasTrailingLParen && II &&
       getLangOpts().implicitFunctionsAllowed()) {
     NamedDecl *D = ImplicitlyDefineFunction(NameLoc, *II, S);
-    if (D) R.addDecl(D);
+    if (D)
+      R.addDecl(D);
   }
 
   // Determine whether this name might be a candidate for
@@ -2836,13 +2822,14 @@ Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
           KeywordReplacement->startToken();
           KeywordReplacement->setKind(II->getTokenID());
           KeywordReplacement->setIdentifierInfo(II);
-          KeywordReplacement->setLocation(BestTC.getCorrectionRange().getBegin());
+          KeywordReplacement->setLocation(
+              BestTC.getCorrectionRange().getBegin());
           // Clean up the state associated with the TypoExpr, since it has
           // now been diagnosed (without a call to CorrectDelayedTyposInExpr).
           clearDelayedTypo(TE);
           // Signal that a correction to a keyword was performed by returning a
           // valid-but-null ExprResult.
-          return (Expr*)nullptr;
+          return (Expr *)nullptr;
         }
         State.Consumer->resetCorrectionStream();
       }
@@ -2909,8 +2896,8 @@ Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
                               isa<MSPropertyDecl>(R.getFoundDecl());
 
     if (MightBeImplicitMember)
-      return BuildPossibleImplicitMemberExpr(SS, TemplateKWLoc,
-                                             R, TemplateArgs, S);
+      return BuildPossibleImplicitMemberExpr(SS, TemplateKWLoc, R, TemplateArgs,
+                                             S);
   }
 
   if (TemplateArgs || TemplateKWLoc.isValid()) {
@@ -2968,7 +2955,7 @@ ExprResult Sema::BuildQualifiedDeclarationNameExpr(
       if (CD->isInvalidDecl())
         return ExprError();
     Diag(NameInfo.getLoc(), diag::err_no_member)
-      << NameInfo.getName() << DC << SS.getRange();
+        << NameInfo.getName() << DC << SS.getRange();
     return ExprError();
   }
 
@@ -3161,9 +3148,9 @@ ExprResult Sema::BuildIvarRefExpr(Scope *S, SourceLocation Loc,
 /// inside an ObjC method. Perform some additional checks and determine if we
 /// should form a reference to an ivar. If so, build an expression referencing
 /// that ivar.
-ExprResult
-Sema::LookupInObjCMethod(LookupResult &Lookup, Scope *S,
-                         IdentifierInfo *II, bool AllowBuiltinCreation) {
+ExprResult Sema::LookupInObjCMethod(LookupResult &Lookup, Scope *S,
+                                    IdentifierInfo *II,
+                                    bool AllowBuiltinCreation) {
   // FIXME: Integrate this lookup step into LookupParsedName.
   DeclResult Ivar = LookupIvarInObjCMethod(Lookup, S, II);
   if (Ivar.isInvalid())
@@ -3199,11 +3186,10 @@ Sema::LookupInObjCMethod(LookupResult &Lookup, Scope *S,
 /// Note that the latter check does not consider access; the access of the
 /// "real" base class is checked as appropriate when checking the access of the
 /// member name.
-ExprResult
-Sema::PerformObjectMemberConversion(Expr *From,
-                                    NestedNameSpecifier *Qualifier,
-                                    NamedDecl *FoundDecl,
-                                    NamedDecl *Member) {
+ExprResult Sema::PerformObjectMemberConversion(Expr *From,
+                                               NestedNameSpecifier *Qualifier,
+                                               NamedDecl *FoundDecl,
+                                               NamedDecl *Member) {
   const auto *RD = dyn_cast<CXXRecordDecl>(Member->getDeclContext());
   if (!RD)
     return From;
@@ -3303,14 +3289,15 @@ Sema::PerformObjectMemberConversion(Expr *From,
     // Otherwise build the appropriate casts.
     if (IsDerivedFrom(FromLoc, FromRecordType, QRecordType)) {
       CXXCastPath BasePath;
-      if (CheckDerivedToBaseConversion(FromRecordType, QRecordType,
-                                       FromLoc, FromRange, &BasePath))
+      if (CheckDerivedToBaseConversion(FromRecordType, QRecordType, FromLoc,
+                                       FromRange, &BasePath))
         return ExprError();
 
       if (PointerConversions)
         QType = Context.getPointerType(QType);
-      From = ImpCastExprToType(From, QType, CK_UncheckedDerivedToBase,
-                               VK, &BasePath).get();
+      From = ImpCastExprToType(From, QType, CK_UncheckedDerivedToBase, VK,
+                               &BasePath)
+                 .get();
 
       FromType = QType;
       FromRecordType = QRecordType;
@@ -3323,13 +3310,13 @@ Sema::PerformObjectMemberConversion(Expr *From,
   }
 
   CXXCastPath BasePath;
-  if (CheckDerivedToBaseConversion(FromRecordType, DestRecordType,
-                                   FromLoc, FromRange, &BasePath,
+  if (CheckDerivedToBaseConversion(FromRecordType, DestRecordType, FromLoc,
+                                   FromRange, &BasePath,
                                    /*IgnoreAccess=*/true))
     return ExprError();
 
-  return ImpCastExprToType(From, DestType, CK_UncheckedDerivedToBase,
-                           VK, &BasePath);
+  return ImpCastExprToType(From, DestType, CK_UncheckedDerivedToBase, VK,
+                           &BasePath);
 }
 
 bool Sema::UseArgumentDependentLookup(const CXXScopeSpec &SS,
@@ -3382,7 +3369,6 @@ bool Sema::UseArgumentDependentLookup(const CXXScopeSpec &SS,
 
   return true;
 }
-
 
 /// Diagnoses obvious problems with the use of the given declaration
 /// as an expression.  This is only actually called for lookups that
@@ -3445,12 +3431,10 @@ ExprResult Sema::BuildDeclarationNameExpr(const CXXScopeSpec &SS,
   // we've picked a target.
   R.suppressDiagnostics();
 
-  UnresolvedLookupExpr *ULE
-    = UnresolvedLookupExpr::Create(Context, R.getNamingClass(),
-                                   SS.getWithLocInContext(Context),
-                                   R.getLookupNameInfo(),
-                                   NeedsADL, R.isOverloadedResult(),
-                                   R.begin(), R.end());
+  UnresolvedLookupExpr *ULE = UnresolvedLookupExpr::Create(
+      Context, R.getNamingClass(), SS.getWithLocInContext(Context),
+      R.getLookupNameInfo(), NeedsADL, R.isOverloadedResult(), R.begin(),
+      R.end());
 
   return ULE;
 }
@@ -3820,7 +3804,7 @@ ExprResult Sema::ActOnCharacterConstant(const Token &Tok, Scope *UDLScope) {
   else if (Literal.isUTF32())
     Ty = Context.Char32Ty; // U'x' -> char32_t in C11 and C++11.
   else if (!getLangOpts().CPlusPlus || Literal.isMultiChar())
-    Ty = Context.IntTy;   // 'x' -> int in C, 'wxyz' -> int in C++.
+    Ty = Context.IntTy; // 'x' -> int in C, 'wxyz' -> int in C++.
   else
     Ty = Context.CharTy; // 'x' -> char in C++;
                          // u8'x' -> char in C11-C17 and in C++ without char8_t.
@@ -3835,8 +3819,8 @@ ExprResult Sema::ActOnCharacterConstant(const Token &Tok, Scope *UDLScope) {
   else if (Literal.isUTF8())
     Kind = CharacterLiteralKind::UTF8;
 
-  Expr *Lit = new (Context) CharacterLiteral(Literal.getValue(), Kind, Ty,
-                                             Tok.getLocation());
+  Expr *Lit = new (Context)
+      CharacterLiteral(Literal.getValue(), Kind, Ty, Tok.getLocation());
 
   if (Literal.getUDSuffix().empty())
     return Lit;
@@ -3844,7 +3828,7 @@ ExprResult Sema::ActOnCharacterConstant(const Token &Tok, Scope *UDLScope) {
   // We're building a user-defined literal.
   IdentifierInfo *UDSuffix = &Context.Idents.get(Literal.getUDSuffix());
   SourceLocation UDSuffixLoc =
-    getUDSuffixLoc(*this, Tok.getLocation(), Literal.getUDSuffixOffset());
+      getUDSuffixLoc(*this, Tok.getLocation(), Literal.getUDSuffixOffset());
 
   // Make sure we're allowed user-defined literals here.
   if (!UDLScope)
@@ -3885,9 +3869,7 @@ static Expr *BuildFloatingLiteral(Sema &S, NumericLiteralParser &Literal,
       APFloat::getSmallest(Format).toString(buffer);
     }
 
-    S.Diag(Loc, diagnostic)
-      << Ty
-      << StringRef(buffer.data(), buffer.size());
+    S.Diag(Loc, diagnostic) << Ty << StringRef(buffer.data(), buffer.size());
   }
 
   bool isExact = (result == APFloat::opOK);
@@ -3927,7 +3909,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
   // cannot have a trigraph, escaped newline, radix prefix, or suffix.
   if (Tok.getLength() == 1) {
     const char Val = PP.getSpellingOfSingleCharacterNumericConstant(Tok);
-    return ActOnIntegerConstant(Tok.getLocation(), Val-'0');
+    return ActOnIntegerConstant(Tok.getLocation(), Val - '0');
   }
 
   SmallString<128> SpellingBuffer;
@@ -3953,7 +3935,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
     // We're building a user-defined literal.
     const IdentifierInfo *UDSuffix = &Context.Idents.get(Literal.getUDSuffix());
     SourceLocation UDSuffixLoc =
-      getUDSuffixLoc(*this, Tok.getLocation(), Literal.getUDSuffixOffset());
+        getUDSuffixLoc(*this, Tok.getLocation(), Literal.getUDSuffixOffset());
 
     // Make sure we're allowed user-defined literals here.
     if (!UDLScope)
@@ -3973,7 +3955,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
     }
 
     DeclarationName OpName =
-      Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
+        Context.DeclarationNames.getCXXLiteralOperatorName(UDSuffix);
     DeclarationNameInfo OpNameInfo(OpName, UDSuffixLoc);
     OpNameInfo.setCXXLiteralOperatorNameLoc(UDSuffixLoc);
 
@@ -4068,7 +4050,8 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
       }
     }
 
-    if (Literal.isUnsigned) Ty = Context.getCorrespondingUnsignedType(Ty);
+    if (Literal.isUnsigned)
+      Ty = Context.getCorrespondingUnsignedType(Ty);
 
     bool isSigned = !Literal.isUnsigned;
     unsigned scale = Context.getFixedPointScale(Ty);
@@ -4092,7 +4075,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
                                               Tok.getLocation(), scale);
   } else if (Literal.isFloatingLiteral()) {
     QualType Ty;
-    if (Literal.isHalf){
+    if (Literal.isHalf) {
       if (getOpenCLOptions().isAvailableOption("cl_khr_fp16", getLangOpts()))
         Ty = Context.HalfTy;
       else {
@@ -4242,7 +4225,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
         // Does it fit in a unsigned int?
         if (ResultVal.isIntN(IntSize)) {
           // Does it fit in a signed int?
-          if (!Literal.isUnsigned && ResultVal[IntSize-1] == 0)
+          if (!Literal.isUnsigned && ResultVal[IntSize - 1] == 0)
             Ty = Context.IntTy;
           else if (AllowUnsigned)
             Ty = Context.UnsignedIntTy;
@@ -4257,7 +4240,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
         // Does it fit in a unsigned long?
         if (ResultVal.isIntN(LongSize)) {
           // Does it fit in a signed long?
-          if (!Literal.isUnsigned && ResultVal[LongSize-1] == 0)
+          if (!Literal.isUnsigned && ResultVal[LongSize - 1] == 0)
             Ty = Context.LongTy;
           else if (AllowUnsigned)
             Ty = Context.UnsignedLongTy;
@@ -4290,8 +4273,9 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
           // Does it fit in a signed long long?
           // To be compatible with MSVC, hex integer literals ending with the
           // LL or i64 suffix are always signed in Microsoft mode.
-          if (!Literal.isUnsigned && (ResultVal[LongLongSize-1] == 0 ||
-              (getLangOpts().MSVCCompat && Literal.isLongLong)))
+          if (!Literal.isUnsigned &&
+              (ResultVal[LongLongSize - 1] == 0 ||
+               (getLangOpts().MSVCCompat && Literal.isLongLong)))
             Ty = Context.LongLongTy;
           else if (AllowUnsigned)
             Ty = Context.UnsignedLongLongTy;
@@ -4330,8 +4314,8 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
 
   // If this is an imaginary literal, create the ImaginaryLiteral wrapper.
   if (Literal.isImaginary) {
-    Res = new (Context) ImaginaryLiteral(Res,
-                                        Context.getComplexType(Res->getType()));
+    Res = new (Context)
+        ImaginaryLiteral(Res, Context.getComplexType(Res->getType()));
 
     Diag(Tok.getLocation(), diag::ext_imaginary_constant);
   }
@@ -4355,8 +4339,7 @@ static bool CheckVecStepTraitOperandType(Sema &S, QualType T,
   // Every built-in scalar type (OpenCL 1.1 6.1.1) is either an arithmetic
   // type (C99 6.2.5p18) or void.
   if (!(T->isArithmeticType() || T->isVoidType() || T->isVectorType())) {
-    S.Diag(Loc, diag::err_vecstep_non_scalar_vector_type)
-      << T << ArgRange;
+    S.Diag(Loc, diag::err_vecstep_non_scalar_vector_type) << T << ArgRange;
     return true;
   }
 
@@ -4371,8 +4354,7 @@ static bool CheckVectorElementsTraitOperandType(Sema &S, QualType T,
   // builtin_vectorelements supports both fixed-sized and scalable vectors.
   if (!T->isVectorType() && !T->isSizelessVectorType())
     return S.Diag(Loc, diag::err_builtin_non_vector_type)
-           << ""
-           << "__builtin_vectorelements" << T << ArgRange;
+           << "" << "__builtin_vectorelements" << T << ArgRange;
 
   return false;
 }
@@ -4415,8 +4397,7 @@ static bool CheckObjCTraitOperandConstraints(Sema &S, QualType T,
   // runtime doesn't allow it.
   if (!S.LangOpts.ObjCRuntime.allowsSizeofAlignof() && T->isObjCObjectType()) {
     S.Diag(Loc, diag::err_sizeof_nonfragile_interface)
-      << T << (TraitKind == UETT_SizeOf)
-      << ArgRange;
+        << T << (TraitKind == UETT_SizeOf) << ArgRange;
     return true;
   }
 
@@ -4436,9 +4417,9 @@ static void warnOnSizeofOnArrayDecay(Sema &S, SourceLocation Loc, QualType T,
   if (!ICE || ICE->getCastKind() != CK_ArrayToPointerDecay)
     return;
 
-  S.Diag(Loc, diag::warn_sizeof_array_decay) << ICE->getSourceRange()
-                                             << ICE->getType()
-                                             << ICE->getSubExpr()->getType();
+  S.Diag(Loc, diag::warn_sizeof_array_decay)
+      << ICE->getSourceRange() << ICE->getType()
+      << ICE->getSubExpr()->getType();
 }
 
 /// Check the constraints on expression operands to unary type expression
@@ -4470,8 +4451,7 @@ bool Sema::CheckUnaryExprOrTypeTraitOperand(Expr *E,
   // used to build SFINAE gadgets.
   // FIXME: Should we consider instantiation-dependent operands to 'alignof'?
   if (IsUnevaluatedOperand && !inTemplateInstantiation() &&
-      !E->isInstantiationDependent() &&
-      !E->getType()->isVariableArrayType() &&
+      !E->isInstantiationDependent() && !E->getType()->isVariableArrayType() &&
       E->HasSideEffects(Context, false))
     Diag(E->getExprLoc(), diag::warn_side_effects_unevaluated_context);
 
@@ -4534,8 +4514,7 @@ bool Sema::CheckUnaryExprOrTypeTraitOperand(Expr *E,
         QualType OType = PVD->getOriginalType();
         QualType Type = PVD->getType();
         if (Type->isPointerType() && OType->isArrayType()) {
-          Diag(E->getExprLoc(), diag::warn_sizeof_array_param)
-            << Type << OType;
+          Diag(E->getExprLoc(), diag::warn_sizeof_array_param) << Type << OType;
           Diag(PVD->getLocation(), diag::note_declared_at);
         }
       }
@@ -4562,7 +4541,7 @@ static bool CheckAlignOfExpr(Sema &S, Expr *E, UnaryExprOrTypeTrait ExprKind) {
 
   if (E->getObjectKind() == OK_BitField) {
     S.Diag(E->getExprLoc(), diag::err_sizeof_alignof_typeof_bitfield)
-       << 1 << E->getSourceRange();
+        << 1 << E->getSourceRange();
     return true;
   }
 
@@ -4596,7 +4575,7 @@ static bool CheckAlignOfExpr(Sema &S, Expr *E, UnaryExprOrTypeTrait ExprKind) {
     // definition if we can find a member of it.
     if (!FD->getParent()->isCompleteDefinition()) {
       S.Diag(E->getExprLoc(), diag::err_alignof_member_of_incomplete_type)
-        << E->getSourceRange();
+          << E->getSourceRange();
       return true;
     }
 
@@ -4864,9 +4843,8 @@ ExprResult Sema::CreateUnaryExprOrTypeTraitExpr(TypeSourceInfo *TInfo,
 
 /// Build a sizeof or alignof expression given an expression
 /// operand.
-ExprResult
-Sema::CreateUnaryExprOrTypeTraitExpr(Expr *E, SourceLocation OpLoc,
-                                     UnaryExprOrTypeTrait ExprKind) {
+ExprResult Sema::CreateUnaryExprOrTypeTraitExpr(Expr *E, SourceLocation OpLoc,
+                                                UnaryExprOrTypeTrait ExprKind) {
   ExprResult PE = CheckPlaceholderExpr(E);
   if (PE.isInvalid())
     return ExprError();
@@ -4882,9 +4860,9 @@ Sema::CreateUnaryExprOrTypeTraitExpr(Expr *E, SourceLocation OpLoc,
   } else if (ExprKind == UETT_VecStep) {
     isInvalid = CheckVecStepExpr(E);
   } else if (ExprKind == UETT_OpenMPRequiredSimdAlign) {
-      Diag(E->getExprLoc(), diag::err_openmp_default_simd_align_expr);
-      isInvalid = true;
-  } else if (E->refersToBitField()) {  // C99 6.5.3.4p1.
+    Diag(E->getExprLoc(), diag::err_openmp_default_simd_align_expr);
+    isInvalid = true;
+  } else if (E->refersToBitField()) { // C99 6.5.3.4p1.
     Diag(E->getExprLoc(), diag::err_sizeof_alignof_typeof_bitfield) << 0;
     isInvalid = true;
   } else if (ExprKind == UETT_VectorElements) {
@@ -4898,7 +4876,8 @@ Sema::CreateUnaryExprOrTypeTraitExpr(Expr *E, SourceLocation OpLoc,
 
   if (ExprKind == UETT_SizeOf && E->getType()->isVariableArrayType()) {
     PE = TransformToPotentiallyEvaluated(E);
-    if (PE.isInvalid()) return ExprError();
+    if (PE.isInvalid())
+      return ExprError();
     E = PE.get();
   }
 
@@ -4910,16 +4889,17 @@ Sema::CreateUnaryExprOrTypeTraitExpr(Expr *E, SourceLocation OpLoc,
 /// ActOnUnaryExprOrTypeTraitExpr - Handle @c sizeof(type) and @c sizeof @c
 /// expr and the same for @c alignof and @c __alignof
 /// Note that the ArgRange is invalid if isType is false.
-ExprResult
-Sema::ActOnUnaryExprOrTypeTraitExpr(SourceLocation OpLoc,
-                                    UnaryExprOrTypeTrait ExprKind, bool IsType,
-                                    void *TyOrEx, SourceRange ArgRange) {
+ExprResult Sema::ActOnUnaryExprOrTypeTraitExpr(SourceLocation OpLoc,
+                                               UnaryExprOrTypeTrait ExprKind,
+                                               bool IsType, void *TyOrEx,
+                                               SourceRange ArgRange) {
   // If error parsing type, ignore.
-  if (!TyOrEx) return ExprError();
+  if (!TyOrEx)
+    return ExprError();
 
   if (IsType) {
     TypeSourceInfo *TInfo;
-    (void) GetTypeFromParser(ParsedType::getFromOpaquePtr(TyOrEx), &TInfo);
+    (void)GetTypeFromParser(ParsedType::getFromOpaquePtr(TyOrEx), &TInfo);
     return CreateUnaryExprOrTypeTraitExpr(TInfo, OpLoc, ExprKind, ArgRange);
   }
 
@@ -4973,33 +4953,37 @@ static QualType CheckRealImagOperand(Sema &S, ExprResult &V, SourceLocation Loc,
 
   // Test for placeholders.
   ExprResult PR = S.CheckPlaceholderExpr(V.get());
-  if (PR.isInvalid()) return QualType();
+  if (PR.isInvalid())
+    return QualType();
   if (PR.get() != V.get()) {
     V = PR;
     return CheckRealImagOperand(S, V, Loc, IsReal);
   }
 
   // Reject anything else.
-  S.Diag(Loc, diag::err_realimag_invalid_type) << V.get()->getType()
-    << (IsReal ? "__real" : "__imag");
+  S.Diag(Loc, diag::err_realimag_invalid_type)
+      << V.get()->getType() << (IsReal ? "__real" : "__imag");
   return QualType();
 }
 
-
-
-ExprResult
-Sema::ActOnPostfixUnaryOp(Scope *S, SourceLocation OpLoc,
-                          tok::TokenKind Kind, Expr *Input) {
+ExprResult Sema::ActOnPostfixUnaryOp(Scope *S, SourceLocation OpLoc,
+                                     tok::TokenKind Kind, Expr *Input) {
   UnaryOperatorKind Opc;
   switch (Kind) {
-  default: llvm_unreachable("Unknown unary op!");
-  case tok::plusplus:   Opc = UO_PostInc; break;
-  case tok::minusminus: Opc = UO_PostDec; break;
+  default:
+    llvm_unreachable("Unknown unary op!");
+  case tok::plusplus:
+    Opc = UO_PostInc;
+    break;
+  case tok::minusminus:
+    Opc = UO_PostDec;
+    break;
   }
 
   // Since this might is a postfix expression, get rid of ParenListExprs.
   ExprResult Result = MaybeConvertParenListExprToParenExpr(S, Input);
-  if (Result.isInvalid()) return ExprError();
+  if (Result.isInvalid())
+    return ExprError();
   Input = Result.get();
 
   return BuildUnaryOp(S, OpLoc, Opc, Input);
@@ -5008,8 +4992,7 @@ Sema::ActOnPostfixUnaryOp(Scope *S, SourceLocation OpLoc,
 /// Diagnose if arithmetic on the given ObjC pointer is illegal.
 ///
 /// \return true on error
-static bool checkArithmeticOnObjCPointer(Sema &S,
-                                         SourceLocation opLoc,
+static bool checkArithmeticOnObjCPointer(Sema &S, SourceLocation opLoc,
                                          Expr *op) {
   assert(op->getType()->isObjCObjectPointerType());
   if (S.LangOpts.ObjCRuntime.allowsPointerArithmetic() &&
@@ -5017,8 +5000,8 @@ static bool checkArithmeticOnObjCPointer(Sema &S,
     return false;
 
   S.Diag(opLoc, diag::err_arithmetic_nonfragile_interface)
-    << op->getType()->castAs<ObjCObjectPointerType>()->getPointeeType()
-    << op->getSourceRange();
+      << op->getType()->castAs<ObjCObjectPointerType>()->getPointeeType()
+      << op->getSourceRange();
   return true;
 }
 
@@ -5068,8 +5051,9 @@ ExprResult Sema::ActOnArraySubscriptExpr(Scope *S, Expr *base,
 
   if (base && !base->getType().isNull() &&
       base->hasPlaceholderType(BuiltinType::OMPArraySection))
-    return ActOnOMPArraySectionExpr(base, lbLoc, ArgExprs.front(), SourceLocation(),
-                                    SourceLocation(), /*Length*/ nullptr,
+    return ActOnOMPArraySectionExpr(base, lbLoc, ArgExprs.front(),
+                                    SourceLocation(), SourceLocation(),
+                                    /*Length*/ nullptr,
                                     /*Stride=*/nullptr, rbLoc);
 
   // Since this might be a postfix expression, get rid of ParenListExprs.
@@ -5471,7 +5455,8 @@ ExprResult Sema::ActOnOMPArraySectionExpr(Expr *Base, SourceLocation LBLoc,
       // The array section must be a subset of the original array.
       llvm::APSInt LowerBoundValue = Result.Val.getInt();
       if (LowerBoundValue.isNegative()) {
-        Diag(LowerBound->getExprLoc(), diag::err_omp_section_not_subset_of_array)
+        Diag(LowerBound->getExprLoc(),
+             diag::err_omp_section_not_subset_of_array)
             << LowerBound->getSourceRange();
         return ExprError();
       }
@@ -5737,7 +5722,7 @@ ExprResult Sema::ActOnOMPIteratorExpr(Scope *S, SourceLocation IteratorKwLoc,
       // (Endi - Begini)
       ExprResult Res = CreateBuiltinBinOp(D.AssignmentLoc, BO_Sub, D.Range.End,
                                           D.Range.Begin);
-      if(!Res.isUsable()) {
+      if (!Res.isUsable()) {
         IsCorrect = false;
         continue;
       }
@@ -5855,8 +5840,7 @@ ExprResult Sema::ActOnOMPIteratorExpr(Scope *S, SourceLocation IteratorKwLoc,
         IsCorrect = false;
         continue;
       }
-      UpdateRes =
-          ActOnFinishFullExpr(UpdateRes.get(), /*DiscardedValue=*/true);
+      UpdateRes = ActOnFinishFullExpr(UpdateRes.get(), /*DiscardedValue=*/true);
       if (!UpdateRes.isUsable()) {
         IsCorrect = false;
         continue;
@@ -5894,9 +5878,9 @@ ExprResult Sema::ActOnOMPIteratorExpr(Scope *S, SourceLocation IteratorKwLoc,
                                  LLoc, RLoc, ID, Helpers);
 }
 
-ExprResult
-Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
-                                      Expr *Idx, SourceLocation RLoc) {
+ExprResult Sema::CreateBuiltinArraySubscriptExpr(Expr *Base,
+                                                 SourceLocation LLoc, Expr *Idx,
+                                                 SourceLocation RLoc) {
   Expr *LHSExp = Base;
   Expr *RHSExp = Idx;
 
@@ -5943,7 +5927,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     IndexExpr = RHSExp;
     ResultType = PTy->getPointeeType();
   } else if (const ObjCObjectPointerType *PTy =
-               LHSTy->getAs<ObjCObjectPointerType>()) {
+                 LHSTy->getAs<ObjCObjectPointerType>()) {
     BaseExpr = LHSExp;
     IndexExpr = RHSExp;
 
@@ -5955,23 +5939,23 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
 
     ResultType = PTy->getPointeeType();
   } else if (const PointerType *PTy = RHSTy->getAs<PointerType>()) {
-     // Handle the uncommon case of "123[Ptr]".
+    // Handle the uncommon case of "123[Ptr]".
     BaseExpr = RHSExp;
     IndexExpr = LHSExp;
     ResultType = PTy->getPointeeType();
   } else if (const ObjCObjectPointerType *PTy =
-               RHSTy->getAs<ObjCObjectPointerType>()) {
-     // Handle the uncommon case of "123[Ptr]".
+                 RHSTy->getAs<ObjCObjectPointerType>()) {
+    // Handle the uncommon case of "123[Ptr]".
     BaseExpr = RHSExp;
     IndexExpr = LHSExp;
     ResultType = PTy->getPointeeType();
     if (!LangOpts.isSubscriptPointerArithmetic()) {
       Diag(LLoc, diag::err_subscript_nonfragile_interface)
-        << ResultType << BaseExpr->getSourceRange();
+          << ResultType << BaseExpr->getSourceRange();
       return ExprError();
     }
   } else if (const VectorType *VTy = LHSTy->getAs<VectorType>()) {
-    BaseExpr = LHSExp;    // vectors: V[123]
+    BaseExpr = LHSExp; // vectors: V[123]
     IndexExpr = RHSExp;
     // We apply C++ DR1213 to vector subscripting too.
     if (getLangOpts().CPlusPlus11 && LHSExp->isPRValue()) {
@@ -6027,7 +6011,8 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     Diag(LHSExp->getBeginLoc(), diag::ext_subscript_non_lvalue)
         << LHSExp->getSourceRange();
     LHSExp = ImpCastExprToType(LHSExp, Context.getArrayDecayedType(LHSTy),
-                               CK_ArrayToPointerDecay).get();
+                               CK_ArrayToPointerDecay)
+                 .get();
     LHSTy = LHSExp->getType();
 
     BaseExpr = LHSExp;
@@ -6038,7 +6023,8 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     Diag(RHSExp->getBeginLoc(), diag::ext_subscript_non_lvalue)
         << RHSExp->getSourceRange();
     RHSExp = ImpCastExprToType(RHSExp, Context.getArrayDecayedType(RHSTy),
-                               CK_ArrayToPointerDecay).get();
+                               CK_ArrayToPointerDecay)
+                 .get();
     RHSTy = RHSExp->getType();
 
     BaseExpr = RHSExp;
@@ -6046,7 +6032,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
     ResultType = RHSTy->castAs<PointerType>()->getPointeeType();
   } else {
     return ExprError(Diag(LLoc, diag::err_typecheck_subscript_value)
-       << LHSExp->getSourceRange() << RHSExp->getSourceRange());
+                     << LHSExp->getSourceRange() << RHSExp->getSourceRange());
   }
   // C99 6.5.2.1p1
   if (!IndexExpr->getType()->isIntegerType() && !IndexExpr->isTypeDependent())
@@ -6075,8 +6061,7 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
 
   if (ResultType->isVoidType() && !getLangOpts().CPlusPlus) {
     // GNU extension: subscripting on pointer to void
-    Diag(LLoc, diag::ext_gnu_subscript_void_type)
-      << BaseExpr->getSourceRange();
+    Diag(LLoc, diag::ext_gnu_subscript_void_type) << BaseExpr->getSourceRange();
 
     // C forbids expressions of unqualified void type from being l-values.
     // See IsCForbiddenLValueType.
@@ -6450,9 +6435,9 @@ ExprResult Sema::BuildCXXDefaultInitExpr(SourceLocation Loc, FieldDecl *Field) {
   return ExprError();
 }
 
-Sema::VariadicCallType
-Sema::getVariadicCallType(FunctionDecl *FDecl, const FunctionProtoType *Proto,
-                          Expr *Fn) {
+Sema::VariadicCallType Sema::getVariadicCallType(FunctionDecl *FDecl,
+                                                 const FunctionProtoType *Proto,
+                                                 Expr *Fn) {
   if (Proto && Proto->isVariadic()) {
     if (isa_and_nonnull<CXXConstructorDecl>(FDecl))
       return VariadicConstructor;
@@ -6493,7 +6478,7 @@ public:
 private:
   const IdentifierInfo *const FunctionName;
 };
-}
+} // namespace
 
 static TypoCorrection TryTypoCorrectionForCall(Sema &S, Expr *Fn,
                                                FunctionDecl *FDecl,
@@ -6539,13 +6524,12 @@ static TypoCorrection TryTypoCorrectionForCall(Sema &S, Expr *Fn,
 /// Fn is the function expression. For a C++ member function, this
 /// routine does not attempt to convert the object argument. Returns
 /// true if the call is ill-formed.
-bool
-Sema::ConvertArgumentsForCall(CallExpr *Call, Expr *Fn,
-                              FunctionDecl *FDecl,
-                              const FunctionProtoType *Proto,
-                              ArrayRef<Expr *> Args,
-                              SourceLocation RParenLoc,
-                              bool IsExecConfig) {
+bool Sema::ConvertArgumentsForCall(CallExpr *Call, Expr *Fn,
+                                   FunctionDecl *FDecl,
+                                   const FunctionProtoType *Proto,
+                                   ArrayRef<Expr *> Args,
+                                   SourceLocation RParenLoc,
+                                   bool IsExecConfig) {
   // Bail out early if calling a builtin with custom typechecking.
   if (FDecl)
     if (unsigned ID = FDecl->getBuiltinID())
@@ -6561,9 +6545,9 @@ Sema::ConvertArgumentsForCall(CallExpr *Call, Expr *Fn,
   bool Invalid = false;
   unsigned MinArgs = FDecl ? FDecl->getMinRequiredArguments() : NumParams;
   unsigned FnKind = Fn->getType()->isBlockPointerType()
-                       ? 1 /* block */
-                       : (IsExecConfig ? 3 /* kernel function (exec config) */
-                                       : 0 /* function */);
+                        ? 1                 /* block */
+                        : (IsExecConfig ? 3 /* kernel function (exec config) */
+                                        : 0 /* function */);
 
   // If too few arguments are available (and we don't have default
   // arguments for the remaining parameters), don't make the call.
@@ -6702,12 +6686,12 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
 
       // Strip the unbridged-cast placeholder expression off, if applicable.
       bool CFAudited = false;
-      if (Arg->getType() == Context.ARCUnbridgedCastTy &&
-          FDecl && FDecl->hasAttr<CFAuditedTransferAttr>() &&
+      if (Arg->getType() == Context.ARCUnbridgedCastTy && FDecl &&
+          FDecl->hasAttr<CFAuditedTransferAttr>() &&
           (!Param || !Param->hasAttr<CFConsumedAttr>()))
         Arg = stripARCUnbridgedCast(Arg);
-      else if (getLangOpts().ObjCAutoRefCount &&
-               FDecl && FDecl->hasAttr<CFAuditedTransferAttr>() &&
+      else if (getLangOpts().ObjCAutoRefCount && FDecl &&
+               FDecl->hasAttr<CFAuditedTransferAttr>() &&
                (!Param || !Param->hasAttr<CFConsumedAttr>()))
         CFAudited = true;
 
@@ -6766,7 +6750,7 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
         AllArgs.push_back(arg.get());
       }
 
-    // Otherwise do argument promotion, (C99 6.5.2.2p7).
+      // Otherwise do argument promotion, (C99 6.5.2.2p7).
     } else {
       for (Expr *A : Args.slice(ArgIx)) {
         ExprResult Arg = DefaultVariadicArgumentPromotion(A, CallType, FDecl);
@@ -6788,7 +6772,7 @@ static void DiagnoseCalleeStaticArrayParam(Sema &S, ParmVarDecl *PVD) {
     TL = DTL.getOriginalLoc();
   if (ArrayTypeLoc ATL = TL.getAs<ArrayTypeLoc>())
     S.Diag(PVD->getLocation(), diag::note_callee_static_array)
-      << ATL.getLocalSourceRange();
+        << ATL.getLocalSourceRange();
 }
 
 /// CheckStaticArrayArgument - If the given argument corresponds to a static
@@ -6799,10 +6783,8 @@ static void DiagnoseCalleeStaticArrayParam(Sema &S, ParmVarDecl *PVD) {
 /// array type derivation, then for each call to the function, the value of the
 /// corresponding actual argument shall provide access to the first element of
 /// an array with at least as many elements as specified by the size expression.
-void
-Sema::CheckStaticArrayArgument(SourceLocation CallLoc,
-                               ParmVarDecl *Param,
-                               const Expr *ArgExpr) {
+void Sema::CheckStaticArrayArgument(SourceLocation CallLoc, ParmVarDecl *Param,
+                                    const Expr *ArgExpr) {
   // Static array parameters are not supported in C++.
   if (!Param || getLangOpts().CPlusPlus)
     return;
@@ -6813,8 +6795,7 @@ Sema::CheckStaticArrayArgument(SourceLocation CallLoc,
   if (!AT || AT->getSizeModifier() != ArraySizeModifier::Static)
     return;
 
-  if (ArgExpr->isNullPointerConstant(Context,
-                                     Expr::NPC_NeverValueDependent)) {
+  if (ArgExpr->isNullPointerConstant(Context, Expr::NPC_NeverValueDependent)) {
     Diag(CallLoc, diag::warn_null_arg) << ArgExpr->getSourceRange();
     DiagnoseCalleeStaticArrayParam(*this, Param);
     return;
@@ -6825,7 +6806,7 @@ Sema::CheckStaticArrayArgument(SourceLocation CallLoc,
     return;
 
   const ConstantArrayType *ArgCAT =
-    Context.getAsConstantArrayType(ArgExpr->IgnoreParenCasts()->getType());
+      Context.getAsConstantArrayType(ArgExpr->IgnoreParenCasts()->getType());
   if (!ArgCAT)
     return;
 
@@ -6862,23 +6843,21 @@ static ExprResult rebuildUnknownAnyFunction(Sema &S, Expr *fn);
 static bool isPlaceholderToRemoveAsArg(QualType type) {
   // Placeholders are never sugared.
   const BuiltinType *placeholder = dyn_cast<BuiltinType>(type);
-  if (!placeholder) return false;
+  if (!placeholder)
+    return false;
 
   switch (placeholder->getKind()) {
-  // Ignore all the non-placeholder types.
-#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    // Ignore all the non-placeholder types.
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix)                   \
   case BuiltinType::Id:
 #include "clang/Basic/OpenCLImageTypes.def"
-#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) \
-  case BuiltinType::Id:
+#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) case BuiltinType::Id:
 #include "clang/Basic/OpenCLExtensionTypes.def"
-  // In practice we'll never use this, since all SVE types are sugared
-  // via TypedefTypes rather than exposed directly as BuiltinTypes.
-#define SVE_TYPE(Name, Id, SingletonId) \
-  case BuiltinType::Id:
+    // In practice we'll never use this, since all SVE types are sugared
+    // via TypedefTypes rather than exposed directly as BuiltinTypes.
+#define SVE_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
 #include "clang/Basic/AArch64SVEACLETypes.def"
-#define PPC_VECTOR_TYPE(Name, Id, Size) \
-  case BuiltinType::Id:
+#define PPC_VECTOR_TYPE(Name, Id, Size) case BuiltinType::Id:
 #include "clang/Basic/PPCTypes.def"
 #define RVV_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
 #include "clang/Basic/RISCVVTypes.def"
@@ -6916,7 +6895,6 @@ static bool isPlaceholderToRemoveAsArg(QualType type) {
   case BuiltinType::OMPArrayShaping:
   case BuiltinType::OMPIterator:
     return true;
-
   }
   llvm_unreachable("bad builtin type kind");
 }
@@ -6928,8 +6906,10 @@ bool Sema::CheckArgsForPlaceholders(MultiExprArg args) {
   for (size_t i = 0, e = args.size(); i != e; i++) {
     if (isPlaceholderToRemoveAsArg(args[i]->getType())) {
       ExprResult result = CheckPlaceholderExpr(args[i]);
-      if (result.isInvalid()) hasInvalid = true;
-      else args[i] = result.get();
+      if (result.isInvalid())
+        hasInvalid = true;
+      else
+        args[i] = result.get();
     }
   }
   return hasInvalid;
@@ -6994,8 +6974,8 @@ static FunctionDecl *rewriteBuiltinFunctionDecl(Sema *Sema, ASTContext &Context,
 
   FunctionProtoType::ExtProtoInfo EPI;
   EPI.Variadic = FT->isVariadic();
-  QualType OverloadTy = Context.getFunctionType(FT->getReturnType(),
-                                                OverloadParams, EPI);
+  QualType OverloadTy =
+      Context.getFunctionType(FT->getReturnType(), OverloadParams, EPI);
   DeclContext *Parent = FDecl->getParent();
   FunctionDecl *OverloadDecl = FunctionDecl::Create(
       Context, Parent, FDecl->getLocation(), FDecl->getLocation(),
@@ -7003,14 +6983,14 @@ static FunctionDecl *rewriteBuiltinFunctionDecl(Sema *Sema, ASTContext &Context,
       /*TInfo=*/nullptr, SC_Extern, Sema->getCurFPFeatures().isFPConstrained(),
       false,
       /*hasPrototype=*/true);
-  SmallVector<ParmVarDecl*, 16> Params;
+  SmallVector<ParmVarDecl *, 16> Params;
   FT = cast<FunctionProtoType>(OverloadTy);
   for (unsigned i = 0, e = FT->getNumParams(); i != e; ++i) {
     QualType ParamType = FT->getParamType(i);
     ParmVarDecl *Parm =
         ParmVarDecl::Create(Context, OverloadDecl, SourceLocation(),
-                                SourceLocation(), nullptr, ParamType,
-                                /*TInfo=*/nullptr, SC_None, nullptr);
+                            SourceLocation(), nullptr, ParamType,
+                            /*TInfo=*/nullptr, SC_None, nullptr);
     Parm->setScopeInfo(0, i);
     Params.push_back(Parm);
   }
@@ -7108,7 +7088,6 @@ tryImplicitlyCaptureThisIfImplicitMemberFunctionAccessWithDependentArgs(
   if (!enclosingClassIsRelatedToClassInWhichMembersWereFound(UME, S))
     return;
 
-
   DeclContext *EnclosingFunctionCtx = S.CurContext->getParent()->getParent();
   // If the enclosing function is not dependent, then this lambda is
   // capture ready, so if we can capture this, do so.
@@ -7198,7 +7177,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
                                bool AllowRecovery) {
   // Since this might be a postfix expression, get rid of ParenListExprs.
   ExprResult Result = MaybeConvertParenListExprToParenExpr(Scope, Fn);
-  if (Result.isInvalid()) return ExprError();
+  if (Result.isInvalid())
+    return ExprError();
   Fn = Result.get();
 
   if (CheckArgsForPlaceholders(ArgExprs))
@@ -7220,7 +7200,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
     }
     if (Fn->getType() == Context.PseudoObjectTy) {
       ExprResult result = CheckPlaceholderExpr(Fn);
-      if (result.isInvalid()) return ExprError();
+      if (result.isInvalid())
+        return ExprError();
       Fn = result.get();
     }
 
@@ -7250,7 +7231,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
 
     if (Fn->getType() == Context.UnknownAnyTy) {
       ExprResult result = rebuildUnknownAnyFunction(*this, Fn);
-      if (result.isInvalid()) return ExprError();
+      if (result.isInvalid())
+        return ExprError();
       Fn = result.get();
     }
 
@@ -7284,7 +7266,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
   // If we're directly calling a function, get the appropriate declaration.
   if (Fn->getType() == Context.UnknownAnyTy) {
     ExprResult result = rebuildUnknownAnyFunction(*this, Fn);
-    if (result.isInvalid()) return ExprError();
+    if (result.isInvalid())
+      return ExprError();
     Fn = result.get();
   }
 
@@ -7347,10 +7330,14 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
 
         // Add address space cast if target address spaces are different
         bool NeedImplicitASC =
-          ParamAS != LangAS::Default &&       // Pointer params in generic AS don't need special handling.
-          ( ArgAS == LangAS::Default  ||      // We do allow implicit conversion from generic AS
-                                              // or from specific AS which has target AS matching that of Param.
-          getASTContext().getTargetAddressSpace(ArgAS) == getASTContext().getTargetAddressSpace(ParamAS));
+            ParamAS != LangAS::Default && // Pointer params in generic AS don't
+                                          // need special handling.
+            (ArgAS ==
+                 LangAS::Default || // We do allow implicit conversion from
+                                    // generic AS or from specific AS which has
+                                    // target AS matching that of Param.
+             getASTContext().getTargetAddressSpace(ArgAS) ==
+                 getASTContext().getTargetAddressSpace(ParamAS));
         if (!NeedImplicitASC)
           continue;
 
@@ -7366,9 +7353,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
         ArgPtQuals.setAddressSpace(ParamAS);
         auto NewArgPtTy =
             Context.getQualifiedType(ArgPtTy.getUnqualifiedType(), ArgPtQuals);
-        auto NewArgTy =
-            Context.getQualifiedType(Context.getPointerType(NewArgPtTy),
-                                     ArgTy.getQualifiers());
+        auto NewArgTy = Context.getQualifiedType(
+            Context.getPointerType(NewArgPtTy), ArgTy.getQualifiers());
 
         // Finally perform an implicit address space cast
         ArgExprs[Idx] = ImpCastExprToType(ArgExprs[Idx], NewArgTy,
@@ -7586,11 +7572,13 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
     // dependent types properly, so make sure any TypoExprs have been
     // dealt with.
     ExprResult Result = CorrectDelayedTyposInExpr(TheCall);
-    if (!Result.isUsable()) return ExprError();
+    if (!Result.isUsable())
+      return ExprError();
     CallExpr *TheOldCall = TheCall;
     TheCall = dyn_cast<CallExpr>(Result.get());
     bool CorrectedTypos = TheCall != TheOldCall;
-    if (!TheCall) return Result;
+    if (!TheCall)
+      return Result;
     Args = llvm::ArrayRef(TheCall->getArgs(), TheCall->getNumArgs());
 
     // A new call expression node was created if some typos were corrected.
@@ -7619,7 +7607,8 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
     if (Config) {
       // CUDA: Kernel calls must be to global functions
       if (FDecl && !FDecl->hasAttr<CUDAGlobalAttr>())
-        return ExprError(Diag(LParenLoc,diag::err_kern_call_not_global_function)
+        return ExprError(
+            Diag(LParenLoc, diag::err_kern_call_not_global_function)
             << FDecl << Fn->getSourceRange());
 
       // CUDA: Kernel function must have 'void' return type
@@ -7627,12 +7616,12 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
           !FuncT->getReturnType()->getAs<AutoType>() &&
           !FuncT->getReturnType()->isInstantiationDependentType())
         return ExprError(Diag(LParenLoc, diag::err_kern_type_not_void_return)
-            << Fn->getType() << Fn->getSourceRange());
+                         << Fn->getType() << Fn->getSourceRange());
     } else {
       // CUDA: Calls to global functions must be configured
       if (FDecl && FDecl->hasAttr<CUDAGlobalAttr>())
         return ExprError(Diag(LParenLoc, diag::err_global_call_not_config)
-            << FDecl << Fn->getSourceRange());
+                         << FDecl << Fn->getSourceRange());
     }
   }
 
@@ -7668,9 +7657,11 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
       const FunctionDecl *Def = nullptr;
       if (FDecl->hasBody(Def) && Args.size() != Def->param_size()) {
         Proto = Def->getType()->getAs<FunctionProtoType>();
-       if (!Proto || !(Proto->isVariadic() && Args.size() >= Def->param_size()))
+        if (!Proto ||
+            !(Proto->isVariadic() && Args.size() >= Def->param_size()))
           Diag(RParenLoc, diag::warn_call_wrong_number_of_arguments)
-          << (Args.size() > Def->param_size()) << FDecl << Fn->getSourceRange();
+              << (Args.size() > Def->param_size()) << FDecl
+              << Fn->getSourceRange();
       }
 
       // If the function we're calling isn't a function prototype, but we have
@@ -7769,9 +7760,9 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
   return CheckForImmediateInvocation(MaybeBindToTemporary(TheCall), FDecl);
 }
 
-ExprResult
-Sema::ActOnCompoundLiteral(SourceLocation LParenLoc, ParsedType Ty,
-                           SourceLocation RParenLoc, Expr *InitExpr) {
+ExprResult Sema::ActOnCompoundLiteral(SourceLocation LParenLoc, ParsedType Ty,
+                                      SourceLocation RParenLoc,
+                                      Expr *InitExpr) {
   assert(Ty && "ActOnCompoundLiteral(): missing type");
   assert(InitExpr && "ActOnCompoundLiteral(): missing expression");
 
@@ -7783,9 +7774,10 @@ Sema::ActOnCompoundLiteral(SourceLocation LParenLoc, ParsedType Ty,
   return BuildCompoundLiteralExpr(LParenLoc, TInfo, RParenLoc, InitExpr);
 }
 
-ExprResult
-Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
-                               SourceLocation RParenLoc, Expr *LiteralExpr) {
+ExprResult Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc,
+                                          TypeSourceInfo *TInfo,
+                                          SourceLocation RParenLoc,
+                                          Expr *LiteralExpr) {
   QualType literalType = TInfo->getType();
 
   if (literalType->isArrayType()) {
@@ -7814,20 +7806,21 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
         return ExprError();
     }
   } else if (!literalType->isDependentType() &&
-             RequireCompleteType(LParenLoc, literalType,
-               diag::err_typecheck_decl_incomplete_type,
-               SourceRange(LParenLoc, LiteralExpr->getSourceRange().getEnd())))
+             RequireCompleteType(
+                 LParenLoc, literalType,
+                 diag::err_typecheck_decl_incomplete_type,
+                 SourceRange(LParenLoc,
+                             LiteralExpr->getSourceRange().getEnd())))
     return ExprError();
 
-  InitializedEntity Entity
-    = InitializedEntity::InitializeCompoundLiteralInit(TInfo);
-  InitializationKind Kind
-    = InitializationKind::CreateCStyleCast(LParenLoc,
-                                           SourceRange(LParenLoc, RParenLoc),
-                                           /*InitList=*/true);
+  InitializedEntity Entity =
+      InitializedEntity::InitializeCompoundLiteralInit(TInfo);
+  InitializationKind Kind = InitializationKind::CreateCStyleCast(
+      LParenLoc, SourceRange(LParenLoc, RParenLoc),
+      /*InitList=*/true);
   InitializationSequence InitSeq(*this, Entity, Kind, LiteralExpr);
-  ExprResult Result = InitSeq.Perform(*this, Entity, Kind, LiteralExpr,
-                                      &literalType);
+  ExprResult Result =
+      InitSeq.Perform(*this, Entity, Kind, LiteralExpr, &literalType);
   if (Result.isInvalid())
     return ExprError();
   LiteralExpr = Result.get();
@@ -7864,11 +7857,10 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
         ILE->setInit(i, ConstantExpr::Create(Context, Init));
       }
 
-  auto *E = new (Context) CompoundLiteralExpr(LParenLoc, TInfo, literalType,
-                                              VK, LiteralExpr, isFileScope);
+  auto *E = new (Context) CompoundLiteralExpr(LParenLoc, TInfo, literalType, VK,
+                                              LiteralExpr, isFileScope);
   if (isFileScope) {
-    if (!LiteralExpr->isTypeDependent() &&
-        !LiteralExpr->isValueDependent() &&
+    if (!LiteralExpr->isTypeDependent() && !LiteralExpr->isValueDependent() &&
         !literalType->isDependentType()) // C99 6.5.2.5p3
       if (CheckForConstantInitializer(LiteralExpr, literalType))
         return ExprError();
@@ -7878,7 +7870,7 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
     //   "If the compound literal occurs inside the body of a function, the
     //   type name shall not be qualified by an address-space qualifier."
     Diag(LParenLoc, diag::err_compound_literal_with_address_space)
-      << SourceRange(LParenLoc, LiteralExpr->getSourceRange().getEnd());
+        << SourceRange(LParenLoc, LiteralExpr->getSourceRange().getEnd());
     return ExprError();
   }
 
@@ -7908,9 +7900,9 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
   return MaybeBindToTemporary(E);
 }
 
-ExprResult
-Sema::ActOnInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
-                    SourceLocation RBraceLoc) {
+ExprResult Sema::ActOnInitList(SourceLocation LBraceLoc,
+                               MultiExprArg InitArgList,
+                               SourceLocation RBraceLoc) {
   // Only produce each kind of designated initialization diagnostic once.
   SourceLocation FirstDesignator;
   bool DiagnosedArrayDesignator = false;
@@ -7930,14 +7922,14 @@ Sema::ActOnInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
       if (!DiagnosedNestedDesignator && DIE->size() > 1) {
         DiagnosedNestedDesignator = true;
         Diag(DIE->getBeginLoc(), diag::ext_designated_init_nested)
-          << DIE->getDesignatorsSourceRange();
+            << DIE->getDesignatorsSourceRange();
       }
 
       for (auto &Desig : DIE->designators()) {
         if (!Desig.isFieldDesignator() && !DiagnosedArrayDesignator) {
           DiagnosedArrayDesignator = true;
           Diag(Desig.getBeginLoc(), diag::ext_designated_init_array)
-            << Desig.getSourceRange();
+              << Desig.getSourceRange();
         }
       }
 
@@ -7945,18 +7937,18 @@ Sema::ActOnInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
           !isa<DesignatedInitExpr>(InitArgList[0])) {
         DiagnosedMixedDesignator = true;
         Diag(DIE->getBeginLoc(), diag::ext_designated_init_mixed)
-          << DIE->getSourceRange();
+            << DIE->getSourceRange();
         Diag(InitArgList[0]->getBeginLoc(), diag::note_designated_init_mixed)
-          << InitArgList[0]->getSourceRange();
+            << InitArgList[0]->getSourceRange();
       }
     } else if (getLangOpts().CPlusPlus && !DiagnosedMixedDesignator &&
                isa<DesignatedInitExpr>(InitArgList[0])) {
       DiagnosedMixedDesignator = true;
       auto *DIE = cast<DesignatedInitExpr>(InitArgList[0]);
       Diag(DIE->getBeginLoc(), diag::ext_designated_init_mixed)
-        << DIE->getSourceRange();
+          << DIE->getSourceRange();
       Diag(InitArgList[I]->getBeginLoc(), diag::note_designated_init_mixed)
-        << InitArgList[I]->getSourceRange();
+          << InitArgList[I]->getSourceRange();
     }
   }
 
@@ -7976,9 +7968,9 @@ Sema::ActOnInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
   return BuildInitList(LBraceLoc, InitArgList, RBraceLoc);
 }
 
-ExprResult
-Sema::BuildInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
-                    SourceLocation RBraceLoc) {
+ExprResult Sema::BuildInitList(SourceLocation LBraceLoc,
+                               MultiExprArg InitArgList,
+                               SourceLocation RBraceLoc) {
   // Semantic analysis for initializers is done by ActOnDeclarator() and
   // CheckInitializer() - it requires knowledge of the object being initialized.
 
@@ -7990,14 +7982,15 @@ Sema::BuildInitList(SourceLocation LBraceLoc, MultiExprArg InitArgList,
 
       // Ignore failures; dropping the entire initializer list because
       // of one failure would be terrible for indexing/etc.
-      if (result.isInvalid()) continue;
+      if (result.isInvalid())
+        continue;
 
       InitArgList[I] = result.get();
     }
   }
 
-  InitListExpr *E = new (Context) InitListExpr(Context, LBraceLoc, InitArgList,
-                                               RBraceLoc);
+  InitListExpr *E =
+      new (Context) InitListExpr(Context, LBraceLoc, InitArgList, RBraceLoc);
   E->setType(Context.VoidTy); // FIXME: just a place holder for now.
   return E;
 }
@@ -8008,7 +8001,8 @@ void Sema::maybeExtendBlockObject(ExprResult &E) {
   assert(E.get()->isPRValue());
 
   // Only do this in an r-value context.
-  if (!getLangOpts().ObjCAutoRefCount) return;
+  if (!getLangOpts().ObjCAutoRefCount)
+    return;
 
   E = ImplicitCastExpr::Create(
       Context, E.get()->getType(), CK_ARCExtendBlockObject, E.get(),
@@ -8061,7 +8055,8 @@ CastKind Sema::PrepareScalarCast(ExprResult &Src, QualType DestTy) {
     }
     case Type::STK_BlockPointer:
       return (SrcKind == Type::STK_BlockPointer
-                ? CK_BitCast : CK_AnyPointerToBlockPointerCast);
+                  ? CK_BitCast
+                  : CK_AnyPointerToBlockPointerCast);
     case Type::STK_ObjCObjectPointer:
       if (SrcKind == Type::STK_ObjCObjectPointer)
         return CK_BitCast;
@@ -8124,13 +8119,13 @@ CastKind Sema::PrepareScalarCast(ExprResult &Src, QualType DestTy) {
       return CK_IntegralToFloating;
     case Type::STK_IntegralComplex:
       Src = ImpCastExprToType(Src.get(),
-                      DestTy->castAs<ComplexType>()->getElementType(),
-                      CK_IntegralCast);
+                              DestTy->castAs<ComplexType>()->getElementType(),
+                              CK_IntegralCast);
       return CK_IntegralRealToComplex;
     case Type::STK_FloatingComplex:
       Src = ImpCastExprToType(Src.get(),
-                      DestTy->castAs<ComplexType>()->getElementType(),
-                      CK_IntegralToFloating);
+                              DestTy->castAs<ComplexType>()->getElementType(),
+                              CK_IntegralToFloating);
       return CK_FloatingRealToComplex;
     case Type::STK_MemberPointer:
       llvm_unreachable("member pointer type in C");
@@ -8252,7 +8247,8 @@ static bool breakDownVectorType(QualType type, uint64_t &len,
 
   // We allow lax conversion to and from non-vector types, but only if
   // they're real types (i.e. non-complex, non-pointer scalar types).
-  if (!type->isRealType()) return false;
+  if (!type->isRealType())
+    return false;
 
   len = 1;
   eltType = type;
@@ -8372,8 +8368,10 @@ bool Sema::areLaxCompatibleVectorTypes(QualType srcTy, QualType destTy) {
   // depend on them).  Most scalar OP ExtVector cases are handled by the
   // splat path anyway, which does what we want (convert, not bitcast).
   // What this rules out for ExtVectors is crazy things like char4*float.
-  if (srcTy->isScalarType() && destTy->isExtVectorType()) return false;
-  if (destTy->isScalarType() && srcTy->isExtVectorType()) return false;
+  if (srcTy->isScalarType() && destTy->isExtVectorType())
+    return false;
+  if (destTy->isScalarType() && srcTy->isExtVectorType())
+    return false;
 
   return areVectorTypesSameSize(srcTy, destTy);
 }
@@ -8401,7 +8399,7 @@ bool Sema::isLaxVectorConversion(QualType srcTy, QualType destTy) {
     // OK, integer (vector) -> integer (vector) bitcast.
     break;
 
-    case LangOptions::LaxVectorConversionKind::All:
+  case LangOptions::LaxVectorConversionKind::All:
     break;
   }
 
@@ -8436,14 +8434,14 @@ bool Sema::CheckVectorCast(SourceRange R, QualType VectorTy, QualType Ty,
   if (Ty->isVectorType() || Ty->isIntegralType(Context)) {
     if (!areLaxCompatibleVectorTypes(Ty, VectorTy))
       return Diag(R.getBegin(),
-                  Ty->isVectorType() ?
-                  diag::err_invalid_conversion_between_vectors :
-                  diag::err_invalid_conversion_between_vector_and_integer)
-        << VectorTy << Ty << R;
+                  Ty->isVectorType()
+                      ? diag::err_invalid_conversion_between_vectors
+                      : diag::err_invalid_conversion_between_vector_and_integer)
+             << VectorTy << Ty << R;
   } else
     return Diag(R.getBegin(),
                 diag::err_invalid_conversion_between_vector_and_scalar)
-      << VectorTy << Ty << R;
+           << VectorTy << Ty << R;
 
   Kind = CK_BitCast;
   return false;
@@ -8496,8 +8494,8 @@ ExprResult Sema::CheckExtVectorCast(SourceRange R, QualType DestTy,
     if (!areLaxCompatibleVectorTypes(SrcTy, DestTy) ||
         (getLangOpts().OpenCL &&
          !Context.hasSameUnqualifiedType(DestTy, SrcTy))) {
-      Diag(R.getBegin(),diag::err_invalid_conversion_between_ext_vectors)
-        << DestTy << SrcTy << R;
+      Diag(R.getBegin(), diag::err_invalid_conversion_between_ext_vectors)
+          << DestTy << SrcTy << R;
       return ExprError();
     }
     Kind = CK_BitCast;
@@ -8510,16 +8508,15 @@ ExprResult Sema::CheckExtVectorCast(SourceRange R, QualType DestTy,
   if (SrcTy->isPointerType())
     return Diag(R.getBegin(),
                 diag::err_invalid_conversion_between_vector_and_scalar)
-      << DestTy << SrcTy << R;
+           << DestTy << SrcTy << R;
 
   Kind = CK_VectorSplat;
   return prepareVectorSplat(DestTy, CastExpr);
 }
 
-ExprResult
-Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
-                    Declarator &D, ParsedType &Ty,
-                    SourceLocation RParenLoc, Expr *CastExpr) {
+ExprResult Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
+                               Declarator &D, ParsedType &Ty,
+                               SourceLocation RParenLoc, Expr *CastExpr) {
   assert(!D.isInvalidType() && (CastExpr != nullptr) &&
          "ActOnCastExpr(): missing type or expr");
 
@@ -8549,8 +8546,9 @@ Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
   // i.e. all the elements are integer constants.
   ParenExpr *PE = dyn_cast<ParenExpr>(CastExpr);
   ParenListExpr *PLE = dyn_cast<ParenListExpr>(CastExpr);
-  if ((getLangOpts().AltiVec || getLangOpts().ZVector || getLangOpts().OpenCL)
-       && castType->isVectorType() && (PE || PLE)) {
+  if ((getLangOpts().AltiVec || getLangOpts().ZVector ||
+       getLangOpts().OpenCL) &&
+      castType->isVectorType() && (PE || PLE)) {
     if (PLE && PLE->getNumExprs() == 0) {
       Diag(PLE->getExprLoc(), diag::err_altivec_empty_initializer);
       return ExprError();
@@ -8559,8 +8557,7 @@ Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
       Expr *E = (PE ? PE->getSubExpr() : PLE->getExpr(0));
       if (!E->isTypeDependent() && !E->getType()->isVectorType())
         isVectorLiteral = true;
-    }
-    else
+    } else
       isVectorLiteral = true;
   }
 
@@ -8574,7 +8571,8 @@ Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
   // sequence of BinOp comma operators.
   if (isa<ParenListExpr>(CastExpr)) {
     ExprResult Result = MaybeConvertParenListExprToParenExpr(S, CastExpr);
-    if (Result.isInvalid()) return ExprError();
+    if (Result.isInvalid())
+      return ExprError();
     CastExpr = Result.get();
   }
 
@@ -8639,16 +8637,12 @@ ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,
       Literal = ImpCastExprToType(Literal.get(), ElemTy,
                                   PrepareScalarCast(Literal, ElemTy));
       return BuildCStyleCastExpr(LParenLoc, TInfo, RParenLoc, Literal.get());
-    }
-    else if (numExprs < numElems) {
-      Diag(E->getExprLoc(),
-           diag::err_incorrect_number_of_vector_initializers);
+    } else if (numExprs < numElems) {
+      Diag(E->getExprLoc(), diag::err_incorrect_number_of_vector_initializers);
       return ExprError();
-    }
-    else
+    } else
       initExprs.append(exprs, exprs + numExprs);
-  }
-  else {
+  } else {
     // For OpenCL, when the number of initializers is a single value,
     // it will be replicated to all components of the vector.
     if (getLangOpts().OpenCL && VTy->getVectorKind() == VectorKind::Generic &&
@@ -8666,16 +8660,16 @@ ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,
   }
   // FIXME: This means that pretty-printing the final AST will produce curly
   // braces instead of the original commas.
-  InitListExpr *initE = new (Context) InitListExpr(Context, LiteralLParenLoc,
-                                                   initExprs, LiteralRParenLoc);
+  InitListExpr *initE = new (Context)
+      InitListExpr(Context, LiteralLParenLoc, initExprs, LiteralRParenLoc);
   initE->setType(Ty);
   return BuildCompoundLiteralExpr(LParenLoc, TInfo, RParenLoc, initE);
 }
 
 /// This is not an AltiVec-style cast or or C++ direct-initialization, so turn
 /// the ParenListExpr into a sequence of comma binary operators.
-ExprResult
-Sema::MaybeConvertParenListExprToParenExpr(Scope *S, Expr *OrigExpr) {
+ExprResult Sema::MaybeConvertParenListExprToParenExpr(Scope *S,
+                                                      Expr *OrigExpr) {
   ParenListExpr *E = dyn_cast<ParenListExpr>(OrigExpr);
   if (!E)
     return OrigExpr;
@@ -8683,16 +8677,16 @@ Sema::MaybeConvertParenListExprToParenExpr(Scope *S, Expr *OrigExpr) {
   ExprResult Result(E->getExpr(0));
 
   for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid(); ++i)
-    Result = ActOnBinOp(S, E->getExprLoc(), tok::comma, Result.get(),
-                        E->getExpr(i));
+    Result =
+        ActOnBinOp(S, E->getExprLoc(), tok::comma, Result.get(), E->getExpr(i));
 
-  if (Result.isInvalid()) return ExprError();
+  if (Result.isInvalid())
+    return ExprError();
 
   return ActOnParenExpr(E->getLParenLoc(), E->getRParenLoc(), Result.get());
 }
 
-ExprResult Sema::ActOnParenListExpr(SourceLocation L,
-                                    SourceLocation R,
+ExprResult Sema::ActOnParenListExpr(SourceLocation L, SourceLocation R,
                                     MultiExprArg Val) {
   return ParenListExpr::Create(Context, L, Val, R);
 }
@@ -8704,16 +8698,14 @@ bool Sema::DiagnoseConditionalForNull(const Expr *LHSExpr, const Expr *RHSExpr,
                                       SourceLocation QuestionLoc) {
   const Expr *NullExpr = LHSExpr;
   const Expr *NonPointerExpr = RHSExpr;
-  Expr::NullPointerConstantKind NullKind =
-      NullExpr->isNullPointerConstant(Context,
-                                      Expr::NPC_ValueDependentIsNotNull);
+  Expr::NullPointerConstantKind NullKind = NullExpr->isNullPointerConstant(
+      Context, Expr::NPC_ValueDependentIsNotNull);
 
   if (NullKind == Expr::NPCK_NotNull) {
     NullExpr = RHSExpr;
     NonPointerExpr = LHSExpr;
-    NullKind =
-        NullExpr->isNullPointerConstant(Context,
-                                        Expr::NPC_ValueDependentIsNotNull);
+    NullKind = NullExpr->isNullPointerConstant(
+        Context, Expr::NPC_ValueDependentIsNotNull);
   }
 
   if (NullKind == Expr::NPCK_NotNull)
@@ -8746,15 +8738,16 @@ static bool checkCondition(Sema &S, const Expr *Cond,
   // OpenCL v1.1 s6.3.i says the condition cannot be a floating point type.
   if (S.getLangOpts().OpenCL && CondTy->isFloatingType()) {
     S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_nonfloat)
-      << CondTy << Cond->getSourceRange();
+        << CondTy << Cond->getSourceRange();
     return true;
   }
 
   // C99 6.5.15p2
-  if (CondTy->isScalarType()) return false;
+  if (CondTy->isScalarType())
+    return false;
 
   S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_scalar)
-    << CondTy << Cond->getSourceRange();
+      << CondTy << Cond->getSourceRange();
   return true;
 }
 
@@ -8764,7 +8757,7 @@ static bool checkConditionalNullPointer(Sema &S, ExprResult &NullExpr,
                                         QualType PointerTy) {
   if ((!PointerTy->isAnyPointerType() && !PointerTy->isBlockPointerType()) ||
       !NullExpr.get()->isNullPointerConstant(S.Context,
-                                            Expr::NPC_ValueDependentIsNull))
+                                             Expr::NPC_ValueDependentIsNull))
     return true;
 
   NullExpr = S.ImpCastExprToType(NullExpr.get(), PointerTy, CK_NullToPointer);
@@ -8826,7 +8819,8 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
     return QualType();
   }
 
-  unsigned MergedCVRQual = lhQual.getCVRQualifiers() | rhQual.getCVRQualifiers();
+  unsigned MergedCVRQual =
+      lhQual.getCVRQualifiers() | rhQual.getCVRQualifiers();
   auto LHSCastKind = CK_BitCast, RHSCastKind = CK_BitCast;
   lhQual.removeCVRQualifiers();
   rhQual.removeCVRQualifiers();
@@ -8919,8 +8913,8 @@ static QualType checkConditionalBlockPointerCompatibility(Sema &S,
       return destType;
     }
     S.Diag(Loc, diag::err_typecheck_cond_incompatible_operands)
-      << LHSTy << RHSTy << LHS.get()->getSourceRange()
-      << RHS.get()->getSourceRange();
+        << LHSTy << RHSTy << LHS.get()->getSourceRange()
+        << RHS.get()->getSourceRange();
     return QualType();
   }
 
@@ -8929,10 +8923,8 @@ static QualType checkConditionalBlockPointerCompatibility(Sema &S,
 }
 
 /// Return the resulting type when the operands are both pointers.
-static QualType
-checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
-                                            ExprResult &RHS,
-                                            SourceLocation Loc) {
+static QualType checkConditionalObjectPointersCompatibility(
+    Sema &S, ExprResult &LHS, ExprResult &RHS, SourceLocation Loc) {
   // get the pointer types
   QualType LHSTy = LHS.get()->getType();
   QualType RHSTy = RHS.get()->getType();
@@ -8944,8 +8936,8 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
   // ignore qualifiers on void (C99 6.5.15p3, clause 6)
   if (lhptee->isVoidType() && rhptee->isIncompleteOrObjectType()) {
     // Figure out necessary qualifiers (C99 6.5.15p6)
-    QualType destPointee
-      = S.Context.getQualifiedType(lhptee, rhptee.getQualifiers());
+    QualType destPointee =
+        S.Context.getQualifiedType(lhptee, rhptee.getQualifiers());
     QualType destType = S.Context.getPointerType(destPointee);
     // Add qualifiers if necessary.
     LHS = S.ImpCastExprToType(LHS.get(), destType, CK_NoOp);
@@ -8954,8 +8946,8 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
     return destType;
   }
   if (rhptee->isVoidType() && lhptee->isIncompleteOrObjectType()) {
-    QualType destPointee
-      = S.Context.getQualifiedType(rhptee, lhptee.getQualifiers());
+    QualType destPointee =
+        S.Context.getQualifiedType(rhptee, lhptee.getQualifiers());
     QualType destType = S.Context.getPointerType(destPointee);
     // Add qualifiers if necessary.
     RHS = S.ImpCastExprToType(RHS.get(), destType, CK_NoOp);
@@ -8970,7 +8962,7 @@ checkConditionalObjectPointersCompatibility(Sema &S, ExprResult &LHS,
 /// Return false if the first expression is not an integer and the second
 /// expression is not a pointer, true otherwise.
 static bool checkPointerIntegerMismatch(Sema &S, ExprResult &Int,
-                                        Expr* PointerExpr, SourceLocation Loc,
+                                        Expr *PointerExpr, SourceLocation Loc,
                                         bool IsIntFirstExpr) {
   if (!PointerExpr->getType()->isPointerType() ||
       !Int.get()->getType()->isIntegerType())
@@ -8980,8 +8972,8 @@ static bool checkPointerIntegerMismatch(Sema &S, ExprResult &Int,
   Expr *Expr2 = IsIntFirstExpr ? PointerExpr : Int.get();
 
   S.Diag(Loc, diag::ext_typecheck_cond_pointer_integer_mismatch)
-    << Expr1->getType() << Expr2->getType()
-    << Expr1->getSourceRange() << Expr2->getSourceRange();
+      << Expr1->getType() << Expr2->getType() << Expr1->getSourceRange()
+      << Expr2->getSourceRange();
   Int = S.ImpCastExprToType(Int.get(), PointerExpr->getType(),
                             CK_IntegralToPointer);
   return true;
@@ -9012,19 +9004,19 @@ static QualType OpenCLArithmeticConversions(Sema &S, ExprResult &LHS,
   // For conversion purposes, we ignore any qualifiers.
   // For example, "const float" and "float" are equivalent.
   QualType LHSType =
-    S.Context.getCanonicalType(LHS.get()->getType()).getUnqualifiedType();
+      S.Context.getCanonicalType(LHS.get()->getType()).getUnqualifiedType();
   QualType RHSType =
-    S.Context.getCanonicalType(RHS.get()->getType()).getUnqualifiedType();
+      S.Context.getCanonicalType(RHS.get()->getType()).getUnqualifiedType();
 
   if (!LHSType->isIntegerType() && !LHSType->isRealFloatingType()) {
     S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_int_float)
-      << LHSType << LHS.get()->getSourceRange();
+        << LHSType << LHS.get()->getSourceRange();
     return QualType();
   }
 
   if (!RHSType->isIntegerType() && !RHSType->isRealFloatingType()) {
     S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_int_float)
-      << RHSType << RHS.get()->getSourceRange();
+        << RHSType << RHS.get()->getSourceRange();
     return QualType();
   }
 
@@ -9038,8 +9030,8 @@ static QualType OpenCLArithmeticConversions(Sema &S, ExprResult &LHS,
                                  /*IsCompAssign = */ false);
 
   // Finally, we have two differing integer types.
-  return handleIntegerConversion<doIntegralCast, doIntegralCast>
-  (S, LHS, RHS, LHSType, RHSType, /*IsCompAssign = */ false);
+  return handleIntegerConversion<doIntegralCast, doIntegralCast>(
+      S, LHS, RHS, LHSType, RHSType, /*IsCompAssign = */ false);
 }
 
 /// Convert scalar operands to a vector that matches the
@@ -9053,11 +9045,12 @@ static QualType OpenCLArithmeticConversions(Sema &S, ExprResult &LHS,
 /// into a vector of that type where the length matches the condition
 /// vector type. s6.11.6 requires that the element types of the result
 /// and the condition must have the same number of bits.
-static QualType
-OpenCLConvertScalarsToVectors(Sema &S, ExprResult &LHS, ExprResult &RHS,
-                              QualType CondTy, SourceLocation QuestionLoc) {
+static QualType OpenCLConvertScalarsToVectors(Sema &S, ExprResult &LHS,
+                                              ExprResult &RHS, QualType CondTy,
+                                              SourceLocation QuestionLoc) {
   QualType ResTy = OpenCLArithmeticConversions(S, LHS, RHS, QuestionLoc);
-  if (ResTy.isNull()) return QualType();
+  if (ResTy.isNull())
+    return QualType();
 
   const VectorType *CV = CondTy->getAs<VectorType>();
   assert(CV);
@@ -9067,8 +9060,8 @@ OpenCLConvertScalarsToVectors(Sema &S, ExprResult &LHS, ExprResult &RHS,
   QualType VectorTy = S.Context.getExtVectorType(ResTy, NumElements);
 
   // Ensure that all types have the same number of bits
-  if (S.Context.getTypeSize(CV->getElementType())
-      != S.Context.getTypeSize(ResTy)) {
+  if (S.Context.getTypeSize(CV->getElementType()) !=
+      S.Context.getTypeSize(ResTy)) {
     // Since VectorTy is created internally, it does not pretty print
     // with an OpenCL name. Instead, we just print a description.
     std::string EleTyName = ResTy.getUnqualifiedType().getAsString();
@@ -9076,7 +9069,7 @@ OpenCLConvertScalarsToVectors(Sema &S, ExprResult &LHS, ExprResult &RHS,
     llvm::raw_svector_ostream OS(Str);
     OS << "(vector of " << NumElements << " '" << EleTyName << "' values)";
     S.Diag(QuestionLoc, diag::err_conditional_vector_element_size)
-      << CondTy << OS.str();
+        << CondTy << OS.str();
     return QualType();
   }
 
@@ -9095,10 +9088,11 @@ static bool checkOpenCLConditionVector(Sema &S, Expr *Cond,
   const VectorType *CondTy = Cond->getType()->getAs<VectorType>();
   assert(CondTy);
   QualType EleTy = CondTy->getElementType();
-  if (EleTy->isIntegerType()) return false;
+  if (EleTy->isIntegerType())
+    return false;
 
   S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_nonfloat)
-    << Cond->getType() << Cond->getSourceRange();
+      << Cond->getType() << Cond->getSourceRange();
   return true;
 }
 
@@ -9116,7 +9110,7 @@ static bool checkVectorResult(Sema &S, QualType CondTy, QualType VecResTy,
 
   if (CV->getNumElements() != RV->getNumElements()) {
     S.Diag(QuestionLoc, diag::err_conditional_vector_size)
-      << CondTy << VecResTy;
+        << CondTy << VecResTy;
     return true;
   }
 
@@ -9125,7 +9119,7 @@ static bool checkVectorResult(Sema &S, QualType CondTy, QualType VecResTy,
 
   if (S.Context.getTypeSize(CVE) != S.Context.getTypeSize(RVE)) {
     S.Diag(QuestionLoc, diag::err_conditional_vector_element_size)
-      << CondTy << VecResTy;
+        << CondTy << VecResTy;
     return true;
   }
 
@@ -9135,10 +9129,9 @@ static bool checkVectorResult(Sema &S, QualType CondTy, QualType VecResTy,
 /// Return the resulting type for the conditional operator in
 ///        OpenCL (aka "ternary selection operator", OpenCL v1.1
 ///        s6.3.i) when the condition is a vector type.
-static QualType
-OpenCLCheckVectorConditional(Sema &S, ExprResult &Cond,
-                             ExprResult &LHS, ExprResult &RHS,
-                             SourceLocation QuestionLoc) {
+static QualType OpenCLCheckVectorConditional(Sema &S, ExprResult &Cond,
+                                             ExprResult &LHS, ExprResult &RHS,
+                                             SourceLocation QuestionLoc) {
   Cond = S.DefaultFunctionArrayLvalueConversion(Cond.get());
   if (Cond.isInvalid())
     return QualType();
@@ -9194,11 +9187,13 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
                                         SourceLocation QuestionLoc) {
 
   ExprResult LHSResult = CheckPlaceholderExpr(LHS.get());
-  if (!LHSResult.isUsable()) return QualType();
+  if (!LHSResult.isUsable())
+    return QualType();
   LHS = LHSResult;
 
   ExprResult RHSResult = CheckPlaceholderExpr(RHS.get());
-  if (!RHSResult.isUsable()) return QualType();
+  if (!RHSResult.isUsable())
+    return QualType();
   RHS = RHSResult;
 
   // C++ is sufficiently different to merit its own checker.
@@ -9257,16 +9252,16 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
   // Diagnose attempts to convert between __ibm128, __float128 and long double
   // where such conversions currently can't be handled.
   if (unsupportedTypeConversion(*this, LHSTy, RHSTy)) {
-    Diag(QuestionLoc,
-         diag::err_typecheck_cond_incompatible_operands) << LHSTy << RHSTy
-      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+    Diag(QuestionLoc, diag::err_typecheck_cond_incompatible_operands)
+        << LHSTy << RHSTy << LHS.get()->getSourceRange()
+        << RHS.get()->getSourceRange();
     return QualType();
   }
 
   // OpenCL v2.0 s6.12.5 - Blocks cannot be used as expressions of the ternary
   // selection operator (?:).
-  if (getLangOpts().OpenCL &&
-      ((int)checkBlockType(*this, LHS.get()) | (int)checkBlockType(*this, RHS.get()))) {
+  if (getLangOpts().OpenCL && ((int)checkBlockType(*this, LHS.get()) |
+                               (int)checkBlockType(*this, RHS.get()))) {
     return QualType();
   }
 
@@ -9291,7 +9286,7 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
 
   // If both operands are the same structure or union type, the result is that
   // type.
-  if (const RecordType *LHSRT = LHSTy->getAs<RecordType>()) {    // C99 6.5.15p3
+  if (const RecordType *LHSRT = LHSTy->getAs<RecordType>()) { // C99 6.5.15p3
     if (const RecordType *RHSRT = RHSTy->getAs<RecordType>())
       if (LHSRT->getDecl() == RHSRT->getDecl())
         // "If both the operands have structure or union type, the result has
@@ -9329,17 +9324,17 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
 
   // C99 6.5.15p6 - "if one operand is a null pointer constant, the result has
   // the type of the other operand."
-  if (!checkConditionalNullPointer(*this, RHS, LHSTy)) return LHSTy;
-  if (!checkConditionalNullPointer(*this, LHS, RHSTy)) return RHSTy;
+  if (!checkConditionalNullPointer(*this, RHS, LHSTy))
+    return LHSTy;
+  if (!checkConditionalNullPointer(*this, LHS, RHSTy))
+    return RHSTy;
 
   // All objective-c pointer type analysis is done here.
-  QualType compositeType = FindCompositeObjCPointerType(LHS, RHS,
-                                                        QuestionLoc);
+  QualType compositeType = FindCompositeObjCPointerType(LHS, RHS, QuestionLoc);
   if (LHS.isInvalid() || RHS.isInvalid())
     return QualType();
   if (!compositeType.isNull())
     return compositeType;
-
 
   // Handle block pointer types.
   if (LHSTy->isBlockPointerType() || RHSTy->isBlockPointerType())
@@ -9354,10 +9349,10 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
   // GCC compatibility: soften pointer/integer mismatch.  Note that
   // null pointers have been filtered out by this point.
   if (checkPointerIntegerMismatch(*this, LHS, RHS.get(), QuestionLoc,
-      /*IsIntFirstExpr=*/true))
+                                  /*IsIntFirstExpr=*/true))
     return RHSTy;
   if (checkPointerIntegerMismatch(*this, RHS, LHS.get(), QuestionLoc,
-      /*IsIntFirstExpr=*/false))
+                                  /*IsIntFirstExpr=*/false))
     return LHSTy;
 
   // Emit a better diagnostic if one of the expressions is a null pointer
@@ -9373,8 +9368,8 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
 
   // Otherwise, the operands are not compatible.
   Diag(QuestionLoc, diag::err_typecheck_cond_incompatible_operands)
-    << LHSTy << RHSTy << LHS.get()->getSourceRange()
-    << RHS.get()->getSourceRange();
+      << LHSTy << RHSTy << LHS.get()->getSourceRange()
+      << RHS.get()->getSourceRange();
   return QualType();
 }
 
@@ -9427,8 +9422,10 @@ QualType Sema::FindCompositeObjCPointerType(ExprResult &LHS, ExprResult &RHS,
       // Two identical object pointer types are always compatible.
       return LHSTy;
     }
-    const ObjCObjectPointerType *LHSOPT = LHSTy->castAs<ObjCObjectPointerType>();
-    const ObjCObjectPointerType *RHSOPT = RHSTy->castAs<ObjCObjectPointerType>();
+    const ObjCObjectPointerType *LHSOPT =
+        LHSTy->castAs<ObjCObjectPointerType>();
+    const ObjCObjectPointerType *RHSOPT =
+        RHSTy->castAs<ObjCObjectPointerType>();
     QualType compositeType = LHSTy;
 
     // If both operands are interfaces and either operand can be
@@ -9444,8 +9441,8 @@ QualType Sema::FindCompositeObjCPointerType(ExprResult &LHS, ExprResult &RHS,
 
     // FIXME: Consider unifying with 'areComparableObjCPointerTypes'.
     // It could return the composite type.
-    if (!(compositeType =
-          Context.areCommonBaseCompatible(LHSOPT, RHSOPT)).isNull()) {
+    if (!(compositeType = Context.areCommonBaseCompatible(LHSOPT, RHSOPT))
+             .isNull()) {
       // Nothing more to do.
     } else if (Context.canAssignObjCInterfaces(LHSOPT, RHSOPT)) {
       compositeType = RHSOPT->isObjCBuiltinType() ? RHSTy : LHSTy;
@@ -9464,8 +9461,8 @@ QualType Sema::FindCompositeObjCPointerType(ExprResult &LHS, ExprResult &RHS,
       compositeType = Context.getObjCIdType();
     } else {
       Diag(QuestionLoc, diag::ext_typecheck_cond_incompatible_operands)
-      << LHSTy << RHSTy
-      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+          << LHSTy << RHSTy << LHS.get()->getSourceRange()
+          << RHS.get()->getSourceRange();
       QualType incompatTy = Context.getObjCIdType();
       LHS = ImpCastExprToType(LHS.get(), incompatTy, CK_BitCast);
       RHS = ImpCastExprToType(RHS.get(), incompatTy, CK_BitCast);
@@ -9481,15 +9478,16 @@ QualType Sema::FindCompositeObjCPointerType(ExprResult &LHS, ExprResult &RHS,
     if (getLangOpts().ObjCAutoRefCount) {
       // ARC forbids the implicit conversion of object pointers to 'void *',
       // so these types are not compatible.
-      Diag(QuestionLoc, diag::err_cond_voidptr_arc) << LHSTy << RHSTy
-          << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      Diag(QuestionLoc, diag::err_cond_voidptr_arc)
+          << LHSTy << RHSTy << LHS.get()->getSourceRange()
+          << RHS.get()->getSourceRange();
       LHS = RHS = true;
       return QualType();
     }
     QualType lhptee = LHSTy->castAs<PointerType>()->getPointeeType();
     QualType rhptee = RHSTy->castAs<ObjCObjectPointerType>()->getPointeeType();
-    QualType destPointee
-    = Context.getQualifiedType(lhptee, rhptee.getQualifiers());
+    QualType destPointee =
+        Context.getQualifiedType(lhptee, rhptee.getQualifiers());
     QualType destType = Context.getPointerType(destPointee);
     // Add qualifiers if necessary.
     LHS = ImpCastExprToType(LHS.get(), destType, CK_NoOp);
@@ -9501,15 +9499,16 @@ QualType Sema::FindCompositeObjCPointerType(ExprResult &LHS, ExprResult &RHS,
     if (getLangOpts().ObjCAutoRefCount) {
       // ARC forbids the implicit conversion of object pointers to 'void *',
       // so these types are not compatible.
-      Diag(QuestionLoc, diag::err_cond_voidptr_arc) << LHSTy << RHSTy
-          << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      Diag(QuestionLoc, diag::err_cond_voidptr_arc)
+          << LHSTy << RHSTy << LHS.get()->getSourceRange()
+          << RHS.get()->getSourceRange();
       LHS = RHS = true;
       return QualType();
     }
     QualType lhptee = LHSTy->castAs<ObjCObjectPointerType>()->getPointeeType();
     QualType rhptee = RHSTy->castAs<PointerType>()->getPointeeType();
-    QualType destPointee
-    = Context.getQualifiedType(rhptee, lhptee.getQualifiers());
+    QualType destPointee =
+        Context.getQualifiedType(rhptee, lhptee.getQualifiers());
     QualType destType = Context.getPointerType(destPointee);
     // Add qualifiers if necessary.
     RHS = ImpCastExprToType(RHS.get(), destType, CK_NoOp);
@@ -9528,9 +9527,9 @@ static void SuggestParentheses(Sema &Self, SourceLocation Loc,
   SourceLocation EndLoc = Self.getLocForEndOfToken(ParenRange.getEnd());
   if (ParenRange.getBegin().isFileID() && ParenRange.getEnd().isFileID() &&
       EndLoc.isValid()) {
-    Self.Diag(Loc, Note)
-      << FixItHint::CreateInsertion(ParenRange.getBegin(), "(")
-      << FixItHint::CreateInsertion(EndLoc, ")");
+    Self.Diag(Loc, Note) << FixItHint::CreateInsertion(ParenRange.getBegin(),
+                                                       "(")
+                         << FixItHint::CreateInsertion(EndLoc, ")");
   } else {
     // We can't display the parentheses, so just show the bare note.
     Self.Diag(Loc, Note) << ParenRange;
@@ -9579,8 +9578,8 @@ static bool IsArithmeticBinaryExpr(const Expr *E, BinaryOperatorKind *Opcode,
     // Make sure this is really a binary operator that is safe to pass into
     // BinaryOperator::getOverloadedOpcode(), e.g. it's not a subscript op.
     OverloadedOperatorKind OO = Call->getOperator();
-    if (OO < OO_Plus || OO > OO_Arrow ||
-        OO == OO_PlusPlus || OO == OO_MinusMinus)
+    if (OO < OO_Plus || OO > OO_Arrow || OO == OO_PlusPlus ||
+        OO == OO_MinusMinus)
       return false;
 
     BinaryOperatorKind OpKind = BinaryOperator::getOverloadedOpcode(OO);
@@ -9636,9 +9635,8 @@ static void DiagnoseConditionalPrecedence(Sema &Self, SourceLocation OpLoc,
                         ? diag::warn_precedence_bitwise_conditional
                         : diag::warn_precedence_conditional;
 
-  Self.Diag(OpLoc, DiagID)
-      << Condition->getSourceRange()
-      << BinaryOperator::getOpcodeStr(CondOpcode);
+  Self.Diag(OpLoc, DiagID) << Condition->getSourceRange()
+                           << BinaryOperator::getOpcodeStr(CondOpcode);
 
   SuggestParentheses(
       Self, OpLoc,
@@ -9678,7 +9676,7 @@ static QualType computeConditionalNullability(QualType ResTy, bool IsBin,
       MergedKind = NullabilityKind::NonNull;
     else
       MergedKind = RHSKind;
-  // Compute nullability of a normal conditional expression.
+    // Compute nullability of a normal conditional expression.
   } else {
     if (LHSKind == NullabilityKind::Nullable ||
         RHSKind == NullabilityKind::Nullable)
@@ -9707,9 +9705,8 @@ static QualType computeConditionalNullability(QualType ResTy, bool IsBin,
 /// ActOnConditionalOp - Parse a ?: operation.  Note that 'LHS' may be null
 /// in the case of a the GNU conditional expr extension.
 ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
-                                    SourceLocation ColonLoc,
-                                    Expr *CondExpr, Expr *LHSExpr,
-                                    Expr *RHSExpr) {
+                                    SourceLocation ColonLoc, Expr *CondExpr,
+                                    Expr *LHSExpr, Expr *RHSExpr) {
   if (!Context.isDependenceAllowed()) {
     // C cannot handle TypoExpr nodes in the condition because it
     // doesn't handle dependent types properly, so make sure any TypoExprs have
@@ -9745,18 +9742,17 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
     // as Objective-C++'s dictionary subscripting syntax.
     if (commonExpr->hasPlaceholderType()) {
       ExprResult result = CheckPlaceholderExpr(commonExpr);
-      if (!result.isUsable()) return ExprError();
+      if (!result.isUsable())
+        return ExprError();
       commonExpr = result.get();
     }
     // We usually want to apply unary conversions *before* saving, except
     // in the special case of a C++ l-value conditional.
-    if (!(getLangOpts().CPlusPlus
-          && !commonExpr->isTypeDependent()
-          && commonExpr->getValueKind() == RHSExpr->getValueKind()
-          && commonExpr->isGLValue()
-          && commonExpr->isOrdinaryOrBitFieldObject()
-          && RHSExpr->isOrdinaryOrBitFieldObject()
-          && Context.hasSameType(commonExpr->getType(), RHSExpr->getType()))) {
+    if (!(getLangOpts().CPlusPlus && !commonExpr->isTypeDependent() &&
+          commonExpr->getValueKind() == RHSExpr->getValueKind() &&
+          commonExpr->isGLValue() && commonExpr->isOrdinaryOrBitFieldObject() &&
+          RHSExpr->isOrdinaryOrBitFieldObject() &&
+          Context.hasSameType(commonExpr->getType(), RHSExpr->getType()))) {
       ExprResult commonRes = UsualUnaryConversions(commonExpr);
       if (commonRes.isInvalid())
         return ExprError();
@@ -9773,11 +9769,9 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
       commonExpr = MatExpr.get();
     }
 
-    opaqueValue = new (Context) OpaqueValueExpr(commonExpr->getExprLoc(),
-                                                commonExpr->getType(),
-                                                commonExpr->getValueKind(),
-                                                commonExpr->getObjectKind(),
-                                                commonExpr);
+    opaqueValue = new (Context) OpaqueValueExpr(
+        commonExpr->getExprLoc(), commonExpr->getType(),
+        commonExpr->getValueKind(), commonExpr->getObjectKind(), commonExpr);
     LHSExpr = CondExpr = opaqueValue;
   }
 
@@ -9785,10 +9779,9 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
   ExprValueKind VK = VK_PRValue;
   ExprObjectKind OK = OK_Ordinary;
   ExprResult Cond = CondExpr, LHS = LHSExpr, RHS = RHSExpr;
-  QualType result = CheckConditionalOperands(Cond, LHS, RHS,
-                                             VK, OK, QuestionLoc);
-  if (result.isNull() || Cond.isInvalid() || LHS.isInvalid() ||
-      RHS.isInvalid())
+  QualType result =
+      CheckConditionalOperands(Cond, LHS, RHS, VK, OK, QuestionLoc);
+  if (result.isNull() || Cond.isInvalid() || LHS.isInvalid() || RHS.isInvalid())
     return ExprError();
 
   DiagnoseConditionalPrecedence(*this, QuestionLoc, Cond.get(), LHS.get(),
@@ -9796,8 +9789,8 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
 
   CheckBoolLikeConversion(Cond.get(), QuestionLoc);
 
-  result = computeConditionalNullability(result, commonExpr, LHSTy, RHSTy,
-                                         Context);
+  result =
+      computeConditionalNullability(result, commonExpr, LHSTy, RHSTy, Context);
 
   if (!commonExpr)
     return new (Context)
@@ -9882,10 +9875,9 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType,
 
     // It's okay to add or remove GC or lifetime qualifiers when converting to
     // and from void*.
-    else if (lhq.withoutObjCGCAttr().withoutObjCLifetime()
-                        .compatiblyIncludes(
-                                rhq.withoutObjCGCAttr().withoutObjCLifetime())
-             && (lhptee->isVoidType() || rhptee->isVoidType()))
+    else if (lhq.withoutObjCGCAttr().withoutObjCLifetime().compatiblyIncludes(
+                 rhq.withoutObjCGCAttr().withoutObjCLifetime()) &&
+             (lhptee->isVoidType() || rhptee->isVoidType()))
       ; // keep old
 
     // Treat lifetime mismatches as fatal.
@@ -9894,7 +9886,8 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType,
 
     // For GCC/MS compatibility, other qualifier mismatches are treated
     // as still compatible in C.
-    else ConvTy = Sema::CompatiblePointerDiscardsQualifiers;
+    else
+      ConvTy = Sema::CompatiblePointerDiscardsQualifiers;
   }
 
   // C99 6.5.16.1p1 (constraint 4): If one operand is a pointer to an object or
@@ -9959,9 +9952,9 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType,
     if (isa<PointerType>(lhptee) && isa<PointerType>(rhptee)) {
       do {
         std::tie(lhptee, lhq) =
-          cast<PointerType>(lhptee)->getPointeeType().split().asPair();
+            cast<PointerType>(lhptee)->getPointeeType().split().asPair();
         std::tie(rhptee, rhq) =
-          cast<PointerType>(rhptee)->getPointeeType().split().asPair();
+            cast<PointerType>(rhptee)->getPointeeType().split().asPair();
 
         // Inconsistent address spaces at this point is invalid, even if the
         // address spaces would be compatible.
@@ -10084,9 +10077,9 @@ checkObjCPointerTypesForAssignment(Sema &S, QualType LHSType,
   return Sema::IncompatiblePointer;
 }
 
-Sema::AssignConvertType
-Sema::CheckAssignmentConstraints(SourceLocation Loc,
-                                 QualType LHSType, QualType RHSType) {
+Sema::AssignConvertType Sema::CheckAssignmentConstraints(SourceLocation Loc,
+                                                         QualType LHSType,
+                                                         QualType RHSType) {
   // Fake up an opaque expression.  We don't actually care about what
   // cast operations are required, so if CheckAssignmentConstraints
   // adds casts to this they'll be wasted, but fortunately that doesn't
@@ -10123,9 +10116,10 @@ static bool isVector(QualType QT, QualType ElementType) {
 /// C99 spec dictates.
 ///
 /// Sets 'Kind' for any result kind except Incompatible.
-Sema::AssignConvertType
-Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
-                                 CastKind &Kind, bool ConvertRHS) {
+Sema::AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
+                                                         ExprResult &RHS,
+                                                         CastKind &Kind,
+                                                         bool ConvertRHS) {
   QualType RHSType = RHS.get()->getType();
   QualType OrigLHSType = LHSType;
 
@@ -10153,7 +10147,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
   // atomic qualification step.
   if (const AtomicType *AtomicTy = dyn_cast<AtomicType>(LHSType)) {
     Sema::AssignConvertType result =
-      CheckAssignmentConstraints(AtomicTy->getValueType(), RHS, Kind);
+        CheckAssignmentConstraints(AtomicTy->getValueType(), RHS, Kind);
     if (result != Compatible)
       return result;
     if (Kind != CK_NoOp && ConvertRHS)
@@ -10381,7 +10375,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
     if (RHSType->isObjCObjectPointerType()) {
       Kind = CK_BitCast;
       Sema::AssignConvertType result =
-        checkObjCPointerTypesForAssignment(*this, LHSType, RHSType);
+          checkObjCPointerTypesForAssignment(*this, LHSType, RHSType);
       if (getLangOpts().allowsNonTrivialObjCLifetimeQualifiers() &&
           result == Compatible &&
           !CheckObjCARCUnavailableWeakConversion(OrigLHSType, RHSType))
@@ -10494,8 +10488,8 @@ static void ConstructTransparentUnion(Sema &S, ASTContext &C,
   // Build an initializer list that designates the appropriate member
   // of the transparent union.
   Expr *E = EResult.get();
-  InitListExpr *Initializer = new (C) InitListExpr(C, SourceLocation(),
-                                                   E, SourceLocation());
+  InitListExpr *Initializer =
+      new (C) InitListExpr(C, SourceLocation(), E, SourceLocation());
   Initializer->setType(UnionType);
   Initializer->setInitializedFieldInUnion(Field);
 
@@ -10535,16 +10529,14 @@ Sema::CheckTransparentUnionArgumentConstraints(QualType ArgType,
 
       if (RHS.get()->isNullPointerConstant(Context,
                                            Expr::NPC_ValueDependentIsNull)) {
-        RHS = ImpCastExprToType(RHS.get(), it->getType(),
-                                CK_NullToPointer);
+        RHS = ImpCastExprToType(RHS.get(), it->getType(), CK_NullToPointer);
         InitField = it;
         break;
       }
     }
 
     CastKind Kind;
-    if (CheckAssignmentConstraints(it->getType(), RHS, Kind)
-          == Compatible) {
+    if (CheckAssignmentConstraints(it->getType(), RHS, Kind) == Compatible) {
       RHS = ImpCastExprToType(RHS.get(), it->getType(), Kind);
       InitField = it;
       break;
@@ -10560,8 +10552,7 @@ Sema::CheckTransparentUnionArgumentConstraints(QualType ArgType,
 
 Sema::AssignConvertType
 Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
-                                       bool Diagnose,
-                                       bool DiagnoseCFAudited,
+                                       bool Diagnose, bool DiagnoseCFAudited,
                                        bool ConvertRHS) {
   // We need to be able to tell the caller whether we diagnosed a problem, if
   // they ask us to issue diagnostics.
@@ -10594,13 +10585,12 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
         RHS = PerformImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
                                         AA_Assigning);
       } else {
-        ImplicitConversionSequence ICS =
-            TryImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
-                                  /*SuppressUserConversions=*/false,
-                                  AllowedExplicit::None,
-                                  /*InOverloadResolution=*/false,
-                                  /*CStyle=*/false,
-                                  /*AllowObjCWritebackConversion=*/false);
+        ImplicitConversionSequence ICS = TryImplicitConversion(
+            RHS.get(), LHSType.getUnqualifiedType(),
+            /*SuppressUserConversions=*/false, AllowedExplicit::None,
+            /*InOverloadResolution=*/false,
+            /*CStyle=*/false,
+            /*AllowObjCWritebackConversion=*/false);
         if (ICS.isFailure())
           return Incompatible;
         RHS = PerformImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
@@ -10700,7 +10690,7 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
 
   CastKind Kind;
   Sema::AssignConvertType result =
-    CheckAssignmentConstraints(LHSType, RHS, Kind, ConvertRHS);
+      CheckAssignmentConstraints(LHSType, RHS, Kind, ConvertRHS);
 
   // C99 6.5.16.1p2: The value of the right operand is converted to the
   // type of the assignment expression.
@@ -10761,27 +10751,27 @@ struct OriginalOperand {
   Expr *Orig;
   NamedDecl *Conversion;
 };
-}
+} // namespace
 
 QualType Sema::InvalidOperands(SourceLocation Loc, ExprResult &LHS,
                                ExprResult &RHS) {
   OriginalOperand OrigLHS(LHS.get()), OrigRHS(RHS.get());
 
   Diag(Loc, diag::err_typecheck_invalid_operands)
-    << OrigLHS.getType() << OrigRHS.getType()
-    << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      << OrigLHS.getType() << OrigRHS.getType() << LHS.get()->getSourceRange()
+      << RHS.get()->getSourceRange();
 
   // If a user-defined conversion was applied to either of the operands prior
   // to applying the built-in operator rules, tell the user about it.
   if (OrigLHS.Conversion) {
     Diag(OrigLHS.Conversion->getLocation(),
          diag::note_typecheck_invalid_operands_converted)
-      << 0 << LHS.get()->getType();
+        << 0 << LHS.get()->getType();
   }
   if (OrigRHS.Conversion) {
     Diag(OrigRHS.Conversion->getLocation(),
          diag::note_typecheck_invalid_operands_converted)
-      << 1 << RHS.get()->getType();
+        << 1 << RHS.get()->getType();
   }
 
   return QualType();
@@ -10827,18 +10817,17 @@ QualType Sema::InvalidLogicalVectorOperands(SourceLocation Loc, ExprResult &LHS,
 /// \param scalar - if non-null, actually perform the conversions
 /// \return true if the operation fails (but without diagnosing the failure)
 static bool tryVectorConvertAndSplat(Sema &S, ExprResult *scalar,
-                                     QualType scalarTy,
-                                     QualType vectorEltTy,
-                                     QualType vectorTy,
-                                     unsigned &DiagID) {
+                                     QualType scalarTy, QualType vectorEltTy,
+                                     QualType vectorTy, unsigned &DiagID) {
   // The conversion to apply to the scalar before splatting it,
   // if necessary.
   CastKind scalarCast = CK_NoOp;
 
   if (vectorEltTy->isIntegralType(S.Context)) {
-    if (S.getLangOpts().OpenCL && (scalarTy->isRealFloatingType() ||
-        (scalarTy->isIntegerType() &&
-         S.Context.getIntegerTypeOrder(vectorEltTy, scalarTy) < 0))) {
+    if (S.getLangOpts().OpenCL &&
+        (scalarTy->isRealFloatingType() ||
+         (scalarTy->isIntegerType() &&
+          S.Context.getIntegerTypeOrder(vectorEltTy, scalarTy) < 0))) {
       DiagID = diag::err_opencl_scalar_type_rank_greater_than_vector_type;
       return true;
     }
@@ -10853,8 +10842,7 @@ static bool tryVectorConvertAndSplat(Sema &S, ExprResult *scalar,
         return true;
       }
       scalarCast = CK_FloatingCast;
-    }
-    else if (scalarTy->isIntegralType(S.Context))
+    } else if (scalarTy->isIntegralType(S.Context))
       scalarCast = CK_IntegralToFloating;
     else
       return true;
@@ -11259,11 +11247,11 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
     if (!IsCompAssign) {
       *OtherExpr = ImpCastExprToType(OtherExpr->get(), VecType, CK_BitCast);
       return VecType;
-    // In a compound assignment, lhs += rhs, 'lhs' is a lvalue src, forbidding
-    // any implicit cast. Here, the 'rhs' should be implicit casted to 'lhs'
-    // type. Note that this is already done by non-compound assignments in
-    // CheckAssignmentConstraints. If it's a scalar type, only bitcast for
-    // <1 x T> -> T. The result is also a vector type.
+      // In a compound assignment, lhs += rhs, 'lhs' is a lvalue src, forbidding
+      // any implicit cast. Here, the 'rhs' should be implicit casted to 'lhs'
+      // type. Note that this is already done by non-compound assignments in
+      // CheckAssignmentConstraints. If it's a scalar type, only bitcast for
+      // <1 x T> -> T. The result is also a vector type.
     } else if (OtherType->isExtVectorType() || OtherType->isVectorType() ||
                (OtherType->isScalarType() && VT->getNumElements() == 1)) {
       ExprResult *RHSExpr = &RHS;
@@ -11278,8 +11266,8 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
   if ((!RHSVecType && !RHSType->isRealType()) ||
       (!LHSVecType && !LHSType->isRealType())) {
     Diag(Loc, diag::err_typecheck_vector_not_convertable_non_scalar)
-      << LHSType << RHSType
-      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+        << LHSType << RHSType << LHS.get()->getSourceRange()
+        << RHS.get()->getSourceRange();
     return QualType();
   }
 
@@ -11287,14 +11275,12 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
   // If the operands are of more than one vector type, then an error shall
   // occur. Implicit conversions between vector types are not permitted, per
   // section 6.2.1.
-  if (getLangOpts().OpenCL &&
-      RHSVecType && isa<ExtVectorType>(RHSVecType) &&
+  if (getLangOpts().OpenCL && RHSVecType && isa<ExtVectorType>(RHSVecType) &&
       LHSVecType && isa<ExtVectorType>(LHSVecType)) {
-    Diag(Loc, diag::err_opencl_implicit_vector_conversion) << LHSType
-                                                           << RHSType;
+    Diag(Loc, diag::err_opencl_implicit_vector_conversion)
+        << LHSType << RHSType;
     return QualType();
   }
-
 
   // If there is a vector type that is not a ExtVector and a scalar, we reach
   // this point if scalar could not be converted to the vector's element type
@@ -11304,17 +11290,15 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
     QualType Scalar = LHSVecType ? RHSType : LHSType;
     QualType Vector = LHSVecType ? LHSType : RHSType;
     unsigned ScalarOrVector = LHSVecType && RHSVecType ? 1 : 0;
-    Diag(Loc,
-         diag::err_typecheck_vector_not_convertable_implict_truncation)
+    Diag(Loc, diag::err_typecheck_vector_not_convertable_implict_truncation)
         << ScalarOrVector << Scalar << Vector;
 
     return QualType();
   }
 
   // Otherwise, use the generic diagnostic.
-  Diag(Loc, DiagID)
-    << LHSType << RHSType
-    << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+  Diag(Loc, DiagID) << LHSType << RHSType << LHS.get()->getSourceRange()
+                    << RHS.get()->getSourceRange();
   return QualType();
 }
 
@@ -11428,12 +11412,12 @@ static void checkArithmeticNull(Sema &S, ExprResult &LHS, ExprResult &RHS,
     return;
 
   S.Diag(Loc, diag::warn_null_in_comparison_operation)
-      << LHSNull /* LHS is NULL */ << NonNullType
-      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      << LHSNull /* LHS is NULL */ << NonNullType << LHS.get()->getSourceRange()
+      << RHS.get()->getSourceRange();
 }
 
 static void DiagnoseDivisionSizeofPointerOrArray(Sema &S, Expr *LHS, Expr *RHS,
-                                          SourceLocation Loc) {
+                                                 SourceLocation Loc) {
   const auto *LUE = dyn_cast<UnaryExprOrTypeTraitExpr>(LHS);
   const auto *RUE = dyn_cast<UnaryExprOrTypeTraitExpr>(RHS);
   if (!LUE || !RUE)
@@ -11480,7 +11464,7 @@ static void DiagnoseDivisionSizeofPointerOrArray(Sema &S, Expr *LHS, Expr *RHS,
   }
 }
 
-static void DiagnoseBadDivideOrRemainderValues(Sema& S, ExprResult &LHS,
+static void DiagnoseBadDivideOrRemainderValues(Sema &S, ExprResult &LHS,
                                                ExprResult &RHS,
                                                SourceLocation Loc, bool IsDiv) {
   // Check for division/remainder by zero.
@@ -11490,7 +11474,7 @@ static void DiagnoseBadDivideOrRemainderValues(Sema& S, ExprResult &LHS,
       RHSValue.Val.getInt() == 0)
     S.DiagRuntimeBehavior(Loc, RHS.get(),
                           S.PDiag(diag::warn_remainder_division_by_zero)
-                            << IsDiv << RHS.get()->getSourceRange());
+                              << IsDiv << RHS.get()->getSourceRange());
 }
 
 QualType Sema::CheckMultiplyDivideOperands(ExprResult &LHS, ExprResult &RHS,
@@ -11522,7 +11506,6 @@ QualType Sema::CheckMultiplyDivideOperands(ExprResult &LHS, ExprResult &RHS,
   if (LHS.isInvalid() || RHS.isInvalid())
     return QualType();
 
-
   if (compType.isNull() || !compType->isArithmeticType())
     return InvalidOperands(Loc, LHS, RHS);
   if (IsDiv) {
@@ -11532,8 +11515,8 @@ QualType Sema::CheckMultiplyDivideOperands(ExprResult &LHS, ExprResult &RHS,
   return compType;
 }
 
-QualType Sema::CheckRemainderOperands(
-  ExprResult &LHS, ExprResult &RHS, SourceLocation Loc, bool IsCompAssign) {
+QualType Sema::CheckRemainderOperands(ExprResult &LHS, ExprResult &RHS,
+                                      SourceLocation Loc, bool IsCompAssign) {
   checkArithmeticNull(*this, LHS, RHS, Loc, /*IsCompare=*/false);
 
   if (LHS.get()->getType()->isVectorType() ||
@@ -11573,19 +11556,19 @@ QualType Sema::CheckRemainderOperands(
 static void diagnoseArithmeticOnTwoVoidPointers(Sema &S, SourceLocation Loc,
                                                 Expr *LHSExpr, Expr *RHSExpr) {
   S.Diag(Loc, S.getLangOpts().CPlusPlus
-                ? diag::err_typecheck_pointer_arith_void_type
-                : diag::ext_gnu_void_ptr)
-    << 1 /* two pointers */ << LHSExpr->getSourceRange()
-                            << RHSExpr->getSourceRange();
+                  ? diag::err_typecheck_pointer_arith_void_type
+                  : diag::ext_gnu_void_ptr)
+      << 1 /* two pointers */ << LHSExpr->getSourceRange()
+      << RHSExpr->getSourceRange();
 }
 
 /// Diagnose invalid arithmetic on a void pointer.
 static void diagnoseArithmeticOnVoidPointer(Sema &S, SourceLocation Loc,
                                             Expr *Pointer) {
   S.Diag(Loc, S.getLangOpts().CPlusPlus
-                ? diag::err_typecheck_pointer_arith_void_type
-                : diag::ext_gnu_void_ptr)
-    << 0 /* one pointer */ << Pointer->getSourceRange();
+                  ? diag::err_typecheck_pointer_arith_void_type
+                  : diag::ext_gnu_void_ptr)
+      << 0 /* one pointer */ << Pointer->getSourceRange();
 }
 
 /// Diagnose invalid arithmetic on a null pointer.
@@ -11596,11 +11579,10 @@ static void diagnoseArithmeticOnVoidPointer(Sema &S, SourceLocation Loc,
 static void diagnoseArithmeticOnNullPointer(Sema &S, SourceLocation Loc,
                                             Expr *Pointer, bool IsGNUIdiom) {
   if (IsGNUIdiom)
-    S.Diag(Loc, diag::warn_gnu_null_ptr_arith)
-      << Pointer->getSourceRange();
+    S.Diag(Loc, diag::warn_gnu_null_ptr_arith) << Pointer->getSourceRange();
   else
     S.Diag(Loc, diag::warn_pointer_arith_null_ptr)
-      << S.getLangOpts().CPlusPlus << Pointer->getSourceRange();
+        << S.getLangOpts().CPlusPlus << Pointer->getSourceRange();
 }
 
 /// Diagnose invalid subraction on a null pointer.
@@ -11627,14 +11609,15 @@ static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
   assert(LHS->getType()->isAnyPointerType());
   assert(RHS->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
-                ? diag::err_typecheck_pointer_arith_function_type
-                : diag::ext_gnu_ptr_func_arith)
-    << 1 /* two pointers */ << LHS->getType()->getPointeeType()
-    // We only show the second type if it differs from the first.
-    << (unsigned)!S.Context.hasSameUnqualifiedType(LHS->getType(),
-                                                   RHS->getType())
-    << RHS->getType()->getPointeeType()
-    << LHS->getSourceRange() << RHS->getSourceRange();
+                  ? diag::err_typecheck_pointer_arith_function_type
+                  : diag::ext_gnu_ptr_func_arith)
+      << 1 /* two pointers */
+      << LHS->getType()->getPointeeType()
+      // We only show the second type if it differs from the first.
+      << (unsigned)!S.Context.hasSameUnqualifiedType(LHS->getType(),
+                                                     RHS->getType())
+      << RHS->getType()->getPointeeType() << LHS->getSourceRange()
+      << RHS->getSourceRange();
 }
 
 /// Diagnose invalid arithmetic on a function pointer.
@@ -11642,11 +11625,11 @@ static void diagnoseArithmeticOnFunctionPointer(Sema &S, SourceLocation Loc,
                                                 Expr *Pointer) {
   assert(Pointer->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
-                ? diag::err_typecheck_pointer_arith_function_type
-                : diag::ext_gnu_ptr_func_arith)
-    << 0 /* one pointer */ << Pointer->getType()->getPointeeType()
-    << 0 /* one pointer, so only one type */
-    << Pointer->getSourceRange();
+                  ? diag::err_typecheck_pointer_arith_function_type
+                  : diag::ext_gnu_ptr_func_arith)
+      << 0 /* one pointer */ << Pointer->getType()->getPointeeType()
+      << 0 /* one pointer, so only one type */
+      << Pointer->getSourceRange();
 }
 
 /// Emit error if Operand is incomplete pointer type
@@ -11680,7 +11663,8 @@ static bool checkArithmeticOpPointerOperand(Sema &S, SourceLocation Loc,
   if (const AtomicType *ResAtomicType = ResType->getAs<AtomicType>())
     ResType = ResAtomicType->getValueType();
 
-  if (!ResType->isAnyPointerType()) return true;
+  if (!ResType->isAnyPointerType())
+    return true;
 
   QualType PointeeTy = ResType->getPointeeType();
   if (PointeeTy->isVoidType()) {
@@ -11692,7 +11676,8 @@ static bool checkArithmeticOpPointerOperand(Sema &S, SourceLocation Loc,
     return !S.getLangOpts().CPlusPlus;
   }
 
-  if (checkArithmeticIncompletePointerType(S, Loc, Operand)) return false;
+  if (checkArithmeticIncompletePointerType(S, Loc, Operand))
+    return false;
 
   return true;
 }
@@ -11710,11 +11695,14 @@ static bool checkArithmeticBinOpPointerOperands(Sema &S, SourceLocation Loc,
                                                 Expr *LHSExpr, Expr *RHSExpr) {
   bool isLHSPointer = LHSExpr->getType()->isAnyPointerType();
   bool isRHSPointer = RHSExpr->getType()->isAnyPointerType();
-  if (!isLHSPointer && !isRHSPointer) return true;
+  if (!isLHSPointer && !isRHSPointer)
+    return true;
 
   QualType LHSPointeeTy, RHSPointeeTy;
-  if (isLHSPointer) LHSPointeeTy = LHSExpr->getType()->getPointeeType();
-  if (isRHSPointer) RHSPointeeTy = RHSExpr->getType()->getPointeeType();
+  if (isLHSPointer)
+    LHSPointeeTy = LHSExpr->getType()->getPointeeType();
+  if (isRHSPointer)
+    RHSPointeeTy = RHSExpr->getType()->getPointeeType();
 
   // if both are pointers check if operation is valid wrt address spaces
   if (isLHSPointer && isRHSPointer) {
@@ -11731,9 +11719,12 @@ static bool checkArithmeticBinOpPointerOperands(Sema &S, SourceLocation Loc,
   bool isLHSVoidPtr = isLHSPointer && LHSPointeeTy->isVoidType();
   bool isRHSVoidPtr = isRHSPointer && RHSPointeeTy->isVoidType();
   if (isLHSVoidPtr || isRHSVoidPtr) {
-    if (!isRHSVoidPtr) diagnoseArithmeticOnVoidPointer(S, Loc, LHSExpr);
-    else if (!isLHSVoidPtr) diagnoseArithmeticOnVoidPointer(S, Loc, RHSExpr);
-    else diagnoseArithmeticOnTwoVoidPointers(S, Loc, LHSExpr, RHSExpr);
+    if (!isRHSVoidPtr)
+      diagnoseArithmeticOnVoidPointer(S, Loc, LHSExpr);
+    else if (!isLHSVoidPtr)
+      diagnoseArithmeticOnVoidPointer(S, Loc, RHSExpr);
+    else
+      diagnoseArithmeticOnTwoVoidPointers(S, Loc, LHSExpr, RHSExpr);
 
     return !S.getLangOpts().CPlusPlus;
   }
@@ -11741,10 +11732,12 @@ static bool checkArithmeticBinOpPointerOperands(Sema &S, SourceLocation Loc,
   bool isLHSFuncPtr = isLHSPointer && LHSPointeeTy->isFunctionType();
   bool isRHSFuncPtr = isRHSPointer && RHSPointeeTy->isFunctionType();
   if (isLHSFuncPtr || isRHSFuncPtr) {
-    if (!isRHSFuncPtr) diagnoseArithmeticOnFunctionPointer(S, Loc, LHSExpr);
-    else if (!isLHSFuncPtr) diagnoseArithmeticOnFunctionPointer(S, Loc,
-                                                                RHSExpr);
-    else diagnoseArithmeticOnTwoFunctionPointers(S, Loc, LHSExpr, RHSExpr);
+    if (!isRHSFuncPtr)
+      diagnoseArithmeticOnFunctionPointer(S, Loc, LHSExpr);
+    else if (!isLHSFuncPtr)
+      diagnoseArithmeticOnFunctionPointer(S, Loc, RHSExpr);
+    else
+      diagnoseArithmeticOnTwoFunctionPointers(S, Loc, LHSExpr, RHSExpr);
 
     return !S.getLangOpts().CPlusPlus;
   }
@@ -11761,15 +11754,15 @@ static bool checkArithmeticBinOpPointerOperands(Sema &S, SourceLocation Loc,
 /// literal.
 static void diagnoseStringPlusInt(Sema &Self, SourceLocation OpLoc,
                                   Expr *LHSExpr, Expr *RHSExpr) {
-  StringLiteral* StrExpr = dyn_cast<StringLiteral>(LHSExpr->IgnoreImpCasts());
-  Expr* IndexExpr = RHSExpr;
+  StringLiteral *StrExpr = dyn_cast<StringLiteral>(LHSExpr->IgnoreImpCasts());
+  Expr *IndexExpr = RHSExpr;
   if (!StrExpr) {
     StrExpr = dyn_cast<StringLiteral>(RHSExpr->IgnoreImpCasts());
     IndexExpr = LHSExpr;
   }
 
-  bool IsStringPlusInt = StrExpr &&
-      IndexExpr->getType()->isIntegralOrUnscopedEnumerationType();
+  bool IsStringPlusInt =
+      StrExpr && IndexExpr->getType()->isIntegralOrUnscopedEnumerationType();
   if (!IsStringPlusInt || IndexExpr->isValueDependent())
     return;
 
@@ -11817,11 +11810,9 @@ static void diagnoseStringPlusChar(Sema &Self, SourceLocation OpLoc,
   SourceRange DiagRange(LHSExpr->getBeginLoc(), RHSExpr->getEndLoc());
 
   const QualType CharType = CharExpr->getType();
-  if (!CharType->isAnyCharacterType() &&
-      CharType->isIntegerType() &&
+  if (!CharType->isAnyCharacterType() && CharType->isIntegerType() &&
       llvm::isUIntN(Ctx.getCharWidth(), CharExpr->getValue())) {
-    Self.Diag(OpLoc, diag::warn_string_plus_char)
-        << DiagRange << Ctx.CharTy;
+    Self.Diag(OpLoc, diag::warn_string_plus_char) << DiagRange << Ctx.CharTy;
   } else {
     Self.Diag(OpLoc, diag::warn_string_plus_char)
         << DiagRange << CharExpr->getType();
@@ -11845,14 +11836,14 @@ static void diagnosePointerIncompatibility(Sema &S, SourceLocation Loc,
   assert(LHSExpr->getType()->isAnyPointerType());
   assert(RHSExpr->getType()->isAnyPointerType());
   S.Diag(Loc, diag::err_typecheck_sub_ptr_compatible)
-    << LHSExpr->getType() << RHSExpr->getType() << LHSExpr->getSourceRange()
-    << RHSExpr->getSourceRange();
+      << LHSExpr->getType() << RHSExpr->getType() << LHSExpr->getSourceRange()
+      << RHSExpr->getSourceRange();
 }
 
 // C99 6.5.6
 QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
                                      SourceLocation Loc, BinaryOperatorKind Opc,
-                                     QualType* CompLHSTy) {
+                                     QualType *CompLHSTy) {
   checkArithmeticNull(*this, LHS, RHS, Loc, /*IsCompare=*/false);
 
   if (LHS.get()->getType()->isVectorType() ||
@@ -11863,7 +11854,8 @@ QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
                             /*AllowBoolConversions*/ getLangOpts().ZVector,
                             /*AllowBooleanOperation*/ false,
                             /*ReportInvalid*/ true);
-    if (CompLHSTy) *CompLHSTy = compType;
+    if (CompLHSTy)
+      *CompLHSTy = compType;
     return compType;
   }
 
@@ -11898,7 +11890,8 @@ QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
 
   // handle the common case first (both operands are arithmetic).
   if (!compType.isNull() && compType->isArithmeticType()) {
-    if (CompLHSTy) *CompLHSTy = compType;
+    if (CompLHSTy)
+      *CompLHSTy = compType;
     return compType;
   }
 
@@ -11931,10 +11924,9 @@ QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
           Context, Expr::NPC_ValueDependentIsNotNull)) {
     // In C++ adding zero to a null pointer is defined.
     Expr::EvalResult KnownVal;
-    if (!getLangOpts().CPlusPlus ||
-        (!IExp->isValueDependent() &&
-         (!IExp->EvaluateAsInt(KnownVal, Context) ||
-          KnownVal.Val.getInt() != 0))) {
+    if (!getLangOpts().CPlusPlus || (!IExp->isValueDependent() &&
+                                     (!IExp->EvaluateAsInt(KnownVal, Context) ||
+                                      KnownVal.Val.getInt() != 0))) {
       // Check the conditions to see if this is the 'p = nullptr + n' idiom.
       bool IsGNUIdiom = BinaryOperator::isNullPointerArithmeticExtension(
           Context, BO_Add, PExp, IExp);
@@ -11967,7 +11959,7 @@ QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
 // C99 6.5.6
 QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
                                         SourceLocation Loc,
-                                        QualType* CompLHSTy) {
+                                        QualType *CompLHSTy) {
   checkArithmeticNull(*this, LHS, RHS, Loc, /*IsCompare=*/false);
 
   if (LHS.get()->getType()->isVectorType() ||
@@ -11978,7 +11970,8 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
                             /*AllowBoolConversions*/ getLangOpts().ZVector,
                             /*AllowBooleanOperation*/ false,
                             /*ReportInvalid*/ true);
-    if (CompLHSTy) *CompLHSTy = compType;
+    if (CompLHSTy)
+      *CompLHSTy = compType;
     return compType;
   }
 
@@ -12009,7 +12002,8 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
 
   // Handle the common case first (both operands are arithmetic).
   if (!compType.isNull() && compType->isArithmeticType()) {
-    if (CompLHSTy) *CompLHSTy = compType;
+    if (CompLHSTy)
+      *CompLHSTy = compType;
     return compType;
   }
 
@@ -12027,8 +12021,8 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
       // Subtracting from a null pointer should produce a warning.
       // The last argument to the diagnose call says this doesn't match the
       // GNU int-to-pointer idiom.
-      if (LHS.get()->IgnoreParenCasts()->isNullPointerConstant(Context,
-                                           Expr::NPC_ValueDependentIsNotNull)) {
+      if (LHS.get()->IgnoreParenCasts()->isNullPointerConstant(
+              Context, Expr::NPC_ValueDependentIsNotNull)) {
         // In C++ adding zero to a null pointer is defined.
         Expr::EvalResult KnownVal;
         if (!getLangOpts().CPlusPlus ||
@@ -12043,16 +12037,17 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
         return QualType();
 
       // Check array bounds for pointer arithemtic
-      CheckArrayAccess(LHS.get(), RHS.get(), /*ArraySubscriptExpr*/nullptr,
-                       /*AllowOnePastEnd*/true, /*IndexNegated*/true);
+      CheckArrayAccess(LHS.get(), RHS.get(), /*ArraySubscriptExpr*/ nullptr,
+                       /*AllowOnePastEnd*/ true, /*IndexNegated*/ true);
 
-      if (CompLHSTy) *CompLHSTy = LHS.get()->getType();
+      if (CompLHSTy)
+        *CompLHSTy = LHS.get()->getType();
       return LHS.get()->getType();
     }
 
     // Handle pointer-pointer subtractions.
-    if (const PointerType *RHSPTy
-          = RHS.get()->getType()->getAs<PointerType>()) {
+    if (const PointerType *RHSPTy =
+            RHS.get()->getType()->getAs<PointerType>()) {
       QualType rpointee = RHSPTy->getPointeeType();
 
       if (getLangOpts().CPlusPlus) {
@@ -12070,8 +12065,8 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
         }
       }
 
-      if (!checkArithmeticBinOpPointerOperands(*this, Loc,
-                                               LHS.get(), RHS.get()))
+      if (!checkArithmeticBinOpPointerOperands(*this, Loc, LHS.get(),
+                                               RHS.get()))
         return QualType();
 
       bool LHSIsNullPtr = LHS.get()->IgnoreParenCasts()->isNullPointerConstant(
@@ -12091,13 +12086,14 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
       if (!rpointee->isVoidType() && !rpointee->isFunctionType()) {
         CharUnits ElementSize = Context.getTypeSizeInChars(rpointee);
         if (ElementSize.isZero()) {
-          Diag(Loc,diag::warn_sub_ptr_zero_size_types)
-            << rpointee.getUnqualifiedType()
-            << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+          Diag(Loc, diag::warn_sub_ptr_zero_size_types)
+              << rpointee.getUnqualifiedType() << LHS.get()->getSourceRange()
+              << RHS.get()->getSourceRange();
         }
       }
 
-      if (CompLHSTy) *CompLHSTy = LHS.get()->getType();
+      if (CompLHSTy)
+        *CompLHSTy = LHS.get()->getType();
       return Context.getPointerDiffType();
     }
   }
@@ -12111,11 +12107,12 @@ static bool isScopedEnumerationType(QualType T) {
   return false;
 }
 
-static void DiagnoseBadShiftValues(Sema& S, ExprResult &LHS, ExprResult &RHS,
+static void DiagnoseBadShiftValues(Sema &S, ExprResult &LHS, ExprResult &RHS,
                                    SourceLocation Loc, BinaryOperatorKind Opc,
                                    QualType LHSType) {
-  // OpenCL 6.3j: shift values are effectively % word size of LHS (more defined),
-  // so skip remaining warnings as we don't want to modify values within Sema.
+  // OpenCL 6.3j: shift values are effectively % word size of LHS (more
+  // defined), so skip remaining warnings as we don't want to modify values
+  // within Sema.
   if (S.getLangOpts().OpenCL)
     return;
 
@@ -12129,7 +12126,7 @@ static void DiagnoseBadShiftValues(Sema& S, ExprResult &LHS, ExprResult &RHS,
   if (Right.isNegative()) {
     S.DiagRuntimeBehavior(Loc, RHS.get(),
                           S.PDiag(diag::warn_shift_negative)
-                            << RHS.get()->getSourceRange());
+                              << RHS.get()->getSourceRange());
     return;
   }
 
@@ -12144,7 +12141,7 @@ static void DiagnoseBadShiftValues(Sema& S, ExprResult &LHS, ExprResult &RHS,
   if (Right.uge(LeftSize)) {
     S.DiagRuntimeBehavior(Loc, RHS.get(),
                           S.PDiag(diag::warn_shift_gt_typewidth)
-                            << RHS.get()->getSourceRange());
+                              << RHS.get()->getSourceRange());
     return;
   }
 
@@ -12177,7 +12174,7 @@ static void DiagnoseBadShiftValues(Sema& S, ExprResult &LHS, ExprResult &RHS,
   if (Left.isNegative()) {
     S.DiagRuntimeBehavior(Loc, LHS.get(),
                           S.PDiag(diag::warn_shift_lhs_negative)
-                            << LHS.get()->getSourceRange());
+                              << LHS.get()->getSourceRange());
     return;
   }
 
@@ -12199,8 +12196,8 @@ static void DiagnoseBadShiftValues(Sema& S, ExprResult &LHS, ExprResult &RHS,
   // turned off separately if needed.
   if (ResultBits - 1 == LeftSize) {
     S.Diag(Loc, diag::warn_shift_result_sets_sign_bit)
-        << HexResult << LHSType
-        << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+        << HexResult << LHSType << LHS.get()->getSourceRange()
+        << RHS.get()->getSourceRange();
     return;
   }
 
@@ -12218,18 +12215,20 @@ static QualType checkVectorShift(Sema &S, ExprResult &LHS, ExprResult &RHS,
   if ((S.LangOpts.OpenCL || S.LangOpts.ZVector) &&
       !LHS.get()->getType()->isVectorType()) {
     S.Diag(Loc, diag::err_shift_rhs_only_vector)
-      << RHS.get()->getType() << LHS.get()->getType()
-      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+        << RHS.get()->getType() << LHS.get()->getType()
+        << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
     return QualType();
   }
 
   if (!IsCompAssign) {
     LHS = S.UsualUnaryConversions(LHS.get());
-    if (LHS.isInvalid()) return QualType();
+    if (LHS.isInvalid())
+      return QualType();
   }
 
   RHS = S.UsualUnaryConversions(RHS.get());
-  if (RHS.isInvalid()) return QualType();
+  if (RHS.isInvalid())
+    return QualType();
 
   QualType LHSType = LHS.get()->getType();
   // Note that LHS might be a scalar because the routine calls not only in
@@ -12254,13 +12253,13 @@ static QualType checkVectorShift(Sema &S, ExprResult &LHS, ExprResult &RHS,
   // The operands need to be integers.
   if (!LHSEleType->isIntegerType()) {
     S.Diag(Loc, diag::err_typecheck_expect_int)
-      << LHS.get()->getType() << LHS.get()->getSourceRange();
+        << LHS.get()->getType() << LHS.get()->getSourceRange();
     return QualType();
   }
 
   if (!RHSEleType->isIntegerType()) {
     S.Diag(Loc, diag::err_typecheck_expect_int)
-      << RHS.get()->getType() << RHS.get()->getSourceRange();
+        << RHS.get()->getType() << RHS.get()->getSourceRange();
     return QualType();
   }
 
@@ -12269,7 +12268,7 @@ static QualType checkVectorShift(Sema &S, ExprResult &LHS, ExprResult &RHS,
     if (IsCompAssign)
       return RHSType;
     if (LHSEleType != RHSEleType) {
-      LHS = S.ImpCastExprToType(LHS.get(),RHSEleType, CK_IntegralCast);
+      LHS = S.ImpCastExprToType(LHS.get(), RHSEleType, CK_IntegralCast);
       LHSEleType = RHSEleType;
     }
     QualType VecTy =
@@ -12282,8 +12281,8 @@ static QualType checkVectorShift(Sema &S, ExprResult &LHS, ExprResult &RHS,
     // that the number of elements is the same as LHS...
     if (RHSVecTy->getNumElements() != LHSVecTy->getNumElements()) {
       S.Diag(Loc, diag::err_typecheck_vector_lengths_not_equal)
-        << LHS.get()->getType() << RHS.get()->getType()
-        << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+          << LHS.get()->getType() << RHS.get()->getType()
+          << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
       return QualType();
     }
     if (!S.LangOpts.OpenCL && !S.LangOpts.ZVector) {
@@ -12299,7 +12298,7 @@ static QualType checkVectorShift(Sema &S, ExprResult &LHS, ExprResult &RHS,
   } else {
     // ...else expand RHS to match the number of elements in LHS.
     QualType VecTy =
-      S.Context.getExtVectorType(RHSEleType, LHSVecTy->getNumElements());
+        S.Context.getExtVectorType(RHSEleType, LHSVecTy->getNumElements());
     RHS = S.ImpCastExprToType(RHS.get(), VecTy, CK_VectorSplat);
   }
 
@@ -12434,7 +12433,8 @@ QualType Sema::CheckShiftOperands(ExprResult &LHS, ExprResult &RHS,
   if (LHS.isInvalid())
     return QualType();
   QualType LHSType = LHS.get()->getType();
-  if (IsCompAssign) LHS = OldLHS;
+  if (IsCompAssign)
+    LHS = OldLHS;
 
   // The RHS is simpler.
   RHS = UsualUnaryConversions(RHS.get());
@@ -12451,8 +12451,7 @@ QualType Sema::CheckShiftOperands(ExprResult &LHS, ExprResult &RHS,
 
   // C++0x: Don't allow scoped enums. FIXME: Use something better than
   // hasIntegerRepresentation() above instead of this.
-  if (isScopedEnumerationType(LHSType) ||
-      isScopedEnumerationType(RHSType)) {
+  if (isScopedEnumerationType(LHSType) || isScopedEnumerationType(RHSType)) {
     return InvalidOperands(Loc, LHS, RHS);
   }
   DiagnoseBadShiftValues(*this, LHS, RHS, Loc, Opc, LHSType);
@@ -12467,8 +12466,8 @@ static void diagnoseDistinctPointerComparison(Sema &S, SourceLocation Loc,
                                               bool IsError) {
   S.Diag(Loc, IsError ? diag::err_typecheck_comparison_of_distinct_pointers
                       : diag::ext_typecheck_comparison_of_distinct_pointers)
-    << LHS.get()->getType() << RHS.get()->getType()
-    << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      << LHS.get()->getType() << RHS.get()->getType()
+      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
 }
 
 /// Returns false if the pointers are converted to a composite type,
@@ -12493,7 +12492,7 @@ static bool convertPointersToCompositeType(Sema &S, SourceLocation Loc,
   if (T.isNull()) {
     if ((LHSType->isAnyPointerType() || LHSType->isMemberPointerType()) &&
         (RHSType->isAnyPointerType() || RHSType->isMemberPointerType()))
-      diagnoseDistinctPointerComparison(S, Loc, LHS, RHS, /*isError*/true);
+      diagnoseDistinctPointerComparison(S, Loc, LHS, RHS, /*isError*/ true);
     else
       S.InvalidOperands(Loc, LHS, RHS);
     return true;
@@ -12508,8 +12507,8 @@ static void diagnoseFunctionPointerToVoidComparison(Sema &S, SourceLocation Loc,
                                                     bool IsError) {
   S.Diag(Loc, IsError ? diag::err_typecheck_comparison_of_fptr_to_void
                       : diag::ext_typecheck_comparison_of_fptr_to_void)
-    << LHS.get()->getType() << RHS.get()->getType()
-    << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+      << LHS.get()->getType() << RHS.get()->getType()
+      << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
 }
 
 static bool isObjCObjectLiteral(ExprResult &E) {
@@ -12527,7 +12526,7 @@ static bool isObjCObjectLiteral(ExprResult &E) {
 
 static bool hasIsEqualMethod(Sema &S, const Expr *LHS, const Expr *RHS) {
   const ObjCObjectPointerType *Type =
-    LHS->getType()->getAs<ObjCObjectPointerType>();
+      LHS->getType()->getAs<ObjCObjectPointerType>();
 
   // If this is not actually an Objective-C object, bail out.
   if (!Type)
@@ -12542,8 +12541,7 @@ static bool hasIsEqualMethod(Sema &S, const Expr *LHS, const Expr *RHS) {
 
   // Try to find the -isEqual: method.
   Selector IsEqualSel = S.NSAPIObj->getIsEqualSelector();
-  ObjCMethodDecl *Method = S.LookupMethodInObjectType(IsEqualSel,
-                                                      InterfaceType,
+  ObjCMethodDecl *Method = S.LookupMethodInObjectType(IsEqualSel, InterfaceType,
                                                       /*IsInstance=*/true);
   if (!Method) {
     if (Type->isObjCIdType()) {
@@ -12574,48 +12572,48 @@ static bool hasIsEqualMethod(Sema &S, const Expr *LHS, const Expr *RHS) {
 Sema::ObjCLiteralKind Sema::CheckLiteralKind(Expr *FromE) {
   FromE = FromE->IgnoreParenImpCasts();
   switch (FromE->getStmtClass()) {
+  default:
+    break;
+  case Stmt::ObjCStringLiteralClass:
+    // "string literal"
+    return LK_String;
+  case Stmt::ObjCArrayLiteralClass:
+    // "array literal"
+    return LK_Array;
+  case Stmt::ObjCDictionaryLiteralClass:
+    // "dictionary literal"
+    return LK_Dictionary;
+  case Stmt::BlockExprClass:
+    return LK_Block;
+  case Stmt::ObjCBoxedExprClass: {
+    Expr *Inner = cast<ObjCBoxedExpr>(FromE)->getSubExpr()->IgnoreParens();
+    switch (Inner->getStmtClass()) {
+    case Stmt::IntegerLiteralClass:
+    case Stmt::FloatingLiteralClass:
+    case Stmt::CharacterLiteralClass:
+    case Stmt::ObjCBoolLiteralExprClass:
+    case Stmt::CXXBoolLiteralExprClass:
+      // "numeric literal"
+      return LK_Numeric;
+    case Stmt::ImplicitCastExprClass: {
+      CastKind CK = cast<CastExpr>(Inner)->getCastKind();
+      // Boolean literals can be represented by implicit casts.
+      if (CK == CK_IntegralToBoolean || CK == CK_IntegralCast)
+        return LK_Numeric;
+      break;
+    }
     default:
       break;
-    case Stmt::ObjCStringLiteralClass:
-      // "string literal"
-      return LK_String;
-    case Stmt::ObjCArrayLiteralClass:
-      // "array literal"
-      return LK_Array;
-    case Stmt::ObjCDictionaryLiteralClass:
-      // "dictionary literal"
-      return LK_Dictionary;
-    case Stmt::BlockExprClass:
-      return LK_Block;
-    case Stmt::ObjCBoxedExprClass: {
-      Expr *Inner = cast<ObjCBoxedExpr>(FromE)->getSubExpr()->IgnoreParens();
-      switch (Inner->getStmtClass()) {
-        case Stmt::IntegerLiteralClass:
-        case Stmt::FloatingLiteralClass:
-        case Stmt::CharacterLiteralClass:
-        case Stmt::ObjCBoolLiteralExprClass:
-        case Stmt::CXXBoolLiteralExprClass:
-          // "numeric literal"
-          return LK_Numeric;
-        case Stmt::ImplicitCastExprClass: {
-          CastKind CK = cast<CastExpr>(Inner)->getCastKind();
-          // Boolean literals can be represented by implicit casts.
-          if (CK == CK_IntegralToBoolean || CK == CK_IntegralCast)
-            return LK_Numeric;
-          break;
-        }
-        default:
-          break;
-      }
-      return LK_Boxed;
     }
+    return LK_Boxed;
+  }
   }
   return LK_None;
 }
 
 static void diagnoseObjCLiteralComparison(Sema &S, SourceLocation Loc,
                                           ExprResult &LHS, ExprResult &RHS,
-                                          BinaryOperator::Opcode Opc){
+                                          BinaryOperator::Opcode Opc) {
   Expr *Literal;
   Expr *Other;
   if (isObjCObjectLiteral(LHS)) {
@@ -12643,22 +12641,22 @@ static void diagnoseObjCLiteralComparison(Sema &S, SourceLocation Loc,
 
   if (LiteralKind == Sema::LK_String)
     S.Diag(Loc, diag::warn_objc_string_literal_comparison)
-      << Literal->getSourceRange();
+        << Literal->getSourceRange();
   else
     S.Diag(Loc, diag::warn_objc_literal_comparison)
-      << LiteralKind << Literal->getSourceRange();
+        << LiteralKind << Literal->getSourceRange();
 
   if (BinaryOperator::isEqualityOp(Opc) &&
       hasIsEqualMethod(S, LHS.get(), RHS.get())) {
     SourceLocation Start = LHS.get()->getBeginLoc();
     SourceLocation End = S.getLocForEndOfToken(RHS.get()->getEndLoc());
     CharSourceRange OpRange =
-      CharSourceRange::getCharRange(Loc, S.getLocForEndOfToken(Loc));
+        CharSourceRange::getCharRange(Loc, S.getLocForEndOfToken(Loc));
 
     S.Diag(Loc, diag::note_objc_literal_comparison_isequal)
-      << FixItHint::CreateInsertion(Start, Opc == BO_EQ ? "[" : "![")
-      << FixItHint::CreateReplacement(OpRange, " isEqual:")
-      << FixItHint::CreateInsertion(End, "]");
+        << FixItHint::CreateInsertion(Start, Opc == BO_EQ ? "[" : "![")
+        << FixItHint::CreateReplacement(OpRange, " isEqual:")
+        << FixItHint::CreateInsertion(End, "]");
   }
 }
 
@@ -12668,14 +12666,17 @@ static void diagnoseLogicalNotOnLHSofCheck(Sema &S, ExprResult &LHS,
                                            BinaryOperatorKind Opc) {
   // Check that left hand side is !something.
   UnaryOperator *UO = dyn_cast<UnaryOperator>(LHS.get()->IgnoreImpCasts());
-  if (!UO || UO->getOpcode() != UO_LNot) return;
+  if (!UO || UO->getOpcode() != UO_LNot)
+    return;
 
   // Only check if the right hand side is non-bool arithmetic type.
-  if (RHS.get()->isKnownToHaveBooleanValue()) return;
+  if (RHS.get()->isKnownToHaveBooleanValue())
+    return;
 
   // Make sure that the something in !something is not bool.
   Expr *SubExpr = UO->getSubExpr()->IgnoreImpCasts();
-  if (SubExpr->isKnownToHaveBooleanValue()) return;
+  if (SubExpr->isKnownToHaveBooleanValue())
+    return;
 
   // Emit warning.
   bool IsBitwiseOp = Opc == BO_And || Opc == BO_Or || Opc == BO_Xor;
@@ -12689,8 +12690,7 @@ static void diagnoseLogicalNotOnLHSofCheck(Sema &S, ExprResult &LHS,
   if (FirstClose.isInvalid())
     FirstOpen = SourceLocation();
   S.Diag(UO->getOperatorLoc(), diag::note_logical_not_fix)
-      << IsBitwiseOp
-      << FixItHint::CreateInsertion(FirstOpen, "(")
+      << IsBitwiseOp << FixItHint::CreateInsertion(FirstOpen, "(")
       << FixItHint::CreateInsertion(FirstClose, ")");
 
   // Second note suggests (!x) < y
@@ -12837,8 +12837,8 @@ static void diagnoseTautologicalComparison(Sema &S, SourceLocation Loc,
     LiteralStringStripped = LHSStripped;
   } else if ((isa<StringLiteral>(RHSStripped) ||
               isa<ObjCEncodeExpr>(RHSStripped)) &&
-             !LHSStripped->isNullPointerConstant(S.Context,
-                                          Expr::NPC_ValueDependentIsNull)) {
+             !LHSStripped->isNullPointerConstant(
+                 S.Context, Expr::NPC_ValueDependentIsNull)) {
     LiteralString = RHS;
     LiteralStringStripped = RHSStripped;
   }
@@ -13047,7 +13047,7 @@ void Sema::CheckPtrComparisonWithNullChar(ExprResult &E, ExprResult &NullE) {
   if (!E.get()->getType()->isAnyPointerType() &&
       E.get()->isNullPointerConstant(Context,
                                      Expr::NPC_ValueDependentIsNotNull) ==
-        Expr::NPCK_ZeroExpression) {
+          Expr::NPCK_ZeroExpression) {
     if (const auto *CL = dyn_cast<CharacterLiteral>(E.get())) {
       if (CL->getValue() == 0)
         Diag(E.get()->getExprLoc(), diag::warn_pointer_compare)
@@ -13055,14 +13055,14 @@ void Sema::CheckPtrComparisonWithNullChar(ExprResult &E, ExprResult &NullE) {
             << FixItHint::CreateReplacement(E.get()->getExprLoc(),
                                             NullValue ? "NULL" : "(void *)0");
     } else if (const auto *CE = dyn_cast<CStyleCastExpr>(E.get())) {
-        TypeSourceInfo *TI = CE->getTypeInfoAsWritten();
-        QualType T = Context.getCanonicalType(TI->getType()).getUnqualifiedType();
-        if (T == Context.CharTy)
-          Diag(E.get()->getExprLoc(), diag::warn_pointer_compare)
-              << NullValue
-              << FixItHint::CreateReplacement(E.get()->getExprLoc(),
-                                              NullValue ? "NULL" : "(void *)0");
-      }
+      TypeSourceInfo *TI = CE->getTypeInfoAsWritten();
+      QualType T = Context.getCanonicalType(TI->getType()).getUnqualifiedType();
+      if (T == Context.CharTy)
+        Diag(E.get()->getExprLoc(), diag::warn_pointer_compare)
+            << NullValue
+            << FixItHint::CreateReplacement(E.get()->getExprLoc(),
+                                            NullValue ? "NULL" : "(void *)0");
+    }
   }
 }
 
@@ -13239,9 +13239,9 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
     // All of the following pointer-related warnings are GCC extensions, except
     // when handling null pointer constants.
     QualType LCanPointeeTy =
-      LHSType->castAs<PointerType>()->getPointeeType().getCanonicalType();
+        LHSType->castAs<PointerType>()->getPointeeType().getCanonicalType();
     QualType RCanPointeeTy =
-      RHSType->castAs<PointerType>()->getPointeeType().getCanonicalType();
+        RHSType->castAs<PointerType>()->getPointeeType().getCanonicalType();
 
     // C99 6.5.9p2 and C99 6.5.8p2
     if (Context.typesAreCompatible(LCanPointeeTy.getUnqualifiedType(),
@@ -13260,13 +13260,15 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
     } else if (!IsRelational &&
                (LCanPointeeTy->isVoidType() || RCanPointeeTy->isVoidType())) {
       // Valid unless comparison between non-null pointer and function pointer
-      if ((LCanPointeeTy->isFunctionType() || RCanPointeeTy->isFunctionType())
-          && !LHSIsNull && !RHSIsNull)
+      if ((LCanPointeeTy->isFunctionType() ||
+           RCanPointeeTy->isFunctionType()) &&
+          !LHSIsNull && !RHSIsNull)
         diagnoseFunctionPointerToVoidComparison(*this, Loc, LHS, RHS,
-                                                /*isError*/false);
+                                                /*isError*/ false);
     } else {
       // Invalid
-      diagnoseDistinctPointerComparison(*this, Loc, LHS, RHS, /*isError*/false);
+      diagnoseDistinctPointerComparison(*this, Loc, LHS, RHS,
+                                        /*isError*/ false);
     }
     if (LCanPointeeTy != RCanPointeeTy) {
       // Treat NULL constant as a special case in OpenCL.
@@ -13280,8 +13282,8 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
       }
       LangAS AddrSpaceL = LCanPointeeTy.getAddressSpace();
       LangAS AddrSpaceR = RCanPointeeTy.getAddressSpace();
-      CastKind Kind = AddrSpaceL != AddrSpaceR ? CK_AddressSpaceConversion
-                                               : CK_BitCast;
+      CastKind Kind =
+          AddrSpaceL != AddrSpaceR ? CK_AddressSpaceConversion : CK_BitCast;
       if (LHSIsNull && !RHSIsNull)
         LHS = ImpCastExprToType(LHS.get(), RHSType, Kind);
       else
@@ -13289,7 +13291,6 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
     }
     return computeResultTy();
   }
-
 
   // C++ [expr.eq]p4:
   //   Two operands of type std::nullptr_t or one operand of type
@@ -13385,34 +13386,36 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
     if (!LHSIsNull && !RHSIsNull &&
         !Context.typesAreCompatible(lpointee, rpointee)) {
       Diag(Loc, diag::err_typecheck_comparison_of_distinct_blocks)
-        << LHSType << RHSType << LHS.get()->getSourceRange()
-        << RHS.get()->getSourceRange();
+          << LHSType << RHSType << LHS.get()->getSourceRange()
+          << RHS.get()->getSourceRange();
     }
     RHS = ImpCastExprToType(RHS.get(), LHSType, CK_BitCast);
     return computeResultTy();
   }
 
   // Allow block pointers to be compared with null pointer constants.
-  if (!IsOrdered
-      && ((LHSType->isBlockPointerType() && RHSType->isPointerType())
-          || (LHSType->isPointerType() && RHSType->isBlockPointerType()))) {
+  if (!IsOrdered &&
+      ((LHSType->isBlockPointerType() && RHSType->isPointerType()) ||
+       (LHSType->isPointerType() && RHSType->isBlockPointerType()))) {
     if (!LHSIsNull && !RHSIsNull) {
-      if (!((RHSType->isPointerType() && RHSType->castAs<PointerType>()
-             ->getPointeeType()->isVoidType())
-            || (LHSType->isPointerType() && LHSType->castAs<PointerType>()
-                ->getPointeeType()->isVoidType())))
+      if (!((RHSType->isPointerType() &&
+             RHSType->castAs<PointerType>()->getPointeeType()->isVoidType()) ||
+            (LHSType->isPointerType() &&
+             LHSType->castAs<PointerType>()->getPointeeType()->isVoidType())))
         Diag(Loc, diag::err_typecheck_comparison_of_distinct_blocks)
-          << LHSType << RHSType << LHS.get()->getSourceRange()
-          << RHS.get()->getSourceRange();
+            << LHSType << RHSType << LHS.get()->getSourceRange()
+            << RHS.get()->getSourceRange();
     }
     if (LHSIsNull && !RHSIsNull)
       LHS = ImpCastExprToType(LHS.get(), RHSType,
-                              RHSType->isPointerType() ? CK_BitCast
-                                : CK_AnyPointerToBlockPointerCast);
+                              RHSType->isPointerType()
+                                  ? CK_BitCast
+                                  : CK_AnyPointerToBlockPointerCast);
     else
       RHS = ImpCastExprToType(RHS.get(), LHSType,
-                              LHSType->isPointerType() ? CK_BitCast
-                                : CK_AnyPointerToBlockPointerCast);
+                              LHSType->isPointerType()
+                                  ? CK_BitCast
+                                  : CK_AnyPointerToBlockPointerCast);
     return computeResultTy();
   }
 
@@ -13427,7 +13430,7 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
       if (!LPtrToVoid && !RPtrToVoid &&
           !Context.typesAreCompatible(LHSType, RHSType)) {
         diagnoseDistinctPointerComparison(*this, Loc, LHS, RHS,
-                                          /*isError*/false);
+                                          /*isError*/ false);
       }
       // FIXME: If LPtrToVoid, we should presumably convert the LHS rather than
       // the RHS, but we have test coverage for this behavior.
@@ -13437,17 +13440,16 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
         if (getLangOpts().ObjCAutoRefCount)
           CheckObjCConversion(SourceRange(), RHSType, E,
                               CCK_ImplicitConversion);
-        LHS = ImpCastExprToType(E, RHSType,
-                                RPT ? CK_BitCast :CK_CPointerToObjCPointerCast);
-      }
-      else {
+        LHS = ImpCastExprToType(
+            E, RHSType, RPT ? CK_BitCast : CK_CPointerToObjCPointerCast);
+      } else {
         Expr *E = RHS.get();
         if (getLangOpts().ObjCAutoRefCount)
           CheckObjCConversion(SourceRange(), LHSType, E, CCK_ImplicitConversion,
                               /*Diagnose=*/true,
                               /*DiagnoseCFAudited=*/false, Opc);
-        RHS = ImpCastExprToType(E, LHSType,
-                                LPT ? CK_BitCast :CK_CPointerToObjCPointerCast);
+        RHS = ImpCastExprToType(
+            E, LHSType, LPT ? CK_BitCast : CK_CPointerToObjCPointerCast);
       }
       return computeResultTy();
     }
@@ -13455,7 +13457,7 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
         RHSType->isObjCObjectPointerType()) {
       if (!Context.areComparableObjCPointerTypes(LHSType, RHSType))
         diagnoseDistinctPointerComparison(*this, Loc, LHS, RHS,
-                                          /*isError*/false);
+                                          /*isError*/ false);
       if (isObjCObjectLiteral(LHS) || isObjCObjectLiteral(RHS))
         diagnoseObjCLiteralComparison(*this, Loc, LHS, RHS, Opc);
 
@@ -13491,8 +13493,9 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
       if (IsOrdered) {
         isError = getLangOpts().CPlusPlus;
         DiagID =
-          isError ? diag::err_typecheck_ordered_comparison_of_pointer_and_zero
-                  : diag::ext_typecheck_ordered_comparison_of_pointer_and_zero;
+            isError
+                ? diag::err_typecheck_ordered_comparison_of_pointer_and_zero
+                : diag::ext_typecheck_ordered_comparison_of_pointer_and_zero;
       }
     } else if (getLangOpts().CPlusPlus) {
       DiagID = diag::err_typecheck_comparison_of_pointer_integer;
@@ -13503,30 +13506,31 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
       DiagID = diag::ext_typecheck_comparison_of_pointer_integer;
 
     if (DiagID) {
-      Diag(Loc, DiagID)
-        << LHSType << RHSType << LHS.get()->getSourceRange()
-        << RHS.get()->getSourceRange();
+      Diag(Loc, DiagID) << LHSType << RHSType << LHS.get()->getSourceRange()
+                        << RHS.get()->getSourceRange();
       if (isError)
         return QualType();
     }
 
     if (LHSType->isIntegerType())
       LHS = ImpCastExprToType(LHS.get(), RHSType,
-                        LHSIsNull ? CK_NullToPointer : CK_IntegralToPointer);
+                              LHSIsNull ? CK_NullToPointer
+                                        : CK_IntegralToPointer);
     else
       RHS = ImpCastExprToType(RHS.get(), LHSType,
-                        RHSIsNull ? CK_NullToPointer : CK_IntegralToPointer);
+                              RHSIsNull ? CK_NullToPointer
+                                        : CK_IntegralToPointer);
     return computeResultTy();
   }
 
   // Handle block pointers.
-  if (!IsOrdered && RHSIsNull
-      && LHSType->isBlockPointerType() && RHSType->isIntegerType()) {
+  if (!IsOrdered && RHSIsNull && LHSType->isBlockPointerType() &&
+      RHSType->isIntegerType()) {
     RHS = ImpCastExprToType(RHS.get(), LHSType, CK_NullToPointer);
     return computeResultTy();
   }
-  if (!IsOrdered && LHSIsNull
-      && LHSType->isIntegerType() && RHSType->isBlockPointerType()) {
+  if (!IsOrdered && LHSIsNull && LHSType->isIntegerType() &&
+      RHSType->isBlockPointerType()) {
     LHS = ImpCastExprToType(LHS.get(), RHSType, CK_NullToPointer);
     return computeResultTy();
   }
@@ -14143,11 +14147,14 @@ inline QualType Sema::CheckLogicalOperands(ExprResult &LHS, ExprResult &RHS,
 
 static bool IsReadonlyMessage(Expr *E, Sema &S) {
   const MemberExpr *ME = dyn_cast<MemberExpr>(E);
-  if (!ME) return false;
-  if (!isa<FieldDecl>(ME->getMemberDecl())) return false;
+  if (!ME)
+    return false;
+  if (!isa<FieldDecl>(ME->getMemberDecl()))
+    return false;
   ObjCMessageExpr *Base = dyn_cast<ObjCMessageExpr>(
       ME->getBase()->IgnoreImplicit()->IgnoreParenImpCasts());
-  if (!Base) return false;
+  if (!Base)
+    return false;
   return Base->getMethodDecl() != nullptr;
 }
 
@@ -14161,13 +14168,17 @@ static NonConstCaptureKind isReferenceToNonConstCapture(Sema &S, Expr *E) {
 
   // Must be a reference to a declaration from an enclosing scope.
   DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E);
-  if (!DRE) return NCCK_None;
-  if (!DRE->refersToEnclosingVariableOrCapture()) return NCCK_None;
+  if (!DRE)
+    return NCCK_None;
+  if (!DRE->refersToEnclosingVariableOrCapture())
+    return NCCK_None;
 
   // The declaration must be a variable which is not declared 'const'.
   VarDecl *var = dyn_cast<VarDecl>(DRE->getDecl());
-  if (!var) return NCCK_None;
-  if (var->getType().isConstQualified()) return NCCK_None;
+  if (!var)
+    return NCCK_None;
+  if (var->getType().isConstQualified())
+    return NCCK_None;
   assert(var->hasLocalStorage() && "capture added 'const' to non-local?");
 
   // Decide whether the first capture was for a block or a lambda.
@@ -14206,7 +14217,7 @@ enum {
   ConstMember,
   ConstMethod,
   NestedConstMember,
-  ConstUnknown,  // Keep as last element
+  ConstUnknown, // Keep as last element
 };
 
 /// Emit the "read-only variable not assignable" error and print notes to give
@@ -14287,8 +14298,8 @@ static void DiagnoseConstAssignment(Sema &S, const Expr *E,
     const FunctionDecl *FD = CE->getDirectCallee();
     if (FD && !IsTypeModifiable(FD->getReturnType(), IsDereference)) {
       if (!DiagnosticEmitted) {
-        S.Diag(Loc, diag::err_typecheck_assign_const) << ExprRange
-                                                      << ConstFunction << FD;
+        S.Diag(Loc, diag::err_typecheck_assign_const)
+            << ExprRange << ConstFunction << FD;
         DiagnosticEmitted = true;
       }
       S.Diag(FD->getReturnTypeSourceRange().getBegin(),
@@ -14314,8 +14325,8 @@ static void DiagnoseConstAssignment(Sema &S, const Expr *E,
       if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(DC)) {
         if (MD->isConst()) {
           if (!DiagnosticEmitted) {
-            S.Diag(Loc, diag::err_typecheck_assign_const) << ExprRange
-                                                          << ConstMethod << MD;
+            S.Diag(Loc, diag::err_typecheck_assign_const)
+                << ExprRange << ConstMethod << MD;
             DiagnosticEmitted = true;
           }
           S.Diag(MD->getLocation(), diag::note_typecheck_assign_const)
@@ -14332,11 +14343,7 @@ static void DiagnoseConstAssignment(Sema &S, const Expr *E,
   S.Diag(Loc, diag::err_typecheck_assign_const) << ExprRange << ConstUnknown;
 }
 
-enum OriginalExprKind {
-  OEK_Variable,
-  OEK_Member,
-  OEK_LValue
-};
+enum OriginalExprKind { OEK_Variable, OEK_Member, OEK_LValue };
 
 static void DiagnoseRecursiveConstFields(Sema &S, const ValueDecl *VD,
                                          const RecordType *Ty,
@@ -14357,13 +14364,12 @@ static void DiagnoseRecursiveConstFields(Sema &S, const ValueDecl *VD,
       if (FieldTy.isConstQualified()) {
         if (!DiagnosticEmitted) {
           S.Diag(Loc, diag::err_typecheck_assign_const)
-              << Range << NestedConstMember << OEK << VD
-              << IsNested << Field;
+              << Range << NestedConstMember << OEK << VD << IsNested << Field;
           DiagnosticEmitted = true;
         }
         S.Diag(Field->getLocation(), diag::note_typecheck_assign_const)
-            << NestedConstMember << IsNested << Field
-            << FieldTy << Field->getSourceRange();
+            << NestedConstMember << IsNested << Field << FieldTy
+            << Field->getSourceRange();
       }
 
       // Then we append it to the list to check next in order.
@@ -14388,14 +14394,14 @@ static void DiagnoseRecursiveConstFields(Sema &S, const Expr *E,
   bool DiagEmitted = false;
 
   if (const MemberExpr *ME = dyn_cast<MemberExpr>(E))
-    DiagnoseRecursiveConstFields(S, ME->getMemberDecl(), RTy, Loc,
-            Range, OEK_Member, DiagEmitted);
+    DiagnoseRecursiveConstFields(S, ME->getMemberDecl(), RTy, Loc, Range,
+                                 OEK_Member, DiagEmitted);
   else if (const DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E))
-    DiagnoseRecursiveConstFields(S, DRE->getDecl(), RTy, Loc,
-            Range, OEK_Variable, DiagEmitted);
+    DiagnoseRecursiveConstFields(S, DRE->getDecl(), RTy, Loc, Range,
+                                 OEK_Variable, DiagEmitted);
   else
-    DiagnoseRecursiveConstFields(S, nullptr, RTy, Loc,
-            Range, OEK_LValue, DiagEmitted);
+    DiagnoseRecursiveConstFields(S, nullptr, RTy, Loc, Range, OEK_LValue,
+                                 DiagEmitted);
   if (!DiagEmitted)
     DiagnoseConstAssignment(S, E, Loc);
 }
@@ -14408,8 +14414,7 @@ static bool CheckForModifiableLvalue(Expr *E, SourceLocation Loc, Sema &S) {
   S.CheckShadowingDeclModification(E, Loc);
 
   SourceLocation OrigLoc = Loc;
-  Expr::isModifiableLvalueResult IsLV = E->isModifiableLvalue(S.Context,
-                                                              &Loc);
+  Expr::isModifiableLvalueResult IsLV = E->isModifiableLvalue(S.Context, &Loc);
   if (IsLV == Expr::MLV_ClassTemporary && IsReadonlyMessage(E, S))
     IsLV = Expr::MLV_InvalidMessageExpression;
   if (IsLV == Expr::MLV_Valid)
@@ -14446,15 +14451,15 @@ static bool CheckForModifiableLvalue(Expr *E, SourceLocation Loc, Sema &S) {
           ObjCMethodDecl *method = S.getCurMethodDecl();
           if (method && var == method->getSelfDecl()) {
             DiagID = method->isClassMethod()
-              ? diag::err_typecheck_arc_assign_self_class_method
-              : diag::err_typecheck_arc_assign_self;
+                         ? diag::err_typecheck_arc_assign_self_class_method
+                         : diag::err_typecheck_arc_assign_self;
 
-          //  - Objective-C externally_retained attribute.
+            //  - Objective-C externally_retained attribute.
           } else if (var->hasAttr<ObjCExternallyRetainedAttr>() ||
                      isa<ParmVarDecl>(var)) {
             DiagID = diag::err_typecheck_arc_assign_externally_retained;
 
-          //  - fast enumeration variables
+            //  - fast enumeration variables
           } else {
             DiagID = diag::err_typecheck_arr_assign_enumeration;
           }
@@ -14505,8 +14510,9 @@ static bool CheckForModifiableLvalue(Expr *E, SourceLocation Loc, Sema &S) {
     break;
   case Expr::MLV_IncompleteType:
   case Expr::MLV_IncompleteVoidType:
-    return S.RequireCompleteType(Loc, E->getType(),
-             diag::err_typecheck_incomplete_type_not_modifiable_lvalue, E);
+    return S.RequireCompleteType(
+        Loc, E->getType(),
+        diag::err_typecheck_incomplete_type_not_modifiable_lvalue, E);
   case Expr::MLV_DuplicateVectorComponents:
     DiagID = diag::err_typecheck_duplicate_vector_components_not_mlvalue;
     break;
@@ -14531,8 +14537,7 @@ static bool CheckForModifiableLvalue(Expr *E, SourceLocation Loc, Sema &S) {
 }
 
 static void CheckIdentityFieldAssignment(Expr *LHSExpr, Expr *RHSExpr,
-                                         SourceLocation Loc,
-                                         Sema &Sema) {
+                                         SourceLocation Loc, Sema &Sema) {
   if (Sema.inTemplateInstantiation())
     return;
   if (Sema.isUnevaluatedContext())
@@ -14586,16 +14591,16 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
     return QualType();
 
   QualType LHSType = LHSExpr->getType();
-  QualType RHSType = CompoundType.isNull() ? RHS.get()->getType() :
-                                             CompoundType;
+  QualType RHSType =
+      CompoundType.isNull() ? RHS.get()->getType() : CompoundType;
   // OpenCL v1.2 s6.1.1.1 p2:
   // The half data type can only be used to declare a pointer to a buffer that
   // contains half values
   if (getLangOpts().OpenCL &&
       !getOpenCLOptions().isAvailableOption("cl_khr_fp16", getLangOpts()) &&
       LHSType->isHalfType()) {
-    Diag(Loc, diag::err_opencl_half_load_store) << 1
-        << LHSType.getUnqualifiedType();
+    Diag(Loc, diag::err_opencl_half_load_store)
+        << 1 << LHSType.getUnqualifiedType();
     return QualType();
   }
 
@@ -14623,10 +14628,8 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
           LHSType->isObjCObjectPointerType())))
       ConvTy = Compatible;
 
-    if (ConvTy == Compatible &&
-        LHSType->isObjCObjectType())
-        Diag(Loc, diag::err_objc_object_assignment)
-          << LHSType;
+    if (ConvTy == Compatible && LHSType->isObjCObjectType())
+      Diag(Loc, diag::err_objc_object_assignment) << LHSType;
 
     // If the RHS is a unary plus or minus, check to see if they = and + are
     // right next to each other.  If so, the user may have typo'd "x =+ 4"
@@ -14643,8 +14646,8 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
           Loc.getLocWithOffset(2) != UO->getSubExpr()->getBeginLoc() &&
           UO->getSubExpr()->getBeginLoc().isFileID()) {
         Diag(Loc, diag::warn_not_compound_assign)
-          << (UO->getOpcode() == UO_Plus ? "+" : "-")
-          << SourceRange(UO->getOperatorLoc(), UO->getOperatorLoc());
+            << (UO->getOpcode() == UO_Plus ? "+" : "-")
+            << SourceRange(UO->getOperatorLoc(), UO->getOperatorLoc());
       }
     }
 
@@ -14683,8 +14686,8 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
     ConvTy = CheckAssignmentConstraints(Loc, LHSType, RHSType);
   }
 
-  if (DiagnoseAssignmentResult(ConvTy, Loc, LHSType, RHSType,
-                               RHS.get(), AA_Assigning))
+  if (DiagnoseAssignmentResult(ConvTy, Loc, LHSType, RHSType, RHS.get(),
+                               AA_Assigning))
     return QualType();
 
   CheckForNullPointerDereference(*this, LHSExpr);
@@ -14824,8 +14827,8 @@ static QualType CheckCommaOperands(Sema &S, ExprResult &LHS, ExprResult &RHS,
 static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
                                                ExprValueKind &VK,
                                                ExprObjectKind &OK,
-                                               SourceLocation OpLoc,
-                                               bool IsInc, bool IsPrefix) {
+                                               SourceLocation OpLoc, bool IsInc,
+                                               bool IsPrefix) {
   if (Op->isTypeDependent())
     return S.Context.DependentTy;
 
@@ -14847,7 +14850,7 @@ static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
     // Increment of bool sets it to true, but is deprecated.
     S.Diag(OpLoc, S.getLangOpts().CPlusPlus17 ? diag::ext_increment_bool
                                               : diag::warn_increment_bool)
-      << Op->getSourceRange();
+        << Op->getSourceRange();
   } else if (S.getLangOpts().CPlusPlus && ResType->isEnumeralType()) {
     // Error on enum increments and decrements in C++ mode
     S.Diag(OpLoc, diag::err_increment_decrement_enum) << IsInc << ResType;
@@ -14867,12 +14870,13 @@ static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
   } else if (ResType->isAnyComplexType()) {
     // C99 does not support ++/-- on complex types, we allow as an extension.
     S.Diag(OpLoc, diag::ext_integer_increment_complex)
-      << ResType << Op->getSourceRange();
+        << ResType << Op->getSourceRange();
   } else if (ResType->isPlaceholderType()) {
     ExprResult PR = S.CheckPlaceholderExpr(Op);
-    if (PR.isInvalid()) return QualType();
-    return CheckIncrementDecrementOperand(S, PR.get(), VK, OK, OpLoc,
-                                          IsInc, IsPrefix);
+    if (PR.isInvalid())
+      return QualType();
+    return CheckIncrementDecrementOperand(S, PR.get(), VK, OK, OpLoc, IsInc,
+                                          IsPrefix);
   } else if (S.getLangOpts().AltiVec && ResType->isVectorType()) {
     // OK! ( C/C++ Language Extensions for CBEA(Version 2.6) 10.3 )
   } else if (S.getLangOpts().ZVector && ResType->isVectorType() &&
@@ -14884,7 +14888,7 @@ static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
     // OpenCL V1.2 6.3 says dec/inc ops operate on integer vector types.
   } else {
     S.Diag(OpLoc, diag::err_typecheck_illegal_increment_decrement)
-      << ResType << int(IsInc) << Op->getSourceRange();
+        << ResType << int(IsInc) << Op->getSourceRange();
     return QualType();
   }
   // At this point, we know we have a real, complex or pointer type.
@@ -14909,7 +14913,6 @@ static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
     return ResType.getUnqualifiedType();
   }
 }
-
 
 /// getPrimaryDecl - Helper function for CheckAddressOfOperand().
 /// This routine allows us to typecheck complex/recursive expressions
@@ -14941,8 +14944,8 @@ static ValueDecl *getPrimaryDecl(Expr *E) {
   case Stmt::ArraySubscriptExprClass: {
     // FIXME: This code shouldn't be necessary!  We should catch the implicit
     // promotion of register arrays earlier.
-    Expr* Base = cast<ArraySubscriptExpr>(E)->getBase();
-    if (ImplicitCastExpr* ICE = dyn_cast<ImplicitCastExpr>(Base)) {
+    Expr *Base = cast<ArraySubscriptExpr>(E)->getBase();
+    if (ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(Base)) {
       if (ICE->getSubExpr()->getType()->isArrayType())
         return getPrimaryDecl(ICE->getSubExpr());
     }
@@ -14951,7 +14954,7 @@ static ValueDecl *getPrimaryDecl(Expr *E) {
   case Stmt::UnaryOperatorClass: {
     UnaryOperator *UO = cast<UnaryOperator>(E);
 
-    switch(UO->getOpcode()) {
+    switch (UO->getOpcode()) {
     case UO_Real:
     case UO_Imag:
     case UO_Extension:
@@ -14986,8 +14989,8 @@ enum {
 /// Diagnose invalid operand for address of operations.
 ///
 /// \param Type The type of operand which cannot have its address taken.
-static void diagnoseAddressOfInvalidType(Sema &S, SourceLocation Loc,
-                                         Expr *E, unsigned Type) {
+static void diagnoseAddressOfInvalidType(Sema &S, SourceLocation Loc, Expr *E,
+                                         unsigned Type) {
   S.Diag(Loc, diag::err_typecheck_address_of) << Type << E->getSourceRange();
 }
 
@@ -15027,13 +15030,14 @@ bool Sema::CheckUseOfCXXMethodAsAddressOfOperand(SourceLocation OpLoc,
 /// In C++, the operand might be an overloaded function name, in which case
 /// we allow the '&' but retain the overloaded-function type.
 QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
-  if (const BuiltinType *PTy = OrigOp.get()->getType()->getAsPlaceholderType()){
+  if (const BuiltinType *PTy =
+          OrigOp.get()->getType()->getAsPlaceholderType()) {
     if (PTy->getKind() == BuiltinType::Overload) {
       Expr *E = OrigOp.get()->IgnoreParens();
       if (!isa<OverloadExpr>(E)) {
         assert(cast<UnaryOperator>(E)->getOpcode() == UO_AddrOf);
         Diag(OpLoc, diag::err_typecheck_invalid_lvalue_addrof_addrof_function)
-          << OrigOp.get()->getSourceRange();
+            << OrigOp.get()->getSourceRange();
         return QualType();
       }
 
@@ -15041,7 +15045,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
       if (isa<UnresolvedMemberExpr>(Ovl))
         if (!ResolveSingleFunctionTemplateSpecialization(Ovl)) {
           Diag(OpLoc, diag::err_invalid_form_pointer_member_function)
-            << OrigOp.get()->getSourceRange();
+              << OrigOp.get()->getSourceRange();
           return QualType();
         }
 
@@ -15053,12 +15057,13 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
 
     if (PTy->getKind() == BuiltinType::BoundMember) {
       Diag(OpLoc, diag::err_invalid_form_pointer_member_function)
-        << OrigOp.get()->getSourceRange();
+          << OrigOp.get()->getSourceRange();
       return QualType();
     }
 
     OrigOp = CheckPlaceholderExpr(OrigOp.get());
-    if (OrigOp.isInvalid()) return QualType();
+    if (OrigOp.isInvalid())
+      return QualType();
   }
 
   if (OrigOp.get()->isTypeDependent())
@@ -15075,7 +15080,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
   // depending on a vendor implementation. Thus preventing
   // taking an address of the capture to avoid invalid AS casts.
   if (LangOpts.OpenCL) {
-    auto* VarRef = dyn_cast<DeclRefExpr>(op);
+    auto *VarRef = dyn_cast<DeclRefExpr>(op);
     if (VarRef && VarRef->refersToEnclosingVariableOrCapture()) {
       Diag(op->getExprLoc(), diag::err_opencl_taking_address_capture);
       return QualType();
@@ -15084,7 +15089,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
 
   if (getLangOpts().C99) {
     // Implement C99-only parts of addressof rules.
-    if (UnaryOperator* uOp = dyn_cast<UnaryOperator>(op)) {
+    if (UnaryOperator *uOp = dyn_cast<UnaryOperator>(op)) {
       if (uOp->getOpcode() == UO_Deref)
         // Per C99 6.5.3.2, the address of a deref always returns a valid result
         // (assuming the deref expression is valid).
@@ -15107,7 +15112,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
     bool sfinae = (bool)isSFINAEContext();
     Diag(OpLoc, isSFINAEContext() ? diag::err_typecheck_addrof_temporary
                                   : diag::ext_typecheck_addrof_temporary)
-      << op->getType() << op->getSourceRange();
+        << op->getType() << op->getSourceRange();
     if (sfinae)
       return QualType();
     // Materialize the temporary as an lvalue so that we can take its address.
@@ -15122,7 +15127,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
     // If the underlying expression isn't a decl ref, give up.
     if (!isa<DeclRefExpr>(op)) {
       Diag(OpLoc, diag::err_invalid_form_pointer_member_function)
-        << OrigOp.get()->getSourceRange();
+          << OrigOp.get()->getSourceRange();
       return QualType();
     }
     DeclRefExpr *DRE = cast<DeclRefExpr>(op);
@@ -15145,7 +15150,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
         AddressOfError = AO_Property_Expansion;
       } else {
         Diag(OpLoc, diag::err_typecheck_invalid_lvalue_addrof)
-          << op->getType() << op->getSourceRange();
+            << op->getType() << op->getSourceRange();
         return QualType();
       }
     } else if (const auto *DRE = dyn_cast<DeclRefExpr>(op)) {
@@ -15168,8 +15173,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
     if (const VarDecl *vd = dyn_cast<VarDecl>(dcl)) {
       // in C++ it is not error to take address of a register
       // variable (c++03 7.1.1P3)
-      if (vd->getStorageClass() == SC_Register &&
-          !getLangOpts().CPlusPlus) {
+      if (vd->getStorageClass() == SC_Register && !getLangOpts().CPlusPlus) {
         AddressOfError = AO_Register_Variable;
       }
     } else if (isa<MSPropertyDecl>(dcl)) {
@@ -15186,7 +15190,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
           if (dcl->getType()->isReferenceType()) {
             Diag(OpLoc,
                  diag::err_cannot_form_pointer_to_member_of_reference_type)
-              << dcl->getDeclName() << dcl->getType();
+                << dcl->getDeclName() << dcl->getType();
             return QualType();
           }
 
@@ -15253,7 +15257,7 @@ static void RecordModifiableNonNullParam(Sema &S, const Expr *Exp) {
   const ParmVarDecl *Param = dyn_cast<ParmVarDecl>(D);
   if (!Param)
     return;
-  if (const FunctionDecl* FD = dyn_cast<FunctionDecl>(Param->getDeclContext()))
+  if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(Param->getDeclContext()))
     if (!FD->hasAttr<NonNullAttr>() && !Param->hasAttr<NonNullAttr>())
       return;
   if (FunctionScopeInfo *FD = S.getCurFunction())
@@ -15276,27 +15280,26 @@ static QualType CheckIndirectionOperand(Sema &S, Expr *Op, ExprValueKind &VK,
 
   if (isa<CXXReinterpretCastExpr>(Op)) {
     QualType OpOrigType = Op->IgnoreParenCasts()->getType();
-    S.CheckCompatibleReinterpretCast(OpOrigType, OpTy, /*IsDereference*/true,
+    S.CheckCompatibleReinterpretCast(OpOrigType, OpTy, /*IsDereference*/ true,
                                      Op->getSourceRange());
   }
 
-  if (const PointerType *PT = OpTy->getAs<PointerType>())
-  {
+  if (const PointerType *PT = OpTy->getAs<PointerType>()) {
     Result = PT->getPointeeType();
-  }
-  else if (const ObjCObjectPointerType *OPT =
-             OpTy->getAs<ObjCObjectPointerType>())
+  } else if (const ObjCObjectPointerType *OPT =
+                 OpTy->getAs<ObjCObjectPointerType>())
     Result = OPT->getPointeeType();
   else {
     ExprResult PR = S.CheckPlaceholderExpr(Op);
-    if (PR.isInvalid()) return QualType();
+    if (PR.isInvalid())
+      return QualType();
     if (PR.get() != Op)
       return CheckIndirectionOperand(S, PR.get(), VK, OpLoc);
   }
 
   if (Result.isNull()) {
     S.Diag(OpLoc, diag::err_typecheck_indirection_requires_pointer)
-      << OpTy << Op->getSourceRange();
+        << OpTy << Op->getSourceRange();
     return QualType();
   }
 
@@ -15326,60 +15329,150 @@ static QualType CheckIndirectionOperand(Sema &S, Expr *Op, ExprValueKind &VK,
 BinaryOperatorKind Sema::ConvertTokenKindToBinaryOpcode(tok::TokenKind Kind) {
   BinaryOperatorKind Opc;
   switch (Kind) {
-  default: llvm_unreachable("Unknown binop!");
-  case tok::periodstar:           Opc = BO_PtrMemD; break;
-  case tok::arrowstar:            Opc = BO_PtrMemI; break;
-  case tok::star:                 Opc = BO_Mul; break;
-  case tok::slash:                Opc = BO_Div; break;
-  case tok::percent:              Opc = BO_Rem; break;
-  case tok::plus:                 Opc = BO_Add; break;
-  case tok::minus:                Opc = BO_Sub; break;
-  case tok::lessless:             Opc = BO_Shl; break;
-  case tok::greatergreater:       Opc = BO_Shr; break;
-  case tok::lessequal:            Opc = BO_LE; break;
-  case tok::less:                 Opc = BO_LT; break;
-  case tok::greaterequal:         Opc = BO_GE; break;
-  case tok::greater:              Opc = BO_GT; break;
-  case tok::exclaimequal:         Opc = BO_NE; break;
-  case tok::equalequal:           Opc = BO_EQ; break;
-  case tok::spaceship:            Opc = BO_Cmp; break;
-  case tok::amp:                  Opc = BO_And; break;
-  case tok::caret:                Opc = BO_Xor; break;
-  case tok::pipe:                 Opc = BO_Or; break;
-  case tok::ampamp:               Opc = BO_LAnd; break;
-  case tok::pipepipe:             Opc = BO_LOr; break;
-  case tok::equal:                Opc = BO_Assign; break;
-  case tok::starequal:            Opc = BO_MulAssign; break;
-  case tok::slashequal:           Opc = BO_DivAssign; break;
-  case tok::percentequal:         Opc = BO_RemAssign; break;
-  case tok::plusequal:            Opc = BO_AddAssign; break;
-  case tok::minusequal:           Opc = BO_SubAssign; break;
-  case tok::lesslessequal:        Opc = BO_ShlAssign; break;
-  case tok::greatergreaterequal:  Opc = BO_ShrAssign; break;
-  case tok::ampequal:             Opc = BO_AndAssign; break;
-  case tok::caretequal:           Opc = BO_XorAssign; break;
-  case tok::pipeequal:            Opc = BO_OrAssign; break;
-  case tok::comma:                Opc = BO_Comma; break;
+  default:
+    llvm_unreachable("Unknown binop!");
+  case tok::periodstar:
+    Opc = BO_PtrMemD;
+    break;
+  case tok::arrowstar:
+    Opc = BO_PtrMemI;
+    break;
+  case tok::star:
+    Opc = BO_Mul;
+    break;
+  case tok::slash:
+    Opc = BO_Div;
+    break;
+  case tok::percent:
+    Opc = BO_Rem;
+    break;
+  case tok::plus:
+    Opc = BO_Add;
+    break;
+  case tok::minus:
+    Opc = BO_Sub;
+    break;
+  case tok::lessless:
+    Opc = BO_Shl;
+    break;
+  case tok::greatergreater:
+    Opc = BO_Shr;
+    break;
+  case tok::lessequal:
+    Opc = BO_LE;
+    break;
+  case tok::less:
+    Opc = BO_LT;
+    break;
+  case tok::greaterequal:
+    Opc = BO_GE;
+    break;
+  case tok::greater:
+    Opc = BO_GT;
+    break;
+  case tok::exclaimequal:
+    Opc = BO_NE;
+    break;
+  case tok::equalequal:
+    Opc = BO_EQ;
+    break;
+  case tok::spaceship:
+    Opc = BO_Cmp;
+    break;
+  case tok::amp:
+    Opc = BO_And;
+    break;
+  case tok::caret:
+    Opc = BO_Xor;
+    break;
+  case tok::pipe:
+    Opc = BO_Or;
+    break;
+  case tok::ampamp:
+    Opc = BO_LAnd;
+    break;
+  case tok::pipepipe:
+    Opc = BO_LOr;
+    break;
+  case tok::equal:
+    Opc = BO_Assign;
+    break;
+  case tok::starequal:
+    Opc = BO_MulAssign;
+    break;
+  case tok::slashequal:
+    Opc = BO_DivAssign;
+    break;
+  case tok::percentequal:
+    Opc = BO_RemAssign;
+    break;
+  case tok::plusequal:
+    Opc = BO_AddAssign;
+    break;
+  case tok::minusequal:
+    Opc = BO_SubAssign;
+    break;
+  case tok::lesslessequal:
+    Opc = BO_ShlAssign;
+    break;
+  case tok::greatergreaterequal:
+    Opc = BO_ShrAssign;
+    break;
+  case tok::ampequal:
+    Opc = BO_AndAssign;
+    break;
+  case tok::caretequal:
+    Opc = BO_XorAssign;
+    break;
+  case tok::pipeequal:
+    Opc = BO_OrAssign;
+    break;
+  case tok::comma:
+    Opc = BO_Comma;
+    break;
   }
   return Opc;
 }
 
-static inline UnaryOperatorKind ConvertTokenKindToUnaryOpcode(
-  tok::TokenKind Kind) {
+static inline UnaryOperatorKind
+ConvertTokenKindToUnaryOpcode(tok::TokenKind Kind) {
   UnaryOperatorKind Opc;
   switch (Kind) {
-  default: llvm_unreachable("Unknown unary op!");
-  case tok::plusplus:     Opc = UO_PreInc; break;
-  case tok::minusminus:   Opc = UO_PreDec; break;
-  case tok::amp:          Opc = UO_AddrOf; break;
-  case tok::star:         Opc = UO_Deref; break;
-  case tok::plus:         Opc = UO_Plus; break;
-  case tok::minus:        Opc = UO_Minus; break;
-  case tok::tilde:        Opc = UO_Not; break;
-  case tok::exclaim:      Opc = UO_LNot; break;
-  case tok::kw___real:    Opc = UO_Real; break;
-  case tok::kw___imag:    Opc = UO_Imag; break;
-  case tok::kw___extension__: Opc = UO_Extension; break;
+  default:
+    llvm_unreachable("Unknown unary op!");
+  case tok::plusplus:
+    Opc = UO_PreInc;
+    break;
+  case tok::minusminus:
+    Opc = UO_PreDec;
+    break;
+  case tok::amp:
+    Opc = UO_AddrOf;
+    break;
+  case tok::star:
+    Opc = UO_Deref;
+    break;
+  case tok::plus:
+    Opc = UO_Plus;
+    break;
+  case tok::minus:
+    Opc = UO_Minus;
+    break;
+  case tok::tilde:
+    Opc = UO_Not;
+    break;
+  case tok::exclaim:
+    Opc = UO_LNot;
+    break;
+  case tok::kw___real:
+    Opc = UO_Real;
+    break;
+  case tok::kw___imag:
+    Opc = UO_Imag;
+    break;
+  case tok::kw___extension__:
+    Opc = UO_Extension;
+    break;
   }
   return Opc;
 }
@@ -15432,14 +15525,13 @@ static void DiagnoseSelfAssignment(Sema &S, Expr *LHSExpr, Expr *RHSExpr,
   RHSExpr = RHSExpr->IgnoreParenImpCasts();
   const DeclRefExpr *LHSDeclRef = dyn_cast<DeclRefExpr>(LHSExpr);
   const DeclRefExpr *RHSDeclRef = dyn_cast<DeclRefExpr>(RHSExpr);
-  if (!LHSDeclRef || !RHSDeclRef ||
-      LHSDeclRef->getLocation().isMacroID() ||
+  if (!LHSDeclRef || !RHSDeclRef || LHSDeclRef->getLocation().isMacroID() ||
       RHSDeclRef->getLocation().isMacroID())
     return;
   const ValueDecl *LHSDecl =
-    cast<ValueDecl>(LHSDeclRef->getDecl()->getCanonicalDecl());
+      cast<ValueDecl>(LHSDeclRef->getDecl()->getCanonicalDecl());
   const ValueDecl *RHSDecl =
-    cast<ValueDecl>(RHSDeclRef->getDecl()->getCanonicalDecl());
+      cast<ValueDecl>(RHSDeclRef->getDecl()->getCanonicalDecl());
   if (LHSDecl != RHSDecl)
     return;
   if (LHSDecl->getType().isVolatileQualified())
@@ -15474,8 +15566,7 @@ static void checkObjCPointerIntrospection(Sema &S, ExprResult &L, ExprResult &R,
   if (LHS->IgnoreParenCasts()->getType()->isObjCObjectPointerType()) {
     ObjCPointerExpr = LHS;
     OtherExpr = RHS;
-  }
-  else if (RHS->IgnoreParenCasts()->getType()->isObjCObjectPointerType()) {
+  } else if (RHS->IgnoreParenCasts()->getType()->isObjCObjectPointerType()) {
     ObjCPointerExpr = RHS;
     OtherExpr = LHS;
   }
@@ -15498,8 +15589,7 @@ static void checkObjCPointerIntrospection(Sema &S, ExprResult &L, ExprResult &R,
         Diag = diag::warn_objc_pointer_masking_performSelector;
     }
 
-    S.Diag(OpLoc, Diag)
-      << ObjCPointerExpr->getSourceRange();
+    S.Diag(OpLoc, Diag) << ObjCPointerExpr->getSourceRange();
   }
 }
 
@@ -15602,8 +15692,8 @@ static bool needsConversionOfHalfVec(bool OpRequiresConversion, ASTContext &Ctx,
 /// operator @p Opc at location @c TokLoc. This routine only supports
 /// built-in operations; ActOnBinOp handles overloaded operators.
 ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
-                                    BinaryOperatorKind Opc,
-                                    Expr *LHSExpr, Expr *RHSExpr) {
+                                    BinaryOperatorKind Opc, Expr *LHSExpr,
+                                    Expr *RHSExpr) {
   if (getLangOpts().CPlusPlus11 && isa<InitListExpr>(RHSExpr)) {
     // The syntax only allows initializer lists on the RHS of assignment,
     // so we don't need to worry about accepting invalid code for
@@ -15623,7 +15713,7 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   }
 
   ExprResult LHS = LHSExpr, RHS = RHSExpr;
-  QualType ResultTy;     // Result type of the binary operator.
+  QualType ResultTy; // Result type of the binary operator.
   // The following two variables are used for compound assignment operators
   QualType CompLHSTy;    // Type of LHS after promotions for computation
   QualType CompResultTy; // Type of computation result
@@ -15651,9 +15741,8 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
 
     // OpenCL special types - image, sampler, pipe, and blocks are to be used
     // only with a builtin functions and therefore should be disallowed here.
-    if (LHSTy->isImageType() || RHSTy->isImageType() ||
-        LHSTy->isSamplerT() || RHSTy->isSamplerT() ||
-        LHSTy->isPipeType() || RHSTy->isPipeType() ||
+    if (LHSTy->isImageType() || RHSTy->isImageType() || LHSTy->isSamplerT() ||
+        RHSTy->isSamplerT() || LHSTy->isPipeType() || RHSTy->isPipeType() ||
         LHSTy->isBlockPointerType() || RHSTy->isBlockPointerType()) {
       ResultTy = InvalidOperands(OpLoc, LHS, RHS);
       return ExprError();
@@ -15702,14 +15791,14 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
     break;
   case BO_PtrMemD:
   case BO_PtrMemI:
-    ResultTy = CheckPointerToMemberOperands(LHS, RHS, VK, OpLoc,
-                                            Opc == BO_PtrMemI);
+    ResultTy =
+        CheckPointerToMemberOperands(LHS, RHS, VK, OpLoc, Opc == BO_PtrMemI);
     break;
   case BO_Mul:
   case BO_Div:
     ConvertHalfVec = true;
-    ResultTy = CheckMultiplyDivideOperands(LHS, RHS, OpLoc, false,
-                                           Opc == BO_Div);
+    ResultTy =
+        CheckMultiplyDivideOperands(LHS, RHS, OpLoc, false, Opc == BO_Div);
     break;
   case BO_Rem:
     ResultTy = CheckRemainderOperands(LHS, RHS, OpLoc);
@@ -15758,8 +15847,8 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   case BO_MulAssign:
   case BO_DivAssign:
     ConvertHalfVec = true;
-    CompResultTy = CheckMultiplyDivideOperands(LHS, RHS, OpLoc, true,
-                                               Opc == BO_DivAssign);
+    CompResultTy =
+        CheckMultiplyDivideOperands(LHS, RHS, OpLoc, true, Opc == BO_DivAssign);
     CompLHSTy = CompResultTy;
     if (!CompResultTy.isNull() && !LHS.isInvalid() && !RHS.isInvalid())
       ResultTy =
@@ -15831,10 +15920,11 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   CheckArrayAccess(LHS.get());
   CheckArrayAccess(RHS.get());
 
-  if (const ObjCIsaExpr *OISA = dyn_cast<ObjCIsaExpr>(LHS.get()->IgnoreParenCasts())) {
-    NamedDecl *ObjectSetClass = LookupSingleName(TUScope,
-                                                 &Context.Idents.get("object_setClass"),
-                                                 SourceLocation(), LookupOrdinaryName);
+  if (const ObjCIsaExpr *OISA =
+          dyn_cast<ObjCIsaExpr>(LHS.get()->IgnoreParenCasts())) {
+    NamedDecl *ObjectSetClass =
+        LookupSingleName(TUScope, &Context.Idents.get("object_setClass"),
+                         SourceLocation(), LookupOrdinaryName);
     if (ObjectSetClass && isa<ObjCIsaExpr>(LHS.get())) {
       SourceLocation RHSLocEnd = getLocForEndOfToken(RHS.get()->getEndLoc());
       Diag(LHS.get()->getExprLoc(), diag::warn_objc_isa_assign)
@@ -15843,12 +15933,10 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
           << FixItHint::CreateReplacement(SourceRange(OISA->getOpLoc(), OpLoc),
                                           ",")
           << FixItHint::CreateInsertion(RHSLocEnd, ")");
-    }
-    else
+    } else
       Diag(LHS.get()->getExprLoc(), diag::warn_objc_isa_assign);
-  }
-  else if (const ObjCIvarRefExpr *OIRE =
-           dyn_cast<ObjCIvarRefExpr>(LHS.get()->IgnoreParenCasts()))
+  } else if (const ObjCIvarRefExpr *OIRE =
+                 dyn_cast<ObjCIvarRefExpr>(LHS.get()->IgnoreParenCasts()))
     DiagnoseDirectIsaAccess(*this, OIRE, OpLoc, RHS.get());
 
   // Opc is not a compound assignment if CompResultTy is null.
@@ -15861,8 +15949,8 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   }
 
   // Handle compound assignments.
-  if (getLangOpts().CPlusPlus && LHS.get()->getObjectKind() !=
-      OK_ObjCProperty) {
+  if (getLangOpts().CPlusPlus &&
+      LHS.get()->getObjectKind() != OK_ObjCProperty) {
     VK = VK_LValue;
     OK = LHS.get()->getObjectKind();
   }
@@ -15915,29 +16003,29 @@ static void DiagnoseBitwisePrecedence(Sema &Self, BinaryOperatorKind Opc,
           : SourceRange(LHSExpr->getBeginLoc(), RHSBO->getLHS()->getEndLoc());
 
   Self.Diag(OpLoc, diag::warn_precedence_bitwise_rel)
-    << DiagRange << BinaryOperator::getOpcodeStr(Opc) << OpStr;
+      << DiagRange << BinaryOperator::getOpcodeStr(Opc) << OpStr;
   SuggestParentheses(Self, OpLoc,
-    Self.PDiag(diag::note_precedence_silence) << OpStr,
-    (isLeftComp ? LHSExpr : RHSExpr)->getSourceRange());
+                     Self.PDiag(diag::note_precedence_silence) << OpStr,
+                     (isLeftComp ? LHSExpr : RHSExpr)->getSourceRange());
   SuggestParentheses(Self, OpLoc,
-    Self.PDiag(diag::note_precedence_bitwise_first)
-      << BinaryOperator::getOpcodeStr(Opc),
-    ParensRange);
+                     Self.PDiag(diag::note_precedence_bitwise_first)
+                         << BinaryOperator::getOpcodeStr(Opc),
+                     ParensRange);
 }
 
 /// It accepts a '&&' expr that is inside a '||' one.
 /// Emit a diagnostic together with a fixit hint that wraps the '&&' expression
 /// in parentheses.
-static void
-EmitDiagnosticForLogicalAndInLogicalOr(Sema &Self, SourceLocation OpLoc,
-                                       BinaryOperator *Bop) {
+static void EmitDiagnosticForLogicalAndInLogicalOr(Sema &Self,
+                                                   SourceLocation OpLoc,
+                                                   BinaryOperator *Bop) {
   assert(Bop->getOpcode() == BO_LAnd);
   Self.Diag(Bop->getOperatorLoc(), diag::warn_logical_and_in_logical_or)
       << Bop->getSourceRange() << OpLoc;
   SuggestParentheses(Self, Bop->getOperatorLoc(),
-    Self.PDiag(diag::note_precedence_silence)
-      << Bop->getOpcodeStr(),
-    Bop->getSourceRange());
+                     Self.PDiag(diag::note_precedence_silence)
+                         << Bop->getOpcodeStr(),
+                     Bop->getSourceRange());
 }
 
 /// Look for '&&' in the left hand of a '||' expr.
@@ -15982,12 +16070,12 @@ static void DiagnoseBitwiseOpInBitwiseOp(Sema &S, BinaryOperatorKind Opc,
   if (BinaryOperator *Bop = dyn_cast<BinaryOperator>(SubExpr)) {
     if (Bop->isBitwiseOp() && Bop->getOpcode() < Opc) {
       S.Diag(Bop->getOperatorLoc(), diag::warn_bitwise_op_in_bitwise_op)
-        << Bop->getOpcodeStr() << BinaryOperator::getOpcodeStr(Opc)
-        << Bop->getSourceRange() << OpLoc;
+          << Bop->getOpcodeStr() << BinaryOperator::getOpcodeStr(Opc)
+          << Bop->getSourceRange() << OpLoc;
       SuggestParentheses(S, Bop->getOperatorLoc(),
-        S.PDiag(diag::note_precedence_silence)
-          << Bop->getOpcodeStr(),
-        Bop->getSourceRange());
+                         S.PDiag(diag::note_precedence_silence)
+                             << Bop->getOpcodeStr(),
+                         Bop->getSourceRange());
     }
   }
 }
@@ -16000,14 +16088,14 @@ static void DiagnoseAdditionInShift(Sema &S, SourceLocation OpLoc,
       S.Diag(Bop->getOperatorLoc(), diag::warn_addition_in_bitshift)
           << Bop->getSourceRange() << OpLoc << Shift << Op;
       SuggestParentheses(S, Bop->getOperatorLoc(),
-          S.PDiag(diag::note_precedence_silence) << Op,
-          Bop->getSourceRange());
+                         S.PDiag(diag::note_precedence_silence) << Op,
+                         Bop->getSourceRange());
     }
   }
 }
 
-static void DiagnoseShiftCompare(Sema &S, SourceLocation OpLoc,
-                                 Expr *LHSExpr, Expr *RHSExpr) {
+static void DiagnoseShiftCompare(Sema &S, SourceLocation OpLoc, Expr *LHSExpr,
+                                 Expr *RHSExpr) {
   CXXOperatorCallExpr *OCE = dyn_cast<CXXOperatorCallExpr>(LHSExpr);
   if (!OCE)
     return;
@@ -16036,27 +16124,28 @@ static void DiagnoseShiftCompare(Sema &S, SourceLocation OpLoc,
 /// precedence.
 static void DiagnoseBinOpPrecedence(Sema &Self, BinaryOperatorKind Opc,
                                     SourceLocation OpLoc, Expr *LHSExpr,
-                                    Expr *RHSExpr){
+                                    Expr *RHSExpr) {
   // Diagnose "arg1 'bitwise' arg2 'eq' arg3".
   if (BinaryOperator::isBitwiseOp(Opc))
     DiagnoseBitwisePrecedence(Self, Opc, OpLoc, LHSExpr, RHSExpr);
 
   // Diagnose "arg1 & arg2 | arg3"
   if ((Opc == BO_Or || Opc == BO_Xor) &&
-      !OpLoc.isMacroID()/* Don't warn in macros. */) {
+      !OpLoc.isMacroID() /* Don't warn in macros. */) {
     DiagnoseBitwiseOpInBitwiseOp(Self, Opc, OpLoc, LHSExpr);
     DiagnoseBitwiseOpInBitwiseOp(Self, Opc, OpLoc, RHSExpr);
   }
 
   // Warn about arg1 || arg2 && arg3, as GCC 4.3+ does.
   // We don't warn for 'assert(a || b && "bad")' since this is safe.
-  if (Opc == BO_LOr && !OpLoc.isMacroID()/* Don't warn in macros. */) {
+  if (Opc == BO_LOr && !OpLoc.isMacroID() /* Don't warn in macros. */) {
     DiagnoseLogicalAndInLogicalOrLHS(Self, OpLoc, LHSExpr, RHSExpr);
     DiagnoseLogicalAndInLogicalOrRHS(Self, OpLoc, LHSExpr, RHSExpr);
   }
 
-  if ((Opc == BO_Shl && LHSExpr->getType()->isIntegralType(Self.getASTContext()))
-      || Opc == BO_Shr) {
+  if ((Opc == BO_Shl &&
+       LHSExpr->getType()->isIntegralType(Self.getASTContext())) ||
+      Opc == BO_Shr) {
     StringRef Shift = BinaryOperator::getOpcodeStr(Opc);
     DiagnoseAdditionInShift(Self, OpLoc, LHSExpr, Shift);
     DiagnoseAdditionInShift(Self, OpLoc, RHSExpr, Shift);
@@ -16070,8 +16159,7 @@ static void DiagnoseBinOpPrecedence(Sema &Self, BinaryOperatorKind Opc,
 
 // Binary Operators.  'Tok' is the token for the operator.
 ExprResult Sema::ActOnBinOp(Scope *S, SourceLocation TokLoc,
-                            tok::TokenKind Kind,
-                            Expr *LHSExpr, Expr *RHSExpr) {
+                            tok::TokenKind Kind, Expr *LHSExpr, Expr *RHSExpr) {
   BinaryOperatorKind Opc = ConvertTokenKindToBinaryOpcode(Kind);
   assert(LHSExpr && "ActOnBinOp(): missing left expression");
   assert(RHSExpr && "ActOnBinOp(): missing right expression");
@@ -16097,8 +16185,8 @@ void Sema::LookupBinOp(Scope *S, SourceLocation OpLoc, BinaryOperatorKind Opc,
 
 /// Build an overloaded binary operator expression in the given scope.
 static ExprResult BuildOverloadedBinOp(Sema &S, Scope *Sc, SourceLocation OpLoc,
-                                       BinaryOperatorKind Opc,
-                                       Expr *LHS, Expr *RHS) {
+                                       BinaryOperatorKind Opc, Expr *LHS,
+                                       Expr *RHS) {
   switch (Opc) {
   case BO_Assign:
     // In the non-overloaded case, we warn about self-assignment (x = x) for
@@ -16133,8 +16221,8 @@ static ExprResult BuildOverloadedBinOp(Sema &S, Scope *Sc, SourceLocation OpLoc,
 }
 
 ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
-                            BinaryOperatorKind Opc,
-                            Expr *LHSExpr, Expr *RHSExpr) {
+                            BinaryOperatorKind Opc, Expr *LHSExpr,
+                            Expr *RHSExpr) {
   ExprResult LHS, RHS;
   std::tie(LHS, RHS) = CorrectDelayedTyposInBinOp(*this, Opc, LHSExpr, RHSExpr);
   if (!LHS.isUsable() || !RHS.isUsable())
@@ -16163,7 +16251,8 @@ ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
       // that an overload set can be dependently-typed, but it never
       // instantiates to having an overloadable type.
       ExprResult resolvedRHS = CheckPlaceholderExpr(RHSExpr);
-      if (resolvedRHS.isInvalid()) return ExprError();
+      if (resolvedRHS.isInvalid())
+        return ExprError();
       RHSExpr = resolvedRHS.get();
 
       if (RHSExpr->isTypeDependent() ||
@@ -16188,13 +16277,14 @@ ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
         Diag(OE->getQualifier() ? OE->getQualifierLoc().getBeginLoc()
                                 : OE->getNameLoc(),
              diag::err_template_kw_missing)
-          << OE->getName().getAsString() << "";
+            << OE->getName().getAsString() << "";
         return ExprError();
       }
     }
 
     ExprResult LHS = CheckPlaceholderExpr(LHSExpr);
-    if (LHS.isInvalid()) return ExprError();
+    if (LHS.isInvalid())
+      return ExprError();
     LHSExpr = LHS.get();
   }
 
@@ -16217,7 +16307,8 @@ ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
       return BuildOverloadedBinOp(*this, S, OpLoc, Opc, LHSExpr, RHSExpr);
 
     ExprResult resolvedRHS = CheckPlaceholderExpr(RHSExpr);
-    if (!resolvedRHS.isUsable()) return ExprError();
+    if (!resolvedRHS.isUsable())
+      return ExprError();
     RHSExpr = resolvedRHS.get();
   }
 
@@ -16303,10 +16394,11 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     QualType Ty = InputExpr->getType();
     // The only legal unary operation for atomics is '&'.
     if ((Opc != UO_AddrOf && Ty->isAtomicType()) ||
-    // OpenCL special types - image, sampler, pipe, and blocks are to be used
-    // only with a builtin functions and therefore should be disallowed here.
-        (Ty->isImageType() || Ty->isSamplerT() || Ty->isPipeType()
-        || Ty->isBlockPointerType())) {
+        // OpenCL special types - image, sampler, pipe, and blocks are to be
+        // used only with a builtin functions and therefore should be disallowed
+        // here.
+        (Ty->isImageType() || Ty->isSamplerT() || Ty->isPipeType() ||
+         Ty->isBlockPointerType())) {
       return ExprError(Diag(OpLoc, diag::err_typecheck_unary_expr)
                        << InputExpr->getType()
                        << Input.get()->getSourceRange());
@@ -16325,12 +16417,10 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   case UO_PreDec:
   case UO_PostInc:
   case UO_PostDec:
-    resultType = CheckIncrementDecrementOperand(*this, Input.get(), VK, OK,
-                                                OpLoc,
-                                                Opc == UO_PreInc ||
-                                                Opc == UO_PostInc,
-                                                Opc == UO_PreInc ||
-                                                Opc == UO_PreDec);
+    resultType =
+        CheckIncrementDecrementOperand(*this, Input.get(), VK, OK, OpLoc,
+                                       Opc == UO_PreInc || Opc == UO_PostInc,
+                                       Opc == UO_PreInc || Opc == UO_PreDec);
     CanOverflow = isOverflowingIntegerType(Context, resultType);
     break;
   case UO_AddrOf:
@@ -16340,7 +16430,8 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     break;
   case UO_Deref: {
     Input = DefaultFunctionArrayLvalueConversion(Input.get());
-    if (Input.isInvalid()) return ExprError();
+    if (Input.isInvalid())
+      return ExprError();
     resultType =
         CheckIndirectionOperand(*this, Input.get(), VK, OpLoc, IsAfterAmp);
     break;
@@ -16350,7 +16441,8 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     CanOverflow = Opc == UO_Minus &&
                   isOverflowingIntegerType(Context, Input.get()->getType());
     Input = UsualUnaryConversions(Input.get());
-    if (Input.isInvalid()) return ExprError();
+    if (Input.isInvalid())
+      return ExprError();
     // Unary plus and minus require promoting an operand of half vector to a
     // float vector and truncating the result back to a half vector. For now, we
     // do this only when HalfArgsAndReturns is set (that is, when the target is
@@ -16374,12 +16466,11 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     else if (resultType->isSveVLSBuiltinType()) // SVE vectors allow + and -
       break;
     else if (getLangOpts().CPlusPlus && // C++ [expr.unary.op]p6
-             Opc == UO_Plus &&
-             resultType->isPointerType())
+             Opc == UO_Plus && resultType->isPointerType())
       break;
 
     return ExprError(Diag(OpLoc, diag::err_typecheck_unary_expr)
-      << resultType << Input.get()->getSourceRange());
+                     << resultType << Input.get()->getSourceRange());
 
   case UO_Not: // bitwise complement
     Input = UsualUnaryConversions(Input.get());
@@ -16401,7 +16492,7 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
       QualType T = resultType->castAs<ExtVectorType>()->getElementType();
       if (!T->isIntegerType())
         return ExprError(Diag(OpLoc, diag::err_typecheck_unary_expr)
-                          << resultType << Input.get()->getSourceRange());
+                         << resultType << Input.get()->getSourceRange());
     } else {
       return ExprError(Diag(OpLoc, diag::err_typecheck_unary_expr)
                        << resultType << Input.get()->getSourceRange());
@@ -16411,12 +16502,14 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   case UO_LNot: // logical negation
     // Unlike +/-/~, integer promotions aren't done here (C99 6.5.3.3p5).
     Input = DefaultFunctionArrayLvalueConversion(Input.get());
-    if (Input.isInvalid()) return ExprError();
+    if (Input.isInvalid())
+      return ExprError();
     resultType = Input.get()->getType();
 
     // Though we still have to promote half FP to float...
     if (resultType->isHalfType() && !Context.getLangOpts().NativeHalfType) {
-      Input = ImpCastExprToType(Input.get(), Context.FloatTy, CK_FloatingCast).get();
+      Input = ImpCastExprToType(Input.get(), Context.FloatTy, CK_FloatingCast)
+                  .get();
       resultType = Context.FloatTy;
     }
 
@@ -16468,7 +16561,7 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
       break;
     } else {
       return ExprError(Diag(OpLoc, diag::err_typecheck_unary_expr)
-        << resultType << Input.get()->getSourceRange());
+                       << resultType << Input.get()->getSourceRange());
     }
 
     // LNot always has type int. C99 6.5.3.3p5.
@@ -16480,7 +16573,8 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     resultType = CheckRealImagOperand(*this, Input, OpLoc, Opc == UO_Real);
     // _Real maps ordinary l-values into ordinary l-values. _Imag maps ordinary
     // complex l-values to ordinary l-values and all other values to r-values.
-    if (Input.isInvalid()) return ExprError();
+    if (Input.isInvalid())
+      return ExprError();
     if (Opc == UO_Real || Input.get()->getType()->isAnyComplexType()) {
       if (Input.get()->isGLValue() &&
           Input.get()->getObjectKind() == OK_Ordinary)
@@ -16499,8 +16593,8 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
     // It's unnecessary to represent the pass-through operator co_await in the
     // AST; just return the input expression instead.
     assert(!Input.get()->getType()->isDependentType() &&
-                   "the co_await expression must be non-dependant before "
-                   "building operator co_await");
+           "the co_await expression must be non-dependant before "
+           "building operator co_await");
     return Input;
   }
   if (resultType.isNull() || Input.isInvalid())
@@ -16585,15 +16679,15 @@ ExprResult Sema::BuildUnaryOp(Scope *S, SourceLocation OpLoc,
 
     // & gets special logic for several kinds of placeholder.
     // The builtin code knows what to do.
-    if (Opc == UO_AddrOf &&
-        (pty->getKind() == BuiltinType::Overload ||
-         pty->getKind() == BuiltinType::UnknownAny ||
-         pty->getKind() == BuiltinType::BoundMember))
+    if (Opc == UO_AddrOf && (pty->getKind() == BuiltinType::Overload ||
+                             pty->getKind() == BuiltinType::UnknownAny ||
+                             pty->getKind() == BuiltinType::BoundMember))
       return CreateBuiltinUnaryOp(OpLoc, Opc, Input);
 
     // Anything else needs to be handled now.
     ExprResult Result = CheckPlaceholderExpr(Input);
-    if (Result.isInvalid()) return ExprError();
+    if (Result.isInvalid())
+      return ExprError();
     Input = Result.get();
   }
 
@@ -16735,32 +16829,32 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
   // a struct/union/class.
   if (!Dependent && !ArgTy->isRecordType())
     return ExprError(Diag(BuiltinLoc, diag::err_offsetof_record_type)
-                       << ArgTy << TypeRange);
+                     << ArgTy << TypeRange);
 
   // Type must be complete per C99 7.17p3 because a declaring a variable
   // with an incomplete type would be ill-formed.
-  if (!Dependent
-      && RequireCompleteType(BuiltinLoc, ArgTy,
-                             diag::err_offsetof_incomplete_type, TypeRange))
+  if (!Dependent &&
+      RequireCompleteType(BuiltinLoc, ArgTy, diag::err_offsetof_incomplete_type,
+                          TypeRange))
     return ExprError();
 
   bool DidWarnAboutNonPOD = false;
   QualType CurrentType = ArgTy;
   SmallVector<OffsetOfNode, 4> Comps;
-  SmallVector<Expr*, 4> Exprs;
+  SmallVector<Expr *, 4> Exprs;
   for (const OffsetOfComponent &OC : Components) {
     if (OC.isBrackets) {
       // Offset of an array sub-field.  TODO: Should we allow vector elements?
       if (!CurrentType->isDependentType()) {
         const ArrayType *AT = Context.getAsArrayType(CurrentType);
-        if(!AT)
+        if (!AT)
           return ExprError(Diag(OC.LocEnd, diag::err_offsetof_array_type)
                            << CurrentType);
         CurrentType = AT->getElementType();
       } else
         CurrentType = Context.DependentTy;
 
-      ExprResult IdxRval = DefaultLvalueConversion(static_cast<Expr*>(OC.U.E));
+      ExprResult IdxRval = DefaultLvalueConversion(static_cast<Expr *>(OC.U.E));
       if (IdxRval.isInvalid())
         return ExprError();
       Expr *Idx = IdxRval.get();
@@ -16808,9 +16902,10 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
     //   If type is not a standard-layout class (Clause 9), the results are
     //   undefined.
     if (CXXRecordDecl *CRD = dyn_cast<CXXRecordDecl>(RD)) {
-      bool IsSafe = LangOpts.CPlusPlus11? CRD->isStandardLayout() : CRD->isPOD();
-      unsigned DiagID =
-        LangOpts.CPlusPlus11? diag::ext_offsetof_non_standardlayout_type
+      bool IsSafe =
+          LangOpts.CPlusPlus11 ? CRD->isStandardLayout() : CRD->isPOD();
+      unsigned DiagID = LangOpts.CPlusPlus11
+                            ? diag::ext_offsetof_non_standardlayout_type
                             : diag::ext_offsetof_non_pod_type;
 
       if (!IsSafe && !DidWarnAboutNonPOD && !isUnevaluatedContext()) {
@@ -16846,8 +16941,7 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
     // We diagnose this as an error.
     if (MemberDecl->isBitField()) {
       Diag(OC.LocEnd, diag::err_offsetof_bitfield)
-        << MemberDecl->getDeclName()
-        << SourceRange(BuiltinLoc, RParenLoc);
+          << MemberDecl->getDeclName() << SourceRange(BuiltinLoc, RParenLoc);
       Diag(MemberDecl->getLocation(), diag::note_bitfield_decl);
       return ExprError();
     }
@@ -16863,8 +16957,7 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
                       Paths)) {
       if (Paths.getDetectedVirtual()) {
         Diag(OC.LocEnd, diag::err_offsetof_field_of_virtual_base)
-          << MemberDecl->getDeclName()
-          << SourceRange(BuiltinLoc, RParenLoc);
+            << MemberDecl->getDeclName() << SourceRange(BuiltinLoc, RParenLoc);
         return ExprError();
       }
 
@@ -16876,8 +16969,8 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
     if (IndirectMemberDecl) {
       for (auto *FI : IndirectMemberDecl->chain()) {
         assert(isa<FieldDecl>(FI));
-        Comps.push_back(OffsetOfNode(OC.LocStart,
-                                     cast<FieldDecl>(FI), OC.LocEnd));
+        Comps.push_back(
+            OffsetOfNode(OC.LocStart, cast<FieldDecl>(FI), OC.LocEnd));
       }
     } else
       Comps.push_back(OffsetOfNode(OC.LocStart, MemberDecl, OC.LocEnd));
@@ -16889,8 +16982,7 @@ ExprResult Sema::BuildBuiltinOffsetOf(SourceLocation BuiltinLoc,
                               Comps, Exprs, RParenLoc);
 }
 
-ExprResult Sema::ActOnBuiltinOffsetOf(Scope *S,
-                                      SourceLocation BuiltinLoc,
+ExprResult Sema::ActOnBuiltinOffsetOf(Scope *S, SourceLocation BuiltinLoc,
                                       SourceLocation TypeLoc,
                                       ParsedType ParsedArgTy,
                                       ArrayRef<OffsetOfComponent> Components,
@@ -16907,9 +16999,7 @@ ExprResult Sema::ActOnBuiltinOffsetOf(Scope *S,
   return BuildBuiltinOffsetOf(BuiltinLoc, ArgTInfo, Components, RParenLoc);
 }
 
-
-ExprResult Sema::ActOnChooseExpr(SourceLocation BuiltinLoc,
-                                 Expr *CondExpr,
+ExprResult Sema::ActOnChooseExpr(SourceLocation BuiltinLoc, Expr *CondExpr,
                                  Expr *LHSExpr, Expr *RHSExpr,
                                  SourceLocation RPLoc) {
   assert((CondExpr && LHSExpr && RHSExpr) && "Missing type argument(s)");
@@ -17006,8 +17096,8 @@ void Sema::ActOnBlockArguments(SourceLocation CaretLoc, Declarator &ParamInfo,
   // Look for an explicit signature in that function type.
   FunctionProtoTypeLoc ExplicitSignature;
 
-  if ((ExplicitSignature = Sig->getTypeLoc()
-                               .getAsAdjusted<FunctionProtoTypeLoc>())) {
+  if ((ExplicitSignature =
+           Sig->getTypeLoc().getAsAdjusted<FunctionProtoTypeLoc>())) {
 
     // Check whether that explicit signature was synthesized by
     // GetTypeForDeclarator.  If so, don't save that as part of the
@@ -17046,7 +17136,7 @@ void Sema::ActOnBlockArguments(SourceLocation CaretLoc, Declarator &ParamInfo,
   }
 
   // Push block parameters from the declarator if we had them.
-  SmallVector<ParmVarDecl*, 8> Params;
+  SmallVector<ParmVarDecl *, 8> Params;
   if (ExplicitSignature) {
     for (unsigned I = 0, E = ExplicitSignature.getNumParams(); I != E; ++I) {
       ParmVarDecl *Param = ExplicitSignature.getParam(I);
@@ -17059,8 +17149,8 @@ void Sema::ActOnBlockArguments(SourceLocation CaretLoc, Declarator &ParamInfo,
       Params.push_back(Param);
     }
 
-  // Fake up parameter variables if we have a typedef, like
-  //   ^ fntype { ... }
+    // Fake up parameter variables if we have a typedef, like
+    //   ^ fntype { ... }
   } else if (const FunctionProtoType *Fn = T->getAs<FunctionProtoType>()) {
     for (const auto &I : Fn->param_types()) {
       ParmVarDecl *Param = BuildParmVarDeclForTypedef(
@@ -17109,8 +17199,8 @@ void Sema::ActOnBlockError(SourceLocation CaretLoc, Scope *CurScope) {
 
 /// ActOnBlockStmtExpr - This is called when the body of a block statement
 /// literal was successfully completed.  ^(int x){...}
-ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
-                                    Stmt *Body, Scope *CurScope) {
+ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc, Stmt *Body,
+                                    Scope *CurScope) {
   // If blocks are disabled, emit an error.
   if (!LangOpts.Blocks)
     Diag(CaretLoc, diag::err_blocks_disable) << LangOpts.OpenCL;
@@ -17140,7 +17230,8 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
     const FunctionType *FTy = BSI->FunctionType->castAs<FunctionType>();
 
     FunctionType::ExtInfo Ext = FTy->getExtInfo();
-    if (NoReturn && !Ext.getNoReturn()) Ext = Ext.withNoReturn(true);
+    if (NoReturn && !Ext.getNoReturn())
+      Ext = Ext.withNoReturn(true);
 
     // Turn protoless block types into nullary block types.
     if (isa<FunctionNoProtoType>(FTy)) {
@@ -17154,7 +17245,7 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
                (!NoReturn || FTy->getNoReturnAttr())) {
       BlockTy = BSI->FunctionType;
 
-    // Otherwise, make the minimal modifications to the function type.
+      // Otherwise, make the minimal modifications to the function type.
     } else {
       const FunctionProtoType *FPT = cast<FunctionProtoType>(FTy);
       FunctionProtoType::ExtProtoInfo EPI = FPT->getExtProtoInfo();
@@ -17163,7 +17254,7 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
       BlockTy = Context.getFunctionType(RetTy, FPT->getParamTypes(), EPI);
     }
 
-  // If we don't have a function type, just build one from nothing.
+    // If we don't have a function type, just build one from nothing.
   } else {
     FunctionProtoType::ExtProtoInfo EPI;
     EPI.ExtInfo = FunctionType::ExtInfo().withNoReturn(NoReturn);
@@ -17174,8 +17265,7 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
   BlockTy = Context.getBlockPointerType(BlockTy);
 
   // If needed, diagnose invalid gotos and switches in the block.
-  if (getCurFunction()->NeedsScopeChecking() &&
-      !PP.isCodeCompletionEnabled())
+  if (getCurFunction()->NeedsScopeChecking() && !PP.isCodeCompletionEnabled())
     DiagnoseInvalidJumps(cast<CompoundStmt>(Body));
 
   BD->setBody(cast<CompoundStmt>(Body));
@@ -17193,7 +17283,7 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
   if (RetTy.hasNonTrivialToPrimitiveDestructCUnion() ||
       RetTy.hasNonTrivialToPrimitiveCopyCUnion())
     checkNonTrivialCUnion(RetTy, BD->getCaretLocation(), NTCUC_FunctionReturn,
-                          NTCUK_Destruct|NTCUK_Copy);
+                          NTCUK_Destruct | NTCUK_Copy);
 
   PopDeclContext();
 
@@ -17250,9 +17340,9 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
         // Build a full-expression copy expression if initialization
         // succeeded and used a non-trivial constructor.  Recover from
         // errors by pretending that the copy isn't necessary.
-        if (!Result.isInvalid() &&
-            !cast<CXXConstructExpr>(Result.get())->getConstructor()
-                ->isTrivial()) {
+        if (!Result.isInvalid() && !cast<CXXConstructExpr>(Result.get())
+                                        ->getConstructor()
+                                        ->isTrivial()) {
           Result = MaybeCreateExprWithCleanups(Result);
           CopyExpr = Result.get();
         }
@@ -17305,9 +17395,8 @@ ExprResult Sema::ActOnVAArg(SourceLocation BuiltinLoc, Expr *E, ParsedType Ty,
   return BuildVAArgExpr(BuiltinLoc, E, TInfo, RPLoc);
 }
 
-ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
-                                Expr *E, TypeSourceInfo *TInfo,
-                                SourceLocation RPLoc) {
+ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc, Expr *E,
+                                TypeSourceInfo *TInfo, SourceLocation RPLoc) {
   Expr *OrigExpr = E;
   bool IsMS = false;
 
@@ -17329,7 +17418,8 @@ ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
   // as Microsoft ABI on an actual Microsoft platform, where
   // __builtin_ms_va_list and __builtin_va_list are the same.)
   if (!E->isTypeDependent() && Context.getTargetInfo().hasBuiltinMSVaList() &&
-      Context.getTargetInfo().getBuiltinVaListKind() != TargetInfo::CharPtrBuiltinVaList) {
+      Context.getTargetInfo().getBuiltinVaListKind() !=
+          TargetInfo::CharPtrBuiltinVaList) {
     QualType MSVaListType = Context.getBuiltinMSVaListType();
     if (Context.hasSameType(MSVaListType, E->getType())) {
       if (CheckForModifiableLvalue(E, BuiltinLoc, *this))
@@ -17382,19 +17472,17 @@ ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
                             TInfo->getTypeLoc()))
       return ExprError();
 
-    if (RequireNonAbstractType(TInfo->getTypeLoc().getBeginLoc(),
-                               TInfo->getType(),
-                               diag::err_second_parameter_to_va_arg_abstract,
-                               TInfo->getTypeLoc()))
+    if (RequireNonAbstractType(
+            TInfo->getTypeLoc().getBeginLoc(), TInfo->getType(),
+            diag::err_second_parameter_to_va_arg_abstract, TInfo->getTypeLoc()))
       return ExprError();
 
     if (!TInfo->getType().isPODType(Context)) {
       Diag(TInfo->getTypeLoc().getBeginLoc(),
            TInfo->getType()->isObjCLifetimeType()
-             ? diag::warn_second_parameter_to_va_arg_ownership_qualified
-             : diag::warn_second_parameter_to_va_arg_not_pod)
-        << TInfo->getType()
-        << TInfo->getTypeLoc().getSourceRange();
+               ? diag::warn_second_parameter_to_va_arg_ownership_qualified
+               : diag::warn_second_parameter_to_va_arg_not_pod)
+          << TInfo->getType() << TInfo->getTypeLoc().getSourceRange();
     }
 
     // Check for va_arg where arguments of the given type will be promoted
@@ -17449,11 +17537,11 @@ ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
     if (TInfo->getType()->isSpecificBuiltinType(BuiltinType::Float))
       PromoteType = Context.DoubleTy;
     if (!PromoteType.isNull())
-      DiagRuntimeBehavior(TInfo->getTypeLoc().getBeginLoc(), E,
-                  PDiag(diag::warn_second_parameter_to_va_arg_never_compatible)
-                          << TInfo->getType()
-                          << PromoteType
-                          << TInfo->getTypeLoc().getSourceRange());
+      DiagRuntimeBehavior(
+          TInfo->getTypeLoc().getBeginLoc(), E,
+          PDiag(diag::warn_second_parameter_to_va_arg_never_compatible)
+              << TInfo->getType() << PromoteType
+              << TInfo->getTypeLoc().getSourceRange());
   }
 
   QualType T = TInfo->getType().getNonLValueExprType(Context);
@@ -17605,30 +17693,29 @@ bool Sema::CheckConversionToObjCLiteral(QualType DstType, Expr *&Exp,
       SrcExpr = OV->getSourceExpr()->IgnoreParenImpCasts();
 
   if (auto *SL = dyn_cast<StringLiteral>(SrcExpr)) {
-    if (!PT->isObjCIdType() &&
-        !(ID && ID->getIdentifier()->isStr("NSString")))
+    if (!PT->isObjCIdType() && !(ID && ID->getIdentifier()->isStr("NSString")))
       return false;
     if (!SL->isOrdinary())
       return false;
 
     if (Diagnose) {
       Diag(SL->getBeginLoc(), diag::err_missing_atsign_prefix)
-          << /*string*/0 << FixItHint::CreateInsertion(SL->getBeginLoc(), "@");
+          << /*string*/ 0 << FixItHint::CreateInsertion(SL->getBeginLoc(), "@");
       Exp = BuildObjCStringLiteral(SL->getBeginLoc(), SL).get();
     }
     return true;
   }
 
   if ((isa<IntegerLiteral>(SrcExpr) || isa<CharacterLiteral>(SrcExpr) ||
-      isa<FloatingLiteral>(SrcExpr) || isa<ObjCBoolLiteralExpr>(SrcExpr) ||
-      isa<CXXBoolLiteralExpr>(SrcExpr)) &&
-      !SrcExpr->isNullPointerConstant(
-          getASTContext(), Expr::NPC_NeverValueDependent)) {
+       isa<FloatingLiteral>(SrcExpr) || isa<ObjCBoolLiteralExpr>(SrcExpr) ||
+       isa<CXXBoolLiteralExpr>(SrcExpr)) &&
+      !SrcExpr->isNullPointerConstant(getASTContext(),
+                                      Expr::NPC_NeverValueDependent)) {
     if (!ID || !ID->getIdentifier()->isStr("NSNumber"))
       return false;
     if (Diagnose) {
       Diag(SrcExpr->getBeginLoc(), diag::err_missing_atsign_prefix)
-          << /*number*/1
+          << /*number*/ 1
           << FixItHint::CreateInsertion(SrcExpr->getBeginLoc(), "@");
       Expr *NumLit =
           BuildObjCNumericLiteral(SrcExpr->getBeginLoc(), SrcExpr).get();
@@ -17661,10 +17748,9 @@ static bool maybeDiagnoseAssignmentToFunction(Sema &S, QualType DstType,
 }
 
 bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
-                                    SourceLocation Loc,
-                                    QualType DstType, QualType SrcType,
-                                    Expr *SrcExpr, AssignmentAction Action,
-                                    bool *Complained) {
+                                    SourceLocation Loc, QualType DstType,
+                                    QualType SrcType, Expr *SrcExpr,
+                                    AssignmentAction Action, bool *Complained) {
   if (Complained)
     *Complained = false;
 
@@ -17680,8 +17766,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
 
   switch (ConvTy) {
   case Compatible:
-      DiagnoseAssignmentEnum(DstType, SrcType, SrcExpr);
-      return false;
+    DiagnoseAssignmentEnum(DstType, SrcType, SrcExpr);
+    return false;
 
   case PointerToInt:
     if (getLangOpts().CPlusPlus) {
@@ -17729,7 +17815,7 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       DiagKind = diag::ext_typecheck_convert_incompatible_pointer;
     }
     CheckInferredResultType = DstType->isObjCObjectPointerType() &&
-      SrcType->isObjCObjectPointerType();
+                              SrcType->isObjCObjectPointerType();
     if (!CheckInferredResultType) {
       ConvHints.tryToFixConversion(SrcExpr, SrcType, DstType, *this);
     } else if (CheckInferredResultType) {
@@ -17756,7 +17842,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     break;
   case IncompatiblePointerDiscardsQualifiers: {
     // Perform array-to-pointer decay if necessary.
-    if (SrcType->isArrayType()) SrcType = Context.getArrayDecayedType(SrcType);
+    if (SrcType->isArrayType())
+      SrcType = Context.getArrayDecayedType(SrcType);
 
     isInvalid = true;
 
@@ -17788,10 +17875,10 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
         IsStringLiteralToNonConstPointerConversion(SrcExpr, DstType))
       return false;
     if (getLangOpts().CPlusPlus) {
-      DiagKind =  diag::err_typecheck_convert_discards_qualifiers;
+      DiagKind = diag::err_typecheck_convert_discards_qualifiers;
       isInvalid = true;
     } else {
-      DiagKind =  diag::ext_typecheck_convert_discards_qualifiers;
+      DiagKind = diag::ext_typecheck_convert_discards_qualifiers;
     }
 
     break;
@@ -17818,24 +17905,23 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
   case IncompatibleObjCQualifiedId: {
     if (SrcType->isObjCQualifiedIdType()) {
       const ObjCObjectPointerType *srcOPT =
-                SrcType->castAs<ObjCObjectPointerType>();
+          SrcType->castAs<ObjCObjectPointerType>();
       for (auto *srcProto : srcOPT->quals()) {
         PDecl = srcProto;
         break;
       }
       if (const ObjCInterfaceType *IFaceT =
-            DstType->castAs<ObjCObjectPointerType>()->getInterfaceType())
+              DstType->castAs<ObjCObjectPointerType>()->getInterfaceType())
         IFace = IFaceT->getDecl();
-    }
-    else if (DstType->isObjCQualifiedIdType()) {
+    } else if (DstType->isObjCQualifiedIdType()) {
       const ObjCObjectPointerType *dstOPT =
-        DstType->castAs<ObjCObjectPointerType>();
+          DstType->castAs<ObjCObjectPointerType>();
       for (auto *dstProto : dstOPT->quals()) {
         PDecl = dstProto;
         break;
       }
       if (const ObjCInterfaceType *IFaceT =
-            SrcType->castAs<ObjCObjectPointerType>()->getInterfaceType())
+              SrcType->castAs<ObjCObjectPointerType>()->getInterfaceType())
         IFace = IFaceT->getDecl();
     }
     if (getLangOpts().CPlusPlus) {
@@ -17918,7 +18004,9 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       FDiag << H;
   }
 
-  if (MayHaveConvFixit) { FDiag << (unsigned) (ConvHints.Kind); }
+  if (MayHaveConvFixit) {
+    FDiag << (unsigned)(ConvHints.Kind);
+  }
 
   if (MayHaveFunctionDiff)
     HandleFunctionTypeMismatch(FDiag, SecondType, FirstType);
@@ -17931,8 +18019,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
         << IFace << PDecl;
 
   if (SecondType == Context.OverloadTy)
-    NoteAllOverloadCandidates(OverloadExpr::find(SrcExpr).Expression,
-                              FirstType, /*TakingAddress=*/true);
+    NoteAllOverloadCandidates(OverloadExpr::find(SrcExpr).Expression, FirstType,
+                              /*TakingAddress=*/true);
 
   if (CheckInferredResultType)
     EmitRelatedResultTypeNote(SrcExpr);
@@ -17945,8 +18033,7 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
   return isInvalid;
 }
 
-ExprResult Sema::VerifyIntegerConstantExpression(Expr *E,
-                                                 llvm::APSInt *Result,
+ExprResult Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
                                                  AllowFoldKind CanFold) {
   class SimpleICEDiagnoser : public VerifyICEDiagnoser {
   public:
@@ -17963,8 +18050,7 @@ ExprResult Sema::VerifyIntegerConstantExpression(Expr *E,
   return VerifyIntegerConstantExpression(E, Result, Diagnoser, CanFold);
 }
 
-ExprResult Sema::VerifyIntegerConstantExpression(Expr *E,
-                                                 llvm::APSInt *Result,
+ExprResult Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
                                                  unsigned DiagID,
                                                  AllowFoldKind CanFold) {
   class IDDiagnoser : public VerifyICEDiagnoser {
@@ -17972,7 +18058,7 @@ ExprResult Sema::VerifyIntegerConstantExpression(Expr *E,
 
   public:
     IDDiagnoser(unsigned DiagID)
-      : VerifyICEDiagnoser(DiagID == 0), DiagID(DiagID) { }
+        : VerifyICEDiagnoser(DiagID == 0), DiagID(DiagID) {}
 
     SemaDiagnosticBuilder diagnoseNotICE(Sema &S, SourceLocation Loc) override {
       return S.Diag(Loc, DiagID);
@@ -17993,10 +18079,9 @@ Sema::VerifyICEDiagnoser::diagnoseFold(Sema &S, SourceLocation Loc) {
   return S.Diag(Loc, diag::ext_expr_not_ice) << S.LangOpts.CPlusPlus;
 }
 
-ExprResult
-Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
-                                      VerifyICEDiagnoser &Diagnoser,
-                                      AllowFoldKind CanFold) {
+ExprResult Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
+                                                 VerifyICEDiagnoser &Diagnoser,
+                                                 AllowFoldKind CanFold) {
   SourceLocation DiagLoc = E->getBeginLoc();
 
   if (getLangOpts().CPlusPlus11) {
@@ -18008,6 +18093,7 @@ Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
     ExprResult Converted;
     class CXX11ConvertDiagnoser : public ICEConvertDiagnoser {
       VerifyICEDiagnoser &BaseDiagnoser;
+
     public:
       CXX11ConvertDiagnoser(VerifyICEDiagnoser &BaseDiagnoser)
           : ICEConvertDiagnoser(/*AllowScopedEnumerations*/ false,
@@ -18019,41 +18105,43 @@ Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
         return BaseDiagnoser.diagnoseNotICEType(S, Loc, T);
       }
 
-      SemaDiagnosticBuilder diagnoseIncomplete(
-          Sema &S, SourceLocation Loc, QualType T) override {
+      SemaDiagnosticBuilder diagnoseIncomplete(Sema &S, SourceLocation Loc,
+                                               QualType T) override {
         return S.Diag(Loc, diag::err_ice_incomplete_type) << T;
       }
 
-      SemaDiagnosticBuilder diagnoseExplicitConv(
-          Sema &S, SourceLocation Loc, QualType T, QualType ConvTy) override {
+      SemaDiagnosticBuilder diagnoseExplicitConv(Sema &S, SourceLocation Loc,
+                                                 QualType T,
+                                                 QualType ConvTy) override {
         return S.Diag(Loc, diag::err_ice_explicit_conversion) << T << ConvTy;
       }
 
-      SemaDiagnosticBuilder noteExplicitConv(
-          Sema &S, CXXConversionDecl *Conv, QualType ConvTy) override {
+      SemaDiagnosticBuilder noteExplicitConv(Sema &S, CXXConversionDecl *Conv,
+                                             QualType ConvTy) override {
         return S.Diag(Conv->getLocation(), diag::note_ice_conversion_here)
-                 << ConvTy->isEnumeralType() << ConvTy;
+               << ConvTy->isEnumeralType() << ConvTy;
       }
 
-      SemaDiagnosticBuilder diagnoseAmbiguous(
-          Sema &S, SourceLocation Loc, QualType T) override {
+      SemaDiagnosticBuilder diagnoseAmbiguous(Sema &S, SourceLocation Loc,
+                                              QualType T) override {
         return S.Diag(Loc, diag::err_ice_ambiguous_conversion) << T;
       }
 
-      SemaDiagnosticBuilder noteAmbiguous(
-          Sema &S, CXXConversionDecl *Conv, QualType ConvTy) override {
+      SemaDiagnosticBuilder noteAmbiguous(Sema &S, CXXConversionDecl *Conv,
+                                          QualType ConvTy) override {
         return S.Diag(Conv->getLocation(), diag::note_ice_conversion_here)
-                 << ConvTy->isEnumeralType() << ConvTy;
+               << ConvTy->isEnumeralType() << ConvTy;
       }
 
-      SemaDiagnosticBuilder diagnoseConversion(
-          Sema &S, SourceLocation Loc, QualType T, QualType ConvTy) override {
+      SemaDiagnosticBuilder diagnoseConversion(Sema &S, SourceLocation Loc,
+                                               QualType T,
+                                               QualType ConvTy) override {
         llvm_unreachable("conversion functions are permitted");
       }
     } ConvertDiagnoser(Diagnoser);
 
-    Converted = PerformContextualImplicitConversion(DiagLoc, E,
-                                                    ConvertDiagnoser);
+    Converted =
+        PerformContextualImplicitConversion(DiagLoc, E, ConvertDiagnoser);
     if (Converted.isInvalid())
       return Converted;
     E = Converted.get();
@@ -18109,8 +18197,8 @@ Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
   // If our only note is the usual "invalid subexpression" note, just point
   // the caret at its location rather than producing an essentially
   // redundant note.
-  if (Notes.size() == 1 && Notes[0].second.getDiagID() ==
-        diag::note_invalid_subexpr_in_const_expr) {
+  if (Notes.size() == 1 &&
+      Notes[0].second.getDiagID() == diag::note_invalid_subexpr_in_const_expr) {
     DiagLoc = Notes[0].first;
     Notes.clear();
   }
@@ -18135,58 +18223,57 @@ Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
 }
 
 namespace {
-  // Handle the case where we conclude a expression which we speculatively
-  // considered to be unevaluated is actually evaluated.
-  class TransformToPE : public TreeTransform<TransformToPE> {
-    typedef TreeTransform<TransformToPE> BaseTransform;
+// Handle the case where we conclude a expression which we speculatively
+// considered to be unevaluated is actually evaluated.
+class TransformToPE : public TreeTransform<TransformToPE> {
+  typedef TreeTransform<TransformToPE> BaseTransform;
 
-  public:
-    TransformToPE(Sema &SemaRef) : BaseTransform(SemaRef) { }
+public:
+  TransformToPE(Sema &SemaRef) : BaseTransform(SemaRef) {}
 
-    // Make sure we redo semantic analysis
-    bool AlwaysRebuild() { return true; }
-    bool ReplacingOriginal() { return true; }
+  // Make sure we redo semantic analysis
+  bool AlwaysRebuild() { return true; }
+  bool ReplacingOriginal() { return true; }
 
-    // We need to special-case DeclRefExprs referring to FieldDecls which
-    // are not part of a member pointer formation; normal TreeTransforming
-    // doesn't catch this case because of the way we represent them in the AST.
-    // FIXME: This is a bit ugly; is it really the best way to handle this
-    // case?
-    //
-    // Error on DeclRefExprs referring to FieldDecls.
-    ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
-      if (isa<FieldDecl>(E->getDecl()) &&
-          !SemaRef.isUnevaluatedContext())
-        return SemaRef.Diag(E->getLocation(),
-                            diag::err_invalid_non_static_member_use)
-            << E->getDecl() << E->getSourceRange();
+  // We need to special-case DeclRefExprs referring to FieldDecls which
+  // are not part of a member pointer formation; normal TreeTransforming
+  // doesn't catch this case because of the way we represent them in the AST.
+  // FIXME: This is a bit ugly; is it really the best way to handle this
+  // case?
+  //
+  // Error on DeclRefExprs referring to FieldDecls.
+  ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+    if (isa<FieldDecl>(E->getDecl()) && !SemaRef.isUnevaluatedContext())
+      return SemaRef.Diag(E->getLocation(),
+                          diag::err_invalid_non_static_member_use)
+             << E->getDecl() << E->getSourceRange();
 
-      return BaseTransform::TransformDeclRefExpr(E);
-    }
+    return BaseTransform::TransformDeclRefExpr(E);
+  }
 
-    // Exception: filter out member pointer formation
-    ExprResult TransformUnaryOperator(UnaryOperator *E) {
-      if (E->getOpcode() == UO_AddrOf && E->getType()->isMemberPointerType())
-        return E;
+  // Exception: filter out member pointer formation
+  ExprResult TransformUnaryOperator(UnaryOperator *E) {
+    if (E->getOpcode() == UO_AddrOf && E->getType()->isMemberPointerType())
+      return E;
 
-      return BaseTransform::TransformUnaryOperator(E);
-    }
+    return BaseTransform::TransformUnaryOperator(E);
+  }
 
-    // The body of a lambda-expression is in a separate expression evaluation
-    // context so never needs to be transformed.
-    // FIXME: Ideally we wouldn't transform the closure type either, and would
-    // just recreate the capture expressions and lambda expression.
-    StmtResult TransformLambdaBody(LambdaExpr *E, Stmt *Body) {
-      return SkipLambdaBody(E, Body);
-    }
-  };
-}
+  // The body of a lambda-expression is in a separate expression evaluation
+  // context so never needs to be transformed.
+  // FIXME: Ideally we wouldn't transform the closure type either, and would
+  // just recreate the capture expressions and lambda expression.
+  StmtResult TransformLambdaBody(LambdaExpr *E, Stmt *Body) {
+    return SkipLambdaBody(E, Body);
+  }
+};
+} // namespace
 
 ExprResult Sema::TransformToPotentiallyEvaluated(Expr *E) {
   assert(isUnevaluatedContext() &&
          "Should only transform unevaluated expressions");
   ExprEvalContexts.back().Context =
-      ExprEvalContexts[ExprEvalContexts.size()-2].Context;
+      ExprEvalContexts[ExprEvalContexts.size() - 2].Context;
   if (isUnevaluatedContext())
     return E;
   return TransformToPE(*this).TransformExpr(E);
@@ -18202,8 +18289,7 @@ TypeSourceInfo *Sema::TransformToPotentiallyEvaluated(TypeSourceInfo *TInfo) {
   return TransformToPE(*this).TransformType(TInfo);
 }
 
-void
-Sema::PushExpressionEvaluationContext(
+void Sema::PushExpressionEvaluationContext(
     ExpressionEvaluationContext NewContext, Decl *LambdaContextDecl,
     ExpressionEvaluationContextRecord::ExpressionKind ExprContext) {
   ExprEvalContexts.emplace_back(NewContext, ExprCleanupObjects.size(), Cleanup,
@@ -18232,8 +18318,7 @@ Sema::PushExpressionEvaluationContext(
     std::swap(MaybeODRUseExprs, ExprEvalContexts.back().SavedMaybeODRUseExprs);
 }
 
-void
-Sema::PushExpressionEvaluationContext(
+void Sema::PushExpressionEvaluationContext(
     ExpressionEvaluationContext NewContext, ReuseLambdaContextDecl_t,
     ExpressionEvaluationContextRecord::ExpressionKind ExprContext) {
   Decl *ClosureContextDecl = ExprEvalContexts.back().ManglingContextDecl;
@@ -18457,7 +18542,7 @@ static void RemoveNestedImmediateInvocation(
                   SmallVector<Sema::ImmediateInvocationCandidate,
                               4>::reverse_iterator Current)
         : Base(SemaRef), DRSet(DR), IISet(II), CurrentII(Current) {}
-    void RemoveImmediateInvocation(ConstantExpr* E) {
+    void RemoveImmediateInvocation(ConstantExpr *E) {
       auto It = std::find_if(CurrentII, IISet.rend(),
                              [E](Sema::ImmediateInvocationCandidate Elem) {
                                return Elem.getPointer() == E;
@@ -18630,7 +18715,7 @@ HandleImmediateInvocations(Sema &SemaRef,
 }
 
 void Sema::PopExpressionEvaluationContext() {
-  ExpressionEvaluationContextRecord& Rec = ExprEvalContexts.back();
+  ExpressionEvaluationContextRecord &Rec = ExprEvalContexts.back();
   unsigned NumTypos = Rec.NumTypos;
 
   if (!Rec.Lambdas.empty()) {
@@ -18693,7 +18778,7 @@ void Sema::PopExpressionEvaluationContext() {
     Cleanup = Rec.ParentCleanup;
     CleanupVarDeclMarking();
     std::swap(MaybeODRUseExprs, Rec.SavedMaybeODRUseExprs);
-  // Otherwise, merge the contexts together.
+    // Otherwise, merge the contexts together.
   } else {
     Cleanup.mergeFrom(Rec.ParentCleanup);
     MaybeODRUseExprs.insert(Rec.SavedMaybeODRUseExprs.begin(),
@@ -18708,9 +18793,9 @@ void Sema::PopExpressionEvaluationContext() {
 }
 
 void Sema::DiscardCleanupsInEvaluationContext() {
-  ExprCleanupObjects.erase(
-         ExprCleanupObjects.begin() + ExprEvalContexts.back().NumCleanupObjects,
-         ExprCleanupObjects.end());
+  ExprCleanupObjects.erase(ExprCleanupObjects.begin() +
+                               ExprEvalContexts.back().NumCleanupObjects,
+                           ExprCleanupObjects.end());
   Cleanup.reset();
   MaybeODRUseExprs.clear();
 }
@@ -18731,27 +18816,27 @@ static bool isPotentiallyConstantEvaluatedContext(Sema &SemaRef) {
   /// C++2a [expr.const]p12:
   //   An expression or conversion is potentially constant evaluated if it is
   switch (SemaRef.ExprEvalContexts.back().Context) {
-    case Sema::ExpressionEvaluationContext::ConstantEvaluated:
-    case Sema::ExpressionEvaluationContext::ImmediateFunctionContext:
+  case Sema::ExpressionEvaluationContext::ConstantEvaluated:
+  case Sema::ExpressionEvaluationContext::ImmediateFunctionContext:
 
-      // -- a manifestly constant-evaluated expression,
-    case Sema::ExpressionEvaluationContext::PotentiallyEvaluated:
-    case Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed:
-    case Sema::ExpressionEvaluationContext::DiscardedStatement:
-      // -- a potentially-evaluated expression,
-    case Sema::ExpressionEvaluationContext::UnevaluatedList:
-      // -- an immediate subexpression of a braced-init-list,
+    // -- a manifestly constant-evaluated expression,
+  case Sema::ExpressionEvaluationContext::PotentiallyEvaluated:
+  case Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed:
+  case Sema::ExpressionEvaluationContext::DiscardedStatement:
+    // -- a potentially-evaluated expression,
+  case Sema::ExpressionEvaluationContext::UnevaluatedList:
+    // -- an immediate subexpression of a braced-init-list,
 
-      // -- [FIXME] an expression of the form & cast-expression that occurs
-      //    within a templated entity
-      // -- a subexpression of one of the above that is not a subexpression of
-      // a nested unevaluated operand.
-      return true;
+    // -- [FIXME] an expression of the form & cast-expression that occurs
+    //    within a templated entity
+    // -- a subexpression of one of the above that is not a subexpression of
+    // a nested unevaluated operand.
+    return true;
 
-    case Sema::ExpressionEvaluationContext::Unevaluated:
-    case Sema::ExpressionEvaluationContext::UnevaluatedAbstract:
-      // Expressions in this context are never evaluated.
-      return false;
+  case Sema::ExpressionEvaluationContext::Unevaluated:
+  case Sema::ExpressionEvaluationContext::UnevaluatedAbstract:
+    // Expressions in this context are never evaluated.
+    return false;
   }
   llvm_unreachable("Invalid context");
 }
@@ -18850,26 +18935,26 @@ static OdrUseContext isOdrUseContext(Sema &SemaRef) {
   OdrUseContext Result;
 
   switch (SemaRef.ExprEvalContexts.back().Context) {
-    case Sema::ExpressionEvaluationContext::Unevaluated:
-    case Sema::ExpressionEvaluationContext::UnevaluatedList:
-    case Sema::ExpressionEvaluationContext::UnevaluatedAbstract:
-      return OdrUseContext::None;
+  case Sema::ExpressionEvaluationContext::Unevaluated:
+  case Sema::ExpressionEvaluationContext::UnevaluatedList:
+  case Sema::ExpressionEvaluationContext::UnevaluatedAbstract:
+    return OdrUseContext::None;
 
-    case Sema::ExpressionEvaluationContext::ConstantEvaluated:
-    case Sema::ExpressionEvaluationContext::ImmediateFunctionContext:
-    case Sema::ExpressionEvaluationContext::PotentiallyEvaluated:
-      Result = OdrUseContext::Used;
-      break;
+  case Sema::ExpressionEvaluationContext::ConstantEvaluated:
+  case Sema::ExpressionEvaluationContext::ImmediateFunctionContext:
+  case Sema::ExpressionEvaluationContext::PotentiallyEvaluated:
+    Result = OdrUseContext::Used;
+    break;
 
-    case Sema::ExpressionEvaluationContext::DiscardedStatement:
-      Result = OdrUseContext::FormallyOdrUsed;
-      break;
+  case Sema::ExpressionEvaluationContext::DiscardedStatement:
+    Result = OdrUseContext::FormallyOdrUsed;
+    break;
 
-    case Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed:
-      // A default argument formally results in odr-use, but doesn't actually
-      // result in a use in any real sense until it itself is used.
-      Result = OdrUseContext::FormallyOdrUsed;
-      break;
+  case Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed:
+    // A default argument formally results in odr-use, but doesn't actually
+    // result in a use in any real sense until it itself is used.
+    Result = OdrUseContext::FormallyOdrUsed;
+    break;
   }
 
   if (SemaRef.CurContext->isDependentContext())
@@ -19037,7 +19122,7 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
           PointOfInstantiation = Loc;
           if (auto *MSI = Func->getMemberSpecializationInfo())
             MSI->setPointOfInstantiation(Loc);
-            // FIXME: Notify listener.
+          // FIXME: Notify listener.
           else
             Func->setTemplateSpecializationKind(TSK, PointOfInstantiation);
         } else if (TSK != TSK_ImplicitInstantiation) {
@@ -19121,8 +19206,7 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
     if (!Func->isDefined()) {
       if (mightHaveNonExternalLinkage(Func))
         UndefinedButUsed.insert(std::make_pair(Func->getCanonicalDecl(), Loc));
-      else if (Func->getMostRecentDecl()->isInlined() &&
-               !LangOpts.GNUInline &&
+      else if (Func->getMostRecentDecl()->isInlined() && !LangOpts.GNUInline &&
                !Func->getMostRecentDecl()->hasAttr<GNUInlineAttr>())
         UndefinedButUsed.insert(std::make_pair(Func->getCanonicalDecl(), Loc));
       else if (isExternalWithNoLinkageType(Func))
@@ -19239,8 +19323,7 @@ void diagnoseUncapturableValueReferenceOrBinding(Sema &S, SourceLocation loc,
   //  If the parameter still belongs to the translation unit, then
   //  we're actually just using one parameter in the declaration of
   //  the next.
-  if (isa<ParmVarDecl>(var) &&
-      isa<TranslationUnitDecl>(VarDC))
+  if (isa<ParmVarDecl>(var) && isa<TranslationUnitDecl>(VarDC))
     return;
 
   // For C code, don't diagnose about capture if we're not actually in code
@@ -19265,9 +19348,8 @@ void diagnoseUncapturableValueReferenceOrBinding(Sema &S, SourceLocation loc,
   }
 
   S.Diag(loc, diag::err_reference_to_local_in_enclosing_context)
-    << var << ValueKind << ContextKind << VarDC;
-  S.Diag(var->getLocation(), diag::note_entity_declared_at)
-      << var;
+      << var << ValueKind << ContextKind << VarDC;
+  S.Diag(var->getLocation(), diag::note_entity_declared_at) << var;
 
   // FIXME: Add additional diagnostic info about class etc. which prevents
   // capture.
@@ -19428,8 +19510,7 @@ static bool captureInBlock(BlockScopeInfo *BSI, ValueDecl *Var,
   if (!Invalid &&
       CaptureType.getObjCLifetime() == Qualifiers::OCL_Autoreleasing) {
     if (BuildAndDiagnose) {
-      S.Diag(Loc, diag::err_arc_autoreleasing_capture)
-        << /*block*/ 0;
+      S.Diag(Loc, diag::err_arc_autoreleasing_capture) << /*block*/ 0;
       S.Diag(Var->getLocation(), diag::note_previous_decl) << Var;
       Invalid = true;
     } else {
@@ -19495,8 +19576,8 @@ static bool captureInCapturedRegion(
     if (S.isOpenMPPrivateDecl(Var, RSI->OpenMPLevel, RSI->OpenMPCaptureLevel) !=
         OMPC_unknown)
       return true;
-    ByRef = S.isOpenMPCapturedByRef(Var, RSI->OpenMPLevel,
-                                    RSI->OpenMPCaptureLevel);
+    ByRef =
+        S.isOpenMPCapturedByRef(Var, RSI->OpenMPLevel, RSI->OpenMPCaptureLevel);
   }
 
   if (ByRef)
@@ -19560,7 +19641,7 @@ static bool captureInLambda(LambdaScopeInfo *LSI, ValueDecl *Var,
     //   captured entity is a reference to a function, the
     //   corresponding data member is also a reference to a
     //   function. - end note ]
-    if (const ReferenceType *RefType = CaptureType->getAs<ReferenceType>()){
+    if (const ReferenceType *RefType = CaptureType->getAs<ReferenceType>()) {
       if (!RefType->getPointeeType()->isFunctionType())
         CaptureType = RefType->getPointeeType();
     }
@@ -19571,7 +19652,7 @@ static bool captureInLambda(LambdaScopeInfo *LSI, ValueDecl *Var,
       if (BuildAndDiagnose) {
         S.Diag(Loc, diag::err_arc_autoreleasing_capture) << /*lambda*/ 1;
         S.Diag(Var->getLocation(), diag::note_previous_decl)
-          << Var->getDeclName();
+            << Var->getDeclName();
         Invalid = true;
       } else {
         return false;
@@ -19743,7 +19824,8 @@ bool Sema::tryCaptureVariable(
   assert(VD && "Cannot capture a null variable");
 
   const unsigned MaxFunctionScopesIndex = FunctionScopeIndexToStopAt
-      ? *FunctionScopeIndexToStopAt : FunctionScopes.size() - 1;
+                                              ? *FunctionScopeIndexToStopAt
+                                              : FunctionScopes.size() - 1;
   // We need to sync up the Declaration Context with the
   // FunctionScopeIndexToStopAt
   if (FunctionScopeIndexToStopAt) {
@@ -19818,7 +19900,7 @@ bool Sema::tryCaptureVariable(
       return true;
     }
 
-    FunctionScopeInfo  *FSI = FunctionScopes[FunctionScopesIndex];
+    FunctionScopeInfo *FSI = FunctionScopes[FunctionScopesIndex];
     CapturingScopeInfo *CSI = cast<CapturingScopeInfo>(FSI);
 
     // Check whether we've already captured it.
@@ -19964,13 +20046,13 @@ bool Sema::tryCaptureVariable(
   // If the variable had already been captured previously, we start capturing
   // at the lambda nested within that one.
   bool Invalid = false;
-  for (unsigned I = ++FunctionScopesIndex, N = MaxFunctionScopesIndex + 1; I != N;
-       ++I) {
+  for (unsigned I = ++FunctionScopesIndex, N = MaxFunctionScopesIndex + 1;
+       I != N; ++I) {
     CapturingScopeInfo *CSI = cast<CapturingScopeInfo>(FunctionScopes[I]);
 
-    // Certain capturing entities (lambdas, blocks etc.) are not allowed to capture
-    // certain types of variables (unnamed, variably modified types etc.)
-    // so check for eligibility.
+    // Certain capturing entities (lambdas, blocks etc.) are not allowed to
+    // capture certain types of variables (unnamed, variably modified types
+    // etc.) so check for eligibility.
     if (!Invalid)
       Invalid =
           !isVariableCapturable(CSI, Var, ExprLoc, BuildAndDiagnose, *this);
@@ -19981,10 +20063,12 @@ bool Sema::tryCaptureVariable(
       return true;
 
     if (BlockScopeInfo *BSI = dyn_cast<BlockScopeInfo>(CSI)) {
-      Invalid = !captureInBlock(BSI, Var, ExprLoc, BuildAndDiagnose, CaptureType,
-                               DeclRefType, Nested, *this, Invalid);
+      Invalid =
+          !captureInBlock(BSI, Var, ExprLoc, BuildAndDiagnose, CaptureType,
+                          DeclRefType, Nested, *this, Invalid);
       Nested = true;
-    } else if (CapturedRegionScopeInfo *RSI = dyn_cast<CapturedRegionScopeInfo>(CSI)) {
+    } else if (CapturedRegionScopeInfo *RSI =
+                   dyn_cast<CapturedRegionScopeInfo>(CSI)) {
       Invalid = !captureInCapturedRegion(
           RSI, Var, ExprLoc, BuildAndDiagnose, CaptureType, DeclRefType, Nested,
           Kind, /*IsTopScope*/ I == N - 1, *this, Invalid);
@@ -20009,8 +20093,8 @@ bool Sema::tryCaptureVariable(ValueDecl *Var, SourceLocation Loc,
   QualType CaptureType;
   QualType DeclRefType;
   return tryCaptureVariable(Var, Loc, Kind, EllipsisLoc,
-                            /*BuildAndDiagnose=*/true, CaptureType,
-                            DeclRefType, nullptr);
+                            /*BuildAndDiagnose=*/true, CaptureType, DeclRefType,
+                            nullptr);
 }
 
 bool Sema::NeedToCaptureVariable(ValueDecl *Var, SourceLocation Loc) {
@@ -20027,8 +20111,8 @@ QualType Sema::getCapturedDeclRefType(ValueDecl *Var, SourceLocation Loc) {
 
   // Determine whether we can capture this variable.
   if (tryCaptureVariable(Var, Loc, TryCapture_Implicit, SourceLocation(),
-                         /*BuildAndDiagnose=*/false, CaptureType,
-                         DeclRefType, nullptr))
+                         /*BuildAndDiagnose=*/false, CaptureType, DeclRefType,
+                         nullptr))
     return QualType();
 
   return DeclRefType;
@@ -20042,23 +20126,24 @@ namespace {
 class CopiedTemplateArgs {
   bool HasArgs;
   TemplateArgumentListInfo TemplateArgStorage;
+
 public:
-  template<typename RefExpr>
+  template <typename RefExpr>
   CopiedTemplateArgs(RefExpr *E) : HasArgs(E->hasExplicitTemplateArgs()) {
     if (HasArgs)
       E->copyTemplateArgumentsInto(TemplateArgStorage);
   }
-  operator TemplateArgumentListInfo*()
+  operator TemplateArgumentListInfo *()
 #ifdef __has_cpp_attribute
 #if __has_cpp_attribute(clang::lifetimebound)
-  [[clang::lifetimebound]]
+      [[clang::lifetimebound]]
 #endif
 #endif
   {
     return HasArgs ? &TemplateArgStorage : nullptr;
   }
 };
-}
+} // namespace
 
 /// Walk the set of potential results of an expression and mark them all as
 /// non-odr-uses if they satisfy the side-conditions of the NonOdrUseReason.
@@ -20232,7 +20317,7 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
       if (!Sub.isUsable())
         return Sub;
       LHS = Sub.get();
-    //   -- If e is a comma expression, ...
+      //   -- If e is a comma expression, ...
     } else if (BO->getOpcode() == BO_Comma) {
       ExprResult Sub = Rebuild(RHS);
       if (!Sub.isUsable())
@@ -20241,8 +20326,8 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
     } else {
       break;
     }
-    return S.BuildBinOp(nullptr, BO->getOperatorLoc(), BO->getOpcode(),
-                        LHS, RHS);
+    return S.BuildBinOp(nullptr, BO->getOperatorLoc(), BO->getOpcode(), LHS,
+                        RHS);
   }
 
   //   -- If e has the form (e1)...
@@ -20396,7 +20481,7 @@ ExprResult Sema::CheckLValueToRValueConversionOperand(Expr *E) {
        E->getType().hasNonTrivialToPrimitiveCopyCUnion()))
     checkNonTrivialCUnion(E->getType(), E->getExprLoc(),
                           Sema::NTCUC_LValueToRValueVolatile,
-                          NTCUK_Destruct|NTCUK_Copy);
+                          NTCUK_Destruct | NTCUK_Copy);
 
   // C++2a [basic.def.odr]p4:
   //   [...] an expression of non-volatile-qualified non-class type to which
@@ -20432,8 +20517,8 @@ void Sema::CleanupVarDeclMarking() {
 
   for (Expr *E : LocalMaybeODRUseExprs) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
-      MarkVarDeclODRUsed(cast<VarDecl>(DRE->getDecl()),
-                         DRE->getLocation(), *this);
+      MarkVarDeclODRUsed(cast<VarDecl>(DRE->getDecl()), DRE->getLocation(),
+                         *this);
     } else if (auto *ME = dyn_cast<MemberExpr>(E)) {
       MarkVarDeclODRUsed(cast<VarDecl>(ME->getMemberDecl()), ME->getMemberLoc(),
                          *this);
@@ -20545,7 +20630,7 @@ static void DoMarkVarDeclReferenced(
         PointOfInstantiation = Loc;
         if (MSI)
           MSI->setPointOfInstantiation(PointOfInstantiation);
-          // FIXME: Notify listener.
+        // FIXME: Notify listener.
         else
           Var->setTemplateSpecializationKind(TSK, PointOfInstantiation);
       }
@@ -20564,8 +20649,8 @@ static void DoMarkVarDeclReferenced(
         else if (auto *ME = dyn_cast_or_null<MemberExpr>(E))
           ME->setMemberDecl(ME->getMemberDecl());
       } else if (FirstInstantiation) {
-        SemaRef.PendingInstantiations
-            .push_back(std::make_pair(Var, PointOfInstantiation));
+        SemaRef.PendingInstantiations.push_back(
+            std::make_pair(Var, PointOfInstantiation));
       } else {
         bool Inserted = false;
         for (auto &I : SemaRef.SavedPendingInstantiations) {
@@ -20587,8 +20672,8 @@ static void DoMarkVarDeclReferenced(
         // no direct way to avoid enqueueing the pending instantiation
         // multiple times.
         if (isa<VarTemplateSpecializationDecl>(Var) && !Inserted)
-          SemaRef.PendingInstantiations
-            .push_back(std::make_pair(Var, PointOfInstantiation));
+          SemaRef.PendingInstantiations.push_back(
+              std::make_pair(Var, PointOfInstantiation));
       }
     }
   }
@@ -20740,8 +20825,8 @@ MarkExprReferenced(Sema &SemaRef, SourceLocation Loc, Decl *D, Expr *E,
   if (!MD)
     return;
   // Only attempt to devirtualize if this is truly a virtual call.
-  bool IsVirtualCall = MD->isVirtual() &&
-                          ME->performsVirtualDispatch(SemaRef.getLangOpts());
+  bool IsVirtualCall =
+      MD->isVirtual() && ME->performsVirtualDispatch(SemaRef.getLangOpts());
   if (!IsVirtualCall)
     return;
 
@@ -20826,25 +20911,25 @@ void Sema::MarkAnyDeclReferenced(SourceLocation Loc, Decl *D,
 }
 
 namespace {
-  // Mark all of the declarations used by a type as referenced.
-  // FIXME: Not fully implemented yet! We need to have a better understanding
-  // of when we're entering a context we should not recurse into.
-  // FIXME: This is and EvaluatedExprMarker are more-or-less equivalent to
-  // TreeTransforms rebuilding the type in a new context. Rather than
-  // duplicating the TreeTransform logic, we should consider reusing it here.
-  // Currently that causes problems when rebuilding LambdaExprs.
-  class MarkReferencedDecls : public RecursiveASTVisitor<MarkReferencedDecls> {
-    Sema &S;
-    SourceLocation Loc;
+// Mark all of the declarations used by a type as referenced.
+// FIXME: Not fully implemented yet! We need to have a better understanding
+// of when we're entering a context we should not recurse into.
+// FIXME: This is and EvaluatedExprMarker are more-or-less equivalent to
+// TreeTransforms rebuilding the type in a new context. Rather than
+// duplicating the TreeTransform logic, we should consider reusing it here.
+// Currently that causes problems when rebuilding LambdaExprs.
+class MarkReferencedDecls : public RecursiveASTVisitor<MarkReferencedDecls> {
+  Sema &S;
+  SourceLocation Loc;
 
-  public:
-    typedef RecursiveASTVisitor<MarkReferencedDecls> Inherited;
+public:
+  typedef RecursiveASTVisitor<MarkReferencedDecls> Inherited;
 
-    MarkReferencedDecls(Sema &S, SourceLocation Loc) : S(S), Loc(Loc) { }
+  MarkReferencedDecls(Sema &S, SourceLocation Loc) : S(S), Loc(Loc) {}
 
-    bool TraverseTemplateArgument(const TemplateArgument &Arg);
-  };
-}
+  bool TraverseTemplateArgument(const TemplateArgument &Arg);
+};
+} // namespace
 
 bool MarkReferencedDecls::TraverseTemplateArgument(
     const TemplateArgument &Arg) {
@@ -20923,9 +21008,8 @@ public:
 /// \param SkipLocalVariables If true, don't mark local variables as
 /// 'referenced'.
 /// \param StopAt Subexpressions that we shouldn't recurse into.
-void Sema::MarkDeclarationsReferencedInExpr(Expr *E,
-                                            bool SkipLocalVariables,
-                                            ArrayRef<const Expr*> StopAt) {
+void Sema::MarkDeclarationsReferencedInExpr(Expr *E, bool SkipLocalVariables,
+                                            ArrayRef<const Expr *> StopAt) {
   EvaluatedExprMarker(*this, SkipLocalVariables, StopAt).Visit(E);
 }
 
@@ -20977,7 +21061,7 @@ bool Sema::DiagIfReachable(SourceLocation Loc, ArrayRef<const Stmt *> Stmts,
 /// behavior of a program, such as passing a non-POD value through an ellipsis.
 /// Failure to do so will likely result in spurious diagnostics or failures
 /// during overload resolution or within sizeof/alignof/typeof/typeid.
-bool Sema::DiagRuntimeBehavior(SourceLocation Loc, ArrayRef<const Stmt*> Stmts,
+bool Sema::DiagRuntimeBehavior(SourceLocation Loc, ArrayRef<const Stmt *> Stmts,
                                const PartialDiagnostic &PD) {
 
   if (ExprEvalContexts.back().isDiscardedStatementContext())
@@ -21029,12 +21113,12 @@ bool Sema::CheckCallReturnType(QualType ReturnType, SourceLocation Loc,
 
   public:
     CallReturnIncompleteDiagnoser(FunctionDecl *FD, CallExpr *CE)
-      : FD(FD), CE(CE) { }
+        : FD(FD), CE(CE) {}
 
     void diagnose(Sema &S, SourceLocation Loc, QualType T) override {
       if (!FD) {
         S.Diag(Loc, diag::err_call_incomplete_return)
-          << T << CE->getSourceRange();
+            << T << CE->getSourceRange();
         return;
       }
 
@@ -21066,8 +21150,8 @@ void Sema::DiagnoseAssignmentAsCondition(Expr *E) {
     IsOrAssign = Op->getOpcode() == BO_OrAssign;
 
     // Greylist some idioms by putting them into a warning subcategory.
-    if (ObjCMessageExpr *ME
-          = dyn_cast<ObjCMessageExpr>(Op->getRHS()->IgnoreParenCasts())) {
+    if (ObjCMessageExpr *ME =
+            dyn_cast<ObjCMessageExpr>(Op->getRHS()->IgnoreParenCasts())) {
       Selector Sel = ME->getSelector();
 
       // self = [<foo> init...]
@@ -21098,15 +21182,15 @@ void Sema::DiagnoseAssignmentAsCondition(Expr *E) {
   SourceLocation Open = E->getBeginLoc();
   SourceLocation Close = getLocForEndOfToken(E->getSourceRange().getEnd());
   Diag(Loc, diag::note_condition_assign_silence)
-        << FixItHint::CreateInsertion(Open, "(")
-        << FixItHint::CreateInsertion(Close, ")");
+      << FixItHint::CreateInsertion(Open, "(")
+      << FixItHint::CreateInsertion(Close, ")");
 
   if (IsOrAssign)
     Diag(Loc, diag::note_condition_or_assign_to_comparison)
-      << FixItHint::CreateReplacement(Loc, "!=");
+        << FixItHint::CreateReplacement(Loc, "!=");
   else
     Diag(Loc, diag::note_condition_assign_to_comparison)
-      << FixItHint::CreateReplacement(Loc, "==");
+        << FixItHint::CreateReplacement(Loc, "==");
 }
 
 /// Redundant parentheses over an equality comparison can indicate
@@ -21124,17 +21208,17 @@ void Sema::DiagnoseEqualityWithExtraParens(ParenExpr *ParenE) {
 
   if (BinaryOperator *opE = dyn_cast<BinaryOperator>(E))
     if (opE->getOpcode() == BO_EQ &&
-        opE->getLHS()->IgnoreParenImpCasts()->isModifiableLvalue(Context)
-                                                           == Expr::MLV_Valid) {
+        opE->getLHS()->IgnoreParenImpCasts()->isModifiableLvalue(Context) ==
+            Expr::MLV_Valid) {
       SourceLocation Loc = opE->getOperatorLoc();
 
       Diag(Loc, diag::warn_equality_with_extra_parens) << E->getSourceRange();
       SourceRange ParenERange = ParenE->getSourceRange();
       Diag(Loc, diag::note_equality_comparison_silence)
-        << FixItHint::CreateRemoval(ParenERange.getBegin())
-        << FixItHint::CreateRemoval(ParenERange.getEnd());
+          << FixItHint::CreateRemoval(ParenERange.getBegin())
+          << FixItHint::CreateRemoval(ParenERange.getEnd());
       Diag(Loc, diag::note_equality_comparison_to_assign)
-        << FixItHint::CreateReplacement(Loc, "=");
+          << FixItHint::CreateReplacement(Loc, "=");
     }
 }
 
@@ -21145,7 +21229,8 @@ ExprResult Sema::CheckBooleanCondition(SourceLocation Loc, Expr *E,
     DiagnoseEqualityWithExtraParens(parenE);
 
   ExprResult result = CheckPlaceholderExpr(E);
-  if (result.isInvalid()) return ExprError();
+  if (result.isInvalid())
+    return ExprError();
   E = result.get();
 
   if (!E->isTypeDependent()) {
@@ -21160,7 +21245,7 @@ ExprResult Sema::CheckBooleanCondition(SourceLocation Loc, Expr *E,
     QualType T = E->getType();
     if (!T->isScalarType()) { // C99 6.8.4.1p1
       Diag(Loc, diag::err_typecheck_statement_requires_scalar)
-        << T << E->getSourceRange();
+          << T << E->getSourceRange();
       return ExprError();
     }
     CheckBoolLikeConversion(E, Loc);
@@ -21207,190 +21292,182 @@ Sema::ConditionResult Sema::ActOnCondition(Scope *S, SourceLocation Loc,
 }
 
 namespace {
-  /// A visitor for rebuilding a call to an __unknown_any expression
-  /// to have an appropriate type.
-  struct RebuildUnknownAnyFunction
+/// A visitor for rebuilding a call to an __unknown_any expression
+/// to have an appropriate type.
+struct RebuildUnknownAnyFunction
     : StmtVisitor<RebuildUnknownAnyFunction, ExprResult> {
 
-    Sema &S;
+  Sema &S;
 
-    RebuildUnknownAnyFunction(Sema &S) : S(S) {}
+  RebuildUnknownAnyFunction(Sema &S) : S(S) {}
 
-    ExprResult VisitStmt(Stmt *S) {
-      llvm_unreachable("unexpected statement!");
-    }
+  ExprResult VisitStmt(Stmt *S) { llvm_unreachable("unexpected statement!"); }
 
-    ExprResult VisitExpr(Expr *E) {
-      S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_call)
+  ExprResult VisitExpr(Expr *E) {
+    S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_call)
         << E->getSourceRange();
+    return ExprError();
+  }
+
+  /// Rebuild an expression which simply semantically wraps another
+  /// expression which it shares the type and value kind of.
+  template <class T> ExprResult rebuildSugarExpr(T *E) {
+    ExprResult SubResult = Visit(E->getSubExpr());
+    if (SubResult.isInvalid())
       return ExprError();
-    }
 
-    /// Rebuild an expression which simply semantically wraps another
-    /// expression which it shares the type and value kind of.
-    template <class T> ExprResult rebuildSugarExpr(T *E) {
-      ExprResult SubResult = Visit(E->getSubExpr());
-      if (SubResult.isInvalid()) return ExprError();
+    Expr *SubExpr = SubResult.get();
+    E->setSubExpr(SubExpr);
+    E->setType(SubExpr->getType());
+    E->setValueKind(SubExpr->getValueKind());
+    assert(E->getObjectKind() == OK_Ordinary);
+    return E;
+  }
 
-      Expr *SubExpr = SubResult.get();
-      E->setSubExpr(SubExpr);
-      E->setType(SubExpr->getType());
-      E->setValueKind(SubExpr->getValueKind());
-      assert(E->getObjectKind() == OK_Ordinary);
-      return E;
-    }
+  ExprResult VisitParenExpr(ParenExpr *E) { return rebuildSugarExpr(E); }
 
-    ExprResult VisitParenExpr(ParenExpr *E) {
-      return rebuildSugarExpr(E);
-    }
+  ExprResult VisitUnaryExtension(UnaryOperator *E) {
+    return rebuildSugarExpr(E);
+  }
 
-    ExprResult VisitUnaryExtension(UnaryOperator *E) {
-      return rebuildSugarExpr(E);
-    }
+  ExprResult VisitUnaryAddrOf(UnaryOperator *E) {
+    ExprResult SubResult = Visit(E->getSubExpr());
+    if (SubResult.isInvalid())
+      return ExprError();
 
-    ExprResult VisitUnaryAddrOf(UnaryOperator *E) {
-      ExprResult SubResult = Visit(E->getSubExpr());
-      if (SubResult.isInvalid()) return ExprError();
+    Expr *SubExpr = SubResult.get();
+    E->setSubExpr(SubExpr);
+    E->setType(S.Context.getPointerType(SubExpr->getType()));
+    assert(E->isPRValue());
+    assert(E->getObjectKind() == OK_Ordinary);
+    return E;
+  }
 
-      Expr *SubExpr = SubResult.get();
-      E->setSubExpr(SubExpr);
-      E->setType(S.Context.getPointerType(SubExpr->getType()));
-      assert(E->isPRValue());
-      assert(E->getObjectKind() == OK_Ordinary);
-      return E;
-    }
+  ExprResult resolveDecl(Expr *E, ValueDecl *VD) {
+    if (!isa<FunctionDecl>(VD))
+      return VisitExpr(E);
 
-    ExprResult resolveDecl(Expr *E, ValueDecl *VD) {
-      if (!isa<FunctionDecl>(VD)) return VisitExpr(E);
+    E->setType(VD->getType());
 
-      E->setType(VD->getType());
+    assert(E->isPRValue());
+    if (S.getLangOpts().CPlusPlus &&
+        !(isa<CXXMethodDecl>(VD) && cast<CXXMethodDecl>(VD)->isInstance()))
+      E->setValueKind(VK_LValue);
 
-      assert(E->isPRValue());
-      if (S.getLangOpts().CPlusPlus &&
-          !(isa<CXXMethodDecl>(VD) &&
-            cast<CXXMethodDecl>(VD)->isInstance()))
-        E->setValueKind(VK_LValue);
+    return E;
+  }
 
-      return E;
-    }
+  ExprResult VisitMemberExpr(MemberExpr *E) {
+    return resolveDecl(E, E->getMemberDecl());
+  }
 
-    ExprResult VisitMemberExpr(MemberExpr *E) {
-      return resolveDecl(E, E->getMemberDecl());
-    }
-
-    ExprResult VisitDeclRefExpr(DeclRefExpr *E) {
-      return resolveDecl(E, E->getDecl());
-    }
-  };
-}
+  ExprResult VisitDeclRefExpr(DeclRefExpr *E) {
+    return resolveDecl(E, E->getDecl());
+  }
+};
+} // namespace
 
 /// Given a function expression of unknown-any type, try to rebuild it
 /// to have a function type.
 static ExprResult rebuildUnknownAnyFunction(Sema &S, Expr *FunctionExpr) {
   ExprResult Result = RebuildUnknownAnyFunction(S).Visit(FunctionExpr);
-  if (Result.isInvalid()) return ExprError();
+  if (Result.isInvalid())
+    return ExprError();
   return S.DefaultFunctionArrayConversion(Result.get());
 }
 
 namespace {
-  /// A visitor for rebuilding an expression of type __unknown_anytype
-  /// into one which resolves the type directly on the referring
-  /// expression.  Strict preservation of the original source
-  /// structure is not a goal.
-  struct RebuildUnknownAnyExpr
-    : StmtVisitor<RebuildUnknownAnyExpr, ExprResult> {
+/// A visitor for rebuilding an expression of type __unknown_anytype
+/// into one which resolves the type directly on the referring
+/// expression.  Strict preservation of the original source
+/// structure is not a goal.
+struct RebuildUnknownAnyExpr : StmtVisitor<RebuildUnknownAnyExpr, ExprResult> {
 
-    Sema &S;
+  Sema &S;
 
-    /// The current destination type.
-    QualType DestType;
+  /// The current destination type.
+  QualType DestType;
 
-    RebuildUnknownAnyExpr(Sema &S, QualType CastType)
+  RebuildUnknownAnyExpr(Sema &S, QualType CastType)
       : S(S), DestType(CastType) {}
 
-    ExprResult VisitStmt(Stmt *S) {
-      llvm_unreachable("unexpected statement!");
-    }
+  ExprResult VisitStmt(Stmt *S) { llvm_unreachable("unexpected statement!"); }
 
-    ExprResult VisitExpr(Expr *E) {
-      S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_expr)
+  ExprResult VisitExpr(Expr *E) {
+    S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_expr)
         << E->getSourceRange();
+    return ExprError();
+  }
+
+  ExprResult VisitCallExpr(CallExpr *E);
+  ExprResult VisitObjCMessageExpr(ObjCMessageExpr *E);
+
+  /// Rebuild an expression which simply semantically wraps another
+  /// expression which it shares the type and value kind of.
+  template <class T> ExprResult rebuildSugarExpr(T *E) {
+    ExprResult SubResult = Visit(E->getSubExpr());
+    if (SubResult.isInvalid())
+      return ExprError();
+    Expr *SubExpr = SubResult.get();
+    E->setSubExpr(SubExpr);
+    E->setType(SubExpr->getType());
+    E->setValueKind(SubExpr->getValueKind());
+    assert(E->getObjectKind() == OK_Ordinary);
+    return E;
+  }
+
+  ExprResult VisitParenExpr(ParenExpr *E) { return rebuildSugarExpr(E); }
+
+  ExprResult VisitUnaryExtension(UnaryOperator *E) {
+    return rebuildSugarExpr(E);
+  }
+
+  ExprResult VisitUnaryAddrOf(UnaryOperator *E) {
+    const PointerType *Ptr = DestType->getAs<PointerType>();
+    if (!Ptr) {
+      S.Diag(E->getOperatorLoc(), diag::err_unknown_any_addrof)
+          << E->getSourceRange();
       return ExprError();
     }
 
-    ExprResult VisitCallExpr(CallExpr *E);
-    ExprResult VisitObjCMessageExpr(ObjCMessageExpr *E);
-
-    /// Rebuild an expression which simply semantically wraps another
-    /// expression which it shares the type and value kind of.
-    template <class T> ExprResult rebuildSugarExpr(T *E) {
-      ExprResult SubResult = Visit(E->getSubExpr());
-      if (SubResult.isInvalid()) return ExprError();
-      Expr *SubExpr = SubResult.get();
-      E->setSubExpr(SubExpr);
-      E->setType(SubExpr->getType());
-      E->setValueKind(SubExpr->getValueKind());
-      assert(E->getObjectKind() == OK_Ordinary);
-      return E;
-    }
-
-    ExprResult VisitParenExpr(ParenExpr *E) {
-      return rebuildSugarExpr(E);
-    }
-
-    ExprResult VisitUnaryExtension(UnaryOperator *E) {
-      return rebuildSugarExpr(E);
-    }
-
-    ExprResult VisitUnaryAddrOf(UnaryOperator *E) {
-      const PointerType *Ptr = DestType->getAs<PointerType>();
-      if (!Ptr) {
-        S.Diag(E->getOperatorLoc(), diag::err_unknown_any_addrof)
+    if (isa<CallExpr>(E->getSubExpr())) {
+      S.Diag(E->getOperatorLoc(), diag::err_unknown_any_addrof_call)
           << E->getSourceRange();
-        return ExprError();
-      }
-
-      if (isa<CallExpr>(E->getSubExpr())) {
-        S.Diag(E->getOperatorLoc(), diag::err_unknown_any_addrof_call)
-          << E->getSourceRange();
-        return ExprError();
-      }
-
-      assert(E->isPRValue());
-      assert(E->getObjectKind() == OK_Ordinary);
-      E->setType(DestType);
-
-      // Build the sub-expression as if it were an object of the pointee type.
-      DestType = Ptr->getPointeeType();
-      ExprResult SubResult = Visit(E->getSubExpr());
-      if (SubResult.isInvalid()) return ExprError();
-      E->setSubExpr(SubResult.get());
-      return E;
+      return ExprError();
     }
 
-    ExprResult VisitImplicitCastExpr(ImplicitCastExpr *E);
+    assert(E->isPRValue());
+    assert(E->getObjectKind() == OK_Ordinary);
+    E->setType(DestType);
 
-    ExprResult resolveDecl(Expr *E, ValueDecl *VD);
+    // Build the sub-expression as if it were an object of the pointee type.
+    DestType = Ptr->getPointeeType();
+    ExprResult SubResult = Visit(E->getSubExpr());
+    if (SubResult.isInvalid())
+      return ExprError();
+    E->setSubExpr(SubResult.get());
+    return E;
+  }
 
-    ExprResult VisitMemberExpr(MemberExpr *E) {
-      return resolveDecl(E, E->getMemberDecl());
-    }
+  ExprResult VisitImplicitCastExpr(ImplicitCastExpr *E);
 
-    ExprResult VisitDeclRefExpr(DeclRefExpr *E) {
-      return resolveDecl(E, E->getDecl());
-    }
-  };
-}
+  ExprResult resolveDecl(Expr *E, ValueDecl *VD);
+
+  ExprResult VisitMemberExpr(MemberExpr *E) {
+    return resolveDecl(E, E->getMemberDecl());
+  }
+
+  ExprResult VisitDeclRefExpr(DeclRefExpr *E) {
+    return resolveDecl(E, E->getDecl());
+  }
+};
+} // namespace
 
 /// Rebuilds a call expression which yielded __unknown_anytype.
 ExprResult RebuildUnknownAnyExpr::VisitCallExpr(CallExpr *E) {
   Expr *CalleeExpr = E->getCallee();
 
-  enum FnKind {
-    FK_MemberFunction,
-    FK_FunctionPointer,
-    FK_BlockPointer
-  };
+  enum FnKind { FK_MemberFunction, FK_FunctionPointer, FK_BlockPointer };
 
   FnKind Kind;
   QualType CalleeType = CalleeExpr->getType();
@@ -21413,8 +21490,7 @@ ExprResult RebuildUnknownAnyExpr::VisitCallExpr(CallExpr *E) {
     if (Kind == FK_BlockPointer)
       diagID = diag::err_block_returning_array_function;
 
-    S.Diag(E->getExprLoc(), diagID)
-      << DestType->isFunctionType() << DestType;
+    S.Diag(E->getExprLoc(), diagID) << DestType->isFunctionType() << DestType;
     return ExprError();
   }
 
@@ -21457,8 +21533,7 @@ ExprResult RebuildUnknownAnyExpr::VisitCallExpr(CallExpr *E) {
     DestType = S.Context.getFunctionType(DestType, ParamTypes,
                                          Proto->getExtProtoInfo());
   } else {
-    DestType = S.Context.getFunctionNoProtoType(DestType,
-                                                FnType->getExtInfo());
+    DestType = S.Context.getFunctionNoProtoType(DestType, FnType->getExtInfo());
   }
 
   // Rebuild the appropriate pointer-to-function type.
@@ -21478,7 +21553,8 @@ ExprResult RebuildUnknownAnyExpr::VisitCallExpr(CallExpr *E) {
 
   // Finally, we can recurse.
   ExprResult CalleeResult = Visit(CalleeExpr);
-  if (!CalleeResult.isUsable()) return ExprError();
+  if (!CalleeResult.isUsable())
+    return ExprError();
   E->setCallee(CalleeResult.get());
 
   // Bind a temporary if necessary.
@@ -21489,7 +21565,7 @@ ExprResult RebuildUnknownAnyExpr::VisitObjCMessageExpr(ObjCMessageExpr *E) {
   // Verify that this is a legal result type of a call.
   if (DestType->isArrayType() || DestType->isFunctionType()) {
     S.Diag(E->getExprLoc(), diag::err_func_returning_array_function)
-      << DestType->isFunctionType() << DestType;
+        << DestType->isFunctionType() << DestType;
     return ExprError();
   }
 
@@ -21518,7 +21594,8 @@ ExprResult RebuildUnknownAnyExpr::VisitImplicitCastExpr(ImplicitCastExpr *E) {
     DestType = DestType->castAs<PointerType>()->getPointeeType();
 
     ExprResult Result = Visit(E->getSubExpr());
-    if (!Result.isUsable()) return ExprError();
+    if (!Result.isUsable())
+      return ExprError();
 
     E->setSubExpr(Result.get());
     return E;
@@ -21534,7 +21611,8 @@ ExprResult RebuildUnknownAnyExpr::VisitImplicitCastExpr(ImplicitCastExpr *E) {
     DestType = S.Context.getLValueReferenceType(DestType);
 
     ExprResult Result = Visit(E->getSubExpr());
-    if (!Result.isUsable()) return ExprError();
+    if (!Result.isUsable())
+      return ExprError();
 
     E->setSubExpr(Result.get());
     return E;
@@ -21554,14 +21632,15 @@ ExprResult RebuildUnknownAnyExpr::resolveDecl(Expr *E, ValueDecl *VD) {
     if (const PointerType *Ptr = Type->getAs<PointerType>()) {
       DestType = Ptr->getPointeeType();
       ExprResult Result = resolveDecl(E, VD);
-      if (Result.isInvalid()) return ExprError();
+      if (Result.isInvalid())
+        return ExprError();
       return S.ImpCastExprToType(Result.get(), Type, CK_FunctionToPointerDecay,
                                  VK_PRValue);
     }
 
     if (!Type->isFunctionType()) {
       S.Diag(E->getExprLoc(), diag::err_unknown_any_function)
-        << VD << E->getSourceRange();
+          << VD << E->getSourceRange();
       return ExprError();
     }
     if (const FunctionProtoType *FT = Type->getAs<FunctionProtoType>()) {
@@ -21570,9 +21649,11 @@ ExprResult RebuildUnknownAnyExpr::resolveDecl(Expr *E, ValueDecl *VD) {
       // type. See the lengthy commentary in that routine.
       QualType FDT = FD->getType();
       const FunctionType *FnType = FDT->castAs<FunctionType>();
-      const FunctionProtoType *Proto = dyn_cast_or_null<FunctionProtoType>(FnType);
+      const FunctionProtoType *Proto =
+          dyn_cast_or_null<FunctionProtoType>(FnType);
       DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E);
-      if (DRE && Proto && Proto->getParamTypes().empty() && Proto->isVariadic()) {
+      if (DRE && Proto && Proto->getParamTypes().empty() &&
+          Proto->isVariadic()) {
         SourceLocation Loc = FD->getLocation();
         FunctionDecl *NewFD = FunctionDecl::Create(
             S.Context, FD->getDeclContext(), Loc, Loc,
@@ -21584,10 +21665,9 @@ ExprResult RebuildUnknownAnyExpr::resolveDecl(Expr *E, ValueDecl *VD) {
         if (FD->getQualifier())
           NewFD->setQualifierInfo(FD->getQualifierLoc());
 
-        SmallVector<ParmVarDecl*, 16> Params;
+        SmallVector<ParmVarDecl *, 16> Params;
         for (const auto &AI : FT->param_types()) {
-          ParmVarDecl *Param =
-            S.BuildParmVarDeclForTypedef(FD, Loc, AI);
+          ParmVarDecl *Param = S.BuildParmVarDeclForTypedef(FD, Loc, AI);
           Param->setScopeInfo(0, Params.size());
           Params.push_back(Param);
         }
@@ -21607,20 +21687,20 @@ ExprResult RebuildUnknownAnyExpr::resolveDecl(Expr *E, ValueDecl *VD) {
     if (!S.getLangOpts().CPlusPlus)
       ValueKind = VK_PRValue;
 
-  //  - variables
+    //  - variables
   } else if (isa<VarDecl>(VD)) {
     if (const ReferenceType *RefTy = Type->getAs<ReferenceType>()) {
       Type = RefTy->getPointeeType();
     } else if (Type->isFunctionType()) {
       S.Diag(E->getExprLoc(), diag::err_unknown_any_var_function_type)
-        << VD << E->getSourceRange();
+          << VD << E->getSourceRange();
       return ExprError();
     }
 
-  //  - nothing else
+    //  - nothing else
   } else {
     S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_decl)
-      << VD << E->getSourceRange();
+        << VD << E->getSourceRange();
     return ExprError();
   }
 
@@ -21645,7 +21725,8 @@ ExprResult Sema::checkUnknownAnyCast(SourceRange TypeRange, QualType CastType,
 
   // Rewrite the casted expression from scratch.
   ExprResult result = RebuildUnknownAnyExpr(*this, CastType).Visit(CastExpr);
-  if (!result.isUsable()) return ExprError();
+  if (!result.isUsable())
+    return ExprError();
 
   CastExpr = result.get();
   VK = CastExpr->getValueKind();
@@ -21658,14 +21739,15 @@ ExprResult Sema::forceUnknownAnyToType(Expr *E, QualType ToType) {
   return RebuildUnknownAnyExpr(*this, ToType).Visit(E);
 }
 
-ExprResult Sema::checkUnknownAnyArg(SourceLocation callLoc,
-                                    Expr *arg, QualType &paramType) {
+ExprResult Sema::checkUnknownAnyArg(SourceLocation callLoc, Expr *arg,
+                                    QualType &paramType) {
   // If the syntactic form of the argument is not an explicit cast of
   // any sort, just do default argument promotion.
   ExplicitCastExpr *castArg = dyn_cast<ExplicitCastExpr>(arg->IgnoreParens());
   if (!castArg) {
     ExprResult result = DefaultArgumentPromotion(arg);
-    if (result.isInvalid()) return ExprError();
+    if (result.isInvalid())
+      return ExprError();
     paramType = result.get()->getType();
     return result;
   }
@@ -21676,8 +21758,8 @@ ExprResult Sema::checkUnknownAnyArg(SourceLocation callLoc,
 
   // Copy-initialize a parameter of that type.
   InitializedEntity entity =
-    InitializedEntity::InitializeParameter(Context, paramType,
-                                           /*consumed*/ false);
+      InitializedEntity::InitializeParameter(Context, paramType,
+                                             /*consumed*/ false);
   return PerformCopyInitialization(entity, callLoc, arg);
 }
 
@@ -21708,13 +21790,13 @@ static ExprResult diagnoseUnknownAnyExpr(Sema &S, Expr *E) {
     d = msg->getMethodDecl();
     if (!d) {
       S.Diag(loc, diag::err_uncasted_send_to_unknown_any_method)
-        << static_cast<unsigned>(msg->isClassMessage()) << msg->getSelector()
-        << orig->getSourceRange();
+          << static_cast<unsigned>(msg->isClassMessage()) << msg->getSelector()
+          << orig->getSourceRange();
       return ExprError();
     }
   } else {
     S.Diag(E->getExprLoc(), diag::err_unsupported_unknown_any_expr)
-      << E->getSourceRange();
+        << E->getSourceRange();
     return ExprError();
   }
 
@@ -21732,12 +21814,14 @@ ExprResult Sema::CheckPlaceholderExpr(Expr *E) {
     // doesn't handle dependent types properly, so make sure any TypoExprs have
     // been dealt with before checking the operands.
     ExprResult Result = CorrectDelayedTyposInExpr(E);
-    if (!Result.isUsable()) return ExprError();
+    if (!Result.isUsable())
+      return ExprError();
     E = Result.get();
   }
 
   const BuiltinType *placeholderType = E->getType()->getAsPlaceholderType();
-  if (!placeholderType) return E;
+  if (!placeholderType)
+    return E;
 
   switch (placeholderType->getKind()) {
 
@@ -21863,18 +21947,15 @@ ExprResult Sema::CheckPlaceholderExpr(Expr *E) {
   case BuiltinType::OMPIterator:
     return ExprError(Diag(E->getBeginLoc(), diag::err_omp_iterator_use));
 
-  // Everything else should be impossible.
-#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+    // Everything else should be impossible.
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix)                   \
   case BuiltinType::Id:
 #include "clang/Basic/OpenCLImageTypes.def"
-#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) \
-  case BuiltinType::Id:
+#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) case BuiltinType::Id:
 #include "clang/Basic/OpenCLExtensionTypes.def"
-#define SVE_TYPE(Name, Id, SingletonId) \
-  case BuiltinType::Id:
+#define SVE_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
 #include "clang/Basic/AArch64SVEACLETypes.def"
-#define PPC_VECTOR_TYPE(Name, Id, Size) \
-  case BuiltinType::Id:
+#define PPC_VECTOR_TYPE(Name, Id, Size) case BuiltinType::Id:
 #include "clang/Basic/PPCTypes.def"
 #define RVV_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
 #include "clang/Basic/RISCVVTypes.def"
@@ -21898,8 +21979,8 @@ bool Sema::CheckCaseExpression(Expr *E) {
 }
 
 /// ActOnObjCBoolLiteral - Parse {__objc_yes,__objc_no} literals.
-ExprResult
-Sema::ActOnObjCBoolLiteral(SourceLocation OpLoc, tok::TokenKind Kind) {
+ExprResult Sema::ActOnObjCBoolLiteral(SourceLocation OpLoc,
+                                      tok::TokenKind Kind) {
   assert((Kind == tok::kw___objc_yes || Kind == tok::kw___objc_no) &&
          "Unknown Objective-C Boolean value!");
   QualType BoolT = Context.ObjCBuiltinBoolTy;

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -76,6 +76,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   enum f { three };
   enum f x = __builtin_elementwise_add_sat(one, three);
+  // expected-warning@-1 {{comparison of different enumeration types ('enum e' and 'enum f')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_add_sat(ext, ext);
@@ -134,6 +135,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   enum f { three };
   enum f x = __builtin_elementwise_sub_sat(one, three);
+  // expected-warning@-1 {{comparison of different enumeration types ('enum e' and 'enum f')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_sub_sat(ext, ext);
@@ -189,6 +191,7 @@ void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, u
 
   enum f { three };
   enum f x = __builtin_elementwise_max(one, three);
+  // expected-warning@-1 {{comparison of different enumeration types ('enum e' and 'enum f')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_max(ext, ext);
@@ -244,6 +247,7 @@ void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, u
 
   enum f { three };
   enum f x = __builtin_elementwise_min(one, three);
+  // expected-warning@-1 {{comparison of different enumeration types ('enum e' and 'enum f')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_min(ext, ext);

--- a/clang/test/Sema/warn-compare-enum-types-mismatch.c
+++ b/clang/test/Sema/warn-compare-enum-types-mismatch.c
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -x c -fsyntax-only -verify -Wenum-compare -Wno-unused-comparison %s
+// RUN: %clang_cc1 -x c++ -fsyntax-only -verify -Wenum-compare -Wno-unused-comparison %s
+
+typedef enum EnumA {
+  A
+} EnumA;
+
+enum EnumB {
+  B
+};
+
+enum {
+  C
+};
+
+void foo(void) {
+  enum EnumA a = A;
+  enum EnumB b = B;
+  A == B;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  a == (B);
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  a == b;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  A > B;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  A >= b;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  a > b;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  (A) <= ((B));
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  a < B;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+  a < b;
+  // expected-warning@-1 {{comparison of different enumeration types}}
+
+  // In the following cases we purposefully differ from GCC and dont warn 
+  a == C; 
+  A < C;
+  b >= C; 
+}

--- a/clang/test/Sema/warn-conditional-enum-types-mismatch.c
+++ b/clang/test/Sema/warn-conditional-enum-types-mismatch.c
@@ -21,7 +21,7 @@ int get_flag(int cond) {
   #ifdef __cplusplus
   // expected-warning@-2 {{conditional expression between different enumeration types ('ro' and 'rw')}}
   #else 
-  // expected-no-diagnostics
+  // expected-warning@-4 {{conditional expression between different enumeration types ('enum ro' and 'enum rw')}}
   #endif
 }
 

--- a/clang/test/Sema/warn-overlap.c
+++ b/clang/test/Sema/warn-overlap.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wtautological-overlap-compare %s
-// RUN: %clang_cc1 -fsyntax-only -verify -Wall -Wno-unused -Wno-loop-analysis %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wtautological-overlap-compare -Wno-enum-compare %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wall -Wno-unused -Wno-loop-analysis -Wno-enum-compare %s
 
 #define mydefine 2
 


### PR DESCRIPTION
…C mode

Factored logic from `CheckImplicitConversion` into new methods `Expr::getEnumConstantDecl` and `Expr::getEnumCoercedType` for use in `checkEnumArithmeticConversions`.

Fix #29217