### PR TITLE
[lldb][test] Modernize assertEqual(value, bool)

### DIFF
--- a/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
+++ b/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
@@ -46,7 +46,7 @@ class ExprCommandWithThrowTestCase(TestBase):
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
         self.assertTrue(value.IsValid())
-        self.assertEqual(value.GetError().Success(), False)
+        self.assertFalse(value.GetError().Success())
 
         self.check_after_call()
 

--- a/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
+++ b/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
@@ -54,7 +54,7 @@ class TestAllowJIT(TestBase):
         # First make sure we can call the function with the default option set.
         options = lldb.SBExpressionOptions()
         # Check that the default is to allow JIT:
-        self.assertEqual(options.GetAllowJIT(), True, "Default is true")
+        self.assertTrue(options.GetAllowJIT(), "Default is true")
 
         # Now use the options:
         result = frame.EvaluateExpression("call_me(10)", options)
@@ -64,9 +64,7 @@ class TestAllowJIT(TestBase):
         # Now disallow JIT and make sure it fails:
         options.SetAllowJIT(False)
         # Check that we got the right value:
-        self.assertEqual(
-            options.GetAllowJIT(), False, "Got False after setting to False"
-        )
+        self.assertFalse(options.GetAllowJIT(), "Got False after setting to False")
 
         # Again use it and ensure we fail:
         result = frame.EvaluateExpression("call_me(10)", options)
@@ -79,7 +77,7 @@ class TestAllowJIT(TestBase):
 
         # Finally set the allow JIT value back to true and make sure that works:
         options.SetAllowJIT(True)
-        self.assertEqual(options.GetAllowJIT(), True, "Set back to True correctly")
+        self.assertTrue(options.GetAllowJIT(), "Set back to True correctly")
 
         # And again, make sure this works:
         result = frame.EvaluateExpression("call_me(10)", options)

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -937,7 +937,7 @@ class SettingsCommandTestCase(TestBase):
         self.runCmd("settings set target.arg0 %s" % arg_value)
 
         settings_json = self.get_setting_json()
-        self.assertEqual(settings_json["auto-confirm"], True)
+        self.assertTrue(settings_json["auto-confirm"])
         self.assertEqual(settings_json["tab-size"], 4)
         self.assertEqual(settings_json["target"]["arg0"], arg_value)
 

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -937,7 +937,7 @@ class SettingsCommandTestCase(TestBase):
         self.runCmd("settings set target.arg0 %s" % arg_value)
 
         settings_json = self.get_setting_json()
-        self.assertTrue(settings_json["auto-confirm"])
+        self.assertEqual(settings_json["auto-confirm"], True)
         self.assertEqual(settings_json["tab-size"], 4)
         self.assertEqual(settings_json["target"]["arg0"], arg_value)
 

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -35,17 +35,13 @@ class TestCase(TestBase):
         )
 
     def verify_key_in_dict(self, key, d, description):
