### PR TITLE
[Clang] Fix assert when transforming a pack indexing type.

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6561,8 +6561,10 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
       return QualType();
     if (!ShouldExpand) {
       Sema::ArgumentPackSubstitutionIndexRAII SubstIndex(getSema(), -1);
-      // FIXME: should we keep TypeLoc for individual expansions in PackIndexingTypeLoc?
-      TypeSourceInfo* TI = SemaRef.getASTContext().getTrivialTypeSourceInfo(T, TL.getBeginLoc());
+      // FIXME: should we keep TypeLoc for individual expansions in
+      // PackIndexingTypeLoc?
+      TypeSourceInfo *TI =
+          SemaRef.getASTContext().getTrivialTypeSourceInfo(T, TL.getBeginLoc());
       QualType Pack = getDerived().TransformType(TLB, TI->getTypeLoc());
       if (Pack.isNull())
         return QualType();

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6561,7 +6561,9 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
       return QualType();
     if (!ShouldExpand) {
       Sema::ArgumentPackSubstitutionIndexRAII SubstIndex(getSema(), -1);
-      QualType Pack = getDerived().TransformType(T);
+      // FIXME: should we keep TypeLoc for individual expansions in PackIndexingTypeLoc?
+      TypeSourceInfo* TI = SemaRef.getASTContext().getTrivialTypeSourceInfo(T, TL.getBeginLoc());
+      QualType Pack = getDerived().TransformType(TLB, TI->getTypeLoc());
       if (Pack.isNull())
         return QualType();
       if (NotYetExpanded) {

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -135,3 +135,22 @@ using Splice = typename SpliceImpl<Tl, Il>::type;
 using type = Splice<TL<char, short, long, double>, IL<1, 2>>;
 static_assert(is_same<type, TL<short, long>>);
 }
+
+
+namespace GH81697 {
+
+template<class... Ts> struct tuple {
+    int __x0;
+};
+
+template<auto I, class... Ts>
+Ts...[I]& get(tuple<Ts...>& t) {
+  return t.__x0;
+}
+
+void f() {
+  tuple<int> x;
+  get<0>(x);
+}
+
+}


### PR DESCRIPTION
When a pack in a pack indexing specifier cannot be immediately expanded, we were creating an incomplete TypeLoc
(causing assertion failure).

As we do not keep track of typelocs of expanded elements, we create a trivial typeloc

Fixes #81697