### PR TITLE
[Docs] Allow building man pages without myst_parser

### DIFF
--- a/clang/docs/conf.py
+++ b/clang/docs/conf.py
@@ -35,8 +35,16 @@ templates_path = ["_templates"]
 
 import sphinx
 
-if sphinx.version_info >= (3, 0):
-    extensions.append("myst_parser")
+# When building man pages, we do not use the markdown pages,
+# So, we can continue without the myst_parser dependencies.
+# Doing so reduces dependencies of some packaged llvm distributions.
+try:
+  import myst_parser
+  extensions.append("myst_parser")
+except ImportError:
+  if not tags.has("builder-man"):
+    raise
+
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/clang/docs/conf.py
+++ b/clang/docs/conf.py
@@ -39,11 +39,12 @@ import sphinx
 # So, we can continue without the myst_parser dependencies.
 # Doing so reduces dependencies of some packaged llvm distributions.
 try:
-  import myst_parser
-  extensions.append("myst_parser")
+    import myst_parser
+
+    extensions.append("myst_parser")
 except ImportError:
-  if not tags.has("builder-man"):
-    raise
+    if not tags.has("builder-man"):
+        raise
 
 
 # The encoding of source files.

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -22,12 +22,22 @@ from datetime import date
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    "myst_parser",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autodoc",
 ]
+
+# When building man pages, we do not use the markdown pages,
+# So, we can continue without the myst_parser dependencies.
+# Doing so reduces dependencies of some packaged llvm distributions.
+try:
+  import myst_parser
+  extensions.append("myst_parser")
+except ImportError:
+  if not tags.has("builder-man"):
+    raise
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -32,11 +32,12 @@ extensions = [
 # So, we can continue without the myst_parser dependencies.
 # Doing so reduces dependencies of some packaged llvm distributions.
 try:
-  import myst_parser
-  extensions.append("myst_parser")
+    import myst_parser
+
+    extensions.append("myst_parser")
 except ImportError:
-  if not tags.has("builder-man"):
-    raise
+    if not tags.has("builder-man"):
+        raise
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -26,7 +26,17 @@ sys.path.insert(0, os.path.abspath("."))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["myst_parser", "sphinx.ext.intersphinx", "sphinx.ext.todo"]
+extensions = ["sphinx.ext.intersphinx", "sphinx.ext.todo"]
+
+# When building man pages, we do not use the markdown pages,
+# So, we can continue without the myst_parser dependencies.
+# Doing so reduces dependencies of some packaged llvm distributions.
+try:
+  import myst_parser
+  extensions.append("myst_parser")
+except ImportError:
+  if not tags.has("builder-man"):
+    raise
 
 # Automatic anchors for markdown titles
 from llvm_slug import make_slug

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -32,11 +32,12 @@ extensions = ["sphinx.ext.intersphinx", "sphinx.ext.todo"]
 # So, we can continue without the myst_parser dependencies.
 # Doing so reduces dependencies of some packaged llvm distributions.
 try:
-  import myst_parser
-  extensions.append("myst_parser")
+    import myst_parser
+
+    extensions.append("myst_parser")
 except ImportError:
-  if not tags.has("builder-man"):
-    raise
+    if not tags.has("builder-man"):
+        raise
 
 # Automatic anchors for markdown titles
 from llvm_slug import make_slug


### PR DESCRIPTION
The man pages do not depend on the doc present in markdown files, so they can be built without myst_parser.
Doing so might allow llvm distributions to have less development dependencies.

As we do not have the ennvironment to test these configuration, this capability is provided on a best-effort basis.

This restores a capability accidentally lost in #65664.