### PR TITLE
[libc++] Refactor more __enable_ifs to the canonical style

### DIFF
--- a/libcxx/include/__algorithm/search.h
+++ b/libcxx/include/__algorithm/search.h
@@ -117,17 +117,18 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __searc
   }
 }
 
-template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
+template <class _Iter1,
+          class _Sent1,
+          class _Iter2,
+          class _Sent2,
+          class _Pred,
+          class _Proj1,
+          class _Proj2,
+          __enable_if_t<__has_random_access_iterator_category<_Iter1>::value &&
+                            __has_random_access_iterator_category<_Iter2>::value,
+                        int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
-    _Iter1 __first1,
-    _Sent1 __last1,
-    _Iter2 __first2,
-    _Sent2 __last2,
-    _Pred& __pred,
-    _Proj1& __proj1,
-    _Proj2& __proj2,
-    __enable_if_t<__has_random_access_iterator_category<_Iter1>::value &&
-                  __has_random_access_iterator_category<_Iter2>::value>* = nullptr) {
+    _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   auto __size2 = __last2 - __first2;
   if (__size2 == 0)
     return std::make_pair(__first1, __first1);
@@ -141,18 +142,20 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __searc
       __first1, __last1, __first2, __last2, __pred, __proj1, __proj2, __size1, __size2);
 }
 
-template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
-    _Iter1 __first1,
-    _Sent1 __last1,
-    _Iter2 __first2,
-    _Sent2 __last2,
-    _Pred& __pred,
-    _Proj1& __proj1,
-    _Proj2& __proj2,
+template <
+    class _Iter1,
+    class _Sent1,
+    class _Iter2,
+    class _Sent2,
+    class _Pred,
+    class _Proj1,
+    class _Proj2,
     __enable_if_t<__has_forward_iterator_category<_Iter1>::value && __has_forward_iterator_category<_Iter2>::value &&
-                  !(__has_random_access_iterator_category<_Iter1>::value &&
-                    __has_random_access_iterator_category<_Iter2>::value)>* = nullptr) {
+                      !(__has_random_access_iterator_category<_Iter1>::value &&
+                        __has_random_access_iterator_category<_Iter2>::value),
+                  int> = 0>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
+    _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   return std::__search_forward_impl<_ClassicAlgPolicy>(__first1, __last1, __first2, __last2, __pred, __proj1, __proj2);
 }
 

--- a/libcxx/include/__algorithm/search_n.h
+++ b/libcxx/include/__algorithm/search_n.h
@@ -108,29 +108,30 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 std::pair<_Iter, _Iter> __se
   }
 }
 
