### PR TITLE
[llvm-pdbutil] Add output file option for pdb2yaml

### DIFF
--- a/llvm/test/tools/llvm-pdbutil/type-server-no-dbi.test
+++ b/llvm/test/tools/llvm-pdbutil/type-server-no-dbi.test
@@ -1,6 +1,6 @@
 
 RUN: llvm-pdbutil dump -all %p/Inputs/TypeServerTest.pdb | FileCheck %s --check-prefix=NO-DBI
-RUN: llvm-pdbutil pdb2yaml -all %p/Inputs/TypeServerTest.pdb > %t
+RUN: llvm-pdbutil pdb2yaml -all %p/Inputs/TypeServerTest.pdb --yaml %t
 RUN: FileCheck --input-file=%t %s --check-prefix=NO-DBI-YAML
 
 NO-DBI-NOT: Native PDB Error: The specified stream could not be loaded.

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
@@ -38,10 +38,13 @@ static bool checkModuleSubsection(opts::ModuleSubsection MS) {
                 });
 }
 
-YAMLOutputStyle::YAMLOutputStyle(PDBFile &File)
-    : File(File), Out(outs()), Obj(File.getAllocator()) {
+YAMLOutputStyle::YAMLOutputStyle(PDBFile &File, raw_ostream &OS)
+    : File(File), Out(OS), Obj(File.getAllocator()) {
   Out.setWriteDefaultValues(!opts::pdb2yaml::Minimal);
 }
+
+YAMLOutputStyle::YAMLOutputStyle(PDBFile &File)
+    : YAMLOutputStyle::YAMLOutputStyle(File, llvm::outs()) {}
 
 Error YAMLOutputStyle::dump() {
   if (opts::pdb2yaml::StreamDirectory)

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.h
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.h
@@ -21,7 +21,7 @@ namespace pdb {
 class YAMLOutputStyle : public OutputStyle {
 public:
   YAMLOutputStyle(PDBFile &File);
-
+  YAMLOutputStyle(PDBFile &File, raw_ostream &Output);
   Error dump() override;
 
 private:

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -732,6 +732,10 @@ cl::opt<bool> DumpSectionHeaders("section-headers",
 cl::list<std::string> InputFilename(cl::Positional,
                                     cl::desc("<input PDB file>"), cl::Required,
                                     cl::sub(PdbToYamlSubcommand));
+cl::opt<std::string> PdbYamlOutputFile(
+    "yaml", cl::desc("the name of the yaml file to write (default stdout)"),
+    cl::sub(PdbToYamlSubcommand));
+
 } // namespace pdb2yaml
 
 namespace merge {
@@ -973,8 +977,35 @@ static void pdb2Yaml(StringRef Path) {
   std::unique_ptr<IPDBSession> Session;
   auto &File = loadPDB(Path, Session);
 
-  auto O = std::make_unique<YAMLOutputStyle>(File);
-
+  std::unique_ptr<YAMLOutputStyle> O;
+  std::unique_ptr<raw_fd_ostream> OutputFile;
+  if (!opts::pdb2yaml::PdbYamlOutputFile.empty()) {
+    std::error_code EC;
+    if (!sys::fs::exists(opts::pdb2yaml::PdbYamlOutputFile)) {
+      auto ParentPath =
+          sys::path::parent_path(opts::pdb2yaml::PdbYamlOutputFile);
+      if (!ParentPath.empty()) {
+        EC = sys::fs::create_directories(
+            sys::path::parent_path(opts::pdb2yaml::PdbYamlOutputFile));
+        if (EC) {
+          errs() << "Error creating directory: "
+                 << sys::path::parent_path(opts::pdb2yaml::PdbYamlOutputFile)
+                 << "\n";
+          exit(1);
+        }
+      }
+    }
+    OutputFile = std::make_unique<raw_fd_ostream>(
+        opts::pdb2yaml::PdbYamlOutputFile, EC, sys::fs::FA_Write);
+    if (EC || !OutputFile) {
+      errs() << "Error opening file for writing: "
+             << opts::pdb2yaml::PdbYamlOutputFile << "\n";
+      exit(1);
+    }
+    O = std::make_unique<YAMLOutputStyle>(File, *OutputFile);
+  } else {
+    O = std::make_unique<YAMLOutputStyle>(File);
+  }
   ExitOnErr(O->dump());
 }
 


### PR DESCRIPTION
Adds `--yaml=<filename>` option to `pdb2yaml`. This is added primarily because we can't always count on having a utf-8 shell to redirect our output from, and if the shell is UTF-16 (like certain Windows shells), we'll output garbage.