### PR TITLE
[HLSL] Expose `half` types and intrinsics always

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_basic_types.h
+++ b/clang/lib/Headers/hlsl/hlsl_basic_types.h
@@ -56,11 +56,9 @@ typedef vector<uint64_t, 2> uint64_t2;
 typedef vector<uint64_t, 3> uint64_t3;
 typedef vector<uint64_t, 4> uint64_t4;
 
-#ifdef __HLSL_ENABLE_16_BIT
 typedef vector<half, 2> half2;
 typedef vector<half, 3> half3;
 typedef vector<half, 4> half4;
-#endif
 
 typedef vector<float, 2> float2;
 typedef vector<float, 3> float3;

--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -21,6 +21,13 @@ namespace hlsl {
 #define _HLSL_AVAILABILITY(environment, version)                               \
   __attribute__((availability(environment, introduced = version)))
 
+#ifdef __HLSL_ENABLE_16_BIT
+#define _HLSL_16BIT_AVAILABILITY(environment, version)                         \
+  __attribute__((availability(environment, introduced = version)))
+#else
+#define _HLSL_16BIT_AVAILABILITY(environment, version)
+#endif
+
 //===----------------------------------------------------------------------===//
 // abs builtins
 //===----------------------------------------------------------------------===//
@@ -42,20 +49,20 @@ int16_t3 abs(int16_t3);
 _HLSL_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
+#endif
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half abs(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half2 abs(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half3 abs(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half4 abs(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int abs(int);
@@ -102,20 +109,18 @@ double4 abs(double4);
 /// the input value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half ceil(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half2 ceil(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half3 ceil(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half4 ceil(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 float ceil(float);
@@ -143,20 +148,18 @@ double4 ceil(double4);
 /// \brief Returns the cosine of the input value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half cos(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half2 cos(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half3 cos(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half4 cos(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 float cos(float);
@@ -185,20 +188,18 @@ double4 cos(double4);
 /// value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half floor(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half2 floor(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half3 floor(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half4 floor(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 float floor(float);
@@ -229,20 +230,18 @@ double4 floor(double4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half log(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half2 log(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half3 log(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half4 log(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 float log(float);
@@ -273,20 +272,18 @@ double4 log(double4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half log10(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half2 log10(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half3 log10(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half4 log10(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 float log10(float);
@@ -317,20 +314,18 @@ double4 log10(double4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half log2(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half2 log2(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half3 log2(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half4 log2(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 float log2(float);
@@ -359,20 +354,20 @@ double4 log2(double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half max(half, half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half2 max(half2, half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half3 max(half3, half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half4 max(half4, half4);
 
+#ifdef __HLSL_ENABLE_16_BIT
 _HLSL_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t max(int16_t, int16_t);
@@ -463,20 +458,20 @@ double4 max(double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half min(half, half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half2 min(half2, half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half3 min(half3, half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half4 min(half4, half4);
 
+#ifdef __HLSL_ENABLE_16_BIT
 _HLSL_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t min(int16_t, int16_t);
@@ -567,20 +562,18 @@ double4 min(double4, double4);
 /// \param Val The input value.
 /// \param Pow The specified power.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half pow(half, half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half2 pow(half2, half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half3 pow(half3, half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half4 pow(half4, half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 float pow(float, float);
@@ -680,20 +673,18 @@ uint64_t4 reversebits(uint64_t4);
 /// \brief Returns the sine of the input value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half sin(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half2 sin(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half3 sin(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half4 sin(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 float sin(float);
@@ -721,11 +712,9 @@ double4 sin(double4);
 /// \brief Returns the square root of the input value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_sqrtf16)
 half sqrt(half In);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_sqrtf)
 float sqrt(float In);
@@ -741,20 +730,18 @@ double sqrt(double In);
 /// \brief Returns the truncated integer value of the input value, \a Val.
 /// \param Val The input value.
 
-#ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half trunc(half);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half2 trunc(half2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half3 trunc(half3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half4 trunc(half4);
-#endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 float trunc(float);

--- a/clang/test/CodeGenHLSL/builtins/abs.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/abs.hlsl
@@ -3,10 +3,11 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 using hlsl::abs;
 
+#ifdef __HLSL_ENABLE_16_BIT
 // CHECK: define noundef i16 @
 // CHECK: call i16 @llvm.abs.i16(
 int16_t test_abs_int16_t ( int16_t p0 ) {
@@ -27,6 +28,8 @@ int16_t3 test_abs_int16_t3 ( int16_t3 p0 ) {
 int16_t4 test_abs_int16_t4 ( int16_t4 p0 ) {
   return abs ( p0 );
 }
+#endif // __HLSL_ENABLE_16_BIT
+
 // CHECK: define noundef half @
 // CHECK: call half @llvm.fabs.f16(
 // NO_HALF: define noundef float @"?test_abs_half@@YA$halff@$halff@@Z"(

--- a/clang/test/CodeGenHLSL/builtins/ceil.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ceil.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 using hlsl::ceil;
 

--- a/clang/test/CodeGenHLSL/builtins/cos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cos.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.cos.f16(

--- a/clang/test/CodeGenHLSL/builtins/floor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/floor.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 using hlsl::floor;
 

--- a/clang/test/CodeGenHLSL/builtins/log.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.log.f16(

--- a/clang/test/CodeGenHLSL/builtins/log10.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log10.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.log10.f16(

--- a/clang/test/CodeGenHLSL/builtins/log2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.log2.f16(

--- a/clang/test/CodeGenHLSL/builtins/max.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/max.hlsl
@@ -3,63 +3,47 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 #ifdef __HLSL_ENABLE_16_BIT
 // CHECK: define noundef i16 @
 // CHECK: call i16 @llvm.smax.i16(
-// NO_HALF: define noundef i16 @"?test_max_short@@YAFFF@Z"(
-// NO_HALF: call i16 @llvm.smax.i16(
 int16_t test_max_short ( int16_t p0, int16_t p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <2 x i16> @
 // CHECK: call <2 x i16> @llvm.smax.v2i16(
-// NO_HALF: define noundef <2 x i16> @"?test_max_short2@@YAT?$__vector@F$01@__clang@@T12@0@Z"(
-// NO_HALF: call <2 x i16> @llvm.smax.v2i16(
 int16_t2 test_max_short2 ( int16_t2 p0, int16_t2 p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <3 x i16> @
 // CHECK: call <3 x i16> @llvm.smax.v3i16
-// NO_HALF: define noundef <3 x i16> @"?test_max_short3@@YAT?$__vector@F$02@__clang@@T12@0@Z"(
-// NO_HALF: call <3 x i16> @llvm.smax.v3i16(
 int16_t3 test_max_short3 ( int16_t3 p0, int16_t3 p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <4 x i16> @
 // CHECK: call <4 x i16> @llvm.smax.v4i16
-// NO_HALF: define noundef <4 x i16> @"?test_max_short4@@YAT?$__vector@F$03@__clang@@T12@0@Z"(
-// NO_HALF: call <4 x i16> @llvm.smax.v4i16(
 int16_t4 test_max_short4 ( int16_t4 p0, int16_t4 p1 ) {
   return max ( p0, p1 );
 }
 
 // CHECK: define noundef i16 @
 // CHECK: call i16 @llvm.umax.i16(
-// NO_HALF: define noundef i16 @"?test_max_ushort@@YAGGG@Z"(
-// NO_HALF: call i16 @llvm.umax.i16(
 uint16_t test_max_ushort ( uint16_t p0, uint16_t p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <2 x i16> @
 // CHECK: call <2 x i16> @llvm.umax.v2i16
-// NO_HALF: define noundef <2 x i16> @"?test_max_ushort2@@YAT?$__vector@G$01@__clang@@T12@0@Z"(
-// NO_HALF: call <2 x i16> @llvm.umax.v2i16(
 uint16_t2 test_max_ushort2 ( uint16_t2 p0, uint16_t2 p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <3 x i16> @
 // CHECK: call <3 x i16> @llvm.umax.v3i16
-// NO_HALF: define noundef <3 x i16> @"?test_max_ushort3@@YAT?$__vector@G$02@__clang@@T12@0@Z"(
-// NO_HALF: call <3 x i16> @llvm.umax.v3i16(
 uint16_t3 test_max_ushort3 ( uint16_t3 p0, uint16_t3 p1 ) {
   return max ( p0, p1 );
 }
 // CHECK: define noundef <4 x i16> @
 // CHECK: call <4 x i16> @llvm.umax.v4i16
-// NO_HALF: define noundef <4 x i16> @"?test_max_ushort4@@YAT?$__vector@G$03@__clang@@T12@0@Z"(
-// NO_HALF: call <4 x i16> @llvm.umax.v4i16(
 uint16_t4 test_max_ushort4 ( uint16_t4 p0, uint16_t4 p1 ) {
   return max ( p0, p1 );
 }

--- a/clang/test/CodeGenHLSL/builtins/min.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/min.hlsl
@@ -3,34 +3,26 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 #ifdef __HLSL_ENABLE_16_BIT
 // CHECK: define noundef i16 @
 // CHECK: call i16 @llvm.smin.i16(
-// NO_HALF: define noundef i16 @"?test_min_short@@YAFFF@Z"(
-// NO_HALF: call i16 @llvm.smin.i16(
 int16_t test_min_short ( int16_t p0, int16_t p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <2 x i16> @
 // CHECK: call <2 x i16> @llvm.smin.v2i16(
-// NO_HALF: define noundef <2 x i16> @"?test_min_short2@@YAT?$__vector@F$01@__clang@@T12@0@Z"(
-// NO_HALF: call <2 x i16> @llvm.smin.v2i16(
 int16_t2 test_min_short2 ( int16_t2 p0, int16_t2 p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <3 x i16> @
 // CHECK: call <3 x i16> @llvm.smin.v3i16
-// NO_HALF: define noundef <3 x i16> @"?test_min_short3@@YAT?$__vector@F$02@__clang@@T12@0@Z"(
-// NO_HALF: call <3 x i16> @llvm.smin.v3i16(
 int16_t3 test_min_short3 ( int16_t3 p0, int16_t3 p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <4 x i16> @
 // CHECK: call <4 x i16> @llvm.smin.v4i16
-// NO_HALF: define noundef <4 x i16> @"?test_min_short4@@YAT?$__vector@F$03@__clang@@T12@0@Z"(
-// NO_HALF: call <4 x i16> @llvm.smin.v4i16(
 int16_t4 test_min_short4 ( int16_t4 p0, int16_t4 p1 ) {
   return min ( p0, p1 );
 }
@@ -38,29 +30,21 @@ int16_t4 test_min_short4 ( int16_t4 p0, int16_t4 p1 ) {
 
 // CHECK: define noundef i16 @
 // CHECK: call i16 @llvm.umin.i16(
-// NO_HALF: define noundef i16 @"?test_min_ushort@@YAGGG@Z"(
-// NO_HALF: call i16 @llvm.umin.i16(
 uint16_t test_min_ushort ( uint16_t p0, uint16_t p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <2 x i16> @
 // CHECK: call <2 x i16> @llvm.umin.v2i16
-// NO_HALF: define noundef <2 x i16> @"?test_min_ushort2@@YAT?$__vector@G$01@__clang@@T12@0@Z"(
-// NO_HALF: call <2 x i16> @llvm.umin.v2i16(
 uint16_t2 test_min_ushort2 ( uint16_t2 p0, uint16_t2 p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <3 x i16> @
 // CHECK: call <3 x i16> @llvm.umin.v3i16
-// NO_HALF: define noundef <3 x i16> @"?test_min_ushort3@@YAT?$__vector@G$02@__clang@@T12@0@Z"(
-// NO_HALF: call <3 x i16> @llvm.umin.v3i16(
 uint16_t3 test_min_ushort3 ( uint16_t3 p0, uint16_t3 p1 ) {
   return min ( p0, p1 );
 }
 // CHECK: define noundef <4 x i16> @
 // CHECK: call <4 x i16> @llvm.umin.v4i16
-// NO_HALF: define noundef <4 x i16> @"?test_min_ushort4@@YAT?$__vector@G$03@__clang@@T12@0@Z"(
-// NO_HALF: call <4 x i16> @llvm.umin.v4i16(
 uint16_t4 test_min_ushort4 ( uint16_t4 p0, uint16_t4 p1 ) {
   return min ( p0, p1 );
 }

--- a/clang/test/CodeGenHLSL/builtins/pow.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/pow.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.pow.f16(

--- a/clang/test/CodeGenHLSL/builtins/reversebits.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/reversebits.hlsl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
-// RUN:   -D__HLSL_ENABLE_16_BIT -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
+// RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 
 #ifdef __HLSL_ENABLE_16_BIT
 // CHECK: define noundef i16 @

--- a/clang/test/CodeGenHLSL/builtins/sin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.sin.f16(

--- a/clang/test/CodeGenHLSL/builtins/trunc.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc.hlsl
@@ -3,7 +3,7 @@
 // RUN:   -emit-llvm -disable-llvm-passes -O3 -o - | FileCheck %s
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -D__HLSL_ENABLE_16_BIT -o - | FileCheck %s --check-prefix=NO_HALF
+// RUN:   -o - | FileCheck %s --check-prefix=NO_HALF
 
 // CHECK: define noundef half @
 // CHECK: call half @llvm.trunc.f16(


### PR DESCRIPTION
We previously made an implmenetation error when adding `half` overloads for HLSL library functionalitly. The `half` type is always defined in HLSL and `half` intrinsics should not be conditionally included.

When native 16-bit types are disabled `half` is a unique 32-bit float type with lesser promotion rank than `float`.

Fixes #81049