-template <class _Iter, class _Sent, class _DiffT, class _Type, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter> __search_n_impl(
-    _Iter __first,
-    _Sent __last,
-    _DiffT __count,
-    const _Type& __value,
-    _Pred& __pred,
-    _Proj& __proj,
-    __enable_if_t<__has_random_access_iterator_category<_Iter>::value>* = nullptr) {
+template <class _Iter,
+          class _Sent,
+          class _DiffT,
+          class _Type,
+          class _Pred,
+          class _Proj,
+          __enable_if_t<__has_random_access_iterator_category<_Iter>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter>
+__search_n_impl(_Iter __first, _Sent __last, _DiffT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
   return std::__search_n_random_access_impl<_ClassicAlgPolicy>(
       __first, __last, __count, __value, __pred, __proj, __last - __first);
 }
 
-template <class _Iter1, class _Sent1, class _DiffT, class _Type, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_n_impl(
-    _Iter1 __first,
-    _Sent1 __last,
-    _DiffT __count,
-    const _Type& __value,
-    _Pred& __pred,
-    _Proj& __proj,
-    __enable_if_t<__has_forward_iterator_category<_Iter1>::value &&
-                  !__has_random_access_iterator_category<_Iter1>::value>* = nullptr) {
+template <class _Iter1,
+          class _Sent1,
+          class _DiffT,
+          class _Type,
+          class _Pred,
+          class _Proj,
+          __enable_if_t<__has_forward_iterator_category<_Iter1>::value &&
+                            !__has_random_access_iterator_category<_Iter1>::value,
+                        int> = 0>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1>
+__search_n_impl(_Iter1 __first, _Sent1 __last, _DiffT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
   return std::__search_n_forward_impl<_ClassicAlgPolicy>(__first, __last, __count, __value, __pred, __proj);
 }
 

--- a/libcxx/include/__functional/reference_wrapper.h
+++ b/libcxx/include/__functional/reference_wrapper.h
@@ -16,6 +16,7 @@
 #include <__memory/addressof.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/remove_cvref.h>
+#include <__type_traits/void_t.h>
 #include <__utility/declval.h>
 #include <__utility/forward.h>
 
@@ -38,9 +39,9 @@ private:
   static void __fun(_Tp&&) = delete;
 
 public:
-  template <
-      class _Up,
-      class = __enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(std::declval<_Up>())) > >
+  template <class _Up,
+            class = __void_t<decltype(__fun(std::declval<_Up>()))>,
+            __enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference_wrapper(_Up&& __u)
       _NOEXCEPT_(noexcept(__fun(std::declval<_Up>()))) {
     type& __f = static_cast<_Up&&>(__u);

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -802,7 +802,7 @@ public:
     return __emplace_unique_key_args(_NodeTypes::__get_key(__x), std::move(__x));
   }
 
-  template <class _Pp, class = __enable_if_t<!__is_same_uncvref<_Pp, __container_value_type>::value> >
+  template <class _Pp, __enable_if_t<!__is_same_uncvref<_Pp, __container_value_type>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> __insert_unique(_Pp&& __x) {
     return __emplace_unique(std::forward<_Pp>(__x));
   }

--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -61,7 +61,7 @@ __advance(_RandIter& __i, typename iterator_traits<_RandIter>::difference_type _
 template < class _InputIter,
            class _Distance,
            class _IntegralDistance = decltype(std::__convert_to_integral(std::declval<_Distance>())),
-           class                   = __enable_if_t<is_integral<_IntegralDistance>::value> >
+           __enable_if_t<is_integral<_IntegralDistance>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 void advance(_InputIter& __i, _Distance __orig_n) {
   typedef typename iterator_traits<_InputIter>::difference_type _Difference;
   _Difference __n = static_cast<_Difference>(std::__convert_to_integral(__orig_n));

--- a/libcxx/include/__iterator/bounded_iter.h
+++ b/libcxx/include/__iterator/bounded_iter.h
@@ -58,7 +58,7 @@ struct __bounded_iter {
   _LIBCPP_HIDE_FROM_ABI __bounded_iter(__bounded_iter const&) = default;
   _LIBCPP_HIDE_FROM_ABI __bounded_iter(__bounded_iter&&)      = default;
 
-  template <class _OtherIterator, class = __enable_if_t< is_convertible<_OtherIterator, _Iterator>::value > >
+  template <class _OtherIterator, __enable_if_t< is_convertible<_OtherIterator, _Iterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __bounded_iter(__bounded_iter<_OtherIterator> const& __other) _NOEXCEPT
       : __current_(__other.__current_),
         __begin_(__other.__begin_),

--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -157,14 +157,14 @@ public:
 #else
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 move_iterator() : __current_() {}
 
-  template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value > >
+  template <class _Up, __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 move_iterator(const move_iterator<_Up>& __u)
       : __current_(__u.base()) {}
 
   template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value &&
-                                   is_assignable<_Iter&, const _Up&>::value > >
+            __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value &&
+                               is_assignable<_Iter&, const _Up&>::value,
+                           int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 move_iterator& operator=(const move_iterator<_Up>& __u) {
     __current_ = __u.base();
     return *this;

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -96,14 +96,14 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 explicit reverse_iterator(_Iter __x) : __t_(__x), current(__x) {}
 
-  template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value > >
+  template <class _Up, __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator(const reverse_iterator<_Up>& __u)
       : __t_(__u.base()), current(__u.base()) {}
 
   template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value &&
-                                   is_assignable<_Iter&, _Up const&>::value > >
+            __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value &&
+                              is_assignable<_Iter&, _Up const&>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator& operator=(const reverse_iterator<_Up>& __u) {
     __t_ = current = __u.base();
     return *this;
@@ -113,14 +113,14 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 explicit reverse_iterator(_Iter __x) : current(__x) {}
 
-  template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value > >
+  template <class _Up, __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator(const reverse_iterator<_Up>& __u)
       : current(__u.base()) {}
 
   template <class _Up,
-            class = __enable_if_t< !is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value &&
-                                   is_assignable<_Iter&, _Up const&>::value > >
+            __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value &&
+                              is_assignable<_Iter&, _Up const&>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator& operator=(const reverse_iterator<_Up>& __u) {
     current = __u.base();
     return *this;

--- a/libcxx/include/__memory/allocator_traits.h
+++ b/libcxx/include/__memory/allocator_traits.h
@@ -281,16 +281,16 @@ struct _LIBCPP_TEMPLATE_VIS allocator_traits {
     return __a.allocate(__n);
   }
 
-  template <class _Ap = _Alloc, class = __enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>::value> >
+  template <class _Ap = _Alloc, __enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
   _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer __hint) {
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     return __a.allocate(__n, __hint);
     _LIBCPP_SUPPRESS_DEPRECATED_POP
   }
-  template <class _Ap = _Alloc,
-            class     = void,
-            class     = __enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>::value> >
+  template <class _Ap                                                                           = _Alloc,
+            class                                                                               = void,
+            __enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
   _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer) {
     return __a.allocate(__n);
@@ -313,7 +313,7 @@ struct _LIBCPP_TEMPLATE_VIS allocator_traits {
     __a.deallocate(__p, __n);
   }
 
-  template <class _Tp, class... _Args, class = __enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>::value> >
+  template <class _Tp, class... _Args, __enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void
   construct(allocator_type& __a, _Tp* __p, _Args&&... __args) {
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
@@ -322,43 +322,43 @@ struct _LIBCPP_TEMPLATE_VIS allocator_traits {
   }
   template <class _Tp,
             class... _Args,
-            class = void,
-            class = __enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>::value> >
+            class                                                                       = void,
+            __enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void
   construct(allocator_type&, _Tp* __p, _Args&&... __args) {
     std::__construct_at(__p, std::forward<_Args>(__args)...);
   }
 
-  template <class _Tp, class = __enable_if_t<__has_destroy<allocator_type, _Tp*>::value> >
+  template <class _Tp, __enable_if_t<__has_destroy<allocator_type, _Tp*>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void destroy(allocator_type& __a, _Tp* __p) {
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     __a.destroy(__p);
     _LIBCPP_SUPPRESS_DEPRECATED_POP
   }
-  template <class _Tp, class = void, class = __enable_if_t<!__has_destroy<allocator_type, _Tp*>::value> >
+  template <class _Tp, class = void, __enable_if_t<!__has_destroy<allocator_type, _Tp*>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void destroy(allocator_type&, _Tp* __p) {
     std::__destroy_at(__p);
   }
 
-  template <class _Ap = _Alloc, class = __enable_if_t<__has_max_size<const _Ap>::value> >
+  template <class _Ap = _Alloc, __enable_if_t<__has_max_size<const _Ap>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static size_type max_size(const allocator_type& __a) _NOEXCEPT {
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     return __a.max_size();
     _LIBCPP_SUPPRESS_DEPRECATED_POP
   }
-  template <class _Ap = _Alloc, class = void, class = __enable_if_t<!__has_max_size<const _Ap>::value> >
+  template <class _Ap = _Alloc, class = void, __enable_if_t<!__has_max_size<const _Ap>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static size_type max_size(const allocator_type&) _NOEXCEPT {
     return numeric_limits<size_type>::max() / sizeof(value_type);
   }
 
-  template <class _Ap = _Alloc, class = __enable_if_t<__has_select_on_container_copy_construction<const _Ap>::value> >
+  template <class _Ap = _Alloc, __enable_if_t<__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a) {
     return __a.select_on_container_copy_construction();
   }
-  template <class _Ap = _Alloc,
-            class     = void,
-            class     = __enable_if_t<!__has_select_on_container_copy_construction<const _Ap>::value> >
+  template <class _Ap                                                                          = _Alloc,
+            class                                                                              = void,
+            __enable_if_t<!__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a) {
     return __a;

--- a/libcxx/include/__memory/compressed_pair.h
+++ b/libcxx/include/__memory/compressed_pair.h
@@ -48,7 +48,7 @@ struct __compressed_pair_elem {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(__default_init_tag) {}
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(__value_init_tag) : __value_() {}
 
-  template <class _Up, class = __enable_if_t<!is_same<__compressed_pair_elem, __decay_t<_Up> >::value> >
+  template <class _Up, __enable_if_t<!is_same<__compressed_pair_elem, __decay_t<_Up> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(_Up&& __u)
       : __value_(std::forward<_Up>(__u)) {}
 
@@ -77,7 +77,7 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(__default_init_tag) {}
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(__value_init_tag) : __value_type() {}
 
-  template <class _Up, class = __enable_if_t<!is_same<__compressed_pair_elem, __decay_t<_Up> >::value> >
+  template <class _Up, __enable_if_t<!is_same<__compressed_pair_elem, __decay_t<_Up> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair_elem(_Up&& __u)
       : __value_type(std::forward<_Up>(__u)) {}
 
@@ -107,9 +107,10 @@ public:
   using _Base1 _LIBCPP_NODEBUG = __compressed_pair_elem<_T1, 0>;
   using _Base2 _LIBCPP_NODEBUG = __compressed_pair_elem<_T2, 1>;
 
-  template <bool _Dummy = true,
-            class       = __enable_if_t< __dependent_type<is_default_constructible<_T1>, _Dummy>::value &&
-                                   __dependent_type<is_default_constructible<_T2>, _Dummy>::value > >
+  template <bool _Dummy         = true,
+            __enable_if_t< __dependent_type<is_default_constructible<_T1>, _Dummy>::value &&
+                               __dependent_type<is_default_constructible<_T2>, _Dummy>::value,
+                           int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __compressed_pair()
       : _Base1(__value_init_tag()), _Base2(__value_init_tag()) {}
 

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -201,7 +201,7 @@ struct _IsFancyPointer {
 };
 
 // enable_if is needed here to avoid instantiating checks for fancy pointers on raw pointers
-template <class _Pointer, class = __enable_if_t< _And<is_class<_Pointer>, _IsFancyPointer<_Pointer> >::value > >
+template <class _Pointer, __enable_if_t< _And<is_class<_Pointer>, _IsFancyPointer<_Pointer> >::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
     __decay_t<decltype(__to_address_helper<_Pointer>::__call(std::declval<const _Pointer&>()))>
     __to_address(const _Pointer& __p) _NOEXCEPT {

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -430,15 +430,16 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR shared_ptr(nullptr_t) _NOEXCEPT : __ptr_(nullptr), __cntrl_(nullptr) {}
 
   template <class _Yp,
-            class = __enable_if_t< _And< __raw_pointer_compatible_with<_Yp, _Tp>
+            __enable_if_t< _And< __raw_pointer_compatible_with<_Yp, _Tp>
   // In C++03 we get errors when trying to do SFINAE with the
   // delete operator, so we always pretend that it's deletable.
   // The same happens on GCC.
 #if !defined(_LIBCPP_CXX03_LANG) && !defined(_LIBCPP_COMPILER_GCC)
-                                         ,
-                                         _If<is_array<_Tp>::value, __is_array_deletable<_Yp*>, __is_deletable<_Yp*> >
+                                 ,
+                                 _If<is_array<_Tp>::value, __is_array_deletable<_Yp*>, __is_deletable<_Yp*> >
 #endif
-                                         >::value > >
+                                 >::value,
+                           int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit shared_ptr(_Yp* __p) : __ptr_(__p) {
     unique_ptr<_Yp> __hold(__p);
     typedef typename __shared_ptr_default_allocator<_Yp>::type _AllocT;
@@ -448,7 +449,7 @@ public:
     __enable_weak_this(__p, __p);
   }
 
-  template <class _Yp, class _Dp, class = __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value> >
+  template <class _Yp, class _Dp, __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(_Yp* __p, _Dp __d) : __ptr_(__p) {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
@@ -472,7 +473,7 @@ public:
   template <class _Yp,
             class _Dp,
             class _Alloc,
-            class = __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value> >
+            __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(_Yp* __p, _Dp __d, _Alloc __a) : __ptr_(__p) {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     try {
@@ -567,7 +568,7 @@ public:
       __cntrl_->__add_shared();
   }
 
-  template <class _Yp, class = __enable_if_t<__compatible_with<_Yp, _Tp>::value> >
+  template <class _Yp, __enable_if_t<__compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(const shared_ptr<_Yp>& __r) _NOEXCEPT : __ptr_(__r.__ptr_), __cntrl_(__r.__cntrl_) {
     if (__cntrl_)
       __cntrl_->__add_shared();
@@ -578,13 +579,13 @@ public:
     __r.__cntrl_ = nullptr;
   }
 
-  template <class _Yp, class = __enable_if_t<__compatible_with<_Yp, _Tp>::value> >
+  template <class _Yp, __enable_if_t<__compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(shared_ptr<_Yp>&& __r) _NOEXCEPT : __ptr_(__r.__ptr_), __cntrl_(__r.__cntrl_) {
     __r.__ptr_   = nullptr;
     __r.__cntrl_ = nullptr;
   }
 
-  template <class _Yp, class = __enable_if_t<__compatible_with<_Yp, _Tp>::value> >
+  template <class _Yp, __enable_if_t<__compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit shared_ptr(const weak_ptr<_Yp>& __r)
       : __ptr_(__r.__ptr_), __cntrl_(__r.__cntrl_ ? __r.__cntrl_->lock() : __r.__cntrl_) {
     if (__cntrl_ == nullptr)
@@ -592,7 +593,7 @@ public:
   }
 
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
-  template <class _Yp, class = __enable_if_t<is_convertible<_Yp*, element_type*>::value> >
+  template <class _Yp, __enable_if_t<is_convertible<_Yp*, element_type*>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(auto_ptr<_Yp>&& __r) : __ptr_(__r.get()) {
     typedef __shared_ptr_pointer<_Yp*, default_delete<_Yp>, allocator<_Yp> > _CntrlBlk;
     __cntrl_ = new _CntrlBlk(__r.get(), default_delete<_Yp>(), allocator<_Yp>());
@@ -603,8 +604,9 @@ public:
 
   template <class _Yp,
             class _Dp,
-            class = __enable_if_t< !is_lvalue_reference<_Dp>::value && __compatible_with<_Yp, _Tp>::value &&
-                                   is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*>::value > >
+            __enable_if_t<!is_lvalue_reference<_Dp>::value && __compatible_with<_Yp, _Tp>::value &&
+                              is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(unique_ptr<_Yp, _Dp>&& __r) : __ptr_(__r.get()) {
 #if _LIBCPP_STD_VER >= 14
     if (__ptr_ == nullptr)
@@ -622,9 +624,10 @@ public:
 
   template <class _Yp,
             class _Dp,
-            class = void,
-            class = __enable_if_t< is_lvalue_reference<_Dp>::value && __compatible_with<_Yp, _Tp>::value &&
-                                   is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*>::value > >
+            class              = void,
+            __enable_if_t<is_lvalue_reference<_Dp>::value && __compatible_with<_Yp, _Tp>::value &&
+                              is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(unique_ptr<_Yp, _Dp>&& __r) : __ptr_(__r.get()) {
 #if _LIBCPP_STD_VER >= 14
     if (__ptr_ == nullptr)
@@ -653,7 +656,7 @@ public:
     return *this;
   }
 
-  template <class _Yp, class = __enable_if_t<__compatible_with<_Yp, _Tp>::value> >
+  template <class _Yp, __enable_if_t<__compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT {
     shared_ptr(__r).swap(*this);
     return *this;
@@ -664,7 +667,7 @@ public:
     return *this;
   }
 
-  template <class _Yp, class = __enable_if_t<__compatible_with<_Yp, _Tp>::value> >
+  template <class _Yp, __enable_if_t<__compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(shared_ptr<_Yp>&& __r) {
     shared_ptr(std::move(__r)).swap(*this);
     return *this;
@@ -672,19 +675,19 @@ public:
 
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
   template <class _Yp,
-            class = __enable_if_t< !is_array<_Yp>::value &&
-                                   is_convertible<_Yp*, typename shared_ptr<_Tp>::element_type*>::value > >
+            __enable_if_t<!is_array<_Yp>::value && is_convertible<_Yp*, typename shared_ptr<_Tp>::element_type*>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(auto_ptr<_Yp>&& __r) {
     shared_ptr(std::move(__r)).swap(*this);
     return *this;
   }
 #endif
 
-  template <
-      class _Yp,
-      class _Dp,
-      class = __enable_if_t<_And< __compatible_with<_Yp, _Tp>,
-                                  is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*> >::value> >
+  template <class _Yp,
+            class _Dp,
+            __enable_if_t<_And< __compatible_with<_Yp, _Tp>,
+                                is_convertible<typename unique_ptr<_Yp, _Dp>::pointer, element_type*> >::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(unique_ptr<_Yp, _Dp>&& __r) {
     shared_ptr(std::move(__r)).swap(*this);
     return *this;
@@ -697,12 +700,12 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void reset() _NOEXCEPT { shared_ptr().swap(*this); }
 
-  template <class _Yp, class = __enable_if_t< __raw_pointer_compatible_with<_Yp, _Tp>::value > >
+  template <class _Yp, __enable_if_t<__raw_pointer_compatible_with<_Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void reset(_Yp* __p) {
     shared_ptr(__p).swap(*this);
   }
 
-  template <class _Yp, class _Dp, class = __enable_if_t< __shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value> >
+  template <class _Yp, class _Dp, __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void reset(_Yp* __p, _Dp __d) {
     shared_ptr(__p, __d).swap(*this);
   }
@@ -710,7 +713,7 @@ public:
   template <class _Yp,
             class _Dp,
             class _Alloc,
-            class = __enable_if_t< __shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value> >
+            __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void reset(_Yp* __p, _Dp __d, _Alloc __a) {
     shared_ptr(__p, __d, __a).swap(*this);
   }
@@ -780,7 +783,7 @@ private:
 
   template <class _Yp,
             class _OrigPtr,
-            class = __enable_if_t< is_convertible<_OrigPtr*, const enable_shared_from_this<_Yp>*>::value > >
+            __enable_if_t<is_convertible<_OrigPtr*, const enable_shared_from_this<_Yp>*>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __enable_weak_this(const enable_shared_from_this<_Yp>* __e, _OrigPtr* __ptr) _NOEXCEPT {
     typedef __remove_cv_t<_Yp> _RawYp;
     if (__e && __e->__weak_this_.expired()) {
@@ -815,7 +818,7 @@ shared_ptr(unique_ptr<_Tp, _Dp>) -> shared_ptr<_Tp>;
 //
 // std::allocate_shared and std::make_shared
 //
-template <class _Tp, class _Alloc, class... _Args, class = __enable_if_t<!is_array<_Tp>::value> >
+template <class _Tp, class _Alloc, class... _Args, __enable_if_t<!is_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, _Args&&... __args) {
   using _ControlBlock          = __shared_ptr_emplace<_Tp, _Alloc>;
   using _ControlBlockAllocator = typename __allocator_traits_rebind<_Alloc, _ControlBlock>::type;
@@ -826,7 +829,7 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, _Args&&
       (*__control_block).__get_elem(), std::addressof(*__control_block));
 }
 
-template <class _Tp, class... _Args, class = __enable_if_t<!is_array<_Tp>::value> >
+template <class _Tp, class... _Args, __enable_if_t<!is_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared(_Args&&... __args) {
   return std::allocate_shared<_Tp>(allocator<_Tp>(), std::forward<_Args>(__args)...);
 }
@@ -1032,12 +1035,12 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Array> __allocate_shared_bounded_array(const _
 #if _LIBCPP_STD_VER >= 20
 
 // bounded array variants
-template <class _Tp, class _Alloc, class = __enable_if_t<is_bounded_array<_Tp>::value>>
+template <class _Tp, class _Alloc, __enable_if_t<is_bounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a) {
   return std::__allocate_shared_bounded_array<_Tp>(__a);
 }
 
-template <class _Tp, class _Alloc, class = __enable_if_t<is_bounded_array<_Tp>::value>>
+template <class _Tp, class _Alloc, __enable_if_t<is_bounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, const remove_extent_t<_Tp>& __u) {
   return std::__allocate_shared_bounded_array<_Tp>(__a, __u);
 }
@@ -1049,12 +1052,12 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared_for_overwrite(const _Alloc
   return std::__allocate_shared_bounded_array<_Tp>(__alloc);
 }
 
-template <class _Tp, class = __enable_if_t<is_bounded_array<_Tp>::value>>
+template <class _Tp, __enable_if_t<is_bounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared() {
   return std::__allocate_shared_bounded_array<_Tp>(allocator<_Tp>());
 }
 
-template <class _Tp, class = __enable_if_t<is_bounded_array<_Tp>::value>>
+template <class _Tp, __enable_if_t<is_bounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared(const remove_extent_t<_Tp>& __u) {
   return std::__allocate_shared_bounded_array<_Tp>(allocator<_Tp>(), __u);
 }
@@ -1065,12 +1068,12 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared_for_overwrite() {
 }
 
 // unbounded array variants
-template <class _Tp, class _Alloc, class = __enable_if_t<is_unbounded_array<_Tp>::value>>
+template <class _Tp, class _Alloc, __enable_if_t<is_unbounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, size_t __n) {
   return std::__allocate_shared_unbounded_array<_Tp>(__a, __n);
 }
 
-template <class _Tp, class _Alloc, class = __enable_if_t<is_unbounded_array<_Tp>::value>>
+template <class _Tp, class _Alloc, __enable_if_t<is_unbounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, size_t __n, const remove_extent_t<_Tp>& __u) {
   return std::__allocate_shared_unbounded_array<_Tp>(__a, __n, __u);
 }
@@ -1082,12 +1085,12 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared_for_overwrite(const _Alloc
   return std::__allocate_shared_unbounded_array<_Tp>(__alloc, __n);
 }
 
-template <class _Tp, class = __enable_if_t<is_unbounded_array<_Tp>::value>>
+template <class _Tp, __enable_if_t<is_unbounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared(size_t __n) {
   return std::__allocate_shared_unbounded_array<_Tp>(allocator<_Tp>(), __n);
 }
 
-template <class _Tp, class = __enable_if_t<is_unbounded_array<_Tp>::value>>
+template <class _Tp, __enable_if_t<is_unbounded_array<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> make_shared(size_t __n, const remove_extent_t<_Tp>& __u) {
   return std::__allocate_shared_unbounded_array<_Tp>(allocator<_Tp>(), __n, __u);
 }

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -366,7 +366,7 @@ uninitialized_move_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofir
 // the correct type.
 template <class _Alloc,
           class _BidirIter,
-          class = __enable_if_t< __has_bidirectional_iterator_category<_BidirIter>::value >>
+          __enable_if_t<__has_bidirectional_iterator_category<_BidirIter>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI constexpr void
 __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _BidirIter __last) noexcept {
   using _ValueType = typename iterator_traits<_BidirIter>::value_type;
@@ -569,8 +569,9 @@ template <class _Alloc,
           __enable_if_t<
               // using _RawTypeIn because of the allocator<T const> extension
               is_trivially_copy_constructible<_RawTypeIn>::value && is_trivially_copy_assignable<_RawTypeIn>::value &&
-              is_same<__remove_const_t<_In>, __remove_const_t<_Out> >::value &&
-              __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>::value>* = nullptr>
+                  is_same<__remove_const_t<_In>, __remove_const_t<_Out> >::value &&
+                  __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>::value,
+              int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Out*
 __uninitialized_allocator_copy_impl(_Alloc&, _In* __first1, _In* __last1, _Out* __first2) {
   // TODO: Remove the const_cast once we drop support for std::allocator<T const>

--- a/libcxx/include/__random/seed_seq.h
+++ b/libcxx/include/__random/seed_seq.h
@@ -35,7 +35,7 @@ public:
   // constructors
   _LIBCPP_HIDE_FROM_ABI seed_seq() _NOEXCEPT {}
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _Tp, __enable_if_t<is_integral<_Tp>::value>* = nullptr>
+  template <class _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI seed_seq(initializer_list<_Tp> __il) {
     __init(__il.begin(), __il.end());
   }

--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -157,7 +157,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI thread() _NOEXCEPT : __t_(_LIBCPP_NULL_THREAD) {}
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _Fp, class... _Args, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, thread>::value> >
+  template <class _Fp, class... _Args, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, thread>::value, int> = 0>
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS explicit thread(_Fp&& __f, _Args&&... __args);
 #else // _LIBCPP_CXX03_LANG
   template <class _Fp>
@@ -203,7 +203,7 @@ _LIBCPP_HIDE_FROM_ABI void* __thread_proxy(void* __vp) {
   return nullptr;
 }
 
-template <class _Fp, class... _Args, class >
+template <class _Fp, class... _Args, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, thread>::value, int> >
 thread::thread(_Fp&& __f, _Args&&... __args) {
   typedef unique_ptr<__thread_struct> _TSPtr;
   _TSPtr __tsp(new __thread_struct);

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -547,10 +547,8 @@ struct __tree_key_value_types<__value_type<_Key, _Tp> > {
     return __t.__get_value();
   }
 
-  template <class _Up>
-  _LIBCPP_HIDE_FROM_ABI static __enable_if_t<__is_same_uncvref<_Up, __container_value_type>::value,
-                                             __container_value_type const&>
-  __get_value(_Up& __t) {
+  template <class _Up, __enable_if_t<__is_same_uncvref<_Up, __container_value_type>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI static __container_value_type const& __get_value(_Up& __t) {
     return __t;
   }
 
@@ -1117,12 +1115,12 @@ public:
     return __emplace_hint_unique_key_args(__p, _NodeTypes::__get_key(__v), std::move(__v)).first;
   }
 
-  template <class _Vp, class = __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value> >
+  template <class _Vp, __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> __insert_unique(_Vp&& __v) {
     return __emplace_unique(std::forward<_Vp>(__v));
   }
 
-  template <class _Vp, class = __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value> >
+  template <class _Vp, __enable_if_t<!is_same<__remove_const_ref_t<_Vp>, __container_value_type>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator __insert_unique(const_iterator __p, _Vp&& __v) {
     return __emplace_hint_unique(__p, std::forward<_Vp>(__v));
   }

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -107,10 +107,11 @@ struct _LIBCPP_TEMPLATE_VIS pair
   // Extension: This is provided in C++03 because it allows properly handling the
   //            assignment to a pair containing references, which would be a hard
   //            error otherwise.
-  template <class _U1,
-            class _U2,
-            class = __enable_if_t< is_assignable<first_type&, _U1 const&>::value &&
-                                   is_assignable<second_type&, _U2 const&>::value > >
+  template <
+      class _U1,
+      class _U2,
+      __enable_if_t<is_assignable<first_type&, _U1 const&>::value && is_assignable<second_type&, _U2 const&>::value,
+                    int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair& operator=(pair<_U1, _U2> const& __p) {
     first  = __p.first;
     second = __p.second;
@@ -205,9 +206,7 @@ struct _LIBCPP_TEMPLATE_VIS pair
   }
 
 #  if _LIBCPP_STD_VER >= 23
-  template <class _U1,
-            class _U2,
-            __enable_if_t< _CheckArgs::template __is_pair_constructible<_U1&, _U2&>() >* = nullptr>
+  template <class _U1, class _U2, __enable_if_t<_CheckArgs::template __is_pair_constructible<_U1&, _U2&>(), int> = 0>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_CheckArgs::template __is_implicit<_U1&, _U2&>())
       pair(pair<_U1, _U2>& __p) noexcept((is_nothrow_constructible<first_type, _U1&>::value &&
                                           is_nothrow_constructible<second_type, _U2&>::value))
@@ -243,7 +242,7 @@ struct _LIBCPP_TEMPLATE_VIS pair
 #  if _LIBCPP_STD_VER >= 23
   template <class _U1,
             class _U2,
-            __enable_if_t< _CheckArgs::template __is_pair_constructible<const _U1&&, const _U2&&>() >* = nullptr>
+            __enable_if_t<_CheckArgs::template __is_pair_constructible<const _U1&&, const _U2&&>(), int> = 0>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_CheckArgs::template __is_implicit<const _U1&&, const _U2&&>())
       pair(const pair<_U1, _U2>&& __p) noexcept(is_nothrow_constructible<first_type, const _U1&&>::value &&
                                                 is_nothrow_constructible<second_type, const _U2&&>::value)
@@ -298,20 +297,20 @@ struct _LIBCPP_TEMPLATE_VIS pair
     return *this;
   }
 
-  template <class _U1,
-            class _U2,
-            __enable_if_t< is_assignable<first_type&, _U1 const&>::value &&
-                           is_assignable<second_type&, _U2 const&>::value >* = nullptr>
+  template <
+      class _U1,
+      class _U2,
+      __enable_if_t<is_assignable<first_type&, _U1 const&>::value && is_assignable<second_type&, _U2 const&>::value,
+                    int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2> const& __p) {
     first  = __p.first;
     second = __p.second;
     return *this;
   }
 
-  template <
-      class _U1,
-      class _U2,
-      __enable_if_t< is_assignable<first_type&, _U1>::value && is_assignable<second_type&, _U2>::value >* = nullptr>
+  template <class _U1,
+            class _U2,
+            __enable_if_t<is_assignable<first_type&, _U1>::value && is_assignable<second_type&, _U2>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2>&& __p) {
     first  = std::forward<_U1>(__p.first);
     second = std::forward<_U2>(__p.second);
@@ -381,38 +380,36 @@ struct _LIBCPP_TEMPLATE_VIS pair
   // pair-like types. This was historically provided as an extension.
 #  if _LIBCPP_STD_VER < 23
   // from std::tuple
-  template <
-      class _U1,
-      class _U2,
-      __enable_if_t< is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value >* = nullptr>
+  template <class _U1,
+            class _U2,
+            __enable_if_t<is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2> const& __p)
       : first(std::get<0>(__p)), second(std::get<1>(__p)) {}
 
-  template <
-      class _U1,
-      class _U2,
-      __enable_if_t< is_constructible<_T1, _U1 const&>::value && is_constructible<_T2, _U2 const&>::value &&
-                     !(is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value) >* = nullptr>
+  template < class _U1,
+             class _U2,
+             __enable_if_t<is_constructible<_T1, _U1 const&>::value && is_constructible<_T2, _U2 const&>::value &&
+                               !(is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value),
+                           int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2> const& __p)
       : first(std::get<0>(__p)), second(std::get<1>(__p)) {}
 
   template <class _U1,
             class _U2,
-            __enable_if_t< is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value >* = nullptr>
+            __enable_if_t<is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2>&& __p)
       : first(std::get<0>(std::move(__p))), second(std::get<1>(std::move(__p))) {}
 
   template <class _U1,
             class _U2,
-            __enable_if_t< is_constructible<_T1, _U1>::value && is_constructible<_T2, _U2>::value &&
-                           !(is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value) >* = nullptr>
+            __enable_if_t<is_constructible<_T1, _U1>::value && is_constructible<_T2, _U2>::value &&
+                          !(is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value) > = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2>&& __p)
       : first(std::get<0>(std::move(__p))), second(std::get<1>(std::move(__p))) {}
 
-  template <
-      class _U1,
-      class _U2,
-      __enable_if_t< is_assignable<_T1&, _U1 const&>::value && is_assignable<_T2&, _U2 const&>::value >* = nullptr>
+  template <class _U1,
+            class _U2,
+            __enable_if_t<is_assignable<_T1&, _U1 const&>::value && is_assignable<_T2&, _U2 const&>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2> const& __p) {
     first  = std::get<0>(__p);
     second = std::get<1>(__p);
@@ -421,7 +418,7 @@ struct _LIBCPP_TEMPLATE_VIS pair
 
   template <class _U1,
             class _U2,
-            __enable_if_t< is_assignable<_T1&, _U1&&>::value && is_assignable<_T2&, _U2&&>::value >* = nullptr>
+            __enable_if_t<is_assignable<_T1&, _U1&&>::value && is_assignable<_T2&, _U2&&>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2>&& __p) {
     first  = std::get<0>(std::move(__p));
     second = std::get<1>(std::move(__p));
@@ -429,38 +426,37 @@ struct _LIBCPP_TEMPLATE_VIS pair
   }
 
   // from std::array
-  template <
-      class _Up,
-      __enable_if_t< is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value >* = nullptr>
+  template <class _Up,
+            __enable_if_t<is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2> const& __p) : first(__p[0]), second(__p[1]) {}
 
-  template <
-      class _Up,
-      __enable_if_t< is_constructible<_T1, _Up const&>::value && is_constructible<_T2, _Up const&>::value &&
-                     !(is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value) >* = nullptr>
+  template <class _Up,
+            __enable_if_t<is_constructible<_T1, _Up const&>::value && is_constructible<_T2, _Up const&>::value &&
+                              !(is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value),
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2> const& __p)
       : first(__p[0]), second(__p[1]) {}
 
-  template <class _Up, __enable_if_t< is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value >* = nullptr>
+  template <class _Up, __enable_if_t< is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2>&& __p)
       : first(std::move(__p)[0]), second(std::move(__p)[1]) {}
 
   template <class _Up,
-            __enable_if_t< is_constructible<_T1, _Up>::value && is_constructible<_T2, _Up>::value &&
-                           !(is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value) >* = nullptr>
+            __enable_if_t<is_constructible<_T1, _Up>::value && is_constructible<_T2, _Up>::value &&
+                              !(is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value),
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2>&& __p)
       : first(std::move(__p)[0]), second(std::move(__p)[1]) {}
 
