### PR TITLE
[flang][docs] Update llvm-test-suite docs

### DIFF
--- a/flang/docs/FortranLLVMTestSuite.md
+++ b/flang/docs/FortranLLVMTestSuite.md
@@ -21,7 +21,9 @@ cmake -G "Ninja" -DCMAKE_C_COMPILER=<path to C compiler> \
     -DCMAKE_Fortran_COMPILER=<path to Fortran compiler> \
     -DTEST_SUITE_COLLECT_CODE_SIZE:STRING=OFF \
     -DTEST_SUITE_SUBDIRS:STRING="Fortran" \
-    -DTEST_SUITE_FORTRAN:STRING=ON ..
+    -DTEST_SUITE_FORTRAN:STRING=ON \
+    -DTEST_SUITE_LIT=<path to llvm-lit> \
+    <path to llvm-test-suite>
 ```
 
 This will configure the test-suite to run only the Fortran tests which
@@ -33,6 +35,19 @@ If your Fortran compiler is Flang, you may want to set the `NO_STOP_MESSAGE`
 environment variable to `1` in order to avoid test failures due to warnings
 about INEXACT signaling exceptions.
 
+In addition, flang must be installed to some location (`ninja install`). Otherwise
+you will get this error when configuring:
+```
+CMake Error at Fortran/gfortran/CMakeLists.txt:649 (find_file):
+  Could not find ISO_FORTRAN_C_HEADER using the following files:
+  ISO_Fortran_binding.h
+```
+
+Then to build and run the tests:
+```
+ninja
+ninja check
+```
 
 ## Running the SPEC CPU 2017
 

--- a/flang/docs/FortranLLVMTestSuite.md
+++ b/flang/docs/FortranLLVMTestSuite.md
@@ -31,17 +31,9 @@ are found in the Fortran subdirectory. To run the C/C++ tests
 alongside the Fortran tests omit the `-DTEST_SUITE_SUBDIRS` CMake
 variable.
 
-If your Fortran compiler is Flang, you may want to set the `NO_STOP_MESSAGE`
-environment variable to `1` in order to avoid test failures due to warnings
-about INEXACT signaling exceptions.
-
-In addition, flang must be installed to some location (`ninja install`). Otherwise
-you will get this error when configuring:
-```
-CMake Error at Fortran/gfortran/CMakeLists.txt:649 (find_file):
-  Could not find ISO_FORTRAN_C_HEADER using the following files:
-  ISO_Fortran_binding.h
-```
+If your Fortran compiler is Flang, there are a couple of other things you need
+to do, which are explained
+[here](https://github.com/llvm/llvm-test-suite/blob/main/Fortran/gfortran/README.md#usage).
 
 Then to build and run the tests:
 ```


### PR DESCRIPTION
With some missing config options and a link to the test suite docs that explain how to setup `ISO_FORTRAN_C_HEADER` and set the stop message variable.