### PR TITLE
[AMDGPU] Consolidate SGPRSpill and VGPRSpill into single Spill bit

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -88,7 +88,7 @@ enum : uint64_t {
   DS = 1 << 25,
 
   // Combined SGPR/VGPR Spill bit
-  // logic to seperate them out is done in isSGPRSpill and isVGPRSpill
+  // Logic to separate them out is done in isSGPRSpill and isVGPRSpill
   Spill = 1 << 26,
 
   // LDSDIR instruction format.

--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -87,9 +87,9 @@ enum : uint64_t {
   FLAT = 1 << 24,
   DS = 1 << 25,
 
-  // Pseudo instruction formats.
-  VGPRSpill = 1 << 26,
-  SGPRSpill = 1 << 27,
+  // Combined SGPR/VGPR Spill bit
+  // logic to seperate them out is done in isSGPRSpill and isVGPRSpill
+  Spill = 1 << 26,
 
   // LDSDIR instruction format.
   LDSDIR = 1 << 28,

--- a/llvm/lib/Target/AMDGPU/SIInstrFormats.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrFormats.td
@@ -46,9 +46,8 @@ class InstSI <dag outs, dag ins, string asm = "",
   field bit FLAT = 0;
   field bit DS = 0;
 
-  // Pseudo instruction formats.
-  field bit VGPRSpill = 0;
-  field bit SGPRSpill = 0;
+  // Combined SGPR/VGPR spill bit
+  field bit Spill = 0;
 
   // LDSDIR instruction format.
   field bit LDSDIR = 0;
@@ -187,8 +186,10 @@ class InstSI <dag outs, dag ins, string asm = "",
   let TSFlags{24} = FLAT;
   let TSFlags{25} = DS;
 
-  let TSFlags{26} = VGPRSpill;
-  let TSFlags{27} = SGPRSpill;
+  let TSFlags{26} = Spill;
+
+  // Reserved, must be 0
+  let TSFlags{27} = 0;
 
   let TSFlags{28} = LDSDIR;
   let TSFlags{29} = VINTERP;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5424,7 +5424,7 @@ adjustAllocatableRegClass(const GCNSubtarget &ST, const SIRegisterInfo &RI,
                           bool IsAllocatable) {
   if ((IsAllocatable || !ST.hasGFX90AInsts() || !MRI.reservedRegsFrozen()) &&
       (((TID.mayLoad() || TID.mayStore()) &&
-        !(TID.TSFlags & SIInstrFlags::VGPRSpill)) ||
+        !(TID.TSFlags & SIInstrFlags::Spill)) ||
        (TID.TSFlags & (SIInstrFlags::DS | SIInstrFlags::MIMG)))) {
     switch (RCID) {
     case AMDGPU::AV_32RegClassID:

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -8814,7 +8814,7 @@ bool SIInstrInfo::isBasicBlockPrologue(const MachineInstr &MI,
   // be included.
   return IsNullOrVectorRegister &&
          (isSpill(Opcode) || (!MI.isTerminator() && Opcode != AMDGPU::COPY &&
-                                 MI.modifiesRegister(AMDGPU::EXEC, &RI)));
+                              MI.modifiesRegister(AMDGPU::EXEC, &RI)));
 }
 
 MachineInstrBuilder

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -8809,11 +8809,11 @@ bool SIInstrInfo::isBasicBlockPrologue(const MachineInstr &MI,
     IsNullOrVectorRegister = !RI.isSGPRClass(RI.getRegClassForReg(MRI, Reg));
   }
 
-  uint16_t Opc = MI.getOpcode();
+  uint16_t Opcode = MI.getOpcode();
   // FIXME: Copies inserted in the block prolog for live-range split should also
   // be included.
   return IsNullOrVectorRegister &&
-         (isSpillOpcode(Opc) || (!MI.isTerminator() && Opc != AMDGPU::COPY &&
+         (isSpill(Opcode) || (!MI.isTerminator() && Opcode != AMDGPU::COPY &&
                                  MI.modifiesRegister(AMDGPU::EXEC, &RI)));
 }
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -716,25 +716,25 @@ public:
   static bool isVGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            MI.getOpcode() != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-           (isSpill(MI) & isVALU(MI));
+           (isSpill(MI) && isVALU(MI));
   }
 
   bool isVGPRSpill(uint16_t Opcode) const {
     return Opcode != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            Opcode != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-           (isSpill(Opcode) & isVALU(Opcode));
+           (isSpill(Opcode) && isVALU(Opcode));
   }
 
   static bool isSGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            MI.getOpcode() == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-           (isSpill(MI) & isSALU(MI));
+           (isSpill(MI) && isSALU(MI));
   }
 
   bool isSGPRSpill(uint16_t Opcode) const {
     return Opcode == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            Opcode == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-           (isSpill(Opcode) & isSALU(Opcode));
+           (isSpill(Opcode) && isSALU(Opcode));
   }
 
   bool isSpill(uint16_t Opcode) const {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -716,33 +716,33 @@ public:
   static bool isVGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            MI.getOpcode() != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-           ((MI.getDesc().TSFlags & SIInstrFlags::Spill) &&
-            (MI.getDesc().TSFlags & SIInstrFlags::VALU));
+		   (isSpill(MI) & isVALU(MI));
   }
 
   bool isVGPRSpill(uint16_t Opcode) const {
     return Opcode != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            Opcode != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-           ((get(Opcode).TSFlags & SIInstrFlags::Spill) &&
-            (get(Opcode).TSFlags & SIInstrFlags::VALU));
+		   (isSpill(Opcode) & isVALU(Opcode));
   }
 
   static bool isSGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            MI.getOpcode() == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-           ((MI.getDesc().TSFlags & SIInstrFlags::Spill) &&
-            (MI.getDesc().TSFlags & SIInstrFlags::SALU));
+		   (isSpill(MI) & isSALU(MI));
   }
 
   bool isSGPRSpill(uint16_t Opcode) const {
     return Opcode == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            Opcode == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-           ((get(Opcode).TSFlags & SIInstrFlags::Spill) &&
-            (get(Opcode).TSFlags & SIInstrFlags::SALU));
+	       (isSpill(Opcode) & isSALU(Opcode));
   }
 
