### PR TITLE
[NFC] Make RingBuffer an atomic pointer

### DIFF
--- a/compiler-rt/lib/scudo/standalone/atomic_helpers.h
+++ b/compiler-rt/lib/scudo/standalone/atomic_helpers.h
@@ -54,6 +54,11 @@ struct atomic_u64 {
   alignas(8) volatile Type ValDoNotUse;
 };
 
+struct atomic_voidptr {
+  typedef void *Type;
+  volatile Type ValDoNotUse;
+};
+
 struct atomic_uptr {
   typedef uptr Type;
   volatile Type ValDoNotUse;

--- a/compiler-rt/lib/scudo/standalone/atomic_helpers.h
+++ b/compiler-rt/lib/scudo/standalone/atomic_helpers.h
@@ -54,11 +54,6 @@ struct atomic_u64 {
   alignas(8) volatile Type ValDoNotUse;
 };
 
-struct atomic_voidptr {
-  typedef void *Type;
-  volatile Type ValDoNotUse;
-};
-
 struct atomic_uptr {
   typedef uptr Type;
   volatile Type ValDoNotUse;

--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -1312,7 +1312,7 @@ private:
   void storeSecondaryAllocationStackMaybe(const Options &Options, void *Ptr,
                                           uptr Size) {
     auto *RingBuffer = getRingBufferIfEnabled(Options);
-    if (!RingBuffer->Depot)
+    if (!RingBuffer)
       return;
     u32 Trace = collectStackTrace(RingBuffer->Depot);
     u32 Tid = getThreadID();
@@ -1327,7 +1327,7 @@ private:
   void storeDeallocationStackMaybe(const Options &Options, void *Ptr,
                                    u8 PrevTag, uptr Size) {
     auto *RingBuffer = getRingBufferIfEnabled(Options);
-    if (!RingBuffer->Depot)
+    if (!RingBuffer)
       return;
     auto *Ptr32 = reinterpret_cast<u32 *>(Ptr);
     u32 AllocationTrace = Ptr32[MemTagAllocationTraceIndex];

--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -177,6 +177,18 @@ public:
     mapAndInitializeRingBuffer();
   }
 
+  void enableRingBuffer() {
+    AllocationRingBuffer *RB = getRingBuffer();
+    if (RB)
+      RB->Depot->enable();
+  }
+
+  void disableRingBuffer() {
+    AllocationRingBuffer *RB = getRingBuffer();
+    if (RB)
+      RB->Depot->disable();
+  }
+
   // Initialize the embedded GWP-ASan instance. Requires the main allocator to
   // be functional, best called from PostInitCallback.
   void initGwpAsan() {
@@ -688,16 +700,12 @@ public:
     Quarantine.disable();
     Primary.disable();
     Secondary.disable();
-    AllocationRingBuffer *RB = getRingBuffer();
-    if (RB)
-      RB->disable();
+    disableRingBuffer();
   }
 
   void enable() NO_THREAD_SAFETY_ANALYSIS {
     initThreadMaybe();
-    AllocationRingBuffer *RB = getRingBuffer();
-    if (RB)
-      RB->enable();
+    enableRingBuffer();
     Secondary.enable();
     Primary.enable();
     Quarantine.enable();
@@ -1072,10 +1080,6 @@ private:
     atomic_uptr Pos;
     // An array of Size (at least one) elements of type Entry is immediately
     // following to this struct.
-
-    void enable() { Depot->enable(); }
-
-    void disable() { Depot->disable(); }
   };
   // Pointer to memory mapped area starting with AllocationRingBuffer struct,
   // and immediately followed by Size elements of type Entry.

--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -1086,12 +1086,6 @@ private:
         atomic_load(&RingBufferAddress, memory_order_acquire));
   }
 
-  AllocationRingBuffer *getRingBufferIfEnabled(const Options &Options) {
-    if (!UNLIKELY(Options.get(OptionBit::TrackAllocationStacks)))
-      return nullptr;
-    return getRingBuffer();
-  }
-
   // The following might get optimized out by the compiler.
   NOINLINE void performSanityChecks() {
     // Verify that the header offset field can hold the maximum offset. In the
@@ -1280,7 +1274,9 @@ private:
   }
 
   void storePrimaryAllocationStackMaybe(const Options &Options, void *Ptr) {
-    AllocationRingBuffer *RB = getRingBufferIfEnabled(Options);
+    if (!UNLIKELY(Options.get(OptionBit::TrackAllocationStacks)))
+      return;
+    AllocationRingBuffer *RB = getRingBuffer();
     if (!RB)
       return;
     auto *Ptr32 = reinterpret_cast<u32 *>(Ptr);
@@ -1315,7 +1311,9 @@ private:
 
   void storeSecondaryAllocationStackMaybe(const Options &Options, void *Ptr,
                                           uptr Size) {
-    auto *RB = getRingBufferIfEnabled(Options);
+    if (!UNLIKELY(Options.get(OptionBit::TrackAllocationStacks)))
+      return;
+    AllocationRingBuffer *RB = getRingBuffer();
     if (!RB)
       return;
     u32 Trace = collectStackTrace(RB->Depot);
@@ -1330,7 +1328,9 @@ private:
 
   void storeDeallocationStackMaybe(const Options &Options, void *Ptr,
                                    u8 PrevTag, uptr Size) {
-    auto *RB = getRingBufferIfEnabled(Options);
+    if (!UNLIKELY(Options.get(OptionBit::TrackAllocationStacks)))
+      return;
+    AllocationRingBuffer *RB = getRingBuffer();
     if (!RB)
       return;
     auto *Ptr32 = reinterpret_cast<u32 *>(Ptr);


### PR DESCRIPTION
This will allow us to atomically swap out RingBuffer and StackDepot.

Patched into AOSP and ran debuggerd_tests.