-        self.assertEqual(
-            key in d,
-            True,
-            'make sure key "%s" is in dictionary %s' % (key, description),
+        self.assertIn(
+            key, d, 'make sure key "%s" is in dictionary %s' % (key, description)
         )
 
     def verify_key_not_in_dict(self, key, d, description):
-        self.assertEqual(
-            key in d,
-            False,
-            'make sure key "%s" is in dictionary %s' % (key, description),
+        self.assertNotIn(
+            key, d, 'make sure key "%s" is in dictionary %s' % (key, description)
         )
 
     def verify_keys(self, dict, description, keys_exist, keys_missing=None):
@@ -120,9 +116,7 @@ class TestCase(TestBase):
         self.verify_success_fail_count(stats, "frameVariable", 1, 0)
 
         # Test that "stopCount" is available when the process has run
-        self.assertEqual(
-            "stopCount" in stats, True, 'ensure "stopCount" is in target JSON'
-        )
+        self.assertIn("stopCount", stats, 'ensure "stopCount" is in target JSON')
         self.assertGreater(
             stats["stopCount"], 0, 'make sure "stopCount" is greater than zero'
         )
@@ -484,9 +478,9 @@ class TestCase(TestBase):
         exe = self.getBuildArtifact(exe_name)
         dsym = self.getBuildArtifact(exe_name + ".dSYM")
         # Make sure the executable file exists after building.
-        self.assertEqual(os.path.exists(exe), True)
+        self.assertTrue(os.path.exists(exe))
         # Make sure the dSYM file exists after building.
-        self.assertEqual(os.path.isdir(dsym), True)
+        self.assertTrue(os.path.isdir(dsym))
 
         # Create the target
         target = self.createTestTarget(file_path=exe)
@@ -532,9 +526,9 @@ class TestCase(TestBase):
         exe = self.getBuildArtifact(exe_name)
         dsym = self.getBuildArtifact(exe_name + ".dSYM")
         # Make sure the executable file exists after building.
-        self.assertEqual(os.path.exists(exe), True)
+        self.assertTrue(os.path.exists(exe))
         # Make sure the dSYM file doesn't exist after building.
-        self.assertEqual(os.path.isdir(dsym), False)
+        self.assertFalse(os.path.isdir(dsym))
 
         # Create the target
         target = self.createTestTarget(file_path=exe)
@@ -585,11 +579,11 @@ class TestCase(TestBase):
         dsym = self.getBuildArtifact(exe_name + ".dSYM")
         main_obj = self.getBuildArtifact("main.o")
         # Make sure the executable file exists after building.
-        self.assertEqual(os.path.exists(exe), True)
+        self.assertTrue(os.path.exists(exe))
         # Make sure the dSYM file doesn't exist after building.
-        self.assertEqual(os.path.isdir(dsym), False)
+        self.assertFalse(os.path.isdir(dsym))
         # Make sure the main.o object file exists after building.
-        self.assertEqual(os.path.exists(main_obj), True)
+        self.assertTrue(os.path.exists(main_obj))
 
         # Delete the main.o file that contains the debug info so we force an
         # error when we run to main and try to get variables
@@ -604,7 +598,7 @@ class TestCase(TestBase):
 
         # Make sure we have "debugInfoHadVariableErrors" variable that is set to
         # false before failing to get local variables due to missing .o file.
-        self.assertEqual(exe_stats["debugInfoHadVariableErrors"], False)
+        self.assertFalse(exe_stats["debugInfoHadVariableErrors"])
 
         # Verify that the top level statistic that aggregates the number of
         # modules with debugInfoHadVariableErrors is zero
@@ -624,7 +618,7 @@ class TestCase(TestBase):
 
         # Make sure we have "hadFrameVariableErrors" variable that is set to
         # true after failing to get local variables due to missing .o file.
-        self.assertEqual(exe_stats["debugInfoHadVariableErrors"], True)
+        self.assertTrue(exe_stats["debugInfoHadVariableErrors"])
 
         # Verify that the top level statistic that aggregates the number of
         # modules with debugInfoHadVariableErrors is greater than zero

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -179,11 +179,11 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
         res = lldb.SBCommandReturnObject()
 
         ci.HandleCommand("thread trace dump instructions -c 10 --forwards", res)
-        self.assertEqual(res.Succeeded(), True)
+        self.assertTrue(res.Succeeded())
         first_ten_instructions = res.GetOutput()
 
         ci.HandleCommand("thread trace dump instructions -c 10", res)
-        self.assertEqual(res.Succeeded(), True)
+        self.assertTrue(res.Succeeded())
         last_ten_instructions = res.GetOutput()
 
         # Now, save the trace to <trace_copy_dir>
@@ -203,11 +203,11 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
 
         # Compare with instructions saved at the first time
         ci.HandleCommand("thread trace dump instructions -c 10 --forwards", res)
-        self.assertEqual(res.Succeeded(), True)
+        self.assertTrue(res.Succeeded())
         self.assertEqual(res.GetOutput(), first_ten_instructions)
 
         ci.HandleCommand("thread trace dump instructions -c 10", res)
-        self.assertEqual(res.Succeeded(), True)
+        self.assertTrue(res.Succeeded())
         self.assertEqual(res.GetOutput(), last_ten_instructions)
 
     def testSaveKernelTrace(self):

--- a/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestBadAddressBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestBadAddressBreakpoints.py
@@ -40,7 +40,7 @@ class BadAddressBreakpointTestCase(TestBase):
             bkpt = target.BreakpointCreateByAddress(illegal_address)
             # Verify that breakpoint is not resolved.
             for bp_loc in bkpt:
-                self.assertEqual(bp_loc.IsResolved(), False)
+                self.assertFalse(bp_loc.IsResolved())
         else:
             self.fail(
                 "Could not find an illegal address at which to set a bad breakpoint."

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -572,9 +572,9 @@ class BreakpointCommandTestCase(TestBase):
         res = target.GetStatistics().GetAsJSON(stream)
         self.assertTrue(res.Success())
         debug_stats = json.loads(stream.GetData())
-        self.assertEqual(
-            "targets" in debug_stats,
-            True,
+        self.assertIn(
+            "targets",
+            debug_stats,
             'Make sure the "targets" key in in target.GetStatistics()',
         )
         target_stats = debug_stats["targets"][0]
@@ -659,9 +659,9 @@ class BreakpointCommandTestCase(TestBase):
         res = target.GetStatistics().GetAsJSON(stream)
         self.assertTrue(res.Success())
         debug_stats = json.loads(stream.GetData())
-        self.assertEqual(
-            "targets" in debug_stats,
-            True,
+        self.assertIn(
+            "targets",
+            debug_stats,
             'Make sure the "targets" key in in target.GetStatistics()',
         )
         target_stats = debug_stats["targets"][0]

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
@@ -389,7 +389,7 @@ class BreakpointNames(TestBase):
         )
 
     def check_permission_results(self, bp_name):
-        self.assertEqual(bp_name.GetAllowDelete(), False, "Didn't set allow delete.")
+        self.assertFalse(bp_name.GetAllowDelete(), "Didn't set allow delete.")
         protected_bkpt = self.target.BreakpointCreateByLocation(self.main_file_spec, 10)
         protected_id = protected_bkpt.GetID()
 
@@ -402,14 +402,11 @@ class BreakpointNames(TestBase):
         self.assertSuccess(success, "Couldn't add this name to the breakpoint")
 
         self.target.DisableAllBreakpoints()
-        self.assertEqual(
-            protected_bkpt.IsEnabled(),
-            True,
-            "Didnt' keep breakpoint from being disabled",
+        self.assertTrue(
+            protected_bkpt.IsEnabled(), "Didnt' keep breakpoint from being disabled"
         )
-        self.assertEqual(
+        self.assertFalse(
             unprotected_bkpt.IsEnabled(),
-            False,
             "Protected too many breakpoints from disabling.",
         )
 
@@ -418,14 +415,11 @@ class BreakpointNames(TestBase):
         result = lldb.SBCommandReturnObject()
         self.dbg.GetCommandInterpreter().HandleCommand("break disable", result)
         self.assertTrue(result.Succeeded())
-        self.assertEqual(
-            protected_bkpt.IsEnabled(),
-            True,
-            "Didnt' keep breakpoint from being disabled",
+        self.assertTrue(
+            protected_bkpt.IsEnabled(), "Didnt' keep breakpoint from being disabled"
         )
-        self.assertEqual(
+        self.assertFalse(
             unprotected_bkpt.IsEnabled(),
-            False,
             "Protected too many breakpoints from disabling.",
         )
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestJLink6Armv7RegisterDefinition.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestJLink6Armv7RegisterDefinition.py
@@ -198,7 +198,7 @@ class TestJLink6Armv7RegisterDefinition(GDBRemoteTestBase):
         error = lldb.SBError()
         data = lldb.SBData()
         data.SetData(error, val, lldb.eByteOrderBig, 4)
-        self.assertEqual(r1_valobj.SetData(data, error), True)
+        self.assertTrue(r1_valobj.SetData(data, error))
         self.assertSuccess(error)
 
         r1_valobj = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("r1")

--- a/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
+++ b/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
@@ -66,18 +66,16 @@ class ModuleCacheTestcaseSimple(TestBase):
         # get a different creation and modification time for the file since some
         # OSs store the modification time in seconds since Jan 1, 1970.
         os.remove(exe)
-        self.assertEqual(
-            os.path.exists(exe),
-            False,
-            "make sure we were able to remove the executable",
+        self.assertFalse(
+            os.path.exists(exe), "make sure we were able to remove the executable"
         )
         time.sleep(2)
         # Now rebuild the binary so it has a different content which should
         # update the UUID to make the cache miss when it tries to load the
         # symbol table from the binary at the same path.
         self.build(dictionary={"CFLAGS_EXTRAS": "-DEXTRA_FUNCTION"})
-        self.assertEqual(
-            os.path.exists(exe), True, "make sure executable exists after rebuild"
+        self.assertTrue(
+            os.path.exists(exe), "make sure executable exists after rebuild"
         )
         # Make sure the modification time has changed or this test will fail.
         exe_mtime_2 = os.path.getmtime(exe)
@@ -99,9 +97,8 @@ class ModuleCacheTestcaseSimple(TestBase):
         main_module = target.GetModuleAtIndex(0)
         self.assertTrue(main_module.IsValid())
         main_module.GetNumSymbols()
-        self.assertEqual(
+        self.assertTrue(
             os.path.exists(symtab_cache_path),
-            True,
             'make sure "symtab" cache files exists after cache is updated',
         )
         symtab_mtime_2 = os.path.getmtime(symtab_cache_path)

--- a/lldb/test/API/functionalities/stats_api/TestStatisticsAPI.py
+++ b/lldb/test/API/functionalities/stats_api/TestStatisticsAPI.py
@@ -33,47 +33,47 @@ class TestStatsAPI(TestBase):
         stream = lldb.SBStream()
         res = stats.GetAsJSON(stream)
         debug_stats = json.loads(stream.GetData())
-        self.assertEqual(
-            "targets" in debug_stats,
-            True,
+        self.assertIn(
+            "targets",
+            debug_stats,
             'Make sure the "targets" key in in target.GetStatistics()',
         )
-        self.assertEqual(
-            "modules" in debug_stats,
-            True,
+        self.assertIn(
+            "modules",
+            debug_stats,
             'Make sure the "modules" key in in target.GetStatistics()',
         )
         stats_json = debug_stats["targets"][0]
-        self.assertEqual(
-            "expressionEvaluation" in stats_json,
-            True,
+        self.assertIn(
+            "expressionEvaluation",
+            stats_json,
             'Make sure the "expressionEvaluation" key in in target.GetStatistics()["targets"][0]',
         )
-        self.assertEqual(
-            "frameVariable" in stats_json,
-            True,
+        self.assertIn(
+            "frameVariable",
+            stats_json,
             'Make sure the "frameVariable" key in in target.GetStatistics()["targets"][0]',
         )
         expressionEvaluation = stats_json["expressionEvaluation"]
-        self.assertEqual(
-            "successes" in expressionEvaluation,
-            True,
+        self.assertIn(
+            "successes",
+            expressionEvaluation,
             'Make sure the "successes" key in in "expressionEvaluation" dictionary"',
         )
-        self.assertEqual(
-            "failures" in expressionEvaluation,
-            True,
+        self.assertIn(
+            "failures",
+            expressionEvaluation,
             'Make sure the "failures" key in in "expressionEvaluation" dictionary"',
         )
         frameVariable = stats_json["frameVariable"]
-        self.assertEqual(
-            "successes" in frameVariable,
-            True,
+        self.assertIn(
+            "successes",
+            frameVariable,
             'Make sure the "successes" key in in "frameVariable" dictionary"',
         )
-        self.assertEqual(
-            "failures" in frameVariable,
-            True,
+        self.assertIn(
+            "failures",
+            frameVariable,
             'Make sure the "failures" key in in "frameVariable" dictionary"',
         )
 

--- a/lldb/test/API/functionalities/thread/backtrace_limit/TestBacktraceLimit.py
+++ b/lldb/test/API/functionalities/thread/backtrace_limit/TestBacktraceLimit.py
@@ -23,5 +23,5 @@ class BacktraceLimitSettingTest(TestBase):
         interp.HandleCommand(
             "settings set target.process.thread.max-backtrace-depth 30", result
         )
-        self.assertEqual(True, result.Succeeded())
+        self.assertTrue(result.Succeeded())
         self.assertEqual(30, thread.GetNumFrames())

--- a/lldb/test/API/macosx/arm-corefile-regctx/TestArmMachoCorefileRegctx.py
+++ b/lldb/test/API/macosx/arm-corefile-regctx/TestArmMachoCorefileRegctx.py
@@ -28,7 +28,7 @@ class TestArmMachoCorefileRegctx(TestBase):
         target = self.dbg.CreateTarget("")
         err = lldb.SBError()
         process = target.LoadCore(self.corefile)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         thread = process.GetSelectedThread()
         frame = thread.GetSelectedFrame()
 
@@ -51,7 +51,7 @@ class TestArmMachoCorefileRegctx(TestBase):
         target = self.dbg.CreateTarget("")
         err = lldb.SBError()
         process = target.LoadCore(self.corefile)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         thread = process.GetSelectedThread()
         frame = thread.GetSelectedFrame()
 

--- a/lldb/test/API/macosx/lc-note/addrable-bits/TestAddrableBitsCorefile.py
+++ b/lldb/test/API/macosx/lc-note/addrable-bits/TestAddrableBitsCorefile.py
@@ -29,7 +29,7 @@ class TestAddrableBitsCorefile(TestBase):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.c")
         )
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
 
         found_main = False
         for f in thread.frames:

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
@@ -73,7 +73,7 @@ class TestFirmwareCorefiles(TestBase):
         if self.TraceOn():
             self.runCmd("script print('loading corefile %s')" % verstr_corefile)
         process = target.LoadCore(verstr_corefile)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")
@@ -91,7 +91,7 @@ class TestFirmwareCorefiles(TestBase):
                 "script print('loading corefile %s')" % verstr_corefile_invalid_ident
             )
         process = target.LoadCore(verstr_corefile_invalid_ident)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
 
         # Third, try the "kern ver str" corefile where it loads at an address
         target = self.dbg.CreateTarget("")
@@ -99,7 +99,7 @@ class TestFirmwareCorefiles(TestBase):
         if self.TraceOn():
             self.runCmd("script print('loading corefile %s')" % verstr_corefile_addr)
         process = target.LoadCore(verstr_corefile_addr)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")
@@ -178,7 +178,7 @@ class TestFirmwareCorefiles(TestBase):
         if self.TraceOn():
             self.runCmd("script print('loading corefile %s')" % binspec_corefile)
         process = target.LoadCore(binspec_corefile)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")
@@ -192,7 +192,7 @@ class TestFirmwareCorefiles(TestBase):
         if self.TraceOn():
             self.runCmd("script print('loading corefile %s')" % binspec_corefile_addr)
         process = target.LoadCore(binspec_corefile_addr)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")
@@ -212,7 +212,7 @@ class TestFirmwareCorefiles(TestBase):
                 "script print('loading corefile %s')" % binspec_corefile_slideonly
             )
         process = target.LoadCore(binspec_corefile_slideonly)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")
@@ -352,7 +352,7 @@ class TestFirmwareCorefiles(TestBase):
             )
 
         process = target.LoadCore(binspec_corefile_addr)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
             self.runCmd("target mod dump sections")

--- a/lldb/test/API/macosx/lc-note/kern-ver-str/TestKernVerStrLCNOTE.py
+++ b/lldb/test/API/macosx/lc-note/kern-ver-str/TestKernVerStrLCNOTE.py
@@ -94,7 +94,7 @@ class TestKernVerStrLCNOTE(TestBase):
         self.target = self.dbg.CreateTarget("")
         err = lldb.SBError()
         self.process = self.target.LoadCore(self.corefile)
-        self.assertEqual(self.process.IsValid(), True)
+        self.assertTrue(self.process.IsValid())
         if self.TraceOn():
             self.runCmd("image list")
         self.assertEqual(self.target.GetNumModules(), 1)

--- a/lldb/test/API/macosx/lc-note/multiple-binary-corefile/TestMultipleBinaryCorefile.py
+++ b/lldb/test/API/macosx/lc-note/multiple-binary-corefile/TestMultipleBinaryCorefile.py
@@ -45,7 +45,7 @@ class TestMultipleBinaryCorefile(TestBase):
         if self.TraceOn():
             print("loading corefile %s" % self.corefile)
         process = target.LoadCore(self.corefile)
-        self.assertEqual(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         if self.TraceOn():
             print("image list after loading corefile:")
             self.runCmd("image list")

--- a/lldb/test/API/macosx/queues/TestQueues.py
+++ b/lldb/test/API/macosx/queues/TestQueues.py
@@ -457,9 +457,8 @@ class TestQueues(TestBase):
             "doing_the_work_2",
             "queue 2's pending item #0 should be doing_the_work_2",
         )
-        self.assertEqual(
+        self.assertFalse(
             queue_performer_2.GetPendingItemAtIndex(9999).IsValid(),
-            False,
             "queue 2's pending item #9999 is invalid",
         )
 

--- a/lldb/test/API/macosx/safe-to-func-call/TestSafeFuncCalls.py
+++ b/lldb/test/API/macosx/safe-to-func-call/TestSafeFuncCalls.py
@@ -49,8 +49,7 @@ class TestSafeFuncCalls(TestBase):
             main_thread.SafeToCallFunctions(),
             "It is safe to call functions on the main thread",
         )
-        self.assertEqual(
+        self.assertFalse(
             select_thread.SafeToCallFunctions(),
-            False,
             "It is not safe to call functions on the select thread",
         )

--- a/lldb/test/API/python_api/interpreter/TestRunCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestRunCommandInterpreterAPI.py
@@ -79,13 +79,13 @@ class SBCommandInterpreterRunOptionsCase(TestBase):
         opts = lldb.SBCommandInterpreterRunOptions()
 
         # Check getters with default values
-        self.assertEqual(opts.GetStopOnContinue(), False)
-        self.assertEqual(opts.GetStopOnError(), False)
-        self.assertEqual(opts.GetStopOnCrash(), False)
-        self.assertEqual(opts.GetEchoCommands(), True)
-        self.assertEqual(opts.GetPrintResults(), True)
-        self.assertEqual(opts.GetPrintErrors(), True)
-        self.assertEqual(opts.GetAddToHistory(), True)
+        self.assertFalse(opts.GetStopOnContinue())
+        self.assertFalse(opts.GetStopOnError())
+        self.assertFalse(opts.GetStopOnCrash())
+        self.assertTrue(opts.GetEchoCommands())
+        self.assertTrue(opts.GetPrintResults())
+        self.assertTrue(opts.GetPrintErrors())
+        self.assertTrue(opts.GetAddToHistory())
 
         # Invert values
         opts.SetStopOnContinue(not opts.GetStopOnContinue())
@@ -97,10 +97,10 @@ class SBCommandInterpreterRunOptionsCase(TestBase):
         opts.SetAddToHistory(not opts.GetAddToHistory())
 
         # Check the value changed
-        self.assertEqual(opts.GetStopOnContinue(), True)
-        self.assertEqual(opts.GetStopOnError(), True)
-        self.assertEqual(opts.GetStopOnCrash(), True)
-        self.assertEqual(opts.GetEchoCommands(), False)
-        self.assertEqual(opts.GetPrintResults(), False)
-        self.assertEqual(opts.GetPrintErrors(), False)
-        self.assertEqual(opts.GetAddToHistory(), False)
+        self.assertTrue(opts.GetStopOnContinue())
+        self.assertTrue(opts.GetStopOnError())
+        self.assertTrue(opts.GetStopOnCrash())
+        self.assertFalse(opts.GetEchoCommands())
+        self.assertFalse(opts.GetPrintResults())
+        self.assertFalse(opts.GetPrintErrors())
+        self.assertFalse(opts.GetAddToHistory())


### PR DESCRIPTION
Any time we see the pattern `assertEqual(value, bool)`, we can replace that with `assert<bool>(value)`. Likewise for `assertNotEqual`.

Technically this relaxes the test a bit, as we may want to make sure `value` is either `True` or `False`, and not something that implicitly converts to a bool. For example, `assertEqual("foo", True)` will fail, but `assertTrue("foo")` will not. In most cases, this distinction is not important.

There are two such places that this patch does **not** transform, since it seems intentional that we want the result to be a bool:
* https://github.com/llvm/llvm-project/blob/5daf2001a1e4d71ce1273a1e7e31cf6e6ac37c10/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py#L90
* https://github.com/llvm/llvm-project/blob/5daf2001a1e4d71ce1273a1e7e31cf6e6ac37c10/lldb/test/API/commands/settings/TestSettings.py#L940

Followup to 9c2468821ec51defd09c246fea4a47886fff8c01. I patched `teyit` with a `visit_assertEqual` node handler to generate this.