### PR TITLE
[LLVM] Add 'LLVM_EXTRA_RUNTIME_TARGETS' to append to default list

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -57,9 +57,14 @@ if(LLVM_LIBC_FULL_BUILD OR LIBC_GPU_BUILD OR LIBC_GPU_ARCHITECTURES)
   endif()
 endif()
 
+foreach(name default ${LLVM_RUNTIME_TARGETS} ${LLVM_EXTRA_RUNTIME_TARGETS})
+  if("libc" IN_LIST LLVM_ENABLE_RUNTIMES OR "libc" IN_LIST RUNTIMES_${name}_LLVM_ENABLE_RUNTIMES)
+    set(LIBC_RUNTIMES_BUILD ON)
+  endif()
+endforeach()
+
 option(LIBC_HDRGEN_ONLY "Only build the 'libc-hdrgen' executable" OFF)
-if(("libc" IN_LIST LLVM_ENABLE_RUNTIMES AND NOT LLVM_RUNTIMES_BUILD) OR 
-   LIBC_HDRGEN_ONLY)
+if((LIBC_RUNTIMES_BUILD AND NOT LLVM_RUNTIMES_BUILD) OR LIBC_HDRGEN_ONLY)
   # When libc is build as part of the runtimes/bootstrap build's CMake run, we
   # only need to build the host tools to build the libc. So, we just do enough
   # to build libc-hdrgen and return.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -168,15 +168,17 @@ foreach(proj IN LISTS LLVM_ENABLE_RUNTIMES)
   endif()
 endforeach()
 
-if ("libc" IN_LIST LLVM_ENABLE_RUNTIMES)
-  # To build the libc runtime, we need to be able to build few libc build
-  # tools from the "libc" project. So, we add it to the list of enabled
-  # projects.
-  if (NOT "libc" IN_LIST LLVM_ENABLE_PROJECTS)
-    message(STATUS "Enabling libc project to build libc build tools")
-    list(APPEND LLVM_ENABLE_PROJECTS "libc")
+foreach(name default ${LLVM_RUNTIME_TARGETS} ${LLVM_EXTRA_RUNTIME_TARGETS})
+  if("libc" IN_LIST LLVM_ENABLE_RUNTIMES OR "libc" IN_LIST RUNTIMES_${name}_LLVM_ENABLE_RUNTIMES)
+    # To build the libc runtime, we need to be able to build few libc build
+    # tools from the "libc" project. So, we add it to the list of enabled
+    # projects.
+    if(NOT "libc" IN_LIST LLVM_ENABLE_PROJECTS)
+      message(STATUS "Enabling libc project to build libc build tools")
+      list(APPEND LLVM_ENABLE_PROJECTS "libc")
+    endif()
   endif()
-endif()
+endforeach()
 
 # LLVM_ENABLE_PROJECTS_USED is `ON` if the user has ever used the
 # `LLVM_ENABLE_PROJECTS` CMake cache variable.  This exists for

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -449,14 +449,14 @@ if(runtimes)
       endforeach()
     endif()
   endif()
-  if(NOT LLVM_RUNTIME_TARGETS)
+  if(NOT LLVM_RUNTIME_TARGETS AND NOT LLVM_EXTRA_RUNTIME_TARGETS)
     runtime_default_target(
       DEPENDS ${builtins_dep} ${extra_deps}
       CMAKE_ARGS ${libc_cmake_args}
       PREFIXES ${prefixes})
     set(test_targets check-runtimes)
   else()
-    if("default" IN_LIST LLVM_RUNTIME_TARGETS)
+    if("default" IN_LIST LLVM_RUNTIME_TARGETS OR LLVM_EXTRA_RUNTIME_TARGETS)
       runtime_default_target(
         DEPENDS ${builtins_dep} ${extra_deps}
         CMAKE_ARGS ${libc_cmake_args}
@@ -481,7 +481,7 @@ if(runtimes)
       endif()
     endif()
 
-    foreach(name ${LLVM_RUNTIME_TARGETS})
+    foreach(name ${LLVM_RUNTIME_TARGETS} ${LLVM_EXTRA_RUNTIME_TARGETS})
       if(builtins_dep)
         if (LLVM_BUILTIN_TARGETS)
           set(builtins_dep_name "${builtins_dep}-${name}")


### PR DESCRIPTION
Summary:
One problem with using the standard `LLVM_RUNTIME_TARGETS` is that it
requires setting 'default' manually. This is very good for use-cases
where the user wants to completely override their build, but it is bad
for builds where we want to augment the normal list. This is because it
requires changing things other than the projects that require it. This
patch introduces `LLVM_EXTRA_RUNTIME_TARGETS` which is only expected to
append to the default list. This patch also fixes the use-case of
`libc` using this new potentially different list.

This unblocks https://github.com/llvm/llvm-project/pull/81921 so
hopefully this is less contentious and can be merged soon.
