### PR TITLE
[libFuzzer] Fix incorrect coverage number in fork mode

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
@@ -349,7 +349,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
                         &NewFeatures, Env.Cov, &NewCov, CFPath,
                         /*Verbose=*/false, /*IsSetCoverMerge=*/false);
     Env.Features.insert(NewFeatures.begin(), NewFeatures.end());
-    Env.Cov.insert(NewFeatures.begin(), NewFeatures.end());
+    Env.Cov.insert(NewCov.begin(), NewCov.end());
     RemoveFile(CFPath);
   }
 


### PR DESCRIPTION
Closes #82307.

I built LLVM with the changes and tested fuzzing in fork mode. The coverage number was correct:
```
[ye@ye-arch ~]$ /home/ye/work/llvm-project/build/bin/clang++ -fsanitize=fuzzer test_fuzzer.cc
[ye@ye-arch ~]$ ./a.out corpus -fork=4
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3152497917
INFO: Loaded 1 modules   (40 inline 8-bit counters): 40 [0x5aa6f7b310d0, 0x5aa6f7b310f8), 
INFO: Loaded 1 PC tables (40 PCs): 40 [0x5aa6f7b310f8,0x5aa6f7b31378), 
INFO: -fork=4: fuzzing in separate process(s)
INFO: -fork=4: 56 seed inputs, starting to fuzz in /tmp/libFuzzerTemp.FuzzWithFork54465.dir
#600649: cov: 36 ft: 224 corp: 56 exec/s: 300324 oom/timeout/crash: 0/0/0 time: 2s job: 1 dft_time: 0
#1548208: cov: 36 ft: 224 corp: 56 exec/s: 315853 oom/timeout/crash: 0/0/0 time: 3s job: 2 dft_time: 0
#2465991: cov: 36 ft: 224 corp: 56 exec/s: 229445 oom/timeout/crash: 0/0/0 time: 4s job: 3 dft_time: 0
#3887877: cov: 36 ft: 224 corp: 56 exec/s: 284377 oom/timeout/crash: 0/0/0 time: 5s job: 4 dft_time: 0
```