### PR TITLE
[libc++] Add details about string annotations

### DIFF
--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -125,6 +125,8 @@ Improvements and New Features
   ``${PREFIX}/share/libc++/v1``.
 
 - AddressSanitizer annotations have been added to ``std::basic_string``.
+  These annotations are enabled for all allocators by default.
+  It's only enabled for long strings, strings using the small buffer optimization are not annotated.
 
 - The libc++ source code has been formatted with ``clang-format``. This
   `discourse thread <https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all>`_


### PR DESCRIPTION
This commit adds information that only long strings are annotated, and with all allocators by default.

To read why short string annotations are not turned on yet, read comments in a related PR: https://github.com/llvm/llvm-project/pull/79536

Upstreamed in: 7661ade5d1ac4fc8e1e2339b2476cb8e45c24641
Upstream PR: #80912

---------

Co-authored-by: Mark de Wever <zar-rpg@xs4all.nl>