### PR TITLE
[mlir] expose transform interpreter to Python

### DIFF
--- a/mlir/include/mlir-c/Dialect/Transform/Interpreter.h
+++ b/mlir/include/mlir-c/Dialect/Transform/Interpreter.h
@@ -1,0 +1,77 @@
+//===-- mlir-c/Dialect/Transform/Interpreter.h --------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// C interface to the transform dialect interpreter.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEFINE_C_API_STRUCT(name, storage)                                     \
+  struct name {                                                                \
+    storage *ptr;                                                              \
+  };                                                                           \
+  typedef struct name name
+
+DEFINE_C_API_STRUCT(MlirTransformOptions, void);
+
+#undef DEFINE_C_API_STRUCT
+
+//----------------------------------------------------------------------------//
+// MlirTransformOptions
+//----------------------------------------------------------------------------//
+
+/// Creates a default-initialized transform options object.
+MLIR_CAPI_EXPORTED MlirTransformOptions mlirTransformOptionsCreate(void);
+
+/// Enables or disables expensive checks in transform options.
+MLIR_CAPI_EXPORTED void
+mlirTransformOptionsEnableExpensiveChecks(MlirTransformOptions transformOptions,
+                                          bool enable);
+
+/// Returns true if expensive checks are enabled in transform options.
+MLIR_CAPI_EXPORTED bool mlirTransformOptionsGetExpensiveChecksEnabled(
+    MlirTransformOptions transformOptions);
+
+/// Enables or disables the enforcement of the top-level transform op being
+/// single in transform options.
+MLIR_CAPI_EXPORTED void mlirTransformOptionsEnforceSingleTopLevelTransformOp(
+    MlirTransformOptions transformOptions, bool enable);
+
+/// Returns true if the enforcement of the top-level transform op being single
+/// is enabled in transform options.
+MLIR_CAPI_EXPORTED bool mlirTransformOptionsGetEnforceSingleTopLevelTransformOp(
+    MlirTransformOptions transformOptions);
+
+/// Destroys a transform options object previously created by
+/// mlirTransformOptionsCreate.
+MLIR_CAPI_EXPORTED void
+mlirTransformOptionsDestroy(MlirTransformOptions transformOptions);
+
+//----------------------------------------------------------------------------//
+// Transform interpreter.
+//----------------------------------------------------------------------------//
+
+/// Applies the transformation script starting at the given transform root
+/// operation to the given payload operation. The module containing the
+/// transform root as well as the transform options should be provided. The
+/// transform operation must implement TransformOpInterface and the module must
+/// be a ModuleOp. Returns the status of the application.
+MLIR_CAPI_EXPORTED MlirLogicalResult mlirTransformApplyNamedSequence(
+    MlirOperation payload, MlirOperation transformRoot,
+    MlirOperation transformModule, MlirTransformOptions transformOptions);
+
+#ifdef __cplusplus
+}
+#endif

--- a/mlir/include/mlir/Bindings/Python/PybindAdaptors.h
+++ b/mlir/include/mlir/Bindings/Python/PybindAdaptors.h
@@ -23,6 +23,7 @@
 #include <pybind11/stl.h>
 
 #include "mlir-c/Bindings/Python/Interop.h"
+#include "mlir-c/Diagnostics.h"
 #include "mlir-c/IR.h"
 
 #include "llvm/ADT/Twine.h"
@@ -569,6 +570,41 @@ public:
 };
 
 } // namespace adaptors
+
+/// RAII scope intercepting all diagnostics into a string. The message must be
+/// checked before this goes out of scope.
+class CollectDiagnosticsToStringScope {
+public:
+  explicit CollectDiagnosticsToStringScope(MlirContext ctx) : context(ctx) {
+    handlerID = mlirContextAttachDiagnosticHandler(ctx, &handler, &errorMessage,
+                                                   /*deleteUserData=*/nullptr);
+  }
+  ~CollectDiagnosticsToStringScope() {
+    assert(errorMessage.empty() && "unchecked error message");
+    mlirContextDetachDiagnosticHandler(context, handlerID);
+  }
+
+  [[nodiscard]] std::string takeMessage() { return std::move(errorMessage); }
+
+private:
+  static MlirLogicalResult handler(MlirDiagnostic diag, void *data) {
+    auto printer = +[](MlirStringRef message, void *data) {
+      *static_cast<std::string *>(data) +=
+          llvm::StringRef(message.data, message.length);
+    };
+    MlirLocation loc = mlirDiagnosticGetLocation(diag);
+    *static_cast<std::string *>(data) += "at ";
+    mlirLocationPrint(loc, printer, data);
+    *static_cast<std::string *>(data) += ": ";
+    mlirDiagnosticPrint(diag, printer, data);
+    return mlirLogicalResultSuccess();
+  }
+
+  MlirContext context;
+  MlirDiagnosticHandlerID handlerID;
+  std::string errorMessage = "";
+};
+
 } // namespace python
 } // namespace mlir
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -678,6 +678,10 @@ void PyMlirContext::clearOperationsInside(PyOperationBase &op) {
   mlirOperationWalk(op.getOperation(), invalidatingCallback,
                     static_cast<void *>(&data), MlirWalkPreOrder);
 }
