### PR TITLE
[libc][docs] start documenting c23 support

### DIFF
--- a/libc/docs/c23.rst
+++ b/libc/docs/c23.rst
@@ -1,0 +1,114 @@
+.. _c23_support:
+
+===========
+C23 Support
+===========
+
+.. contents:: Table of Contents
+  :depth: 4
+  :local:
+
+---------------------
+Implementation Status
+---------------------
+
+(It's helpful to review 'Annex B (Informative) Library Summary' for these.)
+
+New headers:
+
+* stdbit.h
+* stdckdint.h
+* stdnoreturn.h
+
+Additions:
+
+* uchar.h
+
+  * mbrtoc8
+  * c8rtomb
+
+* string.h
+
+  * memset_explicit
+  * memccpy
+  * strdup
+  * strndup
+
+* time.h
+
+  * gmtime_r
+  * localtime_r
+  * timegm
+  * timespec_getres
+  * strftime conversion specifiers
+
+    * 0b
+    * 0B
+* math.h
+
+  * acospi*
+  * asinpi*
+  * atanpi*
+  * atan2pi*
+  * cospi*
+  * sinpi*
+  * tanpi*
+  * exp10*
+  * exp10m1*
+  * exp2m1*
+  * log10p1*
+  * logp1
+  * log2p1*
+  * rsqrt*
+  * __STDC_IEC_60559_DFP__ functions (_Decimal32, _Decimal64, _Decimal128)
+  * compoundn*
+  * totalorder*
+  * totalordermag*
+  * getpayload*
+  * setpayload*
+  * iscannonical
+  * issignaling
+  * issubnormal
+  * iszero
+  * llogb*
+  * pown*
+  * powr*
+  * rootn*
+  * roundeven*
+  * fromfp*
+  * ufromfp*
+  * fromfpx*
+  * nextup*
+  * nextdown*
+  * canonicalize*
+  * fmaximum*
+  * fminimum*
+  * fmaximum_mag*
+  * fminimum_mag*
+  * fmaximum_mag_num*
+  * fminimum_mag_num*
+  * fadd*
+  * fsub*
+  * fmul*
+  * fdiv*
+  * ffma*
+  * dfmal
+  * fsqrt*
+  * dsqrtl
+* fenv.h
+
+  * fesetexcept
+  * fetestexceptflag
+  * fegetmode
+  * fesetmode
+* stddef.h
+
+  * unreachable
+* stdlib.h
+
+  * free_sized
+  * free_aligned_sized
+  * memalignment
+* tgmath.h
+
+  * <TODO>

--- a/libc/docs/c23.rst
+++ b/libc/docs/c23.rst
@@ -18,7 +18,6 @@ New headers:
 
 * stdbit.h
 * stdckdint.h
-* stdnoreturn.h
 
 Additions:
 
@@ -26,6 +25,7 @@ Additions:
 
   * mbrtoc8
   * c8rtomb
+  * char*_t
 
 * string.h
 

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -67,6 +67,7 @@ stages there is no ABI stability in any form.
    stdio
    stdbit
    libc_search
+   c23
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
I've been diffing the c17 vs c23 latest publicly available drafts and think I
have most of the library related differences. I haven't yet annotated what we
actually support or not.

Link: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf (C17)
Link: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf (C23)
