### PR TITLE
[Flang]: Fix to bind(C) procs inside BLOCK construct

### DIFF
--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -182,7 +182,8 @@ Fortran::lower::mangle::mangleName(const Fortran::semantics::Symbol &symbol,
                                    bool underscoring) {
   assert((symbol.owner().kind() !=
               Fortran::semantics::Scope::Kind::BlockConstruct ||
-          symbol.has<Fortran::semantics::SubprogramDetails>()) &&
+          symbol.has<Fortran::semantics::SubprogramDetails>() ||
+          Fortran::semantics::IsBindCProcedure(symbol)) &&
          "block object mangling must specify a scopeBlockIdMap");
   ScopeBlockIdMap scopeBlockIdMap;
   return mangleName(symbol, scopeBlockIdMap, keepExternalInScope, underscoring);

--- a/flang/test/Lower/HLFIR/block_bindc_pocs.f90
+++ b/flang/test/Lower/HLFIR/block_bindc_pocs.f90
@@ -1,0 +1,20 @@
+! This test checks bind(c) procs inside BLOCK construct.
+
+!RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
+
+module m
+    interface
+       subroutine test_proc() bind(C)
+       end subroutine test_proc
+    end interface
+end module m
+!CHECK-DAG: %[[S0:.*]] = fir.call @llvm.stacksave.p0() fastmath<contract> : () -> !fir.ref<i8>
+!CHECK-DAG: fir.call @test_proc() fastmath<contract> : () -> ()
+!CHECK-DAG: fir.call @llvm.stackrestore.p0(%[[S0]]) fastmath<contract> : (!fir.ref<i8>) -> ()
+!CHECK-DAG: func.func private @test_proc() attributes {fir.bindc_name = "test_proc"}
+subroutine test
+    BLOCK
+        use m
+        call test_proc
+    END BLOCK
+end subroutine test


### PR DESCRIPTION
Name mangling is invoked for a bind(C) procedure contained in a block in a context that does not have access to block ID mapping. Relaxing an assert to account for this.

Fixes #79408 