### PR TITLE
[DebugInfo][LoopIdiomRecognize] Fix #82582: Wrong debug location update in processLoopStoreOfLoopLoad

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1419,6 +1419,10 @@ bool LoopIdiomRecognize::processLoopStoreOfLoopLoad(
         AATags.TBAA, AATags.TBAAStruct, AATags.Scope, AATags.NoAlias);
   }
   
+  // As the `NewCall` is created in the preheader, it is out of the loop.
+  // The `TheStore` is in the loop body, so set the debug location of the
+  // `TheStore` to the `NewCall` will make debugging confusing.
+  // As a result, we need to drop the debug location of the `NewCall`.
   NewCall->dropLocation();
 
   if (MSSAU) {

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1418,7 +1418,8 @@ bool LoopIdiomRecognize::processLoopStoreOfLoopLoad(
         StoreBasePtr, *StoreAlign, LoadBasePtr, *LoadAlign, NumBytes, StoreSize,
         AATags.TBAA, AATags.TBAAStruct, AATags.Scope, AATags.NoAlias);
   }
-  NewCall->setDebugLoc(TheStore->getDebugLoc());
+  
+  NewCall->dropLocation();
 
   if (MSSAU) {
     MemoryAccess *NewMemAcc = MSSAU->createMemoryAccessInBB(

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1435,7 +1435,7 @@ bool LoopIdiomRecognize::processLoopStoreOfLoopLoad(
 
   ORE.emit([&]() {
     return OptimizationRemark(DEBUG_TYPE, "ProcessLoopStoreOfLoopLoad",
-                              NewCall->getDebugLoc(), Preheader)
+                              TheStore->getDebugLoc(), Preheader)
            << "Formed a call to "
            << ore::NV("NewFunction", NewCall->getCalledFunction())
            << "() intrinsic from " << ore::NV("Inst", InstRemark)

--- a/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
+++ b/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
@@ -10,11 +10,12 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Check that everything still works when debuginfo is present, and that it is reasonably propagated.
 
-; CHECK: remark: <unknown>:0:0: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
+; CHECK: remark: <stdin>:6:1: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
 
 ; YAML:      --- !Passed
 ; YAML-NEXT: Pass:            loop-idiom
 ; YAML-NEXT: Name:            ProcessLoopStoreOfLoopLoad
+; YAML-NEXT: DebugLoc:        { File: '<stdin>', Line: 6, Column: 1 }
 ; YAML-NEXT: Function:        test6_dest_align
 ; YAML-NEXT: Args:
 ; YAML-NEXT:   - String:          'Formed a call to '
@@ -33,7 +34,7 @@ define void @test6_dest_align(ptr noalias align 1 %Base, ptr noalias align 4 %De
 ; CHECK-LABEL: @test6_dest_align(
 ; CHECK-NEXT:  bb.nph:
 ; CHECK-NEXT:    [[TMP0:%.*]] = shl nuw i64 [[SIZE:%.*]], 2, !dbg [[DBG18:![0-9]+]]
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[DEST:%.*]], ptr align 1 [[BASE:%.*]], i64 [[TMP0]], i1 false)
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[DEST:%.*]], ptr align 1 [[BASE:%.*]], i64 [[TMP0]], i1 false){{$}}
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]], !dbg [[DBG18]]
 ; CHECK:       for.body:
 ; CHECK-NEXT:    [[INDVAR:%.*]] = phi i64 [ 0, [[BB_NPH:%.*]] ], [ [[INDVAR_NEXT:%.*]], [[FOR_BODY]] ], !dbg [[DBG20:![0-9]+]]

--- a/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
+++ b/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
@@ -10,12 +10,11 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Check that everything still works when debuginfo is present, and that it is reasonably propagated.
 
-; CHECK: remark: <stdin>:6:1: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
+; CHECK: remark: <unknown>:0:0: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
 
 ; YAML:      --- !Passed
 ; YAML-NEXT: Pass:            loop-idiom
 ; YAML-NEXT: Name:            ProcessLoopStoreOfLoopLoad
-; YAML-NEXT: DebugLoc:        { File: '<stdin>', Line: 6, Column: 1 }
 ; YAML-NEXT: Function:        test6_dest_align
 ; YAML-NEXT: Args:
 ; YAML-NEXT:   - String:          'Formed a call to '