-  template <
-      class _Up,
-      __enable_if_t< is_assignable<_T1&, _Up const&>::value && is_assignable<_T2&, _Up const&>::value >* = nullptr>
+  template <class _Up,
+            __enable_if_t<is_assignable<_T1&, _Up const&>::value && is_assignable<_T2&, _Up const&>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2> const& __p) {
     first  = std::get<0>(__p);
     second = std::get<1>(__p);
     return *this;
   }
 
-  template <class _Up, __enable_if_t< is_assignable<_T1&, _Up>::value && is_assignable<_T2&, _Up>::value >* = nullptr>
+  template <class _Up, __enable_if_t<is_assignable<_T1&, _Up>::value && is_assignable<_T2&, _Up>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2>&& __p) {
     first  = std::get<0>(std::move(__p));
     second = std::get<1>(std::move(__p));

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -618,7 +618,7 @@ public:
   // 23.3.5.1 constructors:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bitset() _NOEXCEPT {}
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bitset(unsigned long long __v) _NOEXCEPT : base(__v) {}
-  template <class _CharT, class = __enable_if_t<_IsCharLikeType<_CharT>::value> >
+  template <class _CharT, __enable_if_t<_IsCharLikeType<_CharT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit bitset(
       const _CharT* __str,
 #if _LIBCPP_STD_VER >= 26

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -581,7 +581,7 @@ public:
 #endif
   _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const value_type& __v);
 
-  template <class = __enable_if_t<__is_allocator<_Allocator>::value> >
+  template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const value_type& __v, const allocator_type& __a)
       : __map_(__pointer_allocator(__a)), __start_(0), __size_(0, __a) {
     __annotate_new(0);

--- a/libcxx/include/experimental/memory
+++ b/libcxx/include/experimental/memory
@@ -79,7 +79,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr observer_ptr(nullptr_t) noexcept : __ptr_(nullptr) {}
   _LIBCPP_HIDE_FROM_ABI constexpr explicit observer_ptr(element_type* __p) noexcept : __ptr_(__p) {}
 
-  template <class _W2, class = __enable_if_t<is_convertible<_W2*, _Wp*>::value>>
+  template <class _W2, __enable_if_t<is_convertible<_W2*, _Wp*>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI constexpr observer_ptr(observer_ptr<_W2> __other) noexcept : __ptr_(__other.get()) {}
 
   // observers

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -689,22 +689,16 @@ public:
 #endif
   _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v);
 
