### PR TITLE
[HLSL] add BuiltinsHLSL and set it up as target builtins.

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -4512,12 +4512,6 @@ def GetDeviceSideMangledName : LangBuiltin<"CUDA_LANG"> {
 }
 
 // HLSL
-def HLSLWaveActiveCountBits : LangBuiltin<"HLSL_LANG"> {
-  let Spellings = ["__builtin_hlsl_wave_active_count_bits"];
-  let Attributes = [NoThrow, Const];
-  let Prototype = "unsigned int(bool)";
-}
-
 def HLSLCreateHandle : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_create_handle"];
   let Attributes = [NoThrow, Const];

--- a/clang/include/clang/Basic/BuiltinsHLSL.td
+++ b/clang/include/clang/Basic/BuiltinsHLSL.td
@@ -1,0 +1,15 @@
+//===--- BuiltinsHLSL.td - HLSL Builtin function database ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+include "clang/Basic/BuiltinsBase.td"
+
+def HLSLWaveActiveCountBits : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_wave_active_count_bits"];
+  let Attributes = [NoThrow, Const];
+  let Prototype = "unsigned int(bool)";
+}

--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -65,7 +65,11 @@ clang_tablegen(BuiltinsBPF.inc -gen-clang-builtins
   SOURCE BuiltinsBPF.td
   TARGET ClangBuiltinsBPF)
 
-clang_tablegen(BuiltinsRISCV.inc -gen-clang-builtins
+clang_tablegen(BuiltinsHLSL.inc -gen-clang-builtins
+  SOURCE BuiltinsHLSL.td
+  TARGET ClangBuiltinsHLSL)
+
+  clang_tablegen(BuiltinsRISCV.inc -gen-clang-builtins
   SOURCE BuiltinsRISCV.td
   TARGET ClangBuiltinsRISCV)
 

--- a/clang/include/clang/Basic/TargetBuiltins.h
+++ b/clang/include/clang/Basic/TargetBuiltins.h
@@ -89,6 +89,16 @@ namespace clang {
   };
   }
 
+  /// HLSL builtins
+  namespace hlsl {
+  enum {
+    LastTIBuiltin = clang::Builtin::FirstTSBuiltin - 1,
+#define BUILTIN(ID, TYPE, ATTRS) BI##ID,
+#include "clang/Basic/BuiltinsHLSL.inc"
+    LastTSBuiltin
+  };
+  } // namespace hlsl
+
   /// PPC builtins
   namespace PPC {
     enum {

--- a/clang/lib/Basic/Targets/DirectX.cpp
+++ b/clang/lib/Basic/Targets/DirectX.cpp
@@ -12,11 +12,24 @@
 
 #include "DirectX.h"
 #include "Targets.h"
+#include "clang/Basic/MacroBuilder.h"
+#include "clang/Basic/TargetBuiltins.h"
 
 using namespace clang;
 using namespace clang::targets;
 
+static constexpr Builtin::Info BuiltinInfo[] = {
+#define BUILTIN(ID, TYPE, ATTRS)                                               \
+  {#ID, TYPE, ATTRS, nullptr, HeaderDesc::NO_HEADER, ALL_LANGUAGES},
+#include "clang/Basic/BuiltinsHLSL.inc"
+};
+
 void DirectXTargetInfo::getTargetDefines(const LangOptions &Opts,
                                          MacroBuilder &Builder) const {
   DefineStd(Builder, "DIRECTX", Opts);
+}
+
+ArrayRef<Builtin::Info> DirectXTargetInfo::getTargetBuiltins() const {
+  return llvm::ArrayRef(BuiltinInfo,
+                        clang::hlsl::LastTSBuiltin - Builtin::FirstTSBuiltin);
 }

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -73,9 +73,7 @@ public:
     return Feature == "directx";
   }
 
-  ArrayRef<Builtin::Info> getTargetBuiltins() const override {
-    return std::nullopt;
-  }
+  ArrayRef<Builtin::Info> getTargetBuiltins() const override;
 
   std::string_view getClobbers() const override { return ""; }
 


### PR DESCRIPTION
1. This change moves hlsl specific builtins from Builtins.td to BuiltinsHLSL.td.
2. Adds changes to the build system to build BuiltinsHLSL.td.
3. Setups HLSL builtins as TargetBuiltins.

Motivations: 
Small changes to `Builtins.td `  rebuilds all of clang.  moving to `BuiltinsHLSL.td` reduces re-build time significantly.