### PR TITLE
[AMDGPU] Add function attribute to force enable WQM

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
@@ -484,6 +484,10 @@ char SIWholeQuadMode::scanInstructions(MachineFunction &MF,
   bool HasImplicitDerivatives =
       MF.getFunction().getCallingConv() == CallingConv::AMDGPU_PS;
 
+  // Force soft WQM to be full WQM if requested.
+  if (MF.getFunction().hasFnAttribute("amdgpu-requires-wqm"))
+    GlobalFlags |= StateWQM;
+
   // We need to visit the basic blocks in reverse post-order so that we visit
   // defs before uses, in particular so that we don't accidentally mark an
   // instruction as needing e.g. WQM before visiting it and realizing it needs


### PR DESCRIPTION
Add "amdgpu-requires-wqm" function attribute to force enable WQM for intrinsics (softwqm/set.inactive) that are normally only WQM if other WQM usage exists.

This is used if we wish to force helper lanes to engage in subgroup operations.