### PR TITLE
[libc] fix lint warnings from including <fenv.h>

### DIFF
--- a/libc/src/__support/FPUtil/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/FEnvImpl.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FENVIMPL_H
 
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"     // LIBC_HAS_BUILTIN
 #include "src/__support/macros/properties/architectures.h"
 #include "src/errno/libc_errno.h"
 
-#include <fenv.h>
 #include <math.h>
 
 #if defined(LIBC_TARGET_ARCH_IS_AARCH64)

--- a/libc/src/__support/FPUtil/aarch64/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/aarch64/FEnvImpl.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_AARCH64_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_AARCH64_FENVIMPL_H
 
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/properties/architectures.h"
 
@@ -17,7 +19,6 @@
 #endif
 
 #include <arm_acle.h>
-#include <fenv.h>
 #include <stdint.h>
 
 #include "src/__support/FPUtil/FPBits.h"

--- a/libc/src/__support/FPUtil/arm/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/arm/FEnvImpl.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_ARM_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_ARM_FENVIMPL_H
 
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/macros/attributes.h" // For LIBC_INLINE
 
-#include <fenv.h>
 #include <stdint.h>
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/__support/FPUtil/riscv/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/riscv/FEnvImpl.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_RISCV_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_RISCV_FENVIMPL_H
 
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/macros/attributes.h" // For LIBC_INLINE_ASM
 #include "src/__support/macros/config.h"     // For LIBC_INLINE
 
-#include <fenv.h>
 #include <stdint.h>
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/__support/FPUtil/rounding_mode.h
+++ b/libc/src/__support/FPUtil/rounding_mode.h
@@ -9,9 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_ROUNDING_MODE_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_ROUNDING_MODE_H
 
+#include "include/llvm-libc-macros/fenv-macros.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
-
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE::fputil {
 

--- a/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_X86_64_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_X86_64_FENVIMPL_H
 
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/properties/architectures.h"
 
@@ -16,7 +18,6 @@
 #error "Invalid include"
 #endif
 
-#include <fenv.h>
 #include <stdint.h>
 
 #include "src/__support/macros/sanitizer.h"

--- a/libc/src/fenv/fegetenv.h
+++ b/libc/src/fenv/fegetenv.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FEGETENV_H
 #define LLVM_LIBC_SRC_FENV_FEGETENV_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fenv_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fegetexceptflag.cpp
+++ b/libc/src/fenv/fegetexceptflag.cpp
@@ -6,11 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-types/fexcept_t.h"
 #include "src/fenv/fegetexceptflag.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
-
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fegetexceptflag.cpp
+++ b/libc/src/fenv/fegetexceptflag.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "include/llvm-libc-types/fexcept_t.h"
 #include "src/fenv/fegetexceptflag.h"
+#include "include/llvm-libc-types/fexcept_t.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
 

--- a/libc/src/fenv/fegetexceptflag.h
+++ b/libc/src/fenv/fegetexceptflag.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FEGETEXCEPTFLAG_H
 #define LLVM_LIBC_SRC_FENV_FEGETEXCEPTFLAG_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fexcept_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/feholdexcept.cpp
+++ b/libc/src/fenv/feholdexcept.cpp
@@ -7,10 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/fenv/feholdexcept.h"
+
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
-
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/feholdexcept.h
+++ b/libc/src/fenv/feholdexcept.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FEHOLDEXCEPT_H
 #define LLVM_LIBC_SRC_FENV_FEHOLDEXCEPT_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fenv_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fesetenv.h
+++ b/libc/src/fenv/fesetenv.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FESETENV_H
 #define LLVM_LIBC_SRC_FENV_FESETENV_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fenv_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fesetexceptflag.cpp
+++ b/libc/src/fenv/fesetexceptflag.cpp
@@ -7,10 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/fenv/fesetexceptflag.h"
+
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fexcept_t.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
-
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fesetexceptflag.h
+++ b/libc/src/fenv/fesetexceptflag.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FESETEXCEPTFLAG_H
 #define LLVM_LIBC_SRC_FENV_FESETEXCEPTFLAG_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fexcept_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/feupdateenv.cpp
+++ b/libc/src/fenv/feupdateenv.cpp
@@ -6,11 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/fenv-macros.h"
+#include "include/llvm-libc-types/fenv_t.h"
 #include "src/fenv/feupdateenv.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
 
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/feupdateenv.cpp
+++ b/libc/src/fenv/feupdateenv.cpp
@@ -6,12 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/fenv/feupdateenv.h"
 #include "include/llvm-libc-macros/fenv-macros.h"
 #include "include/llvm-libc-types/fenv_t.h"
-#include "src/fenv/feupdateenv.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
-
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/feupdateenv.h
+++ b/libc/src/fenv/feupdateenv.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FEUPDATEENV_H
 #define LLVM_LIBC_SRC_FENV_FEUPDATEENV_H
 
-#include <fenv.h>
+#include "include/llvm-libc-types/fenv_t.h"
 
 namespace LIBC_NAMESPACE {
 


### PR DESCRIPTION
Towards the goal of getting ninja libc-lint back to green, fixes just src/ and
not test/. Fixes:

    libc/src/fenv/fegetexceptflag.cpp:13:1: error: system include fenv.h not
    allowed [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]
       13 | #include <fenv.h>
          | ^~~~~~~~~~~~~~~~~

    /android0/llvm-project/libc/src/fenv/feholdexcept.h:12:1: error: system
    include fenv.h not allowed, transitively included from
    libc/src/fenv/feholdexcept.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/__support/FPUtil/FEnvImpl.h:17:1: error: system include fenv.h not
    allowed, transitively included from libc/src/__support/FPUtil/FEnvImpl.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/__support/FPUtil/rounding_mode.h:14:1: error: system include
    fenv.h not allowed, transitively included from
    libc/src/__support/FPUtil/rounding_mode.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/__support/FPUtil/x86_64/FEnvImpl.h:19:1: error: system include
    fenv.h not allowed, transitively included from
    libc/src/__support/FPUtil/x86_64/FEnvImpl.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/fegetexceptflag.h:12:1: error: system include fenv.h not
    allowed, transitively included from libc/src/fenv/fegetexceptflag.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/feholdexcept.cpp:13:1: error: system include fenv.h not
    allowed [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/fesetenv.h:12:1: error: system include fenv.h not allowed,
    transitively included from libc/src/fenv/fesetenv.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/fesetexceptflag.cpp:13:1: error: system include fenv.h not
    allowed [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/fesetexceptflag.h:12:1: error: system include fenv.h not
    allowed, transitively included from libc/src/fenv/fesetexceptflag.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/feupdateenv.cpp:13:1: error: system include fenv.h not
    allowed [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]

    libc/src/fenv/feupdateenv.h:12:1: error: system include fenv.h not allowed,
    transitively included from libc/src/fenv/feupdateenv.h
    [llvmlibc-restrict-system-libc-headers,-warnings-as-errors]
