### PR TITLE
[clang][dataflow][NFC] Add a FIXME to handling of union initialization.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -664,6 +664,7 @@ public:
     QualType Type = S->getType();
 
     if (Type->isUnionType()) {
+      // FIXME: Initialize unions properly.
       if (auto *Val = Env.createValue(Type))
         Env.setValue(*S, *Val);
       return;


### PR DESCRIPTION
We want to make it clear that the current behavior doesn't yet handle unions
properly.