### PR TITLE
[lld][WebAssembly] Add `--no-growable-memory`

### DIFF
--- a/lld/docs/WebAssembly.rst
+++ b/lld/docs/WebAssembly.rst
@@ -131,6 +131,10 @@ WebAssembly-specific options:
 
   Initial size of the linear memory. Default: the sum of stack, static data and heap sizes.
 
+.. option:: --max-memory-growth=<value>
+
+  Maximum size of memory that can be allocated dynamically. Default: unlimited.
+
 .. option:: --max-memory=<value>
 
   Maximum size of the linear memory. Default: unlimited.

--- a/lld/docs/WebAssembly.rst
+++ b/lld/docs/WebAssembly.rst
@@ -131,13 +131,13 @@ WebAssembly-specific options:
 
   Initial size of the linear memory. Default: the sum of stack, static data and heap sizes.
 
-.. option:: --max-memory-growth=<value>
-
-  Maximum size of memory that can be allocated dynamically. Default: unlimited.
-
 .. option:: --max-memory=<value>
 
   Maximum size of the linear memory. Default: unlimited.
+
+.. option:: --no-growable-memory
+
+  Set maximum size of the linear memory to its initial size, disallowing memory growth.
 
 By default the function table is neither imported nor exported, but defined
 for internal use only.

--- a/lld/test/wasm/data-layout.s
+++ b/lld/test/wasm/data-layout.s
@@ -103,37 +103,21 @@ local_struct_internal_ptr:
 # CHECK-MAX-NEXT:         Minimum:         0x2
 # CHECK-MAX-NEXT:         Maximum:         0x2
 
-# RUN: wasm-ld --no-entry --initial-memory=327680 --max-memory-growth=0 \
+# RUN: wasm-ld --no-entry --initial-memory=327680 --no-growable-memory \
 # RUN:     -o %t_max.wasm %t.hello32.o
-# RUN: obj2yaml %t_max.wasm | FileCheck %s -check-prefix=CHECK-MAX-GROWTH-ZERO
+# RUN: obj2yaml %t_max.wasm | FileCheck %s -check-prefix=CHECK-NO-GROWTH
 
-# CHECK-MAX-GROWTH-ZERO:        - Type:            MEMORY
-# CHECK-MAX-GROWTH-ZERO-NEXT:     Memories:
-# CHECK-MAX-GROWTH-ZERO:           - Flags:           [ HAS_MAX ]
-# CHECK-MAX-GROWTH-ZERO:             Minimum:         0x5
-# CHECK-MAX-GROWTH-ZERO:             Maximum:         0x5
+# CHECK-NO-GROWTH:        - Type:            MEMORY
+# CHECK-NO-GROWTH-NEXT:     Memories:
+# CHECK-NO-GROWTH-NEXT:       - Flags:           [ HAS_MAX ]
+# CHECK-NO-GROWTH-NEXT:         Minimum:         0x5
+# CHECK-NO-GROWTH-NEXT:         Maximum:         0x5
 
-# RUN: wasm-ld --initial-memory=196608 --max-memory-growth=262144 \
-# RUN:     --no-entry -o %t_max.wasm %t.hello32.o
-# RUN: obj2yaml %t_max.wasm | FileCheck %s -check-prefix=CHECK-MAX-GROWTH-SOME
-
-# CHECK-MAX-GROWTH-SOME:        - Type:            MEMORY
-# CHECK-MAX-GROWTH-SOME-NEXT:     Memories:
-# CHECK-MAX-GROWTH-SOME:           - Flags:           [ HAS_MAX ]
-# CHECK-MAX-GROWTH-SOME:             Minimum:         0x3
-# CHECK-MAX-GROWTH-SOME:             Maximum:         0x7
-
-# RUN: not wasm-ld --max-memory-growth=131073 \
+# RUN: not wasm-ld --max-memory=262144 --no-growable-memory \
 # RUN:     --no-entry -o %t_max.wasm %t.hello32.o 2>&1 \
-# RUN: | FileCheck %s --check-prefix CHECK-MAX-GROWTH-ALIGN-ERROR
+# RUN: | FileCheck %s --check-prefix CHECK-NO-GROWTH-COMPAT-ERROR
 
-# CHECK-MAX-GROWTH-ALIGN-ERROR: maximum memory growth must be 65536-byte aligned
-
-# RUN: not wasm-ld --initial-memory=131072 --max-memory=262144 --max-memory-growth=131072 \
-# RUN:     --no-entry -o %t_max.wasm %t.hello32.o 2>&1 \
-# RUN: | FileCheck %s --check-prefix CHECK-MAX-GROWTH-COMPAT-ERROR
-
-# CHECK-MAX-GROWTH-COMPAT-ERROR: --max-memory-growth and --max-memory are mutually exclusive
+# CHECK-NO-GROWTH-COMPAT-ERROR: --max-memory and --no-growable-memory are mutually exclusive
 
 # RUN: wasm-ld -no-gc-sections --allow-undefined --no-entry --shared-memory \
 # RUN:     --features=atomics,bulk-memory --initial-memory=131072 \

