### PR TITLE
[LLVM] Add `LLVM_<proj>_RUNTIME_TARGETS` to set targets per-project

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -253,8 +253,7 @@ function(runtime_default_target)
                                       ${COMMON_CMAKE_ARGS}
                                       ${RUNTIMES_CMAKE_ARGS}
                                       ${ARG_CMAKE_ARGS}
-                           PASSTHROUGH_PREFIXES LLVM_ENABLE_RUNTIMES
-                                                LLVM_USE_LINKER
+                           PASSTHROUGH_PREFIXES LLVM_USE_LINKER
                                                 ${ARG_PREFIXES}
                            EXTRA_TARGETS ${extra_targets}
                                          ${test_targets}
@@ -338,8 +337,6 @@ function(runtime_register_target name)
   endif()
 
   set(${name}_extra_args ${ARG_CMAKE_ARGS})
-  string(REPLACE ";" "|" LLVM_ENABLE_RUNTIMES_PASSTHROUGH "${LLVM_ENABLE_RUNTIMES}")
-  list(APPEND ${name}_extra_args -DLLVM_ENABLE_RUNTIMES=${LLVM_ENABLE_RUNTIMES_PASSTHROUGH})
   list(APPEND ${name}_extra_args -DLLVM_USE_LINKER=${LLVM_USE_LINKER})
 
   get_cmake_property(variable_names VARIABLES)
@@ -449,39 +446,65 @@ if(runtimes)
       endforeach()
     endif()
   endif()
-  if(NOT LLVM_RUNTIME_TARGETS)
-    runtime_default_target(
-      DEPENDS ${builtins_dep} ${extra_deps}
-      CMAKE_ARGS ${libc_cmake_args}
-      PREFIXES ${prefixes})
-    set(test_targets check-runtimes)
-  else()
-    if("default" IN_LIST LLVM_RUNTIME_TARGETS)
+
+  # Get the list of all target triples requested for this build.
+  set(runtime_targets "default")
+  if (LLVM_RUNTIME_TARGETS)
+    set(runtime_targets ${LLVM_RUNTIME_TARGETS})
+  endif()
+  set(all_targets ${runtime_targets})
+  foreach(proj ${LLVM_ENABLE_RUNTIMES})
+    string(TOUPPER "${proj}" canon_name)
+    string(REGEX REPLACE "-" "_" canon_name ${canon_name})
+    if(LLVM_${canon_name}_RUNTIME_TARGETS)
+      list(APPEND all_targets ${LLVM_${canon_name}_RUNTIME_TARGETS})
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES all_targets)
+
+  # If we have any non-default triples we need to create custom targets.
+  if(NOT "default" IN_LIST all_targets)
+    add_custom_target(runtimes)
+    add_custom_target(runtimes-configure)
+    add_custom_target(install-runtimes)
+    add_custom_target(install-runtimes-stripped)
+    if(LLVM_INCLUDE_TESTS)
+      add_custom_target(check-runtimes)
+      add_custom_target(runtimes-test-depends)
+      set(test_targets "")
+    endif()
+    if(LLVM_RUNTIME_DISTRIBUTION_COMPONENTS)
+      foreach(component ${LLVM_RUNTIME_DISTRIBUTION_COMPONENTS})
+        add_custom_target(${component})
+        add_custom_target(install-${component})
+        add_custom_target(install-${component}-stripped)
+      endforeach()
+    endif()
+  endif()
+
+  # Register each requested target triple using the projects that requested that
+  # target. It should be used if it is in the base list of enabled runtimes and
+  # not overridden on the project level.
+  foreach(name ${all_targets})
+    set(_enabled_runtimes "")
+    foreach(proj ${LLVM_ENABLE_RUNTIMES})
+      string(TOUPPER "${proj}" canon_name)
+      string(REGEX REPLACE "-" "_" canon_name ${canon_name})
+      if((NOT LLVM_${canon_name}_RUNTIME_TARGETS AND ${name} IN_LIST runtime_targets)
+          OR ${name} IN_LIST LLVM_${canon_name}_RUNTIME_TARGETS)
+        list(APPEND _enabled_runtimes ${proj})
+      endif()
+    endforeach()
+    string(REPLACE ";" "|" enabled_runtimes "${_enabled_runtimes}")
+
+    if("${name}" STREQUAL "default")
       runtime_default_target(
         DEPENDS ${builtins_dep} ${extra_deps}
-        CMAKE_ARGS ${libc_cmake_args}
+        CMAKE_ARGS -DLLVM_ENABLE_RUNTIMES=${enabled_runtimes}
+                   ${libc_cmake_args}
         PREFIXES ${prefixes})
