### PR TITLE
[libc] Update integration tests to use the C functions directly

### DIFF
--- a/libc/test/IntegrationTest/test.cpp
+++ b/libc/test/IntegrationTest/test.cpp
@@ -9,47 +9,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Integration tests rely on the following memory functions. This is because the
-// compiler code generation can emit calls to them. We want to map the external
-// entrypoint to the internal implementation of the function used for testing.
-// This is done manually as not all targets support aliases.
-
-namespace LIBC_NAMESPACE {
-
-int bcmp(const void *lhs, const void *rhs, size_t count);
-void bzero(void *ptr, size_t count);
-int memcmp(const void *lhs, const void *rhs, size_t count);
-void *memcpy(void *__restrict, const void *__restrict, size_t);
-void *memmove(void *dst, const void *src, size_t count);
-void *memset(void *ptr, int value, size_t count);
-int atexit(void (*func)(void));
-
-} // namespace LIBC_NAMESPACE
-
-extern "C" {
-
-int bcmp(const void *lhs, const void *rhs, size_t count) {
-  return LIBC_NAMESPACE::bcmp(lhs, rhs, count);
-}
-void bzero(void *ptr, size_t count) { LIBC_NAMESPACE::bzero(ptr, count); }
-int memcmp(const void *lhs, const void *rhs, size_t count) {
-  return LIBC_NAMESPACE::memcmp(lhs, rhs, count);
-}
-void *memcpy(void *__restrict dst, const void *__restrict src, size_t count) {
-  return LIBC_NAMESPACE::memcpy(dst, src, count);
-}
-void *memmove(void *dst, const void *src, size_t count) {
-  return LIBC_NAMESPACE::memmove(dst, src, count);
-}
-void *memset(void *ptr, int value, size_t count) {
-  return LIBC_NAMESPACE::memset(ptr, value, count);
-}
-
-// This is needed if the test was compiled with '-fno-use-cxa-atexit'.
-int atexit(void (*func)(void)) { return LIBC_NAMESPACE::atexit(func); }
-
-} // extern "C"
-
 // Integration tests cannot use the SCUDO standalone allocator as SCUDO pulls
 // various other parts of the libc. Since SCUDO development does not use
 // LLVM libc build rules, it is very hard to keep track or pull all that SCUDO

--- a/libc/test/integration/src/stdio/sprintf_size_test.cpp
+++ b/libc/test/integration/src/stdio/sprintf_size_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for getenv ----------------------------------------------===//
+//===-- Unittests for sprintf ---------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,55 +6,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stddef.h>
-
 #ifndef INTEGRATION_DISABLE_PRINTF
-#include "src/stdio/sprintf.h"
+#include <stdio.h> // sprintf
 #endif
 
 #include "test/IntegrationTest/test.h"
 
