### PR TITLE
[AArch64] Fix syntax of gcsstr and gcssttr instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1243,7 +1243,7 @@ def : InstAlias<"chkfeat\tx16", (CHKFEAT), 0>;
 def : InstAlias<"chkfeat\tx16", (CHKFEAT), 1>, Requires<[HasCHK]>;
 
 class GCSSt<string mnemonic, bits<3> op>
-    : I<(outs), (ins GPR64:$Rt, GPR64sp:$Rn), mnemonic, "\t$Rt, $Rn", "", []>, Sched<[]> {
+    : I<(outs), (ins GPR64:$Rt, GPR64sp:$Rn), mnemonic, "\t$Rt, [$Rn]", "", []>, Sched<[]> {
   bits<5> Rt;
   bits<5> Rn;
   let Inst{31-15} = 0b11011001000111110;

--- a/llvm/test/MC/AArch64/armv9.4a-gcs.s
+++ b/llvm/test/MC/AArch64/armv9.4a-gcs.s
@@ -86,20 +86,20 @@ hint #19
 // ERROR-NO-GCS-NOT: [[@LINE-2]]:1: error: instruction requires: gcs
 // NO-GCS: hint #19                              // encoding: [0x7f,0x22,0x03,0xd5]
 
-gcsstr x26, x27
-// CHECK: gcsstr x26, x27                          // encoding: [0x7a,0x0f,0x1f,0xd9]
+gcsstr x26, [x27]
+// CHECK: gcsstr x26, [x27]                        // encoding: [0x7a,0x0f,0x1f,0xd9]
 // ERROR-NO-GCS: [[@LINE-2]]:1: error: instruction requires: gcs
 
-gcsstr x26, sp
-// CHECK: gcsstr x26, sp                           // encoding: [0xfa,0x0f,0x1f,0xd9]
+gcsstr x26, [sp]
+// CHECK: gcsstr x26, [sp]                         // encoding: [0xfa,0x0f,0x1f,0xd9]
 // ERROR-NO-GCS: [[@LINE-2]]:1: error: instruction requires: gcs
 
-gcssttr x26, x27
-// CHECK: gcssttr x26, x27                         // encoding: [0x7a,0x1f,0x1f,0xd9]
+gcssttr x26, [x27]
+// CHECK: gcssttr x26, [x27]                       // encoding: [0x7a,0x1f,0x1f,0xd9]
 // ERROR-NO-GCS: [[@LINE-2]]:1: error: instruction requires: gcs
 
-gcssttr x26, sp
-// CHECK: gcssttr x26, sp                          // encoding: [0xfa,0x1f,0x1f,0xd9]
+gcssttr x26, [sp]
+// CHECK: gcssttr x26, [sp]                        // encoding: [0xfa,0x1f,0x1f,0xd9]
 // ERROR-NO-GCS: [[@LINE-2]]:1: error: instruction requires: gcs
 
 gcspushx

--- a/llvm/test/MC/Disassembler/AArch64/armv9.4a-gcs.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.4a-gcs.txt
@@ -69,16 +69,16 @@
 // CHECK: gcsb    dsync
 
 [0x7a,0x0f,0x1f,0xd9]
-// CHECK: gcsstr   x26, x27
+// CHECK: gcsstr   x26, [x27]
 
 [0xfa,0x0f,0x1f,0xd9]
-// CHECK: gcsstr   x26, sp
+// CHECK: gcsstr   x26, [sp]
 
 [0x7a,0x1f,0x1f,0xd9]
-// CHECK: gcssttr  x26, x27
+// CHECK: gcssttr  x26, [x27]
 
 [0xfa,0x1f,0x1f,0xd9]
-// CHECK: gcssttr  x26, sp
+// CHECK: gcssttr  x26, [sp]
 
 [0x9f,0x77,0x08,0xd5]
 // CHECK: gcspushx


### PR DESCRIPTION
The address register should be surrounded by square brackets, like in all the other str instructions.

Fixes https://github.com/llvm/llvm-project/issues/81846