### PR TITLE
[BOLT] Fix runtime/instrument-wrong-target.s test

### DIFF
--- a/bolt/test/runtime/instrument-wrong-target.s
+++ b/bolt/test/runtime/instrument-wrong-target.s
@@ -1,7 +1,8 @@
 # Test that BOLT errs when trying to instrument a binary with a different
 # architecture than the one BOLT is built for.
 
-# REQUIRES: x86_64-linux,bolt-runtime,target=x86_64{{.*}}
+# REQUIRES: x86_64-linux,bolt-runtime
+# REQUIRES: target-x86_64 && aarch64-registered-target
 
 # RUN: llvm-mc -triple aarch64 -filetype=obj %s -o %t.o
 # RUN: ld.lld -q -pie -o %t.exe %t.o


### PR DESCRIPTION
Test was failing when only X86 was specified for LLVM_TARGETS_TO_BUILD. Changed so that it will now report unsupporeted.

For "X86;AArch64" it still passes.
For "X86" reports UNSUPPORTED: BOLT :: runtime/instrument-wrong-target.s (1 of 1)