### PR TITLE
[Clang][AArch64] Fix 'svzero_za' intrinsic to take no arguments.

### DIFF
--- a/clang/include/clang/Basic/arm_sme.td
+++ b/clang/include/clang/Basic/arm_sme.td
@@ -142,7 +142,7 @@ let TargetGuard = "sme" in {
   def SVZERO_MASK_ZA : SInst<"svzero_mask_za", "vi", "", MergeNone, "aarch64_sme_zero",
                              [IsOverloadNone, IsStreamingCompatible, IsInOutZA],
                              [ImmCheck<0, ImmCheck0_255>]>;
-  def SVZERO_ZA      : SInst<"svzero_za", "v", "", MergeNone, "aarch64_sme_zero",
+  def SVZERO_ZA      : SInst<"svzero_za", "vv", "", MergeNone, "aarch64_sme_zero",
                              [IsOverloadNone, IsStreamingCompatible, IsOutZA]>;
 }
 

--- a/clang/test/Sema/aarch64-sme-intrinsics/acle_sme_zero.c
+++ b/clang/test/Sema/aarch64-sme-intrinsics/acle_sme_zero.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sme -target-feature +sve -fsyntax-only -verify %s
+
+void test_svzero_args(uint64_t m) {
+  svzero_za(0); // expected-error {{too many arguments to function call, expected 0, have 1}}
+  svzero_za(m); // expected-error {{too many arguments to function call, expected 0, have 1}}
+  svzero_mask_za(m); // expected-error {{argument to 'svzero_mask_za' must be a constant integer}}
+}


### PR DESCRIPTION
We previously defined svzero_za as:

  void svzero_za();

rather than:

  void svzero_za(void);

Which meant that Clang accepted arguments. Compiling for example `svzero_za(<non-constant integer>)` ended up with incorrect IR and a compiler crash because it couldn't select an instruction for it.