### PR TITLE
[flang] Register LLVMTranslationDialectInterface for FIR.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -70,6 +70,9 @@ bool canLegallyInline(mlir::Operation *, mlir::Operation *, bool);
 // Register the FIRInlinerInterface to FIROpsDialect
 void addFIRInlinerExtension(mlir::DialectRegistry &registry);
 
+// Register implementation of LLVMTranslationDialectInterface.
+void addFIRToLLVMIRExtension(mlir::DialectRegistry &registry);
+
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIRDIALECT_H

--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -58,6 +58,7 @@ inline void addFIRExtensions(mlir::DialectRegistry &registry,
                              bool addFIRInlinerInterface = true) {
   if (addFIRInlinerInterface)
     addFIRInlinerExtension(registry);
+  addFIRToLLVMIRExtension(registry);
 }
 
 inline void loadNonCodegenDialects(mlir::MLIRContext &context) {

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -15,6 +15,7 @@
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 using namespace fir;
@@ -74,6 +75,22 @@ void fir::addFIRInlinerExtension(mlir::DialectRegistry &registry) {
   registry.addExtension(
       +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {
         dialect->addInterface<FIRInlinerInterface>();
+      });
+}
+
+// We do not provide LLVMTranslationDialectInterface implementation
+// for FIR dialect, since at the point of translation to LLVM IR
+// there should not be any FIR operations (the CodeGen converts
+// them to LLVMIR dialect operations).
+// Here we register the default implementation of
+// LLVMTranslationDialectInterface that will drop all FIR dialect
+// attributes - this helps to avoid warnings about unhandled attributes.
+// We can provide our own implementation of the interface,
+// when more sophisticated translation is required.
+void fir::addFIRToLLVMIRExtension(mlir::DialectRegistry &registry) {
+  registry.addExtension(
+      +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {
+        dialect->addInterface<mlir::LLVMTranslationDialectInterface>();
       });
 }
 


### PR DESCRIPTION
Register the LLVM IR translation interface for FIR to avoid
warnings about "Unhandled parameter attribute" after #78228.
