### PR TITLE
[RISCV] Take SEW/LMUL into account for value tracking of vsetvli[max]

### DIFF
--- a/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-knownbits.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-knownbits.ll
@@ -91,8 +91,7 @@ entry:
 define i64 @vsetvl_e8m1_and14bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8m1_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 0)
   %b = and i64 %a, 16383
@@ -113,8 +112,7 @@ define i64 @vsetvl_e8m1_and13bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e8m1_constant_avl() nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8m1_constant_avl(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 1, i64 0, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 1, i64 0, i64 0)
   %b = and i64 %a, 1
@@ -124,8 +122,7 @@ define i64 @vsetvl_e8m1_constant_avl() nounwind #0 {
 define i64 @vsetvl_e8m2_and15bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8m2_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 1)
   %b = and i64 %a, 32767
@@ -146,8 +143,7 @@ define i64 @vsetvl_e8m2_and14bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e8m4_and16bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8m4_and16bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 65535
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 2)
   %b = and i64 %a, 65535
@@ -189,8 +185,7 @@ define i64 @vsetvl_e8m8_and16bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e8mf2_and11bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8mf2_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 5)
   %b = and i64 %a, 2047
@@ -211,8 +206,7 @@ define i64 @vsetvl_e8mf2_and10bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e8mf4_and12bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8mf4_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 6)
   %b = and i64 %a, 4095
@@ -233,8 +227,7 @@ define i64 @vsetvl_e8mf4_and11bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e8mf8_and13bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e8mf8_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 0, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 0, i64 7)
   %b = and i64 %a, 8191
@@ -255,8 +248,7 @@ define i64 @vsetvl_e8mf8_and12bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16m1_and13bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16m1_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 0)
   %b = and i64 %a, 8191
@@ -277,8 +269,7 @@ define i64 @vsetvl_e16m1_and12bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16m2_and14bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16m2_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 1)
   %b = and i64 %a, 16383
@@ -299,8 +290,7 @@ define i64 @vsetvl_e16m2_and13bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16m4_and15bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16m4_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 2)
   %b = and i64 %a, 32767
@@ -321,8 +311,7 @@ define i64 @vsetvl_e16m4_and14bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16m8_and16bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16m8_and16bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 65535
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 3)
   %b = and i64 %a, 65535
@@ -343,8 +332,7 @@ define i64 @vsetvl_e16m8_and15bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16mf2_and10bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16mf2_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 5)
   %b = and i64 %a, 1023
@@ -365,8 +353,7 @@ define i64 @vsetvl_e16mf2_and9bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16mf4_and11bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16mf4_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 6)
   %b = and i64 %a, 2047
@@ -387,8 +374,7 @@ define i64 @vsetvl_e16mf4_and10bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e16mf8_and12bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e16mf8_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 1, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 1, i64 7)
   %b = and i64 %a, 4095
@@ -409,8 +395,7 @@ define i64 @vsetvl_e16mf8_and11bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32m1_and12bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32m1_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 0)
   %b = and i64 %a, 4095
@@ -431,8 +416,7 @@ define i64 @vsetvl_e32m1_and11bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32m2_and13bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32m2_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 1)
   %b = and i64 %a, 8191
@@ -453,8 +437,7 @@ define i64 @vsetvl_e32m2_and12bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32m4_and14bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32m4_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 2)
   %b = and i64 %a, 16383
@@ -475,8 +458,7 @@ define i64 @vsetvl_e32m4_and13bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32m8_and15bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32m8_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 3)
   %b = and i64 %a, 32767
@@ -497,8 +479,7 @@ define i64 @vsetvl_e32m8_and14bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32mf2_and9bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32mf2_and9bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 511
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 5)
   %b = and i64 %a, 511
@@ -519,8 +500,7 @@ define i64 @vsetvl_e32mf2_and8bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32mf4_and10bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32mf4_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 6)
   %b = and i64 %a, 1023
@@ -541,8 +521,7 @@ define i64 @vsetvl_e32mf4_and9bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e32mf8_and11bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e32mf8_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 2, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 2, i64 7)
   %b = and i64 %a, 2047
@@ -563,8 +542,7 @@ define i64 @vsetvl_e32mf8_and10bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64m1_and11bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64m1_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 0)
   %b = and i64 %a, 2047
