### PR TITLE
[Docs][DebugInfo][RemoveDIs] Revise debug info migration guide title

### DIFF
--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -1,4 +1,4 @@
-# What's all this then?
+# Debug info migration: From intrinsics to records
 
 We're planning on removing debug info intrinsics from LLVM, as they're slow, unwieldy and can confuse optimisation passes if they're not expecting them. Instead of having a sequence of instructions that looks like this:
 


### PR DESCRIPTION
As @aeubanks [mentioned](https://github.com/llvm/llvm-project/pull/79167#issuecomment-1935067804), the debug info migration guide could use a better title for clarity. This revises the title to make the topic more obvious.