### PR TITLE
[GlobalIsel] Lower integer constants to constant pool in `LegalizerHelper`.

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -365,6 +365,7 @@ public:
   LegalizeResult bitcastInsertVectorElt(MachineInstr &MI, unsigned TypeIdx,
                                         LLT CastTy);
 
+  LegalizeResult lowerConstant(MachineInstr &MI);
   LegalizeResult lowerFConstant(MachineInstr &MI);
   LegalizeResult lowerBitcast(MachineInstr &MI);
   LegalizeResult lowerLoad(GAnyLoad &MI);

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -3011,7 +3011,7 @@ static void emitLoadFromConstantPool(Register DstReg, const Constant *ConstVal,
 
 LegalizerHelper::LegalizeResult
 LegalizerHelper::lowerConstant(MachineInstr &MI) {
-  MachineOperand ConstOperand = MI.getOperand(1);
+  const MachineOperand &ConstOperand = MI.getOperand(1);
   const Constant *ConstantVal = ConstOperand.getCImm();
 
   emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);
@@ -3022,7 +3022,7 @@ LegalizerHelper::lowerConstant(MachineInstr &MI) {
 
 LegalizerHelper::LegalizeResult
 LegalizerHelper::lowerFConstant(MachineInstr &MI) {
-  MachineOperand ConstOperand = MI.getOperand(1);
+  const MachineOperand &ConstOperand = MI.getOperand(1);
   const Constant *ConstantVal = ConstOperand.getFPImm();
 
   emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -3012,7 +3012,6 @@ static void emitLoadFromConstantPool(Register DstReg, const Constant *ConstVal,
 LegalizerHelper::LegalizeResult
 LegalizerHelper::lowerConstant(MachineInstr &MI) {
   MachineOperand ConstOperand = MI.getOperand(1);
-  assert(ConstOperand.isCImm());
   const Constant *ConstantVal = ConstOperand.getCImm();
 
   emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);
@@ -3024,7 +3023,6 @@ LegalizerHelper::lowerConstant(MachineInstr &MI) {
 LegalizerHelper::LegalizeResult
 LegalizerHelper::lowerFConstant(MachineInstr &MI) {
   MachineOperand ConstOperand = MI.getOperand(1);
-  assert(ConstOperand.isFPImm());
   const Constant *ConstantVal = ConstOperand.getFPImm();
 
   emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -2987,27 +2987,35 @@ static void getUnmergePieces(SmallVectorImpl<Register> &Pieces,
     Pieces.push_back(Unmerge.getReg(I));
 }
 
-LegalizerHelper::LegalizeResult
-LegalizerHelper::lowerConstant(MachineInstr &MI) {
-  Register Dst = MI.getOperand(0).getReg();
-
+static void emitLoadFromConstantPool(Register DstReg, const Constant *ConstVal,
+                                     MachineIRBuilder &MIRBuilder) {
+  MachineRegisterInfo &MRI = *MIRBuilder.getMRI();
   MachineFunction &MF = MIRBuilder.getMF();
   const DataLayout &DL = MIRBuilder.getDataLayout();
-
   unsigned AddrSpace = DL.getDefaultGlobalsAddressSpace();
   LLT AddrPtrTy = LLT::pointer(AddrSpace, DL.getPointerSizeInBits(AddrSpace));
-  Align Alignment = Align(DL.getABITypeAlign(
-      getFloatTypeForLLT(MF.getFunction().getContext(), MRI.getType(Dst))));
+  LLT DstLLT = MRI.getType(DstReg);
+
+  Align Alignment(DL.getABITypeAlign(ConstVal->getType()));
 
   auto Addr = MIRBuilder.buildConstantPool(
-      AddrPtrTy, MF.getConstantPool()->getConstantPoolIndex(
-                     MI.getOperand(1).getFPImm(), Alignment));
+      AddrPtrTy,
+      MF.getConstantPool()->getConstantPoolIndex(ConstVal, Alignment));
 
-  MachineMemOperand *MMO = MF.getMachineMemOperand(
-      MachinePointerInfo::getConstantPool(MF), MachineMemOperand::MOLoad,
-      MRI.getType(Dst), Alignment);
+  MachineMemOperand *MMO =
+      MF.getMachineMemOperand(MachinePointerInfo::getConstantPool(MF),
+                              MachineMemOperand::MOLoad, DstLLT, Alignment);
 
-  MIRBuilder.buildLoadInstr(TargetOpcode::G_LOAD, Dst, Addr, *MMO);
+  MIRBuilder.buildLoadInstr(TargetOpcode::G_LOAD, DstReg, Addr, *MMO);
+}
+
+LegalizerHelper::LegalizeResult
+LegalizerHelper::lowerConstant(MachineInstr &MI) {
+  MachineOperand ConstOperand = MI.getOperand(1);
+  assert(ConstOperand.isCImm());
+  const Constant *ConstantVal = ConstOperand.getCImm();
+
+  emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);
   MI.eraseFromParent();
 
   return Legalized;
@@ -3015,25 +3023,11 @@ LegalizerHelper::lowerConstant(MachineInstr &MI) {
 
 LegalizerHelper::LegalizeResult
 LegalizerHelper::lowerFConstant(MachineInstr &MI) {
-  Register Dst = MI.getOperand(0).getReg();
+  MachineOperand ConstOperand = MI.getOperand(1);
+  assert(ConstOperand.isFPImm());
+  const Constant *ConstantVal = ConstOperand.getFPImm();
 
-  MachineFunction &MF = MIRBuilder.getMF();
-  const DataLayout &DL = MIRBuilder.getDataLayout();
-
-  unsigned AddrSpace = DL.getDefaultGlobalsAddressSpace();
-  LLT AddrPtrTy = LLT::pointer(AddrSpace, DL.getPointerSizeInBits(AddrSpace));
-  Align Alignment = Align(DL.getABITypeAlign(
-      getFloatTypeForLLT(MF.getFunction().getContext(), MRI.getType(Dst))));
-
-  auto Addr = MIRBuilder.buildConstantPool(
-      AddrPtrTy, MF.getConstantPool()->getConstantPoolIndex(
-                     MI.getOperand(1).getFPImm(), Alignment));
-
-  MachineMemOperand *MMO = MF.getMachineMemOperand(
-      MachinePointerInfo::getConstantPool(MF), MachineMemOperand::MOLoad,
-      MRI.getType(Dst), Alignment);
-
-  MIRBuilder.buildLoadInstr(TargetOpcode::G_LOAD, Dst, Addr, *MMO);
+  emitLoadFromConstantPool(MI.getOperand(0).getReg(), ConstantVal, MIRBuilder);
   MI.eraseFromParent();
 
   return Legalized;

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
@@ -38,8 +38,6 @@ public:
 
 private:
   bool shouldBeInConstantPool(APInt APImm, bool ShouldOptForSize) const;
-  bool emitLoadFromConstantPool(Register DstReg, const Constant *CPVal,
-                                MachineIRBuilder &MIRBuilder) const;
   bool legalizeShlAshrLshr(MachineInstr &MI, MachineIRBuilder &MIRBuilder,
                            GISelChangeObserver &Observer) const;
 


### PR DESCRIPTION
Extend LegalizerHelper's API to lower integer constants to a load from  constant pool. Previously, this lowering existed only for FP constants.  Apply this change to RISCV.
