### PR TITLE
[compiler-rt][nfc] Return size 0 explicitly when both pointers are NULL

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -93,7 +93,7 @@ uint64_t __llvm_profile_get_counters_size(const char *Begin, const char *End) {
 COMPILER_RT_VISIBILITY
 uint64_t __llvm_profile_get_num_bitmap_bytes(const char *Begin,
                                              const char *End) {
-    if (Begin == NULL && End == NULL)
+  if (Begin == NULL && End == NULL)
     return 0;
   return (End - Begin);
 }

--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -93,11 +93,15 @@ uint64_t __llvm_profile_get_counters_size(const char *Begin, const char *End) {
 COMPILER_RT_VISIBILITY
 uint64_t __llvm_profile_get_num_bitmap_bytes(const char *Begin,
                                              const char *End) {
+    if (Begin == NULL && End == NULL)
+    return 0;
   return (End - Begin);
 }
 
 COMPILER_RT_VISIBILITY
 uint64_t __llvm_profile_get_name_size(const char *Begin, const char *End) {
+  if (Begin == NULL && End == NULL)
+    return 0;
   return End - Begin;
 }
 

--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -93,14 +93,14 @@ uint64_t __llvm_profile_get_counters_size(const char *Begin, const char *End) {
 COMPILER_RT_VISIBILITY
 uint64_t __llvm_profile_get_num_bitmap_bytes(const char *Begin,
                                              const char *End) {
-  if (Begin == NULL && End == NULL)
+  if (Begin == End)
     return 0;
   return (End - Begin);
 }
 
 COMPILER_RT_VISIBILITY
 uint64_t __llvm_profile_get_name_size(const char *Begin, const char *End) {
-  if (Begin == NULL && End == NULL)
+  if (Begin == End)
     return 0;
   return End - Begin;
 }


### PR DESCRIPTION
* Mark as nfc as both clang and gcc implementation won't make this an undefined behavior (https://gcc.godbolt.org/z/3TTr8b1fY)

* Subtracting two NULL pointers is [undefined behavior](https://stackoverflow.com/questions/55747642/can-we-subtract-null-pointers#:~:text=Subtracting%20two%20NULL%20pointers%20is,of%20the%20two%20array%20elements.) in C standard. Converting NULL to `intptr_t` and subtracting two `intptr_t` is also implementation specific behavior. (This [SO](https://stackoverflow.com/questions/64739189/three-questions-is-null-null-defined-is-uintptr-tnull-uintptr-tnull-de?noredirect=1&lq=1) discusses a similar question)
* On the other hand, it's defined behavior to add or subtract NULL from [since C++03](https://stackoverflow.com/questions/8128168/is-the-behavior-of-subtracting-two-null-pointers-defined)