### PR TITLE
[lldb][X86] Fix setting target features in ClangExpressionParser

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -445,8 +445,8 @@ ClangExpressionParser::ClangExpressionParser(
   // Supported subsets of x86
   if (target_machine == llvm::Triple::x86 ||
       target_machine == llvm::Triple::x86_64) {
-    m_compiler->getTargetOpts().Features.push_back("+sse");
-    m_compiler->getTargetOpts().Features.push_back("+sse2");
+    m_compiler->getTargetOpts().FeaturesAsWritten.push_back("+sse");
+    m_compiler->getTargetOpts().FeaturesAsWritten.push_back("+sse2");
   }
 
   // Set the target CPU to generate code for. This will be empty for any CPU


### PR DESCRIPTION
Currently, for x86 and x86_64 triples, "+sse" and "+sse2" are appended to `Features` vector of `TargetOptions` unconditionally. This vector is later reset in `TargetInfo::CreateTargetInfo` and filled using info from `FeaturesAsWritten` vector, so previous modifications of the `Features` vector have no effect. For x86_64 triple, we append "sse2" unconditionally in `X86TargetInfo::initFeatureMap`, so despite the `Features` vector reset, we still have the desired sse features enabled. The corresponding code in `X86TargetInfo::initFeatureMap` is marked as FIXME, so we should not probably rely on it and should set desired features properly in `ClangExpressionParser`.

This patch changes the vector the features are appended to from `Features` to `FeaturesAsWritten`. It's not reset later and is used to compute resulting `Features` vector.