### PR TITLE
[LLVM][DebugInfo] Refactor some code for easier sharing.

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -562,6 +562,17 @@ public:
     uint64_t getEntryOffset() const { return EntryOffset; }
   };
 
+  // Offsets for the start of various important tables from the start of the
+  // section.
+  struct DWARFDebugNamesOffsets {
+    uint64_t CUsBase;
+    uint64_t BucketsBase;
+    uint64_t HashesBase;
+    uint64_t StringOffsetsBase;
+    uint64_t EntryOffsetsBase;
+    uint64_t EntriesBase;
+  };
+
   /// Represents a single accelerator table within the DWARF v5 .debug_names
   /// section.
   class NameIndex {
@@ -572,12 +583,7 @@ public:
     // Base of the whole unit and of various important tables, as offsets from
     // the start of the section.
     uint64_t Base;
-    uint64_t CUsBase;
-    uint64_t BucketsBase;
-    uint64_t HashesBase;
-    uint64_t StringOffsetsBase;
-    uint64_t EntryOffsetsBase;
-    uint64_t EntriesBase;
+    DWARFDebugNamesOffsets Offsets;
 
     void dumpCUs(ScopedPrinter &W) const;
     void dumpLocalTUs(ScopedPrinter &W) const;
@@ -638,7 +644,7 @@ public:
     /// Returns the Entry at the relative `Offset` from the start of the Entry
     /// pool.
     Expected<Entry> getEntryAtRelativeOffset(uint64_t Offset) const {
-      auto OffsetFromSection = Offset + this->EntriesBase;
+      auto OffsetFromSection = Offset + this->Offsets.EntriesBase;
       return getEntry(&OffsetFromSection);
     }
 
@@ -792,6 +798,14 @@ public:
   /// there is no Name Index covering that unit.
   const NameIndex *getCUNameIndex(uint64_t CUOffset);
 };
+
+// Calculates the starting offsets for various sections within the
+// debug_names section. This has been pulled out of DWARFDebugNames, to
+// allow easier sharing of the code with other tools, such as LLD.
+uint64_t FindDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
+                               uint64_t HdrSize,
+                               const dwarf::DwarfFormat Format,
+                               const DWARFDebugNames::Header &Hdr);
 
 /// If `Name` is the name of a templated function that includes template
 /// parameters, returns a substring of `Name` containing no template

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -802,8 +802,7 @@ public:
 /// Calculates the starting offsets for various sections within the
 /// .debug_names section.
 void findDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
-                           uint64_t HdrSize,
-                           const dwarf::DwarfFormat Format,
+                           uint64_t HdrSize, const dwarf::DwarfFormat Format,
                            const DWARFDebugNames::Header &Hdr);
 
 /// If `Name` is the name of a templated function that includes template

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -562,8 +562,8 @@ public:
     uint64_t getEntryOffset() const { return EntryOffset; }
   };
 
-  // Offsets for the start of various important tables from the start of the
-  // section.
+  /// Offsets for the start of various important tables from the start of the
+  /// section.
   struct DWARFDebugNamesOffsets {
     uint64_t CUsBase;
     uint64_t BucketsBase;
@@ -799,13 +799,12 @@ public:
   const NameIndex *getCUNameIndex(uint64_t CUOffset);
 };
 
-// Calculates the starting offsets for various sections within the
-// debug_names section. This has been pulled out of DWARFDebugNames, to
-// allow easier sharing of the code with other tools, such as LLD.
-uint64_t FindDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
-                               uint64_t HdrSize,
-                               const dwarf::DwarfFormat Format,
-                               const DWARFDebugNames::Header &Hdr);
+/// Calculates the starting offsets for various sections within the
+/// .debug_names section.
+void findDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
+                           uint64_t HdrSize,
+                           const dwarf::DwarfFormat Format,
+                           const DWARFDebugNames::Header &Hdr);
 
 /// If `Name` is the name of a templated function that includes template
 /// parameters, returns a substring of `Name` containing no template

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -552,11 +552,10 @@ DWARFDebugNames::NameIndex::extractAbbrev(uint64_t *Offset) {
   return Abbrev(Code, dwarf::Tag(Tag), AbbrevOffset, std::move(*AttrEncOr));
 }
 
