### PR TITLE
[scudo] Move ALWAYS_INLINE up in tsd_shared's ScopedTSD ctor

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tsd_exclusive.h
+++ b/compiler-rt/lib/scudo/standalone/tsd_exclusive.h
@@ -30,7 +30,7 @@ template <class Allocator> struct TSDRegistryExT {
   using ThisT = TSDRegistryExT<Allocator>;
 
   struct ScopedTSD {
-    ScopedTSD(ThisT &TSDRegistry) {
+    ALWAYS_INLINE ScopedTSD(ThisT &TSDRegistry) {
       CurrentTSD = TSDRegistry.getTSDAndLock(&UnlockRequired);
       DCHECK_NE(CurrentTSD, nullptr);
     }

--- a/compiler-rt/lib/scudo/standalone/tsd_shared.h
+++ b/compiler-rt/lib/scudo/standalone/tsd_shared.h
@@ -133,7 +133,7 @@ struct TSDRegistrySharedT {
   }
 
 private:
-  TSD<Allocator> *getTSDAndLock() NO_THREAD_SAFETY_ANALYSIS {
+  ALWAYS_INLINE TSD<Allocator> *getTSDAndLock() NO_THREAD_SAFETY_ANALYSIS {
     TSD<Allocator> *TSD = getCurrentTSD();
     DCHECK(TSD);
     // Try to lock the currently associated context.

--- a/compiler-rt/lib/scudo/standalone/tsd_shared.h
+++ b/compiler-rt/lib/scudo/standalone/tsd_shared.h
@@ -29,7 +29,7 @@ struct TSDRegistrySharedT {
   using ThisT = TSDRegistrySharedT<Allocator, TSDsArraySize, DefaultTSDCount>;
 
   struct ScopedTSD {
-    ScopedTSD(ThisT &TSDRegistry) {
+    ALWAYS_INLINE ScopedTSD(ThisT &TSDRegistry) {
       CurrentTSD = TSDRegistry.getTSDAndLock();
       DCHECK_NE(CurrentTSD, nullptr);
     }
@@ -133,7 +133,7 @@ struct TSDRegistrySharedT {
   }
 
 private:
-  ALWAYS_INLINE TSD<Allocator> *getTSDAndLock() NO_THREAD_SAFETY_ANALYSIS {
+  TSD<Allocator> *getTSDAndLock() NO_THREAD_SAFETY_ANALYSIS {
     TSD<Allocator> *TSD = getCurrentTSD();
     DCHECK(TSD);
     // Try to lock the currently associated context.


### PR DESCRIPTION
Fix for performance regression introduced by #80061 that slowed
down Fuchsia's MallocFree microbenchmark by 3.5 - 8%