### PR TITLE
[DirectX][NFC] Use LLVM Types in DXIL Operation specifications in DXIL.td

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -139,7 +139,7 @@ class DXILOperationDesc {
 }
 
 class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory opCategory, string doc,
-              list<DXILScalarType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
+              list<DXILType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
               list<string> statsGroup = []> : DXILOperationDesc {
   let OpName = name;
   let OpCode = opCode;

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -35,78 +35,18 @@ def BinaryUintCategory : DXILOpCategory<"Binary uint">;
 def UnaryFloatCategory : DXILOpCategory<"Unary float">;
 def ComputeIDCategory : DXILOpCategory<"Compute/Mesh/Amplification shader">;
 
-// Abstraction of DXIL Data Type Categories
-class DXILTypeCategory<string categoryStr> {
-  string Name = categoryStr;
-}
-
-// Concrete DXIL Data Type Categories that are supported
-foreach cat = ["Scalar", "Vector", "Matrix",
-               "Sampler", "Texture", "Buffer",
-               "Struct", "UserDefined", "Array", "StateObject"] in {
-  def cat : DXILTypeCategory<cat>;
-}
-
-// Pseudo DXIL Type category to represent data characteristics not supported
-// as DXIL types.
-def PseudoCategory : DXILTypeCategory<"PseudoCategory">;
-
-// Abstraction of DXIL Types
-class DXILType<DXILTypeCategory category, string name> {
-    DXILTypeCategory Category = category;
-    string Name = name;
-}
-
-// Supported DXIL Type categories
-class DXILScalarType<string typeNameString> : DXILType<Scalar, typeNameString>;
-class DXILVectorType<string typeNameString> : DXILType<Vector, typeNameString>;
-class DXILMatrixType<string typeNameString> : DXILType<Matrix, typeNameString>;
-class DXILSamplerType<string typeNameString> : DXILType<Sampler, typeNameString>;
-class DXILTextureType<string typeNameString> : DXILType<Texture, typeNameString>;
-class DXILBufferType<string typeNameString> : DXILType<Buffer, typeNameString>;
-class DXILStructType<string typeNameString> : DXILType<Struct, typeNameString>;
-class DXILUserDefinedType<string typeNameString> : DXILType<UserDefined, typeNameString>;
-class DXILArrayType<string typeNameString> : DXILType<Array, typeNameString>;
-class DXILStateObjectType<string typeNameString> : DXILType<StateObject, typeNameString>;
-
-// Concrete Pseudo Types
-
-// Overload - used to convey overload specification of DXIL operation parameters.
-def OverloadTy : DXILType<PseudoCategory, "overload">;
-
-// Handle - used to represent handle (i8*) type
-def HandleTy   : DXILType<PseudoCategory, "handle">;
-
-//  Resource - used to represent a resource
-def ResourceTy : DXILType<PseudoCategory, "resource">;
-
-// Concrete scalar types supported by DXIL operations.
-def VoidTy  : DXILScalarType<"void">;
-
-// Floating point types
-def Float16Ty   : DXILScalarType<"f16">;
-def Float32Ty   : DXILScalarType<"f32">;
-def Float64Ty   : DXILScalarType<"f64">;
-
-// Integer types
-def Int1Ty   : DXILScalarType<"i1">;
-def Int8Ty   : DXILScalarType<"i8">;
-def Int16Ty  : DXILScalarType<"i16">;
-def Int32Ty  : DXILScalarType<"i32">;
-def Int64Ty  : DXILScalarType<"i64">;
-
-// Any of the above scalar types
-def AnyScalarTy  : DXILScalarType<"anyScalar">;
-
-// Concrete buffer types
-def CBufferTy : DXILBufferType<"cbuffer">;
+// Represent as any pointer type with an option to change to a qualified pointer
+// type with address space specified.
+def dxil_handle_ty  : LLVMAnyPointerType;
+def dxil_cbuffer_ty : LLVMAnyPointerType;
+def dxil_resource_ty : LLVMAnyPointerType;
 
 // The parameter description for a DXIL operation
-class DXILOpParameter<int pos, DXILType type, string name, string doc,
+class DXILOpParameter<int pos, LLVMType type, string name, string doc,
                  bit isConstant = 0, string enumName = "",
                  int maxValue = 0> {
   int Pos = pos;               // Position in parameter list
-  DXILType ParamType = type;   // Parameter type
+  LLVMType ParamType = type;   // Parameter type
   string Name = name;          // Short, unique parameter name
   string Doc = doc;            // Description of this parameter
   bit IsConstant = isConstant; // Whether this parameter requires a constant value in the IR
@@ -122,7 +62,7 @@ class DXILOperationDesc {
   DXILOpCategory OpCategory;  // Category of the operation
   string Doc = "";            // Description of the operation
   list<DXILOpParameter> Params = []; // Parameter list of the operation
-  list<DXILType> OverloadTypes = [];  // Overload types, if applicable
+  list<LLVMType> OverloadTypes = [];  // Overload types, if applicable
   EnumAttr Attribute;         // Operation Attribute. Leverage attributes defined in Attributes.td
                               // ReadNone - operation does not access memory.
                               // ReadOnly - only reads from memory.
@@ -139,7 +79,7 @@ class DXILOperationDesc {
 }
 
 class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory opCategory, string doc,
-              list<DXILType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
+              list<LLVMType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
               list<string> statsGroup = []> : DXILOperationDesc {
   let OpName = name;
   let OpCode = opCode;
@@ -156,55 +96,55 @@ class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory
 class LLVMIntrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
 
 def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
-  [Float16Ty,Float32Ty], ReadNone,
+  [llvm_half_ty,llvm_float_ty], ReadNone,
   [
-    DXILOpParameter<0, OverloadTy, "", "operation result">,
-    DXILOpParameter<1, Int32Ty, "opcode", "DXIL opcode">,
-    DXILOpParameter<2, OverloadTy, "value", "input value">
+    DXILOpParameter<0, llvm_anyfloat_ty, "", "operation result">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, llvm_anyfloat_ty, "value", "input value">
   ],
   ["floats"]>,
   LLVMIntrinsic<int_sin>;
 
 def UMax : DXILOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
-    [Int16Ty,Int32Ty,Int64Ty],  ReadNone,
+    [llvm_i16_ty, llvm_i32_ty, llvm_i64_ty],  ReadNone,
   [
-    DXILOpParameter<0,  OverloadTy,  "",  "operation result">,
-    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  OverloadTy,  "a",  "input value">,
-    DXILOpParameter<3,  OverloadTy,  "b",  "input value">
+    DXILOpParameter<0,  llvm_anyint_ty,  "",  "operation result">,
+    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  llvm_anyint_ty,  "a",  "input value">,
+    DXILOpParameter<3,  llvm_anyint_ty,  "b",  "input value">
   ],
   ["uints"]>,
   LLVMIntrinsic<int_umax>;
 
-def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", [Int32Ty],  ReadNone,
+def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", [llvm_i32_ty],  ReadNone,
   [
-    DXILOpParameter<0,  Int32Ty,  "",  "thread ID component">,
-    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  Int32Ty,  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  llvm_i32_ty,  "",  "thread ID component">,
+    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id>;
 
-def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [Int32Ty],  ReadNone,
+def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [llvm_i32_ty],  ReadNone,
   [
-    DXILOpParameter<0,  Int32Ty,  "",  "group ID component">,
-    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  Int32Ty,  "component",  "component to read">
+    DXILOpParameter<0,  llvm_i32_ty,  "",  "group ID component">,
+    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read">
   ]>,
   LLVMIntrinsic<int_dx_group_id>;
 
 def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
-  "reads the thread ID within the group (SV_GroupThreadID)", [Int32Ty],  ReadNone,
+  "reads the thread ID within the group (SV_GroupThreadID)", [llvm_i32_ty],  ReadNone,
   [
-    DXILOpParameter<0,  Int32Ty,  "",  "thread ID in group component">,
-    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  Int32Ty,  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  llvm_i32_ty,  "",  "thread ID in group component">,
+    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id_in_group>;
 
 def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
-   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [Int32Ty],  ReadNone,
+   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [llvm_i32_ty],  ReadNone,
   [
-    DXILOpParameter<0,  Int32Ty,  "",  "result">,
-    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">
+    DXILOpParameter<0,  llvm_i32_ty,  "",  "result">,
+    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">
   ]>,
   LLVMIntrinsic<int_dx_flattened_thread_id_in_group>;

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -35,30 +35,78 @@ def BinaryUintCategory : DXILOpCategory<"Binary uint">;
 def UnaryFloatCategory : DXILOpCategory<"Unary float">;
 def ComputeIDCategory : DXILOpCategory<"Compute/Mesh/Amplification shader">;
 
-// Following are the scalar types supported by DXIL operations and are synonymous
-// to llvm_*_ty defined for readability and ease of use in the context of this file.
+// Abstraction of DXIL Data Type Categories
+class DXILTypeCategory<string categoryStr> {
+  string Name = categoryStr;
+}
 
-def voidTy  : LLVMType<isVoid>;
+// Concrete DXIL Data Type Categories that are supported
+foreach cat = ["Scalar", "Vector", "Matrix",
+               "Sampler", "Texture", "Buffer",
+               "Struct", "UserDefined", "Array", "StateObject"] in {
+  def cat : DXILTypeCategory<cat>;
+}
+
+// Pseudo DXIL Type category to represent data characteristics not supported
+// as DXIL types.
+def PseudoCategory : DXILTypeCategory<"PseudoCategory">;
+
+// Abstraction of DXIL Types
+class DXILType<DXILTypeCategory category, string name> {
+    DXILTypeCategory Category = category;
+    string Name = name;
+}
+
+// Supported DXIL Type categories
+class DXILScalarType<string typeNameString> : DXILType<Scalar, typeNameString>;
+class DXILVectorType<string typeNameString> : DXILType<Vector, typeNameString>;
+class DXILMatrixType<string typeNameString> : DXILType<Matrix, typeNameString>;
+class DXILSamplerType<string typeNameString> : DXILType<Sampler, typeNameString>;
+class DXILTextureType<string typeNameString> : DXILType<Texture, typeNameString>;
+class DXILBufferType<string typeNameString> : DXILType<Buffer, typeNameString>;
+class DXILStructType<string typeNameString> : DXILType<Struct, typeNameString>;
+class DXILUserDefinedType<string typeNameString> : DXILType<UserDefined, typeNameString>;
+class DXILArrayType<string typeNameString> : DXILType<Array, typeNameString>;
+class DXILStateObjectType<string typeNameString> : DXILType<StateObject, typeNameString>;
+
+// Concrete Pseudo Types
+
+// Overload - used to convey overload specification of DXIL operation parameters.
+def OverloadTy : DXILType<PseudoCategory, "overload">;
+
+// Handle - used to represent handle (i8*) type
+def HandleTy   : DXILType<PseudoCategory, "handle">;
+
+//  Resource - used to represent a resource
+def ResourceTy : DXILType<PseudoCategory, "resource">;
+
+// Concrete scalar types supported by DXIL operations.
+def VoidTy  : DXILScalarType<"void">;
 
 // Floating point types
-def f16Ty   : LLVMType<f16>;
-def f32Ty   : LLVMType<f32>;
-def f64Ty   : LLVMType<f64>;
+def Float16Ty   : DXILScalarType<"f16">;
+def Float32Ty   : DXILScalarType<"f32">;
+def Float64Ty   : DXILScalarType<"f64">;
 
 // Integer types
-def i1Ty   : LLVMType<i1>;
-def i8Ty   : LLVMType<i8>;
-def i16Ty  : LLVMType<i16>;
-def i32Ty  : LLVMType<i32>;
-def i64Ty  : LLVMType<i64>;
+def Int1Ty   : DXILScalarType<"i1">;
+def Int8Ty   : DXILScalarType<"i8">;
+def Int16Ty  : DXILScalarType<"i16">;
+def Int32Ty  : DXILScalarType<"i32">;
+def Int64Ty  : DXILScalarType<"i64">;
+
+// Any of the above scalar types
+def AnyScalarTy  : DXILScalarType<"anyScalar">;
+
+// Concrete buffer types
+def CBufferTy : DXILBufferType<"cbuffer">;
 
 // The parameter description for a DXIL operation
-class DXILOpParameter<int pos, string type, string name, string doc,
+class DXILOpParameter<int pos, DXILType type, string name, string doc,
                  bit isConstant = 0, string enumName = "",
                  int maxValue = 0> {
   int Pos = pos;               // Position in parameter list
-  string Type = type;          // LLVM type name, $o for overload, $r for resource
-                               // type, $cb for legacy cbuffer, $u4 for u4 struct
+  DXILType ParamType = type;   // Parameter type
   string Name = name;          // Short, unique parameter name
   string Doc = doc;            // Description of this parameter
   bit IsConstant = isConstant; // Whether this parameter requires a constant value in the IR
@@ -74,7 +122,7 @@ class DXILOperationDesc {
   DXILOpCategory OpCategory;  // Category of the operation
   string Doc = "";            // Description of the operation
   list<DXILOpParameter> Params = []; // Parameter list of the operation
-  list<LLVMType> OverloadTypes = [];  // Overload types, if applicable
+  list<DXILType> OverloadTypes = [];  // Overload types, if applicable
   EnumAttr Attribute;         // Operation Attribute. Leverage attributes defined in Attributes.td
                               // ReadNone - operation does not access memory.
                               // ReadOnly - only reads from memory.
@@ -91,7 +139,7 @@ class DXILOperationDesc {
 }
 
 class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory opCategory, string doc,
-              list<LLVMType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
+              list<DXILScalarType> oloadTypes, EnumAttr attrs, list<DXILOpParameter> params,
               list<string> statsGroup = []> : DXILOperationDesc {
   let OpName = name;
   let OpCode = opCode;
@@ -108,55 +156,55 @@ class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory
 class LLVMIntrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
 
 def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
-  [f16Ty,f32Ty], ReadNone,
+  [Float16Ty,Float32Ty], ReadNone,
   [
-    DXILOpParameter<0, "$o", "", "operation result">,
-    DXILOpParameter<1, "i32", "opcode", "DXIL opcode">,
-    DXILOpParameter<2, "$o", "value", "input value">
+    DXILOpParameter<0, OverloadTy, "", "operation result">,
+    DXILOpParameter<1, Int32Ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, OverloadTy, "value", "input value">
   ],
   ["floats"]>,
   LLVMIntrinsic<int_sin>;
 
 def UMax : DXILOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
-    [i16Ty,i32Ty,i64Ty],  ReadNone,
+    [Int16Ty,Int32Ty,Int64Ty],  ReadNone,
   [
-    DXILOpParameter<0,  "$o",  "",  "operation result">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "$o",  "a",  "input value">,
-    DXILOpParameter<3,  "$o",  "b",  "input value">
+    DXILOpParameter<0,  OverloadTy,  "",  "operation result">,
+    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  OverloadTy,  "a",  "input value">,
+    DXILOpParameter<3,  OverloadTy,  "b",  "input value">
   ],
   ["uints"]>,
   LLVMIntrinsic<int_umax>;
 
-def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", [i32Ty],  ReadNone,
+def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", [Int32Ty],  ReadNone,
   [
-    DXILOpParameter<0,  "i32",  "",  "thread ID component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  Int32Ty,  "",  "thread ID component">,
+    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  Int32Ty,  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id>;
 
-def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [i32Ty],  ReadNone,
+def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [Int32Ty],  ReadNone,
   [
-    DXILOpParameter<0,  "i32",  "",  "group ID component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read">
+    DXILOpParameter<0,  Int32Ty,  "",  "group ID component">,
+    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  Int32Ty,  "component",  "component to read">
   ]>,
   LLVMIntrinsic<int_dx_group_id>;
 
 def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
-  "reads the thread ID within the group (SV_GroupThreadID)", [i32Ty],  ReadNone,
+  "reads the thread ID within the group (SV_GroupThreadID)", [Int32Ty],  ReadNone,
   [
-    DXILOpParameter<0,  "i32",  "",  "thread ID in group component">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  "i32",  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0,  Int32Ty,  "",  "thread ID in group component">,
+    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">,
+    DXILOpParameter<2,  Int32Ty,  "component",  "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id_in_group>;
 
 def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
-   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [i32Ty],  ReadNone,
+   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [Int32Ty],  ReadNone,
   [
-    DXILOpParameter<0,  "i32",  "",  "result">,
-    DXILOpParameter<1,  "i32",  "opcode",  "DXIL opcode">
+    DXILOpParameter<0,  Int32Ty,  "",  "result">,
+    DXILOpParameter<1,  Int32Ty,  "opcode",  "DXIL opcode">
   ]>,
   LLVMIntrinsic<int_dx_flattened_thread_id_in_group>;

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -96,7 +96,7 @@ class DXILOperation<string name, int opCode, DXILOpClass opClass, DXILOpCategory
 class LLVMIntrinsic<Intrinsic llvm_intrinsic_> { Intrinsic llvm_intrinsic = llvm_intrinsic_; }
 
 def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine(theta) for theta in radians.",
-  [llvm_half_ty,llvm_float_ty], ReadNone,
+  [llvm_half_ty, llvm_float_ty], ReadNone,
   [
     DXILOpParameter<0, llvm_anyfloat_ty, "", "operation result">,
     DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
@@ -105,46 +105,46 @@ def Sin : DXILOperation<"Sin", 13, UnaryClass, UnaryFloatCategory, "returns sine
   ["floats"]>,
   LLVMIntrinsic<int_sin>;
 
-def UMax : DXILOperation< "UMax", 39,  BinaryClass,  BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
-    [llvm_i16_ty, llvm_i32_ty, llvm_i64_ty],  ReadNone,
+def UMax : DXILOperation< "UMax", 39, BinaryClass, BinaryUintCategory, "unsigned integer maximum. UMax(a,b) = a > b ? a : b",
+    [llvm_i16_ty, llvm_i32_ty, llvm_i64_ty], ReadNone,
   [
-    DXILOpParameter<0,  llvm_anyint_ty,  "",  "operation result">,
-    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  llvm_anyint_ty,  "a",  "input value">,
-    DXILOpParameter<3,  llvm_anyint_ty,  "b",  "input value">
+    DXILOpParameter<0, llvm_anyint_ty, "", "operation result">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, llvm_anyint_ty, "a", "input value">,
+    DXILOpParameter<3, llvm_anyint_ty, "b", "input value">
   ],
   ["uints"]>,
   LLVMIntrinsic<int_umax>;
 
-def ThreadId : DXILOperation< "ThreadId", 93,  ThreadIdClass, ComputeIDCategory, "reads the thread ID", [llvm_i32_ty],  ReadNone,
+def ThreadId : DXILOperation< "ThreadId", 93, ThreadIdClass, ComputeIDCategory, "reads the thread ID", [llvm_i32_ty], ReadNone,
   [
-    DXILOpParameter<0,  llvm_i32_ty,  "",  "thread ID component">,
-    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0, llvm_i32_ty, "", "thread ID component">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, llvm_i32_ty, "component", "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id>;
 
-def GroupId : DXILOperation< "GroupId", 94,  GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [llvm_i32_ty],  ReadNone,
+def GroupId : DXILOperation< "GroupId", 94, GroupIdClass, ComputeIDCategory, "reads the group ID (SV_GroupID)", [llvm_i32_ty], ReadNone,
   [
-    DXILOpParameter<0,  llvm_i32_ty,  "",  "group ID component">,
-    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read">
+    DXILOpParameter<0, llvm_i32_ty, "", "group ID component">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, llvm_i32_ty, "component", "component to read">
   ]>,
   LLVMIntrinsic<int_dx_group_id>;
 
-def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95,  ThreadIdInGroupClass, ComputeIDCategory,
-  "reads the thread ID within the group (SV_GroupThreadID)", [llvm_i32_ty],  ReadNone,
+def ThreadIdInGroup : DXILOperation< "ThreadIdInGroup", 95, ThreadIdInGroupClass, ComputeIDCategory,
+  "reads the thread ID within the group (SV_GroupThreadID)", [llvm_i32_ty], ReadNone,
   [
-    DXILOpParameter<0,  llvm_i32_ty,  "",  "thread ID in group component">,
-    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">,
-    DXILOpParameter<2,  llvm_i32_ty,  "component",  "component to read (x,y,z)">
+    DXILOpParameter<0, llvm_i32_ty, "", "thread ID in group component">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">,
+    DXILOpParameter<2, llvm_i32_ty, "component", "component to read (x,y,z)">
   ]>,
   LLVMIntrinsic<int_dx_thread_id_in_group>;
 
-def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96,  FlattenedThreadIdInGroupClass, ComputeIDCategory,
-   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [llvm_i32_ty],  ReadNone,
+def FlattenedThreadIdInGroup : DXILOperation< "FlattenedThreadIdInGroup", 96, FlattenedThreadIdInGroupClass, ComputeIDCategory,
+   "provides a flattened index for a given thread within a given group (SV_GroupIndex)", [llvm_i32_ty], ReadNone,
   [
-    DXILOpParameter<0,  llvm_i32_ty,  "",  "result">,
-    DXILOpParameter<1,  llvm_i32_ty,  "opcode",  "DXIL opcode">
+    DXILOpParameter<0, llvm_i32_ty, "", "result">,
+    DXILOpParameter<1, llvm_i32_ty, "opcode", "DXIL opcode">
   ]>,
   LLVMIntrinsic<int_dx_flattened_thread_id_in_group>;

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -82,19 +82,20 @@ struct DXILOperationDesc {
 */
 static ParameterKind getDXILTypeNameToKind(StringRef typeNameStr) {
   auto paramKind = StringSwitch<ParameterKind>(typeNameStr)
-                       .Case("VoidTy", ParameterKind::VOID)
-                       .Case("Float16Ty", ParameterKind::HALF)
-                       .Case("Float32Ty", ParameterKind::FLOAT)
-                       .Case("Float64Ty", ParameterKind::DOUBLE)
-                       .Case("Int1Ty", ParameterKind::I1)
-                       .Case("Int8Ty", ParameterKind::I8)
-                       .Case("Int16Ty", ParameterKind::I16)
-                       .Case("Int32Ty", ParameterKind::I32)
-                       .Case("Int64Ty", ParameterKind::I64)
-                       .Case("OverloadTy", ParameterKind::OVERLOAD)
-                       .Case("HandleTy", ParameterKind::DXIL_HANDLE)
-                       .Case("CbufferTy", ParameterKind::CBUFFER_RET)
-                       .Case("ResourceTy", ParameterKind::RESOURCE_RET)
+                       .Case("llvm_void_ty", ParameterKind::VOID)
+                       .Case("llvm_half_ty", ParameterKind::HALF)
+                       .Case("llvm_float_ty", ParameterKind::FLOAT)
+                       .Case("llvm_double_ty", ParameterKind::DOUBLE)
+                       .Case("llvm_i1_ty", ParameterKind::I1)
+                       .Case("llvm_i8_ty", ParameterKind::I8)
+                       .Case("llvm_i16_ty", ParameterKind::I16)
+                       .Case("llvm_i32_ty", ParameterKind::I32)
+                       .Case("llvm_i64_ty", ParameterKind::I64)
+                       .Case("llvm_anyfloat_ty", ParameterKind::OVERLOAD)
+                       .Case("llvm_anyint_ty", ParameterKind::OVERLOAD)
+                       .Case("dxil_handle_ty", ParameterKind::DXIL_HANDLE)
+                       .Case("dxil_cbuffer_ty", ParameterKind::CBUFFER_RET)
+                       .Case("dxil_resource_ty", ParameterKind::RESOURCE_RET)
                        .Default(ParameterKind::INVALID);
   assert(paramKind != ParameterKind::INVALID &&
          "Unsupported DXIL Type specified");

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -80,7 +80,7 @@ struct DXILOperationDesc {
  @param typeNameStr Type name string
  @return ParameterKind As defined in llvm/Support/DXILABI.h
 */
-static ParameterKind getDXILTypeNameToKind(StringRef typeNameStr) {
+static ParameterKind lookupParameterKind(StringRef typeNameStr) {
   auto paramKind = StringSwitch<ParameterKind>(typeNameStr)
                        .Case("llvm_void_ty", ParameterKind::VOID)
                        .Case("llvm_half_ty", ParameterKind::HALF)
@@ -131,7 +131,7 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
 
   for (unsigned I = 0; I < OverloadTypeList->size(); ++I) {
     Record *R = OverloadTypeList->getElementAsRecord(I);
-    OverloadTypes.emplace_back(getDXILTypeNameToKind(R->getNameInitAsString()));
+    OverloadTypes.emplace_back(lookupParameterKind(R->getNameInitAsString()));
   }
   Attr = StringRef(R->getValue("Attribute")->getNameInitAsString());
 }
@@ -139,8 +139,8 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
 DXILParameter::DXILParameter(const Record *R) {
   Name = R->getValueAsString("Name");
   Pos = R->getValueAsInt("Pos");
-  Kind = getDXILTypeNameToKind(
-      R->getValue("ParamType")->getValue()->getAsString());
+  Kind =
+      lookupParameterKind(R->getValue("ParamType")->getValue()->getAsString());
   if (R->getValue("Doc"))
     Doc = R->getValueAsString("Doc");
   IsConst = R->getValueAsBit("IsConstant");

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -82,21 +82,22 @@ struct DXILOperationDesc {
 */
 static ParameterKind getDXILTypeNameToKind(StringRef typeNameStr) {
   auto paramKind = StringSwitch<ParameterKind>(typeNameStr)
-      .Case("VoidTy", ParameterKind::VOID)
-      .Case("Float16Ty", ParameterKind::HALF)
-      .Case("Float32Ty", ParameterKind::FLOAT)
-      .Case("Float64Ty", ParameterKind::DOUBLE)
-      .Case("Int1Ty", ParameterKind::I1)
-      .Case("Int8Ty", ParameterKind::I8)
-      .Case("Int16Ty", ParameterKind::I16)
-      .Case("Int32Ty", ParameterKind::I32)
-      .Case("Int64Ty", ParameterKind::I64)
-      .Case("OverloadTy", ParameterKind::OVERLOAD)
-      .Case("HandleTy", ParameterKind::DXIL_HANDLE)
-      .Case("CbufferTy", ParameterKind::CBUFFER_RET)
-      .Case("ResourceTy", ParameterKind::RESOURCE_RET)
-      .Default(ParameterKind::INVALID);
-  assert( paramKind != ParameterKind::INVALID && "Unsupported DXIL Type specified");
+                       .Case("VoidTy", ParameterKind::VOID)
+                       .Case("Float16Ty", ParameterKind::HALF)
+                       .Case("Float32Ty", ParameterKind::FLOAT)
+                       .Case("Float64Ty", ParameterKind::DOUBLE)
+                       .Case("Int1Ty", ParameterKind::I1)
+                       .Case("Int8Ty", ParameterKind::I8)
+                       .Case("Int16Ty", ParameterKind::I16)
+                       .Case("Int32Ty", ParameterKind::I32)
+                       .Case("Int64Ty", ParameterKind::I64)
+                       .Case("OverloadTy", ParameterKind::OVERLOAD)
+                       .Case("HandleTy", ParameterKind::DXIL_HANDLE)
+                       .Case("CbufferTy", ParameterKind::CBUFFER_RET)
+                       .Case("ResourceTy", ParameterKind::RESOURCE_RET)
+                       .Default(ParameterKind::INVALID);
+  assert(paramKind != ParameterKind::INVALID &&
+         "Unsupported DXIL Type specified");
   return paramKind;
 }
 
@@ -137,7 +138,8 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
 DXILParameter::DXILParameter(const Record *R) {
   Name = R->getValueAsString("Name");
   Pos = R->getValueAsInt("Pos");
-  Kind = getDXILTypeNameToKind(R->getValue("ParamType")->getValue()->getAsString());
+  Kind = getDXILTypeNameToKind(
+      R->getValue("ParamType")->getValue()->getAsString());
   if (R->getValue("Doc"))
     Doc = R->getValueAsString("Doc");
   IsConst = R->getValueAsBit("IsConstant");

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -74,44 +74,30 @@ struct DXILOperationDesc {
 };
 } // end anonymous namespace
 
-// Convert DXIL type name string to dxil::ParameterKind
-//
-// @param typeNameStr Type name string
-// @return ParameterKind as defined in llvm/Support/DXILABI.h
-static ParameterKind getDXILTypeNameToKind(StringRef typeNameStr) {
-  return StringSwitch<ParameterKind>(typeNameStr)
-      .Case("voidTy", ParameterKind::VOID)
-      .Case("f16Ty", ParameterKind::HALF)
-      .Case("f32Ty", ParameterKind::FLOAT)
-      .Case("f64Ty", ParameterKind::DOUBLE)
-      .Case("i1Ty", ParameterKind::I1)
-      .Case("i8Ty", ParameterKind::I8)
-      .Case("i16Ty", ParameterKind::I16)
-      .Case("i32Ty", ParameterKind::I32)
-      .Case("i64Ty", ParameterKind::I64)
-      .Case("overloadTy", ParameterKind::OVERLOAD)
-      .Case("handleTy", ParameterKind::DXIL_HANDLE)
-      .Case("cbufferRetTy", ParameterKind::CBUFFER_RET)
-      .Case("resourceRetTy", ParameterKind::RESOURCE_RET)
-      .Default(ParameterKind::INVALID);
-}
+/*!
+ Convert DXIL type name string to dxil::ParameterKind
 
-static ParameterKind parameterTypeNameToKind(StringRef Name) {
-  return StringSwitch<ParameterKind>(Name)
-      .Case("void", ParameterKind::VOID)
-      .Case("half", ParameterKind::HALF)
-      .Case("float", ParameterKind::FLOAT)
-      .Case("double", ParameterKind::DOUBLE)
-      .Case("i1", ParameterKind::I1)
-      .Case("i8", ParameterKind::I8)
-      .Case("i16", ParameterKind::I16)
-      .Case("i32", ParameterKind::I32)
-      .Case("i64", ParameterKind::I64)
-      .Case("$o", ParameterKind::OVERLOAD)
-      .Case("dx.types.Handle", ParameterKind::DXIL_HANDLE)
-      .Case("dx.types.CBufRet", ParameterKind::CBUFFER_RET)
-      .Case("dx.types.ResRet", ParameterKind::RESOURCE_RET)
+ @param typeNameStr Type name string
+ @return ParameterKind As defined in llvm/Support/DXILABI.h
+*/
+static ParameterKind getDXILTypeNameToKind(StringRef typeNameStr) {
+  auto paramKind = StringSwitch<ParameterKind>(typeNameStr)
+      .Case("VoidTy", ParameterKind::VOID)
+      .Case("Float16Ty", ParameterKind::HALF)
+      .Case("Float32Ty", ParameterKind::FLOAT)
+      .Case("Float64Ty", ParameterKind::DOUBLE)
+      .Case("Int1Ty", ParameterKind::I1)
+      .Case("Int8Ty", ParameterKind::I8)
+      .Case("Int16Ty", ParameterKind::I16)
+      .Case("Int32Ty", ParameterKind::I32)
+      .Case("Int64Ty", ParameterKind::I64)
+      .Case("OverloadTy", ParameterKind::OVERLOAD)
+      .Case("HandleTy", ParameterKind::DXIL_HANDLE)
+      .Case("CbufferTy", ParameterKind::CBUFFER_RET)
+      .Case("ResourceTy", ParameterKind::RESOURCE_RET)
       .Default(ParameterKind::INVALID);
+  assert( paramKind != ParameterKind::INVALID && "Unsupported DXIL Type specified");
+  return paramKind;
 }
 
 DXILOperationDesc::DXILOperationDesc(const Record *R) {
@@ -151,7 +137,7 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
 DXILParameter::DXILParameter(const Record *R) {
   Name = R->getValueAsString("Name");
   Pos = R->getValueAsInt("Pos");
-  Kind = parameterTypeNameToKind(R->getValueAsString("Type"));
+  Kind = getDXILTypeNameToKind(R->getValue("ParamType")->getValue()->getAsString());
   if (R->getValue("Doc"))
     Doc = R->getValueAsString("Doc");
   IsConst = R->getValueAsBit("IsConstant");
@@ -296,10 +282,12 @@ static void emitDXILIntrinsicMap(std::vector<DXILOperationDesc> &Ops,
   OS << "\n";
 }
 
-// Convert operation attribute string to Attribute enum
-//
-// @param Attr string reference
-// @return std::string Attribute enum string
+/*!
+ Convert operation attribute string to Attribute enum
+
+ @param Attr string reference
+ @return std::string Attribute enum string
+ */
 static std::string emitDXILOperationAttr(StringRef Attr) {
   return StringSwitch<std::string>(Attr)
       .Case("ReadNone", "Attribute::ReadNone")


### PR DESCRIPTION
This change uniformly uses LLVM Types in the specification of parameter types and overload types of DXIL operation.

Updated (a) parameter types accordingly in the specification of existing DXILOperations and (b) DXILEmitter.