-  template <class = __enable_if_t<__is_allocator<_Alloc>::value> >
+  template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v, const allocator_type& __a) : base(__a) {
     insert_after(cbefore_begin(), __n, __v);
   }
 
-  template <class _InputIterator>
-  _LIBCPP_HIDE_FROM_ABI
-  forward_list(_InputIterator __f,
-               _InputIterator __l,
-               __enable_if_t<__has_input_iterator_category<_InputIterator>::value>* = nullptr);
-  template <class _InputIterator>
-  _LIBCPP_HIDE_FROM_ABI
-  forward_list(_InputIterator __f,
-               _InputIterator __l,
-               const allocator_type& __a,
-               __enable_if_t<__has_input_iterator_category<_InputIterator>::value>* = nullptr);
+  template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI forward_list(_InputIterator __f, _InputIterator __l);
+
+  template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI forward_list(_InputIterator __f, _InputIterator __l, const allocator_type& __a);
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -938,20 +932,14 @@ forward_list<_Tp, _Alloc>::forward_list(size_type __n, const value_type& __v) {
 }
 
 template <class _Tp, class _Alloc>
-template <class _InputIterator>
-forward_list<_Tp, _Alloc>::forward_list(
-    _InputIterator __f, _InputIterator __l, __enable_if_t<__has_input_iterator_category<_InputIterator>::value>*) {
+template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> >
+forward_list<_Tp, _Alloc>::forward_list(_InputIterator __f, _InputIterator __l) {
   insert_after(cbefore_begin(), __f, __l);
 }
 
 template <class _Tp, class _Alloc>
-template <class _InputIterator>
-forward_list<_Tp, _Alloc>::forward_list(
-    _InputIterator __f,
-    _InputIterator __l,
-    const allocator_type& __a,
-    __enable_if_t<__has_input_iterator_category<_InputIterator>::value>*)
-    : base(__a) {
+template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> >
+forward_list<_Tp, _Alloc>::forward_list(_InputIterator __f, _InputIterator __l, const allocator_type& __a) : base(__a) {
   insert_after(cbefore_begin(), __f, __l);
 }
 

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -1605,9 +1605,11 @@ private:
 public:
   // construction and destruction
   _LIBCPP_HIDE_FROM_ABI packaged_task() _NOEXCEPT : __p_(nullptr) {}
-  template <class _Fp, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
+
+  template <class _Fp, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
-  template <class _Fp, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
+
+  template <class _Fp, class _Allocator, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
       : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
   // ~packaged_task() = default;
@@ -1695,9 +1697,9 @@ private:
 public:
   // construction and destruction
   _LIBCPP_HIDE_FROM_ABI packaged_task() _NOEXCEPT : __p_(nullptr) {}
-  template <class _Fp, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
+  template <class _Fp, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
-  template <class _Fp, class _Allocator, class = __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value> >
+  template <class _Fp, class _Allocator, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
       : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
   // ~packaged_task() = default;

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -464,7 +464,7 @@ struct _LIBCPP_HIDDEN __quoted_output_proxy {
   _LIBCPP_HIDE_FROM_ABI explicit __quoted_output_proxy(const _CharT* __f, const _CharT* __l, _CharT __d, _CharT __e)
       : __first_(__f), __last_(__l), __delim_(__d), __escape_(__e) {}
 
-  template <class _T2, __enable_if_t<_IsSame<_Traits, void>::value || _IsSame<_Traits, _T2>::value>* = nullptr>
+  template <class _T2, __enable_if_t<_IsSame<_Traits, void>::value || _IsSame<_Traits, _T2>::value, int> = 0>
   friend _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _T2>&
   operator<<(basic_ostream<_CharT, _T2>& __os, const __quoted_output_proxy& __p) {
     return std::__quoted_output(__os, __p.__first_, __p.__last_, __p.__delim_, __p.__escape_);

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -706,21 +706,17 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n, const allocator_type& __a);
 #endif
   _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x);
-  template <class = __enable_if_t<__is_allocator<_Alloc>::value> >
+  template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x, const allocator_type& __a) : base(__a) {
     for (; __n > 0; --__n)
       push_back(__x);
   }
 
-  template <class _InpIter>
-  _LIBCPP_HIDE_FROM_ABI
-  list(_InpIter __f, _InpIter __l, __enable_if_t<__has_input_iterator_category<_InpIter>::value>* = 0);
-  template <class _InpIter>
-  _LIBCPP_HIDE_FROM_ABI
-  list(_InpIter __f,
-       _InpIter __l,
-       const allocator_type& __a,
-       __enable_if_t<__has_input_iterator_category<_InpIter>::value>* = 0);
+  template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI list(_InpIter __f, _InpIter __l);
+
+  template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI list(_InpIter __f, _InpIter __l, const allocator_type& __a);
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -750,9 +746,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI void assign(initializer_list<value_type> __il) { assign(__il.begin(), __il.end()); }
 #endif // _LIBCPP_CXX03_LANG
 
-  template <class _InpIter>
-  _LIBCPP_HIDE_FROM_ABI void
-  assign(_InpIter __f, _InpIter __l, __enable_if_t<__has_input_iterator_category<_InpIter>::value>* = 0);
+  template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI void assign(_InpIter __f, _InpIter __l);
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -854,12 +849,9 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, size_type __n, const value_type& __x);
-  template <class _InpIter>
-  _LIBCPP_HIDE_FROM_ABI iterator
-  insert(const_iterator __p,
-         _InpIter __f,
-         _InpIter __l,
-         __enable_if_t<__has_input_iterator_category<_InpIter>::value>* = 0);
+
+  template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, _InpIter __f, _InpIter __l);
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -1024,19 +1016,15 @@ list<_Tp, _Alloc>::list(size_type __n, const value_type& __x) {
 }
 
 template <class _Tp, class _Alloc>
