### PR TITLE
[scudo] increase frames per stack to 16 for stack depot

### DIFF
--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -1520,7 +1520,12 @@ private:
     constexpr u32 kStacksPerRingBufferEntry = 2;
     constexpr u32 kMaxU32Pow2 = ~(UINT32_MAX >> 1);
     static_assert(isPowerOfTwo(kMaxU32Pow2));
-    constexpr u32 kFramesPerStack = 8;
+    // On Android we always have 3 frames at the bottom: __start_main,
+    // __libc_init, main, and 3 at the top: malloc, scudo_malloc and
+    // Allocator::allocate. This leaves 10 frames for the user app. The next
+    // smallest power of two (8) would only leave 2, which is clearly too
+    // little.
+    constexpr u32 kFramesPerStack = 16;
     static_assert(isPowerOfTwo(kFramesPerStack));
 
     // We need StackDepot to be aligned to 8-bytes so the ring we store after


### PR DESCRIPTION
8 was very low and it is likely that in real workloads we have more than an average of 8 frames per stack given on Android we have 3 at the bottom: __start_main, __libc_init, main, and three at the top: malloc, scudo_malloc and Allocator::allocate. That leaves 2 frames for application code, which is clearly unreasonable.