### PR TITLE
[mlir] fix a segment fault in `ConversionPatternRewriter::applySignatureConversion`

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -642,11 +642,10 @@ Block *ArgConverter::applySignatureConversion(
 
       // Legalize the argument output type.
       Type outputType = origOutputType;
-      if (converter){
+      if (converter) {
         if (Type legalOutputType = converter->convertType(outputType))
           outputType = legalOutputType;
       }
-        
 
       newArg = buildUnresolvedArgumentMaterialization(
           rewriter, origArg.getLoc(), replArgs, origOutputType, outputType,

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -642,8 +642,11 @@ Block *ArgConverter::applySignatureConversion(
 
       // Legalize the argument output type.
       Type outputType = origOutputType;
-      if (Type legalOutputType = converter->convertType(outputType))
-        outputType = legalOutputType;
+      if (converter){
+        if (Type legalOutputType = converter->convertType(outputType))
+          outputType = legalOutputType;
+      }
+        
 
       newArg = buildUnresolvedArgumentMaterialization(
           rewriter, origArg.getLoc(), replArgs, origOutputType, outputType,

--- a/mlir/test/Transforms/test-legalize-type-conversion.mlir
+++ b/mlir/test/Transforms/test-legalize-type-conversion.mlir
@@ -30,16 +30,6 @@ func.func @test_invalid_result_materialization() {
 
 // -----
 
-func.func @test_invalid_result_materialization() {
-  // expected-error@below {{failed to materialize conversion for result #0 of operation 'test.type_producer' that remained live after conversion}}
-  %result = "test.type_producer"() : () -> f16
-
-  // expected-note@below {{see existing live user here}}
-  "foo.return"(%result) : (f16) -> ()
-}
-
-// -----
-
 // CHECK-LABEL: @test_transitive_use_materialization
 func.func @test_transitive_use_materialization() {
   // CHECK: %[[V:.*]] = "test.type_producer"() : () -> f64
@@ -95,6 +85,18 @@ func.func @test_block_argument_not_converted() {
     // CHECK: ^bb0({{.*}}: index):
     ^bb0(%0 : index):
       "test.return"(%0) : (index) -> ()
+  }) : () -> ()
+  return
+}
+
+// -----
+
+// Make sure OneToN path of ArgConverter::applySignatureConversion can execute without converter
+func.func @test_one_to_n_signature_conversion_no_converter() {
+  "test.one_to_n_signature_conversion_no_converter"() ({
+  // CHECK: ^{{.*}}(%{{.*}}: f64, %{{.*}}: f64):
+  ^bb0(%arg0: vector<2xf64>):
+    "test.return"() : () -> ()
   }) : () -> ()
   return
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -1967,6 +1967,11 @@ def TestSignatureConversionNoConverterOp
   let regions = (region AnyRegion);
 }
 
+def TestOneToNSignatureConversionNoConverterOp
+  : TEST_Op<"one_to_n_signature_conversion_no_converter"> {
+  let regions = (region AnyRegion);
+}
+
 //===----------------------------------------------------------------------===//
 // Test parser.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestPatterns.cpp
+++ b/mlir/test/lib/Dialect/Test/TestPatterns.cpp
@@ -1465,16 +1465,17 @@ struct TestSignatureConversionUndo
   }
 };
 
-
 struct TestTestOneToNSignatureConversionNoConverter
     : public OpConversionPattern<TestOneToNSignatureConversionNoConverterOp> {
   TestTestOneToNSignatureConversionNoConverter(const TypeConverter &converter,
                                                MLIRContext *context)
-      : OpConversionPattern<TestOneToNSignatureConversionNoConverterOp>(context),
+      : OpConversionPattern<TestOneToNSignatureConversionNoConverterOp>(
+            context),
         converter(converter) {}
 
   LogicalResult
-  matchAndRewrite(TestOneToNSignatureConversionNoConverterOp op, OpAdaptor adaptor,
+  matchAndRewrite(TestOneToNSignatureConversionNoConverterOp op,
+                  OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Region &region = op->getRegion(0);
     Block *entry = &region.front();
@@ -1485,8 +1486,8 @@ struct TestTestOneToNSignatureConversionNoConverter
     if (failed(converter.convertSignatureArgs(argTys, argMap)))
       return failure();
 
-    rewriter.modifyOpInPlace(op, 
-            [&]{ rewriter.applySignatureConversion(&region, argMap); });
+    rewriter.modifyOpInPlace(
+        op, [&] { rewriter.applySignatureConversion(&region, argMap); });
     return success();
   }
 
@@ -1615,12 +1616,11 @@ struct TestTypeConversionDriver
           results.push_back(result);
           return success();
         });
-    converter.addConversion(
-        [&](VectorType type, 
-            SmallVectorImpl<Type> &results) -> std::optional<LogicalResult> {
-          results = SmallVector<Type>(type.getNumElements(), type.getElementType());
-          return success();
-        });
+    converter.addConversion([&](VectorType type, SmallVectorImpl<Type> &results)
+                                -> std::optional<LogicalResult> {
+      results = SmallVector<Type>(type.getNumElements(), type.getElementType());
+      return success();
+    });
 
     /// Add the legal set of type materializations.
     converter.addSourceMaterialization([](OpBuilder &builder, Type resultType,


### PR DESCRIPTION
ConversionPatternRewriter::applySignatureConversion accepts nulltpr for TypeConverter. But `ArgConverter::applySignatureConversion` failed to check it when it calls `converter->convertType(outputType)`. 