### PR TITLE
[ItaniumDemangle] reject A-F in FP literals

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -5541,8 +5541,7 @@ Node *AbstractManglingParser<Alloc, Derived>::parseFloatingLiteral() {
     return nullptr;
   std::string_view Data(First, N);
   for (char C : Data)
-    if (!(C >= '0' && C <= '9') &&
-        !(C >= 'a' && C <= 'f'))
+    if (!(C >= '0' && C <= '9') && !(C >= 'a' && C <= 'f'))
       return nullptr;
   First += N;
   if (!consumeIf('E'))

--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -5541,7 +5541,8 @@ Node *AbstractManglingParser<Alloc, Derived>::parseFloatingLiteral() {
     return nullptr;
   std::string_view Data(First, N);
   for (char C : Data)
-    if (!std::isxdigit(C))
+    if (!(C >= '0' && C <= '9') &&
+        !(C >= 'a' && C <= 'f'))
       return nullptr;
   First += N;
   if (!consumeIf('E'))


### PR DESCRIPTION
The Itanium C++ ABI specifies that FP literals are encoded using a lowercase hexadecimal string. Previously, libc++abi allowed uppercase A-F characters but decoded them by subtracting 'a' from them, producing negative digit values. It is especially confusing to accept an 'E' digit because 'E' marks the end of the FP literal.