### PR TITLE
[InstrProf] Test that entry coverage counts accumulate

### DIFF
--- a/compiler-rt/test/profile/instrprof-block-coverage.c
+++ b/compiler-rt/test/profile/instrprof-block-coverage.c
@@ -5,6 +5,9 @@
 // RUN: %clang_profuse=%t.profdata -mllvm -pgo-verify-bfi -o - -S -emit-llvm %s 2>%t.errs | FileCheck %s --implicit-check-not="!prof"
 // RUN: FileCheck %s < %t.errs --allow-empty --check-prefix=CHECK-ERROR
 
+// RUN: llvm-profdata merge -o %t2.profdata %t1.profraw %t1.profraw %t2.profraw %t2.profraw
+// RUN: llvm-profdata show %t2.profdata | FileCheck %s --check-prefix=COUNTS
+
 #include <stdlib.h>
 
 // CHECK: @foo({{.*}})
@@ -45,3 +48,5 @@ int main(int argc, char *argv[]) {
 // CHECK-DAG: ![[PROF2]] = !{!"branch_weights", i32 0, i32 1}
 
 // CHECK-ERROR-NOT: warning: {{.*}}: Found inconsistent block coverage
+
+// COUNTS: Maximum function count: 4

--- a/compiler-rt/test/profile/instrprof-entry-coverage.c
+++ b/compiler-rt/test/profile/instrprof-entry-coverage.c
@@ -3,10 +3,19 @@
 // RUN: llvm-profdata merge -o %t.profdata %t.profraw
 // RUN: llvm-profdata show --covered %t.profdata | FileCheck %s --implicit-check-not goo
 
+// We deliberately merge the raw profile twice to test that internal counts can
+// grow larger than one. Technically, accumulating coverage values is different
+// than accumulating counts, but this helps discriminate cold functions from hot
+// functions when the number of raw profiles is large.
+// RUN: llvm-profdata merge -o %t2.profdata %t.profraw %t.profraw
+// RUN: llvm-profdata show %t2.profdata | FileCheck %s --check-prefix=COUNTS
+
 // RUN: %clang_cspgogen -O1 -mllvm -pgo-function-entry-coverage %s -o %t.cs.out
 // RUN: env LLVM_PROFILE_FILE=%t.csprofraw %run %t.cs.out
 // RUN: llvm-profdata merge -o %t.csprofdata %t.csprofraw
 // RUN: llvm-profdata show --covered %t.csprofdata --showcs | FileCheck %s --implicit-check-not goo
+// RUN: llvm-profdata merge -o %t2.csprofdata %t.csprofraw %t.csprofraw
+// RUN: llvm-profdata show --showcs %t2.csprofdata | FileCheck %s --check-prefix=COUNTS
 
 void markUsed(int a) {
   volatile int g;
@@ -26,3 +35,5 @@ int main(int argc, char *argv[]) {
 // CHECK-DAG: main
 // CHECK-DAG: foo
 // CHECK-DAG: bar
+
+// COUNTS: Maximum function count: 2


### PR DESCRIPTION
Entry coverage (`-pgo-function-entry-coverage`) and block covearge (`-pgo-block-coverage`) can be useful to reduce the size overhead of instrumented builds, and the profiles they generate can even be used in PGO builds.

When merging raw profiles with coverage, we accumulate their values as if they were counts and `llvm-profdata` considers a value to be "covered" if it's larger than zero. https://github.com/llvm/llvm-project/blob/acdb4cdc04ed4d9a130f0fa706ed1b0f42cc1aa0/llvm/lib/ProfileData/InstrProf.cpp#L841-L842

This is technically different than accumulating counts, but it can help discriminate cold functions from hot functions when the number of raw profiles is large.

See https://github.com/llvm/llvm-project/pull/75425#discussion_r1427177844 for discussion.