### PR TITLE
[mlir][Transforms][NFC] Remove `SplitBlockRewrite`

### DIFF
--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -579,7 +579,7 @@ public:
 
   /// Split the operations starting at "before" (inclusive) out of the given
   /// block into a new block, and return it.
-  virtual Block *splitBlock(Block *block, Block::iterator before);
+  Block *splitBlock(Block *block, Block::iterator before);
 
   /// Unlink this operation from its current block and insert it right before
   /// `existingOp` which may be in the same or another block in the same

--- a/mlir/include/mlir/Transforms/DialectConversion.h
+++ b/mlir/include/mlir/Transforms/DialectConversion.h
@@ -741,9 +741,6 @@ public:
   /// implemented for dialect conversion.
   void eraseBlock(Block *block) override;
 
-  /// PatternRewriter hook for splitting a block into two parts.
-  Block *splitBlock(Block *block, Block::iterator before) override;
-
   /// PatternRewriter hook for inlining the ops of a block into another block.
   void inlineBlockBefore(Block *source, Block *dest, Block::iterator before,
                          ValueRange argValues = std::nullopt) override;


### PR DESCRIPTION
When splitting a block during a dialect conversion, a `SplitBlockRewrite` object is stored in the dialect conversion state. This commit removes `SplitBlockRewrite`. Instead, a combination of `CreateBlockRewrite` and multiple `MoveOperationRewrite` is used.

This change simplifies the internal state of the dialect conversion and is also needed to properly support listeners.

`RewriteBase::splitBlock` is now no longer virtual. All necessary information for committing/rolling back a split block rewrite can be deduced from `Listener::notifyBlockInserted` and `Listener::notifyOperationInserted` (which is also called when moving an operation).