-static bool my_streq(const char *lhs, const char *rhs) {
-  if (lhs == rhs)
-    return true;
-  if (((lhs == static_cast<char *>(nullptr)) &&
-       (rhs != static_cast<char *>(nullptr))) ||
-      ((lhs != static_cast<char *>(nullptr)) &&
-       (rhs == static_cast<char *>(nullptr)))) {
-    return false;
-  }
-  const char *l, *r;
-  for (l = lhs, r = rhs; *l != '\0' && *r != '\0'; ++l, ++r)
-    if (*l != *r)
-      return false;
-
-  return *l == '\0' && *r == '\0';
-}
-
-static int my_strlen(const char *str) {
-  const char *other = str;
-  while (*other)
-    ++other;
-  return static_cast<int>(other - str);
-}
-
 TEST_MAIN(int argc, char **argv, char **envp) {
   ASSERT_EQ(argc, 5);
-  ASSERT_TRUE(my_streq(argv[1], "%s %c %d"));
-  ASSERT_EQ(my_strlen(argv[1]), 8);
-  ASSERT_TRUE(my_streq(argv[2], "First arg"));
-  ASSERT_EQ(my_strlen(argv[2]), 9);
-  ASSERT_TRUE(my_streq(argv[3], "a"));
-  ASSERT_EQ(my_strlen(argv[3]), 1);
-  ASSERT_TRUE(my_streq(argv[4], "0"));
-  ASSERT_EQ(my_strlen(argv[4]), 1);
+  ASSERT_STREQ(argv[1], "%s %c %d");
+  ASSERT_STREQ(argv[2], "First arg");
+  ASSERT_STREQ(argv[3], "a");
+  ASSERT_STREQ(argv[4], "0");
 
 #ifndef INTEGRATION_DISABLE_PRINTF
   char buf[100];
-  ASSERT_EQ(
-      LIBC_NAMESPACE::sprintf(buf, argv[1], argv[2], argv[3][0], argv[4][0]),
-      14);
-  ASSERT_TRUE(my_streq(buf, "First arg a 48"));
+  ASSERT_EQ(sprintf(buf, argv[1], argv[2], argv[3][0], argv[4][0]), 14);
+  ASSERT_STREQ(buf, "First arg a 48");
 #endif
 
   return 0;

--- a/libc/test/integration/src/stdlib/getenv_test.cpp
+++ b/libc/test/integration/src/stdlib/getenv_test.cpp
@@ -6,43 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/stdlib/getenv.h"
-
 #include "test/IntegrationTest/test.h"
 
-static bool my_streq(const char *lhs, const char *rhs) {
-  if (lhs == rhs)
-    return true;
-  if (((lhs == static_cast<char *>(nullptr)) &&
-       (rhs != static_cast<char *>(nullptr))) ||
-      ((lhs != static_cast<char *>(nullptr)) &&
-       (rhs == static_cast<char *>(nullptr)))) {
-    return false;
-  }
-  const char *l, *r;
-  for (l = lhs, r = rhs; *l != '\0' && *r != '\0'; ++l, ++r)
-    if (*l != *r)
-      return false;
-
-  return *l == '\0' && *r == '\0';
-}
+#include <stdlib.h> // getenv
 
 TEST_MAIN(int argc, char **argv, char **envp) {
-  ASSERT_TRUE(
-      my_streq(LIBC_NAMESPACE::getenv(""), static_cast<char *>(nullptr)));
-  ASSERT_TRUE(
-      my_streq(LIBC_NAMESPACE::getenv("="), static_cast<char *>(nullptr)));
-  ASSERT_TRUE(my_streq(LIBC_NAMESPACE::getenv("MISSING ENV VARIABLE"),
-                       static_cast<char *>(nullptr)));
-  ASSERT_FALSE(
-      my_streq(LIBC_NAMESPACE::getenv("PATH"), static_cast<char *>(nullptr)));
-  ASSERT_TRUE(my_streq(LIBC_NAMESPACE::getenv("FRANCE"), "Paris"));
-  ASSERT_FALSE(my_streq(LIBC_NAMESPACE::getenv("FRANCE"), "Berlin"));
-  ASSERT_TRUE(my_streq(LIBC_NAMESPACE::getenv("GERMANY"), "Berlin"));
-  ASSERT_TRUE(
-      my_streq(LIBC_NAMESPACE::getenv("FRANC"), static_cast<char *>(nullptr)));
-  ASSERT_TRUE(my_streq(LIBC_NAMESPACE::getenv("FRANCE1"),
-                       static_cast<char *>(nullptr)));
-
+  ASSERT_STREQ(getenv(""), nullptr);
+  ASSERT_STREQ(getenv("="), nullptr);
+  ASSERT_STREQ(getenv("MISSING ENV VARIABLE"), nullptr);
+  ASSERT_STRNE(getenv("PATH"), nullptr);
+  ASSERT_STREQ(getenv("FRANCE"), "Paris");
+  ASSERT_STRNE(getenv("FRANCE"), "Berlin");
+  ASSERT_STREQ(getenv("GERMANY"), "Berlin");
+  ASSERT_STREQ(getenv("FRANC"), nullptr);
+  ASSERT_STREQ(getenv("FRANCE1"), nullptr);
   return 0;
 }

--- a/libc/test/integration/src/threads/cnd_test.cpp
+++ b/libc/test/integration/src/threads/cnd_test.cpp
@@ -7,17 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/atomic.h"
-#include "src/threads/cnd_broadcast.h"
-#include "src/threads/cnd_destroy.h"
-#include "src/threads/cnd_init.h"
-#include "src/threads/cnd_signal.h"
-#include "src/threads/cnd_wait.h"
-#include "src/threads/mtx_destroy.h"
-#include "src/threads/mtx_init.h"
-#include "src/threads/mtx_lock.h"
-#include "src/threads/mtx_unlock.h"
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_join.h"
 
 #include "test/IntegrationTest/test.h"
 
@@ -42,51 +31,51 @@ static cnd_t broadcast_cnd, threads_ready_cnd;
 static mtx_t broadcast_mtx, threads_ready_mtx;
 
 int broadcast_thread_func(void *) {
-  LIBC_NAMESPACE::mtx_lock(&broadcast_mtx);
+  mtx_lock(&broadcast_mtx);
   unsigned oldval = broadcast_count.fetch_add(1);
   if (oldval == THRD_COUNT - 1) {
-    LIBC_NAMESPACE::mtx_lock(&threads_ready_mtx);
-    LIBC_NAMESPACE::cnd_signal(&threads_ready_cnd);
-    LIBC_NAMESPACE::mtx_unlock(&threads_ready_mtx);
+    mtx_lock(&threads_ready_mtx);
+    cnd_signal(&threads_ready_cnd);
+    mtx_unlock(&threads_ready_mtx);
   }
 
-  LIBC_NAMESPACE::cnd_wait(&broadcast_cnd, &broadcast_mtx);
-  LIBC_NAMESPACE::mtx_unlock(&broadcast_mtx);
+  cnd_wait(&broadcast_cnd, &broadcast_mtx);
+  mtx_unlock(&broadcast_mtx);
   broadcast_count.fetch_sub(1);
   return 0;
 }
 
 void wait_notify_broadcast_test() {
-  LIBC_NAMESPACE::cnd_init(&broadcast_cnd);
-  LIBC_NAMESPACE::cnd_init(&threads_ready_cnd);
-  LIBC_NAMESPACE::mtx_init(&broadcast_mtx, mtx_plain);
-  LIBC_NAMESPACE::mtx_init(&threads_ready_mtx, mtx_plain);
+  cnd_init(&broadcast_cnd);
+  cnd_init(&threads_ready_cnd);
+  mtx_init(&broadcast_mtx, mtx_plain);
+  mtx_init(&threads_ready_mtx, mtx_plain);
 
-  LIBC_NAMESPACE::mtx_lock(&threads_ready_mtx);
+  mtx_lock(&threads_ready_mtx);
   thrd_t threads[THRD_COUNT];
   for (unsigned int i = 0; i < THRD_COUNT; ++i)
-    LIBC_NAMESPACE::thrd_create(&threads[i], broadcast_thread_func, nullptr);
+    thrd_create(&threads[i], broadcast_thread_func, nullptr);
 
-  LIBC_NAMESPACE::cnd_wait(&threads_ready_cnd, &threads_ready_mtx);
-  LIBC_NAMESPACE::mtx_unlock(&threads_ready_mtx);
+  cnd_wait(&threads_ready_cnd, &threads_ready_mtx);
+  mtx_unlock(&threads_ready_mtx);
 
-  LIBC_NAMESPACE::mtx_lock(&broadcast_mtx);
+  mtx_lock(&broadcast_mtx);
   ASSERT_EQ(broadcast_count.val, THRD_COUNT);
-  LIBC_NAMESPACE::cnd_broadcast(&broadcast_cnd);
-  LIBC_NAMESPACE::mtx_unlock(&broadcast_mtx);
+  cnd_broadcast(&broadcast_cnd);
+  mtx_unlock(&broadcast_mtx);
 
   for (unsigned int i = 0; i < THRD_COUNT; ++i) {
     int retval = 0xBAD;
-    LIBC_NAMESPACE::thrd_join(threads[i], &retval);
+    thrd_join(threads[i], &retval);
     ASSERT_EQ(retval, 0);
   }
 
   ASSERT_EQ(broadcast_count.val, 0U);
 
-  LIBC_NAMESPACE::cnd_destroy(&broadcast_cnd);
-  LIBC_NAMESPACE::cnd_destroy(&threads_ready_cnd);
-  LIBC_NAMESPACE::mtx_destroy(&broadcast_mtx);
-  LIBC_NAMESPACE::mtx_destroy(&threads_ready_mtx);
+  cnd_destroy(&broadcast_cnd);
+  cnd_destroy(&threads_ready_cnd);
+  mtx_destroy(&broadcast_mtx);
+  mtx_destroy(&threads_ready_mtx);
 }
 
 } // namespace wait_notify_broadcast_test
