### PR TITLE
[workflows] Delete user branches that are too long

### DIFF
--- a/.github/workflows/user-branch-rules.yml
+++ b/.github/workflows/user-branch-rules.yml
@@ -1,0 +1,33 @@
+name: User Branch Rules
+
+permissions:
+  contents: read
+
+
+on:
+  push:
+    branches:
+      - 'users/**'
+
+
+jobs:
+  user-branch-rules:
+    if: github.repository_owner == 'llvm'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch length
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MAX_BRANCH_LENGTH: 200
+
+        run: |
+          if [ `echo "$GITHUB_REF" | wc -c` -gt "$MAX_BRANCH_LENGTH" ]; then
+            curl -s -X DELETE \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $GITHUB_TOKEN" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    "https://api.github.com/repos/$GITHUB_REPOSITORY/git/$GITHUB_REF"
+            echo "Branch $GITHUB_REF deleted"
+          fi


### PR DESCRIPTION
Long branch names can cause problems with git checkouts on Windows See https://discourse.llvm.org/t/user-created-branches-in-the-monorepo-are-often-misused/75544/34