### PR TITLE
[ARM] Add r12 and lr as scratch registers

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -13789,6 +13789,14 @@ static SDValue PerformADDVecReduce(SDNode *N, SelectionDAG &DAG,
   return SDValue();
 }
 
+const MCPhysReg *ARMTargetLowering::getScratchRegisters(CallingConv::ID) const {
+  // LR is a not a scratch register, but we must treat it as clobbered by any
+  // call site. Hence we include LR in the scratch registers, which are in turn
+  // added as implicit-defs for stackmaps and patchpoints.
+  static const MCPhysReg ScratchRegs[] = {ARM::R12, ARM::LR, 0};
+  return ScratchRegs;
+}
+
 bool
 ARMTargetLowering::isDesirableToCommuteWithShift(const SDNode *N,
                                                  CombineLevel Level) const {

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -738,6 +738,8 @@ class VectorType;
     Align getABIAlignmentForCallingConv(Type *ArgTy,
                                         const DataLayout &DL) const override;
 
+    const MCPhysReg *getScratchRegisters(CallingConv::ID CC) const override;
+
     bool isDesirableToCommuteWithShift(const SDNode *N,
                                        CombineLevel Level) const override;
 


### PR DESCRIPTION
r12 is the intra-procedural scratch register and lr is clobbered across every call.