### PR TITLE
[libc++] Do not forward-declare syncstream outside experimental

### DIFF
--- a/libcxx/include/iosfwd
+++ b/libcxx/include/iosfwd
@@ -143,7 +143,7 @@ typedef fpos<mbstate_t> u8streampos;
 typedef fpos<mbstate_t> u16streampos;
 typedef fpos<mbstate_t> u32streampos;
 
-#if _LIBCPP_STD_VER >= 20
+#if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT>>
 class basic_syncbuf;
@@ -161,7 +161,7 @@ using osyncstream = basic_osyncstream<char>;
 using wosyncstream = basic_osyncstream<wchar_t>;
 #  endif
 
-#endif // _LIBCPP_STD_VER >=20
+#endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 // Include other forward declarations here
 template <class _Tp, class _Alloc = allocator<_Tp> >

--- a/libcxx/modules/std/iosfwd.inc
+++ b/libcxx/modules/std/iosfwd.inc
@@ -18,18 +18,22 @@ export namespace std {
   using std::u8streampos;
 #endif
 
+#ifndef _LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM
   using std::basic_osyncstream;
   using std::basic_syncbuf;
+#endif
 
   using std::istreambuf_iterator;
   using std::ostreambuf_iterator;
 
+#ifndef _LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM
   using std::osyncstream;
   using std::syncbuf;
 
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+# ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using std::wosyncstream;
   using std::wsyncbuf;
+# endif
 #endif
 
   using std::fpos;

--- a/libcxx/modules/std/iosfwd.inc
+++ b/libcxx/modules/std/iosfwd.inc
@@ -30,10 +30,10 @@ export namespace std {
   using std::osyncstream;
   using std::syncbuf;
 
-# ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using std::wosyncstream;
   using std::wsyncbuf;
-# endif
+#  endif
 #endif
 
   using std::fpos;

--- a/libcxx/modules/std/iosfwd.inc
+++ b/libcxx/modules/std/iosfwd.inc
@@ -34,7 +34,7 @@ export namespace std {
   using std::wosyncstream;
   using std::wsyncbuf;
 #  endif
-#endif
+#endif // _LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM
 
   using std::fpos;
 } // namespace std


### PR DESCRIPTION
We only define the classes in `<syncstream>` when experimental library features are enabled, but we would forward-declare them in `<iosfwd>` even when they are disabled. This led to confusing error messages about being unable to instantiate an undefined template.