--- a/lld/test/wasm/data-layout.s
+++ b/lld/test/wasm/data-layout.s
@@ -117,7 +117,7 @@ local_struct_internal_ptr:
 # RUN:     --no-entry -o %t_max.wasm %t.hello32.o 2>&1 \
 # RUN: | FileCheck %s --check-prefix CHECK-NO-GROWTH-COMPAT-ERROR
 
-# CHECK-NO-GROWTH-COMPAT-ERROR: --max-memory and --no-growable-memory are mutually exclusive
+# CHECK-NO-GROWTH-COMPAT-ERROR: --max-memory is incompatible with --no-growable-memory
 
 # RUN: wasm-ld -no-gc-sections --allow-undefined --no-entry --shared-memory \
 # RUN:     --features=atomics,bulk-memory --initial-memory=131072 \

--- a/lld/test/wasm/large-memory.test
+++ b/lld/test/wasm/large-memory.test
@@ -5,14 +5,8 @@ RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/start.s -o %
 RUN: wasm-ld %t.o -o %t1.wasm --max-memory=2147483648
 RUN: obj2yaml %t1.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-2G
 
-RUN: wasm-ld %t.o -o %t1.wasm --initial-memory=131072 --max-memory-growth=2147352576
-RUN: obj2yaml %t1.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-2G
-
 ; And also 4G of total memory
 RUN: wasm-ld %t.o -o %t2.wasm --max-memory=4294967296
-RUN: obj2yaml %t2.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-4G
-
-RUN: wasm-ld %t.o -o %t2.wasm --initial-memory=131072 --max-memory-growth=4294836224
 RUN: obj2yaml %t2.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-4G
 
 CHECK:      - Type:            MEMORY
@@ -25,8 +19,6 @@ CHECK-4G-NEXT:    Maximum:         0x10000
 ; Test error for more than 4G of memory
 RUN: not wasm-ld %t.o -o %t3.wasm --initial-memory=4295032832 2>&1 | FileCheck %s --check-prefix INIT-ERROR
 RUN: not wasm-ld %t.o -o %t4.wasm --max-memory=4295032832 2>&1 | FileCheck %s --check-prefix MAX-ERROR
-RUN: not wasm-ld %t.o -o %t4.wasm --initial-memory=131072 --max-memory-growth=4294901760 2>&1 | FileCheck %s --check-prefix MAX-GROWTH-ERROR
 
 INIT-ERROR: initial memory too large, cannot be greater than 4294967296
 MAX-ERROR: maximum memory too large, cannot be greater than 4294967296
-MAX-GROWTH-ERROR: maximum memory growth too large, cannot be greater than 4294836224

--- a/lld/test/wasm/large-memory.test
+++ b/lld/test/wasm/large-memory.test
@@ -5,8 +5,14 @@ RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/start.s -o %
 RUN: wasm-ld %t.o -o %t1.wasm --max-memory=2147483648
 RUN: obj2yaml %t1.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-2G
 
+RUN: wasm-ld %t.o -o %t1.wasm --initial-memory=131072 --max-memory-growth=2147352576
+RUN: obj2yaml %t1.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-2G
+
 ; And also 4G of total memory
 RUN: wasm-ld %t.o -o %t2.wasm --max-memory=4294967296
+RUN: obj2yaml %t2.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-4G
+
+RUN: wasm-ld %t.o -o %t2.wasm --initial-memory=131072 --max-memory-growth=4294836224
 RUN: obj2yaml %t2.wasm | FileCheck %s --check-prefixes=CHECK,CHECK-4G
 
 CHECK:      - Type:            MEMORY
@@ -19,6 +25,8 @@ CHECK-4G-NEXT:    Maximum:         0x10000
 ; Test error for more than 4G of memory
 RUN: not wasm-ld %t.o -o %t3.wasm --initial-memory=4295032832 2>&1 | FileCheck %s --check-prefix INIT-ERROR
 RUN: not wasm-ld %t.o -o %t4.wasm --max-memory=4295032832 2>&1 | FileCheck %s --check-prefix MAX-ERROR
+RUN: not wasm-ld %t.o -o %t4.wasm --initial-memory=131072 --max-memory-growth=4294901760 2>&1 | FileCheck %s --check-prefix MAX-GROWTH-ERROR
 
 INIT-ERROR: initial memory too large, cannot be greater than 4294967296
 MAX-ERROR: maximum memory too large, cannot be greater than 4294967296
