### PR TITLE
[clangd] SelectionTree marks nodes as complete only if children are complete

### DIFF
--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -688,6 +688,7 @@ TEST(SelectionTest, Selected) {
       )cpp",
       R"cpp( $C[[^$C[[int]] a^]]; )cpp",
       R"cpp( $C[[^$C[[int]] a = $C[[5]]^]]; )cpp",
+      R"cpp( int x = [[2 ^+ $C[[2]]^]]; )cpp",
   };
   for (const char *C : Cases) {
     Annotations Test(C);


### PR DESCRIPTION
This seems to be the semantics expected by ~all callers, and simplifies
upcoming patches extending extract-variable.
