### PR TITLE
[Release] Don't build during test-release.sh Phase 3 install

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -537,6 +537,11 @@ function build_llvmCore() {
         InstallTarget="$InstallTarget install-builtins"
       fi
     fi
+    if [ "$Phase" -eq "3" ]; then
+      # Build everything at once, with the proper parallelism and verbosity,
+      # in Phase 3.
+      BuildTarget=
+    fi
 
     cd $ObjDir
     echo "# Compiling llvm $Release-$RC $Flavor"


### PR DESCRIPTION
As described in [test-release.sh ninja install does builds in Phase 3](https://github.com/llvm/llvm-project/issues/80999), considerable parts of Phase 3 of a `test-release.sh` build are run by `ninja install`, ignoring both `$Verbose` and the parallelism set via `-j NUM`.

This patches fixes this by not specifying any explicit build target for Phase 3, thus running the full build as usual.

Tested on `sparc64-unknown-linux-gnu`.