### PR TITLE
[sanitizer][fuchsia] Fix fuchsia buildbot failure after 64790064e82467b43c04a70b6e9873e6939be81f

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
@@ -413,7 +413,7 @@ void *MmapAlignedOrDieOnFatalError(uptr size, uptr alignment,
   return reinterpret_cast<void *>(addr);
 }
 
-void UnmapOrDie(void *addr, uptr size) {
+void UnmapOrDie(void *addr, uptr size, bool) {
   UnmapOrDieVmar(addr, size, gSanitizerHeapVmar);
 }
 


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/77488, a param `raw_report` is added for function `UnmapOrDie()`.
But missing the corresponding change for fuchsia, causes the buildbot failure, see https://lab.llvm.org/buildbot/#/builders/98/builds/33593.
This patch should fix the fuchsia buildbot failure.