### PR TITLE
[llvm][compiler-rt] Connect lit dependencies to test-depends targets.

### DIFF
--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -116,7 +116,11 @@ endif()
 
 # Now that we've traversed all the directories and know all the lit testsuites,
 # introduce a rule to run to run all of them.
-add_custom_target(compiler-rt-test-depends DEPENDS ${LLVM_COMPILER_RT_LIT_DEPENDS})
+get_property(LLVM_COMPILER_RT_LIT_DEPENDS GLOBAL PROPERTY LLVM_COMPILER_RT_LIT_DEPENDS)
+add_custom_target(compiler-rt-test-depends)
+if(LLVM_COMPILER_RT_LIT_DEPENDS)
+  add_dependencies(compiler-rt-test-depends ${LLVM_COMPILER_RT_LIT_DEPENDS})
+endif()
 umbrella_lit_testsuite_end(check-compiler-rt)
 
 if(COMPILER_RT_STANDALONE_BUILD)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1256,8 +1256,10 @@ if( LLVM_INCLUDE_TESTS )
   get_property(LLVM_ALL_LIT_DEPENDS GLOBAL PROPERTY LLVM_ALL_LIT_DEPENDS)
   get_property(LLVM_ALL_ADDITIONAL_TEST_DEPENDS
       GLOBAL PROPERTY LLVM_ALL_ADDITIONAL_TEST_DEPENDS)
-  add_custom_target(test-depends
-      DEPENDS ${LLVM_ALL_LIT_DEPENDS} ${LLVM_ALL_ADDITIONAL_TEST_DEPENDS})
+  add_custom_target(test-depends)
+  if(LLVM_ALL_LIT_DEPENDS OR LLVM_ALL_ADDITIONAL_TEST_DEPENDS)
+    add_dependencies(test-depends ${LLVM_ALL_LIT_DEPENDS} ${LLVM_ALL_ADDITIONAL_TEST_DEPENDS})
+  endif()
   set_target_properties(test-depends PROPERTIES FOLDER "Tests")
   add_dependencies(check-all test-depends)
 endif()


### PR DESCRIPTION
compiler-rt was creating the test-depends targets and trying to fill its dependencies with a variable, but the variable was empty because it was supposed to take its value from a property. The changes in this commit grab the value of the property and add them as dependencies.

The changes in llvm are to remove the usage of `DEPENDS` arguments from `add_custom_target`, which according to the documentation is reserved for files/outputs created by `add_custom_command`. Use `add_dependencies` instead.

This is similar to the changes introduced in
4eb84582344f97167b6a2b4cb1fb1d75ae07897e for runtimes.