### PR TITLE
[LLVM-C] Add Bindings for eraseNamedMetadata

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -1038,6 +1038,13 @@ LLVMNamedMDNodeRef LLVMGetOrInsertNamedMetadata(LLVMModuleRef M,
                                                 size_t NameLen);
 
 /**
+ * Remove the given NamedMDNode from this module and delete it.
+ *
+ * @see llvm::Module::eraseNamedMetadata()
+ */
+void LLVMEraseNamedMetadata(LLVMModuleRef M, LLVMNamedMDNodeRef NMD);
+
+/**
  * Retrieve the name of a NamedMDNode.
  *
  * @see llvm::NamedMDNode::getName()

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1315,6 +1315,11 @@ LLVMNamedMDNodeRef LLVMGetOrInsertNamedMetadata(LLVMModuleRef M,
   return wrap(unwrap(M)->getOrInsertNamedMetadata({Name, NameLen}));
 }
 
+void LLVMEraseNamedMetadata(LLVMModuleRef M, LLVMNamedMDNodeRef NMD) {
+  NamedMDNode *NamedNode = unwrap(NMD);
+  unwrap(M)->eraseNamedMetadata(NamedNode);
+}
+
 const char *LLVMGetNamedMetadataName(LLVMNamedMDNodeRef NMD, size_t *NameLen) {
   NamedMDNode *NamedNode = unwrap(NMD);
   *NameLen = NamedNode->getName().size();

--- a/llvm/test/Bindings/llvm-c/erase_named_metadata.ll
+++ b/llvm/test/Bindings/llvm-c/erase_named_metadata.ll
@@ -1,0 +1,1 @@
+; RUN: llvm-c-test --erase-named-metadata < /dev/null

--- a/llvm/tools/llvm-c-test/llvm-c-test.h
+++ b/llvm/tools/llvm-c-test/llvm-c-test.h
@@ -43,6 +43,7 @@ int llvm_di_type_get_name(void);
 // metadata.c
 int llvm_add_named_metadata_operand(void);
 int llvm_set_metadata(void);
+int llvm_erase_named_metadata(void);
 int llvm_replace_md_operand(void);
 int llvm_is_a_value_as_metadata(void);
 

--- a/llvm/tools/llvm-c-test/main.c
+++ b/llvm/tools/llvm-c-test/main.c
@@ -44,6 +44,8 @@ static void print_usage(void) {
   fprintf(stderr, "    Read lines of triple, hex ascii machine code from stdin "
                   "- print disassembly\n\n");
   fprintf(stderr, "  * --calc\n");
+  fprintf(stderr, "  * --erase-named-metadata\n"
+                  "    Run test for erasing named metadata\n");
   fprintf(
       stderr,
       "    Read lines of name, rpn from stdin - print generated module\n\n");
@@ -93,6 +95,8 @@ int main(int argc, char **argv) {
     return llvm_add_named_metadata_operand();
   } else if (argc == 2 && !strcmp(argv[1], "--set-metadata")) {
     return llvm_set_metadata();
+  } else if (argc == 2 && !strcmp(argv[1], "--erase-named-metadata")) {
+    return llvm_erase_named_metadata();
   } else if (argc == 2 && !strcmp(argv[1], "--get-di-tag")) {
     return llvm_get_di_tag();
   } else if (argc == 2 && !strcmp(argv[1], "--di-type-get-name")) {

--- a/llvm/tools/llvm-c-test/metadata.c
+++ b/llvm/tools/llvm-c-test/metadata.c
@@ -47,6 +47,21 @@ int llvm_set_metadata(void) {
   return 0;
 }
 
+int llvm_erase_named_metadata(void) {
+  LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
+
+  const char Name[] = "foo";
+  LLVMNamedMDNodeRef MD = LLVMGetOrInsertNamedMetadata(M, Name, strlen(Name));
+  assert(LLVMGetFirstNamedMetadata(M));
+
+  LLVMEraseNamedMetadata(M, MD);
+  assert(!LLVMGetFirstNamedMetadata(M));
+
+  LLVMDisposeModule(M);
+
+  return 0;
+}
+
 int llvm_replace_md_operand(void) {
   LLVMModuleRef M = LLVMModuleCreateWithName("Mod");
   LLVMContextRef Context = LLVMGetModuleContext(M);


### PR DESCRIPTION
There wasn't any way to remove named metadata from a module. This adds the LLVMEraseNamedMetadata binding and a test for it