@@ -585,8 +563,7 @@ define i64 @vsetvl_e64m1_and10bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64m2_and12bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64m2_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 1)
   %b = and i64 %a, 4095
@@ -607,8 +584,7 @@ define i64 @vsetvl_e64m2_and11bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64m4_and13bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64m4_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 2)
   %b = and i64 %a, 8191
@@ -629,8 +605,7 @@ define i64 @vsetvl_e64m4_and12bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64m8_and14bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64m8_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 3)
   %b = and i64 %a, 16383
@@ -651,8 +626,7 @@ define i64 @vsetvl_e64m8_and13bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64mf2_and8bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64mf2_and8bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 255
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 5)
   %b = and i64 %a, 255
@@ -673,8 +647,7 @@ define i64 @vsetvl_e64mf2_and7bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64mf4_and9bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64mf4_and9bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 511
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 6)
   %b = and i64 %a, 511
@@ -695,8 +668,7 @@ define i64 @vsetvl_e64mf4_and8bits(i64 %avl) nounwind #0 {
 define i64 @vsetvl_e64mf8_and10bits(i64 %avl) nounwind #0 {
 ; CHECK-LABEL: @vsetvl_e64mf8_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL:%.*]], i64 3, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvli(i64 %avl, i64 3, i64 7)
   %b = and i64 %a, 1023

--- a/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvlimax-knownbits.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvlimax-knownbits.ll
@@ -91,8 +91,7 @@ entry:
 define i64 @vsetvlmax_e8m1_and14bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8m1_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 0)
   %b = and i64 %a, 16383
@@ -113,8 +112,7 @@ define i64 @vsetvlmax_e8m1_and13bits() nounwind #0 {
 define i64 @vsetvlmax_e8m2_and15bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8m2_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 1)
   %b = and i64 %a, 32767
@@ -135,8 +133,7 @@ define i64 @vsetvlmax_e8m2_and14bits() nounwind #0 {
 define i64 @vsetvlmax_e8m4_and16bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8m4_and16bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 65535
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 2)
   %b = and i64 %a, 65535
@@ -178,8 +175,7 @@ define i64 @vsetvlmax_e8m8_and16bits() nounwind #0 {
 define i64 @vsetvlmax_e8mf2_and11bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8mf2_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 5)
   %b = and i64 %a, 2047
@@ -200,8 +196,7 @@ define i64 @vsetvlmax_e8mf2_and10bits() nounwind #0 {
 define i64 @vsetvlmax_e8mf4_and12bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8mf4_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 6)
   %b = and i64 %a, 4095
@@ -222,8 +217,7 @@ define i64 @vsetvlmax_e8mf4_and11bits() nounwind #0 {
 define i64 @vsetvlmax_e8mf8_and13bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e8mf8_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 0, i64 7)
   %b = and i64 %a, 8191
@@ -244,8 +238,7 @@ define i64 @vsetvlmax_e8mf8_and12bits() nounwind #0 {
 define i64 @vsetvlmax_e16m1_and13bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16m1_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 0)
   %b = and i64 %a, 8191
@@ -266,8 +259,7 @@ define i64 @vsetvlmax_e16m1_and12bits() nounwind #0 {
 define i64 @vsetvlmax_e16m2_and14bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16m2_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 1)
   %b = and i64 %a, 16383
@@ -288,8 +280,7 @@ define i64 @vsetvlmax_e16m2_and13bits() nounwind #0 {
 define i64 @vsetvlmax_e16m4_and15bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16m4_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 2)
   %b = and i64 %a, 32767
@@ -310,8 +301,7 @@ define i64 @vsetvlmax_e16m4_and14bits() nounwind #0 {
 define i64 @vsetvlmax_e16m8_and16bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16m8_and16bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 65535
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 3)
   %b = and i64 %a, 65535
@@ -332,8 +322,7 @@ define i64 @vsetvlmax_e16m8_and15bits() nounwind #0 {
 define i64 @vsetvlmax_e16mf2_and10bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16mf2_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 5)
   %b = and i64 %a, 1023
@@ -354,8 +343,7 @@ define i64 @vsetvlmax_e16mf2_and9bits() nounwind #0 {
 define i64 @vsetvlmax_e16mf4_and11bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16mf4_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 6)
   %b = and i64 %a, 2047
