### PR TITLE
[run-clang-tidy.py] Add option to ignore source files from compilation database

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -475,9 +475,10 @@ def main():
             source_filter_re = re.compile(args.source_filter)
         except:
             print(
-                "Error: unable to compile regex from arg -source-filter.",
+                "Error: unable to compile regex from arg -source-filter:",
                 file=sys.stderr,
             )
+            traceback.print_exc()
             sys.exit(1)
         files = {f for f in files if source_filter_re.match(f)}
 

--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -301,6 +301,12 @@ def main():
         "displayed.",
     )
     parser.add_argument(
+        "-source-ignore",
+        default=None,
+        help="Regular expression matching the names of the "
+        "source files from compilation database to ignore.",
+    )
+    parser.add_argument(
         "-line-filter",
         default=None,
         help="List of files with line ranges to filter the warnings.",
@@ -461,6 +467,15 @@ def main():
     files = set(
         [make_absolute(entry["file"], entry["directory"]) for entry in database]
     )
+
+    # Remove source file to be ignored from database.
+    if args.source_ignore:
+        try:
+            source_ignore_re = re.compile(args.source_ignore)
+        except:
+            print("Error: unable to compile regex from arg -source-ignore.", file=sys.stderr)
+            sys.exit(1)
+        files = {f for f in files if not source_ignore_re.match(f)}
 
     max_task = args.j
     if max_task == 0:

--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -301,10 +301,11 @@ def main():
         "displayed.",
     )
     parser.add_argument(
-        "-source-ignore",
+        "-source-filter",
         default=None,
         help="Regular expression matching the names of the "
-        "source files from compilation database to ignore.",
+        "source files from compilation database to output "
+        "diagnostics from.",
     )
     parser.add_argument(
         "-line-filter",
@@ -468,17 +469,17 @@ def main():
         [make_absolute(entry["file"], entry["directory"]) for entry in database]
     )
 
-    # Remove source file to be ignored from database.
-    if args.source_ignore:
+    # Filter source files from compilation database.
+    if args.source_filter:
         try:
-            source_ignore_re = re.compile(args.source_ignore)
+            source_filter_re = re.compile(args.source_filter)
         except:
             print(
-                "Error: unable to compile regex from arg -source-ignore.",
+                "Error: unable to compile regex from arg -source-filter.",
                 file=sys.stderr,
             )
             sys.exit(1)
-        files = {f for f in files if not source_ignore_re.match(f)}
+        files = {f for f in files if source_filter_re.match(f)}
 
     max_task = args.j
     if max_task == 0:

--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -473,7 +473,10 @@ def main():
         try:
             source_ignore_re = re.compile(args.source_ignore)
         except:
-            print("Error: unable to compile regex from arg -source-ignore.", file=sys.stderr)
+            print(
+                "Error: unable to compile regex from arg -source-ignore.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         files = {f for f in files if not source_ignore_re.match(f)}
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -98,7 +98,8 @@ Improvements to clang-tidy
 --------------------------
 
 - Improved :program:`run-clang-tidy.py` script. Added argument `-source-filter`
-  to filter out source files from the compilation database.
+  to filter source files from the compilation database, via a RegEx. In a
+  similar fashion to what `-header-filter` does for header files.
 
 New checks
 ^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,9 @@ The improvements are...
 Improvements to clang-tidy
 --------------------------
 
+- Improved :program:`run-clang-tidy.py` script. Added argument `-source-filter`
+  to filter out source files from the compilation database.
+
 New checks
 ^^^^^^^^^^
 


### PR DESCRIPTION
I added the option ~~`-source-ignore`~~ `-source-filter` to the `run-clang-tidy.py` script in the clang-tools-extra.

This option allows for handing over a regex, to filter out source files from the compilation database (not run `clang-tidy` on them).

~~**Why "ignore" instead of "filter"?**~~
~~I found it more useful to actively filter out (ignore) source files, rather than the inverse logic. One usually knows where the source files reside and can now easily ignore e.g. the `thirdparty/` directory.~~