### PR TITLE
[flang][bbc] Fix dangling reference to `envDefaults`

### DIFF
--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -354,10 +354,11 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
   loweringOptions.setPolymorphicTypeImpl(enablePolymorphic);
   loweringOptions.setNoPPCNativeVecElemOrder(enableNoPPCNativeVecElemOrder);
   loweringOptions.setLowerToHighLevelFIR(useHLFIR || emitHLFIR);
+  std::vector<Fortran::lower::EnvironmentDefault> envDefaults = {};
   auto burnside = Fortran::lower::LoweringBridge::create(
       ctx, semanticsContext, defKinds, semanticsContext.intrinsics(),
       semanticsContext.targetCharacteristics(), parsing.allCooked(),
-      targetTriple, kindMap, loweringOptions, {},
+      targetTriple, kindMap, loweringOptions, envDefaults,
       semanticsContext.languageFeatures(), targetMachine);
   burnside.lower(parseTree, semanticsContext);
   mlir::ModuleOp mlirModule = burnside.getModule();


### PR DESCRIPTION
The lowering bridge stores the evvironment defaults (passed to the constructor) as a reference. In the call to the constructor in bbc, the defaults were passed as `{}`, which creates a temporary whose lifetime ends immediately after the call.

The flang driver passes a member of the compilation instance to the constructor, which presumably remains alive long enough, so storing the reference in the bridge is justified. To avoid the dangling reference, create an actual object `envDefaults` in bbc.