### PR TITLE
[libc][NFC] Add missing constexpr

### DIFF
--- a/libc/src/__support/number_pair.h
+++ b/libc/src/__support/number_pair.h
@@ -21,8 +21,8 @@ template <typename T> struct NumberPair {
 };
 
 template <typename T>
-cpp::enable_if_t<cpp::is_integral_v<T> && cpp::is_unsigned_v<T>, NumberPair<T>>
-split(T a) {
+cpp::enable_if_t<cpp::is_integral_v<T> && cpp::is_unsigned_v<T>,
+                 NumberPair<T>> constexpr split(T a) {
   constexpr size_t HALF_BIT_WIDTH = sizeof(T) * 4;
   constexpr T LOWER_HALF_MASK = (T(1) << HALF_BIT_WIDTH) - T(1);
   NumberPair<T> result;


### PR DESCRIPTION
This is a fix forward for the Fuchsia build bot
https://lab.llvm.org/buildbot/#/builders/98/builds/33515
