### PR TITLE
[LLVM][DWARF] Refactor code for generating DWARF V5 .debug_names

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -614,9 +614,10 @@ enum AcceleratorTable {
 };
 
 // Uniquify the string hashes and calculate the bucket count for the
-// DWARF v5 Accelerator Table.
-inline uint32_t computeDebugNamesUniqueHashes(MutableArrayRef<uint32_t> hashes,
-                                              uint32_t &uniqueHashCount) {
+// DWARF v5 Accelerator Table. NOTE: This function effectively consumes the
+// 'hashes' input parameter.
+inline uint32_t getDebugNamesBucketCount(MutableArrayRef<uint32_t> hashes,
+                                         uint32_t &uniqueHashCount) {
   uint32_t BucketCount = 0;
 
   sort(hashes);

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -615,9 +615,8 @@ enum AcceleratorTable {
 
 // Uniquify the string hashes and calculate the bucket count for the
 // DWARF v5 Accelerator Table.
-inline uint32_t
-computeDebugNamesUniqueHashes(MutableArrayRef<uint32_t> hashes,
-                              uint32_t &uniqueHashCount) {
+inline uint32_t computeDebugNamesUniqueHashes(MutableArrayRef<uint32_t> hashes,
+                                              uint32_t &uniqueHashCount) {
   uint32_t BucketCount = 0;
 
   sort(hashes);

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -613,6 +613,25 @@ enum AcceleratorTable {
   DW_hash_function_djb = 0u
 };
 
+// Uniquify the string hashes and calculate the bucket count for the
+// DWARF v5 Accelerator Table.
+inline uint32_t
+computeDebugNamesUniqueHashes(MutableArrayRef<uint32_t> hashes,
+                              uint32_t &uniqueHashCount) {
+  uint32_t BucketCount = 0;
+
+  sort(hashes);
+  uniqueHashCount = llvm::unique(hashes) - hashes.begin();
+  if (uniqueHashCount > 1024)
+    BucketCount = uniqueHashCount / 4;
+  else if (uniqueHashCount > 16)
+    BucketCount = uniqueHashCount / 2;
+  else
+    BucketCount = std::max<uint32_t>(uniqueHashCount, 1);
+
+  return BucketCount;
+}
+
 // Constants for the GNU pubnames/pubtypes extensions supporting gdb index.
 enum GDBIndexEntryKind {
   GIEK_NONE,

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -38,8 +38,8 @@ void AccelTableBase::computeBucketCount() {
   for (const auto &E : Entries)
     Uniques.push_back(E.second.HashValue);
 
-  BucketCount = llvm::dwarf::computeDebugNamesUniqueHashes(Uniques,
-                                                           UniqueHashCount);
+  BucketCount =
+      llvm::dwarf::computeDebugNamesUniqueHashes(Uniques, UniqueHashCount);
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -39,7 +39,7 @@ void AccelTableBase::computeBucketCount() {
     Uniques.push_back(E.second.HashValue);
 
   BucketCount =
-      llvm::dwarf::computeDebugNamesUniqueHashes(Uniques, UniqueHashCount);
+      llvm::dwarf::getDebugNamesBucketCount(Uniques, UniqueHashCount);
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -38,8 +38,7 @@ void AccelTableBase::computeBucketCount() {
   for (const auto &E : Entries)
     Uniques.push_back(E.second.HashValue);
 
-  BucketCount =
-      llvm::dwarf::getDebugNamesBucketCount(Uniques, UniqueHashCount);
+  BucketCount = llvm::dwarf::getDebugNamesBucketCount(Uniques, UniqueHashCount);
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -33,22 +33,13 @@ using namespace llvm;
 
 void AccelTableBase::computeBucketCount() {
   // First get the number of unique hashes.
-  std::vector<uint32_t> Uniques;
+  SmallVector<uint32_t, 0> Uniques;
   Uniques.reserve(Entries.size());
   for (const auto &E : Entries)
     Uniques.push_back(E.second.HashValue);
-  array_pod_sort(Uniques.begin(), Uniques.end());
-  std::vector<uint32_t>::iterator P =
-      std::unique(Uniques.begin(), Uniques.end());
 
-  UniqueHashCount = std::distance(Uniques.begin(), P);
-
-  if (UniqueHashCount > 1024)
-    BucketCount = UniqueHashCount / 4;
-  else if (UniqueHashCount > 16)
-    BucketCount = UniqueHashCount / 2;
-  else
-    BucketCount = std::max<uint32_t>(UniqueHashCount, 1);
+  BucketCount = llvm::dwarf::computeDebugNamesUniqueHashes(Uniques,
+                                                           UniqueHashCount);
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {


### PR DESCRIPTION
[LLVM][DWARF]  Refactor code for generating DWARF v5 .debug_names

Refactor the code that uniques the entries and computes the bucket count for the DWARF V5 .debug_names accelerator table. 

