### PR TITLE
Remove the "generic" register completion test.

### DIFF
--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -787,27 +787,6 @@ class CommandLineCompletionTestCase(TestBase):
         # register write can only take exact one register name as argument
         self.complete_from_to("register write rbx ", [])
 
-    def test_register_read_and_write_generic(self):
-        """Test the completion of the commands register read and write on x86"""
-
-        self.build()
-        self.main_source_spec = lldb.SBFileSpec("main.cpp")
-        lldbutil.run_to_source_breakpoint(self, "// Break here", self.main_source_spec)
-
-        # test cases for register read
-        self.complete_from_to("register read f", ["fp"])
-        # register read can take multiple register names as arguments
-        self.complete_from_to("register read sp ", ["sp", "fp"])
-        # complete with prefix '$'
-        self.complete_from_to("register read sp $", ["$sp", "$fp"])
-        self.complete_from_to("register read $x0 ", ["sp", "fp"])
-
-        # test cases for register write
-        self.complete_from_to("register write ", ["fp", "sp"])
-        self.complete_from_to("register write f", ["fp"])
-        # register write can only take exact one register name as argument
-        self.complete_from_to("register write fp ", [])
-
     def test_common_completion_target_stophook_ids(self):
         subcommands = ["delete", "enable", "disable"]
 


### PR DESCRIPTION
For reasons that are not clear to me, on arm64, the alias registers are listed in list of register info's we do completion against, but for x86_64 they are not.  Maybe this is a difference in how the dynamic register builders work for the two systems.  Anyway, it doesn't look possible to make a generic one.