### PR TITLE
[nfc]remove unused variable after pr/81691

### DIFF
--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -456,7 +456,6 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
   Header.BinaryIdOffset = 0;
   Header.TemporalProfTracesOffset = 0;
   Header.VTableNamesOffset = 0;
-  int N = sizeof(IndexedInstrProf::Header) / sizeof(uint64_t);
 
   // Only write out the first four fields. We need to remember the offset of the
   // remaining fields to allow back patching later.


### PR DESCRIPTION
* `N` became unused after [pull request 81691](https://github.com/llvm/llvm-project/pull/81691)
* This should fix the build bot failure of `unused variable` https://lab.llvm.org/buildbot/#/builders/77/builds/34840