### PR TITLE
[TableGen] Efficiency improvements for encoding HwMode collection.

### DIFF
--- a/llvm/utils/TableGen/CodeGenHwModes.h
+++ b/llvm/utils/TableGen/CodeGenHwModes.h
@@ -53,6 +53,9 @@ struct CodeGenHwModes {
     return Modes[Id - 1];
   }
   const HwModeSelect &getHwModeSelect(Record *R) const;
+  const std::map<Record *, HwModeSelect> &getHwModeSelects() const {
+    return ModeSelects;
+  }
   unsigned getNumModeIds() const { return Modes.size() + 1; }
   void dump() const;
 


### PR DESCRIPTION
Currently the DecoderEmitter spends a fair amount of cycles performing repeated linear walks over the entire instruction list. This patch eliminates one such walk during HwMode collection for EncodingInfos.

The eliminated traversal visits every instruction and then every EncodingInfos entry for that instruction merely to collect all referenced HwModes. That information already happens to be present in the HwModeSelects created during the one-time construction of CodeGenHwModes. We instead traverse the HwModeSelects, collecting each one referenced as an encoding select. This set is a small constant in size and does not generally grow with the size of the instruction set.