### PR TITLE
[LoopRotate][coroutines] Avoid hoisting addresses of thread-local variables outside loops in coroutines

### DIFF
--- a/llvm/test/Transforms/LoopRotate/coroutine.ll
+++ b/llvm/test/Transforms/LoopRotate/coroutine.ll
@@ -21,8 +21,9 @@ define void @foo() #0 {
 ; CHECK-NEXT:    ret void
 ; CHECK:       cond.end:
 ; CHECK-NEXT:    call void @bar()
-; CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP0]], align 4
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP2]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = tail call align 4 ptr @llvm.threadlocal.address.p0(ptr align 4 @threadlocalint)
+; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[TMP2]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP3]], 0
 ; CHECK-NEXT:    br i1 [[CMP]], label [[COND_END]], label [[WHILE_COND_COND_FALSE_CRIT_EDGE:%.*]]
 ;
 entry:


### PR DESCRIPTION
Because loops in coroutines may have a co_await statement that reschedules the coroutine to another thread, we cannot cache addresses of thread-local variables obtained inside a loop by moving the computation of thoes addresses outside a loop.

Since LLVM doesn't have a model for coroutine memory accesses, this patch fixes this bug by disabling this optimization for coroutines in the same way as https://reviews.llvm.org/D135550 and https://reviews.llvm.org/D151774.