-  bool isSpillOpcode(uint16_t Opcode) const {
+  bool isSpill(uint16_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::Spill;
+  }
+
+  static bool isSpill(const MachineInstr &MI) {
+	return MI.getDesc().TSFlags & SIInstrFlags::Spill;
   }
 
   static bool isWWMRegSpillOpcode(uint16_t Opcode) {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -716,25 +716,25 @@ public:
   static bool isVGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            MI.getOpcode() != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-		   (isSpill(MI) & isVALU(MI));
+           (isSpill(MI) & isVALU(MI));
   }
 
   bool isVGPRSpill(uint16_t Opcode) const {
     return Opcode != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            Opcode != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
-		   (isSpill(Opcode) & isVALU(Opcode));
+           (isSpill(Opcode) & isVALU(Opcode));
   }
 
   static bool isSGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            MI.getOpcode() == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-		   (isSpill(MI) & isSALU(MI));
+           (isSpill(MI) & isSALU(MI));
   }
 
   bool isSGPRSpill(uint16_t Opcode) const {
     return Opcode == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            Opcode == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
-	       (isSpill(Opcode) & isSALU(Opcode));
+           (isSpill(Opcode) & isSALU(Opcode));
   }
 
   bool isSpill(uint16_t Opcode) const {
@@ -742,7 +742,7 @@ public:
   }
 
   static bool isSpill(const MachineInstr &MI) {
-	return MI.getDesc().TSFlags & SIInstrFlags::Spill;
+    return MI.getDesc().TSFlags & SIInstrFlags::Spill;
   }
 
   static bool isWWMRegSpillOpcode(uint16_t Opcode) {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -711,7 +711,7 @@ public:
   // SI_SPILL_S32_TO_VGPR and SI_RESTORE_S32_FROM_VGPR form a special case of
   // SGPRs spilling to VGPRs which are SGPR spills but from VALU instructions
   // therefore we need an explicit check for them since just checking if the
-  // Spill bit is set and what instruction type it came from miss classifies
+  // Spill bit is set and what instruction type it came from misclassifies
   // them.
   static bool isVGPRSpill(const MachineInstr &MI) {
     return MI.getOpcode() != AMDGPU::SI_SPILL_S32_TO_VGPR &&

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -895,7 +895,7 @@ def V_INDIRECT_REG_READ_GPR_IDX_B32_V16 : V_INDIRECT_REG_READ_GPR_IDX_pseudo<VRe
 def V_INDIRECT_REG_READ_GPR_IDX_B32_V32 : V_INDIRECT_REG_READ_GPR_IDX_pseudo<VReg_1024>;
 
 multiclass SI_SPILL_SGPR <RegisterClass sgpr_class> {
-  let UseNamedOperandTable = 1, SGPRSpill = 1, Uses = [EXEC] in {
+  let UseNamedOperandTable = 1, Spill = 1, SALU = 1, Uses = [EXEC] in {
     def _SAVE : PseudoInstSI <
       (outs),
       (ins sgpr_class:$data, i32imm:$addr)> {
@@ -931,7 +931,7 @@ defm SI_SPILL_S384 : SI_SPILL_SGPR <SReg_384>;
 defm SI_SPILL_S512 : SI_SPILL_SGPR <SReg_512>;
 defm SI_SPILL_S1024 : SI_SPILL_SGPR <SReg_1024>;
 
-let SGPRSpill = 1, VALU = 1, isConvergent = 1 in {
+let Spill = 1, VALU = 1, isConvergent = 1 in {
 def SI_SPILL_S32_TO_VGPR : PseudoInstSI <(outs VGPR_32:$vdst),
   (ins SReg_32:$src0, i32imm:$src1, VGPR_32:$vdst_in)> {
   let Size = 4;
@@ -951,13 +951,13 @@ def SI_RESTORE_S32_FROM_VGPR : PseudoInstSI <(outs SReg_32:$sdst),
   let mayLoad = 0;
   let mayStore = 0;
 }
-} // End SGPRSpill = 1, VALU = 1, isConvergent = 1
+} // End Spill = 1, VALU = 1, isConvergent = 1
 
 // VGPR or AGPR spill instructions. In case of AGPR spilling a temp register
 // needs to be used and an extra instruction to move between VGPR and AGPR.
 // UsesTmp adds to the total size of an expanded spill in this case.
 multiclass SI_SPILL_VGPR <RegisterClass vgpr_class, bit UsesTmp = 0> {
-  let UseNamedOperandTable = 1, VGPRSpill = 1,
+  let UseNamedOperandTable = 1, Spill = 1, VALU = 1,
        SchedRW = [WriteVMEM] in {
     def _SAVE : VPseudoInstSI <
       (outs),
@@ -983,7 +983,7 @@ multiclass SI_SPILL_VGPR <RegisterClass vgpr_class, bit UsesTmp = 0> {
       // Size field is unsigned char and cannot fit more.
       let Size = !if(!le(MaxSize, 256), MaxSize, 252);
     }
-  } // End UseNamedOperandTable = 1, VGPRSpill = 1, SchedRW = [WriteVMEM]
+  } // End UseNamedOperandTable = 1, Spill = 1, VALU = 1, SchedRW = [WriteVMEM]
 }
 
 defm SI_SPILL_V32  : SI_SPILL_VGPR <VGPR_32>;


### PR DESCRIPTION
Follow on to #81525 in the series of consolidating bits in TSFlags.

Merge SGPRSpill and VGPRSpill into single Spill bit

Modify isSGPRSpill and isVGPRSpill helper functions to differentiate VGPR and SGPR spills:

Spill+SALU=SGPR Spill
Spill+VALU=VGPR Spill

The only exception here is SGPR spills to VGPRs which require an explicit instruction check.