### PR TITLE
[Fuzzer] Use user signal to coordinate handler shutdown

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerUtilFuchsia.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilFuchsia.cpp
@@ -292,7 +292,7 @@ void CrashHandler() {
     zx_wait_item_t WaitItems[] = {
         {
             .handle = SignalHandlerEvent,
-            .waitfor = ZX_SIGNAL_HANDLE_CLOSED,
+            .waitfor = ZX_USER_SIGNAL_1,
             .pending = 0,
         },
         {
@@ -378,10 +378,11 @@ void CrashHandler() {
 }
 
 void StopSignalHandler() {
-  _zx_handle_close(SignalHandlerEvent);
+  _zx_object_signal(SignalHandlerEvent, 0, ZX_USER_SIGNAL_1);
   if (SignalHandler.joinable()) {
     SignalHandler.join();
   }
+  _zx_handle_close(SignalHandlerEvent);
 }
 
 } // namespace


### PR DESCRIPTION
This updates the signal handle thread coordinating to use a user signal bit on the SignalHandlerEvent to coordinate shutdown instead of closing the event handle. Closing the event handle is racy as the handle may be closed before the signal handler thread resolves the handle value in _zx_object_wait_many() and we would like to make this an explicit error. Using the user signal bit 1 instead and then closing the event object after the signal handler thread is joined cannot race as the wait will terminate whether the signal is raised before or after the wait begins.