### PR TITLE
[LLD] Use uint64_t timestamp to overcome potential overflow

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -290,7 +290,7 @@ struct Configuration {
   uint32_t minorOSVersion = 0;
   uint32_t majorSubsystemVersion = 6;
   uint32_t minorSubsystemVersion = 0;
-  uint32_t timestamp = 0;
+  uint64_t timestamp = 0;
   uint32_t functionPadMin = 0;
   uint32_t timeTraceGranularity = 0;
   uint16_t dependentLoadFlags = 0;

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1821,7 +1821,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       StringRef value(arg->getValue());
       if (value.getAsInteger(0, config->timestamp))
         fatal(Twine("invalid timestamp: ") + value +
-              ".  Expected 32-bit integer");
+              ".  Expected 64-bit integer");
     }
   } else {
     config->repro = false;
@@ -1830,7 +1830,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       StringRef value(*epoch);
       if (value.getAsInteger(0, config->timestamp))
         fatal(Twine("invalid SOURCE_DATE_EPOCH timestamp: ") + value +
-              ".  Expected 32-bit integer");
+              ".  Expected 64-bit integer");
     } else {
       config->timestamp = time(nullptr);
     }

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1714,7 +1714,8 @@ void elf::postScanRelocations() {
         if (!sym.isDefined()) {
           replaceWithDefined(sym, *in.plt,
                              target->pltHeaderSize +
-                                 target->pltEntrySize * sym.getPltIdx(),
+                                 (uint64_t)target->pltEntrySize *
+                                     sym.getPltIdx(),
                              0);
           sym.setFlags(NEEDS_COPY);
           if (config->emachine == EM_PPC) {

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -167,7 +167,7 @@ uint64_t Symbol::getGotVA() const {
 }
 
 uint64_t Symbol::getGotOffset() const {
-  return getGotIdx() * target->gotEntrySize;
+  return getGotIdx() * (uint64_t)target->gotEntrySize;
 }
 
 uint64_t Symbol::getGotPltVA() const {
@@ -178,8 +178,9 @@ uint64_t Symbol::getGotPltVA() const {
 
 uint64_t Symbol::getGotPltOffset() const {
   if (isInIplt)
-    return getPltIdx() * target->gotEntrySize;
-  return (getPltIdx() + target->gotPltHeaderEntriesNum) * target->gotEntrySize;
+    return getPltIdx() * (uint64_t)target->gotEntrySize;
+  return (getPltIdx() + target->gotPltHeaderEntriesNum) *
+         (uint64_t)target->gotEntrySize;
 }
 
 uint64_t Symbol::getPltVA() const {

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -801,7 +801,7 @@ uint64_t MipsGotSection::getGlobalDynOffset(const InputFile *f,
                                             const Symbol &s) const {
   const FileGot &g = gots[f->mipsGotIndex];
   Symbol *sym = const_cast<Symbol *>(&s);
-  return g.dynTlsSymbols.lookup(sym) * config->wordsize;
+  return g.dynTlsSymbols.lookup(sym) * (uint64_t)config->wordsize;
 }
 
 const Symbol *MipsGotSection::getFirstGlobalEntry() const {

--- a/lld/test/COFF/timestamp.test
+++ b/lld/test/COFF/timestamp.test
@@ -13,8 +13,8 @@ RUN: env SOURCE_DATE_EPOCH=12345 lld-link %t.obj /debug /timestamp:0 /entry:main
 RUN: lld-link %t.obj /debug /timestamp:4294967295 /entry:main /nodefaultlib /out:%t.8.exe
 RUN: env SOURCE_DATE_EPOCH=4294967295 lld-link %t.obj /debug /entry:main /nodefaultlib /out:%t.9.exe
 # Test that setting UINT32_MAX+1 as timestamp fails.
-RUN: env LLD_IN_TEST=1 not lld-link %t.obj /debug /timestamp:4294967296 /entry:main /nodefaultlib /out:%t.10.exe 2>&1 | FileCheck %s --check-prefix=ERROR
-RUN: env SOURCE_DATE_EPOCH=4294967296 env LLD_IN_TEST=1 not lld-link %t.obj /debug /entry:main /nodefaultlib /out:%t.11.exe 2>&1 | FileCheck %s --check-prefix=ERROR2
+RUN: env LLD_IN_TEST=1 not lld-link %t.obj /debug /timestamp:18446744073709551616 /entry:main /nodefaultlib /out:%t.10.exe 2>&1 | FileCheck %s --check-prefix=ERROR
+RUN: env SOURCE_DATE_EPOCH=18446744073709551616 env LLD_IN_TEST=1 not lld-link %t.obj /debug /entry:main /nodefaultlib /out:%t.11.exe 2>&1 | FileCheck %s --check-prefix=ERROR2
 RUN: llvm-readobj --file-headers --coff-debug-directory %t.1.exe | FileCheck %s --check-prefix=HASH
 RUN: llvm-readobj --file-headers --coff-debug-directory %t.2.exe | FileCheck %s --check-prefix=HASH
 RUN: llvm-readobj --file-headers --coff-debug-directory %t.3.exe | FileCheck %s --check-prefix=ZERO
@@ -41,5 +41,5 @@ LARGE: TimeDateStamp: 2038-01-19 03:14:07 (0x7FFFFFFF)
 LARGE: DebugDirectory [
 LARGE: TimeDateStamp: 2038-01-19 03:14:07 (0x7FFFFFFF)
 
-ERROR: error: invalid timestamp: 4294967296.  Expected 32-bit integer
-ERROR2: error: invalid SOURCE_DATE_EPOCH timestamp: 4294967296.  Expected 32-bit integer
+ERROR: error: invalid timestamp: 18446744073709551616.  Expected 64-bit integer
+ERROR2: error: invalid SOURCE_DATE_EPOCH timestamp: 18446744073709551616.  Expected 64-bit integer


### PR DESCRIPTION
Added explicit casting to uint64_t to overcome potential overflow
within some expressions and modified the containing type of a timestamp
variable to store all bits of a time_t value

Co-Authored-by: Demchuk, Tennyson <tennyson.demchuk@intel.com>
Co-Authored-by: Tikhomirova, Kseniya <Kseniya.Tikhomirova@intel.com>
