### PR TITLE
[X86] Use ".lrodata" prefix for large mergeable constants

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -635,7 +635,8 @@ static SmallString<128>
 getELFSectionNameForGlobal(const GlobalObject *GO, SectionKind Kind,
                            Mangler &Mang, const TargetMachine &TM,
                            unsigned EntrySize, bool UniqueSectionName) {
-  SmallString<128> Name;
+  SmallString<128> Name =
+      getSectionPrefixForGlobal(Kind, TM.isLargeGlobalValue(GO));
   if (Kind.isMergeableCString()) {
     // We also need alignment here.
     // FIXME: this is getting the alignment of the character, not the
@@ -643,13 +644,13 @@ getELFSectionNameForGlobal(const GlobalObject *GO, SectionKind Kind,
     Align Alignment = GO->getParent()->getDataLayout().getPreferredAlign(
         cast<GlobalVariable>(GO));
 
-    std::string SizeSpec = ".rodata.str" + utostr(EntrySize) + ".";
-    Name = SizeSpec + utostr(Alignment.value());
-  } else if (Kind.isMergeableConst()) {
-    Name = ".rodata.cst";
+    Name += ".str";
     Name += utostr(EntrySize);
-  } else {
-    Name = getSectionPrefixForGlobal(Kind, TM.isLargeGlobalValue(GO));
+    Name += ".";
+    Name += utostr(Alignment.value());
+  } else if (Kind.isMergeableConst()) {
+    Name += ".cst";
+    Name += utostr(EntrySize);
   }
 
   bool HasPrefix = false;

--- a/llvm/test/CodeGen/X86/code-model-elf-merge-sections.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf-merge-sections.ll
@@ -1,0 +1,16 @@
+; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=medium -large-data-threshold=0 -o %t
+; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE
+; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=medium -large-data-threshold=99 -o %t
+; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL
+
+; LARGE: .lrodata.str4.4 {{.*}} AMSl
+; LARGE: .lrodata.cst8 {{.*}} AMl
+
+; SMALL: .rodata.str4.4 {{.*}} AMS
+; SMALL: .rodata.cst8 {{.*}} AM
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@str = internal unnamed_addr constant [3 x i32] [i32 1, i32 2, i32 0]
+@merge = internal unnamed_addr constant i64 2


### PR DESCRIPTION
Otherwise with a small enough large-data-threshold, we can get .rodata.* sections marked large, making .rodata large in the final binary.