-uint64_t llvm::FindDebugNamesOffsets(
-    DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
-    uint64_t HdrSize,
-    dwarf::DwarfFormat Format,
-    const DWARFDebugNames::Header &Hdr) {
+uint64_t
+llvm::FindDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
+                            uint64_t HdrSize, dwarf::DwarfFormat Format,
+                            const DWARFDebugNames::Header &Hdr) {
   uint32_t DwarfSize = (Format == llvm::dwarf::DwarfFormat::DWARF32) ? 4 : 8;
   uint64_t Offset = HdrSize;
   Offsets.CUsBase = Offset;
@@ -736,7 +735,8 @@ uint64_t DWARFDebugNames::NameIndex::getCUOffset(uint32_t CU) const {
 uint64_t DWARFDebugNames::NameIndex::getLocalTUOffset(uint32_t TU) const {
   assert(TU < Hdr.LocalTypeUnitCount);
   const unsigned SectionOffsetSize = dwarf::getDwarfOffsetByteSize(Hdr.Format);
-  uint64_t Offset = Offsets.CUsBase + SectionOffsetSize * (Hdr.CompUnitCount + TU);
+  uint64_t Offset =
+      Offsets.CUsBase + SectionOffsetSize * (Hdr.CompUnitCount + TU);
   return Section.AccelSection.getRelocatedValue(SectionOffsetSize, &Offset);
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -552,10 +552,9 @@ DWARFDebugNames::NameIndex::extractAbbrev(uint64_t *Offset) {
   return Abbrev(Code, dwarf::Tag(Tag), AbbrevOffset, std::move(*AttrEncOr));
 }
 
-void
-llvm::findDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
-                            uint64_t HdrSize, dwarf::DwarfFormat Format,
-                            const DWARFDebugNames::Header &Hdr) {
+void llvm::findDebugNamesOffsets(
+    DWARFDebugNames::DWARFDebugNamesOffsets &Offsets, uint64_t HdrSize,
+    dwarf::DwarfFormat Format, const DWARFDebugNames::Header &Hdr) {
   uint32_t DwarfSize = (Format == llvm::dwarf::DwarfFormat::DWARF64) ? 8 : 4;
   uint64_t Offset = HdrSize;
   Offsets.CUsBase = Offset;
@@ -589,7 +588,8 @@ Error DWARFDebugNames::NameIndex::extract() {
   const unsigned SectionOffsetSize = dwarf::getDwarfOffsetByteSize(Hdr.Format);
   findDebugNamesOffsets(Offsets, hdrSize, Hdr.Format, Hdr);
 
-  uint64_t Offset = Offsets.EntryOffsetsBase + (Hdr.NameCount * SectionOffsetSize);
+  uint64_t Offset =
+      Offsets.EntryOffsetsBase + (Hdr.NameCount * SectionOffsetSize);
 
   if (!AS.isValidOffsetForDataOfSize(Offset, Hdr.AbbrevTableSize))
     return createStringError(errc::illegal_byte_sequence,

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -552,11 +552,11 @@ DWARFDebugNames::NameIndex::extractAbbrev(uint64_t *Offset) {
   return Abbrev(Code, dwarf::Tag(Tag), AbbrevOffset, std::move(*AttrEncOr));
 }
 
-uint64_t
-llvm::FindDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
+void
+llvm::findDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
                             uint64_t HdrSize, dwarf::DwarfFormat Format,
                             const DWARFDebugNames::Header &Hdr) {
-  uint32_t DwarfSize = (Format == llvm::dwarf::DwarfFormat::DWARF32) ? 4 : 8;
+  uint32_t DwarfSize = (Format == llvm::dwarf::DwarfFormat::DWARF64) ? 8 : 4;
   uint64_t Offset = HdrSize;
   Offsets.CUsBase = Offset;
   Offset += Hdr.CompUnitCount * DwarfSize;
@@ -578,20 +578,18 @@ llvm::FindDebugNamesOffsets(DWARFDebugNames::DWARFDebugNamesOffsets &Offsets,
 
   Offset += Hdr.AbbrevTableSize;
   Offsets.EntriesBase = Offset;
-
-  return Offset;
 }
 
 Error DWARFDebugNames::NameIndex::extract() {
   const DWARFDataExtractor &AS = Section.AccelSection;
-  uint64_t Offset = Base;
-  if (Error E = Hdr.extract(AS, &Offset))
+  uint64_t hdrSize = Base;
+  if (Error E = Hdr.extract(AS, &hdrSize))
     return E;
 
   const unsigned SectionOffsetSize = dwarf::getDwarfOffsetByteSize(Hdr.Format);
-  Offset = FindDebugNamesOffsets(Offsets, Offset, Hdr.Format, Hdr);
+  findDebugNamesOffsets(Offsets, hdrSize, Hdr.Format, Hdr);
 
-  Offset = Offsets.EntryOffsetsBase + (Hdr.NameCount * SectionOffsetSize);
+  uint64_t Offset = Offsets.EntryOffsetsBase + (Hdr.NameCount * SectionOffsetSize);
 
   if (!AS.isValidOffsetForDataOfSize(Offset, Hdr.AbbrevTableSize))
     return createStringError(errc::illegal_byte_sequence,


### PR DESCRIPTION
Refactor the code that calculates the offsets for the various pieces of the DWARF .debug_names index section, to make it easier to share the code with other tools, such as LLD.