### PR TITLE
[libc] Cleanup of hermetic test flag handling

### DIFF
--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -36,9 +36,9 @@ function(add_unittest_framework_library name)
     endif()
     target_compile_options(${lib} PUBLIC ${compile_options})
   endforeach()
+  _get_hermetic_test_compile_options(compile_options -nostdinc++)
   target_include_directories(${name}.hermetic PRIVATE ${LIBC_BUILD_DIR}/include)
-  target_compile_options(${name}.hermetic
-      PRIVATE ${LIBC_HERMETIC_TEST_COMPILE_OPTIONS} -ffreestanding -nostdinc++)
+  target_compile_options(${name}.hermetic PRIVATE ${compile_options})
 
   if(TEST_LIB_DEPENDS)
     foreach(dep IN LISTS ${TEST_LIB_DEPENDS})


### PR DESCRIPTION
Summary:
This cleans up the handling of hermetic test flags. Primarily done to
simplify the GPU rework patch.
