### PR TITLE
[libc][__support][bit] remove compiler has builtin checks

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -93,15 +93,9 @@ template <typename T, typename = cpp::enable_if_t<cpp::is_unsigned_v<T>>>
 #if LIBC_HAS_BUILTIN(__builtin_ctzs)
 ADD_SPECIALIZATION(countr_zero, unsigned short, __builtin_ctzs)
 #endif
-#if LIBC_HAS_BUILTIN(__builtin_ctz)
 ADD_SPECIALIZATION(countr_zero, unsigned int, __builtin_ctz)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_ctzl)
 ADD_SPECIALIZATION(countr_zero, unsigned long, __builtin_ctzl)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_ctzll)
 ADD_SPECIALIZATION(countr_zero, unsigned long long, __builtin_ctzll)
-#endif
 
 /// Count number of 0's from the most significant bit to the least
 ///   stopping at the first 1.
@@ -128,15 +122,9 @@ template <typename T, typename = cpp::enable_if_t<cpp::is_unsigned_v<T>>>
 #if LIBC_HAS_BUILTIN(__builtin_clzs)
 ADD_SPECIALIZATION(countl_zero, unsigned short, __builtin_clzs)
 #endif
-#if LIBC_HAS_BUILTIN(__builtin_clz)
 ADD_SPECIALIZATION(countl_zero, unsigned int, __builtin_clz)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_clzl)
 ADD_SPECIALIZATION(countl_zero, unsigned long, __builtin_clzl)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_clzll)
 ADD_SPECIALIZATION(countl_zero, unsigned long long, __builtin_clzll)
-#endif
 
 #undef ADD_SPECIALIZATION
 
@@ -256,15 +244,9 @@ template <typename T, typename = cpp::enable_if_t<cpp::is_unsigned_v<T>>>
 #if LIBC_HAS_BUILTIN(__builtin_clzs)
 SPECIALIZE_FLZ(first_leading_zero, unsigned short, __builtin_clzs)
 #endif
-#if LIBC_HAS_BUILTIN(__builtin_clz)
 SPECIALIZE_FLZ(first_leading_zero, unsigned int, __builtin_clz)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_clzl)
 SPECIALIZE_FLZ(first_leading_zero, unsigned long, __builtin_clzl)
-#endif
-#if LIBC_HAS_BUILTIN(__builtin_clzll)
 SPECIALIZE_FLZ(first_leading_zero, unsigned long long, __builtin_clzll)
-#endif
 
 #undef SPECIALIZE_FLZ
 


### PR DESCRIPTION
We only support building llvmlibc with modern compilers.
https://libc.llvm.org/compiler_support.html#minimum-supported-versions

All versions of the these compilers support these builtins; GCC does not
support the short variants.
