### PR TITLE
GSym aggregated output to JSON file

### DIFF
--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -35,3 +35,6 @@ defm address : Eq<"address", "Lookup an address in a GSYM file">;
 def addresses_from_stdin :
   FF<"addresses-from-stdin",
      "Lookup addresses in a GSYM file that are read from stdin\nEach input line is expected to be of the following format: <addr> <gsym-path>">;
+defm aggregate_error_file :
+  Eq<"aggregate-error-file",
+     "Output any aggregated errors into the file specified in JSON format.">;

--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -35,6 +35,6 @@ defm address : Eq<"address", "Lookup an address in a GSYM file">;
 def addresses_from_stdin :
   FF<"addresses-from-stdin",
      "Lookup addresses in a GSYM file that are read from stdin\nEach input line is expected to be of the following format: <addr> <gsym-path>">;
-defm aggregate_error_file :
-  Eq<"aggregate-error-file",
-     "Output any aggregated errors into the file specified in JSON format.">;
+defm json_summary_file :
+  Eq<"json-summary-file",
+     "Output a categorized summary of errors into the JSON file specified.">;

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -535,13 +535,16 @@ int llvm_gsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
       }
 
       llvm::json::Object Categories;
-      Aggregation.EnumerateResults([&](StringRef category, unsigned count) {
+      uint64_t ErrorCount = 0;
+      Aggregation.EnumerateResults([&](StringRef Category, unsigned Count) {
         llvm::json::Object Val;
-        Val.try_emplace("count", count);
-        Categories.try_emplace(category, std::move(Val));
+        Val.try_emplace("count", Count);
+        Categories.try_emplace(Category, std::move(Val));
+        ErrorCount += Count;
       });
       llvm::json::Object RootNode;
       RootNode.try_emplace("error-categories", std::move(Categories));
+      RootNode.try_emplace("error-count", ErrorCount);
 
       JsonStream << llvm::json::Value(std::move(RootNode));
     }

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Object/Archive.h"

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -527,20 +527,23 @@ int llvm_gsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     });
     if (!AggregateJsonFile.empty()) {
       std::error_code EC;
-      raw_fd_ostream JsonStream(AggregateJsonFile, EC,
-                                sys::fs::OF_Text | sys::fs::OF_None);
+      raw_fd_ostream JsonStream(AggregateJsonFile, EC, sys::fs::OF_Text);
       if (EC) {
         OS << "error opening aggregate error json file '" << AggregateJsonFile
            << "' for writing: " << EC.message() << '\n';
         return 1;
       }
       JsonStream << "{\"errors\":[\n";
+      bool prev = false;
       Aggregation.EnumerateResults([&](StringRef category, unsigned count) {
-        JsonStream << "\"category\":\"";
+        if (prev)
+          JsonStream << ",\n";
+        JsonStream << "{\"category\":\"";
         llvm::printEscapedString(category, JsonStream);
-        JsonStream << "\",\"count\":" << count;
+        JsonStream << "\",\"count\":" << count << "}";
+        prev = true;
       });
-      JsonStream << "]}\n";
+      JsonStream << "\n]}\n";
     }
     return 0;
   }


### PR DESCRIPTION
In order to make tooling around dwarf health easier, I've added an `--json-summary-file` option to `llvm-gsymutil` that will spit out error summary data with counts to a JSON file.

I've added the same capability to `llvm-dwarfdump` in a [different PR.](https://github.com/llvm/llvm-project/pull/81762)

The format of the json is:
```JSON
{ 
  "error-categories": { 
    "<first category description>": {"count": 1234},
    "<next category description>": {"count":4321}
  },
  "error-count": 5555
}
```
for a clean run:
```JSON
{ 
  "error-categories": {},
  "error-count": 0
}
```