### PR TITLE
[Clang] Add 'CLANG_ALLOW_IMPLICIT_RPATH' to enable toolchain use of -rpath

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -213,6 +213,8 @@ set(CLANG_SPAWN_CC1 OFF CACHE BOOL
 
 option(CLANG_DEFAULT_PIE_ON_LINUX "Default to -fPIE and -pie on linux-gnu" ON)
 
+option(CLANG_ALLOW_IMPLICIT_RPATH "Allow clang to add -rpath automatically" ON)
+
 set(CLANG_DEFAULT_LINKER "" CACHE STRING
   "Default linker to use (linker name or absolute path, empty for platform default)")
 

--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -63,6 +63,9 @@
 /* Define if dladdr() is available on this platform. */
 #cmakedefine CLANG_HAVE_DLADDR ${CLANG_HAVE_DLADDR}
 
+/* Define if we have sys/resource.h (rlimits) */
+#cmakedefine01 CLANG_ALLOW_IMPLICIT_RPATH
+
 /* Linker version detected at compile time. */
 #cmakedefine HOST_LINK_VERSION "${HOST_LINK_VERSION}"
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1107,7 +1107,8 @@ void tools::addOpenMPRuntimeLibraryPath(const ToolChain &TC,
 void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,
                                  ArgStringList &CmdArgs) {
   if (!Args.hasFlag(options::OPT_frtlib_add_rpath,
-                    options::OPT_fno_rtlib_add_rpath, false))
+                    options::OPT_fno_rtlib_add_rpath,
+                    CLANG_ALLOW_IMPLICIT_RPATH))
     return;
 
   for (const auto &CandidateRPath : TC.getArchSpecificLibPaths()) {

--- a/clang/test/Driver/arch-specific-libdir-rpath.c
+++ b/clang/test/Driver/arch-specific-libdir-rpath.c
@@ -1,13 +1,6 @@
 // Test that the driver adds an arch-specific subdirectory in
 // {RESOURCE_DIR}/lib/linux to the linker search path and to '-rpath'
 //
-// Test the default behavior when neither -frtlib-add-rpath nor
-// -fno-rtlib-add-rpath is specified, which is to skip -rpath
-// RUN: %clang %s -### --target=x86_64-linux \
-// RUN:     -fsanitize=address -shared-libasan \
-// RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
-//
 // Test that -rpath is not added under -fno-rtlib-add-rpath even if other
 // conditions are met.
 // RUN: %clang %s -### --target=x86_64-linux \


### PR DESCRIPTION
Summary:
The original discussion in https://reviews.llvm.org/D118493 was that
`clang` should not be adding `-rpath` implicitly for toolchains. The
main motivation behind that change was the 'Fedora' toolchain
disallowing usage of `-rpath` in their tools. This patch introduces a
new clang configuration called `CLANG_ALLOW_IMPLICT_RPATH` that defaults
to on.

The motivation behind this patch is the fact that the LLVM offloading
toolchain is currently in a nearly unusable state for casual users. This
is a problem for other runtimes like `libc++` or `libunwind`, however
`libomptarget` and other offloading runtimes like HIP are much difficult
to support. Currently, `libomptarget` is only supported to be used with
the same build that created the executable. Furthermore, `libomptarget`
is currently shipped by four different vendors, which are not mutually
compatible. Because this is totally broken as far as I'm aware all the
vendor compilers reverted the original patch turning this off.

The presented solution was to advise users to use Clang configruation
files. Since then, this was added to the documentation at the website
https://openmp.llvm.org/SupportAndFAQ.html#q-what-are-the-llvm-components-used-in-offloading-and-how-are-they-found
but this has not had any noticable effect on the number of people I've
had to coach through their broken environment since the patch was
reverted and is roughly equivalent to the currenlty accepted solution of
using LD_LIBRARY_PATH.

This would be solved with static linking, but offloading runtimes also
manage thred pools and device resources that cannot be duplicated. The
Fedora distributors were the only group that were against doing this by
default, so the suggestion is that Fedora uses
`-DCLANG_ALLOW_IMPLICIT_RPATH=OFF` when building.

Fixes https://github.com/llvm/llvm-project/issues/81868