### PR TITLE
[mlir] Handle cycles and back edges in --view-op-graph

### DIFF
--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/IndentedOstream.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/GraphWriter.h"
 #include <map>
@@ -276,6 +277,8 @@ private:
   /// Process a block. Emit a cluster and one node per block argument and
   /// operation inside the cluster.
   void processBlock(Block &block) {
+    sortTopologically(&block);
+
     emitClusterStmt([&]() {
       for (BlockArgument &blockArg : block.getArguments())
         valueToNode[blockArg] = emitNodeStmt(getLabel(blockArg));

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -281,7 +281,7 @@ private:
       for (BlockArgument &blockArg : block.getArguments())
         valueToNode[blockArg] = emitNodeStmt(getLabel(blockArg));
 
-      SmallVector<Operation*> sortedOperations;
+      SmallVector<Operation *> sortedOperations;
       for (Operation &op : block) {
         sortedOperations.push_back(&op);
       }

--- a/mlir/test/Transforms/print-op-graph-back-edges.mlir
+++ b/mlir/test/Transforms/print-op-graph-back-edges.mlir
@@ -8,13 +8,13 @@
 //       DFG:     subgraph cluster_3 {
 //       DFG:       v4 [label = " ", shape = plain];
 //       DFG:       label = "";
-//       DFG:       v5 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 0 : index", shape = ellipse, style = filled];
-//       DFG:       v6 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 1 : index", shape = ellipse, style = filled];
-//       DFG:       v7 [fillcolor = "0.000000 1.0 1.0", label = "arith.addi : (index)\n\noverflowFlags: #arith.overflow<none...", shape = ellipse, style = filled];
+//       DFG:       v5 [fillcolor = "0.000000 1.0 1.0", label = "arith.addi : (index)\n\noverflowFlags: #arith.overflow<none...", shape = ellipse, style = filled];
+//       DFG:       v6 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 0 : index", shape = ellipse, style = filled];
+//       DFG:       v7 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 1 : index", shape = ellipse, style = filled];
 //       DFG:     }
 //       DFG:   }
-//       DFG:   v5 -> v7 [label = "0", style = solid];
-//       DFG:   v6 -> v7 [label = "1", style = solid];
+//       DFG:   v6 -> v5 [label = "0", style = solid];
+//       DFG:   v7 -> v5 [label = "1", style = solid];
 //       DFG: }
 
 module {

--- a/mlir/test/Transforms/print-op-graph-backedges.mlir
+++ b/mlir/test/Transforms/print-op-graph-backedges.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt -view-op-graph %s -o %t 2>&1 | FileCheck -check-prefix=DFG %s
+
+// DFG-LABEL: digraph G {
+//       DFG:   compound = true;
+//       DFG:   subgraph cluster_1 {
+//       DFG:     v2 [label = " ", shape = plain];
+//       DFG:     label = "builtin.module : ()\n";
+//       DFG:     subgraph cluster_3 {
+//       DFG:       v4 [label = " ", shape = plain];
+//       DFG:       label = "";
+//       DFG:       v5 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 0 : index", shape = ellipse, style = filled];
+//       DFG:       v6 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 1 : index", shape = ellipse, style = filled];
+//       DFG:       v7 [fillcolor = "0.000000 1.0 1.0", label = "arith.addi : (index)\n\noverflowFlags: #arith.overflow<none...", shape = ellipse, style = filled];
+//       DFG:     }
+//       DFG:   }
+//       DFG:   v5 -> v7 [label = "0", style = solid];
+//       DFG:   v6 -> v7 [label = "1", style = solid];
+//       DFG: }
+
+module {
+  %add = arith.addi %c0, %c1 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+}

--- a/mlir/test/Transforms/print-op-graph-cycles.mlir
+++ b/mlir/test/Transforms/print-op-graph-cycles.mlir
@@ -1,0 +1,51 @@
+// RUN: mlir-opt -view-op-graph -allow-unregistered-dialect %s -o %t 2>&1 | FileCheck -check-prefix=DFG %s
+
+// DFG-LABEL: digraph G {
+//       DFG:   compound = true;
+//       DFG:   subgraph cluster_1 {
+//       DFG:     v2 [label = " ", shape = plain];
+//       DFG:     label = "builtin.module : ()\n";
+//       DFG:     subgraph cluster_3 {
+//       DFG:       v4 [label = " ", shape = plain];
+//       DFG:       label = "";
+//       DFG:       subgraph cluster_5 {
+//       DFG:         v6 [label = " ", shape = plain];
+//       DFG:         label = "test.graph_region : ()\n";
+//       DFG:         subgraph cluster_7 {
+//       DFG:           v8 [label = " ", shape = plain];
+//       DFG:           label = "";
+//       DFG:           v9 [fillcolor = "0.000000 1.0 1.0", label = "op1 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:           subgraph cluster_10 {
+//       DFG:             v11 [label = " ", shape = plain];
+//       DFG:             label = "test.ssacfg_region : (i32)\n";
+//       DFG:             subgraph cluster_12 {
+//       DFG:               v13 [label = " ", shape = plain];
+//       DFG:               label = "";
+//       DFG:               v14 [fillcolor = "0.166667 1.0 1.0", label = "op2 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:             }
+//       DFG:           }
+//       DFG:           v15 [fillcolor = "0.166667 1.0 1.0", label = "op2 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:           v16 [fillcolor = "0.500000 1.0 1.0", label = "op3 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:         }
+//       DFG:       }
+//       DFG:     }
+//       DFG:   }
+//       DFG:   v9 -> v9 [label = "0", style = solid];
+//       DFG:   v15 -> v9 [label = "1", style = solid];
+//       DFG:   v9 -> v14 [label = "0", style = solid];
+//       DFG:   v11 -> v14 [ltail = cluster_10, style = solid];
+//       DFG:   v15 -> v14 [label = "2", style = solid];
+//       DFG:   v16 -> v14 [label = "3", style = solid];
+//       DFG:   v9 -> v15 [label = "0", style = solid];
+//       DFG:   v16 -> v15 [label = "1", style = solid];
+//       DFG:   v9 -> v16 [label = "", style = solid];
+//       DFG: }
+
+"test.graph_region"() ({ // A Graph region
+  %1 = "op1"(%1, %3) : (i32, i32) -> (i32)  // OK: %1, %3 allowed here
+  %2 = "test.ssacfg_region"() ({
+     %5 = "op2"(%1, %2, %3, %4) : (i32, i32, i32, i32) -> (i32) // OK: %1, %2, %3, %4 all defined in the containing region
+  }) : () -> (i32)
+  %3 = "op2"(%1, %4) : (i32, i32) -> (i32)  // OK: %4 allowed here
+  %4 = "op3"(%1) : (i32) -> (i32)
+}) : () -> ()


### PR DESCRIPTION
Fixes #62128.

Before:

![before](https://github.com/llvm/llvm-project/assets/794591/531b47f2-0638-47d1-864f-9dbed06e176b)

After:

![after](https://github.com/llvm/llvm-project/assets/794591/8a8f438a-7c8b-4b9c-a7af-40971bda8bfd)
