### PR TITLE
[Lint] Add option --lint-abort-on-error

### DIFF
--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -77,6 +77,11 @@
 
 using namespace llvm;
 
+static const char LintAbortOnErrorArgName[] = "lint-abort-on-error";
+static cl::opt<bool>
+    LintAbortOnError(LintAbortOnErrorArgName, cl::init(false),
+                     cl::desc("In the Lint pass, abort on errors."));
+
 namespace {
 namespace MemRef {
 static const unsigned Read = 1;
@@ -715,6 +720,10 @@ PreservedAnalyses LintPass::run(Function &F, FunctionAnalysisManager &AM) {
   Lint L(Mod, DL, AA, AC, DT, TLI);
   L.visit(F);
   dbgs() << L.MessagesStr.str();
+  if (LintAbortOnError && !L.MessagesStr.str().empty())
+    report_fatal_error(Twine("Linter found errors, aborting. (enabled by --") +
+                           LintAbortOnErrorArgName + ")",
+                       false);
   return PreservedAnalyses::all();
 }
 

--- a/llvm/test/Analysis/Lint/abort-on-error.ll
+++ b/llvm/test/Analysis/Lint/abort-on-error.ll
@@ -1,0 +1,10 @@
+; RUN: not opt -passes=lint -disable-output --lint-abort-on-error %s 2>&1 | FileCheck %s
+
+; CHECK: Undefined behavior: Division by zero
+; CHECK-NEXT:   %b = sdiv i32 %a, 0
+; CHECK-NEXT: LLVM ERROR: Linter found errors, aborting. (enabled by --lint-abort-on-error)
+
+define i32 @sdiv_by_zero(i32 %a) {
+  %b = sdiv i32 %a, 0
+  ret i32 %b
+}


### PR DESCRIPTION
This option makes the lint pass abort if errors were found.

This is intended to help lit testing where the lint pass is used and lint errors should be detected.
Previously, this required checking for non-empty stderr.