@@ -34,7 +33,7 @@ define void @test6_dest_align(ptr noalias align 1 %Base, ptr noalias align 4 %De
 ; CHECK-LABEL: @test6_dest_align(
 ; CHECK-NEXT:  bb.nph:
 ; CHECK-NEXT:    [[TMP0:%.*]] = shl nuw i64 [[SIZE:%.*]], 2, !dbg [[DBG18:![0-9]+]]
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[DEST:%.*]], ptr align 1 [[BASE:%.*]], i64 [[TMP0]], i1 false), !dbg [[DBG19:![0-9]+]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[DEST:%.*]], ptr align 1 [[BASE:%.*]], i64 [[TMP0]], i1 false)
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]], !dbg [[DBG18]]
 ; CHECK:       for.body:
 ; CHECK-NEXT:    [[INDVAR:%.*]] = phi i64 [ 0, [[BB_NPH:%.*]] ], [ [[INDVAR_NEXT:%.*]], [[FOR_BODY]] ], !dbg [[DBG20:![0-9]+]]

--- a/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
+++ b/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
@@ -53,6 +53,7 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) #1
 !13 = !DIDerivedType(tag: DW_TAG_restrict_type, baseType: !14)
 !14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !15, size: 64)
 !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!16 = !{}
 !17 = !DILocalVariable(name: "a", arg: 1, scope: !10, file: !1, line: 1, type: !13)
 !18 = !DILocation(line: 0, scope: !10)
 !19 = !DILocalVariable(name: "b", arg: 2, scope: !10, file: !1, line: 1, type: !13)

--- a/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
+++ b/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
@@ -53,7 +53,6 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) #1
 !13 = !DIDerivedType(tag: DW_TAG_restrict_type, baseType: !14)
 !14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !15, size: 64)
 !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!16 = !{}
 !17 = !DILocalVariable(name: "a", arg: 1, scope: !10, file: !1, line: 1, type: !13)
 !18 = !DILocation(line: 0, scope: !10)
 !19 = !DILocalVariable(name: "b", arg: 2, scope: !10, file: !1, line: 1, type: !13)

--- a/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
+++ b/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
@@ -4,7 +4,7 @@
 define dso_local void @fun(ptr noalias noundef %a, ptr noalias noundef %b) #0 !dbg !10 {
 
 ; CHECK-LABEL: entry:
-; CHECK-NOT: call void @llvm.memcpy.p0.p0.i64{{.*}}dbg {{![0-9]+}}
+; CHECK: call void @llvm.memcpy.p0.p0.i64{{\(.*\)$}}
 entry:
   tail call void @llvm.dbg.value(metadata ptr %a, metadata !17, metadata !DIExpression()), !dbg !18
   tail call void @llvm.dbg.value(metadata ptr %b, metadata !19, metadata !DIExpression()), !dbg !18
@@ -46,14 +46,11 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.value(metadata, metadata, metadata) #1
 
-attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 18.0.0git (https://github.com/llvm/llvm-project.git 7e604485e18d40be6ce6310e4a3e583ca0b7df47)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "1423.c", directory: "/home/linuxbrew/llvm-debug/LoopIdiomRecognize", checksumkind: CSK_MD5, checksum: "50c6f3e45074a3e94d8587b0957b242b")
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 18.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "1423.c", directory: "/home/linuxbrew/llvm-debug/LoopIdiomRecognize")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}

