### PR TITLE
[llvm] Clarify llvm/CMakeLists.txt LLVM_ENABLE_RUNTIMES documentation

### DIFF
--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -591,7 +591,7 @@ enabled sub-projects. Nearly all of these variable names begin with
   The full list is:
   ``compiler-rt;libc;libcxx;libcxxabi;libunwind;openmp;pstl;llvm-libgcc``
   To enable the default recommended set of runtimes for usage
-  with ``LLVM_ENABLE_PROJECTS=all`` of them, use: ``LLVM_ENABLE_RUNTIMES=all``.
+  with ``LLVM_ENABLE_PROJECTS=all``, use: ``LLVM_ENABLE_RUNTIMES=all``.
   Note: ``all`` does not enable all runtimes from the full list.
 
 

--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -582,16 +582,17 @@ enabled sub-projects. Nearly all of these variable names begin with
   ``clang;clang-tools-extra;cross-project-tests;libc;libclc;lld;lldb;openmp;polly;pstl``
 
 **LLVM_ENABLE_RUNTIMES**:STRING
-  Build libc++, libc++abi, libunwind or compiler-rt using the just-built compiler.
+  Build llvm runtime sub-projects using the just-built compiler.
   This is the correct way to build runtimes when putting together a toolchain.
   It will build the builtins separately from the other runtimes to preserve
   correct dependency ordering. If you want to build the runtimes using a system
   compiler, see the `libc++ documentation <https://libcxx.llvm.org/BuildingLibcxx.html>`_.
   Note: the list should not have duplicates with `LLVM_ENABLE_PROJECTS`.
   The full list is:
-  ``compiler-rt;libc;libcxx;libcxxabi;libunwind;openmp``
-  To enable all of them, use:
-  ``LLVM_ENABLE_RUNTIMES=all``
+  ``compiler-rt;libc;libcxx;libcxxabi;libunwind;openmp;pstl;llvm-libgcc``
+  To enable the default recommended set of runtimes for usage
+  with ``LLVM_ENABLE_PROJECTS=all`` of them, use: ``LLVM_ENABLE_RUNTIMES=all``.
+  Note: ``all`` does not enable all runtimes from the full list.
 
 
 **LLVM_ENABLE_RTTI**:BOOL


### PR DESCRIPTION
Related issue https://github.com/llvm/llvm-project/issues/80406

LLVM_ENABLE_RUNTIMES=all does not actually enable all runtimes.

The history is that it was modified to be less than all after https://reviews.llvm.org/D132479. The intent was that developers previously using `LLVM_ENABLE_PROJECTS=all` would have a breaking change and would then need to also specify a matching `LLVM_ENABLE_RUNTIMES=all` for the same behavior.

This change:
- Clarifies the intent of `LLVM_ENABLE_RUNTIMES=all` in the documentation. I didn't change any cmake behavior since it's not worth any breaking change. 
- Syncs up the full supported list of runtimes, according to https://github.com/llvm/llvm-project/blob/main/llvm/CMakeLists.txt#L159 (I put the full list here, not just the popular projects to describe entirely what this cmake variable can enable).

I also considered completely un-documenting `LLVM_ENABLE_RUNTIMES=all` since it's quite a confusing name, but decided to just keep it with the clarification instead.

Note. I don't have commit access, so you can commit on my behalf.