### PR TITLE
[workflows] Mention the correct user who makes a /cherry-pick comment

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -65,5 +65,5 @@ jobs:
           release-workflow \
           --branch-repo-token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
           --issue-number ${{ github.event.issue.number }} \
-          --requested-by ${{ (github.event.action == 'opened' && github.event.issue.body.user.login) || github.event.comment.user.login }} \
+          --requested-by ${{ (github.event.action == 'opened' && github.event.issue.user.login) || github.event.comment.user.login }} \
           auto

--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -65,5 +65,5 @@ jobs:
           release-workflow \
           --branch-repo-token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
           --issue-number ${{ github.event.issue.number }} \
-          --requested-by ${{ github.event.issue.user.login }} \
+          --requested-by ${{ (github.event.action == 'opened' && github.event.issue.body.user.login) || github.event.comment.user.login }} \
           auto


### PR DESCRIPTION
We were mentioning the creator of the issue with the comment rather than the creator of the comment.

Fixes #82580