### PR TITLE
[AMDGPU] Use consistent DecoderNamespace for wave64 instructions. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -662,11 +662,11 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     if (Res)
       break;
 
-    Res = tryDecodeInst(DecoderTableWMMAGFX1164, MI, QW, Address, CS);
+    Res = tryDecodeInst(DecoderTableGFX11W6464, MI, QW, Address, CS);
     if (Res)
       break;
 
-    Res = tryDecodeInst(DecoderTableWMMAGFX1264, MI, QW, Address, CS);
+    Res = tryDecodeInst(DecoderTableGFX12W6464, MI, QW, Address, CS);
   } while (false);
 
   if (Res && AMDGPU::isMAC(MI.getOpcode())) {

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -1414,7 +1414,7 @@ multiclass VOP3P_Real_WMMA_gfx12 <bits<7> op, VOP3PWMMA_Profile WMMAP> {
 }
 
 multiclass VOP3P_Real_WMMA_gfx12w64 <bits<7> op, VOP3PWMMA_Profile WMMAP> {
-  let WaveSizePredicate = isWave64, DecoderNamespace = "WMMAGFX12" in {
+  let WaveSizePredicate = isWave64, DecoderNamespace = "GFX12W64" in {
     defm _twoaddr : VOP3P_WMMA_Real_Base <GFX12Gen, op, WMMAP>;
   }
 }
@@ -1544,7 +1544,7 @@ multiclass VOP3P_Real_WMMA <bits<7> op> {
   let WaveSizePredicate = isWave32, DecoderNamespace = "GFX11" in {
     defm _twoaddr_w32 : VOP3P_Real_Base <GFX11Gen, op>;
   }
-  let WaveSizePredicate = isWave64, DecoderNamespace = "WMMAGFX11" in {
+  let WaveSizePredicate = isWave64, DecoderNamespace = "GFX11W64" in {
     defm _twoaddr_w64 : VOP3P_Real_Base <GFX11Gen, op>;
   }
 }


### PR DESCRIPTION
For wave64 WMMA instructions, putting W64 in the DecoderNamespace is
more descriptive than WMMA, and matches other uses for GFX12
GLOBAL_LOAD_TR instructions.
