### PR TITLE
[InstCombine] Support zext nneg in `foldLogicCastConstant`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -1685,7 +1685,7 @@ static Instruction *foldLogicCastConstant(BinaryOperator &Logic, CastInst *Cast,
     }
   }
 
-  if (match(Cast, m_OneUse(m_SExt(m_Value(X))))) {
+  if (match(Cast, m_OneUse(m_SExtLike(m_Value(X))))) {
     if (Constant *TruncC = IC.getLosslessSignedTrunc(C, SrcTy)) {
       // LogicOpc (sext X), C --> sext (LogicOpc X, C)
       Value *NewOp = IC.Builder.CreateBinOp(LogicOpc, X, TruncC);

--- a/llvm/test/Transforms/InstCombine/cast.ll
+++ b/llvm/test/Transforms/InstCombine/cast.ll
@@ -748,8 +748,8 @@ define i32 @test54(i64 %A) {
 define i64 @test55(i32 %A) {
 ; ALL-LABEL: @test55(
 ; ALL-NEXT:    [[TMP1:%.*]] = and i32 [[A:%.*]], 7224
-; ALL-NEXT:    [[C:%.*]] = zext nneg i32 [[TMP1]] to i64
-; ALL-NEXT:    [[D:%.*]] = or disjoint i64 [[C]], -32574
+; ALL-NEXT:    [[TMP2:%.*]] = or disjoint i32 [[TMP1]], -32574
+; ALL-NEXT:    [[D:%.*]] = sext i32 [[TMP2]] to i64
 ; ALL-NEXT:    ret i64 [[D]]
 ;
   %B = trunc i32 %A to i16


### PR DESCRIPTION
This patch extends [D36234](https://reviews.llvm.org/D36234) to handle `zext nneg` instructions.
I found this while adding support for cast instructions in `getFreelyInvertedImpl`.
