### PR TITLE
[AArch64] Fix register reversing crash on MSVC with 1 pair.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3115,14 +3115,16 @@ bool AArch64FrameLowering::restoreCalleeSavedRegisters(
   }
 
   // For performance reasons restore SVE register in increasing order
-  auto IsPPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::PPR; };
-  auto PPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsPPR);
-  auto PPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsPPR);
-  std::reverse(PPRBegin, PPREnd.base());
-  auto IsZPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::ZPR; };
-  auto ZPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsZPR);
-  auto ZPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsZPR);
-  std::reverse(ZPRBegin, ZPREnd.base());
+  if (RegPairs.size() > 1) {
+    auto IsPPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::PPR; };
+    auto PPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsPPR);
+    auto PPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsPPR);
+    std::reverse(PPRBegin, PPREnd.base());
+    auto IsZPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::ZPR; };
+    auto ZPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsZPR);
+    auto ZPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsZPR);
+    std::reverse(ZPRBegin, ZPREnd.base());
+  }
 
   for (const RegPairInfo &RPI : RegPairs) {
     unsigned Reg1 = RPI.Reg1;

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3130,7 +3130,6 @@ bool AArch64FrameLowering::restoreCalleeSavedRegisters(
     std::reverse(ZPRBegin, ZPREnd.base());
   }
 
-
   for (const RegPairInfo &RPI : RegPairs) {
     unsigned Reg1 = RPI.Reg1;
     unsigned Reg2 = RPI.Reg2;

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3116,15 +3116,20 @@ bool AArch64FrameLowering::restoreCalleeSavedRegisters(
 
   // For performance reasons restore SVE register in increasing order
   if (RegPairs.size() > 1) {
-    auto IsPPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::PPR; };
+    auto IsPPR = [](const RegPairInfo &c) {
+      return c.Type == RegPairInfo::PPR;
+    };
     auto PPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsPPR);
     auto PPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsPPR);
     std::reverse(PPRBegin, PPREnd.base());
-    auto IsZPR = [](const RegPairInfo &c) { return c.Type == RegPairInfo::ZPR; };
+    auto IsZPR = [](const RegPairInfo &c) {
+      return c.Type == RegPairInfo::ZPR;
+    };
     auto ZPRBegin = std::find_if(RegPairs.begin(), RegPairs.end(), IsZPR);
     auto ZPREnd = std::find_if(RegPairs.rbegin(), RegPairs.rend(), IsZPR);
     std::reverse(ZPRBegin, ZPREnd.base());
   }
+
 
   for (const RegPairInfo &RPI : RegPairs) {
     unsigned Reg1 = RPI.Reg1;


### PR DESCRIPTION
This fixes the crash reported here: https://github.com/llvm/llvm-project/pull/79623#discussion_r1496160694 where this assert was hit:
```c++
#if _ITERATOR_DEBUG_LEVEL != 0
template <class _Ty>
constexpr void _Verify_range(const _Ty* const _First, const _Ty* const _Last) noexcept {
    // special case range verification for pointers
    _STL_VERIFY(_First <= _Last, "transposed pointer range");
}
#endif // _ITERATOR_DEBUG_LEVEL != 0
```

Info from the debugger on the test case that crashed: 
![image](https://github.com/llvm/llvm-project/assets/4010439/ad33e4cc-0f9a-435b-9816-6aba75a19107)