### PR TITLE
[libc++][vector] Make constructor vector(count, value, allocator) exception-safe

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -433,10 +433,12 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
   vector(size_type __n, const value_type& __x, const allocator_type& __a)
       : __end_cap_(nullptr, __a) {
+    auto __guard = std::__make_exception_guard(__destroy_vector(*this));
     if (__n > 0) {
       __vallocate(__n);
       __construct_at_end(__n, __x);
     }
+    __guard.__complete();
   }
 
   template <class _InputIterator,


### PR DESCRIPTION
The constructor `std::vector(count, value, allocator)` was missing an exception guard,
responsible for destroying successfully created elements, in case an exception was thrown:
- https://godbolt.org/z/MeK37n8fb

Since all constructors filling `std::vector<>` with elements of the same value:
 - `vector(count)`
 - `vector(count, allocator)`
 - `vector(count, value)`
 - `vector(count, value, allocator)`

have nearly identical implementation, their definitions should be physically close to each other.

In order to achieve that goal, the constructor `std::vector(count, value, allocator)` is now defined
outside of the `std::vector<>` class template and has sightly different `enable_if<>` expression,
matching to those used in the constructors taking two iterators:
 - `vector(iterator first, iterator last)`
 - `vector(iterator first, iterator last, allocator)`