### PR TITLE
lldbDataFormatters: fix type error in StringRef printer

### DIFF
--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -242,7 +242,7 @@ def StringRefSummaryProvider(valobj, internal_dict):
         if length == 0:
             return '""'
 
-        data = valobj.GetChildAtIndex(0).GetPointeeData(item_count=length)
+        data = valobj.GetChildAtIndex(0).GetPointeeData(0, length)
         error = lldb.SBError()
         string = data.ReadRawData(error, 0, data.GetByteSize()).decode()
         if error.Fail():


### PR DESCRIPTION
It appears we cannot use keyword arguments for GetPointeeData() and instead have to rely on positional arguments.

```
Traceback (most recent call last):
  File ".../llvm-project/llvm/utils/lldbDataFormatters.py", line 245, in StringRefSummaryProvider
    data = valobj.GetChildAtIndex(0).GetPointeeData(item_count=length)
TypeError: GetPointeeData() got an unexpected keyword argument 'item_count'
```