@@ -101,47 +90,45 @@ mtx_t waiter_mtx, main_thread_mtx;
 cnd_t waiter_cnd, main_thread_cnd;
 
 int waiter_thread_func(void *unused) {
-  LIBC_NAMESPACE::mtx_lock(&waiter_mtx);
+  mtx_lock(&waiter_mtx);
 
-  LIBC_NAMESPACE::mtx_lock(&main_thread_mtx);
-  LIBC_NAMESPACE::cnd_signal(&main_thread_cnd);
-  LIBC_NAMESPACE::mtx_unlock(&main_thread_mtx);
+  mtx_lock(&main_thread_mtx);
+  cnd_signal(&main_thread_cnd);
+  mtx_unlock(&main_thread_mtx);
 
-  LIBC_NAMESPACE::cnd_wait(&waiter_cnd, &waiter_mtx);
-  LIBC_NAMESPACE::mtx_unlock(&waiter_mtx);
+  cnd_wait(&waiter_cnd, &waiter_mtx);
+  mtx_unlock(&waiter_mtx);
 
   return 0x600D;
 }
 
 void single_waiter_test() {
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&waiter_mtx, mtx_plain),
-            int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&main_thread_mtx, mtx_plain),
-            int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::cnd_init(&waiter_cnd), int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::cnd_init(&main_thread_cnd), int(thrd_success));
+  ASSERT_EQ(mtx_init(&waiter_mtx, mtx_plain), int(thrd_success));
+  ASSERT_EQ(mtx_init(&main_thread_mtx, mtx_plain), int(thrd_success));
+  ASSERT_EQ(cnd_init(&waiter_cnd), int(thrd_success));
+  ASSERT_EQ(cnd_init(&main_thread_cnd), int(thrd_success));
 
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&main_thread_mtx), int(thrd_success));
+  ASSERT_EQ(mtx_lock(&main_thread_mtx), int(thrd_success));
 
   thrd_t waiter_thread;
-  LIBC_NAMESPACE::thrd_create(&waiter_thread, waiter_thread_func, nullptr);
+  thrd_create(&waiter_thread, waiter_thread_func, nullptr);
 
-  ASSERT_EQ(LIBC_NAMESPACE::cnd_wait(&main_thread_cnd, &main_thread_mtx),
+  cnd_wait(&main_thread_cnd, &main_thread_mtx),
             int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&main_thread_mtx), int(thrd_success));
+  mtx_unlock(&main_thread_mtx), int(thrd_success));
 
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&waiter_mtx), int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::cnd_signal(&waiter_cnd), int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&waiter_mtx), int(thrd_success));
+  ASSERT_EQ(mtx_lock(&waiter_mtx), int(thrd_success));
+  ASSERT_EQ(cnd_signal(&waiter_cnd), int(thrd_success));
+  mtx_unlock(&waiter_mtx), int(thrd_success));
 
   int retval;
-  LIBC_NAMESPACE::thrd_join(waiter_thread, &retval);
+  thrd_join(waiter_thread, &retval);
   ASSERT_EQ(retval, 0x600D);
 
-  LIBC_NAMESPACE::mtx_destroy(&waiter_mtx);
-  LIBC_NAMESPACE::mtx_destroy(&main_thread_mtx);
-  LIBC_NAMESPACE::cnd_destroy(&waiter_cnd);
-  LIBC_NAMESPACE::cnd_destroy(&main_thread_cnd);
+  mtx_destroy(&waiter_mtx);
+  mtx_destroy(&main_thread_mtx);
+  cnd_destroy(&waiter_cnd);
+  cnd_destroy(&main_thread_cnd);
 }
 
 } // namespace single_waiter_test

--- a/libc/test/integration/src/threads/mtx_test.cpp
+++ b/libc/test/integration/src/threads/mtx_test.cpp
@@ -6,13 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/threads/mtx_destroy.h"
-#include "src/threads/mtx_init.h"
-#include "src/threads/mtx_lock.h"
-#include "src/threads/mtx_unlock.h"
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_join.h"
-
 #include "test/IntegrationTest/test.h"
 
 #include <threads.h>
@@ -26,12 +19,12 @@ static int shared_int = START;
 int counter(void *arg) {
   int last_count = START;
   while (true) {
-    LIBC_NAMESPACE::mtx_lock(&mutex);
+    mtx_lock(&mutex);
     if (shared_int == last_count + 1) {
       shared_int++;
       last_count = shared_int;
     }
-    LIBC_NAMESPACE::mtx_unlock(&mutex);
+    mtx_unlock(&mutex);
     if (last_count >= MAX)
       break;
   }
@@ -39,17 +32,16 @@ int counter(void *arg) {
 }
 
 void relay_counter() {
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&mutex, mtx_plain),
-            static_cast<int>(thrd_success));
+  ASSERT_EQ(mtx_init(&mutex, mtx_plain), static_cast<int>(thrd_success));
 
   // The idea of this test is that two competing threads will update
   // a counter only if the other thread has updated it.
   thrd_t thread;
