### PR TITLE
[mlir] Create an accessor for the operation name in `OperationState`

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1058,6 +1058,9 @@ public:
 
   /// Get the context held by this operation state.
   MLIRContext *getContext() const { return location->getContext(); }
+
+  /// Get the operation name held by this operation state.
+  OperationName getOperationName() const { return name; }
 };
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This accessor provides helpful introspection when building an operation. For example, it allows access to the dialect used to create the operation, which might provide extra context for building an operation.