### PR TITLE
[clang-tidy] fix incorrect hint for InitListExpr in prefer-member-initializer

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -203,7 +203,7 @@ void PreferMemberInitializerCheck::check(
     SourceLocation InsertPos;
     SourceRange ReplaceRange;
     bool AddComma = false;
-    bool AddBracket = false;
+    bool AddBrace = false;
     bool InvalidFix = false;
     unsigned Index = Field->getFieldIndex();
     const CXXCtorInitializer *LastInListInit = nullptr;
@@ -216,8 +216,8 @@ void PreferMemberInitializerCheck::check(
           InsertPos = Init->getRParenLoc();
         else {
           ReplaceRange = Init->getInit()->getSourceRange();
+          AddBrace = isa<InitListExpr>(Init->getInit());
         }
-        AddBracket = isa<InitListExpr>(Init->getInit());
         break;
       }
       if (Init->isMemberInitializer() &&
@@ -281,7 +281,7 @@ void PreferMemberInitializerCheck::check(
     if (HasInitAlready) {
       if (InsertPos.isValid())
         Diag << FixItHint::CreateInsertion(InsertPos, NewInit);
-      else if (AddBracket)
+      else if (AddBrace)
         Diag << FixItHint::CreateReplacement(ReplaceRange,
                                              ("{" + NewInit + "}").str());
       else

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -203,6 +203,7 @@ void PreferMemberInitializerCheck::check(
     SourceLocation InsertPos;
     SourceRange ReplaceRange;
     bool AddComma = false;
+    bool AddBracket = false;
     bool InvalidFix = false;
     unsigned Index = Field->getFieldIndex();
     const CXXCtorInitializer *LastInListInit = nullptr;
@@ -216,6 +217,7 @@ void PreferMemberInitializerCheck::check(
         else {
           ReplaceRange = Init->getInit()->getSourceRange();
         }
+        AddBracket = isa<InitListExpr>(Init->getInit());
         break;
       }
       if (Init->isMemberInitializer() &&
@@ -279,6 +281,9 @@ void PreferMemberInitializerCheck::check(
     if (HasInitAlready) {
       if (InsertPos.isValid())
         Diag << FixItHint::CreateInsertion(InsertPos, NewInit);
+      else if (AddBracket)
+        Diag << FixItHint::CreateReplacement(ReplaceRange,
+                                             ("{" + NewInit + "}").str());
       else
         Diag << FixItHint::CreateReplacement(ReplaceRange, NewInit);
     } else {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -127,7 +127,8 @@ Changes in existing checks
   <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers>`_,
   which was deprecated since :program:`clang-tidy` 17. This rule is now covered
   by :doc:`cppcoreguidelines-use-default-member-init
-  <clang-tidy/checks/cppcoreguidelines/use-default-member-init>`.
+  <clang-tidy/checks/cppcoreguidelines/use-default-member-init>` and fixes
+  incorrect hints when using list-initialization.
 
 - Improved :doc:`google-build-namespaces
   <clang-tidy/checks/google/build-namespaces>` check by replacing the local

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -621,13 +621,13 @@ namespace GH77684 {
 struct S1 {
 // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S1() : M{} { M = 0; }
-// CHECK-FIXES:  S1() : M{0}
+// CHECK-FIXES:  S1() : M{0} { }
   int M;
 };
 struct S2 {
 // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S2() : M{2} { M = 1; }
-// CHECK-FIXES:  S2() : M{1}
+// CHECK-FIXES:  S2() : M{1} { }
   int M;
 };
 struct T { int a; int b; int c; };
@@ -635,7 +635,7 @@ T v;
 struct S3 {
 // CHECK-MESSAGES: :[[@LINE+1]]:21: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S3() : M{1,2,3} { M = v; }
-// CHECK-FIXES:  S3() : M{v}
+// CHECK-FIXES:  S3() : M{v} { }
   T M;
 };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -621,13 +621,13 @@ namespace GH77684 {
 struct S1 {
 // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S1() : M{} { M = 0; }
-// CHECK-FIXES: {{ S1.+M\{0\} }}
+// CHECK-FIXES:  S1() : M{0}
   int M;
 };
 struct S2 {
 // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S2() : M{2} { M = 1; }
-// CHECK-FIXES: {{ S2.+M\{1\} }}
+// CHECK-FIXES:  S2() : M{1}
   int M;
 };
 struct T { int a; int b; int c; };
@@ -635,7 +635,7 @@ T v;
 struct S3 {
 // CHECK-MESSAGES: :[[@LINE+1]]:21: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
   S3() : M{1,2,3} { M = v; }
-// CHECK-FIXES: {{ S3.+M\{v\} }}
+// CHECK-FIXES:  S3() : M{v}
   T M;
 };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -616,3 +616,26 @@ private:
 #undef INVALID_HANDLE_VALUE
 #undef RGB
 }
+
+namespace GH77684 {
+struct S1 {
+// CHECK-MESSAGES: :[[@LINE+1]]:16: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+  S1() : M{} { M = 0; }
+// CHECK-FIXES: {{ S1.+M\{0\} }}
+  int M;
+};
+struct S2 {
+// CHECK-MESSAGES: :[[@LINE+1]]:17: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+  S2() : M{2} { M = 1; }
+// CHECK-FIXES: {{ S2.+M\{1\} }}
+  int M;
+};
+struct T { int a; int b; int c; };
+T v;
+struct S3 {
+// CHECK-MESSAGES: :[[@LINE+1]]:21: warning: 'M' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+  S3() : M{1,2,3} { M = v; }
+// CHECK-FIXES: {{ S3.+M\{v\} }}
+  T M;
+};
+}


### PR DESCRIPTION
Fixes: #77684.