### PR TITLE
[clang-format] Fix crash in TokenAnnotator

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3817,7 +3817,7 @@ void TokenAnnotator::calculateFormattingInformation(AnnotatedLine &Line) const {
         do {
           Tok = Tok->Next;
         } while (Tok && Tok->isNot(TT_OverloadedOperatorLParen));
-        if (!Tok)
+        if (!Tok || !Tok->Next)
           break;
         const auto *LeftParen = Tok;
         for (Tok = Tok->Next; Tok && Tok != LeftParen->MatchingParen;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3817,7 +3817,7 @@ void TokenAnnotator::calculateFormattingInformation(AnnotatedLine &Line) const {
         do {
           Tok = Tok->Next;
         } while (Tok && Tok->isNot(TT_OverloadedOperatorLParen));
-        if (!Tok || !Tok->Next)
+        if (!Tok || !Tok->MatchingParen)
           break;
         const auto *LeftParen = Tok;
         for (Tok = Tok->Next; Tok && Tok != LeftParen->MatchingParen;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -13503,6 +13503,9 @@ TEST_F(FormatTest, IncorrectCodeUnbalancedBraces) {
   verifyFormat("{");
   verifyFormat("#})");
   verifyNoCrash("(/**/[:!] ?[).");
+  verifyNoCrash("struct X{"
+                "  operator iunt("
+                "};");
 }
 
 TEST_F(FormatTest, IncorrectUnbalancedBracesInMacrosWithUnicode) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -13507,7 +13507,7 @@ TEST_F(FormatTest, IncorrectCodeUnbalancedBraces) {
                 "  operator iunt(\n"
                 "};");
   verifyNoCrash("struct Foo {\n"
-                "operator foo(bar\n"
+                "  operator foo(bar\n"
                 "};");
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -13506,6 +13506,9 @@ TEST_F(FormatTest, IncorrectCodeUnbalancedBraces) {
   verifyNoCrash("struct X {\n"
                 "  operator iunt(\n"
                 "};");
+  verifyNoCrash("struct Foo {\n"
+                "operator foo(bar\n"
+                "};");
 }
 
 TEST_F(FormatTest, IncorrectUnbalancedBracesInMacrosWithUnicode) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -13503,8 +13503,8 @@ TEST_F(FormatTest, IncorrectCodeUnbalancedBraces) {
   verifyFormat("{");
   verifyFormat("#})");
   verifyNoCrash("(/**/[:!] ?[).");
-  verifyNoCrash("struct X{"
-                "  operator iunt("
+  verifyNoCrash("struct X {\n"
+                "  operator iunt(\n"
                 "};");
 }
 


### PR DESCRIPTION
The while loop on line 3814 can cause a segmentation fault getting the Next field on a nullptr. This is because further down, on line 3823, there is another for loop, which assigns Tok to Tok->Next in its initializer. This for loop has a condition to check if the result of that isn't null. If it is, the loop is skipped and we drop back out to the outer loop, except, now Tok is null, and we try to dereference it without checking first.

This patch adds a defensive check that returns if Tok->Next is null before we make it to the second for loop.

Fixes https://github.com/llvm/llvm-project/issues/82328