### PR TITLE
[clang][analyzer][NFC] Prepare for clang-format

### DIFF
--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyTIL.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyTIL.h
@@ -128,6 +128,7 @@ enum TIL_CastOpcode : unsigned char {
   CAST_objToPtr
 };
 
+// clang-format off
 const TIL_Opcode       COP_Min  = COP_Future;
 const TIL_Opcode       COP_Max  = COP_Branch;
 const TIL_UnaryOpcode  UOP_Min  = UOP_Minus;
@@ -136,6 +137,7 @@ const TIL_BinaryOpcode BOP_Min  = BOP_Add;
 const TIL_BinaryOpcode BOP_Max  = BOP_LogicOr;
 const TIL_CastOpcode   CAST_Min = CAST_none;
 const TIL_CastOpcode   CAST_Max = CAST_toInt;
+// clang-format on
 
 /// Return the name of a unary opcode.
 StringRef getUnaryOpcodeString(TIL_UnaryOpcode Op);
@@ -188,12 +190,14 @@ struct ValueType {
 
 inline ValueType::SizeType ValueType::getSizeType(unsigned nbytes) {
   switch (nbytes) {
-    case 1: return ST_8;
-    case 2: return ST_16;
-    case 4: return ST_32;
-    case 8: return ST_64;
+    // clang-format off
+    case  1: return ST_8;
+    case  2: return ST_16;
+    case  4: return ST_32;
+    case  8: return ST_64;
     case 16: return ST_128;
     default: return ST_0;
+    // clang-format on
   }
 }
 

--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyTraverse.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyTraverse.h
@@ -440,6 +440,7 @@ protected:
 
   // Return the precedence of a given node, for use in pretty printing.
   unsigned precedence(const SExpr *E) {
+    // clang-format off
     switch (E->opcode()) {
       case COP_Future:     return Prec_Atom;
       case COP_Undefined:  return Prec_Atom;
@@ -479,6 +480,7 @@ protected:
       case COP_IfThenElse: return Prec_Other;
       case COP_Let:        return Prec_Decl;
     }
+    // clang-format on
     return Prec_MAX;
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -393,8 +393,8 @@ public:
   ProgramStateRef processAssume(ProgramStateRef state, SVal cond,
                                 bool assumption);
 
-  /// processRegionChanges - Called by ProgramStateManager whenever a change is made
-  ///  to the store. Used to update checkers that track region values.
+  /// It's called by ProgramStateManager whenever a change is made to the store.
+  /// Used to update checkers that track region values.
   ProgramStateRef
   processRegionChanges(ProgramStateRef state,
                        const InvalidatedSymbols *invalidated,
@@ -587,9 +587,8 @@ public:
                                 ExplodedNode *Pred,
                                 ExplodedNodeSet &Dst);
 
-  /// evalEagerlyAssumeBinOpBifurcation - Given the nodes in 'Src', eagerly assume symbolic
-  ///  expressions of the form 'x != 0' and generate new nodes (stored in Dst)
-  ///  with those assumptions.
+  /// Given the nodes in \p Src, eagerly assume symbolic expressions of the form
+  /// `x != 0` and generate new nodes (stored in \p Dst) with those assumptions.
   void evalEagerlyAssumeBinOpBifurcation(ExplodedNodeSet &Dst, ExplodedNodeSet &Src,
                          const Expr *Ex);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -526,7 +526,7 @@ public:
   }
 };
 
-/// TypedValueRegion - An abstract class representing regions having a typed value.
+/// An abstract class representing regions having a typed value.
 class TypedValueRegion : public TypedRegion {
   void anchor() override;
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h
@@ -1,4 +1,4 @@
-//ProgramStateTrait.h - Partial implementations of ProgramStateTrait -*- C++ -*-
+// ProgramStateTrait.h - Partial implementations of ProgramStateTrait
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -788,8 +788,7 @@ PathDiagnosticRange
           }
           break;
         }
