### PR TITLE
[Clang] CXXConstructExpr may be immediate calls.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -265,6 +265,8 @@ Bug Fixes to C++ Support
 - No longer reject valid use of the ``_Alignas`` specifier when declaring a
   local variable, which is supported as a C11 extension in C++. Previously, it
   was only accepted at namespace scope but not at local function scope.
+- Clang no longer tries to call consteval constructors at runtime when they appear in a member initializer.
+  (`#782154 <https://github.com/llvm/llvm-project/issues/82154>`_`)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6201,6 +6201,12 @@ struct ImmediateCallVisitor : public RecursiveASTVisitor<ImmediateCallVisitor> {
     return RecursiveASTVisitor<ImmediateCallVisitor>::VisitStmt(E);
   }
 
+  bool VisitCXXConstructExpr(CXXConstructExpr *E) {
+    if (const FunctionDecl *FD = E->getConstructor())
+      HasImmediateCalls |= FD->isImmediateFunction();
+    return RecursiveASTVisitor<ImmediateCallVisitor>::VisitStmt(E);
+  }
+
   // SourceLocExpr are not immediate invocations
   // but CXXDefaultInitExpr/CXXDefaultArgExpr containing a SourceLocExpr
   // need to be rebuilt so that they refer to the correct SourceLocation and

--- a/clang/test/CodeGenCXX/cxx2a-consteval.cpp
+++ b/clang/test/CodeGenCXX/cxx2a-consteval.cpp
@@ -258,3 +258,20 @@ void void_call() { // EVAL-FN-LABEL: define {{.*}} @_Z9void_call
   void_test();
   // EVAL-FN: {{^}}}
 }
+
+
+namespace GH82154 {
+struct S1 { consteval S1(int) {} };
+struct S3 { constexpr S3(int) {} };
+
+void f() {
+    struct S2 {
+        S1 s = 0;
+        S3 s2 = 0;
+    };
+    S2 s;
+    // EVAL-FN-LABEL: define {{.*}} void @_ZZN7GH821541fEvEN2S2C2Ev
+    // EVAL-FN-NOT: call void @_ZN7GH821542S1C2Ei
+    // EVAL-FN:     call void @_ZN7GH821542S3C2Ei
+}
+}


### PR DESCRIPTION
A CXXConstructExpr may refer to an immediate constructor, in which case it should be substituted in the
enclosing default init expression.

Fixes #82154