### PR TITLE
[vim] Fix command already exists on opening multiple mir buffers

### DIFF
--- a/llvm/utils/vim/syntax/mir.vim
+++ b/llvm/utils/vim/syntax/mir.vim
@@ -43,6 +43,8 @@ if version >= 508 || !exists("did_c_syn_inits")
   endif
 
   HiLink mirSpecialComment SpecialComment
+
+  delcommand HiLink
 endif
 
 let b:current_syntax = "mir"


### PR DESCRIPTION
When using the vim syntax for mir, an error occurs in nvim (unknown if it affects the original vim) when opening multiple .mir buffers. Add '!' when defining HiLink to redefine the command instead of giving an error. Only the changes to mir.vim and llvm.vim are required to fix the error, but from similarity making the change in all the syntax files seems prudent.

To reproduce:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
Open an .mir file, for example llvm/test/Codegen/X86/expand-post-ra-pseudo.mir                                                                                                                                                   
Open another mir file from within nvim, for example peephole.mir
                                                                                                                                                                 
```
Error detected while processing function 335[30]..<SNR>43_callback[25]..function 335[30]..<SNR>43_callback:                                                                                                                      
line   23:                                                                                                                                                                                                                       
Vim(command):E174: Command already exists: add ! to replace it: HiLink hi def link <args>   
```