### PR TITLE
[AMDGPU] Refactor export instruction definitions. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/EXPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/EXPInstructions.td
@@ -10,7 +10,7 @@
 // EXP classes
 //===----------------------------------------------------------------------===//
 
-class EXPCommon<bit row, bit done, string asm = ""> : InstSI<
+class EXPCommon<bit _row, bit _done, string asm = ""> : InstSI<
   (outs),
   (ins exp_tgt:$tgt,
        ExpSrc0:$src0, ExpSrc1:$src1, ExpSrc2:$src2, ExpSrc3:$src3,
@@ -18,13 +18,16 @@ class EXPCommon<bit row, bit done, string asm = ""> : InstSI<
   asm> {
   let EXP = 1;
   let EXP_CNT = 1;
-  let mayLoad = done;
+  let mayLoad = _done;
   let mayStore = 1;
   let maybeAtomic = 0;
   let UseNamedOperandTable = 1;
-  let Uses = !if(row, [EXEC, M0], [EXEC]);
+  let Uses = !if(_row, [EXEC, M0], [EXEC]);
   let SchedRW = [WriteExport];
   let DisableWQM = 1;
+
+  bit row = _row;
+  bit done = _done;
 }
 
 class EXP_Pseudo<bit row, bit done>
@@ -34,17 +37,17 @@ class EXP_Pseudo<bit row, bit done>
 }
 
 // Real instruction with optional asm operands "compr" and "vm".
-class EXP_Real_ComprVM<bit done, string pseudo, int subtarget>
-  : EXPCommon<0, done, "exp$tgt $src0, $src1, $src2, $src3"
-                       #!if(done, " done", "")#"$compr$vm">,
+class EXP_Real_ComprVM<string pseudo, int subtarget, EXP_Pseudo ps = !cast<EXP_Pseudo>(pseudo)>
+  : EXPCommon<0, ps.done, "exp$tgt $src0, $src1, $src2, $src3"
+                       #!if(ps.done, " done", "")#"$compr$vm">,
     SIMCInstr<pseudo, subtarget> {
   let AsmMatchConverter = "cvtExp";
 }
 
 // Real instruction with optional asm operand "row_en".
-class EXP_Real_Row<bit row, bit done, string pseudo, int subtarget, string name = "exp">
-  : EXPCommon<row, done, name#"$tgt $src0, $src1, $src2, $src3"
-                         #!if(done, " done", "")#!if(row, " row_en", "")>,
+class EXP_Real_Row<string pseudo, int subtarget, string name = "exp", EXP_Pseudo ps = !cast<EXP_Pseudo>(pseudo)>
+  : EXPCommon<ps.row, ps.done, name#"$tgt $src0, $src1, $src2, $src3"
+                         #!if(ps.done, " done", "")#!if(ps.row, " row_en", "")>,
     SIMCInstr<pseudo, subtarget> {
   let AsmMatchConverter = "cvtExp";
 }
@@ -63,82 +66,69 @@ def EXP_ROW_DONE : EXP_Pseudo<1, 1>;
 } // let SubtargetPredicate = isNotGFX90APlus
 
 //===----------------------------------------------------------------------===//
-// SI
+// SI, VI, GFX10.
 //===----------------------------------------------------------------------===//
 
