### PR TITLE
Enable aarch64-amazon-linux triple

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2456,7 +2456,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
   static const char *const AArch64Triples[] = {
       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
-      "aarch64-suse-linux"};
+      "aarch64-suse-linux", "aarch64-amazon-linux"};
   static const char *const AArch64beLibDirs[] = {"/lib"};
   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                  "aarch64_be-linux-gnu"};


### PR DESCRIPTION
Add aarch64-amazon-linux triplet to allow compilation for Amazon Linux 2023 on Graviton CPU

This should address https://github.com/apple/llvm-project/issues/8227

Also submitted to Apple's repo https://github.com/apple/llvm-project/pull/8228