### PR TITLE
Avoid using `__shifted` as an identifier

### DIFF
--- a/libcxx/src/ryu/d2fixed.cpp
+++ b/libcxx/src/ryu/d2fixed.cpp
@@ -82,9 +82,9 @@ inline constexpr int __POW10_ADDITIONAL_BITS = 120;
   const uint64_t __multiplied = __umul256_hi128_lo64(__vHi, __vLo, 0x89705F4136B4A597u, 0x31680A88F8953031u);
 
   // For uint32_t truncation, see the __mod1e9() comment in d2s_intrinsics.h.
-  const uint32_t __shifted = static_cast<uint32_t>(__multiplied >> 29);
+  const uint32_t __shiftedValue = static_cast<uint32_t>(__multiplied >> 29);
 
-  return static_cast<uint32_t>(__vLo) - 1000000000 * __shifted;
+  return static_cast<uint32_t>(__vLo) - 1000000000 * __shiftedValue;
 }
 #endif // ^^^ intrinsics available ^^^
 

--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -172,4 +172,7 @@ static_assert(__builtin_strcmp(STRINGIFY(max), STRINGIFY(SYSTEM_RESERVED_NAME)) 
 static_assert(__builtin_strcmp(STRINGIFY(move), STRINGIFY(SYSTEM_RESERVED_NAME)) == 0, "");
 static_assert(__builtin_strcmp(STRINGIFY(erase), STRINGIFY(SYSTEM_RESERVED_NAME)) == 0, "");
 static_assert(__builtin_strcmp(STRINGIFY(refresh), STRINGIFY(SYSTEM_RESERVED_NAME)) == 0, "");
+
+// __shifted is a reserved keyword on the LLVM Widberg compiler
+#define __shifted SYSTEM_RESERVED_NAME
 """)

--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -17,7 +17,8 @@ sys.path.append(sys.argv[1])
 from libcxx.header_information import lit_header_restrictions, public_headers
 
 for header in public_headers:
-  print(f"""\
+    print(
+        f"""\
 //--- {header}.compile.pass.cpp
 {lit_header_restrictions.get(header, '')}
 
@@ -175,4 +176,5 @@ static_assert(__builtin_strcmp(STRINGIFY(refresh), STRINGIFY(SYSTEM_RESERVED_NAM
 
 // __shifted is a reserved keyword on the LLVM Widberg compiler
 #define __shifted SYSTEM_RESERVED_NAME
-""")
+"""
+    )


### PR DESCRIPTION
According to https://hex-rays.com/products/ida/support/idadoc/1695.shtml, `__shifted` is a reserved keyword in https://github.com/widberg/llvm-project-widberg-extensions. `libcxx/src/ryu/d2fixed.cpp` tries to use `__shifted` as an identifier, causing a compile failure in Compiler Explorer's build work flow: https://github.com/compiler-explorer/compiler-workflows/actions/runs/7908979550/job/21589200908