### PR TITLE
[PowerPC] add PowerPC path for PR labeler

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -823,7 +823,10 @@ backend:X86:
   - llvm/utils/TableGen/X86*
 
 backend:PowerPC:
+  - llvm/include/llvm/BinaryFormat/ELFRelocs/PowerPC*
+  - llvm/include/llvm/BinaryFormat/XCOFF.h
   - llvm/include/llvm/IR/IntrinsicsPowerPC.td
+  - llvm/lib/CodeGen/AsmPrinter/AIXException.cpp
   - llvm/lib/Target/PowerPC/**
   - llvm/test/Analysis/**/PowerPC/**
   - llvm/test/CodeGen/PowerPC/**

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -825,19 +825,23 @@ backend:X86:
 backend:PowerPC:
   - llvm/include/llvm/IR/IntrinsicsPowerPC.td
   - llvm/lib/Target/PowerPC/**
+  - llvm/test/Analysis/**/PowerPC/**
   - llvm/test/CodeGen/PowerPC/**
-  - llvm/test/MC/PowerPC/**
-  - llvm/test/MC/XCOFF/**
+  - llvm/test/CodeGen/MIR/PowerPC/**
   - llvm/test/DebugInfo/XCOFF/**
   - llvm/test/DebugInfo/PowerPC/**
   - llvm/test/LTO/PowerPC/**
-  - clang/lib/Basic/Targets/PPC.*
-  - clang/lib/Driver/ToolChains/PPC.*
-  - clang/lib/Driver/ToolChains/AIX.*
-  - clang/lib/Driver/ToolChains/Arch/PPC.*
-  - clang/lib/CodeGen/Targets/PPC.cpp
-  - clang/test/CodeGen/PowerPC/**
+  - llvm/test/MC/Disassembler/PowerPC/**
+  - llvm/test/MC/PowerPC/**
+  - llvm/test/MC/XCOFF/**
+  - llvm/test/Transforms/**/PowerPC/**
   - clang/include/clang/Basic/BuiltinsPPC.*
+  - clang/lib/Basic/Targets/PPC.*
+  - clang/lib/CodeGen/Targets/PPC.cpp
+  - clang/lib/Driver/ToolChains/PPC*
+  - clang/lib/Driver/ToolChains/AIX*
+  - clang/lib/Driver/ToolChains/Arch/PPC.*
+  - clang/test/CodeGen/PowerPC/**
 
 third-party:unittests:
   - third-party/unittests/**

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -822,6 +822,23 @@ backend:X86:
   - llvm/lib/TargetParser/X86*
   - llvm/utils/TableGen/X86*
 
+backend:PowerPC:
+  - llvm/include/llvm/IR/IntrinsicsPowerPC.td
+  - llvm/lib/Target/PowerPC/**
+  - llvm/test/CodeGen/PowerPC/**
+  - llvm/test/MC/PowerPC/**
+  - llvm/test/MC/XCOFF/**
+  - llvm/test/DebugInfo/XCOFF/**
+  - llvm/test/DebugInfo/PowerPC/**
+  - llvm/test/LTO/PowerPC/**
+  - clang/lib/Basic/Targets/PPC.*
+  - clang/lib/Driver/ToolChains/PPC.*
+  - clang/lib/Driver/ToolChains/AIX.*
+  - clang/lib/Driver/ToolChains/Arch/PPC.*
+  - clang/lib/CodeGen/Targets/PPC.cpp
+  - clang/test/CodeGen/PowerPC/**
+  - clang/include/clang/Basic/BuiltinsPPC.*
+
 third-party:unittests:
   - third-party/unittests/**
 


### PR DESCRIPTION
Add path for PowerPC related changes to the PR labeler.

There is no `pr-subscribers-backend:PowerPC` team in the llvm org yet. Much appreciated if some admin can help to create the team.

I don't think I need to do further change to make Github automatically add the PowerPC team as the reviewers for PowerPC related PRs. The automation logic seems common for all targets.