-template <class _InpIter>
-list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l, __enable_if_t<__has_input_iterator_category<_InpIter>::value>*) {
+template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> >
+list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l) {
   for (; __f != __l; ++__f)
     __emplace_back(*__f);
 }
 
 template <class _Tp, class _Alloc>
-template <class _InpIter>
-list<_Tp, _Alloc>::list(_InpIter __f,
-                        _InpIter __l,
-                        const allocator_type& __a,
-                        __enable_if_t<__has_input_iterator_category<_InpIter>::value>*)
-    : base(__a) {
+template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> >
+list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l, const allocator_type& __a) : base(__a) {
   for (; __f != __l; ++__f)
     __emplace_back(*__f);
 }
@@ -1121,9 +1109,8 @@ inline list<_Tp, _Alloc>& list<_Tp, _Alloc>::operator=(const list& __c) {
 }
 
 template <class _Tp, class _Alloc>
-template <class _InpIter>
-void list<_Tp, _Alloc>::assign(
-    _InpIter __f, _InpIter __l, __enable_if_t<__has_input_iterator_category<_InpIter>::value>*) {
+template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> >
+void list<_Tp, _Alloc>::assign(_InpIter __f, _InpIter __l) {
   __assign_with_sentinel(__f, __l);
 }
 
@@ -1201,9 +1188,8 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
 }
 
 template <class _Tp, class _Alloc>