+void PyMlirContext::clearOperationsInside(MlirOperation op) {
+  PyOperationRef opRef = PyOperation::forOperation(getRef(), op);
+  clearOperationsInside(opRef->getOperation());
+}
 
 size_t PyMlirContext::getLiveModuleCount() { return liveModules.size(); }
 
@@ -2556,6 +2560,9 @@ void mlir::python::populateIRCore(py::module &m) {
       .def("_get_live_operation_objects",
            &PyMlirContext::getLiveOperationObjects)
       .def("_clear_live_operations", &PyMlirContext::clearLiveOperations)
+      .def("_clear_live_operations_inside",
+           py::overload_cast<MlirOperation>(
+               &PyMlirContext::clearOperationsInside))
       .def("_get_live_module_count", &PyMlirContext::getLiveModuleCount)
       .def_property_readonly(MLIR_PYTHON_CAPI_PTR_ATTR,
                              &PyMlirContext::getCapsule)

--- a/mlir/lib/Bindings/Python/IRModule.h
+++ b/mlir/lib/Bindings/Python/IRModule.h
@@ -223,6 +223,7 @@ public:
   /// Clears all operations nested inside the given op using
   /// `clearOperation(MlirOperation)`.
   void clearOperationsInside(PyOperationBase &op);
+  void clearOperationsInside(MlirOperation op);
 
   /// Gets the count of live modules associated with this context.
   /// Used for testing.

--- a/mlir/lib/Bindings/Python/TransformInterpreter.cpp
+++ b/mlir/lib/Bindings/Python/TransformInterpreter.cpp
@@ -1,0 +1,90 @@
+//===- TransformInterpreter.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Pybind classes for the transform dialect interpreter.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/Dialect/Transform/Interpreter.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+#include <pybind11/detail/common.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace {
+struct PyMlirTransformOptions {
+  PyMlirTransformOptions() { options = mlirTransformOptionsCreate(); };
+  PyMlirTransformOptions(PyMlirTransformOptions &&other) {
+    options = other.options;
+    other.options.ptr = nullptr;
+  }
+  PyMlirTransformOptions(const PyMlirTransformOptions &) = delete;
+
+  ~PyMlirTransformOptions() { mlirTransformOptionsDestroy(options); }
+
+  MlirTransformOptions options;
+};
+} // namespace
+
+static void populateTransformInterpreterSubmodule(py::module &m) {
+  py::class_<PyMlirTransformOptions>(m, "TransformOptions", py::module_local())
+      .def(py::init())
+      .def_property(
+          "expensive_checks",
+          [](const PyMlirTransformOptions &self) {
+            return mlirTransformOptionsGetExpensiveChecksEnabled(self.options);
+          },
+          [](PyMlirTransformOptions &self, bool value) {
+            mlirTransformOptionsEnableExpensiveChecks(self.options, value);
+          })
+      .def_property(
+          "enforce_single_top_level_transform_op",
+          [](const PyMlirTransformOptions &self) {
+            return mlirTransformOptionsGetEnforceSingleTopLevelTransformOp(
+                self.options);
+          },
+          [](PyMlirTransformOptions &self, bool value) {
+            mlirTransformOptionsEnforceSingleTopLevelTransformOp(self.options,
+                                                                 value);
+          });
+
+  m.def(
+      "apply_named_sequence",
+      [](MlirOperation payloadRoot, MlirOperation transformRoot,
+         MlirOperation transformModule, const PyMlirTransformOptions &options) {
+        mlir::python::CollectDiagnosticsToStringScope scope(
+            mlirOperationGetContext(transformRoot));
+
+        // Calling back into Python to invalidate everything under the payload
+        // root. This is awkward, but we don't have access to PyMlirContext
+        // object here otherwise.
+        py::object obj = py::cast(payloadRoot);
+        obj.attr("context").attr("_clear_live_operations_inside")(payloadRoot);
+
+        MlirLogicalResult result = mlirTransformApplyNamedSequence(
+            payloadRoot, transformRoot, transformModule, options.options);
+        if (mlirLogicalResultIsSuccess(result))
+          return;
+
+        throw py::value_error(
+            "Failed to apply named transform sequence.\nDiagnostic message " +
+            scope.takeMessage());
+      },
+      py::arg("payload_root"), py::arg("transform_root"),
+      py::arg("transform_module"),
+      py::arg("transform_options") = PyMlirTransformOptions());
+}
+
+PYBIND11_MODULE(_mlirTransformInterpreter, m) {
+  m.doc() = "MLIR Transform dialect interpreter functionality.";
+  populateTransformInterpreterSubmodule(m);
+}

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -198,6 +198,15 @@ add_mlir_upstream_c_api_library(MLIRCAPITransformDialect
   MLIRTransformDialect
 )
 