-  LIBC_NAMESPACE::thrd_create(&thread, counter, nullptr);
+  thrd_create(&thread, counter, nullptr);
 
   int last_count = START;
   while (true) {
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&mutex), static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_lock(&mutex), static_cast<int>(thrd_success));
     if (shared_int == START) {
       ++shared_int;
       last_count = shared_int;
@@ -58,57 +50,51 @@ void relay_counter() {
       ++shared_int;
       last_count = shared_int;
     }
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&mutex),
-              static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_unlock(&mutex), static_cast<int>(thrd_success));
     if (last_count > MAX)
       break;
   }
 
   int retval = 123;
-  LIBC_NAMESPACE::thrd_join(thread, &retval);
+  thrd_join(thread, &retval);
   ASSERT_EQ(retval, 0);
 
-  LIBC_NAMESPACE::mtx_destroy(&mutex);
+  mtx_destroy(&mutex);
 }
 
 mtx_t start_lock, step_lock;
 bool started, step;
 
 int stepper(void *arg) {
-  LIBC_NAMESPACE::mtx_lock(&start_lock);
+  mtx_lock(&start_lock);
   started = true;
-  LIBC_NAMESPACE::mtx_unlock(&start_lock);
+  mtx_unlock(&start_lock);
 
-  LIBC_NAMESPACE::mtx_lock(&step_lock);
+  mtx_lock(&step_lock);
   step = true;
-  LIBC_NAMESPACE::mtx_unlock(&step_lock);
+  mtx_unlock(&step_lock);
   return 0;
 }
 
 void wait_and_step() {
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&start_lock, mtx_plain),
-            static_cast<int>(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&step_lock, mtx_plain),
-            static_cast<int>(thrd_success));
+  ASSERT_EQ(mtx_init(&start_lock, mtx_plain), static_cast<int>(thrd_success));
+  ASSERT_EQ(mtx_init(&step_lock, mtx_plain), static_cast<int>(thrd_success));
 
   // In this test, we start a new thread but block it before it can make a
   // step. Once we ensure that the thread is blocked, we unblock it.
   // After unblocking, we then verify that the thread was indeed unblocked.
   step = false;
   started = false;
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&step_lock),
-            static_cast<int>(thrd_success));
+  ASSERT_EQ(mtx_lock(&step_lock), static_cast<int>(thrd_success));
 
   thrd_t thread;
-  LIBC_NAMESPACE::thrd_create(&thread, stepper, nullptr);
+  thrd_create(&thread, stepper, nullptr);
 
   while (true) {
     // Make sure the thread actually started.
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&start_lock),
-              static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_lock(&start_lock), static_cast<int>(thrd_success));
     bool s = started;
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&start_lock),
-              static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_unlock(&start_lock), static_cast<int>(thrd_success));
     if (s)
       break;
   }
@@ -117,25 +103,22 @@ void wait_and_step() {
   ASSERT_FALSE(step);
 
   // Unlock the step lock and wait until the step is made.
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&step_lock),
-            static_cast<int>(thrd_success));
+  ASSERT_EQ(mtx_unlock(&step_lock), static_cast<int>(thrd_success));
 
   while (true) {
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&step_lock),
-              static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_lock(&step_lock), static_cast<int>(thrd_success));
     bool current_step_value = step;
-    ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&step_lock),
-              static_cast<int>(thrd_success));
+    ASSERT_EQ(mtx_unlock(&step_lock), static_cast<int>(thrd_success));
     if (current_step_value)
       break;
   }
 
   int retval = 123;
-  LIBC_NAMESPACE::thrd_join(thread, &retval);
+  thrd_join(thread, &retval);
   ASSERT_EQ(retval, 0);
 
-  LIBC_NAMESPACE::mtx_destroy(&start_lock);
-  LIBC_NAMESPACE::mtx_destroy(&step_lock);
+  mtx_destroy(&start_lock);
+  mtx_destroy(&step_lock);
 }
 
 static constexpr int THREAD_COUNT = 10;
