### PR TITLE
[clangd] Add support for renaming ObjC properties and implicit properties

### DIFF
--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -740,6 +740,22 @@ llvm::SmallVector<ReferenceLoc> refInDecl(const Decl *D,
                                   /*IsDecl=*/true,
                                   {OIMD}});
     }
+
+    void VisitObjCPropertyImplDecl(const ObjCPropertyImplDecl *OPID) {
+      // Skiped compiler synthesized property impl decls - they will always
+      // have an invalid loc.
+      if (OPID->getLocation().isInvalid())
+        return;
+      if (OPID->isIvarNameSpecified())
+        Refs.push_back(ReferenceLoc{NestedNameSpecifierLoc(),
+                                    OPID->getPropertyIvarDeclLoc(),
+                                    /*IsDecl=*/false,
+                                    {OPID->getPropertyIvarDecl()}});
+      Refs.push_back(ReferenceLoc{NestedNameSpecifierLoc(),
+                                  OPID->getLocation(),
+                                  /*IsDecl=*/false,
+                                  {OPID->getPropertyDecl()}});
+    }
   };
 
   Visitor V{Resolver};

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -861,6 +861,19 @@ TEST(RenameTest, WithinFileRename) {
 
         void func([[Fo^o]] *f) {}
       )cpp",
+
+      // ObjC property.
+      R"cpp(
+        @interface Foo
+        @property(nonatomic) int [[f^oo]];
+        @end
+        @implementation Foo
+        @end
+
+        void func(Foo *f) {
+          f.[[f^oo]] += [f [[fo^o]]];
+        }
+      )cpp",
   };
   llvm::StringRef NewName = "NewName";
   for (llvm::StringRef T : Tests) {
@@ -1008,18 +1021,95 @@ TEST(RenameTest, ObjCWithinFileRename) {
                           "performNewAction:by:",
                           // Expected
                           std::nullopt,
+                      },
+                      {
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int fo^o;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setFoo:[f foo] ];
+                          }
+                        )cpp",
+                        "bar",
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int bar;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setBar:[f bar] ];
+                          }
+                        )cpp",
+                      },
+                      {
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int foo;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setF^oo:[f foo] ];
+                          }
+                        )cpp",
+                        "setBar:",
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int bar;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setBar:[f bar] ];
+                          }
+                        )cpp",
+                      },
+                      {
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int foo;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setFoo:[f fo^o] ];
+                          }
+                        )cpp",
+                        "bar",
+                        R"cpp(
+                          @interface Foo
+                          @property(nonatomic) int bar;
+                          @end
+                          @implementation Foo
+                          @end
+
+                          void func(Foo *f) {
+                            [f setBar:[f bar] ];
+                          }
+                        )cpp",
                       }};
   for (TestCase T : Tests) {
     SCOPED_TRACE(T.Input);
     Annotations Code(T.Input);
     auto TU = TestTU::withCode(Code.code());
     TU.ExtraArgs.push_back("-xobjective-c");
+
     auto AST = TU.build();
     auto Index = TU.index();
     for (const auto &RenamePos : Code.points()) {
       auto RenameResult =
           rename({RenamePos, T.NewName, AST, testPath(TU.Filename),
                   getVFSFromAST(AST), Index.get()});
+
       if (std::optional<StringRef> Expected = T.Expected) {
         ASSERT_TRUE(bool(RenameResult)) << RenameResult.takeError();
         ASSERT_EQ(1u, RenameResult->GlobalChanges.size());

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -1023,7 +1023,7 @@ TEST(RenameTest, ObjCWithinFileRename) {
                           std::nullopt,
                       },
                       {
-                        R"cpp(
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int fo^o;
                           @end
@@ -1034,8 +1034,8 @@ TEST(RenameTest, ObjCWithinFileRename) {
                             [f setFoo:[f foo] ];
                           }
                         )cpp",
-                        "bar",
-                        R"cpp(
+                          "bar",
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int bar;
                           @end
@@ -1048,7 +1048,7 @@ TEST(RenameTest, ObjCWithinFileRename) {
                         )cpp",
                       },
                       {
-                        R"cpp(
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int foo;
                           @end
@@ -1059,8 +1059,8 @@ TEST(RenameTest, ObjCWithinFileRename) {
                             [f setF^oo:[f foo] ];
                           }
                         )cpp",
-                        "setBar:",
-                        R"cpp(
+                          "setBar:",
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int bar;
                           @end
@@ -1073,7 +1073,7 @@ TEST(RenameTest, ObjCWithinFileRename) {
                         )cpp",
                       },
                       {
-                        R"cpp(
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int foo;
                           @end
@@ -1084,8 +1084,8 @@ TEST(RenameTest, ObjCWithinFileRename) {
                             [f setFoo:[f fo^o] ];
                           }
                         )cpp",
-                        "bar",
-                        R"cpp(
+                          "bar",
+                          R"cpp(
                           @interface Foo
                           @property(nonatomic) int bar;
                           @end

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -1096,6 +1096,55 @@ TEST(RenameTest, ObjCWithinFileRename) {
                             [f setBar:[f bar] ];
                           }
                         )cpp",
