### PR TITLE
[llvm-dlltool] Use -N for input native def option to avoid conflict with GNU dlltool --no-delete option.

### DIFF
--- a/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+++ b/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
@@ -205,12 +205,12 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
 
   std::vector<COFFShortExport> Exports, NativeExports;
 
-  if (Args.hasArg(OPT_n)) {
+  if (Args.hasArg(OPT_N)) {
     if (!isArm64EC(Machine)) {
       llvm::errs() << "native .def file is supported only on arm64ec target\n";
       return 1;
     }
-    if (!parseModuleDefinition(Args.getLastArg(OPT_n)->getValue(),
+    if (!parseModuleDefinition(Args.getLastArg(OPT_N)->getValue(),
                                IMAGE_FILE_MACHINE_ARM64, AddUnderscores,
                                NativeExports, OutputFile))
       return 1;

--- a/llvm/lib/ToolDrivers/llvm-dlltool/Options.td
+++ b/llvm/lib/ToolDrivers/llvm-dlltool/Options.td
@@ -12,8 +12,8 @@ def D_long : JoinedOrSeparate<["--"], "dllname">, Alias<D>;
 def d: JoinedOrSeparate<["-"], "d">, HelpText<"Input .def File">;
 def d_long : JoinedOrSeparate<["--"], "input-def">, Alias<d>;
 
-def n: JoinedOrSeparate<["-"], "n">, HelpText<"Input native .def File on ARM64EC">;
-def n_long : JoinedOrSeparate<["--"], "input-native-def">, Alias<d>;
+def N: JoinedOrSeparate<["-"], "N">, HelpText<"Input native .def File on ARM64EC">;
+def N_long : JoinedOrSeparate<["--"], "input-native-def">, Alias<N>;
 
 def k: Flag<["-"], "k">, HelpText<"Kill @n Symbol from export">;
 def k_alias: Flag<["--"], "kill-at">, Alias<k>;

--- a/llvm/test/tools/llvm-dlltool/arm64ec.test
+++ b/llvm/test/tools/llvm-dlltool/arm64ec.test
@@ -16,7 +16,7 @@ ARMAP-NEXT: __imp_aux_func in test.dll
 ARMAP-NEXT: __imp_func in test.dll
 ARMAP-NEXT: func in test.dll
 
-RUN: llvm-dlltool -m arm64ec -d test.def -n test2.def -l test2.lib
+RUN: llvm-dlltool -m arm64ec -d test.def -N test2.def -l test2.lib
 RUN: llvm-nm --print-armap test2.lib | FileCheck --check-prefix=ARMAP2 %s
 
 ARMAP2:      Archive map
@@ -32,7 +32,10 @@ ARMAP2-NEXT: __imp_aux_func in test.dll
 ARMAP2-NEXT: __imp_func in test.dll
 ARMAP2-NEXT: func in test.dll
 
-RUN: not llvm-dlltool -m arm64 -d test.def -n test2.def -l test2.lib 2>&1 | FileCheck --check-prefix=ERR %s
+RUN: llvm-dlltool -m arm64ec -d test.def --input-native-def test2.def -l test3.lib
+RUN: llvm-nm --print-armap test3.lib | FileCheck --check-prefix=ARMAP2 %s
+
+RUN: not llvm-dlltool -m arm64 -d test.def -N test2.def -l test4.lib 2>&1 | FileCheck --check-prefix=ERR %s
 ERR: native .def file is supported only on arm64ec target
 
 #--- test.def


### PR DESCRIPTION
As spotted by @mstorsjo in #81624. Also fixes the long form alias.