### PR TITLE
[BOLT][DWARF][NFC] Expose DebugStrOffsetsWriter::clear

### DIFF
--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -450,10 +450,16 @@ public:
     return std::move(StrOffsetsBuffer);
   }
 
-private:
   /// Initializes Buffer and Stream.
   void initialize(DWARFUnit &Unit);
 
+  /// Clear data.
+  void clear() {
+    IndexToAddressMap.clear();
+    StrOffsets.clear();
+  }
+
+private:
   std::unique_ptr<DebugStrOffsetsBufferVector> StrOffsetsBuffer;
   std::unique_ptr<raw_svector_ostream> StrOffsetsStream;
   std::map<uint32_t, uint32_t> IndexToAddressMap;

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -909,8 +909,7 @@ void DebugStrOffsetsWriter::finalizeSection(DWARFUnit &Unit,
   }
 
   StrOffsetSectionWasModified = false;
-  IndexToAddressMap.clear();
-  StrOffsets.clear();
+  clear();
 }
 
 void DebugStrWriter::create() {


### PR DESCRIPTION
Refactored cod that clears data-structures in DebugStrOffsetsWriter into clear() function and made initialize() public. This is for https://github.com/llvm/llvm-project/pull/81062.