### PR TITLE
[TableGen] Suppress per-HwMode duplicate instructions/tables.

### DIFF
--- a/llvm/test/TableGen/HwModeEncodeDecode2.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode2.td
@@ -44,55 +44,53 @@ def fooTypeEncB : InstructionEncoding {
 }
 
 let OutOperandList = (outs) in {
-def foo : Instruction {
-  let InOperandList = (ins i32imm:$factor);
-  let EncodingInfos = EncodingByHwMode<
-    [ModeA, ModeB], [fooTypeEncA,
-                      fooTypeEncB]
-  >;
-  let AsmString = "foo  $factor";
-}
+  def foo : Instruction {
+    let InOperandList = (ins i32imm:$factor);
+    let EncodingInfos = EncodingByHwMode<
+      [ModeA, ModeB], [fooTypeEncA, fooTypeEncB]
+    >;
+    let AsmString = "foo  $factor";
+  }
 
-// Encoding not overridden, same namespace:
-// In the default case, this instruction is duplicated into both ModeA and
-// ModeB decoder tables.
-// In the suppressed case, this instruction appears in a single decoder table.
-def bar: Instruction {
-  let InOperandList = (ins i32imm:$factor);
-  let Size = 4;
-  bits<32> Inst;
-  bits<32> SoftFail;
-  bits<8> factor;
-  let Inst{31...24} = factor;
-  let Inst{1...0} = 0b10;
-  let AsmString = "bar  $factor";
-}
+  // Encoding not overridden, same namespace:
+  // In the default case, this instruction is duplicated into both ModeA and
+  // ModeB decoder tables.
+  // In the suppressed case, this instruction appears in a single decoder table.
+  def bar: Instruction {
+    let InOperandList = (ins i32imm:$factor);
+    let Size = 4;
+    bits<32> Inst;
+    bits<32> SoftFail;
+    bits<8> factor;
+    let Inst{31...24} = factor;
+    let Inst{1...0} = 0b10;
+    let AsmString = "bar  $factor";
+  }
 
-def baz : Instruction {
-  let InOperandList = (ins i32imm:$factor);
-  bits<32> Inst;
-  let EncodingInfos = EncodingByHwMode<
-    [ModeB], [fooTypeEncA]
-  >;
-  let AsmString = "foo  $factor";
-}
+  def baz : Instruction {
+    let InOperandList = (ins i32imm:$factor);
+    bits<32> Inst;
+    let EncodingInfos = EncodingByHwMode<
+      [ModeB], [fooTypeEncA]
+    >;
+    let AsmString = "foo  $factor";
+  }
 
-// Encoding not overridden, different namespace:
-// In the default case, this instruction is duplicated into two Alt decoder
-// tables (ModeA and ModeB).
-// In the suppressed case, this instruction appears in a single decoder table.
-def unrelated: Instruction {
-  let DecoderNamespace = "Alt";
-  let InOperandList = (ins i32imm:$factor);
-  let Size = 4;
-  bits<32> Inst;
-  bits<32> SoftFail;
-  bits<8> factor;
-  let Inst{31...24} = factor;
-  let Inst{1...0} = 0b10;
-  let AsmString = "unrelated  $factor";
-}
-
+  // Encoding not overridden, different namespace:
+  // In the default case, this instruction is duplicated into two Alt decoder
+  // tables (ModeA and ModeB).
+  // In the suppressed case, this instruction appears in a single decoder table.
+  def unrelated: Instruction {
+    let DecoderNamespace = "Alt";
+    let InOperandList = (ins i32imm:$factor);
+    let Size = 4;
+    bits<32> Inst;
+    bits<32> SoftFail;
+    bits<8> factor;
+    let Inst{31...24} = factor;
+    let Inst{1...0} = 0b10;
+    let AsmString = "unrelated  $factor";
+  }
 }
 
 // DECODER-LABEL: DecoderTableAlt_ModeA32[] =

