### PR TITLE
[PGOForceFunctionAttrs] Don't mark alwaysinline function optnone

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOForceFunctionAttrs.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOForceFunctionAttrs.cpp
@@ -40,7 +40,6 @@ PreservedAnalyses PGOForceFunctionAttrsPass::run(Module &M,
   for (Function &F : M) {
     if (!shouldRunOnFunction(F, PSI, FAM))
       continue;
-    MadeChange = true;
     switch (ColdType) {
     case PGOOptions::ColdFuncOpt::Default:
       llvm_unreachable("bailed out for default above");
@@ -52,10 +51,14 @@ PreservedAnalyses PGOForceFunctionAttrsPass::run(Module &M,
       F.addFnAttr(Attribute::MinSize);
       break;
     case PGOOptions::ColdFuncOpt::OptNone:
+      // alwaysinline is incompatible with optnone.
+      if (F.hasFnAttribute(Attribute::AlwaysInline))
+        continue;
       F.addFnAttr(Attribute::OptimizeNone);
       F.addFnAttr(Attribute::NoInline);
       break;
     }
+    MadeChange = true;
   }
   return MadeChange ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/test/Instrumentation/PGOForceFunctionAttrs/basic.ll
+++ b/llvm/test/Instrumentation/PGOForceFunctionAttrs/basic.ll
@@ -21,6 +21,12 @@
 ; CHECK: Function Attrs: noinline optnone{{$}}
 ; CHECK-NEXT: define void @cold_optnone()
 
+; NONE: Function Attrs: alwaysinline{{$}}
+; OPTSIZE: Function Attrs: alwaysinline optsize{{$}}
+; MINSIZE: Function Attrs: alwaysinline minsize{{$}}
+; OPTNONE: Function Attrs: alwaysinline{{$}}
+; CHECK-NEXT: define void @cold_alwaysinline()
+
 ; NONE: Function Attrs: cold{{$}}
 ; OPTSIZE: Function Attrs: cold optsize{{$}}
 ; MINSIZE: Function Attrs: cold minsize{{$}}
@@ -49,6 +55,11 @@ define void @cold_minsize() minsize !prof !27 {
 }
 
 define void @cold_optnone() noinline optnone !prof !27 {
+  store i32 1, ptr @s, align 4
+  ret void
+}
+
+define void @cold_alwaysinline() alwaysinline !prof !27 {
   store i32 1, ptr @s, align 4
   ret void
 }


### PR DESCRIPTION
optnone requires noinline, which is incompatible with alwaysinline.