+                      },
+                      {
+                          R"cpp(
+                          @interface Foo
+                          - (int)fo^o;
+                          - (void)setFoo:(int)foo;
+                          @end
+                          @implementation Foo
+                          - (int)fo^o { return 0; }
+                          - (void)setFoo:(int)foo {}
+                          @end
+
+                          void func(Foo *f) {
+                            f.foo = f.fo^o + 1;
+                          }
+                        )cpp",
+                          "bar",
+                          R"cpp(
+                          @interface Foo
+                          - (int)bar;
+                          - (void)setFoo:(int)foo;
+                          @end
+                          @implementation Foo
+                          - (int)bar { return 0; }
+                          - (void)setFoo:(int)foo {}
+                          @end
+
+                          void func(Foo *f) {
+                            f.foo = f.bar + 1;
+                          }
+                        )cpp",
+                      },
+                      {
+                          R"cpp(
+                          @interface Foo
+                          - (int)foo;
+                          - (void)setFoo:(int)foo;
+                          @end
+                          @implementation Foo
+                          - (int)foo { return 1; }
+                          - (void)setFoo:(int)foo {}
+                          @end
+
+                          void func(Foo *f) {
+                            f.f^oo += 1;
+                          }
+                        )cpp",
+                          "bar",
+                          std::nullopt,
                       }};
   for (TestCase T : Tests) {
     SCOPED_TRACE(T.Input);

--- a/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
@@ -733,7 +733,7 @@ sizeof...($TemplateParameter[[Elements]]);
         @property(readonly, class) $Class[[Foo]] *$Field_decl_readonly_static[[sharedInstance]];
         @end
         @implementation $Class_def[[Foo]]
-        @synthesize someProperty = _someProperty;
+        @synthesize $Field[[someProperty]] = $Field[[_someProperty]];
         - (int)$Method_def[[otherMethod]] {
           return 0;
         }

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -568,9 +568,8 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
   EXPECT_THAT(Refs,
               Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
                             ElementsAre(isSpelled()))));
-  EXPECT_THAT(Refs,
-              Contains(Pair(findSymbol(Symbols, "Person::setFoo:").ID,
-                            ElementsAre(isSpelled()))));
+  EXPECT_THAT(Refs, Contains(Pair(findSymbol(Symbols, "Person::setFoo:").ID,
+                                  ElementsAre(isSpelled()))));
 }
 
 TEST_F(SymbolCollectorTest, ObjCSymbols) {

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -536,6 +536,7 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
   @interface Person (Category)
   - (void)categoryMethod;
   - (void)multiArg:(id)a method:(id)b;
+  - (void)$setter[[setFoo]]:(id)foo;
   @end
   )");
   Annotations Main(R"(
@@ -549,6 +550,7 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
     [p $say[[say]]:0];
     [p categoryMethod];
     [p multiArg:0 method:0];
+    p.$setter[[foo]] = 0;
   }
   )");
   CollectorOpts.RefFilter = RefKind::All;
@@ -565,6 +567,9 @@ TEST_F(SymbolCollectorTest, ObjCRefs) {
                             ElementsAre(isSpelled()))));
   EXPECT_THAT(Refs,
               Contains(Pair(findSymbol(Symbols, "Person::multiArg:method:").ID,
+                            ElementsAre(isSpelled()))));
+  EXPECT_THAT(Refs,
+              Contains(Pair(findSymbol(Symbols, "Person::setFoo:").ID,
                             ElementsAre(isSpelled()))));
 }
 


### PR DESCRIPTION
Add support for renaming Objective-C properties. These are special since a single property decl could generate 3 different decls - a getter method, a setter method, and an instance variable. In addition, support renaming implicit properties, e.g. referring to a getter method `- (id)foo;` via `self.foo` or a setter method `- (void)setFoo:(id)foo;` via `self.foo =` without an explicit property decl.