### PR TITLE
[KnownBits] Add KnownBits::absdiff to compute the absolute difference of 2 unsigned values

### DIFF
--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -385,6 +385,9 @@ public:
   /// Compute known bits for smin(LHS, RHS).
   static KnownBits smin(const KnownBits &LHS, const KnownBits &RHS);
 
+  /// Compute known bits for absdiff(LHS, RHS).
+  static KnownBits absdiff(const KnownBits &LHS, const KnownBits &RHS);
+
   /// Compute known bits for shl(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
   static KnownBits shl(const KnownBits &LHS, const KnownBits &RHS,

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -176,6 +176,22 @@ KnownBits KnownBits::smin(const KnownBits &LHS, const KnownBits &RHS) {
   return Flip(umax(Flip(LHS), Flip(RHS)));
 }
 
+KnownBits KnownBits::absdiff(const KnownBits &LHS, const KnownBits &RHS) {
+  // absdiff(LHS,RHS) = sub(umax(LHS,RHS), umin(LHS,RHS)).
+  KnownBits UMaxValue = umax(LHS, RHS);
+  KnownBits UMinValue = umin(LHS, RHS);
+  KnownBits MinMaxDiff = computeForAddSub(false, false, UMaxValue, UMinValue);
+
+  // find the common bits between sub(LHS,RHS) and sub(RHS,LHS).
+  KnownBits Diff0 = computeForAddSub(false, false, LHS, RHS);
+  KnownBits Diff1 = computeForAddSub(false, false, RHS, LHS);
+  KnownBits SubDiff = Diff0.intersectWith(Diff1);
+
+  KnownBits KnownAbsDiff = MinMaxDiff.unionWith(SubDiff);
+  assert(!KnownAbsDiff.hasConflict() && "Bad Output");
+  return KnownAbsDiff;
+}
+
 static unsigned getMaxShiftAmount(const APInt &MaxValue, unsigned BitWidth) {
   if (isPowerOf2_32(BitWidth))
     return MaxValue.extractBitsAsZExtValue(Log2_32(BitWidth), 0);


### PR DESCRIPTION
Equivalent to "umax(A, B) - umin(A, B)"

This is just an initial correctness implementation, hopefully we can make this optimal in the future.