@@ -376,8 +364,7 @@ define i64 @vsetvlmax_e16mf4_and10bits() nounwind #0 {
 define i64 @vsetvlmax_e16mf8_and12bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e16mf8_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 1, i64 7)
   %b = and i64 %a, 4095
@@ -398,8 +385,7 @@ define i64 @vsetvlmax_e16mf8_and11bits() nounwind #0 {
 define i64 @vsetvlmax_e32m1_and12bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32m1_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 0)
   %b = and i64 %a, 4095
@@ -420,8 +406,7 @@ define i64 @vsetvlmax_e32m1_and11bits() nounwind #0 {
 define i64 @vsetvlmax_e32m2_and13bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32m2_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 1)
   %b = and i64 %a, 8191
@@ -442,8 +427,7 @@ define i64 @vsetvlmax_e32m2_and12bits() nounwind #0 {
 define i64 @vsetvlmax_e32m4_and14bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32m4_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 2)
   %b = and i64 %a, 16383
@@ -464,8 +448,7 @@ define i64 @vsetvlmax_e32m4_and13bits() nounwind #0 {
 define i64 @vsetvlmax_e32m8_and15bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32m8_and15bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 32767
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 3)
   %b = and i64 %a, 32767
@@ -486,8 +469,7 @@ define i64 @vsetvlmax_e32m8_and14bits() nounwind #0 {
 define i64 @vsetvlmax_e32mf2_and9bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32mf2_and9bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 511
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 5)
   %b = and i64 %a, 511
@@ -508,8 +490,7 @@ define i64 @vsetvlmax_e32mf2_and8bits() nounwind #0 {
 define i64 @vsetvlmax_e32mf4_and10bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32mf4_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 6)
   %b = and i64 %a, 1023
@@ -530,8 +511,7 @@ define i64 @vsetvlmax_e32mf4_and9bits() nounwind #0 {
 define i64 @vsetvlmax_e32mf8_and11bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e32mf8_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 2, i64 7)
   %b = and i64 %a, 2047
@@ -552,8 +532,7 @@ define i64 @vsetvlmax_e32mf8_and10bits() nounwind #0 {
 define i64 @vsetvlmax_e64m1_and11bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64m1_and11bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 0)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 2047
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 0)
   %b = and i64 %a, 2047
@@ -574,8 +553,7 @@ define i64 @vsetvlmax_e64m1_and10bits() nounwind #0 {
 define i64 @vsetvlmax_e64m2_and12bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64m2_and12bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 1)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 4095
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 1)
   %b = and i64 %a, 4095
@@ -596,8 +574,7 @@ define i64 @vsetvlmax_e64m2_and11bits() nounwind #0 {
 define i64 @vsetvlmax_e64m4_and13bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64m4_and13bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 2)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 8191
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 2)
   %b = and i64 %a, 8191
@@ -618,8 +595,7 @@ define i64 @vsetvlmax_e64m4_and12bits() nounwind #0 {
 define i64 @vsetvlmax_e64m8_and14bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64m8_and14bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 3)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 16383
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 3)
   %b = and i64 %a, 16383
@@ -640,8 +616,7 @@ define i64 @vsetvlmax_e64m8_and13bits() nounwind #0 {
 define i64 @vsetvlmax_e64mf2_and8bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64mf2_and8bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 5)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 255
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 5)
   %b = and i64 %a, 255
@@ -662,8 +637,7 @@ define i64 @vsetvlmax_e64mf2_and7bits() nounwind #0 {
 define i64 @vsetvlmax_e64mf4_and9bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64mf4_and9bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 6)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 511
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 6)
   %b = and i64 %a, 511
@@ -684,8 +658,7 @@ define i64 @vsetvlmax_e64mf4_and8bits() nounwind #0 {
 define i64 @vsetvlmax_e64mf8_and10bits() nounwind #0 {
 ; CHECK-LABEL: @vsetvlmax_e64mf8_and10bits(
 ; CHECK-NEXT:    [[A:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 7)
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[A]], 1023
-; CHECK-NEXT:    ret i64 [[B]]
+; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = call i64 @llvm.riscv.vsetvlimax(i64 3, i64 7)
   %b = and i64 %a, 1023


### PR DESCRIPTION
So that we can benefit from some instcombine optimizations.

This PR contains two commits: the first is for adding tests and the second is for the optimization.
