### PR TITLE
fix docs WritingAnLLVMNewPMPass '%' in console can not be copied

### DIFF
--- a/llvm/docs/WritingAnLLVMNewPMPass.rst
+++ b/llvm/docs/WritingAnLLVMNewPMPass.rst
@@ -164,7 +164,7 @@ it to run some LLVM IR through the pass.
 
   $ cat /tmp/a.ll
   define i32 @foo() {
-    %a = add i32 2, 3
+    \%a = add i32 2, 3
     ret i32 %a
   }
 


### PR DESCRIPTION
Hello, I find that in our [page ](https://llvm.org/docs/WritingAnLLVMNewPMPass.html), we can not copy the % in our example .ll file. It seems the format is console, not llvm. I don't know if my fix method well. 
Thanks for your review.