### PR TITLE
[mlir][EmitC] Remove `func.constant` from emitter

### DIFF
--- a/mlir/docs/Dialects/emitc.md
+++ b/mlir/docs/Dialects/emitc.md
@@ -28,7 +28,6 @@ translating the following operations:
     *   `cf.cond_br`
 *   'func' Dialect
     *   `func.call`
-    *   `func.constant`
     *   `func.func`
     *   `func.return`
 *   'arith' Dialect

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -332,14 +332,6 @@ static LogicalResult printOperation(CppEmitter &emitter,
 }
 
 static LogicalResult printOperation(CppEmitter &emitter,
-                                    func::ConstantOp constantOp) {
-  Operation *operation = constantOp.getOperation();
-  Attribute value = constantOp.getValueAttr();
-
-  return printConstantOp(emitter, operation, value);
-}
-
-static LogicalResult printOperation(CppEmitter &emitter,
                                     emitc::AssignOp assignOp) {
   auto variableOp = cast<emitc::VariableOp>(assignOp.getVar().getDefiningOp());
   OpResult result = variableOp->getResult(0);
@@ -1296,7 +1288,7 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
                 emitc::SubOp, emitc::VariableOp, emitc::VerbatimOp>(
               [&](auto op) { return printOperation(*this, op); })
           // Func ops.
-          .Case<func::CallOp, func::ConstantOp, func::FuncOp, func::ReturnOp>(
+          .Case<func::CallOp, func::FuncOp, func::ReturnOp>(
               [&](auto op) { return printOperation(*this, op); })
           // Arithmetic ops.
           .Case<arith::ConstantOp>(


### PR DESCRIPTION
As part of the renaming the Standard dialect to Func dialect, *support* for the `func.constant` operation was added to the emitter. However, the emitter cannot emit function types. Hence the emission for a snippet like

```
%0 = func.constant @myfn : (f32) -> f32

func.func private @myfn(%arg0: f32) -> f32 {
  return %arg0 : f32
}
```

failes with `func.mlir:1:6: error: cannot emit type '(f32) -> f32'`. This removes `func.constant` from the emitter.