### PR TITLE
[Clang][Sema] Remove invalid ctor (NFC)

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -4739,8 +4739,6 @@ public:
     const TemplateArgumentLoc *operator->() const { return &Arg; }
   };
 
-  TemplateArgumentLocInventIterator() { }
-
   explicit TemplateArgumentLocInventIterator(TreeTransform<Derived> &Self,
                                              InputIterator Iter)
     : Self(Self), Iter(Iter) { }


### PR DESCRIPTION
`TemplateArgumentLocInventIterator` default constructor should not exists
https://github.com/llvm/llvm-project/blob/3496927edcd0685807351ba88a7e2cfb006e1c0d/clang/lib/Sema/TreeTransform.h#L4742
 because it doesn't and couldn't initialize `Self` member that is reference:
https://github.com/llvm/llvm-project/blob/3496927edcd0685807351ba88a7e2cfb006e1c0d/clang/lib/Sema/TreeTransform.h#L4721-L4723

Instantiation of this constructor is always a compile-time error. 

Please note, that I didn't run any tests, because cannot imagine situation where this constructor can be properly used. There are no new tests for this fix for the same reason.