+add_mlir_upstream_c_api_library(MLIRCAPITransformDialectTransforms
+  TransformInterpreter.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  MLIRTransformDialectTransforms
+)
+
 add_mlir_upstream_c_api_library(MLIRCAPIQuant
   Quant.cpp
 

--- a/mlir/lib/CAPI/Dialect/TransformInterpreter.cpp
+++ b/mlir/lib/CAPI/Dialect/TransformInterpreter.cpp
@@ -1,0 +1,74 @@
+//===- TransformTransforms.cpp - C Interface for Transform dialect --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// C interface to transforms for the transform dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/Dialect/Transform/Interpreter.h"
+#include "mlir-c/Support.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Wrap.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
+
+using namespace mlir;
+
+DEFINE_C_API_PTR_METHODS(MlirTransformOptions, transform::TransformOptions)
+
+extern "C" {
+
+MlirTransformOptions mlirTransformOptionsCreate() {
+  return wrap(new transform::TransformOptions);
+}
+
+void mlirTransformOptionsEnableExpensiveChecks(
+    MlirTransformOptions transformOptions, bool enable) {
+  unwrap(transformOptions)->enableExpensiveChecks(enable);
+}
+
+bool mlirTransformOptionsGetExpensiveChecksEnabled(
+    MlirTransformOptions transformOptions) {
+  return unwrap(transformOptions)->getExpensiveChecksEnabled();
+}
+
+void mlirTransformOptionsEnforceSingleTopLevelTransformOp(
+    MlirTransformOptions transformOptions, bool enable) {
+  unwrap(transformOptions)->enableEnforceSingleToplevelTransformOp(enable);
+}
+
+bool mlirTransformOptionsGetEnforceSingleTopLevelTransformOp(
+    MlirTransformOptions transformOptions) {
+  return unwrap(transformOptions)->getEnforceSingleToplevelTransformOp();
+}
+
+void mlirTransformOptionsDestroy(MlirTransformOptions transformOptions) {
+  delete unwrap(transformOptions);
+}
+
+MlirLogicalResult mlirTransformApplyNamedSequence(
+    MlirOperation payload, MlirOperation transformRoot,
+    MlirOperation transformModule, MlirTransformOptions transformOptions) {
+  Operation *transformRootOp = unwrap(transformRoot);
+  Operation *transformModuleOp = unwrap(transformModule);
+  if (!isa<transform::TransformOpInterface>(transformRootOp)) {
+    transformRootOp->emitError()
+        << "must implement TransformOpInterface to be used as transform root";
+    return mlirLogicalResultFailure();
+  }
+  if (!isa<ModuleOp>(transformModuleOp)) {
+    transformModuleOp->emitError()
+        << "must be a " << ModuleOp::getOperationName();
+    return mlirLogicalResultFailure();
+  }
+  return wrap(transform::applyTransformNamedSequence(
+      unwrap(payload), unwrap(transformRoot),
+      cast<ModuleOp>(unwrap(transformModule)), *unwrap(transformOptions)));
+}
+}

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -181,6 +181,13 @@ declare_mlir_python_sources(
   SOURCES
     dialects/transform/extras/__init__.py)
 
+declare_mlir_python_sources(
+  MLIRPythonSources.Dialects.transform.interpreter
+  ADD_TO_PARENT MLIRPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  SOURCES
+    dialects/transform/interpreter/__init__.py)
+
 declare_mlir_dialect_extension_python_bindings(
   ADD_TO_PARENT MLIRPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
@@ -607,6 +614,18 @@ declare_mlir_python_extension(MLIRPythonExtension.SparseTensorDialectPasses
     LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPISparseTensor
+)
+
+declare_mlir_python_extension(MLIRPythonExtension.TransformInterpreter
+  MODULE_NAME _mlirTransformInterpreter
+  ADD_TO_PARENT MLIRPythonSources.Dialects.transform
+  ROOT_DIR "${PYTHON_SOURCE_DIR}"
+  SOURCES
+    TransformInterpreter.cpp
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+  EMBED_CAPI_LINK_LIBS
+    MLIRCAPITransformDialectTransforms
 )
 
 # TODO: Figure out how to put this in the test tree.

--- a/mlir/python/mlir/dialects/transform/interpreter/__init__.py
+++ b/mlir/python/mlir/dialects/transform/interpreter/__init__.py
@@ -1,0 +1,33 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ....ir import Operation
+from ...._mlir_libs import _mlirTransformInterpreter as _cextTransformInterpreter
+
+
+TransformOptions = _cextTransformInterpreter.TransformOptions
+
+
+def _unpack_operation(op):
+    if isinstance(op, Operation):
+        return op
+    return op.operation
+
+
+def apply_named_sequence(
+    payload_root, transform_root, transform_module, transform_options=None
+):
+    """Applies the transformation script starting at the given transform root
+    operation to the given payload operation. The module containing the
+    transform root as well as the transform options should be provided.
+    The transform operation must implement TransformOpInterface and the module
+    must be a ModuleOp."""
+
+    args = tuple(
+        map(_unpack_operation, (payload_root, transform_root, transform_module))
+    )
+    if transform_options is None:
+        _cextTransformInterpreter.apply_named_sequence(*args)
+    else:
+        _cextTransformInterpreter(*args, transform_options)

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -86,6 +86,15 @@ _add_capi_test_executable(mlir-capi-transform-test
     MLIRCAPITransformDialect
 )
 
+_add_capi_test_executable(mlir-capi-transform-interpreter-test
+  transform_interpreter.c
+  LINK_LIBS PRIVATE
+    MLIRCAPIIR
+    MLIRCAPIRegisterEverything
+    MLIRCAPITransformDialect
+    MLIRCAPITransformDialectTransforms
+)
+
 _add_capi_test_executable(mlir-capi-translation-test
   translation.c
   LINK_LIBS PRIVATE

--- a/mlir/test/CAPI/transform_interpreter.c
+++ b/mlir/test/CAPI/transform_interpreter.c
@@ -1,0 +1,69 @@
+//===- transform_interpreter.c - Test of the Transform interpreter C API --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: mlir-capi-transform-interpreter-test 2>&1 | FileCheck %s
+
+#include "mlir-c/Dialect/Transform.h"
+#include "mlir-c/Dialect/Transform/Interpreter.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int testApplyNamedSequence(MlirContext ctx) {
+  fprintf(stderr, "%s\n", __FUNCTION__);
+
+  const char module[] =
+      "module attributes {transform.with_named_sequence} {"
+      "  transform.named_sequence @__transform_main(%root: !transform.any_op) {"
+      "    transform.print %root { name = \"from interpreter\" }: "
+      "!transform.any_op"
+      "    transform.yield"
+      "  }"
+      "}";
+
+  MlirStringRef moduleStringRef = mlirStringRefCreateFromCString(module);
+  MlirStringRef nameStringRef = mlirStringRefCreateFromCString("inline-module");
+
+  MlirOperation root =
+      mlirOperationCreateParse(ctx, moduleStringRef, nameStringRef);
+  if (mlirOperationIsNull(root))
+    return 1;
+  MlirBlock body = mlirRegionGetFirstBlock(mlirOperationGetRegion(root, 0));
+  MlirOperation entry = mlirBlockGetFirstOperation(body);
+
+  MlirTransformOptions options = mlirTransformOptionsCreate();
+  mlirTransformOptionsEnableExpensiveChecks(options, true);
+  mlirTransformOptionsEnforceSingleTopLevelTransformOp(options, true);
+
+  MlirLogicalResult result =
+      mlirTransformApplyNamedSequence(root, entry, root, options);
+  mlirTransformOptionsDestroy(options);
+  if (mlirLogicalResultIsFailure(result))
+    return 2;
+
+  return 0;
+}
+// CHECK-LABEL: testApplyNamedSequence
+// CHECK: from interpreter
+// CHECK: transform.named_sequence @__transform_main
+// CHECK:   transform.print %arg0
+// CHECK:   transform.yield
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleRegisterDialect(mlirGetDialectHandle__transform__(), ctx);
+  int result = testApplyNamedSequence(ctx);
+  mlirContextDestroy(ctx);
+  if (result)
+    return result;
+
+  return EXIT_SUCCESS;
+}

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -100,6 +100,7 @@ set(MLIR_TEST_DEPENDS
   mlir-capi-quant-test
   mlir-capi-sparse-tensor-test
   mlir-capi-transform-test
+  mlir-capi-transform-interpreter-test
   mlir-capi-translation-test
   mlir-linalg-ods-yaml-gen
   mlir-lsp-server

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -106,6 +106,7 @@ tools = [
     "mlir-capi-quant-test",
     "mlir-capi-sparse-tensor-test",
     "mlir-capi-transform-test",
+    "mlir-capi-transform-interpreter-test",
     "mlir-capi-translation-test",
     "mlir-cpu-runner",
     add_runtime("mlir_runner_utils"),

--- a/mlir/test/python/dialects/transform_interpreter.py
+++ b/mlir/test/python/dialects/transform_interpreter.py
@@ -1,0 +1,56 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects.transform import interpreter as interp
+
+
+def test_in_context(f):
+    with ir.Context(), ir.Location.unknown():
+        f()
+    return f
+
+
+print_root_module = """
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%root: !transform.any_op) {
+    transform.print %root { name = \"from interpreter\" }: !transform.any_op
+    transform.yield
+  }
+}"""
+
+
+@test_in_context
+def print_self():
+    m = ir.Module.parse(print_root_module.replace("from interpreter", "print_self"))
+    interp.apply_named_sequence(m, m.body.operations[0], m)
+
+
+# CHECK-LABEL: print_self
+# CHECK: transform.named_sequence @__transform_main
+# CHECK: transform.print
+# CHECK: transform.yield
+
+
+@test_in_context
+def print_other():
+    transform = ir.Module.parse(
+        print_root_module.replace("from interpreter", "print_other")
+    )
+    payload = ir.Module.parse("module attributes { this.is.payload } {}")
+    interp.apply_named_sequence(payload, transform.body.operations[0], transform)
+
+
+# CHECK-LABEL: print_other
+# CHECK-NOT: transform
+# CHECK: this.is.payload
+
+
+@test_in_context
+def failed():
+    payload = ir.Module.parse("module attributes { this.is.payload } {}")
+    try:
+        interp.apply_named_sequence(payload, payload, payload)
+    except ValueError as e:
+        assert (
+            "must implement TransformOpInterface to be used as transform root" in str(e)
+        )

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -740,6 +740,25 @@ mlir_c_api_cc_library(
 )
 
 mlir_c_api_cc_library(
+    name = "CAPITransformDialectTransforms",
+    srcs = [
+        "lib/CAPI/Dialect/TransformInterpreter.cpp",
+    ],
+    hdrs = [
+        "include/mlir-c/Dialect/Transform/Interpreter.h",
+    ],
+    capi_deps = [
+        ":CAPIIR",
+        ":CAPITransformDialect",
+    ],
+    includes = ["include"],
+    deps = [
+        ":TransformDialect",
+        ":TransformDialectTransforms",
+    ],
+)
+
+mlir_c_api_cc_library(
     name = "CAPIMLProgram",
     srcs = [
         "lib/CAPI/Dialect/MLProgram.cpp",

--- a/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
@@ -1483,6 +1483,11 @@ filegroup(
     srcs = glob(["mlir/dialects/transform/extras/*.py"]),
 )
 
+filegroup(
+    name = "TransformInterpreterPackagePyFiles",
+    srcs = glob(["mlir/dialects/transform/interpreter/*.py"]),
+)
+
 ##---------------------------------------------------------------------------##
 # Vector dialect.
 ##---------------------------------------------------------------------------##


### PR DESCRIPTION
Transform interpreter functionality can be used standalone without going through the interpreter pass, make it available in Python.