### PR TITLE
[clangd] Fix renaming single argument ObjC methods

### DIFF
--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -812,6 +812,9 @@ renameWithinFile(ParsedAST &AST, const NamedDecl &RenameDecl,
     Locs.push_back(RenameLoc);
   }
   if (const auto *MD = dyn_cast<ObjCMethodDecl>(&RenameDecl)) {
+    // The custom ObjC selector logic doesn't handle the zero arg selector
+    // case. We could use it for the one arg selector case but it's simpler to
+    // use the standard one-token rename logic.
     if (MD->getSelector().getNumArgs() > 1)
       return renameObjCMethodWithinFile(AST, MD, NewName, std::move(Locs));
 

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -811,8 +811,14 @@ renameWithinFile(ParsedAST &AST, const NamedDecl &RenameDecl,
       continue;
     Locs.push_back(RenameLoc);
   }
-  if (const auto *MD = dyn_cast<ObjCMethodDecl>(&RenameDecl))
-    return renameObjCMethodWithinFile(AST, MD, NewName, std::move(Locs));
+  if (const auto *MD = dyn_cast<ObjCMethodDecl>(&RenameDecl)) {
+    if (MD->getSelector().getNumArgs() > 1)
+      return renameObjCMethodWithinFile(AST, MD, NewName, std::move(Locs));
+
+    // Eat trailing : for single argument methods since they're actually
+    // considered a separate token during rename.
+    NewName.consume_back(":");
+  }
   for (const auto &Loc : Locs) {
     if (auto Err = FilteredChanges.add(tooling::Replacement(
             SM, CharSourceRange::getTokenRange(Loc), NewName)))
@@ -930,10 +936,9 @@ renameOutsideFile(const NamedDecl &RenameDecl, llvm::StringRef MainFilePath,
     std::optional<Selector> Selector = std::nullopt;
     llvm::SmallVector<llvm::StringRef, 8> NewNames;
     if (const auto *MD = dyn_cast<ObjCMethodDecl>(&RenameDecl)) {
-      if (MD->getSelector().getNumArgs() > 1) {
-        RenameIdentifier = MD->getSelector().getNameForSlot(0).str();
+      RenameIdentifier = MD->getSelector().getNameForSlot(0).str();
+      if (MD->getSelector().getNumArgs() > 1)
         Selector = MD->getSelector();
-      }
     }
     NewName.split(NewNames, ":");
 

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -813,8 +813,9 @@ renameWithinFile(ParsedAST &AST, const NamedDecl &RenameDecl,
   }
   if (const auto *MD = dyn_cast<ObjCMethodDecl>(&RenameDecl)) {
     // The custom ObjC selector logic doesn't handle the zero arg selector
-    // case. We could use it for the one arg selector case but it's simpler to
-    // use the standard one-token rename logic.
+    // case, as it relies on parsing selectors via the trailing `:`.
+    // We also choose to use regular rename logic for the single-arg selectors
+    // as the AST/Index has the right locations in that case.
     if (MD->getSelector().getNumArgs() > 1)
       return renameObjCMethodWithinFile(AST, MD, NewName, std::move(Locs));
 


### PR DESCRIPTION
Use the legacy non-ObjC rename logic when dealing with selectors that have zero or one arguments. In addition, make sure we don't add an extra `:` during the rename.

Add a few more tests to verify this works (thanks to @ahoppen for the tests and finding this bug).