### PR TITLE
[MLIR] NFC: Change dyn_cast to isa to prevent warning

### DIFF
--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -2953,8 +2953,7 @@ void OpEmitter::buildParamList(SmallVectorImpl<MethodParameter> &paramList,
                              operand->isOptional());
       continue;
     }
-    if ([[maybe_unused]] const auto *operand =
-            llvm::dyn_cast_if_present<NamedProperty *>(arg)) {
+    if (llvm::isa_and_present<NamedProperty *>(arg)) {
       // TODO
       continue;
     }


### PR DESCRIPTION
This is to avoid warnings when invoked from the flang documentation generation build.

The warning can be seen in the CI (https://lab.llvm.org/buildbot/#/builders/89/builds/57451).
```
/home/buildbot/as-worker-4/publish-sphinx-docs/llvm-project/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp:2956:38: warning: unused variable ‘operand’ [-Wunused-variable]
```
