### PR TITLE
[AMDGPU] Stop using SDWA DecoderNamespaces. NFCI.

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP1Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP1Instructions.td
@@ -985,15 +985,11 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
     if !cast<VOP1_Pseudo>(NAME#"_e32").Pfl.HasExtSDWA9 then
     def _sdwa_gfx10 :
       VOP_SDWA10_Real<!cast<VOP1_SDWA_Pseudo>(NAME#"_sdwa")>,
-      VOP1_SDWA9Ae<op{7-0}, !cast<VOP1_SDWA_Pseudo>(NAME#"_sdwa").Pfl> {
-      let DecoderNamespace = "SDWA10";
-    }
+      VOP1_SDWA9Ae<op{7-0}, !cast<VOP1_SDWA_Pseudo>(NAME#"_sdwa").Pfl>;
   }
   multiclass VOP1_Real_dpp_gfx10<bits<9> op> {
     if !cast<VOP1_Pseudo>(NAME#"_e32").Pfl.HasExt32BitDPP then
-    def _dpp_gfx10 : VOP1_DPP16<op{7-0}, !cast<VOP1_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX10> {
-      let DecoderNamespace = "SDWA10";
-    }
+    def _dpp_gfx10 : VOP1_DPP16<op{7-0}, !cast<VOP1_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX10>;
   }
   multiclass VOP1_Real_dpp8_gfx10<bits<9> op> {
     if !cast<VOP1_Pseudo>(NAME#"_e32").Pfl.HasExt32BitDPP then

--- a/llvm/lib/Target/AMDGPU/VOP2Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP2Instructions.td
@@ -1740,15 +1740,11 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
     if !cast<VOP2_Pseudo>(NAME#"_e32").Pfl.HasExtSDWA9 then
     def _sdwa_gfx10 :
       VOP_SDWA10_Real<!cast<VOP2_SDWA_Pseudo>(NAME#"_sdwa")>,
-      VOP2_SDWA9Ae<op{5-0}, !cast<VOP2_SDWA_Pseudo>(NAME#"_sdwa").Pfl> {
-      let DecoderNamespace = "SDWA10";
-    }
+      VOP2_SDWA9Ae<op{5-0}, !cast<VOP2_SDWA_Pseudo>(NAME#"_sdwa").Pfl>;
   }
   multiclass VOP2_Real_dpp_gfx10<bits<6> op> {
     if !cast<VOP2_Pseudo>(NAME#"_e32").Pfl.HasExt32BitDPP then
-    def _dpp_gfx10 : VOP2_DPP16<op, !cast<VOP2_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX10> {
-      let DecoderNamespace = "SDWA10";
-    }
+    def _dpp_gfx10 : VOP2_DPP16<op, !cast<VOP2_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX10>;
   }
   multiclass VOP2_Real_dpp8_gfx10<bits<6> op> {
     if !cast<VOP2_Pseudo>(NAME#"_e32").Pfl.HasExt32BitDPP then
@@ -1777,35 +1773,33 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
         let AsmString = asmName # ps.AsmOperands;
       }
   }
-  let DecoderNamespace = "SDWA10" in {
-    multiclass VOP2_Real_sdwa_gfx10_with_name<bits<6> op, string opName,
-                                              string asmName> {
-      if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExtSDWA9 then
-      def _sdwa_gfx10 :
-        VOP_SDWA10_Real<!cast<VOP2_SDWA_Pseudo>(opName#"_sdwa")>,
-        VOP2_SDWA9Ae<op{5-0}, !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa").Pfl> {
-          VOP2_SDWA_Pseudo ps = !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa");
-          let AsmString = asmName # ps.AsmOperands;
-        }
-    }
-    multiclass VOP2_Real_dpp_gfx10_with_name<bits<6> op, string opName,
-                                             string asmName> {
-      if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExt32BitDPP then
-      def _dpp_gfx10 : VOP2_DPP16<op, !cast<VOP2_DPP_Pseudo>(opName#"_dpp"), SIEncodingFamily.GFX10> {
-        VOP2_Pseudo ps = !cast<VOP2_Pseudo>(opName#"_e32");
-        let AsmString = asmName # ps.Pfl.AsmDPP16;
+  multiclass VOP2_Real_sdwa_gfx10_with_name<bits<6> op, string opName,
+                                            string asmName> {
+    if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExtSDWA9 then
+    def _sdwa_gfx10 :
+      VOP_SDWA10_Real<!cast<VOP2_SDWA_Pseudo>(opName#"_sdwa")>,
+      VOP2_SDWA9Ae<op{5-0}, !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa").Pfl> {
+        VOP2_SDWA_Pseudo ps = !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa");
+        let AsmString = asmName # ps.AsmOperands;
       }
+  }
+  multiclass VOP2_Real_dpp_gfx10_with_name<bits<6> op, string opName,
+                                           string asmName> {
+    if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExt32BitDPP then
+    def _dpp_gfx10 : VOP2_DPP16<op, !cast<VOP2_DPP_Pseudo>(opName#"_dpp"), SIEncodingFamily.GFX10> {
+      VOP2_Pseudo ps = !cast<VOP2_Pseudo>(opName#"_e32");
+      let AsmString = asmName # ps.Pfl.AsmDPP16;
     }
-    multiclass VOP2_Real_dpp8_gfx10_with_name<bits<6> op, string opName,
-                                              string asmName> {
-      if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExt32BitDPP then
-      def _dpp8_gfx10 : VOP2_DPP8<op, !cast<VOP2_Pseudo>(opName#"_e32")> {
-        VOP2_Pseudo ps = !cast<VOP2_Pseudo>(opName#"_e32");
-        let AsmString = asmName # ps.Pfl.AsmDPP8;
-        let DecoderNamespace = "DPP8";
-      }
+  }
+  multiclass VOP2_Real_dpp8_gfx10_with_name<bits<6> op, string opName,
+                                            string asmName> {
+    if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExt32BitDPP then
+    def _dpp8_gfx10 : VOP2_DPP8<op, !cast<VOP2_Pseudo>(opName#"_e32")> {
+      VOP2_Pseudo ps = !cast<VOP2_Pseudo>(opName#"_e32");
+      let AsmString = asmName # ps.Pfl.AsmDPP8;
+      let DecoderNamespace = "DPP8";
     }
-  } // End DecoderNamespace = "SDWA10"
+  }
 
   //===------------------------------ VOP2be ------------------------------===//
   multiclass VOP2be_Real_e32_gfx10<bits<6> op, string opName, string asmName> {
@@ -1832,7 +1826,6 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
       VOP2_SDWA9Ae<op{5-0}, !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa").Pfl> {
         VOP2_SDWA_Pseudo Ps = !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa");
         let AsmString = asmName # !subst(", vcc", "", Ps.AsmOperands);
-        let DecoderNamespace = "SDWA10";
       }
     if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExtSDWA9 then
     def _sdwa_w32_gfx10 :
@@ -1841,9 +1834,8 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
         VOP2_SDWA_Pseudo Ps = !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa");
         let AsmString = asmName # !subst("vcc", "vcc_lo", Ps.AsmOperands);
         let isAsmParserOnly = 1;
-        let DecoderNamespace = "SDWA10";
         let WaveSizePredicate = isWave32;
-      }
+     }
     if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExtSDWA9 then
     def _sdwa_w64_gfx10 :
       Base_VOP_SDWA10_Real<!cast<VOP2_SDWA_Pseudo>(opName#"_sdwa")>,
@@ -1851,7 +1843,6 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
         VOP2_SDWA_Pseudo Ps = !cast<VOP2_SDWA_Pseudo>(opName#"_sdwa");
         let AsmString = asmName # Ps.AsmOperands;
         let isAsmParserOnly = 1;
-        let DecoderNamespace = "SDWA10";
         let WaveSizePredicate = isWave64;
       }
   }
@@ -1861,7 +1852,6 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
       VOP2_DPP16<op, !cast<VOP2_DPP_Pseudo>(opName#"_dpp"), SIEncodingFamily.GFX10, asmName> {
         string AsmDPP = !cast<VOP2_Pseudo>(opName#"_e32").Pfl.AsmDPP16;
         let AsmString = asmName # !subst(", vcc", "", AsmDPP);
-        let DecoderNamespace = "SDWA10";
       }
     if !cast<VOP2_Pseudo>(opName#"_e32").Pfl.HasExt32BitDPP then
     def _dpp_w32_gfx10 :
@@ -2305,7 +2295,7 @@ multiclass VOP2be_Real_e32e64_gfx9 <bits<6> op, string OpName, string AsmName> {
       VOP2_DPPe<op, !cast<VOP2_DPP_Pseudo>(OpName#"_dpp")> {
         VOP2_DPP_Pseudo ps = !cast<VOP2_DPP_Pseudo>(OpName#"_dpp");
         let AsmString = AsmName # ps.AsmOperands;
-        let DecoderNamespace = "SDWA9";
+        let DecoderNamespace = "GFX9";
       }
 }
 
@@ -2329,7 +2319,7 @@ multiclass VOP2_Real_e32e64_gfx9 <bits<6> op> {
     def _dpp_gfx9 :
       VOP_DPP_Real<!cast<VOP2_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX9>,
       VOP2_DPPe<op, !cast<VOP2_DPP_Pseudo>(NAME#"_dpp")> {
-        let DecoderNamespace = "SDWA9";
+        let DecoderNamespace = "GFX9";
       }
 }
 
@@ -2489,7 +2479,7 @@ let AssemblerPredicate = isGFX90APlus, DecoderNamespace = "GFX90A" in {
       def _dpp_gfx90a :
         VOP_DPP_Real<!cast<VOP2_DPP_Pseudo>(NAME#"_dpp"), SIEncodingFamily.GFX90A>,
         VOP2_DPPe<op, !cast<VOP2_DPP_Pseudo>(NAME#"_dpp")> {
-          let DecoderNamespace = "SDWA9";
+          let DecoderNamespace = "GFX9";
         }
   }
 } // End AssemblerPredicate = isGFX90APlus, DecoderNamespace = "GFX90A"

--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -616,7 +616,7 @@ class VOP_SDWA_Pseudo <string opName, VOPProfile P, list<dag> pattern=[]> :
   let AssemblerPredicate = HasSDWA;
   let AsmVariantName = !if(P.HasExtSDWA, AMDGPUAsmVariants.SDWA,
                                          AMDGPUAsmVariants.Disable);
-  let DecoderNamespace = "SDWA";
+  let DecoderNamespace = "GFX8";
 
   VOPProfile Pfl = P;
 }
@@ -672,7 +672,7 @@ class Base_VOP_SDWA9_Real <VOP_SDWA_Pseudo ps> :
   let AssemblerPredicate = HasSDWA9;
   let AsmVariantName = !if(ps.Pfl.HasExtSDWA9, AMDGPUAsmVariants.SDWA9,
                                                AMDGPUAsmVariants.Disable);
-  let DecoderNamespace = "SDWA9";
+  let DecoderNamespace = "GFX9";
 
   // Copy relevant pseudo op flags
   let AsmMatchConverter    = ps.AsmMatchConverter;
@@ -693,7 +693,7 @@ class VOP_SDWA9_Real <VOP_SDWA_Pseudo ps> :
 class Base_VOP_SDWA10_Real<VOP_SDWA_Pseudo ps> : Base_VOP_SDWA9_Real<ps> {
   let SubtargetPredicate = HasSDWA10;
   let AssemblerPredicate = HasSDWA10;
-  let DecoderNamespace = "SDWA10";
+  let DecoderNamespace = "GFX10";
 }
 
 class VOP_SDWA10_Real<VOP_SDWA_Pseudo ps> :


### PR DESCRIPTION
64-bit SDWA encodings have to be checked first because their first 32
bits are a special case of the corresponding 32-bit non-SDWA encoding of
the same instruction. But all 64-bit encodings are checked first, so we
don't need special handling for SDWA.
