### PR TITLE
Make lldbDataFormatters.py compatible with Python 3.8

### DIFF
--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -3,6 +3,7 @@ LLDB Formatters for LLVM data types.
 
 Load into LLDB with 'command script import /path/to/lldbDataFormatters.py'
 """
+from __future__ import annotations
 
 import collections
 import lldb


### PR DESCRIPTION
I just tried to load this into LLDB built against Python 3.8.5 and got the following error: `TypeError: 'type' object is not subscriptable`. I could fix this by wrapping the annotations in quotes but since Python 3.7 this syntax can be enabled with `from __future__ import annotations`.