### PR TITLE
fix generation of unnecessary OpExecutionMode records

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -450,7 +450,9 @@ void SPIRVAsmPrinter::outputExecutionMode(const Module &M) {
   }
   for (auto FI = M.begin(), E = M.end(); FI != E; ++FI) {
     const Function &F = *FI;
-    if (F.isDeclaration())
+    // Only operands of OpEntryPoint instructions are allowed to be
+    // <Entry Point> operands of OpExecutionMode
+    if (F.isDeclaration() || !isEntryPoint(F))
       continue;
     Register FReg = MAI->getFuncReg(&F);
     assert(FReg.isValid());

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -181,20 +181,6 @@ static SPIRVType *getArgSPIRVType(const Function &F, unsigned ArgIdx,
                                                ArgAccessQual);
 }
 
-static bool isEntryPoint(const Function &F) {
-  // OpenCL handling: any function with the SPIR_KERNEL
-  // calling convention will be a potential entry point.
-  if (F.getCallingConv() == CallingConv::SPIR_KERNEL)
-    return true;
-
-  // HLSL handling: special attribute are emitted from the
-  // front-end.
-  if (F.getFnAttribute("hlsl.shader").isValid())
-    return true;
-
-  return false;
-}
-
 static SPIRV::ExecutionModel::ExecutionModel
 getExecutionModel(const SPIRVSubtarget &STI, const Function &F) {
   if (STI.isOpenCLEnv())

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -348,4 +348,18 @@ bool isSpecialOpaqueType(const Type *Ty) {
 
   return false;
 }
+
+bool isEntryPoint(const Function &F) {
+  // OpenCL handling: any function with the SPIR_KERNEL
+  // calling convention will be a potential entry point.
+  if (F.getCallingConv() == CallingConv::SPIR_KERNEL)
+    return true;
+
+  // HLSL handling: special attribute are emitted from the
+  // front-end.
+  if (F.getFnAttribute("hlsl.shader").isValid())
+    return true;
+
+  return false;
+}
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -97,5 +97,8 @@ bool hasBuiltinTypePrefix(StringRef Name);
 
 // Check if given LLVM type is a special opaque builtin type.
 bool isSpecialOpaqueType(const Type *Ty);
+
+// Check if the function is an SPIR-V entry point
+bool isEntryPoint(const Function &F);
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/execution-mode-per-entry-point.ll
+++ b/llvm/test/CodeGen/SPIRV/execution-mode-per-entry-point.ll
@@ -1,0 +1,39 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpMemoryModel
+; CHECK-DAG: OpEntryPoint Kernel %[[#ENTRY1:]] "foo1"
+; CHECK-DAG: OpEntryPoint Kernel %[[#ENTRY4:]] "foo4"
+; CHECK-NOT: OpSource
+; CHECK-DAG: OpExecutionMode %[[#ENTRY1]] {{[a-zA-Z]+}}
+; CHECK-DAG: OpExecutionMode %[[#ENTRY4]] {{[a-zA-Z]+}}
+; CHECK: OpSource
+
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECKN
+
+; CHECKN: OpMemoryModel
+; CHECKN-COUNT-2: OpEntryPoint Kernel
+; CHECKN-NOT: OpEntryPoint Kernel
+; CHECKN-COUNT-2: OpExecutionMode
+; CHECKN-NOT: OpExecutionMode
+; CHECKN: OpSource
+
+define spir_kernel void @foo1() {
+entry:
+  ret void
+}
+
+define void @foo2() {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @foo3() {
+entry:
+  ret void
+}
+
+define spir_kernel void @foo4() {
+entry:
+  ret void
+}


### PR DESCRIPTION
SPIRV-V Backend generates unnecessary OpExecutionMode records, putting into the id's which are not the Entry Point operands of an OpEntryPoint (ref: https://github.com/llvm/llvm-project/issues/81753). This PR is to fix the issue.