### PR TITLE
[flang][openacc] Use the same iv privatized value in the loop region

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -1658,10 +1658,18 @@ static void privatizeIv(Fortran::lower::AbstractConverter &converter,
       mlir::acc::DataClause::acc_private, ivValue.getType());
 
   privateOperands.push_back(op.getAccPtr());
-  ivPrivate.push_back(op.getAccPtr());
   privatizations.push_back(mlir::SymbolRefAttr::get(builder.getContext(),
                                                     recipe.getSymName().str()));
+
+  // Map the new private iv to its symbol for the scope of the loop. bindSymbol
+  // might create a hlfir.declare op, if so, we map its result in order to
+  // use the sym value in the scope.
   converter.bindSymbol(sym, op.getAccPtr());
+  auto privateValue = converter.getSymbolAddress(sym);
+  if (auto declareOp =
+          mlir::dyn_cast<hlfir::DeclareOp>(privateValue.getDefiningOp()))
+    privateValue = declareOp.getResults()[0];
+  ivPrivate.push_back(privateValue);
 }
 
 static mlir::acc::LoopOp


### PR DESCRIPTION
IV variable are privatized during acc loop lowering. An hlfir.declare operation is added when mapping the symbol to the new private value. In order to avoid using multiple value in the acc.loop region, we map the symbol to the result of the hlfir.declare operation inserted.