--- a/llvm/test/TableGen/HwModeEncodeDecode2.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode2.td
@@ -1,0 +1,121 @@
+// RUN: llvm-tblgen -gen-disassembler -I %p/../../include %s | \
+// RUN:     FileCheck %s --check-prefix=DECODER
+// RUN: llvm-tblgen -gen-disassembler --suppress-per-hwmode-duplicates -I \
+// RUN:     %p/../../include %s | FileCheck %s --check-prefix=DECODER-SUPPRESS
+
+// Test duplicate table suppression for per-HwMode decoders.
+
+include "llvm/Target/Target.td"
+
+def archInstrInfo : InstrInfo { }
+
+def arch : Target {
+    let InstructionSet = archInstrInfo;
+}
+
+def  Myi32  : Operand<i32> {
+  let DecoderMethod = "DecodeMyi32";
+}
+
+def HasA : Predicate<"Subtarget->hasA()">;
+def HasB : Predicate<"Subtarget->hasB()">;
+
+def ModeA : HwMode<"+a", [HasA]>;
+def ModeB : HwMode<"+b", [HasB]>;
+
+
+def fooTypeEncA : InstructionEncoding {
+  let Size = 4;
+  field bits<32> SoftFail = 0;
+  bits<32> Inst;
+  bits<8> factor;
+  let Inst{7...0} = factor;
+  let Inst{3...2} = 0b11;
+  let Inst{1...0} = 0b00;
+}
+
+def fooTypeEncB : InstructionEncoding {
+  let Size = 4;
+  field bits<32> SoftFail = 0;
+  bits<32> Inst;
+  bits<8> factor;
+  let Inst{15...8} = factor;
+  let Inst{1...0} = 0b11;
+}
+
+let OutOperandList = (outs) in {
+def foo : Instruction {
+  let InOperandList = (ins i32imm:$factor);
+  let EncodingInfos = EncodingByHwMode<
+    [ModeA, ModeB], [fooTypeEncA,
+                      fooTypeEncB]
+  >;
+  let AsmString = "foo  $factor";
+}
+
+// Encoding not overridden, same namespace:
+// In the default case, this instruction is duplicated into both ModeA and
+// ModeB decoder tables.
+// In the suppressed case, this instruction appears in a single decoder table.
+def bar: Instruction {
+  let InOperandList = (ins i32imm:$factor);
+  let Size = 4;
+  bits<32> Inst;
+  bits<32> SoftFail;
+  bits<8> factor;
+  let Inst{31...24} = factor;
+  let Inst{1...0} = 0b10;
+  let AsmString = "bar  $factor";
+}
+
+def baz : Instruction {
+  let InOperandList = (ins i32imm:$factor);
+  bits<32> Inst;
+  let EncodingInfos = EncodingByHwMode<
+    [ModeB], [fooTypeEncA]
+  >;
+  let AsmString = "foo  $factor";
+}
+
+// Encoding not overridden, different namespace:
+// In the default case, this instruction is duplicated into two Alt decoder
+// tables (ModeA and ModeB).
+// In the suppressed case, this instruction appears in a single decoder table.
+def unrelated: Instruction {
+  let DecoderNamespace = "Alt";
+  let InOperandList = (ins i32imm:$factor);
+  let Size = 4;
+  bits<32> Inst;
+  bits<32> SoftFail;
+  bits<8> factor;
+  let Inst{31...24} = factor;
+  let Inst{1...0} = 0b10;
+  let AsmString = "unrelated  $factor";
+}
+
+}
+
+// DECODER-LABEL: DecoderTableAlt_ModeA32[] =
+// DECODER-DAG: Opcode: unrelated
+// DECODER-LABEL: DecoderTableAlt_ModeB32[] =
+// DECODER-DAG: Opcode: unrelated
+// DECODER-LABEL: DecoderTable_ModeA32[] =
+// DECODER-DAG: Opcode: fooTypeEncA:foo
+// DECODER-DAG: Opcode: bar
+// DECODER-LABEL: DecoderTable_ModeB32[] =
+// DECODER-DAG: Opcode: fooTypeEncB:foo
+// DECODER-DAG: Opcode: fooTypeEncA:baz
+// DECODER-DAG: Opcode: bar
+
+
+// DECODER-SUPPRESS-LABEL: DecoderTableAlt_AllModes32[] =
+// DECODER-SUPPRESS-DAG: Opcode: unrelated
+// DECODER-SUPPRESS-LABEL: DecoderTable_AllModes32[] =
+// DECODER-SUPPRESS-DAG: Opcode: bar
+// DECODER-SUPPRESS-LABEL: DecoderTable_ModeA32[] =
+// DECODER-SUPPRESS-DAG: Opcode: fooTypeEncA:foo
+// DECODER-SUPPRESS-NOT: Opcode: bar
+// DECODER-SUPPRESS-LABEL: DecoderTable_ModeB32[] =
+// DECODER-SUPPRESS-DAG: Opcode: fooTypeEncB:foo
+// DECODER-SUPPRESS-DAG: Opcode: fooTypeEncA:baz
+// DECODER-SUPPRESS-NOT: Opcode: bar

--- a/llvm/utils/TableGen/DisassemblerEmitter.cpp
+++ b/llvm/utils/TableGen/DisassemblerEmitter.cpp
@@ -131,5 +131,7 @@ static void EmitDisassembler(RecordKeeper &Records, raw_ostream &OS) {
   EmitDecoder(Records, OS, PredicateNamespace);
 }
 
+cl::OptionCategory DisassemblerEmitterCat("Options for -gen-disassembler");
+
 static TableGen::Emitter::Opt X("gen-disassembler", EmitDisassembler,
                                 "Generate disassembler");


### PR DESCRIPTION
Currently, for per-HwMode encoding/decoding, those instructions that do not have a HwMode override are duplicated into the decoder tables for all HwModes. This includes inducing multiple tables for instructions that are otherwise unrelated (e.g., different namespace with no overrides at all).

This patch adds support to suppress instruction and table duplicates. TableGen option "-gen-disassembler --suppress-per-hwmode-duplicates" enables the suppression (off by default).

For one downstream backend with a complicated ISA and major cross-generation encoding differences, this eliminates ~32000 duplicate table entries at the time of this patch.

There are legitimate reasons to suppress or not suppress duplicates. If there are relatively few non-overridden related instructions, it can be convenient to pull them into the per-mode tables (only need to decode the per-mode tables, slightly simpler decode function in disassembler). On the other hand, in some backends, the opposite is true or the size is too large to tolerate any duplication in the first place. We let the user decide which makes sense.

This is currently off by default, though there is no reason it couldn't be enabled by default. Any existing backends downstream using the per-HwMode feature will function as before. Turning on the feature requires minor modifications to their disassembler due to more/less tables and naming.