### PR TITLE
[LoongArch] Improve pattern matching for AddLike predicate

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -4214,7 +4214,7 @@ bool SelectionDAGISel::isOrEquivalentToAdd(const SDNode *N) const {
     // the alignment, then this or is really an add.
     return (Off >= 0) && (((A.value() - 1) & Off) == unsigned(Off));
   }
-  return false;
+  return CurDAG->haveNoCommonBitsSet(N->getOperand(0), N->getOperand(1));
 }
 
 void SelectionDAGISel::CannotYetSelect(SDNode *N) {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -4214,7 +4214,7 @@ bool SelectionDAGISel::isOrEquivalentToAdd(const SDNode *N) const {
     // the alignment, then this or is really an add.
     return (Off >= 0) && (((A.value() - 1) & Off) == unsigned(Off));
   }
-  return CurDAG->haveNoCommonBitsSet(N->getOperand(0), N->getOperand(1));
+  return false;
 }
 
 void SelectionDAGISel::CannotYetSelect(SDNode *N) {

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
@@ -1048,7 +1048,7 @@ class PatGprImm_32<SDPatternOperator OpNode, LAInst Inst, Operand ImmOpnd>
 /// Predicates
 def AddLike: PatFrags<(ops node:$A, node:$B),
                       [(add node:$A, node:$B), (or node:$A, node:$B)], [{
-    return N->getOpcode() == ISD::ADD || isOrEquivalentToAdd(N);
+    return CurDAG->isBaseWithConstantOffset(SDValue(N, 0));
 }]>;
 
 /// Simple arithmetic operations

--- a/llvm/test/CodeGen/LoongArch/intrinsic-memcpy.ll
+++ b/llvm/test/CodeGen/LoongArch/intrinsic-memcpy.ll
@@ -22,8 +22,7 @@ define void @box(ptr noalias nocapture noundef writeonly sret(%Box) align 16 der
 ; CHECK-NEXT:    st.d $a1, $a0, 24
 ; CHECK-NEXT:    ld.d $a1, $a3, 16
 ; CHECK-NEXT:    st.d $a1, $a0, 16
-; CHECK-NEXT:    ori $a1, $a3, 8
-; CHECK-NEXT:    ld.d $a1, $a1, 0
+; CHECK-NEXT:    ld.d $a1, $a3, 8
 ; CHECK-NEXT:    st.d $a1, $a0, 8
 ; CHECK-NEXT:    addi.d $sp, $sp, 96
 ; CHECK-NEXT:    ret


### PR DESCRIPTION
This commit updates the pattern matching logic for the `AddLike` predicate in `LoongArchInstrInfo.td` to use the `isBaseWithConstantOffset` function provided by `CurDAG`. This optimization aims to improve the efficiency of pattern matching by identifying cases where the operation can be represented as a base address plus a constant offset, which can lead to more efficient code generation.