### PR TITLE
[SystemZ] Use VT (not ArgVT) for SlotVT in LowerCall().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -1923,7 +1923,7 @@ SystemZTargetLowering::LowerCall(CallLoweringInfo &CLI,
         unsigned N = getNumRegistersForCallingConv(Ctx, CLI.CallConv, OrigArgVT);
         SlotVT = EVT::getIntegerVT(Ctx, PartVT.getSizeInBits() * N);
       } else {
-        SlotVT = Outs[I].ArgVT;
+        SlotVT = Outs[I].VT;
       }
       SDValue SpillSlot = DAG.CreateStackTemporary(SlotVT);
       int FI = cast<FrameIndexSDNode>(SpillSlot)->getIndex();

--- a/llvm/test/CodeGen/SystemZ/frame-29.ll
+++ b/llvm/test/CodeGen/SystemZ/frame-29.ll
@@ -1,0 +1,18 @@
+; RUN: llc %s -o - -mtriple=s390x-linux-gnu -mcpu=z16 -print-after=finalize-isel 2>&1 | FileCheck %s
+;
+; Test that the correct space is allocated for the outgoing stack argument.
+
+declare void @bar(i72 %Arg);
+
+define void @foo() {
+; CHECK-LABEL: # Machine code for function foo: IsSSA, TracksLiveness
+; CHECK-NEXT: Frame Objects:
+; CHECK-NEXT:   fi#0: size=1, align=2, at location [SP]
+; CHECK-NEXT:   fi#1: size=16, align=8, at location [SP]
+
+; CHECK-LABEL: foo:
+; CHECK: aghi %r15, -184
+  %1 = alloca i8, align 2
+  tail call fastcc void @bar(i72 2097168)
+  ret void
+}


### PR DESCRIPTION
When an integer argument is promoted and not split (like i72 -> i128 on a new machine with vector support), the SlotVT should be i128, which is stored in VT - not ArgVT.

Fixes #81417