### PR TITLE
[BOLT][NFC] Remove redundant assertion

### DIFF
--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -221,8 +221,6 @@ void LinuxKernelRewriter::insertLKMarker(uint64_t PC, uint64_t SectionOffset,
 }
 
 void LinuxKernelRewriter::processLKSections() {
-  assert(BC.IsLinuxKernel && "Linux kernel binary expected.");
-
   processLKExTable();
   processLKPCIFixup();
   processLKKSymtab();


### PR DESCRIPTION
processLKSections() used to be a member of RewriteInstance. Since now it is part of the LinuxKernelRewriter, the assertion is no longer needed.