-template <class _InpIter>
-typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(
-    const_iterator __p, _InpIter __f, _InpIter __l, __enable_if_t<__has_input_iterator_category<_InpIter>::value>*) {
+template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> >
+typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(const_iterator __p, _InpIter __f, _InpIter __l) {
   return __insert_with_sentinel(__p, __f, __l);
 }
 

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -803,7 +803,7 @@ public:
     return *this;
   }
 
-  template <class _ValueTp, class = __enable_if_t<__is_same_uncvref<_ValueTp, value_type>::value> >
+  template <class _ValueTp, __enable_if_t<__is_same_uncvref<_ValueTp, value_type>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI __value_type& operator=(_ValueTp&& __v) {
     __ref() = std::forward<_ValueTp>(__v);
     return *this;
@@ -1176,12 +1176,12 @@ public:
     return __tree_.__emplace_hint_unique(__p.__i_, std::forward<_Args>(__args)...);
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(_Pp&& __p) {
     return __tree_.__insert_unique(std::forward<_Pp>(__p));
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __pos, _Pp&& __p) {
     return __tree_.__insert_unique(__pos.__i_, std::forward<_Pp>(__p));
   }
@@ -1858,12 +1858,12 @@ public:
     return __tree_.__emplace_hint_multi(__p.__i_, std::forward<_Args>(__args)...);
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value>>
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(_Pp&& __p) {
     return __tree_.__insert_multi(std::forward<_Pp>(__p));
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value>>
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __pos, _Pp&& __p) {
     return __tree_.__insert_multi(__pos.__i_, std::forward<_Pp>(__p));
   }

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -316,7 +316,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI queue(const queue& __q) : c(__q.c) {}
 
 #if _LIBCPP_STD_VER >= 23
-  template <class _InputIterator, class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>>
+  template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(_InputIterator __first, _InputIterator __last) : c(__first, __last) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -324,14 +324,14 @@ public:
 
   template <class _InputIterator,
             class _Alloc,
-            class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-            class = __enable_if_t<uses_allocator<container_type, _Alloc>::value>>
+            __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
+            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int>        = 0>
   _LIBCPP_HIDE_FROM_ABI queue(_InputIterator __first, _InputIterator __second, const _Alloc& __alloc)
       : c(__first, __second, __alloc) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range,
             class _Alloc,
-            class = __enable_if_t<uses_allocator<container_type, _Alloc>::value>>
+            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(from_range_t, _Range&& __range, const _Alloc& __alloc)
       : c(from_range, std::forward<_Range>(__range), __alloc) {}
 
@@ -356,28 +356,22 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI explicit queue(container_type&& __c) : c(std::move(__c)) {}
 #endif // _LIBCPP_CXX03_LANG
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI explicit queue(const _Alloc& __a,
-                                       __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-      : c(__a) {}
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  queue(const queue& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-      : c(__q.c, __a) {}
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  queue(const container_type& __c, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-      : c(__c, __a) {}
-#ifndef _LIBCPP_CXX03_LANG
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  queue(container_type&& __c, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-      : c(std::move(__c), __a) {}
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  queue(queue&& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
-      : c(std::move(__q.c), __a) {}
 
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI explicit queue(const _Alloc& __a) : c(__a) {}
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI queue(const queue& __q, const _Alloc& __a) : c(__q.c, __a) {}
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI queue(const container_type& __c, const _Alloc& __a) : c(__c, __a) {}
+
+#ifndef _LIBCPP_CXX03_LANG
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI queue(container_type&& __c, const _Alloc& __a) : c(std::move(__c), __a) {}
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI queue(queue&& __q, const _Alloc& __a) : c(std::move(__q.c), __a) {}
 #endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_NODISCARD_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
@@ -447,7 +441,7 @@ queue(_Container, _Alloc) -> queue<typename _Container::value_type, _Container>;
 #endif
 
 #if _LIBCPP_STD_VER >= 23
-template <class _InputIterator, class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>>
+template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
 queue(_InputIterator, _InputIterator) -> queue<__iter_value_type<_InputIterator>>;
 
 template <ranges::input_range _Range>
@@ -455,14 +449,16 @@ queue(from_range_t, _Range&&) -> queue<ranges::range_value_t<_Range>>;
 
 template <class _InputIterator,
           class _Alloc,
-          class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-          class = __enable_if_t<__is_allocator<_Alloc>::value>>
-queue(_InputIterator, _InputIterator, _Alloc)
-    -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+          __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
+          __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
+queue(_InputIterator,
+      _InputIterator,
+      _Alloc) -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
-template <ranges::input_range _Range, class _Alloc, class = __enable_if_t<__is_allocator<_Alloc>::value>>
-queue(from_range_t, _Range&&, _Alloc)
-    -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
+queue(from_range_t,
+      _Range&&,
+      _Alloc) -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 #endif
 
 template <class _Tp, class _Container>
@@ -562,13 +558,15 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, container_type&& __c);
 #endif
-  template <class _InputIter, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
+  template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp = value_compare());
-  template <class _InputIter, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
+
+  template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c);
+
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _InputIter, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
+  template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c);
 #endif // _LIBCPP_CXX03_LANG
@@ -581,68 +579,56 @@ public:
   }
 #endif
 
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI explicit priority_queue(const _Alloc& __a,
-                                                __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  priority_queue(const value_compare& __comp,
-                 const _Alloc& __a,
-                 __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  priority_queue(const value_compare& __comp,
-                 const container_type& __c,
-                 const _Alloc& __a,
-                 __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI priority_queue(
-      const priority_queue& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI explicit priority_queue(const _Alloc& __a);
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, const _Alloc& __a);
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, const container_type& __c, const _Alloc& __a);
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(const priority_queue& __q, const _Alloc& __a);
+
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI
-  priority_queue(const value_compare& __comp,
-                 container_type&& __c,
-                 const _Alloc& __a,
-                 __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
-  template <class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI priority_queue(
-      priority_queue&& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, container_type&& __c, const _Alloc& __a);
+
+  template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(priority_queue&& __q, const _Alloc& __a);
 #endif // _LIBCPP_CXX03_LANG
 
-  template <class _InputIter, class _Alloc, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
-  _LIBCPP_HIDE_FROM_ABI
-  priority_queue(_InputIter __f,
-                 _InputIter __l,
-                 const _Alloc& __a,
-                 __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+  template <
+      class _InputIter,
+      class _Alloc,
+      __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<container_type, _Alloc>::value,
+                    int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(_InputIter __f, _InputIter __l, const _Alloc& __a);
 
-  template <class _InputIter, class _Alloc, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
-  _LIBCPP_HIDE_FROM_ABI priority_queue(
-      _InputIter __f,
-      _InputIter __l,
-      const value_compare& __comp,
-      const _Alloc& __a,
-      __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+  template <
+      class _InputIter,
+      class _Alloc,
+      __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<container_type, _Alloc>::value,
+                    int> = 0>
+  _LIBCPP_HIDE_FROM_ABI priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, const _Alloc& __a);
 
-  template <class _InputIter, class _Alloc, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
+  template <
+      class _InputIter,
+      class _Alloc,
+      __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<container_type, _Alloc>::value,
+                    int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(
-      _InputIter __f,
-      _InputIter __l,
-      const value_compare& __comp,
-      const container_type& __c,
-      const _Alloc& __a,
-      __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+      _InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c, const _Alloc& __a);
 
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _InputIter, class _Alloc, class = __enable_if_t<__has_input_iterator_category<_InputIter>::value> >
-  _LIBCPP_HIDE_FROM_ABI priority_queue(
-      _InputIter __f,
-      _InputIter __l,
-      const value_compare& __comp,
-      container_type&& __c,
-      const _Alloc& __a,
-      __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0);
+  template <
+      class _InputIter,
+      class _Alloc,
+      __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<container_type, _Alloc>::value,
+                    int> = 0>
+  _LIBCPP_HIDE_FROM_ABI
+  priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c, const _Alloc& __a);
 #endif // _LIBCPP_CXX03_LANG
 
 #if _LIBCPP_STD_VER >= 23
@@ -792,7 +778,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_com
 #endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class>
+template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
     _InputIter __f, _InputIter __l, const value_compare& __comp)
     : c(__f, __l), comp(__comp) {
@@ -800,7 +786,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
 }
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class>
+template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
     _InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c)
     : c(__c), comp(__comp) {
@@ -811,7 +797,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class>
+template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
     _InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c)
     : c(std::move(__c)), comp(__comp) {
@@ -822,84 +808,72 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
 #endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
-inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
-    : c(__a) {}
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
+inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const _Alloc& __a) : c(__a) {}
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
-inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    const value_compare& __comp, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
+inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_compare& __comp, const _Alloc& __a)
     : c(__a), comp(__comp) {}
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    const value_compare& __comp,
-    const container_type& __c,
-    const _Alloc& __a,
-    __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+    const value_compare& __comp, const container_type& __c, const _Alloc& __a)
     : c(__c, __a), comp(__comp) {
   std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
-inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    const priority_queue& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
+inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const priority_queue& __q, const _Alloc& __a)
     : c(__q.c, __a), comp(__q.comp) {}
 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    const value_compare& __comp,
