### PR TITLE
[llvm-exegesis][NFC] Refactor all `ValidationEvent` info in a single …

### DIFF
--- a/llvm/include/llvm/Target/TargetPfmCounters.td
+++ b/llvm/include/llvm/Target/TargetPfmCounters.td
@@ -35,6 +35,7 @@ class ValidationEvent <int event_number> {
   int EventNumber = event_number;
 }
 
+// TableGen names for events defined in `llvm::exegesis::ValidationEvent`.
 def InstructionRetired  : ValidationEvent<0>;
 def L1DCacheLoadMiss : ValidationEvent<1>;
 def L1DCacheStoreMiss : ValidationEvent<2>;

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
@@ -17,6 +17,7 @@
 
 #include "LlvmState.h"
 #include "RegisterValue.h"
+#include "ValidationEvent.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstBuilder.h"
@@ -31,20 +32,6 @@ namespace llvm {
 class Error;
 
 namespace exegesis {
-
-enum ValidationEvent {
-  InstructionRetired,
-  L1DCacheLoadMiss,
-  L1DCacheStoreMiss,
-  L1ICacheLoadMiss,
-  DataTLBLoadMiss,
-  DataTLBStoreMiss,
-  InstructionTLBLoadMiss,
-  BranchPredictionMiss
-};
-
-const char *validationEventToString(exegesis::ValidationEvent VE);
-Expected<ValidationEvent> stringToValidationEvent(StringRef Input);
 
 enum class BenchmarkPhaseSelectorE {
   PrepareSnippet,

--- a/llvm/tools/llvm-exegesis/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-exegesis/lib/CMakeLists.txt
@@ -73,6 +73,7 @@ add_llvm_library(LLVMExegesis
   SubprocessMemory.cpp
   Target.cpp
   UopsBenchmarkRunner.cpp
+  ValidationEvent.cpp
 
   LINK_LIBS ${libs}
 

--- a/llvm/tools/llvm-exegesis/lib/LatencyBenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LatencyBenchmarkRunner.cpp
@@ -107,8 +107,8 @@ Expected<std::vector<BenchmarkMeasure>> LatencyBenchmarkRunner::runMeasurements(
     }
 
     for (size_t I = 0; I < ValCounterValues.size(); ++I) {
-      LLVM_DEBUG(dbgs() << validationEventToString(ValidationCounters[I])
-                        << ": " << IterationValCounterValues[I] << "\n");
+      LLVM_DEBUG(dbgs() << getValidationEventName(ValidationCounters[I]) << ": "
+                        << IterationValCounterValues[I] << "\n");
       ValCounterValues[I] += IterationValCounterValues[I];
     }
   }

--- a/llvm/tools/llvm-exegesis/lib/Target.h
+++ b/llvm/tools/llvm-exegesis/lib/Target.h
@@ -22,6 +22,7 @@
 #include "LlvmState.h"
 #include "PerfHelper.h"
 #include "SnippetGenerator.h"
+#include "ValidationEvent.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/LegacyPassManager.h"

--- a/llvm/tools/llvm-exegesis/lib/ValidationEvent.cpp
+++ b/llvm/tools/llvm-exegesis/lib/ValidationEvent.cpp
@@ -1,0 +1,53 @@
+
+#include "ValidationEvent.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+namespace exegesis {
+
+namespace {
+
+struct ValidationEventInfo {
+  const char *const Name;
+  const char *const Description;
+};
+
+// Information about validation events, indexed by `ValidationEvent` enum
+// value.
+static constexpr ValidationEventInfo ValidationEventInfos[NumValidationEvents] =
+    {
+        {"instructions-retired", "Count retired instructions"},
+        {"l1d-cache-load-misses", "Count L1D load cache misses"},
+        {"l1d-cache-store-misses", "Count L1D store cache misses"},
+        {"l1i-cache-load-misses", "Count L1I load cache misses"},
+        {"data-tlb-load-misses", "Count DTLB load misses"},
+        {"data-tlb-store-misses", "Count DTLB store misses"},
+        {"instruction-tlb-load-misses", "Count ITLB load misses"},
+        {"branch-prediction-misses", "Branch prediction misses"},
+};
+
+} // namespace
+
+const char *getValidationEventName(ValidationEvent VE) {
+  return ValidationEventInfos[VE].Name;
+}
+const char *getValidationEventDescription(ValidationEvent VE) {
+  return ValidationEventInfos[VE].Description;
+}
+
+Expected<ValidationEvent> getValidationEventByName(StringRef Name) {
+  int VE = 0;
+  for (const ValidationEventInfo &Info : ValidationEventInfos) {
+    if (Name == Info.Name)
+      return static_cast<ValidationEvent>(VE);
+    ++VE;
+  }
+
+  return make_error<StringError>("Invalid validation event string",
+                                 errc::invalid_argument);
+}
+
+} // namespace exegesis
+} // namespace llvm

--- a/llvm/tools/llvm-exegesis/lib/ValidationEvent.cpp
+++ b/llvm/tools/llvm-exegesis/lib/ValidationEvent.cpp
@@ -16,17 +16,20 @@ struct ValidationEventInfo {
 
 // Information about validation events, indexed by `ValidationEvent` enum
 // value.
-static constexpr ValidationEventInfo ValidationEventInfos[NumValidationEvents] =
-    {
-        {"instructions-retired", "Count retired instructions"},
-        {"l1d-cache-load-misses", "Count L1D load cache misses"},
-        {"l1d-cache-store-misses", "Count L1D store cache misses"},
-        {"l1i-cache-load-misses", "Count L1I load cache misses"},
-        {"data-tlb-load-misses", "Count DTLB load misses"},
-        {"data-tlb-store-misses", "Count DTLB store misses"},
-        {"instruction-tlb-load-misses", "Count ITLB load misses"},
-        {"branch-prediction-misses", "Branch prediction misses"},
+static constexpr ValidationEventInfo ValidationEventInfos[] = {
+    {"instructions-retired", "Count retired instructions"},
+    {"l1d-cache-load-misses", "Count L1D load cache misses"},
+    {"l1d-cache-store-misses", "Count L1D store cache misses"},
+    {"l1i-cache-load-misses", "Count L1I load cache misses"},
+    {"data-tlb-load-misses", "Count DTLB load misses"},
+    {"data-tlb-store-misses", "Count DTLB store misses"},
+    {"instruction-tlb-load-misses", "Count ITLB load misses"},
+    {"branch-prediction-misses", "Branch prediction misses"},
 };
+
+static_assert(sizeof(ValidationEventInfos) ==
+                  NumValidationEvents * sizeof(ValidationEventInfo),
+              "please update ValidationEventInfos");
 
 } // namespace
 

--- a/llvm/tools/llvm-exegesis/lib/ValidationEvent.h
+++ b/llvm/tools/llvm-exegesis/lib/ValidationEvent.h
@@ -1,0 +1,60 @@
+//===-- ValidationEvent.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definitions and utilities for Validation Events.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_EXEGESIS_VALIDATIONEVENT_H
+#define LLVM_TOOLS_LLVM_EXEGESIS_VALIDATIONEVENT_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+
+namespace exegesis {
+
+// The main list of supported validation events. The mapping between validation
+// events and pfm counters is defined in TableDef files for each target.
+enum ValidationEvent {
+  InstructionRetired,
+  L1DCacheLoadMiss,
+  L1DCacheStoreMiss,
+  L1ICacheLoadMiss,
+  DataTLBLoadMiss,
+  DataTLBStoreMiss,
+  InstructionTLBLoadMiss,
+  BranchPredictionMiss,
+  // Number of events.
+  NumValidationEvents,
+};
+
+// Returns the name/description of the given event.
+const char *getValidationEventName(ValidationEvent VE);
+const char *getValidationEventDescription(ValidationEvent VE);
+
+// Returns the ValidationEvent with the given name.
+Expected<ValidationEvent> getValidationEventByName(StringRef Name);
+
+// Command-line options for validation events.
+struct ValidationEventOptions {
+  template <class Opt> void apply(Opt &O) const {
+    for (int I = 0; I < NumValidationEvents; ++I) {
+      const auto VE = static_cast<ValidationEvent>(I);
+      O.getParser().addLiteralOption(getValidationEventName(VE), VE,
+                                     getValidationEventDescription(VE));
+    }
+  }
+};
+
+} // namespace exegesis
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -25,6 +25,7 @@
 #include "lib/SnippetRepetitor.h"
 #include "lib/Target.h"
 #include "lib/TargetSelect.h"
+#include "lib/ValidationEvent.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInstBuilder.h"
@@ -278,24 +279,7 @@ static cl::list<ValidationEvent> ValidationCounters(
     cl::desc(
         "The name of a validation counter to run concurrently with the main "
         "counter to validate benchmarking assumptions"),
-    cl::CommaSeparated, cl::cat(BenchmarkOptions),
-    cl::values(
-        clEnumValN(ValidationEvent::InstructionRetired, "instructions-retired",
-                   "Count retired instructions"),
-        clEnumValN(ValidationEvent::L1DCacheLoadMiss, "l1d-cache-load-misses",
-                   "Count L1D load cache misses"),
-        clEnumValN(ValidationEvent::L1DCacheStoreMiss, "l1d-cache-store-misses",
-                   "Count L1D store cache misses"),
-        clEnumValN(ValidationEvent::L1ICacheLoadMiss, "l1i-cache-load-misses",
-                   "Count L1I load cache misses"),
-        clEnumValN(ValidationEvent::DataTLBLoadMiss, "data-tlb-load-misses",
-                   "Count DTLB load misses"),
-        clEnumValN(ValidationEvent::DataTLBStoreMiss, "data-tlb-store-misses",
-                   "Count DTLB store misses"),
-        clEnumValN(ValidationEvent::InstructionTLBLoadMiss,
-                   "instruction-tlb-load-misses", "Count ITLB load misses"),
-        clEnumValN(ValidationEvent::BranchPredictionMiss,
-                   "branch-prediction-misses", "Branch prediction misses")));
+    cl::CommaSeparated, cl::cat(BenchmarkOptions), ValidationEventOptions());
 
 static ExitOnError ExitOnErr("llvm-exegesis error: ");
 


### PR DESCRIPTION
…table.

All data is derived from a single table rather than being spread out over an enum, a table and the main entry point.

This is intended as a replacement for #82092.