@@ -144,54 +127,54 @@ static mtx_t counter_lock;
 static int wait_count = 0;
 
 int waiter_func(void *) {
-  LIBC_NAMESPACE::mtx_lock(&counter_lock);
+  mtx_lock(&counter_lock);
   ++wait_count;
-  LIBC_NAMESPACE::mtx_unlock(&counter_lock);
+  mtx_unlock(&counter_lock);
 
   // Block on the waiter lock until the main
   // thread unblocks.
-  LIBC_NAMESPACE::mtx_lock(&multiple_waiter_lock);
-  LIBC_NAMESPACE::mtx_unlock(&multiple_waiter_lock);
+  mtx_lock(&multiple_waiter_lock);
+  mtx_unlock(&multiple_waiter_lock);
 
-  LIBC_NAMESPACE::mtx_lock(&counter_lock);
+  mtx_lock(&counter_lock);
   --wait_count;
-  LIBC_NAMESPACE::mtx_unlock(&counter_lock);
+  mtx_unlock(&counter_lock);
 
   return 0;
 }
 
 void multiple_waiters() {
-  LIBC_NAMESPACE::mtx_init(&multiple_waiter_lock, mtx_plain);
-  LIBC_NAMESPACE::mtx_init(&counter_lock, mtx_plain);
+  mtx_init(&multiple_waiter_lock, mtx_plain);
+  mtx_init(&counter_lock, mtx_plain);
 
-  LIBC_NAMESPACE::mtx_lock(&multiple_waiter_lock);
+  mtx_lock(&multiple_waiter_lock);
   thrd_t waiters[THREAD_COUNT];
   for (int i = 0; i < THREAD_COUNT; ++i) {
-    LIBC_NAMESPACE::thrd_create(waiters + i, waiter_func, nullptr);
+    thrd_create(waiters + i, waiter_func, nullptr);
   }
 
   // Spin until the counter is incremented to the desired
   // value.
   while (true) {
-    LIBC_NAMESPACE::mtx_lock(&counter_lock);
+    mtx_lock(&counter_lock);
     if (wait_count == THREAD_COUNT) {
-      LIBC_NAMESPACE::mtx_unlock(&counter_lock);
+      mtx_unlock(&counter_lock);
       break;
     }
-    LIBC_NAMESPACE::mtx_unlock(&counter_lock);
+    mtx_unlock(&counter_lock);
   }
 
-  LIBC_NAMESPACE::mtx_unlock(&multiple_waiter_lock);
+  mtx_unlock(&multiple_waiter_lock);
 
   int retval;
   for (int i = 0; i < THREAD_COUNT; ++i) {
-    LIBC_NAMESPACE::thrd_join(waiters[i], &retval);
+    thrd_join(waiters[i], &retval);
   }
 
   ASSERT_EQ(wait_count, 0);
 
-  LIBC_NAMESPACE::mtx_destroy(&multiple_waiter_lock);
-  LIBC_NAMESPACE::mtx_destroy(&counter_lock);
+  mtx_destroy(&multiple_waiter_lock);
+  mtx_destroy(&counter_lock);
 }
 
 TEST_MAIN() {

--- a/libc/test/integration/src/threads/thrd_equal_test.cpp
+++ b/libc/test/integration/src/threads/thrd_equal_test.cpp
@@ -6,15 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/threads/mtx_destroy.h"
-#include "src/threads/mtx_init.h"
-#include "src/threads/mtx_lock.h"
-#include "src/threads/mtx_unlock.h"
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_current.h"
-#include "src/threads/thrd_equal.h"
-#include "src/threads/thrd_join.h"
-
 #include "test/IntegrationTest/test.h"
 
 #include <threads.h>
@@ -23,21 +14,21 @@ thrd_t child_thread;
 mtx_t mutex;
 
 static int child_func(void *arg) {
-  LIBC_NAMESPACE::mtx_lock(&mutex);
+  mtx_lock(&mutex);
   int *ret = reinterpret_cast<int *>(arg);
-  auto self = LIBC_NAMESPACE::thrd_current();
-  *ret = LIBC_NAMESPACE::thrd_equal(child_thread, self);
-  LIBC_NAMESPACE::mtx_unlock(&mutex);
+  auto self = thrd_current();
+  *ret = thrd_equal(child_thread, self);
+  mtx_unlock(&mutex);
   return 0;
 }
 
 TEST_MAIN() {
   // We init and lock the mutex so that we guarantee that the child thread is
   // waiting after startup.
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_init(&mutex, mtx_plain), int(thrd_success));
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_lock(&mutex), int(thrd_success));
+  ASSERT_EQ(mtx_init(&mutex, mtx_plain), int(thrd_success));
+  ASSERT_EQ(mtx_lock(&mutex), int(thrd_success));
 
-  auto main_thread = LIBC_NAMESPACE::thrd_current();
+  auto main_thread = thrd_current();
 
   // The idea here is that, we start a child thread which will immediately
   // wait on |mutex|. The main thread will update the global |child_thread| var
@@ -46,23 +37,22 @@ TEST_MAIN() {
   // comparison is returned in the thread arg.
   int result = 0;
   thrd_t th;
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_create(&th, child_func, &result),
-            int(thrd_success));
+  ASSERT_EQ(thrd_create(&th, child_func, &result), int(thrd_success));
   // This new thread should of course not be equal to the main thread.
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_equal(th, main_thread), 0);
+  ASSERT_EQ(thrd_equal(th, main_thread), 0);
 
   // Set the |child_thread| global var and unlock to allow the child to perform
   // the comparison.
   child_thread = th;
-  ASSERT_EQ(LIBC_NAMESPACE::mtx_unlock(&mutex), int(thrd_success));
+  ASSERT_EQ(mtx_unlock(&mutex), int(thrd_success));
 
   int retval;
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_join(th, &retval), int(thrd_success));
+  ASSERT_EQ(thrd_join(th, &retval), int(thrd_success));
   ASSERT_EQ(retval, 0);
   // The child thread should see that thrd_current return value is the same as
   // |child_thread|.
   ASSERT_NE(result, 0);
 
-  LIBC_NAMESPACE::mtx_destroy(&mutex);
+  mtx_destroy(&mutex);
   return 0;
 }

--- a/libc/test/integration/src/threads/thrd_exit_test.cpp
+++ b/libc/test/integration/src/threads/thrd_exit_test.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_exit.h"
-#include "src/threads/thrd_join.h"
 #include "test/IntegrationTest/test.h"
 
 #include <threads.h>
@@ -33,7 +30,7 @@ thread_local A thread_local_a(123);
 
 int func(void *) {
   thread_local_a.set(321);
-  LIBC_NAMESPACE::thrd_exit(0);
+  thrd_exit(0);
   return 0;
 }
 
@@ -41,11 +38,11 @@ TEST_MAIN() {
   thrd_t th;
   int retval;
 
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_create(&th, func, nullptr), thrd_success);
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_join(th, &retval), thrd_success);
+  ASSERT_EQ(thrd_create(&th, func, nullptr), thrd_success);
+  ASSERT_EQ(thrd_join(th, &retval), thrd_success);
 
   ASSERT_TRUE(dtor_called);
-  LIBC_NAMESPACE::thrd_exit(0);
+  thrd_exit(0);
   return 0;
 }
 

--- a/libc/test/integration/src/threads/thrd_test.cpp
+++ b/libc/test/integration/src/threads/thrd_test.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_join.h"
-
 #include "test/IntegrationTest/test.h"
 
 #include <threads.h>