-          // FIXME: Provide better range information for different
-          //  terminators.
+        // FIXME: Provide better range information for different terminators.
         case Stmt::IfStmtClass:
         case Stmt::WhileStmtClass:
         case Stmt::DoStmtClass:

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -560,6 +560,7 @@ til::SExpr *SExprBuilder::translateBinAssign(til::TIL_BinaryOpcode Op,
 
 til::SExpr *SExprBuilder::translateBinaryOperator(const BinaryOperator *BO,
                                                   CallingContext *Ctx) {
+  // clang-format off
   switch (BO->getOpcode()) {
   case BO_PtrMemD:
   case BO_PtrMemI:
@@ -601,6 +602,7 @@ til::SExpr *SExprBuilder::translateBinaryOperator(const BinaryOperator *BO,
     // The clang CFG should have already processed both sides.
     return translate(BO->getRHS(), Ctx);
   }
+  // clang-format on
   return new (Arena) til::Undefined(BO);
 }
 

--- a/clang/lib/Analysis/ThreadSafetyTIL.cpp
+++ b/clang/lib/Analysis/ThreadSafetyTIL.cpp
@@ -26,6 +26,7 @@ StringRef til::getUnaryOpcodeString(TIL_UnaryOpcode Op) {
 }
 
 StringRef til::getBinaryOpcodeString(TIL_BinaryOpcode Op) {
+  // clang-format off
   switch (Op) {
     case BOP_Mul:      return "*";
     case BOP_Div:      return "/";
@@ -45,6 +46,7 @@ StringRef til::getBinaryOpcodeString(TIL_BinaryOpcode Op) {
     case BOP_LogicAnd: return "&&";
     case BOP_LogicOr:  return "||";
   }
+  // clang-format on
   return {};
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -387,6 +387,7 @@ static std::optional<uint64_t> GetCFNumberSize(ASTContext &Ctx, uint64_t i) {
 
   QualType T;
 
+  // clang-format off
   switch (i) {
     case kCFNumberCharType:     T = Ctx.CharTy;     break;
     case kCFNumberShortType:    T = Ctx.ShortTy;    break;
@@ -402,6 +403,7 @@ static std::optional<uint64_t> GetCFNumberSize(ASTContext &Ctx, uint64_t i) {
     default:
       return std::nullopt;
   }
+  // clang-format on
 
   return Ctx.getTypeSize(T);
 }
@@ -535,7 +537,8 @@ void CFNumberChecker::checkPreStmt(const CallExpr *CE,
 }
 
 //===----------------------------------------------------------------------===//
-// CFRetain/CFRelease/CFMakeCollectable/CFAutorelease checking for null arguments.
+// checking for null arguments:
+//   CFRetain/CFRelease/CFMakeCollectable/CFAutorelease
 //===----------------------------------------------------------------------===//
 
 namespace {

--- a/clang/lib/StaticAnalyzer/Checkers/CheckerDocumentation.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CheckerDocumentation.cpp
@@ -33,30 +33,32 @@ namespace ento {
 /// checking.
 ///
 /// \sa CheckerContext
-class CheckerDocumentation : public Checker< check::PreStmt<ReturnStmt>,
-                                       check::PostStmt<DeclStmt>,
-                                       check::PreObjCMessage,
-                                       check::PostObjCMessage,
-                                       check::ObjCMessageNil,
-                                       check::PreCall,
-                                       check::PostCall,
-                                       check::BranchCondition,
-                                       check::NewAllocator,
-                                       check::Location,
-                                       check::Bind,
-                                       check::DeadSymbols,
-                                       check::BeginFunction,
-                                       check::EndFunction,
-                                       check::EndAnalysis,
-                                       check::EndOfTranslationUnit,
-                                       eval::Call,
-                                       eval::Assume,
-                                       check::LiveSymbols,
-                                       check::RegionChanges,
-                                       check::PointerEscape,
-                                       check::ConstPointerEscape,
-                                       check::Event<ImplicitNullDerefEvent>,
-                                       check::ASTDecl<FunctionDecl> > {
+class CheckerDocumentation : public Checker<                           //
+                                 check::PreStmt<ReturnStmt>,           //
+                                 check::PostStmt<DeclStmt>,            //
+                                 check::PreObjCMessage,                //
+                                 check::PostObjCMessage,               //
+                                 check::ObjCMessageNil,                //
+                                 check::PreCall,                       //
+                                 check::PostCall,                      //
+                                 check::BranchCondition,               //
+                                 check::NewAllocator,                  //
+                                 check::Location,                      //
+                                 check::Bind,                          //
+                                 check::DeadSymbols,                   //
+                                 check::BeginFunction,                 //
+                                 check::EndFunction,                   //
+                                 check::EndAnalysis,                   //
+                                 check::EndOfTranslationUnit,          //
+                                 eval::Call,                           //
+                                 eval::Assume,                         //
+                                 check::LiveSymbols,                   //
+                                 check::RegionChanges,                 //
+                                 check::PointerEscape,                 //
+                                 check::ConstPointerEscape,            //
+                                 check::Event<ImplicitNullDerefEvent>, //
+                                 check::ASTDecl<FunctionDecl>          //
+                                 > {
 public:
   /// Pre-visit the Statement.
   ///

--- a/clang/lib/StaticAnalyzer/Checkers/ObjCAutoreleaseWriteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ObjCAutoreleaseWriteChecker.cpp
@@ -53,6 +53,7 @@ public:
                         AnalysisManager &AM,
                         BugReporter &BR) const;
 private:
+  // clang-format off
   std::vector<std::string> SelectorsWithAutoreleasingPool = {
       // Common to NSArray,  NSSet, NSOrderedSet
       "enumerateObjectsUsingBlock:",
@@ -92,6 +93,7 @@ private:
       "indexInRange:options:passingTest:",
       "indexesInRange:options:passingTest:"
   };
+  // clang-format on
 
   std::vector<std::string> FunctionsWithAutoreleasingPool = {
       "dispatch_async", "dispatch_group_async", "dispatch_barrier_async"};

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -112,6 +112,7 @@ void ExprEngine::VisitBinaryOperator(const BinaryOperator* B,
 
     assert (B->isCompoundAssignmentOp());
 
+    // clang-format off
     switch (Op) {
       default:
         llvm_unreachable("Invalid opcode for compound assignment.");
@@ -126,6 +127,7 @@ void ExprEngine::VisitBinaryOperator(const BinaryOperator* B,
       case BO_XorAssign: Op = BO_Xor; break;
       case BO_OrAssign:  Op = BO_Or;  break;
     }
+    // clang-format on
 
     // Perform a load (the LHS).  This performs the checks for
     // null dereferences, and so on.


### PR DESCRIPTION
This is the followup PR for #82599 to fix the cases where clang-format would regress the flow of the code.