### PR TITLE
[clang][Sema] Improve error recovery for id-expressions referencing invalid decls

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2928,7 +2928,7 @@ Sema::ActOnIdExpression(Scope *S, CXXScopeSpec &SS,
     return BuildTemplateIdExpr(SS, TemplateKWLoc, R, ADL, TemplateArgs);
   }
 
-  return BuildDeclarationNameExpr(SS, R, ADL);
+  return BuildDeclarationNameExpr(SS, R, ADL, /*AcceptInvalidDecl=*/true);
 }
 
 /// BuildQualifiedDeclarationNameExpr - Build a C++ qualified
@@ -3452,6 +3452,10 @@ ExprResult Sema::BuildDeclarationNameExpr(const CXXScopeSpec &SS,
                                    R.getLookupNameInfo(),
                                    NeedsADL, R.isOverloadedResult(),
                                    R.begin(), R.end());
+
+  if (R.isSingleResult() && R.getFoundDecl()->isInvalidDecl()) {
+    return CreateRecoveryExpr(ULE->getBeginLoc(), ULE->getEndLoc(), {ULE});
+  }
 
   return ULE;
 }

--- a/clang/test/AST/ast-dump-recovery.cpp
+++ b/clang/test/AST/ast-dump-recovery.cpp
@@ -402,6 +402,7 @@ void returnInitListFromVoid() {
   // CHECK-NEXT:   `-IntegerLiteral {{.*}} 'int' 8
 }
 
+void FuncTakingUnknown(Unknown);
 void RecoveryExprForInvalidDecls(Unknown InvalidDecl) {
   InvalidDecl + 1;
   // CHECK:      BinaryOperator {{.*}}
@@ -411,6 +412,11 @@ void RecoveryExprForInvalidDecls(Unknown InvalidDecl) {
   InvalidDecl();
   // CHECK:      CallExpr {{.*}}
   // CHECK-NEXT: `-RecoveryExpr {{.*}} '<dependent type>'
+  FuncTakingUnknown(InvalidDecl);
+  // CHECK:      CallExpr {{.*}} '<dependent type>'
+  // CHECK-NEXT: |-UnresolvedLookupExpr {{.*}} '<overloaded function type>'
+  // CHECK-NEXT: `-RecoveryExpr {{.*}} '<dependent type>'
+  // CHECK-NEXT:   `-DeclRefExpr {{.*}} 'InvalidDecl' 'int'
 }
 
 void RecoverToAnInvalidDecl() {


### PR DESCRIPTION
Passing AcceptInvalidDecl=true to BuildDeclarationNameExpr() allows the RecoveryExpr that's constructed to retain a DeclRefExpr pointing to the invalid decl as a child, preserving information about the reference for use by tools such as clangd.

Fixes https://github.com/clangd/clangd/issues/1820