### PR TITLE
[lldb] Fix `FindDirectNestedType` not working with class templates

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9269,7 +9269,8 @@ ConstString TypeSystemClang::DeclContextGetName(void *opaque_decl_ctx) {
     if (named_decl) {
       std::string name;
       llvm::raw_string_ostream stream{name};
-      named_decl->getNameForDiagnostic(stream, GetTypePrintingPolicy(), /*qualified=*/ false);
+      named_decl->getNameForDiagnostic(stream, GetTypePrintingPolicy(),
+                                       /*qualified=*/false);
       return ConstString(name);
     }
   }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2165,6 +2165,7 @@ PrintingPolicy TypeSystemClang::GetTypePrintingPolicy() {
   // (and we then would have suppressed them from the type name) and also setups
   // where LLDB wasn't able to reconstruct the default arguments.
   printing_policy.SuppressDefaultTemplateArgs = false;
+  printing_policy.AlwaysIncludeTypeForTemplateArgument = true;
   return printing_policy;
 }
 
@@ -9265,8 +9266,12 @@ ConstString TypeSystemClang::DeclContextGetName(void *opaque_decl_ctx) {
   if (opaque_decl_ctx) {
     clang::NamedDecl *named_decl =
         llvm::dyn_cast<clang::NamedDecl>((clang::DeclContext *)opaque_decl_ctx);
-    if (named_decl)
-      return ConstString(named_decl->getName());
+    if (named_decl) {
+      std::string name;
+      llvm::raw_string_ostream stream{name};
+      named_decl->getNameForDiagnostic(stream, GetTypePrintingPolicy(), /*qualified=*/ false);
+      return ConstString(name);
+    }
   }
   return ConstString();
 }

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -150,6 +150,23 @@ class TypeAndTypeListTestCase(TestBase):
         invalid_type = task_type.FindDirectNestedType(None)
         self.assertFalse(invalid_type)
 
+        # Check that FindDirectNestedType works with types from AST
+        pointer = frame0.FindVariable("pointer")
+        pointer_type = pointer.GetType()
+        self.assertTrue(pointer_type)
+        self.DebugSBType(pointer_type)
+        pointer_info_type = pointer_type.template_args[0]
+        self.assertTrue(pointer_info_type)
+        self.DebugSBType(pointer_info_type)
+
+        pointer_masks1_type = pointer_info_type.FindDirectNestedType("Masks1")
+        self.assertTrue(pointer_masks1_type)
+        self.DebugSBType(pointer_masks1_type)
+
+        pointer_masks2_type = pointer_info_type.FindDirectNestedType("Masks2")
+        self.assertTrue(pointer_masks2_type)
+        self.DebugSBType(pointer_masks2_type)
+
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")
         self.DebugSBValue(id)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -155,7 +155,7 @@ class TypeAndTypeListTestCase(TestBase):
         pointer_type = pointer.GetType()
         self.assertTrue(pointer_type)
         self.DebugSBType(pointer_type)
-        pointer_info_type = pointer_type.template_args[0]
+        pointer_info_type = pointer_type.template_args[1]
         self.assertTrue(pointer_info_type)
         self.DebugSBType(pointer_info_type)
 

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -34,6 +34,15 @@ public:
     {}
 };
 
+template <unsigned Value>
+struct PointerInfo {
+  enum Masks1 { pointer_mask };
+  enum class Masks2 { pointer_mask };
+};
+
+template <unsigned Value, typename InfoType = PointerInfo<Value>>
+struct Pointer {};
+
 enum EnumType {};
 enum class ScopedEnumType {};
 enum class EnumUChar : unsigned char {};
@@ -70,6 +79,10 @@ int main (int argc, char const *argv[])
     EnumType enum_type;
     ScopedEnumType scoped_enum_type;
     EnumUChar scoped_enum_type_uchar;
+
+    Pointer<3> pointer;
+    PointerInfo<3>::Masks1 mask1 = PointerInfo<3>::Masks1::pointer_mask;
+    PointerInfo<3>::Masks2 mask2 = PointerInfo<3>::Masks2::pointer_mask;
 
     return 0; // Break at this line
 }

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -34,8 +34,7 @@ public:
     {}
 };
 
-template <unsigned Value>
-struct PointerInfo {
+template <unsigned Value> struct PointerInfo {
   enum Masks1 { pointer_mask };
   enum class Masks2 { pointer_mask };
 };


### PR DESCRIPTION
This patch attempts to fix lookup in class template specialization.

The first fixed problem is that during type lookup `DeclContextGetName` have been dropping template arguments. So when such a name was compared against a name in `DW_AT_name`, which contains template arguments, false mismatches have been occurring.

The second fixed problem is that LLDB's printing policy hasn't been matching Clang's printing policy when it comes to integral non-type template arguments. This again caused some false mismatches during type lookup, because Clang puts e.g. `3U` in debug info for class specializations, but LLDB has been expecting just `3`. This patch brings printing policy in line with what Clang does.