### PR TITLE
Revert "[Support] Introduce formatv variant of createStringError"

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -22,7 +22,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Format.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdint>
@@ -1260,15 +1259,6 @@ template <typename... Ts>
 inline Error createStringError(std::errc EC, char const *Fmt,
                                const Ts &... Vals) {
   return createStringError(std::make_error_code(EC), Fmt, Vals...);
-}
-
-template <typename... Ts>
-inline Error createStringErrorV(std::error_code EC, const char *Fmt,
-                                const Ts &...Vals) {
-  std::string Buffer;
-  raw_string_ostream Stream(Buffer);
-  Stream << formatv(Fmt, Vals...);
-  return make_error<StringError>(Stream.str(), EC);
 }
 
 /// This class wraps a filename and another Error.

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -472,23 +472,6 @@ TEST(Error, createStringError) {
     << "Failed to convert createStringError() result to error_code.";
 }
 
-TEST(Error, createStringErrorV) {
-  static llvm::StringRef Bar("bar");
-  static const std::error_code EC = errc::invalid_argument;
-  std::string Msg;
-  raw_string_ostream S(Msg);
-  logAllUnhandledErrors(createStringErrorV(EC, "foo{0}{1}{2:x}", Bar, 1, 0xff),
-                        S);
-  EXPECT_EQ(S.str(), "foobar10xff\n")
-      << "Unexpected createStringErrorV() log result";
-
-  S.flush();
-  Msg.clear();
-  auto Res = errorToErrorCode(createStringErrorV(EC, "foo{0}", Bar));
-  EXPECT_EQ(Res, EC)
-      << "Failed to convert createStringErrorV() result to error_code.";
-}
-
 // Test that the ExitOnError utility works as expected.
 TEST(ErrorDeathTest, ExitOnError) {
   ExitOnError ExitOnErr;


### PR DESCRIPTION
Reverts llvm/llvm-project#80493

This increased clang compile times by 0.5%. I'll figure out a less expensive way to achieve this.

