### PR TITLE
[RISCV] Remove X0 handling from RISCVInstrInfo::optimizeCondBranch.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1211,13 +1211,7 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
     if (!Op.isReg())
       return false;
     Register Reg = Op.getReg();
-    if (Reg == RISCV::X0) {
-      Imm = 0;
-      return true;
-    }
-    if (!Reg.isVirtual())
-      return false;
-    return isLoadImm(MRI.getVRegDef(Op.getReg()), Imm);
+    return Reg.isVirtual() && isLoadImm(MRI.getVRegDef(Reg), Imm);
   };
 
   MachineOperand &LHS = MI.getOperand(0);


### PR DESCRIPTION
This was trying to rewrite a branch that uses X0 to a branch that uses a register produced by LI of 1 or -1. Using X0 is free so there isn't no reason to rewrite it. Doing so would just extend the live range of the other register increasing register pressure.

In practice this might not have triggered often because we were calling MRI.hasOneUse on X0. I'm not sure what the returns for a physical reigster.