+MAX-GROWTH-ERROR: maximum memory growth too large, cannot be greater than 4294836224

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -77,6 +77,7 @@ struct Configuration {
   uint64_t globalBase;
   uint64_t initialHeap;
   uint64_t initialMemory;
+  uint64_t maxMemoryGrowth;
   uint64_t maxMemory;
   // The table offset at which to place function addresses.  We reserve zero
   // for the null function pointer.  This gets set to 1 for executables and 0

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -77,8 +77,8 @@ struct Configuration {
   uint64_t globalBase;
   uint64_t initialHeap;
   uint64_t initialMemory;
-  uint64_t maxMemoryGrowth;
   uint64_t maxMemory;
+  bool noGrowableMemory;
   // The table offset at which to place function addresses.  We reserve zero
   // for the null function pointer.  This gets set to 1 for executables and 0
   // for shared libraries (since they always added to a dynamic offset at

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -546,6 +546,11 @@ static void readConfigs(opt::InputArgList &args) {
   config->zStackSize =
       args::getZOptionValue(args, OPT_z, "stack-size", WasmPageSize);
 
+  if (config->maxMemory != 0 && config->noGrowableMemory) {
+    // Erroring out here is simpler than defining precedence rules.
+    error("--max-memory is incompatible with --no-growable-memory");
+  }
+
   // Default value of exportDynamic depends on `-shared`
   config->exportDynamic =
       args.hasFlag(OPT_export_dynamic, OPT_no_export_dynamic, config->shared);

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -541,8 +541,8 @@ static void readConfigs(opt::InputArgList &args) {
   config->globalBase = args::getInteger(args, OPT_global_base, 0);
   config->initialHeap = args::getInteger(args, OPT_initial_heap, 0);
   config->initialMemory = args::getInteger(args, OPT_initial_memory, 0);
-  config->maxMemoryGrowth = args::getInteger(args, OPT_max_memory_growth, -1);
   config->maxMemory = args::getInteger(args, OPT_max_memory, 0);
+  config->noGrowableMemory = args.hasArg(OPT_no_growable_memory);
   config->zStackSize =
       args::getZOptionValue(args, OPT_z, "stack-size", WasmPageSize);
 

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -541,6 +541,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->globalBase = args::getInteger(args, OPT_global_base, 0);
   config->initialHeap = args::getInteger(args, OPT_initial_heap, 0);
   config->initialMemory = args::getInteger(args, OPT_initial_memory, 0);
+  config->maxMemoryGrowth = args::getInteger(args, OPT_max_memory_growth, -1);
   config->maxMemory = args::getInteger(args, OPT_max_memory, 0);
   config->zStackSize =
       args::getZOptionValue(args, OPT_z, "stack-size", WasmPageSize);

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -227,11 +227,11 @@ def initial_heap: JJ<"initial-heap=">,
 def initial_memory: JJ<"initial-memory=">,
   HelpText<"Initial size of the linear memory">;
 
-def max_memory_growth: JJ<"max-memory-growth=">,
-  HelpText<"Maximum size of dynamically allocatable linear memory">;
-
 def max_memory: JJ<"max-memory=">,
   HelpText<"Maximum size of the linear memory">;
+
+def no_growable_memory: FF<"no-growable-memory">,
+  HelpText<"Set maximum size of the linear memory to its initial size">;
 
 def no_entry: FF<"no-entry">,
   HelpText<"Do not output any entry point">;

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -227,6 +227,9 @@ def initial_heap: JJ<"initial-heap=">,
 def initial_memory: JJ<"initial-memory=">,
   HelpText<"Initial size of the linear memory">;
 
+def max_memory_growth: JJ<"max-memory-growth=">,
+  HelpText<"Maximum size of dynamically allocatable linear memory">;
+
 def max_memory: JJ<"max-memory=">,
   HelpText<"Maximum size of the linear memory">;
 

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -473,11 +473,6 @@ void Writer::layoutMemory() {
     WasmSym::heapEnd->setVA(memoryPtr);
   }
 
-  if (config->maxMemory != 0 && config->noGrowableMemory) {
-    // Erroring out here is simpler than defining precedence rules.
-    error("--max-memory and --no-growable-memory are mutually exclusive");
-  }
-
   uint64_t maxMemory = 0;
   if (config->maxMemory != 0) {
     if (config->maxMemory != alignTo(config->maxMemory, WasmPageSize))


### PR DESCRIPTION
We recently added `--initial-heap` - an option that allows one to up the initial memory size without the burden of having to know exactly how much is needed.

However, in the process of implementing support for this in Emscripten (https://github.com/emscripten-core/emscripten/pull/21071), we have realized that `--initial-heap` cannot support the use-case of non-growable memories by itself, since with it we don't know what to set `--max-memory` to.

We have thus agreed to move the above work forward by introducing another option to the linker (see https://github.com/emscripten-core/emscripten/pull/21071#discussion_r1491755616), one that would allow users to explicitly specify they want a non-growable memory.

This change does this by introducing `--no-growable-memory`: an option that is mutally exclusive with `--max-memory` (for simplicity - we can also decide that it should override or be overridable by `--max-memory`. In Emscripten a similar mix of options results in `--no-growable-memory` taking precedence). The option specifies that the maximum memory size should be set to the initial memory size, effectively disallowing memory growth.

Closes #81932.