### PR TITLE
[compiler-rt][msan] intercept a subset of non standard FreeBSD's allo…

### DIFF
--- a/compiler-rt/lib/msan/msan.h
+++ b/compiler-rt/lib/msan/msan.h
@@ -255,11 +255,11 @@ char *GetProcSelfMaps();
 void InitializeInterceptors();
 
 void MsanAllocatorInit();
-void MsanDeallocate(BufferedStackTrace *stack, void *ptr);
+void MsanDeallocate(BufferedStackTrace *stack, void *ptr, bool zeroise);
 
-void *msan_malloc(uptr size, BufferedStackTrace *stack);
+void *msan_malloc(uptr size, BufferedStackTrace *stack, bool zeroise);
 void *msan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
-void *msan_realloc(void *ptr, uptr size, BufferedStackTrace *stack);
+void *msan_realloc(void *ptr, uptr size, BufferedStackTrace *stack, bool zeroise);
 void *msan_reallocarray(void *ptr, uptr nmemb, uptr size,
                         BufferedStackTrace *stack);
 void *msan_valloc(uptr size, BufferedStackTrace *stack);

--- a/compiler-rt/lib/msan/msan_allocator.cpp
+++ b/compiler-rt/lib/msan/msan_allocator.cpp
@@ -232,7 +232,7 @@ static void *MsanAllocate(BufferedStackTrace *stack, uptr size, uptr alignment,
   return allocated;
 }
 
