### PR TITLE
[ADT] Add standalone_debug attribute to SmallVectorBase

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -49,7 +49,7 @@ using EnableIfConvertibleToInputIterator = std::enable_if_t<std::is_convertible<
 /// Using 64 bit size is desirable for cases like SmallVector<char>, where a
 /// 32 bit size would limit the vector to ~4GB. SmallVectors are used for
 /// buffering bitcode output - which can exceed 4GB.
-template <class Size_T> class SmallVectorBase {
+template <class Size_T> class LLVM_ATTRIBUTE_STANDALONE_DEBUG SmallVectorBase {
 protected:
   void *BeginX;
   Size_T Size = 0, Capacity;

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -270,6 +270,15 @@
 #define LLVM_ATTRIBUTE_NODEBUG
 #endif
 
+/// LLVM_ATTRIBUTE_STANDALONE_DEBUG - Force the compiler to emit debug info
+/// for the given type even if it assumes it is not required.
+/// This may be needed on certain types to ensure a good debugging experience.
+#if __has_attribute(standalone_debug)
+#define LLVM_ATTRIBUTE_STANDALONE_DEBUG __attribute__((standalone_debug))
+#else
+#define LLVM_ATTRIBUTE_STANDALONE_DEBUG
+#endif
+
 #if __has_attribute(returns_nonnull)
 #define LLVM_ATTRIBUTE_RETURNS_NONNULL __attribute__((returns_nonnull))
 #elif defined(_MSC_VER)


### PR DESCRIPTION
I was surprised to see that the LLDB pretty printers for SmallVector were no longer working for me. It turns out LLDB did not have debug information for SmallVectorBase, so it was unable to query the BeginX and Size members of SmallVectors. This change is similar to 7c2f58278e664d336e9d0ef0687bdd6c3837dc03 for libc++. I am not sure if additional ADT classes need this treatment, but for now SmallVector is the only one I've noticed that has broken pretty-printers.