### PR TITLE
[TargetLowering] Emit SIGN_EXTEND_INREG instead of shift pair from optimizeSetCCOfSignedTruncationCheck.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4083,7 +4083,7 @@ SDValue TargetLowering::optimizeSetCCOfSignedTruncationCheck(
   if (!DAG.getTargetLoweringInfo().shouldTransformSignedTruncationCheck(
           XVT, KeptBits))
     return SDValue();
-Emit as
+
   // Unfold into:  (sext_inreg(%x) cond %x
   // Where 'cond' will be either 'eq' or 'ne'.
   SDValue SExtInReg = DAG.getNode(

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4084,17 +4084,12 @@ SDValue TargetLowering::optimizeSetCCOfSignedTruncationCheck(
           XVT, KeptBits))
     return SDValue();
 
-  const unsigned MaskedBits = XVT.getSizeInBits() - KeptBits;
-  assert(MaskedBits > 0 && MaskedBits < XVT.getSizeInBits() && "unreachable");
-
-  // Unfold into:  ((%x << C) a>> C) cond %x
+  // Unfold into:  (sext_inreg(X) cond %x
   // Where 'cond' will be either 'eq' or 'ne'.
-  SDValue ShiftAmt = DAG.getConstant(MaskedBits, DL, XVT);
-  SDValue T0 = DAG.getNode(ISD::SHL, DL, XVT, X, ShiftAmt);
-  SDValue T1 = DAG.getNode(ISD::SRA, DL, XVT, T0, ShiftAmt);
-  SDValue T2 = DAG.getSetCC(DL, SCCVT, T1, X, NewCond);
-
-  return T2;
+  SDValue SExtInReg = DAG.getNode(
+      ISD::SIGN_EXTEND_INREG, DL, XVT, X,
+      DAG.getValueType(EVT::getIntegerVT(*DAG.getContext(), KeptBits)));
+  return DAG.getSetCC(DL, SCCVT, SExtInReg, X, NewCond);
 }
 
 // (X & (C l>>/<< Y)) ==/!= 0  -->  ((X <</l>> Y) & C) ==/!= 0

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4083,8 +4083,8 @@ SDValue TargetLowering::optimizeSetCCOfSignedTruncationCheck(
   if (!DAG.getTargetLoweringInfo().shouldTransformSignedTruncationCheck(
           XVT, KeptBits))
     return SDValue();
-
-  // Unfold into:  (sext_inreg(X) cond %x
+Emit as
+  // Unfold into:  (sext_inreg(%x) cond %x
   // Where 'cond' will be either 'eq' or 'ne'.
   SDValue SExtInReg = DAG.getNode(
       ISD::SIGN_EXTEND_INREG, DL, XVT, X,

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4084,7 +4084,7 @@ SDValue TargetLowering::optimizeSetCCOfSignedTruncationCheck(
           XVT, KeptBits))
     return SDValue();
 
-  // Unfold into:  (sext_inreg(%x) cond %x
+  // Unfold into:  sext_inreg(%x) cond %x
   // Where 'cond' will be either 'eq' or 'ne'.
   SDValue SExtInReg = DAG.getNode(
       ISD::SIGN_EXTEND_INREG, DL, XVT, X,


### PR DESCRIPTION
sext_inreg is our canonical form of shift pair before op legalization so DAG combiner will probably create it anyway. If it isn't legal LegalizeDAG will get expand to shifts later.