### PR TITLE
[llvm-readelf] Print ARM specific OSABI values in GNU mode

### DIFF
--- a/llvm/test/tools/llvm-readobj/ELF/file-header-os-abi.test
+++ b/llvm/test/tools/llvm-readobj/ELF/file-header-os-abi.test
@@ -190,7 +190,7 @@ FileHeader:
 # RUN: llvm-readelf --file-headers %t.osabi.arm | FileCheck %s --match-full-lines --check-prefix=OSABI-ARM-GNU
 
 # OSABI-ARM-LLVM: OS/ABI: ARM (0x61)
-# OSABI-ARM-GNU:  OS/ABI: 61
+# OSABI-ARM-GNU:  OS/ABI: ARM
 
 ## Check all EM_TI_C6000 specific values.
 

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -3553,6 +3553,9 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
   if (e.e_ident[ELF::EI_OSABI] >= ELF::ELFOSABI_FIRST_ARCH &&
       e.e_ident[ELF::EI_OSABI] <= ELF::ELFOSABI_LAST_ARCH) {
     switch (e.e_machine) {
+    case ELF::EM_ARM:
+      OSABI = ArrayRef(ARMElfOSABI);
+      break;
     case ELF::EM_AMDGPU:
       OSABI = ArrayRef(AMDGPUElfOSABI);
       break;


### PR DESCRIPTION
Similar to #75661. Currently, there is only ELFOSABI_ARM, but I plan to
add ELFOSABI_ARM_FDPIC in a subsequent patch #82187
