### PR TITLE
[lldb-dap] Do not write over the existing error if launchCommands fail during debugger launch.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -122,6 +122,8 @@ class DAPTestCaseBase(TestBase):
         for cmd in commands:
             found = False
             for line in lines:
+                if len(cmd) > 0 and (cmd[0] == "!" or cmd[0] == "?"):
+                    cmd = cmd[1:]
                 if line.startswith(prefix) and cmd in line:
                     found = True
                     break

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -2,7 +2,6 @@
 Test lldb-dap setBreakpoints request
 """
 
-
 import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -398,7 +397,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         # Verify all "preRunCommands" were found in console output
         self.verify_commands("preRunCommands", output, preRunCommands)
 
-        # Verify all "launchCommands" were founc in console output
+        # Verify all "launchCommands" were found in console output
         # After execution, program should launch
         self.verify_commands("launchCommands", output, launchCommands)
         # Verify the "stopCommands" here
@@ -419,6 +418,47 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         # "exitCommands" that were run after the second breakpoint was hit
         output = self.get_console(timeout=1.0)
         self.verify_commands("exitCommands", output, exitCommands)
+
+    @skipIfWindows
+    @skipIfRemote
+    def test_failing_launch_commands(self):
+        """
+        Tests "launchCommands" failures prevents a launch.
+        """
+        self.build_and_create_debug_adaptor()
+        program = self.getBuildArtifact("a.out")
+
+        # Run an invalid launch command, in this case a bad path.
+        launchCommands = ['!target create "/bad/path%s"' % (program)]
+
+        initCommands = ["target list", "platform list"]
+        preRunCommands = ["image list a.out", "image dump sections a.out"]
+        response = self.launch(
+            program,
+            initCommands=initCommands,
+            preRunCommands=preRunCommands,
+            launchCommands=launchCommands,
+            expectFailure=True,
+        )
+
+        self.assertFalse(response["success"])
+        self.assertRegex(
+            response["message"],
+            r"Failed to run launch commands\. See the Debug Console for more details",
+        )
+
+        # Get output from the console. This should contain both the
+        # "initCommands" and the "preRunCommands".
+        output = self.get_console()
+        # Verify all "initCommands" were found in console output
+        self.verify_commands("initCommands", output, initCommands)
+        # Verify all "preRunCommands" were found in console output
+        self.verify_commands("preRunCommands", output, preRunCommands)
+
+        # Verify all "launchCommands" were founc in console output
+        # The launch should fail due to the invalid command.
+        self.verify_commands("launchCommands", output, launchCommands)
+        self.assertRegex(output, r"unable to find executable for '/bad/path/")
 
     @skipIfWindows
     @skipIfNetBSD  # Hangs on NetBSD as well

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1779,8 +1779,10 @@ lldb::SBError LaunchProcess(const llvm::json::Object &request) {
     // Set the launch info so that run commands can access the configured
     // launch details.
     g_dap.target.SetLaunchInfo(launch_info);
-    if (llvm::Error err = g_dap.RunLaunchCommands(launchCommands))
+    if (llvm::Error err = g_dap.RunLaunchCommands(launchCommands)) {
       error.SetErrorString(llvm::toString(std::move(err)).c_str());
+      return error;
+    }
     // The custom commands might have created a new target so we should use the
     // selected target after these commands are run.
     g_dap.target = g_dap.debugger.GetSelectedTarget();


### PR DESCRIPTION
This fixes an issue where the error is lost if a command while executing `launchCommands` when launching the debugger.

This should fix #82048