### PR TITLE
[flang] Fix handling of shadowed procedure name used as interface

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5647,10 +5647,8 @@ void DeclarationVisitor::Post(const parser::ProcInterface &x) {
 void DeclarationVisitor::Post(const parser::ProcDecl &x) {
   const auto &name{std::get<parser::Name>(x.t)};
   const Symbol *procInterface{nullptr};
-  if (interfaceName_) {
-    procInterface = interfaceName_->symbol->has<GenericDetails>()
-        ? interfaceName_->symbol->get<GenericDetails>().specific()
-        : interfaceName_->symbol;
+  if (interfaceName_ && interfaceName_->symbol) {
+    procInterface = &BypassGeneric(*interfaceName_->symbol);
   }
   auto attrs{HandleSaveName(name.source, GetAttrs())};
   DerivedTypeDetails *dtDetails{nullptr};

--- a/flang/test/Semantics/bind-c03.f90
+++ b/flang/test/Semantics/bind-c03.f90
@@ -13,7 +13,13 @@ module m
     end
   end interface
 
+  interface proc3
+    subroutine proc3() bind(c)
+    end
+  end interface
+
   procedure(proc1), bind(c) :: pc1 ! no error
+  procedure(proc3), bind(c) :: pc4 ! no error
 
   !ERROR: An interface name with BIND attribute must be specified if the BIND attribute is specified in a procedure declaration statement
   procedure(proc2), bind(c) :: pc2


### PR DESCRIPTION
Use BypassGeneric() to process the name of an interface in a procedure declaration statement, so that if it's the name of a generic with a homonymous specific procedure, that's what defines the interface.

Fixes https://github.com/llvm/llvm-project/issues/82267.