--- a/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
+++ b/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
@@ -1,0 +1,103 @@
+; RUN: opt < %s -passes=loop-idiom -S | FileCheck %s
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @fun(ptr noalias noundef %a, ptr noalias noundef %b) #0 !dbg !10 {
+
+; CHECK-LABEL: entry:
+; CHECK-NOT: call void @llvm.memcpy.p0.p0.i64{{.*}}dbg {{![0-9]+}}
+entry:
+  tail call void @llvm.dbg.value(metadata ptr %a, metadata !17, metadata !DIExpression()), !dbg !18
+  tail call void @llvm.dbg.value(metadata ptr %b, metadata !19, metadata !DIExpression()), !dbg !18
+  tail call void @llvm.dbg.value(metadata i64 2047, metadata !20, metadata !DIExpression()), !dbg !23
+  br label %for.body, !dbg !24
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.01 = phi i64 [ 2047, %entry ], [ %dec, %for.body ]
+  tail call void @llvm.dbg.value(metadata i64 %i.01, metadata !20, metadata !DIExpression()), !dbg !23
+  %arrayidx = getelementptr inbounds i32, ptr %b, i64 %i.01, !dbg !25
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !25
+  %arrayidx1 = getelementptr inbounds i32, ptr %a, i64 %i.01, !dbg !28
+  store i32 %0, ptr %arrayidx1, align 4, !dbg !29
+  %dec = add nsw i64 %i.01, -1, !dbg !30
+  tail call void @llvm.dbg.value(metadata i64 %dec, metadata !20, metadata !DIExpression()), !dbg !23
+  %cmp = icmp sge i64 %dec, 0, !dbg !31
+  br i1 %cmp, label %for.body, label %for.end, !dbg !24, !llvm.loop !32
+
+for.end:                                          ; preds = %for.body
+  ret void, !dbg !35
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 !dbg !36 {
+entry:
+  %a = alloca [2048 x i32], align 16
+  %b = alloca [2048 x i32], align 16
+  tail call void @llvm.dbg.declare(metadata ptr %a, metadata !39, metadata !DIExpression()), !dbg !43
+  tail call void @llvm.dbg.declare(metadata ptr %b, metadata !44, metadata !DIExpression()), !dbg !45
+  %arraydecay = getelementptr inbounds [2048 x i32], ptr %a, i64 0, i64 0, !dbg !46
+  %arraydecay1 = getelementptr inbounds [2048 x i32], ptr %b, i64 0, i64 0, !dbg !47
+  call void @fun(ptr noundef %arraydecay, ptr noundef %arraydecay1), !dbg !48
+  ret i32 0, !dbg !49
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 18.0.0git (https://github.com/llvm/llvm-project.git 7e604485e18d40be6ce6310e4a3e583ca0b7df47)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "1423.c", directory: "/home/linuxbrew/llvm-debug/LoopIdiomRecognize", checksumkind: CSK_MD5, checksum: "50c6f3e45074a3e94d8587b0957b242b")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!10 = distinct !DISubprogram(name: "fun", scope: !1, file: !1, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !16)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null, !13, !13}
+!13 = !DIDerivedType(tag: DW_TAG_restrict_type, baseType: !14)
+!14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !15, size: 64)
+!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!16 = !{}
+!17 = !DILocalVariable(name: "a", arg: 1, scope: !10, file: !1, line: 1, type: !13)
+!18 = !DILocation(line: 0, scope: !10)
+!19 = !DILocalVariable(name: "b", arg: 2, scope: !10, file: !1, line: 1, type: !13)
+!20 = !DILocalVariable(name: "i", scope: !21, file: !1, line: 2, type: !22)
+!21 = distinct !DILexicalBlock(scope: !10, file: !1, line: 2, column: 5)
+!22 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!23 = !DILocation(line: 0, scope: !21)
+!24 = !DILocation(line: 2, column: 5, scope: !21)
+!25 = !DILocation(line: 3, column: 16, scope: !26)
+!26 = distinct !DILexicalBlock(scope: !27, file: !1, line: 2, column: 38)
+!27 = distinct !DILexicalBlock(scope: !21, file: !1, line: 2, column: 5)
+!28 = !DILocation(line: 3, column: 9, scope: !26)
+!29 = !DILocation(line: 3, column: 14, scope: !26)
+!30 = !DILocation(line: 2, column: 34, scope: !27)
+!31 = !DILocation(line: 2, column: 27, scope: !27)
+!32 = distinct !{!32, !24, !33, !34}
+!33 = !DILocation(line: 4, column: 5, scope: !21)
+!34 = !{!"llvm.loop.mustprogress"}
+!35 = !DILocation(line: 5, column: 1, scope: !10)
+!36 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !37, scopeLine: 7, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !16)
+!37 = !DISubroutineType(types: !38)
+!38 = !{!15}
+!39 = !DILocalVariable(name: "a", scope: !36, file: !1, line: 8, type: !40)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !15, size: 65536, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2048)
+!43 = !DILocation(line: 8, column: 9, scope: !36)
+!44 = !DILocalVariable(name: "b", scope: !36, file: !1, line: 8, type: !40)
+!45 = !DILocation(line: 8, column: 18, scope: !36)
+!46 = !DILocation(line: 9, column: 9, scope: !36)
+!47 = !DILocation(line: 9, column: 12, scope: !36)
+!48 = !DILocation(line: 9, column: 5, scope: !36)
+!49 = !DILocation(line: 10, column: 5, scope: !36)

