### PR TITLE
[C++] Fix parsing of _Alignas in local declarations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -259,6 +259,9 @@ Bug Fixes to C++ Support
   some of (`#80510 <https://github.com/llvm/llvm-project/issues/80510>`).
 - Clang now ignores top-level cv-qualifiers on function parameters in template partial orderings.
   (`#75404 <https://github.com/llvm/llvm-project/issues/75404>`_)
+- No longer reject valid use of the ``_Alignas`` specifier when declaring a
+  local variable, which is supported as a C11 extension in C++. Previously, it
+  was only accepted at namespace scope but not at local function scope.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1842,6 +1842,9 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
 #include "clang/Basic/TransformTypeTraits.def"
     return TPResult::True;
 
+  // C11 _Alignas
+  case tok::kw__Alignas:
+    return TPResult::True;
   // C11 _Atomic
   case tok::kw__Atomic:
     return TPResult::True;

--- a/clang/test/SemaCXX/_Alignas.cpp
+++ b/clang/test/SemaCXX/_Alignas.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 %s -fsyntax-only -verify=expected,cpp
+// RUN: %clang_cc1 -x c %s -fsyntax-only -verify=expected,c
+
+// Ensure that we correctly parse _Alignas as an extension in C++.
+_Alignas(64) int i1;
+_Alignas(long long) int i2;
+int volatile _Alignas(64) i3; // Test strange ordering
+
+void foo(void) {
+  // We previously rejected these valid declarations.
+  _Alignas(8) char i4;
+  _Alignas(char) char i5;
+
+  (void)(int _Alignas(64))0; // expected-warning {{'_Alignas' attribute ignored when parsing type}}
+  // FIXME: C and C++ should both diagnose the same way, as being ignored.
+  (void)(_Alignas(64) int)0; // c-error {{expected expression}} \
+                                cpp-warning {{'_Alignas' attribute ignored when parsing type}}
+}
+
+struct S {
+  _Alignas(int) int i;
+  _Alignas(64) int j;
+};
+
+void bar(_Alignas(8) char c1, char _Alignas(char) c2); // expected-error 2 {{'_Alignas' attribute cannot be applied to a function parameter}}


### PR DESCRIPTION
We support '_Alignas' from C11 as an extension in C++. However, we were not correctly parsing its use in local variable declarations. This patch addresses that issue.