### PR TITLE
[libc++][ranges] `elements_view`: `get()` forward declarations - tests

### DIFF
--- a/libcxx/include/__ranges/elements_view.h
+++ b/libcxx/include/__ranges/elements_view.h
@@ -16,7 +16,6 @@
 #include <__concepts/derived_from.h>
 #include <__concepts/equality_comparable.h>
 #include <__config>
-#include <__fwd/complex.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h>
 #include <__ranges/access.h>

--- a/libcxx/include/__ranges/elements_view.h
+++ b/libcxx/include/__ranges/elements_view.h
@@ -16,6 +16,7 @@
 #include <__concepts/derived_from.h>
 #include <__concepts/equality_comparable.h>
 #include <__config>
+#include <__fwd/complex.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h>
 #include <__ranges/access.h>

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.pass.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.pass.cpp
@@ -12,6 +12,9 @@
 
 #include <array>
 #include <cassert>
+#include <concepts>
+#include <ranges>
+#include <vector>
 
 #include "test_macros.h"
 
@@ -57,6 +60,25 @@ TEST_CONSTEXPR_CXX14 bool tests()
         assert(std::get<1>(tempArray(1, 2, 3)) == 2);
         assert(std::get<2>(tempArray(1, 2, 3)) == 3);
     }
+
+#if TEST_STD_VER >= 20
+    // `get()` allows using `array` with ranges
+    {
+      std::array<int, 2> arr[]{{27, 28}, {82, 94}};
+
+      std::same_as<std::vector<int>> decltype(auto) nums0{
+          arr | std::views::elements<0> | std::ranges::to<std::vector<int>>()};
+      assert(nums0.size() == 2);
+      assert(nums0[0] == 27);
+      assert(nums0[1] == 82);
+
+      std::same_as<std::vector<int>> decltype(auto) nums1{
+          arr | std::views::elements<1> | std::ranges::to<std::vector<int>>()};
+      assert(nums1.size() == 2);
+      assert(nums1[0] == 28);
+      assert(nums1[1] == 94);
+    }
+#endif
 
     return true;
 }

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.pass.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.pass.cpp
@@ -61,7 +61,7 @@ TEST_CONSTEXPR_CXX14 bool tests()
         assert(std::get<2>(tempArray(1, 2, 3)) == 3);
     }
 
-#if TEST_STD_VER >= 20
+#if TEST_STD_VER >= 23
     // `get()` allows using `array` with ranges
     {
       std::array<int, 2> arr[]{{27, 28}, {82, 94}};

--- a/libcxx/test/std/numerics/complex.number/complex.tuple/get.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex.tuple/get.pass.cpp
@@ -111,7 +111,7 @@ constexpr void test() {
 
     std::same_as<std::vector<T>> decltype(auto) imags{
         arr | std::views::elements<1> | std::ranges::to<std::vector<T>>()};
-    assert(reals.size() == 2);
+    assert(imags.size() == 2);
     assert(imags[0] == T{28});
     assert(imags[1] == T{94});
   }

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
@@ -16,9 +16,12 @@
 
 // UNSUPPORTED: c++03
 
-#include <tuple>
-#include <string>
 #include <cassert>
+#include <concepts>
+#include <ranges>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "test_macros.h"
 
@@ -81,6 +84,24 @@ int main(int, char**)
     }
 #endif
 
+#if TEST_STD_VER >= 20
+    // `get()` allows using `tuple` with ranges
+    {
+      std::tuple<int, std::string> arr[]{{27, "hkt"}, {28, "zmt"}};
 
-  return 0;
+      std::same_as<std::vector<int>> decltype(auto) numbers{
+          arr | std::views::elements<0> | std::ranges::to<std::vector<int>>()};
+      assert(numbers.size() == 2);
+      assert(numbers[0] == 27);
+      assert(numbers[1] == 28);
+
+      std::same_as<std::vector<std::string>> decltype(auto) strings{
+          arr | std::views::elements<1> | std::ranges::to<std::vector<std::string>>()};
+      assert(strings.size() == 2);
+      assert(strings[0] == "hkt");
+      assert(strings[1] == "zmt");
+    }
+#endif
+
+    return 0;
 }

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
@@ -84,7 +84,7 @@ int main(int, char**)
     }
 #endif
 
-#if TEST_STD_VER >= 20
+#if TEST_STD_VER >= 23
     // `get()` allows using `tuple` with ranges
     {
       std::tuple<int, std::string> arr[]{{27, "hkt"}, {28, "zmt"}};

--- a/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
@@ -14,8 +14,12 @@
 //     typename tuple_element<I, std::pair<T1, T2> >::type&
 //     get(pair<T1, T2>&);
 
-#include <utility>
 #include <cassert>
+#include <concepts>
+#include <ranges>
+#include <string>
+#include <vector>
+#include <utility>
 
 #include "test_macros.h"
 
@@ -49,6 +53,24 @@ int main(int, char**)
     }
 #endif
 
+#if TEST_STD_VER >= 20
+    // `get()` allows using `pair` with ranges
+    {
+      std::pair<int, std::string> arr[]{{27, "hkt"}, {28, "zmt"}};
+
+      std::same_as<std::vector<int>> decltype(auto) numbers{
+          arr | std::views::elements<0> | std::ranges::to<std::vector<int>>()};
+      assert(numbers.size() == 2);
+      assert(numbers[0] == 27);
+      assert(numbers[1] == 28);
+
+      std::same_as<std::vector<std::string>> decltype(auto) strings{
+          arr | std::views::elements<1> | std::ranges::to<std::vector<std::string>>()};
+      assert(strings.size() == 2);
+      assert(strings[0] == "hkt");
+      assert(strings[1] == "zmt");
+    }
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
@@ -72,5 +72,5 @@ int main(int, char**)
     }
 #endif
 
-  return 0;
+    return 0;
 }

--- a/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_non_const.pass.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
     }
 #endif
 
-#if TEST_STD_VER >= 20
+#if TEST_STD_VER >= 23
     // `get()` allows using `pair` with ranges
     {
       std::pair<int, std::string> arr[]{{27, "hkt"}, {28, "zmt"}};


### PR DESCRIPTION
A follow-up to:
[libc++][ranges] elements_view (re-)add get() forward declarations
https://github.com/llvm/llvm-project/pull/82236