### PR TITLE
[clang][CodeCoverage] Fix CoverageMapping for binary conditionals ops

### DIFF
--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -1942,6 +1942,8 @@ struct CounterCoverageMappingBuilder
 
       extendRegion(E->getTrueExpr());
       OutCount = propagateCounts(TrueCount, E->getTrueExpr());
+    } else {
+      OutCount = TrueCount;
     }
 
     extendRegion(E->getFalseExpr());

--- a/clang/test/CoverageMapping/conditional-operator.c
+++ b/clang/test/CoverageMapping/conditional-operator.c
@@ -11,14 +11,14 @@ int binary_conditional(int x) {
   return y;
 }
 
-// CHECK-LABEL:       tenary_conditional:
+// CHECK-LABEL:       ternary_conditional:
 // CHECK-NEXT:          File 0, [[@LINE+6]]:31 -> {{[0-9]+}}:2 = #0
 // CHECK-NEXT:          File 0, [[@LINE+6]]:7 -> [[@LINE+6]]:8 = #0
 // CHECK-NEXT:          Branch,File 0, [[@LINE+5]]:7 -> [[@LINE+5]]:8 = #1, (#0 - #1)
 // CHECK-NEXT:          Gap,File 0, [[@LINE+4]]:10 -> [[@LINE+4]]:11 = #1
 // CHECK-NEXT:          File 0, [[@LINE+3]]:11 -> [[@LINE+3]]:12 = #1
 // CHECK-NEXT:          File 0, [[@LINE+2]]:15 -> [[@LINE+2]]:16 = (#0 - #1)
-int tenary_conditional(int x) {
+int ternary_conditional(int x) {
   x = x ? x : 4;
   int y = x;
   return y;

--- a/clang/test/CoverageMapping/conditional-operator.c
+++ b/clang/test/CoverageMapping/conditional-operator.c
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only %s | FileCheck %s
+
+// CHECK-LABEL:       binary_conditional:
+// CHECK-NEXT:          File 0, [[@LINE+4]]:31 -> {{[0-9]+}}:2 = #0
+// CHECK-NEXT:          File 0, [[@LINE+4]]:7 -> [[@LINE+4]]:8 = #0
+// CHECK-NEXT:          Branch,File 0, [[@LINE+3]]:7 -> [[@LINE+3]]:8 = #1, (#0 - #1)
+// CHECK-NEXT:          File 0, [[@LINE+2]]:13 -> [[@LINE+2]]:14 = (#0 - #1)
+int binary_conditional(int x) {
+  x = x ? : 4;
+  int y = x;
+  return y;
+}
+
+// CHECK-LABEL:       tenary_conditional:
+// CHECK-NEXT:          File 0, [[@LINE+6]]:31 -> {{[0-9]+}}:2 = #0
+// CHECK-NEXT:          File 0, [[@LINE+6]]:7 -> [[@LINE+6]]:8 = #0
+// CHECK-NEXT:          Branch,File 0, [[@LINE+5]]:7 -> [[@LINE+5]]:8 = #1, (#0 - #1)
+// CHECK-NEXT:          Gap,File 0, [[@LINE+4]]:10 -> [[@LINE+4]]:11 = #1
+// CHECK-NEXT:          File 0, [[@LINE+3]]:11 -> [[@LINE+3]]:12 = #1
+// CHECK-NEXT:          File 0, [[@LINE+2]]:15 -> [[@LINE+2]]:16 = (#0 - #1)
+int tenary_conditional(int x) {
+  x = x ? x : 4;
+  int y = x;
+  return y;
+}


### PR DESCRIPTION
Fix an issue that produces a wrong coverage mapping when using binary conditional operators as show in the example below.

Before this patch:

```
    1|      1|int binary_cond(int x) {
    2|      1|  x = x ?: 4;
    3|      1|  int y = 0;
    4|      0|  return x;       <-- Not covered
    5|      1|}
```

After this patch:

```
    1|      1|int binary_cond(int x) {
    2|      1|  x = x ?: 4;
    3|      1|  int y = 0;
    4|      1|  return x;       <-- Covered
    5|      1|}
```