--- a/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
+++ b/llvm/test/Transforms/LoopIdiom/processloopstoreforloopload-drop-debugloc.ll
@@ -3,6 +3,8 @@
 ; Function Attrs: noinline nounwind uwtable
 define dso_local void @fun(ptr noalias noundef %a, ptr noalias noundef %b) #0 !dbg !10 {
 
+; The newly created memcpy should not have the debugloc
+; so make sure that the CallInst line ends without "!dbg"
 ; CHECK-LABEL: entry:
 ; CHECK: call void @llvm.memcpy.p0.p0.i64{{\(.*\)$}}
 entry:
@@ -29,19 +31,6 @@ for.end:                                          ; preds = %for.body
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
-
-; Function Attrs: noinline nounwind uwtable
-define dso_local i32 @main() #0 !dbg !36 {
-entry:
-  %a = alloca [2048 x i32], align 16
-  %b = alloca [2048 x i32], align 16
-  tail call void @llvm.dbg.declare(metadata ptr %a, metadata !39, metadata !DIExpression()), !dbg !43
-  tail call void @llvm.dbg.declare(metadata ptr %b, metadata !44, metadata !DIExpression()), !dbg !45
-  %arraydecay = getelementptr inbounds [2048 x i32], ptr %a, i64 0, i64 0, !dbg !46
-  %arraydecay1 = getelementptr inbounds [2048 x i32], ptr %b, i64 0, i64 0, !dbg !47
-  call void @fun(ptr noundef %arraydecay, ptr noundef %arraydecay1), !dbg !48
-  ret i32 0, !dbg !49
-}
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.value(metadata, metadata, metadata) #1
@@ -84,17 +73,3 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) #1
 !33 = !DILocation(line: 4, column: 5, scope: !21)
 !34 = !{!"llvm.loop.mustprogress"}
 !35 = !DILocation(line: 5, column: 1, scope: !10)
-!36 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !37, scopeLine: 7, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !16)
-!37 = !DISubroutineType(types: !38)
-!38 = !{!15}
-!39 = !DILocalVariable(name: "a", scope: !36, file: !1, line: 8, type: !40)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !15, size: 65536, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2048)
-!43 = !DILocation(line: 8, column: 9, scope: !36)
-!44 = !DILocalVariable(name: "b", scope: !36, file: !1, line: 8, type: !40)
-!45 = !DILocation(line: 8, column: 18, scope: !36)
-!46 = !DILocation(line: 9, column: 9, scope: !36)
-!47 = !DILocation(line: 9, column: 12, scope: !36)
-!48 = !DILocation(line: 9, column: 5, scope: !36)
-!49 = !DILocation(line: 10, column: 5, scope: !36)


### PR DESCRIPTION
This PR partially fixes #82582 , correcting the debug location of the `NewCall` variable in the function `processLoopStoreOfLoopLoad` (instead of preversing, we drop its debug location). I also add the correponding regression test case constructed from the C source code mentioned in the above issue. Here, I give the original C source code and compilation command of the test case for convinience:
```C
void fun(int *__restrict__ a, int *__restrict__ b) {
    for (long i = 2047; i >= 0; i--) {
        a[i] = b[i];
    }
}

int main() {
    int a[2048], b[2048];
    fun(a, b);
    return 0;
}
```
```Bash
$ clang -S -emit-llvm -Xclang -disable-O0-optnone test.c -g -o test.ll
$ opt -S -passes=mem2reg,loop-rotate,loop-simplifycfg test.ll -o test-idiom.ll
```

In addition to the above modificaitons, the regressiong test case `memcpy-debugify-remarks.ll` needs to be modified. In the original test, it assumes that the `NewCall` has a debug location, so there are checks on the debug location. Now, since we drop the debug location, we need to remove these checks.
