### PR TITLE
[clang][CodeGen] Add missing error check

### DIFF
--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -291,6 +291,9 @@ bool BackendConsumer::LinkInModules(llvm::Module *M, bool ShouldLinkFiles) {
           });
     } else
       Err = Linker::linkModules(*M, std::move(LM.Module), LM.LinkFlags);
+
+    if (Err)
+      return true;
   }
 
   LinkModules.clear();


### PR DESCRIPTION
Add missing error check. This resolves "error: variable 'Err' set but not used" warnings