### PR TITLE
[Flang][OpenMP] : Compilation error involving Cray pointers and data sharing attributes

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2242,16 +2242,22 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (symbol != found) {
           name.symbol = found; // adjust the symbol within region
-        } else if (GetContext().defaultDSA == Symbol::Flag::OmpNone &&
-            !symbol->test(Symbol::Flag::OmpThreadprivate) &&
-            // Exclude indices of sequential loops that are privatised in
-            // the scope of the parallel region, and not in this scope.
-            // TODO: check whether this should be caught in IsObjectWithDSA
-            !symbol->test(Symbol::Flag::OmpPrivate)) {
-          context_.Say(name.source,
-              "The DEFAULT(NONE) clause requires that '%s' must be listed in "
-              "a data-sharing attribute clause"_err_en_US,
-              symbol->name());
+        } else {
+          // If the symbol is a CrayPointee, no need to updates the symbol
+          // flags.
+          if (symbol->test(Symbol::Flag::CrayPointee)) {
+            return;
+          } else if (GetContext().defaultDSA == Symbol::Flag::OmpNone &&
+              !symbol->test(Symbol::Flag::OmpThreadprivate) &&
+              // Exclude indices of sequential loops that are privatised in
+              // the scope of the parallel region, and not in this scope.
+              // TODO: check whether this should be caught in IsObjectWithDSA
+              !symbol->test(Symbol::Flag::OmpPrivate)) {
+            context_.Say(name.source,
+                "The DEFAULT(NONE) clause requires that '%s' must be listed in "
+                "a data-sharing attribute clause"_err_en_US,
+                symbol->name());
+          }
         }
       }
     }

--- a/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
+++ b/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
@@ -1,0 +1,29 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp
+subroutine test_crayptr
+  implicit none
+  integer :: I
+  real*8 var(*)
+  pointer(ivar,var)
+  real*8 pointee(8)
+
+  pointee(1) = 42.0
+  ivar = loc(pointee)
+
+  !$omp parallel num_threads(2) default(none) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(none) private(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(private) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+  !$omp parallel num_threads(2) default(firstprivate) shared(ivar)
+    print *, var(1)
+  !$omp end parallel
+
+end subroutine test_crayptr
+


### PR DESCRIPTION
    Issue description:
            When DEFAULT DSA is NONE, all data refs must be listed in one of the data sharing clause.
            When a Cray pointer is listed in one of the data sharing clause, Cray pointee can be used in parallel region.
            This is valid as per standard.
            "Cray pointees have the same data-sharing attribute as the storage with which their Cray pointers are associated."
            Currently compiler crashes for default(none).
            Also current semantic checks incorrectly updates the symbol flags related to Craypointee symbols.
            due to this incorrect updation, compiler crashes when default(private) and default(firstprivate) is specified.

    Solution:
            Added an additional check to skip updation of symbol flags related to Craypointee symbols.
            This also prevents from checking cray pointee when DEFAULT DSA is NONE.

    This patch has code changes and a test case.