### PR TITLE
[RISCV] Use DAG.getElementCount in lowerEXTRACT_SUBVECTOR. NFCI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -9776,27 +9776,32 @@ SDValue RISCVTargetLowering::lowerEXTRACT_SUBVECTOR(SDValue Op,
   if (SubVecVT.isFixedLengthVector())
     ContainerSubVecVT = getContainerForFixedLengthVector(SubVecVT);
 
-  unsigned SubRegIdx, RemIdx;
-  // extract_subvector scales the index by vscale is the subvector is scalable,
+  unsigned SubRegIdx;
+  ElementCount RemIdx;
+  // extract_subvector scales the index by vscale if the subvector is scalable,
   // and decomposeSubvectorInsertExtractToSubRegs takes this into account. So if
   // we have a fixed length subvector, we need to adjust the index by 1/vscale.
   if (SubVecVT.isFixedLengthVector()) {
     assert(MinVLen == MaxVLen);
     unsigned Vscale = MinVLen / RISCV::RVVBitsPerBlock;
-    std::tie(SubRegIdx, RemIdx) =
+    auto Decompose =
         RISCVTargetLowering::decomposeSubvectorInsertExtractToSubRegs(
             VecVT, ContainerSubVecVT, OrigIdx / Vscale, TRI);
-    RemIdx = (RemIdx * Vscale) + (OrigIdx % Vscale);
+    SubRegIdx = Decompose.first;
+    RemIdx = ElementCount::getFixed((Decompose.second * Vscale) +
+                                    (OrigIdx % Vscale));
   } else {
-    std::tie(SubRegIdx, RemIdx) =
+    auto Decompose =
         RISCVTargetLowering::decomposeSubvectorInsertExtractToSubRegs(
             VecVT, ContainerSubVecVT, OrigIdx, TRI);
+    SubRegIdx = Decompose.first;
+    RemIdx = ElementCount::getScalable(Decompose.second);
   }
 
   // If the Idx has been completely eliminated then this is a subvector extract
   // which naturally aligns to a vector register. These can easily be handled
   // using subregister manipulation.
-  if (RemIdx == 0) {
+  if (RemIdx.isZero()) {
     if (SubVecVT.isFixedLengthVector()) {
       Vec = DAG.getTargetExtractSubreg(SubRegIdx, DL, ContainerSubVecVT, Vec);
       return convertFromScalableVector(SubVecVT, Vec, DAG, Subtarget);
@@ -9823,13 +9828,7 @@ SDValue RISCVTargetLowering::lowerEXTRACT_SUBVECTOR(SDValue Op,
 
   // Slide this vector register down by the desired number of elements in order
   // to place the desired subvector starting at element 0.
-  SDValue SlidedownAmt;
-  if (SubVecVT.isFixedLengthVector())
-    SlidedownAmt = DAG.getConstant(RemIdx, DL, Subtarget.getXLenVT());
-  else
-    SlidedownAmt =
-        DAG.getVScale(DL, XLenVT, APInt(XLenVT.getSizeInBits(), RemIdx));
-
+  SDValue SlidedownAmt = DAG.getElementCount(DL, XLenVT, RemIdx);
   auto [Mask, VL] = getDefaultScalableVLOps(InterSubVT, DL, DAG, Subtarget);
   if (SubVecVT.isFixedLengthVector())
     VL = getVLOp(SubVecVT.getVectorNumElements(), InterSubVT, DL, DAG,


### PR DESCRIPTION
Following up on the review comment in
https://github.com/llvm/llvm-project/pull/79949#discussion_r1482071745