-      list(REMOVE_ITEM LLVM_RUNTIME_TARGETS "default")
+      set(test_targets check-runtimes)
     else()
-      add_custom_target(runtimes)
-      add_custom_target(runtimes-configure)
-      add_custom_target(install-runtimes)
-      add_custom_target(install-runtimes-stripped)
-      if(LLVM_INCLUDE_TESTS)
-        add_custom_target(check-runtimes)
-        add_custom_target(runtimes-test-depends)
-        set(test_targets "")
-      endif()
-      if(LLVM_RUNTIME_DISTRIBUTION_COMPONENTS)
-        foreach(component ${LLVM_RUNTIME_DISTRIBUTION_COMPONENTS})
-          add_custom_target(${component})
-          add_custom_target(install-${component})
-          add_custom_target(install-${component}-stripped)
-        endforeach()
-      endif()
-    endif()
-
-    foreach(name ${LLVM_RUNTIME_TARGETS})
       if(builtins_dep)
         if (LLVM_BUILTIN_TARGETS)
           set(builtins_dep_name "${builtins_dep}-${name}")
@@ -494,22 +517,23 @@ if(runtimes)
 
       runtime_register_target(${name}
         DEPENDS ${builtins_dep_name} ${hdrgen_deps}
-        CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${libc_cmake_args}
+        CMAKE_ARGS -DLLVM_ENABLE_RUNTIMES=${enabled_runtimes}
+                   -DLLVM_DEFAULT_TARGET_TRIPLE=${name}
+                   ${libc_cmake_args}
         EXTRA_ARGS TARGET_TRIPLE ${name})
-    endforeach()
 
-    foreach(multilib ${LLVM_RUNTIME_MULTILIBS})
-      foreach(name ${LLVM_RUNTIME_MULTILIB_${multilib}_TARGETS})
+      foreach(multilib ${LLVM_RUNTIME_MULTILIBS})
         runtime_register_target(${name}+${multilib}
           DEPENDS runtimes-${name}
           CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name}
+                     -DLLVM_ENABLE_RUNTIMES=${enabled_runtimes}
                      -DLLVM_RUNTIMES_PREFIX=${name}/
                      -DLLVM_RUNTIMES_LIBDIR_SUBDIR=${multilib}
           BASE_NAME ${name}
           EXTRA_ARGS TARGET_TRIPLE ${name})
       endforeach()
-    endforeach()
-  endif()
+    endif()
+  endforeach()
 
   if(NOT LLVM_BUILD_INSTRUMENTED AND CLANG_ENABLE_BOOTSTRAP)
     # TODO: This is a hack needed because the libcxx headers are copied into the


### PR DESCRIPTION
Summary:
Currently, the runtimes build allow users to optionally build for
multiple target architectures via the `LLVM_RUNTIME_TARGETS` option.
Once problem is that this applies to every single runtime the user has
enabled, when it's possible that we may wish to enable a different set
for just one target.

The motivating example here is for handling GPU targets as
cross-compiling. We want to be able to perform something like
`LLVM_RUNTIME_TARGETS=amdgcn-amd-amdhsa;nvptx64-nvidia-cuda` to build
runtimes targeting the GPU. However, the current support would force the
other runtimes to be built for the GPU, when this definitely will not
work.

This patch attempts to work around this in a generic way by letting
individual targets overload the set of enabled runtimes triples. The
expected use would be to enable something like the following for
targeting the GPU `libc` and in the future the GPU `libcxx`.

```
-DLLVM_ENABLE_RUNTIMES='openmp;libcxx;libcxx-abi;libc'
-DLLVM_LIBC_RUNTIME_TARGETS='nvptx64-nvidia-cuda;amdgcn-amd-amdhsa'
```
