### PR TITLE
Fix pipeline-invalid.mlir bytecode roundtrip test

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -2334,8 +2334,11 @@ BytecodeReader::Impl::parseOpWithoutRegions(EncodingReader &reader,
   Operation *op = Operation::create(opState);
   readState.curBlock->push_back(op);
 
-  // If the operation had results, update the value references.
-  if (op->getNumResults() && failed(defineValues(reader, op->getResults())))
+  // If the operation had results, update the value references. We don't need to
+  // do this if the current value scope is empty. That is, the op was not
+  // encoded within a parent region.
+  if (readState.numValues && op->getNumResults() &&
+      failed(defineValues(reader, op->getResults())))
     return failure();
 
   /// Store a map for every value that received a custom use-list order from the


### PR DESCRIPTION
If an op was not contained in a region when was written to bytecode,
we don't have an initialized valueScope with forward references to
define.