### PR TITLE
[Flang] Allow reference of a function that returns a procedure pointer to be an actual argument corresponding to a procedure pointer dummy.

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1041,7 +1041,7 @@ static void CheckProcedureArg(evaluate::ActualArgument &arg,
     }
     if (dummyIsPointer && dummy.intent != common::Intent::In) {
       const Symbol *last{GetLastSymbol(*expr)};
-      if (last && IsProcedurePointer(*last)) {
+      if (last && IsProcedurePointer(*expr)) {
         if (dummy.intent != common::Intent::Default &&
             IsIntentIn(last->GetUltimate())) { // 19.6.8
           messages.Say(

--- a/flang/test/Semantics/call09.f90
+++ b/flang/test/Semantics/call09.f90
@@ -87,8 +87,7 @@ module m
     call s02(p) ! ok
     !ERROR: Actual procedure argument has interface incompatible with dummy argument 'p=': function results have distinct types: REAL(4) vs INTEGER(4)
     call s02(ip)
-    !ERROR: Actual argument associated with procedure pointer dummy argument 'p=' must be a pointer unless INTENT(IN)
-    call s02(procptr())
+    call s02(procptr()) ! ok
     call s02(null()) ! ok
     !ERROR: Actual argument associated with procedure pointer dummy argument 'p=' must be a pointer unless INTENT(IN)
     call s05(null())
@@ -99,8 +98,7 @@ module m
     call s02b(p) ! ok
     !ERROR: Actual argument function associated with procedure dummy argument 'p=' is not compatible: function results have distinct types: REAL(4) vs INTEGER(4)
     call s02b(ip)
-    !ERROR: Actual argument associated with procedure pointer dummy argument 'p=' must be a pointer unless INTENT(IN)
-    call s02b(procptr())
+    call s02b(procptr()) ! ok
     call s02b(null())
     !ERROR: Actual argument associated with procedure pointer dummy argument 'p=' must be a pointer unless INTENT(IN)
     call s02b(sin)


### PR DESCRIPTION
This PR is to fix Issue #82005. The result of referencing a function that returns a procedure pointer is a procedure pointer, so it shouldn't require the dummy procedure pointer to have the INTENT(IN) attribute.

Fixes #82005 