### PR TITLE
[LTO] Set default Darwin CPU to apple-a7 for AArch64

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1568,7 +1568,7 @@ StringLiteral lto::getThinLTODefaultCPU(const Triple &TheTriple) {
     return "apple-a12";
   if (TheTriple.getArch() == Triple::aarch64 ||
       TheTriple.getArch() == Triple::aarch64_32)
-    return "cyclone";
+    return "apple-a7";
   return "";
 }
 

--- a/llvm/lib/LTO/LTOModule.cpp
+++ b/llvm/lib/LTO/LTOModule.cpp
@@ -226,7 +226,7 @@ LTOModule::makeLTOModule(MemoryBufferRef Buffer, const TargetOptions &options,
       CPU = "apple-a12";
     else if (Triple.getArch() == llvm::Triple::aarch64 ||
              Triple.getArch() == llvm::Triple::aarch64_32)
-      CPU = "cyclone";
+      CPU = "apple-a7";
   }
 
   TargetMachine *target = march->createTargetMachine(TripleStr, CPU, FeatureStr,

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2797,7 +2797,7 @@ Triple MachOObjectFile::getArchTriple(uint32_t CPUType, uint32_t CPUSubType,
     switch (CPUSubType & ~MachO::CPU_SUBTYPE_MASK) {
     case MachO::CPU_SUBTYPE_ARM64_ALL:
       if (McpuDefault)
-        *McpuDefault = "cyclone";
+        *McpuDefault = "apple-a7";
       if (ArchFlag)
         *ArchFlag = "arm64";
       return Triple("arm64-apple-darwin");
@@ -2814,7 +2814,7 @@ Triple MachOObjectFile::getArchTriple(uint32_t CPUType, uint32_t CPUSubType,
     switch (CPUSubType & ~MachO::CPU_SUBTYPE_MASK) {
     case MachO::CPU_SUBTYPE_ARM64_32_V8:
       if (McpuDefault)
-        *McpuDefault = "cyclone";
+        *McpuDefault = "apple-a7";
       if (ArchFlag)
         *ArchFlag = "arm64_32";
       return Triple("arm64_32-apple-darwin");

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memcpy.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memcpy.mir
@@ -56,7 +56,7 @@
   }
 
 
-  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="cyclone" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="apple-a7" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
   attributes #1 = { argmemonly nounwind }
   attributes #2 = { optsize }
   attributes #3 = { minsize }

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memmove.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memmove.mir
@@ -47,7 +47,7 @@
     ret void
   }
 
-  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="cyclone" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="apple-a7" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
   attributes #1 = { argmemonly nounwind }
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memset.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memset.mir
@@ -50,7 +50,7 @@
 
   declare void @llvm.stackprotector(ptr, ptr) #2
 
-  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="cyclone" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+  attributes #0 = { nounwind ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="apple-a7" "target-features"="+aes,+crypto,+fp-armv8,+neon,+sha2,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
   attributes #1 = { argmemonly nounwind }
 
 ...

--- a/llvm/test/CodeGen/AArch64/arm64-collect-loh.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-collect-loh.ll
@@ -680,4 +680,4 @@ if.end.i:
 }
 declare void @callee(ptr nocapture readonly, ...) 
 
-attributes #0 = { "target-cpu"="cyclone" }
+attributes #0 = { "target-cpu"="apple-a7" }

--- a/llvm/test/CodeGen/AArch64/arm64-vecCmpBr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vecCmpBr.ll
@@ -199,8 +199,8 @@ declare i32 @llvm.aarch64.neon.uminv.i32.v16i8(<16 x i8>) #2
 
 declare i32 @llvm.aarch64.neon.uminv.i32.v8i8(<8 x i8>) #2
 
-attributes #0 = { nounwind ssp "target-cpu"="cyclone" }
-attributes #1 = { "target-cpu"="cyclone" }
+attributes #0 = { nounwind ssp "target-cpu"="apple-a7" }
+attributes #1 = { "target-cpu"="apple-a7" }
 attributes #2 = { nounwind readnone }
 attributes #3 = { nounwind }
 attributes #4 = { nobuiltin nounwind }

--- a/llvm/test/CodeGen/AArch64/machine-outliner-remarks.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-remarks.ll
@@ -102,7 +102,7 @@ define void @bar() #0 !dbg !27 {
   ret void
 }
 
-attributes #0 = { noredzone nounwind ssp uwtable minsize "frame-pointer"="none" "target-cpu"="cyclone" }
+attributes #0 = { noredzone nounwind ssp uwtable minsize "frame-pointer"="none" "target-cpu"="apple-a7" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5, !6}

--- a/llvm/test/CodeGen/AArch64/machine-outliner.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner.ll
@@ -11,7 +11,7 @@
 ; TARGET_FEATURES-SAME: minsize
 ; TARGET_FEATURES-SAME: nounwind
 ; TARGET_FEATURES-SAME: optsize
-; TARGET_FEATURES-SAME: "target-cpu"="cyclone"
+; TARGET_FEATURES-SAME: "target-cpu"="apple-a7"
 ; TARGET_FEATURES-SAME: "target-features"="+sse"
 
 define linkonce_odr void @fish() #0 {
@@ -105,4 +105,4 @@ define void @dog() #0 {
 ; CHECK-DAG: add     sp, sp, #32
 ; CHECK-DAG: ret
 
-attributes #0 = { nounwind noredzone "target-cpu"="cyclone" "target-features"="+sse" }
+attributes #0 = { nounwind noredzone "target-cpu"="apple-a7" "target-features"="+sse" }

--- a/llvm/test/CodeGen/AArch64/print-mrs-system-register.ll
+++ b/llvm/test/CodeGen/AArch64/print-mrs-system-register.ll
@@ -8,4 +8,4 @@ entry:
   ret void
 }
 
-attributes #0 = { "target-cpu"="cyclone" }
+attributes #0 = { "target-cpu"="apple-a7" }


### PR DESCRIPTION
Use apple-a7 as default for AArch64 Darwin targets that are not arm64e, as apple-a7 is the first AArch64 CPU that can run Darwin.