### PR TITLE
[lldb] Standardize command option parsing error messages

### DIFF
--- a/lldb/include/lldb/Interpreter/Options.h
+++ b/lldb/include/lldb/Interpreter/Options.h
@@ -336,6 +336,29 @@ public:
   bool m_did_finalize = false;
 };
 
+/// Creates an error that represents the failure to parse an command line option
+/// argument. This creates an error containing all information needed to show
+/// the developer what went wrong when parsing their command. It is recommended
+/// to use this instead of writing an error by hand.
+///
+/// \param[in] option_arg
+///   The argument that was attempted to be parsed.
+///
+/// \param[in] short_option
+///   The short form of the option. For example, if the flag is -f, the short
+///   option is "f".
+///
+/// \param[in] long_option
+///   The long form of the option. This field is optional. If the flag is
+///   --force, then the long option is "force".
+///
+/// \param[in] additional_context
+///   This is extra context that will get included in the error. This field is
+///   optional.
+///
+/// \return
+///   An llvm::Error that contains a standardized format for what went wrong
+///   when parsing and why.
 llvm::Error CreateOptionParsingError(llvm::StringRef option_arg,
                                      const char short_option,
                                      llvm::StringRef long_option = {},

--- a/lldb/include/lldb/Interpreter/Options.h
+++ b/lldb/include/lldb/Interpreter/Options.h
@@ -336,6 +336,16 @@ public:
   bool m_did_finalize = false;
 };
 
+llvm::Error CreateOptionParsingError(llvm::StringRef option_arg,
+                                     const char short_option,
+                                     llvm::StringRef long_option = {},
+                                     llvm::StringRef additional_context = {});
+
+static constexpr llvm::StringLiteral g_bool_parsing_error_message =
+    "Failed to parse as boolean";
+static constexpr llvm::StringLiteral g_int_parsing_error_message =
+    "Failed to parse as integer";
+
 } // namespace lldb_private
 
 #endif // LLDB_INTERPRETER_OPTIONS_H

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -1365,3 +1365,16 @@ llvm::Expected<Args> Options::Parse(const Args &args,
   argv.erase(argv.begin(), argv.begin() + OptionParser::GetOptionIndex());
   return ReconstituteArgsAfterParsing(argv, args);
 }
+
+llvm::Error lldb_private::CreateOptionParsingError(
+    llvm::StringRef option_arg, const char short_option,
+    llvm::StringRef long_option, llvm::StringRef additional_context) {
+  std::string buffer;
+  llvm::raw_string_ostream stream(buffer);
+  stream << "Invalid value ('" << option_arg << "') for -" << short_option;
+  if (!long_option.empty())
+    stream << " (" << long_option << ")";
+  if (!additional_context.empty())
+    stream << ": " << additional_context;
+  return llvm::createStringError(llvm::inconvertibleErrorCode(), buffer);
+}

--- a/lldb/unittests/Interpreter/CMakeLists.txt
+++ b/lldb/unittests/Interpreter/CMakeLists.txt
@@ -2,6 +2,7 @@ add_lldb_unittest(InterpreterTests
   TestCommandPaths.cpp
   TestCompletion.cpp
   TestOptionArgParser.cpp
+  TestOptions.cpp
   TestOptionValue.cpp
   TestOptionValueFileColonLine.cpp
   TestRegexCommand.cpp

--- a/lldb/unittests/Interpreter/TestOptions.cpp
+++ b/lldb/unittests/Interpreter/TestOptions.cpp
@@ -1,0 +1,29 @@
+//===-- TestOptions.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Interpreter/Options.h"
+#include "gtest/gtest.h"
+
+#include "llvm/Testing/Support/Error.h"
+
+using namespace lldb_private;
+
+TEST(OptionsTest, CreateOptionParsingError) {
+  ASSERT_THAT_ERROR(
+      CreateOptionParsingError("yippee", 'f', "fun",
+                               "unable to convert 'yippee' to boolean"),
+      llvm::FailedWithMessage("Invalid value ('yippee') for -f (fun): unable "
+                              "to convert 'yippee' to boolean"));
+
+  ASSERT_THAT_ERROR(
+      CreateOptionParsingError("52", 'b', "bean-count"),
+      llvm::FailedWithMessage("Invalid value ('52') for -b (bean-count)"));
+
+  ASSERT_THAT_ERROR(CreateOptionParsingError("c", 'm'),
+                    llvm::FailedWithMessage("Invalid value ('c') for -m"));
+}


### PR DESCRIPTION
I have been looking to simplify parsing logic and improve the interfaces so that they are both easier to use and harder to abuse. To be specific, I am referring to functions such as `OptionArgParser::ToBoolean`: I would like to go from its current interface to something more like `llvm::Error<bool> ToBoolean(llvm::StringRef option_arg)`.

Through working on that, I encountered 2 inconveniences:
1. Option parsing code is not uniform. Every function writes a slightly different error message, so incorporating an error message from the `ToBoolean` implementation is going to be laborious as I figure out what exactly needs to change or stay the same.
2. Changing the interface of `ToBoolean` would require a global atomic change across all of the Command code. This would be quite frustrating to do because of the non-uniformity of our existing code.

To address these frustrations, I think it would be easiest to first standardize the error reporting mechanism when parsing options in commands. I do so by introducing `CreateOptionParsingError` which will create an error message of the shape:
Invalid valud ('${option_arg}') for -${short_value} ('${long_value}'): ${additional_context}

Concretely, it would look something like this:
(lldb) breakpoint set -n main -G yay
error: Invalid value ('yay') for -G (auto-continue): Failed to parse as boolean

After this, updating the interfaces for parsing the values themselves should become simpler. Because this can be adopted incrementally, this should be able to done over the course of time instead of all at once as a giant difficult-to-review change. I've changed exactly one function where this function would be used as an illustration of what I am proposing.