### PR TITLE
[DebugInfo][RemoveDIs] Fix another mismatched debug-info flag

### DIFF
--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -153,6 +153,7 @@ FunctionCallee Module::getOrInsertFunction(StringRef Name, FunctionType *Ty,
     if (!New->isIntrinsic())       // Intrinsics get attrs set on construction
       New->setAttributes(AttributeList);
     FunctionList.push_back(New);
+    New->IsNewDbgInfoFormat = IsNewDbgInfoFormat;
     return {Ty, New}; // Return the new prototype.
   }
 


### PR DESCRIPTION
Here's another scenario where we can create a Function and insert it into a module without carrying over the debug-info flag. See the discourse thread, it's starting to feel like playing whackamole here isn't going to be helpful.