-void MsanDeallocate(BufferedStackTrace *stack, void *p) {
+void MsanDeallocate(BufferedStackTrace *stack, void *p, bool zeroise) {
   CHECK(p);
   UnpoisonParam(1);
   RunFreeHooks(p);
@@ -250,6 +250,11 @@ void MsanDeallocate(BufferedStackTrace *stack, void *p) {
       Origin o = Origin::CreateHeapOrigin(stack);
       __msan_set_origin(p, size, o.raw_id());
     }
+  } else {
+    if (allocator.FromPrimary(p))
+      __msan_clear_and_unpoison(p, size);
+    else
+      __msan_unpoison(p, size);  // Mem is already zeroed.
   }
   MsanThread *t = GetCurrentThread();
   if (t) {
@@ -263,7 +268,7 @@ void MsanDeallocate(BufferedStackTrace *stack, void *p) {
 }
 
 static void *MsanReallocate(BufferedStackTrace *stack, void *old_p,
-                            uptr new_size, uptr alignment) {
+                            uptr new_size, uptr alignment, bool zeroise) {
   Metadata *meta = reinterpret_cast<Metadata*>(allocator.GetMetaData(old_p));
   uptr old_size = meta->requested_size;
   uptr actually_allocated_size = allocator.GetActuallyAllocatedSize(old_p);
@@ -279,10 +284,10 @@ static void *MsanReallocate(BufferedStackTrace *stack, void *old_p,
     return old_p;
   }
   uptr memcpy_size = Min(new_size, old_size);
-  void *new_p = MsanAllocate(stack, new_size, alignment, false /*zeroise*/);
+  void *new_p = MsanAllocate(stack, new_size, alignment, zeroise);
   if (new_p) {
     CopyMemory(new_p, old_p, memcpy_size, stack);
-    MsanDeallocate(stack, old_p);
+    MsanDeallocate(stack, old_p, zeroise);
   }
   return new_p;
 }
@@ -324,22 +329,22 @@ static uptr AllocationSizeFast(const void *p) {
   return reinterpret_cast<Metadata *>(allocator.GetMetaData(p))->requested_size;
 }
 
-void *msan_malloc(uptr size, BufferedStackTrace *stack) {
-  return SetErrnoOnNull(MsanAllocate(stack, size, sizeof(u64), false));
+void *msan_malloc(uptr size, BufferedStackTrace *stack, bool zeroise) {
+  return SetErrnoOnNull(MsanAllocate(stack, size, sizeof(u64), zeroise));
 }
 
 void *msan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
   return SetErrnoOnNull(MsanCalloc(stack, nmemb, size));
 }
 
-void *msan_realloc(void *ptr, uptr size, BufferedStackTrace *stack) {
+void *msan_realloc(void *ptr, uptr size, BufferedStackTrace *stack, bool zeroise) {
   if (!ptr)
-    return SetErrnoOnNull(MsanAllocate(stack, size, sizeof(u64), false));
+    return SetErrnoOnNull(MsanAllocate(stack, size, sizeof(u64), zeroise));
   if (size == 0) {
-    MsanDeallocate(stack, ptr);
+    MsanDeallocate(stack, ptr, zeroise);
     return nullptr;
   }
-  return SetErrnoOnNull(MsanReallocate(stack, ptr, size, sizeof(u64)));
+  return SetErrnoOnNull(MsanReallocate(stack, ptr, size, sizeof(u64), zeroise));
 }
 
 void *msan_reallocarray(void *ptr, uptr nmemb, uptr size,
@@ -351,7 +356,7 @@ void *msan_reallocarray(void *ptr, uptr nmemb, uptr size,
     GET_FATAL_STACK_TRACE_IF_EMPTY(stack);
     ReportReallocArrayOverflow(nmemb, size, stack);
   }
-  return msan_realloc(ptr, nmemb * size, stack);
+  return msan_realloc(ptr, nmemb * size, stack, false);
 }
 
 void *msan_valloc(uptr size, BufferedStackTrace *stack) {

--- a/compiler-rt/lib/msan/msan_new_delete.cpp
+++ b/compiler-rt/lib/msan/msan_new_delete.cpp
@@ -32,7 +32,7 @@ namespace std {
 // TODO(alekseys): throw std::bad_alloc instead of dying on OOM.
 #  define OPERATOR_NEW_BODY(nothrow)          \
     GET_MALLOC_STACK_TRACE;                   \
-    void *res = msan_malloc(size, &stack);    \
+    void *res = msan_malloc(size, &stack, false);    \
     if (!nothrow && UNLIKELY(!res)) {         \
       GET_FATAL_STACK_TRACE_IF_EMPTY(&stack); \
       ReportOutOfMemory(size, &stack);        \
@@ -74,7 +74,7 @@ void *operator new[](size_t size, std::align_val_t align, std::nothrow_t const&)
 
 #define OPERATOR_DELETE_BODY \
   GET_MALLOC_STACK_TRACE; \
-  if (ptr) MsanDeallocate(&stack, ptr)
+  if (ptr) MsanDeallocate(&stack, ptr, false)
 
 INTERCEPTOR_ATTRIBUTE
 void operator delete(void *ptr) NOEXCEPT { OPERATOR_DELETE_BODY; }

--- a/compiler-rt/test/msan/FreeBSD/jemalloc.cpp
+++ b/compiler-rt/test/msan/FreeBSD/jemalloc.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx_msan -fsanitize-memory-track-origins -O0 %s -o %t && not %run %t >%t.out 2>&1
+// RUN: FileCheck %s < %t.out
+// RUN: %clangxx_msan -fsanitize-memory-track-origins -O2 %s -o %t && not %run %t >%t.out 2>&1
+// RUN: FileCheck %s < %t.out
+
+#include <malloc_np.h>
+#include <cassert>
+int main(int argc, char **argv) {
+  const int flags = MALLOCX_ZERO;
+  char *a = reinterpret_cast<char *>(mallocx(1024, 0));
+  char index = a[1023];
+  dallocx(a, 0);
+  char *p = reinterpret_cast<char *>(mallocx(16, flags));
+  p = reinterpret_cast<char *>(rallocx(p, 1024, flags));
+  size_t asize = sallocx(p, flags);
+  dallocx(p, flags);
+  assert(asize >= 1024);
+  return 0;
+  // CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
+  // CHECK: {{#0 0x.* in main .*jemalloc.cpp:}}[[@LINE-2]]
+}
+

--- a/compiler-rt/test/msan/FreeBSD/lit.local.cfg.py
+++ b/compiler-rt/test/msan/FreeBSD/lit.local.cfg.py
@@ -1,0 +1,10 @@
+def getRoot(config):
+    if not config.parent:
+        return config
+    return getRoot(config.parent)
+
+
+root = getRoot(config)
+
+if root.host_os not in ["FreeBSD"]:
+    config.unsupported = True


### PR DESCRIPTION
…cator api.

FreeBSD's allocator being jemalloc, its userland uses a subset of its non-standard api.