### PR TITLE
Add new helper `Module::getRequiredFunction`.

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -424,6 +424,10 @@ public:
   /// exist, return null.
   Function *getFunction(StringRef Name) const;
 
+  /// Look up the specified function in the module symbol table.
+  /// If the function does not exist, then bail out.
+  Function *getRequiredFunction(StringRef Name) const;
+
 /// @}
 /// @name Global Variable Accessors
 /// @{

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -170,6 +170,18 @@ Function *Module::getFunction(StringRef Name) const {
   return dyn_cast_or_null<Function>(getNamedValue(Name));
 }
 
+// getRequiredFunction - Look up the specified function in the module symbol
+// table. If the function does not exist, bail out.
+//
+Function *Module::getRequiredFunction(StringRef Name) const {
+  Function *F = getFunction(Name);
+  if (!F)
+    report_fatal_error(Twine("Required function '@") + Name +
+                       "' not found on module '" + getName() + "'!");
+
+  return F;
+}
+
 //===----------------------------------------------------------------------===//
 // Methods for easy access to the global variables in the module.
 //

--- a/llvm/unittests/Analysis/CFGTest.cpp
+++ b/llvm/unittests/Analysis/CFGTest.cpp
@@ -41,9 +41,7 @@ protected:
     if (!M)
       report_fatal_error(os.str().c_str());
 
-    Function *F = M->getFunction("test");
-    if (F == nullptr)
-      report_fatal_error("Test must have a function named @test");
+    Function *F = M->getRequiredFunction("test");
 
     A = B = nullptr;
     for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {

--- a/llvm/unittests/Analysis/VectorUtilsTest.cpp
+++ b/llvm/unittests/Analysis/VectorUtilsTest.cpp
@@ -37,9 +37,7 @@ protected:
     if (!M)
       report_fatal_error(Twine(os.str()));
 
-    Function *F = M->getFunction("test");
-    if (F == nullptr)
-      report_fatal_error("Test must have a function named @test");
+    Function *F = M->getRequiredFunction("test");
 
     A = nullptr;
     for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {


### PR DESCRIPTION
Sometimes the existance of a function on a module is strictly required, thus the caller of `Module::getFunction` needs to handle the possible bailing out.

Add a new helper, `Module::getRequiredFunction`, that adds an additional check.

In the `RewriteDescriptor`, the presence of only a single argument to `getFunction` is required, thus adding a new helper function.

Since we cannot overload functions on the basis of a default value for an argument, I just added a new helper.