-    container_type&& __c,
-    const _Alloc& __a,
-    __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+    const value_compare& __comp, container_type&& __c, const _Alloc& __a)
     : c(std::move(__c), __a), comp(__comp) {
   std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
-template <class _Alloc>
-inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    priority_queue&& __q, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
+inline priority_queue<_Tp, _Container, _Compare>::priority_queue(priority_queue&& __q, const _Alloc& __a)
     : c(std::move(__q.c), __a), comp(std::move(__q.comp)) {}
 
 #endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class _Alloc, class>
-inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    _InputIter __f, _InputIter __l, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+template <
+    class _InputIter,
+    class _Alloc,
+    __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<_Container, _Alloc>::value, int> >
+inline priority_queue<_Tp, _Container, _Compare>::priority_queue(_InputIter __f, _InputIter __l, const _Alloc& __a)
     : c(__f, __l, __a), comp() {
   std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class _Alloc, class>
+template <
+    class _InputIter,
+    class _Alloc,
+    __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<_Container, _Alloc>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    _InputIter __f,
-    _InputIter __l,
-    const value_compare& __comp,
-    const _Alloc& __a,
-    __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+    _InputIter __f, _InputIter __l, const value_compare& __comp, const _Alloc& __a)
     : c(__f, __l, __a), comp(__comp) {
   std::make_heap(c.begin(), c.end(), comp);
 }
 
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class _Alloc, class>
+template <
+    class _InputIter,
+    class _Alloc,
+    __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<_Container, _Alloc>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    _InputIter __f,
-    _InputIter __l,
-    const value_compare& __comp,
-    const container_type& __c,
-    const _Alloc& __a,
-    __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+    _InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c, const _Alloc& __a)
     : c(__c, __a), comp(__comp) {
   c.insert(c.end(), __f, __l);
   std::make_heap(c.begin(), c.end(), comp);
@@ -907,14 +881,12 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
 
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Container, class _Compare>
-template <class _InputIter, class _Alloc, class>
+template <
+    class _InputIter,
+    class _Alloc,
+    __enable_if_t<__has_input_iterator_category<_InputIter>::value && uses_allocator<_Container, _Alloc>::value, int> >
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
-    _InputIter __f,
-    _InputIter __l,
-    const value_compare& __comp,
-    container_type&& __c,
-    const _Alloc& __a,
-    __enable_if_t<uses_allocator<container_type, _Alloc>::value>*)
+    _InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c, const _Alloc& __a)
     : c(std::move(__c), __a), comp(__comp) {
   c.insert(c.end(), __f, __l);
   std::make_heap(c.begin(), c.end(), comp);

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -213,7 +213,7 @@ public:
 #endif // _LIBCPP_CXX03_LANG
 
 #if _LIBCPP_STD_VER >= 23
-  template <class _InputIterator, class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>>
+  template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI stack(_InputIterator __first, _InputIterator __last) : c(__first, __last) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range>
@@ -221,14 +221,14 @@ public:
 
   template <class _InputIterator,
             class _Alloc,
-            class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-            class = __enable_if_t<uses_allocator<container_type, _Alloc>::value>>
+            __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
+            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI stack(_InputIterator __first, _InputIterator __last, const _Alloc& __alloc)
       : c(__first, __last, __alloc) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range,
             class _Alloc,
-            class = __enable_if_t<uses_allocator<container_type, _Alloc>::value>>
+            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI stack(from_range_t, _Range&& __range, const _Alloc& __alloc)
       : c(from_range, std::forward<_Range>(__range), __alloc) {}
 
@@ -297,7 +297,7 @@ stack(_Container, _Alloc) -> stack<typename _Container::value_type, _Container>;
 #endif
 
 #if _LIBCPP_STD_VER >= 23
-template <class _InputIterator, class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>>
+template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
 stack(_InputIterator, _InputIterator) -> stack<__iter_value_type<_InputIterator>>;
 
 template <ranges::input_range _Range>
@@ -305,12 +305,12 @@ stack(from_range_t, _Range&&) -> stack<ranges::range_value_t<_Range>>;
 
 template <class _InputIterator,
           class _Alloc,
-          class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-          class = __enable_if_t<__is_allocator<_Alloc>::value>>
+          __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
+          __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
 stack(_InputIterator, _InputIterator, _Alloc)
     -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
-template <ranges::input_range _Range, class _Alloc, class = __enable_if_t<__is_allocator<_Alloc>::value>>
+template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
 stack(from_range_t, _Range&&, _Alloc)
     -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -337,10 +337,10 @@ public:
   }
 
   template <class _Tp,
