### PR TITLE
[StackSlotColoring] Check for zero stack slot size in RemoveDeadStores

### DIFF
--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -480,7 +480,8 @@ bool StackSlotColoring::RemoveDeadStores(MachineBasicBlock* MBB) {
     if (!(StoreReg = TII->isStoreToStackSlot(*NextMI, SecondSS, StoreSize)))
       continue;
     if (FirstSS != SecondSS || LoadReg != StoreReg || FirstSS == -1 ||
-        LoadSize != StoreSize || !MFI->isSpillSlotObjectIndex(FirstSS))
+        !LoadSize || LoadSize != StoreSize ||
+        !MFI->isSpillSlotObjectIndex(FirstSS))
       continue;
 
     ++NumDead;


### PR DESCRIPTION
The default implementations of the methods isLoadFromStackSlot() and isStoreToStackSlot() used in StackSlotColoring::RemoveDeadStores() set the number of bytes loaded from the stack (MemBytes) to zero to indicate that the value is unknown. This means that StackSlotColoring::RemoveDeadStores() must abort if the size is zero otherwise the stack slot size check doesn't mean anything.

As backends that use this are required to override the default implementations this should not impose any degradation of the code.

As the registers also must match in StackSlotColoring::RemoveDeadStores() for the store to be optimized away there is small risk of this being a real bug. This makes it probably impossible to make a testcase to verify this.