### PR TITLE
[flang] Ensure USE-associated objects can be in NAMELIST

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6061,7 +6061,7 @@ void DeclarationVisitor::FinishNamelists() {
             if (!symbol) {
               symbol = &MakeSymbol(name, ObjectEntityDetails{});
               ApplyImplicitRules(*symbol);
-            } else if (!ConvertToObjectEntity(*symbol)) {
+            } else if (!ConvertToObjectEntity(symbol->GetUltimate())) {
               SayWithDecl(name, *symbol, "'%s' is not a variable"_err_en_US);
               context().SetError(*groupSymbol);
             }

--- a/flang/test/Semantics/namelist01.f90
+++ b/flang/test/Semantics/namelist01.f90
@@ -11,6 +11,7 @@ subroutine C8103a(x)
   integer :: x
   !ERROR: 'dupname' is already declared in this scoping unit
   namelist /dupName/ x, x
+  namelist /nl/ uniquename ! ok
 end subroutine C8103a
 
 subroutine C8103b(y)


### PR DESCRIPTION
The name resolution for NAMELIST objects didn't allow for symbols that are not ObjectEntityDetails symbols.

Fixes https://github.com/llvm/llvm-project/issues/82574.