### PR TITLE
[lldb] Add comment on cross printing of summary/value

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1312,7 +1312,8 @@ bool ValueObject::DumpPrintableRepresentation(
       break;
     }
 
-    // Try summary if no value, and value if no summary.
+    // If the requested display style produced no output, try falling back to
+    // alternative presentations.
     if (str.empty()) {
       if (val_obj_display == eValueObjectRepresentationStyleValue)
         str = GetSummaryAsCString();

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1312,6 +1312,7 @@ bool ValueObject::DumpPrintableRepresentation(
       break;
     }
 
+    // Try summary if no value, and value if no summary.
     if (str.empty()) {
       if (val_obj_display == eValueObjectRepresentationStyleValue)
         str = GetSummaryAsCString();


### PR DESCRIPTION
Adds a comment to indicate intention of a piece of value printing code.

I was initially surprised to see this code (distilled for emphasis):

```cpp
if (str.empty()) {
  if (style == eValueObjectRepresentationStyleValue)
    str = GetSummaryAsCString();
  else if (style == eValueObjectRepresentationStyleSummary)
    str = GetValueAsCString();
}
```

My first thought was "is this a bug?", but I realized it was likely intentional. This change adds a comment to indicate yes, this is intentional.