### PR TITLE
[llvm-exegesis] Remove exegesis prefix in exegesis namespace

### DIFF
--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -72,79 +72,68 @@ static cl::opt<std::string>
                            "results. “-” uses stdin/stdout."),
                   cl::cat(Options), cl::init(""));
 
-static cl::opt<exegesis::Benchmark::ModeE> BenchmarkMode(
+static cl::opt<Benchmark::ModeE> BenchmarkMode(
     "mode", cl::desc("the mode to run"), cl::cat(Options),
-    cl::values(clEnumValN(exegesis::Benchmark::Latency, "latency",
-                          "Instruction Latency"),
-               clEnumValN(exegesis::Benchmark::InverseThroughput,
-                          "inverse_throughput",
+    cl::values(clEnumValN(Benchmark::Latency, "latency", "Instruction Latency"),
+               clEnumValN(Benchmark::InverseThroughput, "inverse_throughput",
                           "Instruction Inverse Throughput"),
-               clEnumValN(exegesis::Benchmark::Uops, "uops",
-                          "Uop Decomposition"),
+               clEnumValN(Benchmark::Uops, "uops", "Uop Decomposition"),
                // When not asking for a specific benchmark mode,
                // we'll analyse the results.
-               clEnumValN(exegesis::Benchmark::Unknown, "analysis",
-                          "Analysis")));
+               clEnumValN(Benchmark::Unknown, "analysis", "Analysis")));
 
-static cl::opt<exegesis::Benchmark::ResultAggregationModeE>
-    ResultAggMode(
-        "result-aggregation-mode",
-        cl::desc("How to aggregate multi-values result"),
-        cl::cat(BenchmarkOptions),
-        cl::values(clEnumValN(exegesis::Benchmark::Min, "min",
-                              "Keep min reading"),
-                   clEnumValN(exegesis::Benchmark::Max, "max",
-                              "Keep max reading"),
-                   clEnumValN(exegesis::Benchmark::Mean, "mean",
-                              "Compute mean of all readings"),
-                   clEnumValN(exegesis::Benchmark::MinVariance,
-                              "min-variance",
-                              "Keep readings set with min-variance")),
-        cl::init(exegesis::Benchmark::Min));
+static cl::opt<Benchmark::ResultAggregationModeE> ResultAggMode(
+    "result-aggregation-mode", cl::desc("How to aggregate multi-values result"),
+    cl::cat(BenchmarkOptions),
+    cl::values(clEnumValN(Benchmark::Min, "min", "Keep min reading"),
+               clEnumValN(Benchmark::Max, "max", "Keep max reading"),
+               clEnumValN(Benchmark::Mean, "mean",
+                          "Compute mean of all readings"),
+               clEnumValN(Benchmark::MinVariance, "min-variance",
+                          "Keep readings set with min-variance")),
+    cl::init(Benchmark::Min));
 
-static cl::opt<exegesis::Benchmark::RepetitionModeE> RepetitionMode(
+static cl::opt<Benchmark::RepetitionModeE> RepetitionMode(
     "repetition-mode", cl::desc("how to repeat the instruction snippet"),
     cl::cat(BenchmarkOptions),
     cl::values(
-        clEnumValN(exegesis::Benchmark::Duplicate, "duplicate",
-                   "Duplicate the snippet"),
-        clEnumValN(exegesis::Benchmark::Loop, "loop", "Loop over the snippet"),
-        clEnumValN(exegesis::Benchmark::AggregateMin, "min",
+        clEnumValN(Benchmark::Duplicate, "duplicate", "Duplicate the snippet"),
+        clEnumValN(Benchmark::Loop, "loop", "Loop over the snippet"),
+        clEnumValN(Benchmark::AggregateMin, "min",
                    "All of the above and take the minimum of measurements"),
-        clEnumValN(exegesis::Benchmark::MiddleHalfDuplicate,
-                   "middle-half-duplicate", "Middle half duplicate mode"),
-        clEnumValN(exegesis::Benchmark::MiddleHalfLoop, "middle-half-loop",
+        clEnumValN(Benchmark::MiddleHalfDuplicate, "middle-half-duplicate",
+                   "Middle half duplicate mode"),
+        clEnumValN(Benchmark::MiddleHalfLoop, "middle-half-loop",
                    "Middle half loop mode")),
-    cl::init(exegesis::Benchmark::Duplicate));
+    cl::init(Benchmark::Duplicate));
 
 static cl::opt<bool> BenchmarkMeasurementsPrintProgress(
     "measurements-print-progress",
     cl::desc("Produce progress indicator when performing measurements"),
     cl::cat(BenchmarkOptions), cl::init(false));
 
-static cl::opt<exegesis::BenchmarkPhaseSelectorE> BenchmarkPhaseSelector(
+static cl::opt<BenchmarkPhaseSelectorE> BenchmarkPhaseSelector(
     "benchmark-phase",
     cl::desc(
         "it is possible to stop the benchmarking process after some phase"),
     cl::cat(BenchmarkOptions),
     cl::values(
-        clEnumValN(exegesis::BenchmarkPhaseSelectorE::PrepareSnippet,
-                   "prepare-snippet",
+        clEnumValN(BenchmarkPhaseSelectorE::PrepareSnippet, "prepare-snippet",
                    "Only generate the minimal instruction sequence"),
-        clEnumValN(exegesis::BenchmarkPhaseSelectorE::PrepareAndAssembleSnippet,
+        clEnumValN(BenchmarkPhaseSelectorE::PrepareAndAssembleSnippet,
                    "prepare-and-assemble-snippet",
                    "Same as prepare-snippet, but also dumps an excerpt of the "
                    "sequence (hex encoded)"),
-        clEnumValN(exegesis::BenchmarkPhaseSelectorE::AssembleMeasuredCode,
+        clEnumValN(BenchmarkPhaseSelectorE::AssembleMeasuredCode,
                    "assemble-measured-code",
                    "Same as prepare-and-assemble-snippet, but also creates the "
                    "full sequence "
                    "that can be dumped to a file using --dump-object-to-disk"),
         clEnumValN(
-            exegesis::BenchmarkPhaseSelectorE::Measure, "measure",
+            BenchmarkPhaseSelectorE::Measure, "measure",
             "Same as prepare-measured-code, but also runs the measurement "
             "(default)")),
-    cl::init(exegesis::BenchmarkPhaseSelectorE::Measure));
+    cl::init(BenchmarkPhaseSelectorE::Measure));
 
 static cl::opt<bool>
     UseDummyPerfCounters("use-dummy-perf-counters",
@@ -176,27 +165,26 @@ static cl::opt<bool> IgnoreInvalidSchedClass(
     cl::desc("ignore instructions that do not define a sched class"),
     cl::cat(BenchmarkOptions), cl::init(false));
 
-static cl::opt<exegesis::BenchmarkFilter> AnalysisSnippetFilter(
+static cl::opt<BenchmarkFilter> AnalysisSnippetFilter(
     "analysis-filter", cl::desc("Filter the benchmarks before analysing them"),
     cl::cat(BenchmarkOptions),
     cl::values(
-        clEnumValN(exegesis::BenchmarkFilter::All, "all",
+        clEnumValN(BenchmarkFilter::All, "all",
                    "Keep all benchmarks (default)"),
-        clEnumValN(exegesis::BenchmarkFilter::RegOnly, "reg-only",
+        clEnumValN(BenchmarkFilter::RegOnly, "reg-only",
                    "Keep only those benchmarks that do *NOT* involve memory"),
-        clEnumValN(exegesis::BenchmarkFilter::WithMem, "mem-only",
+        clEnumValN(BenchmarkFilter::WithMem, "mem-only",
                    "Keep only the benchmarks that *DO* involve memory")),
-    cl::init(exegesis::BenchmarkFilter::All));
+    cl::init(BenchmarkFilter::All));
 
-static cl::opt<exegesis::BenchmarkClustering::ModeE>
-    AnalysisClusteringAlgorithm(
-        "analysis-clustering", cl::desc("the clustering algorithm to use"),
-        cl::cat(AnalysisOptions),
-        cl::values(clEnumValN(exegesis::BenchmarkClustering::Dbscan,
-                              "dbscan", "use DBSCAN/OPTICS algorithm"),
-                   clEnumValN(exegesis::BenchmarkClustering::Naive,
-                              "naive", "one cluster per opcode")),
-        cl::init(exegesis::BenchmarkClustering::Dbscan));
+static cl::opt<BenchmarkClustering::ModeE> AnalysisClusteringAlgorithm(
+    "analysis-clustering", cl::desc("the clustering algorithm to use"),
+    cl::cat(AnalysisOptions),
+    cl::values(clEnumValN(BenchmarkClustering::Dbscan, "dbscan",
+                          "use DBSCAN/OPTICS algorithm"),
+               clEnumValN(BenchmarkClustering::Naive, "naive",
+                          "one cluster per opcode")),
+    cl::init(BenchmarkClustering::Dbscan));
 
 static cl::opt<unsigned> AnalysisDbscanNumPoints(
     "analysis-numpoints",
@@ -478,7 +466,7 @@ void benchmarkMain() {
         "--use-dummy-perf-counters to not query the kernel for real event "
         "counts.");
 #else
-    if (exegesis::pfm::pfmInitialize())
+    if (pfm::pfmInitialize())
       ExitWithError("cannot initialize libpfm");
 #endif
   }
@@ -571,7 +559,7 @@ void benchmarkMain() {
   if (!Configurations.empty())
     runBenchmarkConfigurations(State, Configurations, Repetitors, *Runner);
 
-  exegesis::pfm::pfmTerminate();
+  pfm::pfmTerminate();
 }
 
 // Prints the results of running analysis pass `Pass` to file `OutputFilename`
@@ -596,11 +584,10 @@ static void maybeRunAnalysis(const Analysis &Analyzer, const std::string &Name,
 
 static void filterPoints(MutableArrayRef<Benchmark> Points,
                          const MCInstrInfo &MCII) {
-  if (AnalysisSnippetFilter == exegesis::BenchmarkFilter::All)
+  if (AnalysisSnippetFilter == BenchmarkFilter::All)
     return;
 
-  bool WantPointsWithMemOps =
-      AnalysisSnippetFilter == exegesis::BenchmarkFilter::WithMem;
+  bool WantPointsWithMemOps = AnalysisSnippetFilter == BenchmarkFilter::WithMem;
   for (Benchmark &Point : Points) {
     if (!Point.Error.empty())
       continue;


### PR DESCRIPTION
This patch removes the exegesis:: prefix within the exegesis namespace in llvm-exegesis.cpp as it isn't necessary due to the code already being wrapped in the namespace.