### PR TITLE
[FileCheck] Fix parsing empty global and pseudo variable names

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -297,6 +297,12 @@ Pattern::parseVariable(StringRef &Str, const SourceMgr &SM) {
   if (Str[0] == '$' || IsPseudo)
     ++I;
 
+  if (I == Str.size())
+    return ErrorDiagnostic::get(SM, Str,
+                                StringRef("empty ") +
+                                    (IsPseudo ? "pseudo " : "global ") +
+                                    "variable name");
+
   if (!isValidVarNameStart(Str[I++]))
     return ErrorDiagnostic::get(SM, Str, "invalid variable name");
 

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -298,7 +298,7 @@ Pattern::parseVariable(StringRef &Str, const SourceMgr &SM) {
     ++I;
 
   if (I == Str.size())
-    return ErrorDiagnostic::get(SM, Str,
+    return ErrorDiagnostic::get(SM, Str.slice(I, StringRef::npos),
                                 StringRef("empty ") +
                                     (IsPseudo ? "pseudo " : "global ") +
                                     "variable name");

--- a/llvm/test/FileCheck/empty-variable-name.txt
+++ b/llvm/test/FileCheck/empty-variable-name.txt
@@ -7,7 +7,7 @@ a
 ; CHECK:        a[[]]
 ; CHECK-ERROR:[[DIR]]/empty-variable-name.txt:7:13: error: empty variable name
 ; CHECK-ERROR-NEXT:; CHECK: a{{\[\[\]\]}}
-; CHECK-ERROR-NEXT:            ^
+;      CHECK-ERROR-NEXT:            ^
 
 b
 
@@ -16,9 +16,9 @@ b
 ; RUN:   --match-full-lines --strict-whitespace %s
 
 ; CHECK-PSEUDO: b[[@]]
-; CHECK-ERROR-PSEUDO:[[DIR]]/empty-variable-name.txt:18:20: error: empty pseudo variable name
+; CHECK-ERROR-PSEUDO:[[DIR]]/empty-variable-name.txt:18:21: error: empty pseudo variable name
 ; CHECK-ERROR-PSEUDO-NEXT:; CHECK-PSEUDO: b{{\[\[@\]\]}}
-; CHECK-ERROR-PSEUDO-NEXT:                   ^
+;      CHECK-ERROR-PSEUDO-NEXT:                    ^
 
 c
 
@@ -27,6 +27,6 @@ c
 ; RUN:   --match-full-lines --strict-whitespace %s
 
 ; CHECK-GLOBAL: c[[$]]
-; CHECK-ERROR-GLOBAL:[[DIR]]/empty-variable-name.txt:29:20: error: empty global variable name
+; CHECK-ERROR-GLOBAL:[[DIR]]/empty-variable-name.txt:29:21: error: empty global variable name
 ; CHECK-ERROR-GLOBAL-NEXT:; CHECK-GLOBAL: c{{\[\[\$\]\]}}
-; CHECK-ERROR-GLOBAL-NEXT:                   ^
+;       CHECK-ERROR-GLOBAL-NEXT:                    ^

--- a/llvm/test/FileCheck/empty-variable-name.txt
+++ b/llvm/test/FileCheck/empty-variable-name.txt
@@ -1,0 +1,32 @@
+a
+
+; RUN: not FileCheck -input-file %s %s 2>&1 | \
+; RUN:   FileCheck -check-prefix CHECK-ERROR -DDIR=%S \
+; RUN:   --match-full-lines --strict-whitespace %s
+
+; CHECK:        a[[]]
+; CHECK-ERROR:[[DIR]]/empty-variable-name.txt:7:13: error: empty variable name
+; CHECK-ERROR-NEXT:; CHECK: a{{\[\[\]\]}}
+; CHECK-ERROR-NEXT:            ^
+
+b
+
+; RUN: not FileCheck -input-file %s -check-prefix CHECK-PSEUDO %s 2>&1 | \
+; RUN:   FileCheck -check-prefix CHECK-ERROR-PSEUDO -DDIR=%S \
+; RUN:   --match-full-lines --strict-whitespace %s
+
+; CHECK-PSEUDO: b[[@]]
+; CHECK-ERROR-PSEUDO:[[DIR]]/empty-variable-name.txt:18:20: error: empty pseudo variable name
+; CHECK-ERROR-PSEUDO-NEXT:; CHECK-PSEUDO: b{{\[\[@\]\]}}
+; CHECK-ERROR-PSEUDO-NEXT:                   ^
+
+c
+
+; RUN: not FileCheck -input-file %s -check-prefix CHECK-GLOBAL %s 2>&1 | \
+; RUN:   FileCheck -check-prefix CHECK-ERROR-GLOBAL -DDIR=%S \
+; RUN:   --match-full-lines --strict-whitespace %s
+
+; CHECK-GLOBAL: c[[$]]
+; CHECK-ERROR-GLOBAL:[[DIR]]/empty-variable-name.txt:29:20: error: empty global variable name
+; CHECK-ERROR-GLOBAL-NEXT:; CHECK-GLOBAL: c{{\[\[\$\]\]}}
+; CHECK-ERROR-GLOBAL-NEXT:                   ^

--- a/llvm/test/FileCheck/empty-variable-name.txt
+++ b/llvm/test/FileCheck/empty-variable-name.txt
@@ -5,7 +5,7 @@ a
 ; RUN:   --match-full-lines --strict-whitespace %s
 
 ; CHECK:        a[[]]
-; CHECK-ERROR:[[DIR]]/empty-variable-name.txt:7:13: error: empty variable name
+; CHECK-ERROR:[[DIR]]{{/|\\}}empty-variable-name.txt:7:13: error: empty variable name
 ; CHECK-ERROR-NEXT:; CHECK: a{{\[\[\]\]}}
 ;      CHECK-ERROR-NEXT:            ^
 
@@ -16,7 +16,7 @@ b
 ; RUN:   --match-full-lines --strict-whitespace %s
 
 ; CHECK-PSEUDO: b[[@]]
-; CHECK-ERROR-PSEUDO:[[DIR]]/empty-variable-name.txt:18:21: error: empty pseudo variable name
+; CHECK-ERROR-PSEUDO:[[DIR]]{{/|\\}}empty-variable-name.txt:18:21: error: empty pseudo variable name
 ; CHECK-ERROR-PSEUDO-NEXT:; CHECK-PSEUDO: b{{\[\[@\]\]}}
 ;      CHECK-ERROR-PSEUDO-NEXT:                    ^
 
@@ -27,6 +27,6 @@ c
 ; RUN:   --match-full-lines --strict-whitespace %s
 
 ; CHECK-GLOBAL: c[[$]]
-; CHECK-ERROR-GLOBAL:[[DIR]]/empty-variable-name.txt:29:21: error: empty global variable name
+; CHECK-ERROR-GLOBAL:[[DIR]]{{/|\\}}empty-variable-name.txt:29:21: error: empty global variable name
 ; CHECK-ERROR-GLOBAL-NEXT:; CHECK-GLOBAL: c{{\[\[\$\]\]}}
 ;       CHECK-ERROR-GLOBAL-NEXT:                    ^


### PR DESCRIPTION
In `Pattern::parseVariable`, for global variables (those starting with '$') and for pseudo variables (those starting with '@') the first character is consumed before actual variable name parsing. If the name is empty, it leads to out-of-bound access to the corresponding `StringRef`.

This patch adds an if statement against the case described.