### PR TITLE
[Github] Add ability to filter jobs in job counting script

### DIFF
--- a/llvm/utils/count_running_jobs.py
+++ b/llvm/utils/count_running_jobs.py
@@ -16,7 +16,7 @@ import argparse
 import github
 
 
-def main(token):
+def main(token, filter_gha_runners):
     workflows = (
         github.Github(args.token)
         .get_repo("llvm/llvm-project")
@@ -28,6 +28,8 @@ def main(token):
     for workflow in workflows:
         for job in workflow.jobs():
             if job.status == "in_progress":
+                if filter_gha_runners and job.runner_group_name != "GitHub Actions":
+                    continue
                 print(f"{workflow.name}/{job.name}")
                 in_progress_jobs += 1
 
@@ -45,5 +47,18 @@ if __name__ == "__main__":
         default=None,
         nargs="?",
     )
+    parser.add_argument(
+        "--filter-gha-runners",
+        help="Only consider jobs running on hosted Github actions runners",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--no-filter-gha-runners",
+        dest="filter_gha_runners",
+        action="store_false",
+        help="Consider all running jobs",
+    )
+    parser.set_defaults(filter_gha_runners=True)
+
     args = parser.parse_args()
-    main(args.token)
+    main(args.token, args.filter_gha_runners)

--- a/llvm/utils/count_running_jobs.py
+++ b/llvm/utils/count_running_jobs.py
@@ -28,8 +28,17 @@ def main(token, filter_gha_runners):
     for workflow in workflows:
         for job in workflow.jobs():
             if job.status == "in_progress":
-                if filter_gha_runners and job.runner_group_name != "GitHub Actions":
-                    continue
+                # TODO(boomanaiden154): Remove the try/except block once we are able
+                # to pull in a PyGithub release that has the runner_group_name property
+                # for workflow jobs.
+                try:
+                    if filter_gha_runners and job.runner_group_name != "GitHub Actions":
+                        continue
+                except:
+                    print(
+                        "Failed to filter runners. Your PyGithub version is "
+                        "most likely too old."
+                    )
                 print(f"{workflow.name}/{job.name}")
                 in_progress_jobs += 1
 
@@ -58,7 +67,7 @@ if __name__ == "__main__":
         action="store_false",
         help="Consider all running jobs",
     )
-    parser.set_defaults(filter_gha_runners=True)
+    parser.set_defaults(filter_gha_runners=False)
 
     args = parser.parse_args()
     main(args.token, args.filter_gha_runners)


### PR DESCRIPTION
This patch adds a new flag pair, --filter-gha-runners, and --no-filter-gha-runners, that filters out all non-Github hosted runners so that we can actual counts of the Github runners, where we are actually limited.