@@ -24,10 +21,9 @@ void create_and_join() {
   for (counter = 0; counter <= thread_count;) {
     thrd_t thread;
     int old_counter_val = counter;
-    ASSERT_EQ(LIBC_NAMESPACE::thrd_create(&thread, thread_func, nullptr),
-              (int)thrd_success);
+    ASSERT_EQ(thrd_create(&thread, thread_func, nullptr), (int)thrd_success);
     int retval = thread_count + 1; // Start with a retval we dont expect.
-    ASSERT_EQ(LIBC_NAMESPACE::thrd_join(thread, &retval), (int)thrd_success);
+    ASSERT_EQ(thrd_join(thread, &retval), (int)thrd_success);
     ASSERT_EQ(retval, 0);
     ASSERT_EQ(counter, old_counter_val + 1);
   }
@@ -41,15 +37,13 @@ void spawn_and_join() {
 
   for (int i = 0; i < thread_count; ++i) {
     args[i] = i;
-    ASSERT_EQ(
-        LIBC_NAMESPACE::thrd_create(thread_list + i, return_arg, args + i),
-        (int)thrd_success);
+    ASSERT_EQ(thrd_create(thread_list + i, return_arg, args + i),
+              (int)thrd_success);
   }
 
   for (int i = 0; i < thread_count; ++i) {
     int retval = thread_count + 1; // Start with a retval we dont expect.
-    ASSERT_EQ(LIBC_NAMESPACE::thrd_join(thread_list[i], &retval),
-              (int)thrd_success);
+    ASSERT_EQ(thrd_join(thread_list[i], &retval), (int)thrd_success);
     ASSERT_EQ(retval, i);
   }
 }

--- a/libc/test/integration/src/threads/tss_test.cpp
+++ b/libc/test/integration/src/threads/tss_test.cpp
@@ -6,13 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/threads/thrd_create.h"
-#include "src/threads/thrd_exit.h"
-#include "src/threads/thrd_join.h"
-#include "src/threads/tss_create.h"
-#include "src/threads/tss_delete.h"
-#include "src/threads/tss_get.h"
-#include "src/threads/tss_set.h"
 #include "test/IntegrationTest/test.h"
 
 #include <threads.h>
@@ -31,8 +24,8 @@ void dtor(void *data) {
 }
 
 int func(void *obj) {
-  ASSERT_EQ(LIBC_NAMESPACE::tss_set(key, &child_thread_data), thrd_success);
-  int *d = reinterpret_cast<int *>(LIBC_NAMESPACE::tss_get(key));
+  ASSERT_EQ(tss_set(key, &child_thread_data), thrd_success);
+  int *d = reinterpret_cast<int *>(tss_get(key));
   ASSERT_TRUE(d != nullptr);
   ASSERT_EQ(&child_thread_data, d);
   ASSERT_EQ(*d, THREAD_DATA_INITVAL);
@@ -41,23 +34,23 @@ int func(void *obj) {
 }
 
 TEST_MAIN() {
-  ASSERT_EQ(LIBC_NAMESPACE::tss_create(&key, &dtor), thrd_success);
-  ASSERT_EQ(LIBC_NAMESPACE::tss_set(key, &main_thread_data), thrd_success);
-  int *d = reinterpret_cast<int *>(LIBC_NAMESPACE::tss_get(key));
+  ASSERT_EQ(tss_create(&key, &dtor), thrd_success);
+  ASSERT_EQ(tss_set(key, &main_thread_data), thrd_success);
+  int *d = reinterpret_cast<int *>(tss_get(key));
   ASSERT_TRUE(d != nullptr);
   ASSERT_EQ(&main_thread_data, d);
   ASSERT_EQ(*d, THREAD_DATA_INITVAL);
 
   thrd_t th;
   int arg = 0xBAD;
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_create(&th, &func, &arg), thrd_success);
+  ASSERT_EQ(thrd_create(&th, &func, &arg), thrd_success);
   int retval = THREAD_DATA_INITVAL; // Init to some non-zero val.
-  ASSERT_EQ(LIBC_NAMESPACE::thrd_join(th, &retval), thrd_success);
+  ASSERT_EQ(thrd_join(th, &retval), thrd_success);
   ASSERT_EQ(retval, 0);
   ASSERT_EQ(arg, THREAD_RUN_VAL);
   ASSERT_EQ(child_thread_data, THREAD_DATA_FINIVAL);
 
-  LIBC_NAMESPACE::tss_delete(key);
+  tss_delete(key);
 
   return 0;
 }

--- a/libc/test/integration/src/unistd/CMakeLists.txt
+++ b/libc/test/integration/src/unistd/CMakeLists.txt
@@ -8,7 +8,6 @@ add_integration_test(
   SRCS
     getcwd_test.cpp
   DEPENDS
-    libc.src.__support.CPP.string_view
     libc.src.errno.errno
     libc.src.stdlib.getenv
     libc.src.unistd.getcwd
@@ -90,7 +89,7 @@ add_integration_test(
   DEPENDS
     libc_execv_test_normal_exit
     libc_execv_test_signal_exit
-    libc.include.errno
+    libc.src.errno.errno
     libc.src.sys.wait.waitpid
     libc.src.unistd.execv
     libc.src.unistd.fork

--- a/libc/test/integration/src/unistd/execv_test.cpp
+++ b/libc/test/integration/src/unistd/execv_test.cpp
@@ -6,46 +6,43 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/sys/wait/waitpid.h"
-#include "src/unistd/execv.h"
-#include "src/unistd/fork.h"
-
 #include "test/IntegrationTest/test.h"
 
-#include <signal.h>
-#include <sys/wait.h>
+#include <signal.h>   // SIGUSR1
+#include <sys/wait.h> // waitpid
+#include <unistd.h>   // fork, execv
 
 void fork_and_execv_normal_exit() {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     const char *path = "libc_execv_test_normal_exit";
     char *const argv[] = {
         const_cast<char *>("execv_test_normal_exit"),
         nullptr,
     };
-    LIBC_NAMESPACE::execv(path, argv);
+    execv(path, argv);
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::waitpid(pid, &status, 0);
+  pid_t cpid = waitpid(pid, &status, 0);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_TRUE(WIFEXITED(status));
 }
 
 void fork_and_execv_signal_exit() {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     const char *path = "libc_execv_test_signal_exit";
     char *const argv[] = {
         const_cast<char *>("execv_test_normal_exit"),
         nullptr,
     };
-    LIBC_NAMESPACE::execv(path, argv);
+    execv(path, argv);
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::waitpid(pid, &status, 0);
+  pid_t cpid = waitpid(pid, &status, 0);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_FALSE(WIFEXITED(status));

--- a/libc/test/integration/src/unistd/execv_test_normal_exit.cpp
+++ b/libc/test/integration/src/unistd/execv_test_normal_exit.cpp
@@ -1,6 +1,6 @@
-#include <signal.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <signal.h> // SIGUSR1
+#include <stdlib.h> // getenv
+#include <unistd.h> // raise
 
 int main() {
   char *env = getenv("EXECV_TEST");

--- a/libc/test/integration/src/unistd/execv_test_signal_exit.cpp
+++ b/libc/test/integration/src/unistd/execv_test_signal_exit.cpp
@@ -1,6 +1,6 @@
-#include <signal.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <signal.h> // SIGUSR1
+#include <stdlib.h> // getenv
+#include <unistd.h> // raise
 
 int main() {
   char *env = getenv("__MISSING_ENV_VAR__");

--- a/libc/test/integration/src/unistd/execve_test.cpp
+++ b/libc/test/integration/src/unistd/execve_test.cpp
@@ -6,46 +6,43 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/sys/wait/waitpid.h"
-#include "src/unistd/execve.h"
-#include "src/unistd/fork.h"
-
 #include "test/IntegrationTest/test.h"
 
-#include <signal.h>
-#include <sys/wait.h>
+#include <signal.h>   // SIGUSR1
+#include <sys/wait.h> // waitpid
+#include <unistd.h>   // fork, execve
 
 void fork_and_execv_normal_exit(char **envp) {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     const char *path = "libc_execv_test_normal_exit";
     char *const argv[] = {
         const_cast<char *>("execv_test_normal_exit"),
         nullptr,
     };
-    LIBC_NAMESPACE::execve(path, argv, envp);
+    execve(path, argv, envp);
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::waitpid(pid, &status, 0);
+  pid_t cpid = waitpid(pid, &status, 0);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_TRUE(WIFEXITED(status));
 }
 
 void fork_and_execv_signal_exit(char **envp) {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     const char *path = "libc_execv_test_signal_exit";
     char *const argv[] = {
         const_cast<char *>("execv_test_normal_exit"),
         nullptr,
     };
-    LIBC_NAMESPACE::execve(path, argv, envp);
+    execve(path, argv, envp);
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::waitpid(pid, &status, 0);
+  pid_t cpid = waitpid(pid, &status, 0);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_FALSE(WIFEXITED(status));

--- a/libc/test/integration/src/unistd/getcwd_test.cpp
+++ b/libc/test/integration/src/unistd/getcwd_test.cpp
@@ -6,35 +6,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/string_view.h"
-#include "src/errno/libc_errno.h"
-#include "src/stdlib/getenv.h"
-#include "src/unistd/getcwd.h"
-
 #include "test/IntegrationTest/test.h"
 
-#include <stdlib.h> // For malloc and free
-
-using LIBC_NAMESPACE::cpp::string_view;
+#include <errno.h>  // errno
+#include <stdlib.h> // getenv
+#include <unistd.h> // getcwd
 
 TEST_MAIN(int argc, char **argv, char **envp) {
   char buffer[1024];
-  ASSERT_TRUE(string_view(LIBC_NAMESPACE::getenv("PWD")) ==
-              LIBC_NAMESPACE::getcwd(buffer, 1024));
+  ASSERT_STREQ(getenv("PWD"), getcwd(buffer, 1024));
 
   // nullptr buffer
-  char *cwd = LIBC_NAMESPACE::getcwd(nullptr, 0);
-  ASSERT_TRUE(string_view(LIBC_NAMESPACE::getenv("PWD")) == cwd);
+  char *cwd = getcwd(nullptr, 0);
+  ASSERT_STREQ(getenv("PWD"), cwd);
   free(cwd);
 
   // Bad size
-  cwd = LIBC_NAMESPACE::getcwd(buffer, 0);
+  cwd = getcwd(buffer, 0);
   ASSERT_TRUE(cwd == nullptr);
   ASSERT_ERRNO_EQ(EINVAL);
   LIBC_NAMESPACE::libc_errno = 0;
 
   // Insufficient size
-  cwd = LIBC_NAMESPACE::getcwd(buffer, 2);
+  cwd = getcwd(buffer, 2);
   ASSERT_TRUE(cwd == nullptr);
   int err = LIBC_NAMESPACE::libc_errno;
   ASSERT_EQ(err, ERANGE);

--- a/libc/test/integration/src/unistd/stack_smashing_test.cpp
+++ b/libc/test/integration/src/unistd/stack_smashing_test.cpp
@@ -8,22 +8,16 @@
 
 #include "src/__support/CPP/string.h"
 #include "src/__support/OSUtil/io.h"
-#include "src/pthread/pthread_atfork.h"
-#include "src/signal/raise.h"
-#include "src/sys/wait/wait.h"
-#include "src/sys/wait/wait4.h"
-#include "src/sys/wait/waitpid.h"
-#include "src/unistd/fork.h"
 
 #include "test/IntegrationTest/test.h"
 
 #include <errno.h>
-#include <signal.h>
-#include <sys/wait.h>
-#include <unistd.h>
+#include <signal.h>   // SIGABRT
+#include <sys/wait.h> // wait
+#include <unistd.h>   // fork
 
 void no_stack_smashing_normal_exit() {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     // Child process
     char foo[30];
@@ -33,14 +27,14 @@ void no_stack_smashing_normal_exit() {
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::wait(&status);
+  pid_t cpid = wait(&status);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_TRUE(WIFEXITED(status));
 }
 
 void stack_smashing_abort() {
-  pid_t pid = LIBC_NAMESPACE::fork();
+  pid_t pid = fork();
   if (pid == 0) {
     // Child process
     char foo[30];
@@ -55,7 +49,7 @@ void stack_smashing_abort() {
   }
   ASSERT_TRUE(pid > 0);
   int status;
-  pid_t cpid = LIBC_NAMESPACE::wait(&status);
+  pid_t cpid = wait(&status);
   ASSERT_TRUE(cpid > 0);
   ASSERT_EQ(cpid, pid);
   ASSERT_TRUE(WTERMSIG(status) == SIGABRT);

--- a/libc/test/integration/startup/linux/args_test.cpp
+++ b/libc/test/integration/startup/linux/args_test.cpp
@@ -8,31 +8,13 @@
 
 #include "test/IntegrationTest/test.h"
 
-static bool my_streq(const char *lhs, const char *rhs) {
-  const char *l, *r;
-  for (l = lhs, r = rhs; *l != '\0' && *r != '\0'; ++l, ++r)
-    if (*l != *r)
-      return false;
-
-  return *l == '\0' && *r == '\0';
-}
-
 TEST_MAIN(int argc, char **argv, char **envp) {
   ASSERT_TRUE(argc == 4);
-  ASSERT_TRUE(my_streq(argv[1], "1"));
-  ASSERT_TRUE(my_streq(argv[2], "2"));
-  ASSERT_TRUE(my_streq(argv[3], "3"));
-
-  bool found_france = false;
-  bool found_germany = false;
-  for (; *envp != nullptr; ++envp) {
-    if (my_streq(*envp, "FRANCE=Paris"))
-      found_france = true;
-    if (my_streq(*envp, "GERMANY=Berlin"))
-      found_germany = true;
-  }
-
-  ASSERT_TRUE(found_france && found_germany);
-
+  ASSERT_STREQ(argv[1], "1");
+  ASSERT_STREQ(argv[2], "2");
+  ASSERT_STREQ(argv[3], "3");
+  ASSERT_STREQ(envp[0], "FRANCE=Paris");
+  ASSERT_STREQ(envp[1], "GERMANY=Berlin");
+  ASSERT_STREQ(envp[2], nullptr);
   return 0;
 }

--- a/libc/test/integration/startup/linux/tls_test.cpp
+++ b/libc/test/integration/startup/linux/tls_test.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
-#include "src/sys/mman/mmap.h"
 #include "test/IntegrationTest/test.h"
 
 #include <errno.h>
@@ -17,20 +15,19 @@ constexpr int threadLocalDataSize = 101;
 _Thread_local int a[threadLocalDataSize] = {123};
 
 TEST_MAIN(int argc, char **argv, char **envp) {
-  ASSERT_TRUE(a[0] == 123);
+  ASSERT_EQ(a[0], 123);
 
   for (int i = 1; i < threadLocalDataSize; ++i)
     a[i] = i;
   for (int i = 1; i < threadLocalDataSize; ++i)
-    ASSERT_TRUE(a[i] == i);
+    ASSERT_EQ(a[i], i);
 
   // Call mmap with bad params so that an error value is
   // set in errno. Since errno is implemented using a thread
   // local var, this helps us test setting of errno and
   // reading it back.
   ASSERT_ERRNO_SUCCESS();
-  void *addr = LIBC_NAMESPACE::mmap(nullptr, 0, PROT_READ,
-                                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  void *addr = mmap(nullptr, 0, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   ASSERT_TRUE(addr == MAP_FAILED);
   ASSERT_ERRNO_EQ(EINVAL);
 

--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -99,16 +99,17 @@ file(GLOB spec_files ${LIBC_SOURCE_DIR}/spec/*.td)
 
 # Generate api test souce code.
 add_custom_command(
-  OUTPUT ${public_test}
-  COMMAND $<TARGET_FILE:libc-prototype-testgen> -o ${public_test}
-          ${entrypoints_name_list}
-          -I ${LIBC_SOURCE_DIR}
-          ${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/api.td
-
-  DEPENDS ${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/api.td ${spec_files}
-          libc-prototype-testgen ${TARGET_PUBLIC_HEADERS}
-          ${LIBC_TARGET}
+  OUTPUT "${public_test}"
+  COMMAND "$<TARGET_FILE:libc-prototype-testgen> -o ${public_test} ${entrypoints_name_list} -I ${LIBC_SOURCE_DIR} ${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/api.td"
+  DEPENDS 
+    ${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/api.td
+    ${spec_files}
+    libc-prototype-testgen
+    ${TARGET_PUBLIC_HEADERS}
+    ${LIBC_TARGET}
 )
+
+# message(FATAL_ERROR "${public_test}")
 
 add_custom_target(libc-api-test)
 add_dependencies(check-libc libc-api-test)

--- a/libc/utils/HdrGen/PrototypeTestGen/CMakeLists.txt
+++ b/libc/utils/HdrGen/PrototypeTestGen/CMakeLists.txt
@@ -1,5 +1,17 @@
+include(TableGen)
+
+set(LLVM_LINK_COMPONENTS Support)
+
 add_tablegen(libc-prototype-testgen LLVM_LIBC
   PrototypeTestGen.cpp
 )
-target_link_libraries(libc-prototype-testgen PRIVATE LibcTableGenUtil)
-target_include_directories(libc-prototype-testgen PRIVATE ${LIBC_SOURCE_DIR})
+target_link_libraries(libc-prototype-testgen
+  PRIVATE
+    LibcTableGenUtil
+)
+target_include_directories(libc-prototype-testgen
+  PRIVATE
+    ${LIBC_SOURCE_DIR}
+    ${LLVM_INCLUDE_DIR}
+    ${LLVM_MAIN_INCLUDE_DIR}
+)


### PR DESCRIPTION
This patch migrates integration tests so they use the public C API.