### PR TITLE
[llvm][docs] Update the Python version requirement to 3.8.0 for lit testing on Windows with substitute (virtual) drives.

### DIFF
--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -295,8 +295,9 @@ Package                                                     Version      Notes
 
 .. note::
 
-   #. Only needed if you want to run the automated test suite in the
-      ``llvm/test`` directory.
+   #. Only needed if you want to run the automated test suite. Python 3.8.0
+      or later is needed on Windows if a substitute (virtual) drive is used
+      to access LLVM source code due to ``MAX_PATH`` limitations.
    #. Optional, adds compression / uncompression capabilities to selected LLVM
       tools.
    #. Optional, you can use any other build tool supported by CMake.


### PR DESCRIPTION
Following the changes made for:
- https://reviews.llvm.org/D154130: [lit][clang] Avoid realpath on Windows due to MAX_PATH limitations

in commit:
- 05d613ea931b6de1b46dfe04b8e55285359047f4

Python 3.8.0 or newer is now required by at least the following tests when they are run on Windows from a substitute (virtual) drive. A substitute drive is often used as a workaround for `MAX_PATH` limitations on Windows. These tests are impacted because they use the lit `%{?:real}` path expansion syntax to expand symbolic links and substitute drives. This path expansion is implemented with Python's `os.path.realpath()` function which changed behavior in Python 3.8.0 with regard to expansion of substitute drives. The changes mentioned above rely on the newer Python behavior.
- `clang/test/Lexer/case-insensitive-include-absolute.c`
- `clang/test/Lexer/case-insensitive-include-win.c`

This change updates the LLVM Getting Started guide to note this newer Python version dependency for this relatively niche case. Python 3.6.0 remains the minimum required Python version otherwise.