### PR TITLE
[llvm-pdbutil] Fix register enum field dumping/parsing

### DIFF
--- a/llvm/test/tools/llvm-pdbutil/Inputs/register-records.yaml
+++ b/llvm/test/tools/llvm-pdbutil/Inputs/register-records.yaml
@@ -1,0 +1,21 @@
+---
+DbiStream:
+  VerHeader:       V70
+  Age:             1
+  BuildNumber:     36363
+  PdbDllVersion:   0
+  PdbDllRbld:      0
+  Flags:           0
+  MachineType:     Amd64
+  Modules:
+    - Module:          '/tmp/test.obj'
+      Modi:
+        Signature:       4
+        Records:
+          - Kind:            S_REGREL32
+            RegRelativeSym:
+              Offset:          56
+              Type:            4494
+              Register:        RSP
+              VarName:         this
+...

--- a/llvm/test/tools/llvm-pdbutil/register-records.test
+++ b/llvm/test/tools/llvm-pdbutil/register-records.test
@@ -1,0 +1,18 @@
+; RUN: llvm-pdbutil yaml2pdb %p/Inputs/register-records.yaml --pdb=%t.pdb
+; RUN: llvm-pdbutil dump --symbols %t.pdb | FileCheck --check-prefix=CHECK_YAML2PDB %s
+
+; RUN: llvm-pdbutil pdb2yaml --module-syms %t.pdb > %t.yaml
+; RUN: FileCheck --input-file=%t.yaml --check-prefix=CHECK_PDB2YAML %s
+
+CHECK_YAML2PDB:                           Symbols                           
+CHECK_YAML2PDB: ============================================================
+CHECK_YAML2PDB:   Mod 0000 | `/tmp/test.obj`:
+CHECK_YAML2PDB:        4 | S_REGREL32 [size = 20] `this`
+CHECK_YAML2PDB:            type = 0x118E (<unknown UDT>), register = RSP, offset = 56
+
+CHECK_PDB2YAML: - Kind:            S_REGREL32
+CHECK_PDB2YAML:   RegRelativeSym:
+CHECK_PDB2YAML:    Offset:          56
+CHECK_PDB2YAML:    Type:            4494
+CHECK_PDB2YAML:    Register:        RSP
+CHECK_PDB2YAML:    VarName:         this

--- a/llvm/tools/llvm-pdbutil/PdbYaml.cpp
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.cpp
@@ -155,6 +155,13 @@ void MappingTraits<PdbDbiStream>::mapping(IO &IO, PdbDbiStream &Obj) {
   IO.mapOptional("PdbDllRbld", Obj.PdbDllRbld, uint16_t(0U));
   IO.mapOptional("Flags", Obj.Flags, uint16_t(1U));
   IO.mapOptional("MachineType", Obj.MachineType, PDB_Machine::x86);
+  // This is a workaround for IO not having document context with the
+  // machine type. The machine type is needed to properly parse Register enums
+  // in the PDB.
+  if (!IO.getContext()) {
+    Obj.FakeHeader.Machine = static_cast<uint16_t>(Obj.MachineType);
+    IO.setContext(&Obj.FakeHeader);
+  }
   IO.mapOptional("Modules", Obj.ModInfos);
 }
 

--- a/llvm/tools/llvm-pdbutil/PdbYaml.h
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.h
@@ -11,6 +11,7 @@
 
 #include "OutputStyle.h"
 
+#include "llvm/BinaryFormat/COFF.h"
 #include "llvm/DebugInfo/CodeView/SymbolRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
@@ -80,6 +81,7 @@ struct PdbDbiStream {
   PDB_Machine MachineType = PDB_Machine::x86;
 
   std::vector<PdbDbiModuleInfo> ModInfos;
+  COFF::header FakeHeader;
 };
 
 struct PdbTpiStream {

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
@@ -11,6 +11,7 @@
 #include "PdbYaml.h"
 #include "llvm-pdbutil.h"
 
+#include "llvm/BinaryFormat/COFF.h"
 #include "llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/DebugInfo/CodeView/DebugUnknownSubsection.h"
@@ -73,7 +74,15 @@ Error YAMLOutputStyle::dump() {
   if (auto EC = dumpPublics())
     return EC;
 
+  // Fake Coff header for dumping register enumerations.
+  COFF::header Header;
+  auto MachineType =
+      Obj.DbiStream ? Obj.DbiStream->MachineType : PDB_Machine::Unknown;
+  Header.Machine = static_cast<uint16_t>(MachineType);
+  Out.setContext(&Header);
   flush();
+  Out.setContext(nullptr);
+
   return Error::success();
 }
 


### PR DESCRIPTION
This fixes a bug where parsing PDBs with usages of register enums were asserting.

The main problem is that printing out the code view register enums are taken care of here:
https://github.com/nikitalita/llvm-project/blob/e4888a92402f53000a3a5e79d3792c034fc2f343/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp#L152

Which requires a COFF::header in the IO context for the machine type, which we didn't have when dumping a pdb or parsing a yaml file. So, we make a fake one with the machine type.