### PR TITLE
[Object][Wasm] Use offset instead of index for Global address and store size

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -351,7 +351,7 @@ struct WasmGlobal {
   WasmInitExpr InitExpr;
   StringRef SymbolName; // from the "linking" section
   uint32_t Offset; // Offset of the definition in the binary's Global section
-  uint32_t Size;  // Size of the definition in the binary's Global section
+  uint32_t Size;   // Size of the definition in the binary's Global section
 };
 
 struct WasmTag {

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -350,8 +350,8 @@ struct WasmGlobal {
   WasmGlobalType Type;
   WasmInitExpr InitExpr;
   StringRef SymbolName; // from the "linking" section
-  uint32_t Offset;
-  uint32_t Size;
+  uint32_t Offset; // Offset of the definition in the binary's Global section
+  uint32_t Size;  // Size of the definition in the binary's Global section
 };
 
 struct WasmTag {

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -455,7 +455,6 @@ struct WasmSymbolInfo {
     // For a data symbols, the address of the data relative to segment.
     WasmDataReference DataRef;
   };
-  uint32_t Size;
 };
 
 enum class NameType {

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -350,6 +350,8 @@ struct WasmGlobal {
   WasmGlobalType Type;
   WasmInitExpr InitExpr;
   StringRef SymbolName; // from the "linking" section
+  uint32_t Offset;
+  uint32_t Size;
 };
 
 struct WasmTag {
@@ -453,6 +455,7 @@ struct WasmSymbolInfo {
     // For a data symbols, the address of the data relative to segment.
     WasmDataReference DataRef;
   };
+  uint32_t Size;
 };
 
 enum class NameType {

--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -239,7 +239,7 @@ private:
   bool isValidSectionSymbol(uint32_t Index) const;
   wasm::WasmFunction &getDefinedFunction(uint32_t Index);
   const wasm::WasmFunction &getDefinedFunction(uint32_t Index) const;
-  wasm::WasmGlobal &getDefinedGlobal(uint32_t Index);
+  const wasm::WasmGlobal &getDefinedGlobal(uint32_t Index) const;
   wasm::WasmTag &getDefinedTag(uint32_t Index);
 
   const WasmSection &getWasmSection(DataRefImpl Ref) const;

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -1943,7 +1943,7 @@ uint32_t WasmObjectFile::getSymbolSize(SymbolRef Symb) const {
   if (!Sym.isDefined())
     return 0;
   if (Sym.isTypeGlobal())
-    return globals()[Sym.Info.ElementIndex - getNumImportedGlobals()].Size;
+    return getDefinedGlobal(Sym.Info.ElementIndex).Size;
   if (Sym.isTypeData())
     return Sym.Info.DataRef.Size;
   if (Sym.isTypeFunction())

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -534,8 +534,7 @@ Error WasmObjectFile::parseNameSection(ReadContext &Ctx) {
                                   /* ImportModule */ std::nullopt,
                                   /* ImportName */ std::nullopt,
                                   /* ExportName */ std::nullopt,
-                                  {/* ElementIndex */ Index},
-                                  /* Size */ 0};
+                                  {/* ElementIndex */ Index}};
         const wasm::WasmSignature *Signature = nullptr;
         const wasm::WasmGlobalType *GlobalType = nullptr;
         const wasm::WasmTableType *TableType = nullptr;
@@ -557,7 +556,6 @@ Error WasmObjectFile::parseNameSection(ReadContext &Ctx) {
             } else {
               Info.Flags |= wasm::WASM_SYMBOL_BINDING_LOCAL;
             }
-            Info.Size = functions()[Index - getNumImportedFunctions()].Size;
           } else {
             Info.Flags |= wasm::WASM_SYMBOL_UNDEFINED;
           }

--- a/llvm/test/tools/llvm-nm/wasm/exports.yaml
+++ b/llvm/test/tools/llvm-nm/wasm/exports.yaml
@@ -64,4 +64,4 @@ Sections:
 
 # CHECK:      00000000 D dexport
 # CHECK-NEXT: 00000001 T fexport
-# CHECK-NEXT: 00000000 D gexport
+# CHECK-NEXT: 00000001 D gexport

--- a/llvm/test/tools/llvm-nm/wasm/weak-symbols.yaml
+++ b/llvm/test/tools/llvm-nm/wasm/weak-symbols.yaml
@@ -80,6 +80,6 @@ Sections:
 
 # CHECK:      00000000 W weak_defined_data
 # CHECK-NEXT: 00000001 W weak_defined_func
-# CHECK-NEXT: 00000000 W weak_defined_global
+# CHECK-NEXT: 00000001 W weak_defined_global
 # CHECK-NEXT:          w weak_import_data
 # CHECK-NEXT:          w weak_import_func

--- a/llvm/test/tools/llvm-objdump/wasm/linked-symbol-table-namesec.yaml
+++ b/llvm/test/tools/llvm-objdump/wasm/linked-symbol-table-namesec.yaml
@@ -3,10 +3,11 @@
 #
 # CHECK:      SYMBOL TABLE:
 # CHECK-NEXT: 00000000   F *UND* 00000000 my_func_import_name
-# CHECK-NEXT: 00000083 g F CODE 00000003 my_func_export_name
-# CHECK-NEXT: 00000086 l F CODE 00000003 my_func_local_name
+# CHECK-NEXT: 0000008c g F CODE 00000003 my_func_export_name
+# CHECK-NEXT: 0000008f l F CODE 00000003 my_func_local_name
 # CHECK-NEXT: 00000000    *UND* 00000000 my_global_import_name
-# CHECK-NEXT: 00000001 g  GLOBAL 00000000 my_global_export_name
+# CHECK-NEXT: 0000004c g  GLOBAL 00000005 my_global_export_name
+# CHECK-NEXT: 00000051 g  GLOBAL 00000009 my_global_local_name
 # CHECK-NEXT: 00000000 l O DATA 00000004 my_datasegment_name
 
 --- !WASM
@@ -44,6 +45,12 @@ Sections:
         InitExpr:
           Opcode:          I32_CONST
           Value:           42
+      - Index:           2
+        Mutable:         true
+        Type:            I64
+        InitExpr:
+          Opcode:          I64_CONST
+          Value:           5000000000
   - Type:            EXPORT
     Exports:
       - Name:            my_func_export
@@ -82,6 +89,8 @@ Sections:
        Name:         my_global_import_name
      - Index:        1
        Name:         my_global_export_name
+     - Index:        2
+       Name:         my_global_local_name
     DataSegmentNames:
      - Index:        0
        Name:         my_datasegment_name


### PR DESCRIPTION
Currently the address reported by binutils for a global is its index; but its
offset (in the file or section) is more useful for binary size attribution.
This PR treats globals similarly to functions, and tracks their offset and
size. It also centralizes the logic differentiating linked from object and
dylib files (where section addresses are 0).