### PR TITLE
[LLVM][ADT] Put both vesions of 'unique' into STLExtras.h

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -46,6 +46,7 @@
 
 #include "llvm/ADT/GenericUniformityInfo.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -56,10 +57,6 @@
 #define DEBUG_TYPE "uniformity"
 
 namespace llvm {
-
-template <typename Range> auto unique(Range &&R) {
-  return std::unique(adl_begin(R), adl_end(R));
-}
 
 /// Construct a specially modified post-order traversal of cycles.
 ///

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1994,6 +1994,12 @@ auto unique(Range &&R, Predicate P) {
   return std::unique(adl_begin(R), adl_end(R), P);
 }
 
+/// Wrapper function around std::unique to allow calling unique on a
+/// container without having to specify the begin/end iterators.
+template <typename Range> auto unique(Range &&R) {
+  return std::unique(adl_begin(R), adl_end(R));
+}
+
 /// Wrapper function around std::equal to detect if pair-wise elements between
 /// two ranges are the same.
 template <typename L, typename R> bool equal(L &&LRange, R &&RRange) {

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1004,6 +1004,19 @@ TEST(STLExtras, Unique) {
   EXPECT_EQ(3, V[3]);
 }
 
+TEST(STLExtras, UniqueNoPred) {
+  std::vector<uint32_t> V = {1, 5, 5, 4, 3, 3, 3};
+
+  auto I = llvm::unique(V);
+
+  EXPECT_EQ(I, V.begin() + 4);
+
+  EXPECT_EQ(1, V[0]);
+  EXPECT_EQ(5, V[1]);
+  EXPECT_EQ(4, V[2]);
+  EXPECT_EQ(3, V[3]);
+}
+
 TEST(STLExtrasTest, MakeVisitorOneCallable) {
   auto IdentityLambda = [](auto X) { return X; };
   auto IdentityVisitor = makeVisitor(IdentityLambda);


### PR DESCRIPTION
Currently there are two versions of llvm::unique, one that requires a predicate, and is in STLExtras.h; and one that does not require a predicate, and is in GenericUniformityImpl.h. This moves the one from GenericUniformityImp.h to STlExtras.h, so they are both together, and can both be easily called from other places inside LLVM.