### PR TITLE
[mlir][pybind] Support loading DenseElementsAttr of bools

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -694,8 +694,8 @@ public:
         // f16
         assert(view.itemsize == 2 && "mismatched array itemsize");
         bulkLoadElementType = mlirF16TypeGet(context);
-      // } else if (format == "?") {
-      //     bulkLoadElementType = mlirIntegerTypeGet(context, 1);
+      } else if (format == "?") {
+          bulkLoadElementType = mlirIntegerTypeGet(context, 1);
       } else if (isSignedIntegerFormat(format)) {
         if (view.itemsize == 4) {
           // i32

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -695,7 +695,7 @@ public:
         assert(view.itemsize == 2 && "mismatched array itemsize");
         bulkLoadElementType = mlirF16TypeGet(context);
       } else if (format == "?") {
-          bulkLoadElementType = mlirIntegerTypeGet(context, 1);
+        bulkLoadElementType = mlirIntegerTypeGet(context, 1);
       } else if (isSignedIntegerFormat(format)) {
         if (view.itemsize == 4) {
           // i32

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -694,6 +694,8 @@ public:
         // f16
         assert(view.itemsize == 2 && "mismatched array itemsize");
         bulkLoadElementType = mlirF16TypeGet(context);
+      // } else if (format == "?") {
+      //     bulkLoadElementType = mlirIntegerTypeGet(context, 1);
       } else if (isSignedIntegerFormat(format)) {
         if (view.itemsize == 4) {
           // i32

--- a/mlir/test/python/ir/array_attributes.py
+++ b/mlir/test/python/ir/array_attributes.py
@@ -148,6 +148,14 @@ def testNonSplat():
 
 ### explicitly provided types
 
+@run
+def testGetDenseElementsI1():
+    with Context():
+        array = np.array([[True, False, True], [False, False, True]], dtype=np._bool)
+        attr = DenseElementsAttr.get(array, type=IntegerType.get_signless(1))
+        # CHECK: dense<{{\[}}[true, false, true], [false, false, true]]> : tensor<2x3xi1>
+        print(attr)
+
 
 @run
 def testGetDenseElementsBF16():

--- a/mlir/test/python/ir/array_attributes.py
+++ b/mlir/test/python/ir/array_attributes.py
@@ -148,6 +148,7 @@ def testNonSplat():
 
 ### explicitly provided types
 
+
 @run
 def testGetDenseElementsI1():
     with Context():

--- a/mlir/test/python/ir/array_attributes.py
+++ b/mlir/test/python/ir/array_attributes.py
@@ -152,7 +152,7 @@ def testNonSplat():
 @run
 def testGetDenseElementsI1():
     with Context():
-        array = np.array([[True, False, True], [False, False, True]], dtype=np._bool)
+        array = np.array([[True, False, True], [False, False, True]], dtype=np.bool_)
         attr = DenseElementsAttr.get(array, type=IntegerType.get_signless(1))
         # CHECK: dense<{{\[}}[true, false, true], [false, false, true]]> : tensor<2x3xi1>
         print(attr)


### PR DESCRIPTION
We were missing the python binding support for loading tensors of booleans from numpy arrays.