### PR TITLE
llvm-dwarfdump --verify aggregated output to JSON file

### DIFF
--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -206,7 +206,7 @@ struct DIDumpOptions {
   bool IsEH = false;
   bool DumpNonSkeleton = false;
   bool ShowAggregateErrors = false;
-  std::string JsonSummaryFile = "";
+  std::string JsonSummaryFile;
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -206,6 +206,7 @@ struct DIDumpOptions {
   bool IsEH = false;
   bool DumpNonSkeleton = false;
   bool ShowAggregateErrors = false;
+  std::string AggregateErrJsonFile = "";
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -206,7 +206,7 @@ struct DIDumpOptions {
   bool IsEH = false;
   bool DumpNonSkeleton = false;
   bool ShowAggregateErrors = false;
-  std::string AggregateErrJsonFile = "";
+  std::string JsonSummaryFile = "";
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -206,7 +206,7 @@ struct DIDumpOptions {
   bool IsEH = false;
   bool DumpNonSkeleton = false;
   bool ShowAggregateErrors = false;
-  std::string JsonSummaryFile;
+  std::string JsonErrSummaryFile;
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2034,13 +2034,14 @@ void DWARFVerifier::summarize() {
       error() << s << " occurred " << count << " time(s).\n";
     });
   }
-  if (!DumpOpts.JsonSummaryFile.empty()) {
+  if (!DumpOpts.JsonErrSummaryFile.empty()) {
     std::error_code EC;
-    raw_fd_ostream JsonStream(DumpOpts.JsonSummaryFile, EC, sys::fs::OF_Text);
+    raw_fd_ostream JsonStream(DumpOpts.JsonErrSummaryFile, EC,
+                              sys::fs::OF_Text);
     if (EC) {
       error() << "unable to open json summary file '"
-              << DumpOpts.JsonSummaryFile << "' for writing: " << EC.message()
-              << '\n';
+              << DumpOpts.JsonErrSummaryFile
+              << "' for writing: " << EC.message() << '\n';
       return;
     }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2039,7 +2039,7 @@ void DWARFVerifier::summarize() {
   if (!DumpOpts.AggregateErrJsonFile.empty()) {
     std::error_code EC;
     raw_fd_ostream JsonStream(DumpOpts.AggregateErrJsonFile, EC,
-                              sys::fs::OF_Text | sys::fs::OF_None);
+                              sys::fs::OF_Text);
     if (EC) {
       error() << "error opening aggregate error json file '"
               << DumpOpts.AggregateErrJsonFile
@@ -2047,12 +2047,16 @@ void DWARFVerifier::summarize() {
       return;
     }
     JsonStream << "{\"errors\":[\n";
+    bool prev = false;
     ErrorCategory.EnumerateResults([&](StringRef category, unsigned count) {
-      JsonStream << "\"category\":\"";
+      if (prev)
+        JsonStream << ",\n";
+      JsonStream << "{\"category\":\"";
       llvm::printEscapedString(category, JsonStream);
-      JsonStream << "\",\"count\":" << count;
+      JsonStream << "\",\"count\":" << count << "}";
+      prev = true;
     });
-    JsonStream << "]}\n";
+    JsonStream << "\n]}\n";
   }
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2040,7 +2040,7 @@ void DWARFVerifier::summarize() {
     std::error_code EC;
     raw_fd_ostream JsonStream(DumpOpts.JsonSummaryFile, EC, sys::fs::OF_Text);
     if (EC) {
-      error() << "error opening aggregate error json file '"
+      error() << "unable to open json summary file '"
               << DumpOpts.JsonSummaryFile << "' for writing: " << EC.message()
               << '\n';
       return;

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2042,8 +2042,8 @@ void DWARFVerifier::summarize() {
                               sys::fs::OF_Text | sys::fs::OF_None);
     if (EC) {
       error() << "error opening aggregate error json file '"
-              << DumpOpts.AggregateErrJsonFile << "' for writing: "
-              << EC.message() << '\n';
+              << DumpOpts.AggregateErrJsonFile
+              << "' for writing: " << EC.message() << '\n';
       return;
     }
     JsonStream << "{\"errors\":[\n";

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -9,7 +9,6 @@
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 #include "llvm/DebugInfo/DWARF/DWARFAttribute.h"

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -286,6 +286,8 @@ static opt<bool> Verify("verify", desc("Verify the DWARF debug info."),
                         cat(DwarfDumpCategory));
 static opt<ErrorDetailLevel> ErrorDetails(
     "error-display", init(Unspecified),
+    desc("Set the level of detail and summary to display when verifying "
+         "(implies --verify)"),
     values(clEnumValN(NoDetailsOrSummary, "quiet",
                       "Only display whether errors occurred."),
            clEnumValN(NoDetailsOnlySummary, "summary",
@@ -296,10 +298,10 @@ static opt<ErrorDetailLevel> ErrorDetails(
                       "Display each error as well as a summary. [default]")),
     cat(DwarfDumpCategory));
 static opt<std::string> JsonSummaryFile(
-    "json-summary-file", cl::init(""),
-    cl::desc("Output JSON-formatted error summary to the specified file. "
-             "(Implies -verify)"),
-    cl::value_desc("filename.json"), cat(DwarfDumpCategory));
+    "json-summary-file", init(""),
+    desc("Output JSON-formatted error summary to the specified file. "
+         "(Implies --verify)"),
+    value_desc("filename.json"), cat(DwarfDumpCategory));
 static opt<bool> Quiet("quiet", desc("Use with -verify to not emit to STDOUT."),
                        cat(DwarfDumpCategory));
 static opt<bool> DumpUUID("uuid", desc("Show the UUID for each architecture."),

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -297,7 +297,8 @@ static opt<ErrorDetailLevel> ErrorDetails(
     cat(DwarfDumpCategory));
 static opt<std::string> AggregationJsonFile(
     "aggregate-output-file", cl::init(""),
-    cl::desc("Output JSON-formatted error summary to the specified file."),
+    cl::desc("When using --verify, output JSON-formatted error summary to the "
+             "specified file."),
     cl::value_desc("filename.json"), cat(DwarfDumpCategory));
 static opt<bool> Quiet("quiet", desc("Use with -verify to not emit to STDOUT."),
                        cat(DwarfDumpCategory));
@@ -353,6 +354,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
                        ErrorDetails != NoDetailsOrSummary;
     DumpOpts.ShowAggregateErrors = ErrorDetails != OnlyDetailsNoSummary &&
                                    ErrorDetails != NoDetailsOnlySummary;
+    DumpOpts.AggregateErrJsonFile = AggregationJsonFile;
     return DumpOpts.noImplicitRecursion();
   }
   return DumpOpts;
@@ -841,7 +843,8 @@ int main(int argc, char **argv) {
   if (!Verify && ErrorDetails != Unspecified)
     WithColor::warning() << "-error-detail has no affect without -verify";
   if (!Verify && !AggregationJsonFile.empty())
-    WithColor::warning() << "-aggregation-json has no affect without -verify";
+    WithColor::warning()
+        << "-aggregate-output-file has no affect without -verify";
 
   std::error_code EC;
   ToolOutputFile OutputFile(OutputFilename, EC, sys::fs::OF_TextWithCRLF);

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -297,8 +297,8 @@ static opt<ErrorDetailLevel> ErrorDetails(
     cat(DwarfDumpCategory));
 static opt<std::string> JsonSummaryFile(
     "json-summary-file", cl::init(""),
-    cl::desc("When using --verify, output JSON-formatted error summary to the "
-             "specified file."),
+    cl::desc("Output JSON-formatted error summary to the specified file. "
+             "(Implies -verify)"),
     cl::value_desc("filename.json"), cat(DwarfDumpCategory));
 static opt<bool> Quiet("quiet", desc("Use with -verify to not emit to STDOUT."),
                        cat(DwarfDumpCategory));

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -295,6 +295,10 @@ static opt<ErrorDetailLevel> ErrorDetails(
            clEnumValN(BothDetailsAndSummary, "full",
                       "Display each error as well as a summary. [default]")),
     cat(DwarfDumpCategory));
+static opt<std::string> AggregationJsonFile(
+    "aggregate-output-file", cl::init(""),
+    cl::desc("Output JSON-formatted error summary to the specified file."),
+    cl::value_desc("filename.json"), cat(DwarfDumpCategory));
 static opt<bool> Quiet("quiet", desc("Use with -verify to not emit to STDOUT."),
                        cat(DwarfDumpCategory));
 static opt<bool> DumpUUID("uuid", desc("Show the UUID for each architecture."),
@@ -836,6 +840,8 @@ int main(int argc, char **argv) {
   }
   if (!Verify && ErrorDetails != Unspecified)
     WithColor::warning() << "-error-detail has no affect without -verify";
+  if (!Verify && !AggregationJsonFile.empty())
+    WithColor::warning() << "-aggregation-json has no affect without -verify";
 
   std::error_code EC;
   ToolOutputFile OutputFile(OutputFilename, EC, sys::fs::OF_TextWithCRLF);

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -840,10 +840,10 @@ int main(int argc, char **argv) {
                           "-verbose is currently not supported";
     return 1;
   }
-  if (!Verify && ErrorDetails != Unspecified)
-    WithColor::warning() << "-error-detail has no affect without -verify";
-  if (!Verify && !JsonSummaryFile.empty())
-    WithColor::warning() << "-json-summary-file has no affect without -verify";
+  // -error-detail and -json-summary-file both imply -verify
+  if (ErrorDetails != Unspecified || !JsonSummaryFile.empty()) {
+    Verify = true;
+  }
 
   std::error_code EC;
   ToolOutputFile OutputFile(OutputFilename, EC, sys::fs::OF_TextWithCRLF);

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -297,8 +297,8 @@ static opt<ErrorDetailLevel> ErrorDetails(
            clEnumValN(BothDetailsAndSummary, "full",
                       "Display each error as well as a summary. [default]")),
     cat(DwarfDumpCategory));
-static opt<std::string> JsonSummaryFile(
-    "json-summary-file", init(""),
+static opt<std::string> JsonErrSummaryFile(
+    "verify-json", init(""),
     desc("Output JSON-formatted error summary to the specified file. "
          "(Implies --verify)"),
     value_desc("filename.json"), cat(DwarfDumpCategory));
@@ -356,7 +356,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
                        ErrorDetails != NoDetailsOrSummary;
     DumpOpts.ShowAggregateErrors = ErrorDetails != OnlyDetailsNoSummary &&
                                    ErrorDetails != NoDetailsOnlySummary;
-    DumpOpts.JsonSummaryFile = JsonSummaryFile;
+    DumpOpts.JsonErrSummaryFile = JsonErrSummaryFile;
     return DumpOpts.noImplicitRecursion();
   }
   return DumpOpts;
@@ -843,7 +843,7 @@ int main(int argc, char **argv) {
     return 1;
   }
   // -error-detail and -json-summary-file both imply -verify
-  if (ErrorDetails != Unspecified || !JsonSummaryFile.empty()) {
+  if (ErrorDetails != Unspecified || !JsonErrSummaryFile.empty()) {
     Verify = true;
   }
 

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -295,8 +295,8 @@ static opt<ErrorDetailLevel> ErrorDetails(
            clEnumValN(BothDetailsAndSummary, "full",
                       "Display each error as well as a summary. [default]")),
     cat(DwarfDumpCategory));
-static opt<std::string> AggregationJsonFile(
-    "aggregate-output-file", cl::init(""),
+static opt<std::string> JsonSummaryFile(
+    "json-summary-file", cl::init(""),
     cl::desc("When using --verify, output JSON-formatted error summary to the "
              "specified file."),
     cl::value_desc("filename.json"), cat(DwarfDumpCategory));
@@ -354,7 +354,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
                        ErrorDetails != NoDetailsOrSummary;
     DumpOpts.ShowAggregateErrors = ErrorDetails != OnlyDetailsNoSummary &&
                                    ErrorDetails != NoDetailsOnlySummary;
-    DumpOpts.AggregateErrJsonFile = AggregationJsonFile;
+    DumpOpts.JsonSummaryFile = JsonSummaryFile;
     return DumpOpts.noImplicitRecursion();
   }
   return DumpOpts;
@@ -842,9 +842,8 @@ int main(int argc, char **argv) {
   }
   if (!Verify && ErrorDetails != Unspecified)
     WithColor::warning() << "-error-detail has no affect without -verify";
-  if (!Verify && !AggregationJsonFile.empty())
-    WithColor::warning()
-        << "-aggregate-output-file has no affect without -verify";
+  if (!Verify && !JsonSummaryFile.empty())
+    WithColor::warning() << "-json-summary-file has no affect without -verify";
 
   std::error_code EC;
   ToolOutputFile OutputFile(OutputFilename, EC, sys::fs::OF_TextWithCRLF);


### PR DESCRIPTION
In order to make tooling around dwarf health easier, I've added an `--aggregate-output-file` option to `llvm-dwarfdump --verify` that will spit out error summary data with counts to a JSON file.

I've added the same capability to `llvm-gsymutil` in a [different PR.](https://github.com/llvm/llvm-project/pull/81763)

The format of the json is:
``` json
{ 
  "error-categories": { 
    "<first category description>": {"count": 1234},
    "<next category description>": {"count":4321}
  },
  "error-count": 5555
}
```
for a clean run:
``` json
{ 
  "error-categories": {},
  "error-count": 0
}
```