-class EXP_Real_si<bit _done, string pseudo>
-  : EXP_Real_ComprVM<_done, pseudo, SIEncodingFamily.SI>, EXPe_ComprVM {
-  let AssemblerPredicate = isGFX6GFX7;
-  let DecoderNamespace = "GFX6GFX7";
-  let done = _done;
+multiclass EXP_Real_si {
+  defvar ps = !cast<EXP_Pseudo>(NAME);
+  def _si : EXP_Real_ComprVM<NAME, SIEncodingFamily.SI>, EXPe_ComprVM {
+    let AssemblerPredicate = isGFX6GFX7;
+    let DecoderNamespace = "GFX6GFX7";
+    let done = ps.done;
+  }
 }
 
-def EXP_si      : EXP_Real_si<0, "EXP">;
-def EXP_DONE_si : EXP_Real_si<1, "EXP_DONE">;
-
-//===----------------------------------------------------------------------===//
-// VI
-//===----------------------------------------------------------------------===//
-
-class EXP_Real_vi<bit _done, string pseudo>
-  : EXP_Real_ComprVM<_done, pseudo, SIEncodingFamily.VI>, EXPe_vi {
-  let AssemblerPredicate = isGFX8GFX9;
-  let SubtargetPredicate = isNotGFX90APlus;
-  let DecoderNamespace = "GFX8";
-  let done = _done;
+multiclass EXP_Real_vi {
+  defvar ps = !cast<EXP_Pseudo>(NAME);
+  def _vi : EXP_Real_ComprVM<NAME, SIEncodingFamily.VI>, EXPe_vi {
+    let AssemblerPredicate = isGFX8GFX9;
+    let SubtargetPredicate = isNotGFX90APlus;
+    let DecoderNamespace = "GFX8";
+    let done = ps.done;
+  }
 }
 
-def EXP_vi      : EXP_Real_vi<0, "EXP">;
-def EXP_DONE_vi : EXP_Real_vi<1, "EXP_DONE">;
-
-//===----------------------------------------------------------------------===//
-// GFX10
-//===----------------------------------------------------------------------===//
-
-class EXP_Real_gfx10<bit _done, string pseudo>
-  : EXP_Real_ComprVM<_done, pseudo, SIEncodingFamily.GFX10>, EXPe_ComprVM {
-  let AssemblerPredicate = isGFX10Only;
-  let DecoderNamespace = "GFX10";
-  let done = _done;
+multiclass EXP_Real_gfx10 {
+  defvar ps = !cast<EXP_Pseudo>(NAME);
+  def _gfx10 : EXP_Real_ComprVM<NAME, SIEncodingFamily.GFX10>, EXPe_ComprVM {
+    let AssemblerPredicate = isGFX10Only;
+    let DecoderNamespace = "GFX10";
+    let done = ps.done;
+  }
 }
 
-def EXP_gfx10      : EXP_Real_gfx10<0, "EXP">;
-def EXP_DONE_gfx10 : EXP_Real_gfx10<1, "EXP_DONE">;
+defm EXP      : EXP_Real_si, EXP_Real_vi, EXP_Real_gfx10;
+defm EXP_DONE : EXP_Real_si, EXP_Real_vi, EXP_Real_gfx10;
 
 //===----------------------------------------------------------------------===//
-// GFX11
+// GFX11, GFX12.
 //===----------------------------------------------------------------------===//
 
-class EXP_Real_gfx11<bit _row, bit _done, string pseudo>
-  : EXP_Real_Row<_row, _done, pseudo, SIEncodingFamily.GFX11>, EXPe_Row {
-  let AssemblerPredicate = isGFX11Only;
-  let DecoderNamespace = "GFX11";
-  let row = _row;
-  let done = _done;
+multiclass EXP_Real_gfx11 {
+  defvar ps = !cast<EXP_Pseudo>(NAME);
+  def _gfx11 : EXP_Real_Row<NAME, SIEncodingFamily.GFX11>, EXPe_Row {
+    let AssemblerPredicate = isGFX11Only;
+    let DecoderNamespace = "GFX11";
+    let row = ps.row;
+    let done = ps.done;
+  }
 }
 
-def EXP_gfx11          : EXP_Real_gfx11<0, 0, "EXP">;
-def EXP_DONE_gfx11     : EXP_Real_gfx11<0, 1, "EXP_DONE">;
-def EXP_ROW_gfx11      : EXP_Real_gfx11<1, 0, "EXP_ROW">;
-def EXP_ROW_DONE_gfx11 : EXP_Real_gfx11<1, 1, "EXP_ROW_DONE">;
-
-//===----------------------------------------------------------------------===//
-// GFX12+
-//===----------------------------------------------------------------------===//
-
-class VEXPORT_Real_gfx12<bit _row, bit _done, string pseudo>
-  : EXP_Real_Row<_row, _done, pseudo, SIEncodingFamily.GFX12, "export">,
+multiclass VEXPORT_Real_gfx12 {
+  defvar ps = !cast<EXP_Pseudo>(NAME);
+  def _gfx12 : EXP_Real_Row<NAME, SIEncodingFamily.GFX12, "export">,
     EXPe_Row, MnemonicAlias<"exp", "export">, Requires<[isGFX12Plus]> {
-  let AssemblerPredicate = isGFX12Plus;
-  let DecoderNamespace = "GFX12";
-  let row = _row;
-  let done = _done;
+    let AssemblerPredicate = isGFX12Only;
+    let DecoderNamespace = "GFX12";
+    let row = ps.row;
+    let done = ps.done;
+  }
 }
 
-def EXPORT_gfx12          : VEXPORT_Real_gfx12<0, 0, "EXP">;
-def EXPORT_DONE_gfx12     : VEXPORT_Real_gfx12<0, 1, "EXP_DONE">;
-def EXPORT_ROW_gfx12      : VEXPORT_Real_gfx12<1, 0, "EXP_ROW">;
-def EXPORT_ROW_DONE_gfx12 : VEXPORT_Real_gfx12<1, 1, "EXP_ROW_DONE">;
+defm EXP          : EXP_Real_gfx11, VEXPORT_Real_gfx12;
+defm EXP_DONE     : EXP_Real_gfx11, VEXPORT_Real_gfx12;
+defm EXP_ROW      : EXP_Real_gfx11, VEXPORT_Real_gfx12;
+defm EXP_ROW_DONE : EXP_Real_gfx11, VEXPORT_Real_gfx12;
 
 //===----------------------------------------------------------------------===//
 // EXP Patterns


### PR DESCRIPTION
Using multiclasses for the Real instruction definitions has a couple of
benefits:
- It avoids repeating information that was already specified when
  defining the corresponding pseudo, like the row and done bits.
- It allows commoning up the Real definitions for architectures which
  are mostly the same, like GFX11 and GFX12.
