### PR TITLE
[clang][test] Add test for incompatible cv-qualified reference types in conversion function template

### DIFF
--- a/clang/test/CXX/temp/temp.fct.spec/temp.deduct/temp.deduct.conv/p4.cpp
+++ b/clang/test/CXX/temp/temp.fct.spec/temp.deduct/temp.deduct.conv/p4.cpp
@@ -130,6 +130,15 @@ namespace non_ptr_ref_cv_qual {
   int (&test_conv_to_arr_1)[3] = ConvToArr(); // ok
   const int (&test_conv_to_arr_2)[3] = ConvToArr(); // ok, with qualification conversion
 
+  struct ConvToConstArr {
+    template <int N>
+    operator const Arr<int, N> &() { // expected-note {{candidate}}
+      static_assert(N == 3, "");
+    }
+  };
+  Arr<int, 3> &test_conv_to_const_arr_1 = ConvToConstArr(); // expected-error {{no viable}}
+  const Arr<int, 3> &test_conv_to_const_arr_2 = ConvToConstArr(); // ok
+
 #if __cplusplus >= 201702L
   template<bool Noexcept, typename T, typename ...U> using Function = T(U...) noexcept(Noexcept);
   template<bool Noexcept> struct ConvToFunction {


### PR DESCRIPTION
We currently lack test coverage for [SemaTemplateDeduction.cpp#L1619-L1620](https://github.com/llvm/llvm-project/blob/fe20a75/clang/lib/Sema/SemaTemplateDeduction.cpp#L1619-L1620), which handles the case where both the P type and the A type are reference types but A is more cv-qualified than P. This is deemed non-deduced unless both A and P are possibly cv-qualified forms of the template parameter T. This PR adds tests for that logic.