-            class = __enable_if_t<
-                _And< _IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value > >
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(_Tp&& __t)
-      _NOEXCEPT_(is_nothrow_constructible<_Hp, _Tp>::value)
+            __enable_if_t<_And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value,
+                           int> = 0>
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_(is_nothrow_constructible<_Hp, _Tp>::value)
       : __value_(std::forward<_Tp>(__t)) {
     static_assert(__can_bind_reference<_Tp&&>(),
                   "Attempted construction of reference element binds to a temporary whose lifetime has ended");
@@ -405,10 +405,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a) : _Hp(__a) {}
 
   template <class _Tp,
-            class = __enable_if_t<
-                _And< _IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value > >
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(_Tp&& __t)
-      _NOEXCEPT_(is_nothrow_constructible<_Hp, _Tp>::value)
+            __enable_if_t< _And< _IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value,
+                           int> = 0>
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_(is_nothrow_constructible<_Hp, _Tp>::value)
       : _Hp(std::forward<_Tp>(__t)) {}
 
   template <class _Tp, class _Alloc>
@@ -483,7 +483,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
       : __tuple_leaf<_Uf, _Tf>(__uses_alloc_ctor<_Tf, _Alloc, _Up>(), __a, std::forward<_Up>(__u))...,
         __tuple_leaf<_Ul, _Tl>(__uses_alloc_ctor<_Tl, _Alloc>(), __a)... {}
 
-  template <class _Tuple, class = __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value> >
+  template <class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __tuple_impl(_Tuple&& __t) _NOEXCEPT_(
       (__all<is_nothrow_constructible<
            _Tp,
@@ -492,7 +492,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
             std::forward<typename tuple_element<_Indx, typename __make_tuple_types<_Tuple>::type>::type>(
                 std::get<_Indx>(__t)))... {}
 
-  template <class _Alloc, class _Tuple, class = __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value> >
+  template <class _Alloc, class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __tuple_impl(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
       : __tuple_leaf<_Indx, _Tp>(
             __uses_alloc_ctor<_Tp,
@@ -966,7 +966,7 @@ public:
   template <
       class _Up,
       size_t _Np,
-      class = __enable_if_t< _And< _BoolConstant<_Np == sizeof...(_Tp)>, is_assignable<_Tp&, _Up const&>... >::value > >
+      __enable_if_t< _And< _BoolConstant<_Np == sizeof...(_Tp)>, is_assignable<_Tp&, _Up const&>... >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple& operator=(array<_Up, _Np> const& __array)
       _NOEXCEPT_(_And<is_nothrow_assignable<_Tp&, _Up const&>...>::value) {
     std::__memberwise_copy_assign(*this, __array, typename __make_tuple_indices<sizeof...(_Tp)>::type());
@@ -977,7 +977,7 @@ public:
   template <class _Up,
             size_t _Np,
             class = void,
-            class = __enable_if_t< _And< _BoolConstant<_Np == sizeof...(_Tp)>, is_assignable<_Tp&, _Up>... >::value > >
+            __enable_if_t< _And< _BoolConstant<_Np == sizeof...(_Tp)>, is_assignable<_Tp&, _Up>... >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple& operator=(array<_Up, _Np>&& __array)
       _NOEXCEPT_(_And<is_nothrow_assignable<_Tp&, _Up>...>::value) {
     std::__memberwise_forward_assign(

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -877,7 +877,7 @@ public:
     return *this;
   }
 
-  template <class _ValueTp, class = __enable_if_t<__is_same_uncvref<_ValueTp, value_type>::value> >
+  template <class _ValueTp, __enable_if_t<__is_same_uncvref<_ValueTp, value_type>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI __hash_value_type& operator=(_ValueTp&& __v) {
     __ref() = std::forward<_ValueTp>(__v);
     return *this;
@@ -1245,12 +1245,12 @@ public:
     return __table_.__insert_unique(std::move(__x)).first;
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(_Pp&& __x) {
     return __table_.__insert_unique(std::forward<_Pp>(__x));
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator, _Pp&& __x) {
     return insert(std::forward<_Pp>(__x)).first;
   }
@@ -2052,12 +2052,12 @@ public:
     return __table_.__insert_multi(__p.__i_, std::move(__x));
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(_Pp&& __x) {
     return __table_.__insert_multi(std::forward<_Pp>(__x));
   }
 
-  template <class _Pp, class = __enable_if_t<is_constructible<value_type, _Pp>::value> >
+  template <class _Pp, __enable_if_t<is_constructible<value_type, _Pp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, _Pp&& __x) {
     return __table_.__insert_multi(__p.__i_, std::forward<_Pp>(__x));
   }

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -429,7 +429,7 @@ public:
 #endif
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI vector(size_type __n, const value_type& __x);
 
-  template <class = __enable_if_t<__is_allocator<_Allocator>::value> >
+  template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
   vector(size_type __n, const value_type& __x, const allocator_type& __a)
       : __end_cap_(nullptr, __a) {


### PR DESCRIPTION
This brings the code base closer to having only a single style of `enable_if`s.
