### PR TITLE
[AMDGPU] Use HasClamp instead of HasIntClamp in VOP3_Pseudo. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -161,7 +161,7 @@ class VOP3_Pseudo <string opName, VOPProfile P, list<dag> pattern = [],
   let AsmMatchConverter =
     !if(isVOP3P,
         "cvtVOP3P",
-        !if(!or(P.HasModifiers, P.HasOMod, P.HasIntClamp),
+        !if(!or(P.HasModifiers, P.HasOMod, P.HasClamp),
             "cvtVOP3",
             ""));
 }


### PR DESCRIPTION
There is no real reason to differentiate.