### PR TITLE
Revert "[lldb] Migrate distutils.version.LooseVersion to packaging"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1,6 +1,6 @@
 # System modules
+from distutils.version import LooseVersion
 from functools import wraps
-from pkg_resources import packaging
 import ctypes
 import locale
 import os
@@ -65,10 +65,10 @@ def _check_expected_version(comparison, expected, actual):
         ">=": fn_geq,
         "<=": fn_leq,
     }
+    expected_str = ".".join([str(x) for x in expected])
+    actual_str = ".".join([str(x) for x in actual])
 
-    return op_lookup[comparison](
-        packaging.version.parse(actual), packaging.version.parse(expected)
-    )
+    return op_lookup[comparison](LooseVersion(actual_str), LooseVersion(expected_str))
 
 
 def _match_decorator_property(expected, actual):
@@ -238,9 +238,7 @@ def _decorateTest(
             )
         )
         skip_for_py_version = (py_version is None) or _check_expected_version(
-            py_version[0],
-            py_version[1],
-            "{}.{}".format(sys.version_info.major, sys.version_info.minor),
+            py_version[0], py_version[1], sys.version_info
         )
         skip_for_macos_version = (macos_version is None) or (
             (platform.mac_ver()[0] != "")

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -7,8 +7,8 @@ import re
 import subprocess
 import sys
 import os
+from distutils.version import LooseVersion
 from urllib.parse import urlparse
-from pkg_resources import packaging
 
 # LLDB modules
 import lldb
@@ -297,30 +297,27 @@ def expectedCompilerVersion(compiler_version):
     if compiler_version is None:
         return True
     operator = str(compiler_version[0])
-    version_str = str(compiler_version[1])
+    version = compiler_version[1]
 
-    if not version_str:
+    if version is None:
         return True
 
-    test_compiler_version_str = getCompilerVersion()
-    if test_compiler_version_str == "unknown":
+    test_compiler_version = getCompilerVersion()
+    if test_compiler_version == "unknown":
         # Assume the compiler version is at or near the top of trunk.
         return operator in [">", ">=", "!", "!=", "not"]
 
-    version = packaging.version.parse(version_str)
-    test_compiler_version = packaging.version.parse(test_compiler_version_str)
-
     if operator == ">":
-        return test_compiler_version < version
+        return LooseVersion(test_compiler_version) > LooseVersion(version)
     if operator == ">=" or operator == "=>":
-        return test_compiler_version >= version
+        return LooseVersion(test_compiler_version) >= LooseVersion(version)
     if operator == "<":
-        return test_compiler_version < version
+        return LooseVersion(test_compiler_version) < LooseVersion(version)
     if operator == "<=" or operator == "=<":
-        return test_compiler_version <= version
+        return LooseVersion(test_compiler_version) <= LooseVersion(version)
     if operator == "!=" or operator == "!" or operator == "not":
-        return version_str not in test_compiler_version_str
-    return version_str in test_compiler_version_str
+        return str(version) not in str(test_compiler_version)
+    return str(version) in str(test_compiler_version)
 
 
 def expectedCompiler(compilers):

--- a/lldb/test/API/sanity/TestSettingSkipping.py
+++ b/lldb/test/API/sanity/TestSettingSkipping.py
@@ -1,6 +1,7 @@
 """
-This is a sanity check that verifies that test can be skipped based on settings.
+This is a sanity check that verifies that test can be sklipped based on settings.
 """
+
 
 import lldb
 from lldbsuite.test.lldbtest import *
@@ -9,24 +10,24 @@ from lldbsuite.test.decorators import *
 
 class SettingSkipSanityTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    CURRENT_PYTHON_VERSION = "3.0"
 
-    @skipIf(py_version=(">=", CURRENT_PYTHON_VERSION))
+    @skipIf(py_version=(">=", (3, 0)))
     def testSkip(self):
-        self.assertTrue(False, "This test should not run and fail (SKIPPED)")
+        """This setting is on by default"""
+        self.assertTrue(False, "This test should not run!")
 
-    @skipIf(py_version=("<", CURRENT_PYTHON_VERSION))
-    def testNoSKip(self):
-        self.assertTrue(True, "This test should run and pass(PASS)")
-
-    @expectedFailureAll(py_version=(">=", CURRENT_PYTHON_VERSION))
-    def testXFAIL(self):
-        self.assertTrue(False, "This test should expectedly fail (XFAIL)")
-
-    @expectedFailureAll(py_version=("<", CURRENT_PYTHON_VERSION))
-    def testNotXFAIL(self):
-        self.assertTrue(True, "This test should pass (PASS)")
+    @skipIf(py_version=("<", (3, 0)))
+    def testNoMatch(self):
+        self.assertTrue(True, "This test should run!")
 
     @skipIf(setting=("target.i-made-this-one-up", "true"))
     def testNotExisting(self):
         self.assertTrue(True, "This test should run!")
+
+    @expectedFailureAll(py_version=(">=", (3, 0)))
+    def testXFAIL(self):
+        self.assertTrue(False, "This test should run and fail!")
+
+    @expectedFailureAll(py_version=("<", (3, 0)))
+    def testNotXFAIL(self):
+        self.assertTrue(True, "This test should run and succeed!")

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -61,9 +61,9 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Older versions of watchOS (<7.0) only support i386
         if platform_name == "watchos":
-            from pkg_resources import packaging
+            from distutils.version import LooseVersion
 
-            if packaging.version.parse(vers) < packaging.version.parse("7.0"):
+            if LooseVersion(vers) < LooseVersion("7.0"):
                 arch = "i386"
 
         triple = "-".join([arch, "apple", platform_name + vers, "simulator"])

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -519,9 +519,9 @@ class MsvcBuilder(Builder):
 
             # Windows SDK version numbers consist of 4 dotted components, so we
             # have to use LooseVersion, as StrictVersion supports 3 or fewer.
-            from pkg_resources import packaging
+            from distutils.version import LooseVersion
 
-            sdk_versions.sort(key=lambda x: packaging.version.parse(x), reverse=True)
+            sdk_versions.sort(key=lambda x: LooseVersion(x), reverse=True)
             option_value_name = "OptionId.DesktopCPP" + self.msvc_arch_str
             for v in sdk_versions:
                 try:


### PR DESCRIPTION
Reverts llvm/llvm-project#82066 because the following tests started failing after:

[lldb-api.commands/expression/import-std-module/deque-basic.TestDequeFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_deque-basic/TestDequeFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/deque-dbg-info-content.TestDbgInfoContentDequeFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/forward_list.TestForwardListFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_forward_list/TestForwardListFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/forward_list-dbg-info-content.TestDbgInfoContentForwardListFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/list.TestListFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_list/TestListFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/non-module-type-separation.TestNonModuleTypeSeparation.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_non-module-type-separation/TestNonModuleTypeSeparation_py/)
[lldb-api.commands/expression/import-std-module/queue.TestQueueFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_queue/TestQueueFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/retry-with-std-module.TestRetryWithStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_retry-with-std-module/TestRetryWithStdModule_py/)
[lldb-api.commands/expression/import-std-module/unique_ptr.TestUniquePtrFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_unique_ptr/TestUniquePtrFromStdModule_py/)
[lldb-api.commands/expression/import-std-module/unique_ptr-dbg-info-content.TestUniquePtrDbgInfoContent.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent_py/)
[lldb-api.commands/expression/import-std-module/vector-of-vectors.TestVectorOfVectorsFromStdModule.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/commands_expression_import-std-module_vector-of-vectors/TestVectorOfVectorsFromStdModule_py/)
[lldb-api.functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr.TestDataFormatterLibcxxSharedPtr.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/functionalities_data-formatter_data-formatter-stl_libcxx_shared_ptr/TestDataFormatterLibcxxSharedPtr_py/)
[lldb-api.functionalities/data-formatter/data-formatter-stl/libcxx/unique_ptr.TestDataFormatterLibcxxUniquePtr.py](https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/66513/testReport/junit/lldb-api/functionalities_data-formatter_data-formatter-stl_libcxx_unique_ptr/TestDataFormatterLibcxxUniquePtr_py/)