### PR TITLE
[AArch64][SVE]Add error message in the AsmParser for SVEPattern

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -7939,7 +7939,7 @@ ParseStatus AArch64AsmParser::tryParseSVEPattern(OperandVector &Operands) {
 
     auto *MCE = dyn_cast<MCConstantExpr>(ImmVal);
     if (!MCE)
-      return ParseStatus::Failure;
+      return TokError("expected immediate operand");
 
     Pattern = MCE->getValue();
   } else {

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -7939,7 +7939,7 @@ ParseStatus AArch64AsmParser::tryParseSVEPattern(OperandVector &Operands) {
 
     auto *MCE = dyn_cast<MCConstantExpr>(ImmVal);
     if (!MCE)
-      return TokError("expected immediate operand");
+      return TokError("invalid operand for instruction");
 
     Pattern = MCE->getValue();
   } else {

--- a/llvm/test/MC/AArch64/SVE/cntb-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE/cntb-diagnostics.s
@@ -57,6 +57,6 @@ cntb  x0, vl512
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
 
 cntb  x0, #all, mul #1
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected immediate operand
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // CHECK-NEXT: cntb  x0, #all, mul #1
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE/cntb-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE/cntb-diagnostics.s
@@ -55,3 +55,8 @@ cntb  x0, vl512
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand
 // CHECK-NEXT: cntb  x0, vl512
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+cntb  x0, #all, mul #1
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected immediate operand
+// CHECK-NEXT: cntb  x0, #all, mul #1
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE/ptrue-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE/ptrue-diagnostics.s
@@ -27,3 +27,8 @@ ptrue p0.s, #32
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid predicate pattern
 // CHECK-NEXT: ptrue p0.s, #32
 // CHECK-NOT: [[@LINE-3]]:{{[0-9]+}}:
+
+ptrue p0.s, #all
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected immediate operand
+// CHECK-NEXT: ptrue p0.s, #all
+// CHECK-NOT: [[@LINE-3]]:{{[0-9]+}}:$

--- a/llvm/test/MC/AArch64/SVE/ptrue-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE/ptrue-diagnostics.s
@@ -29,6 +29,6 @@ ptrue p0.s, #32
 // CHECK-NOT: [[@LINE-3]]:{{[0-9]+}}:
 
 ptrue p0.s, #all
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected immediate operand
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // CHECK-NEXT: ptrue p0.s, #all
 // CHECK-NOT: [[@LINE-3]]:{{[0-9]+}}:$


### PR DESCRIPTION
All assembly instructions that have an operand using sve_pred_enum and mistakenly use '#' in front of it would fail without an error message.