### PR TITLE
[Release] Install compiler-rt builtins during Phase 1 on AIX

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -532,9 +532,9 @@ function build_llvmCore() {
       BuildTarget="clang"
       InstallTarget="install-clang install-clang-resource-headers"
       # compiler-rt builtins is needed on AIX to have a functional Phase 1 clang.
-      if [ "$System" = "AIX" -o "$Phase" != "1" ]; then
+      if [ "$System" = "AIX" ]; then
         BuildTarget="$BuildTarget runtimes"
-        InstallTarget="$InstallTarget install-runtimes install-builtins"
+        InstallTarget="$InstallTarget install-builtins"
       fi
     fi
 

--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -534,7 +534,7 @@ function build_llvmCore() {
       # compiler-rt builtins is needed on AIX to have a functional Phase 1 clang.
       if [ "$System" = "AIX" -o "$Phase" != "1" ]; then
         BuildTarget="$BuildTarget runtimes"
-        InstallTarget="$InstallTarget install-runtimes"
+        InstallTarget="$InstallTarget install-runtimes install-builtins"
       fi
     fi
 


### PR DESCRIPTION
The current test-release.sh script does not install the necessary compiler-rt builtin's during Phase 1 on AIX, resulting on a non-functional Phase 1 clang. 