### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Don't assume local variables are safe & treat guarded local variable as safe function arguments

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
@@ -53,6 +53,11 @@ class Expr;
 std::pair<const clang::Expr *, bool>
 tryToFindPtrOrigin(const clang::Expr *E, bool StopAtFirstRefCountedObj);
 
+// Returns true if \P V is a variable declaration and \p E is its
+// initialization expression, and there is a "guardian" RefPtr or RefPtr
+// protecting the same value.
+bool isVarDeclGuardedInit(const VarDecl *V, const clang::Expr *InitE);
+
 /// For \p E referring to a ref-countable/-counted pointer/reference we return
 /// whether it's a safe call argument. Examples: function parameter or
 /// this-pointer. The logic relies on the set of recursive rules we enforce for

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -126,7 +126,6 @@ bool isReturnValueRefCounted(const clang::FunctionDecl *F) {
 }
 
 bool isTypeRefCounted(QualType type) {
-  assert(F);
   while (!type.isNull()) {
     if (auto *elaboratedT = type->getAs<ElaboratedType>()) {
       type = elaboratedT->desugar();

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -122,11 +122,21 @@ bool isCtorOfRefCounted(const clang::FunctionDecl *F) {
 
 bool isReturnValueRefCounted(const clang::FunctionDecl *F) {
   assert(F);
-  QualType type = F->getReturnType();
+  return isTypeRefCounted(F->getReturnType());
+}
+
+bool isTypeRefCounted(QualType type) {
+  assert(F);
   while (!type.isNull()) {
     if (auto *elaboratedT = type->getAs<ElaboratedType>()) {
       type = elaboratedT->desugar();
       continue;
+    }
+    if (auto *deduced = type->getAs<DeducedTemplateSpecializationType>()) {
+      if (auto *decl = deduced->getTemplateName().getAsTemplateDecl()) {
+        auto name = decl->getNameAsString();
+        return name == "Ref" || name == "RefPtr";
+      }
     }
     if (auto *specialT = type->getAs<TemplateSpecializationType>()) {
       if (auto *decl = specialT->getTemplateName().getAsTemplateDecl()) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_CLANG_ANALYZER_WEBKIT_PTRTYPESEMANTICS_H
 #define LLVM_CLANG_ANALYZER_WEBKIT_PTRTYPESEMANTICS_H
 
-#include "llvm/ADT/APInt.h"
+#include "clang/AST/Type.h"
 #include "llvm/ADT/DenseMap.h"
 #include <optional>
 
@@ -54,6 +54,9 @@ bool isCtorOfRefCounted(const clang::FunctionDecl *F);
 
 /// \returns true if \p F returns a ref-counted object, false if not.
 bool isReturnValueRefCounted(const clang::FunctionDecl *F);
+
+/// \returns true if \p type is ref-counted object, false if not.
+bool isTypeRefCounted(QualType type);
 
 /// \returns true if \p M is getter of a ref-counted class, false if not.
 std::optional<bool> isGetterOfRefCounted(const clang::CXXMethodDecl* Method);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
@@ -137,6 +137,16 @@ public:
       return true;
     }
 
+    if (auto *DRE = dyn_cast<DeclRefExpr>(ArgOrigin.first)) {
+      auto *Decl = DRE->getFoundDecl();
+      if (auto *VD = dyn_cast<VarDecl>(Decl)) {
+        std::pair<const clang::Expr *, bool> ArgOrigin =
+            tryToFindPtrOrigin(VD->getInit(), false);
+        if (ArgOrigin.first && isVarDeclGuardedInit(VD, ArgOrigin.first))
+          return true;
+      }
+    }
+
     return isASafeCallArg(ArgOrigin.first);
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/guarded-uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/guarded-uncounted-obj-arg.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+
+#include "mock-types.h"
+
+class Number {
+public:
+  Number();
+  ~Number();
+};
+
+int someFunction();
+
+class RefCounted {
+public:
+  void ref() const;
+  void deref() const;
+  void someMethod();
+  bool isDerived() const { return false; }
+};
+
+class Derived : public RefCounted {
+public:
+  void otherMethod();
+  bool isDerived() const { return true; }
+};
+
+template <typename S>
+struct TypeCastTraits<const Derived, S> {
+  static bool isOfType(const S &arg) { return arg.isDerived(); }
+};
+
+RefCounted *object();
+void someFunction(const RefCounted&);
+
+void test() {
+  RefPtr obj = object();
+
+  if (!obj->isDerived()) {
+    auto* base = obj.get();
+    base->someMethod();
+  }
+
+  if (auto *derived = dynamicDowncast<Derived>(*obj))
+    derived->otherMethod();
+
+  while (auto *derived = dynamicDowncast<Derived>(*obj)) {
+    derived->otherMethod();
+    break;
+  }
+
+  for (auto *derived = dynamicDowncast<Derived>(*obj); true; ) {
+    derived->otherMethod();
+    break;
+  }
+
+  do {
+    auto *derived = dynamicDowncast<Derived>(*obj);
+    derived->otherMethod();
+  } while (0);
+
+  auto* derived = dynamicDowncast<Derived>(*obj);
+  derived->otherMethod();
+  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+}
+

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -63,6 +63,28 @@ struct RefCountable {
   void deref() {}
 };
 
-template <typename T> T *downcast(T *t) { return t; }
+template <typename T, typename S>
+struct TypeCastTraits {
+  static bool isOfType(S&);
+};
+
+// Type checking function, to use before casting with downcast<>().
+template <typename T, typename S>
+inline bool is(const S &source) {
+    return TypeCastTraits<const T, const S>::isOfType(source);
+}
+
+template <typename T, typename S>
+inline bool is(S *source) {
+    return source && TypeCastTraits<const T, const S>::isOfType(*source);
+}
+
+template <typename T, typename S> T *downcast(S *t) { return static_cast<T*>(t); }
+template <typename T, typename S> T *dynamicDowncast(S &t) {
+  return is<T>(t) ? &static_cast<T&>(t) : nullptr;
+}
+template <typename T, typename S> T *dynamicDowncast(S *t) {
+  return is<T>(t) ? static_cast<T*>(t) : nullptr;
+}
 
 #endif


### PR DESCRIPTION
[alpha.webkit.UncountedCallArgsChecker] Treat guarded local variable as safe function arguments

This PR extracts the code in UncountedLocalVarsChecker to identify a variable declaration which
has a guardian Ref / RefPtr variable as isVarDeclGuardedInit and integrates it with
alpha.webkit.UncountedCallArgsChecker so that we treat local variables that are "guarded" by
a Ref / RefPtr as safe function arguments.

[alpha.webkit.UncountedCallArgsChecker] Don't assume local variables are safe.

This PR makes alpha.webkit.UncountedCallArgsChecker no longer assume that every local variable to be safe.
Instead, we try to validate the local variable's origin in tryToFindPtrOrigin. To do this, this PR extracts
the code to decide whether a given type is a specialization of Ref / RefPtr as isTypeRefCounted and
calls it in tryToFindPtrOrigin for the declared variable. This PR also fixes a bug in the same function
that we were not detecting DeducedTemplateSpecializationType as a safe origin.