### PR TITLE
Non functional change. Initialize var EnumVal to 0.

### DIFF
--- a/llvm/utils/TableGen/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/CodeGenInstruction.h
@@ -301,7 +301,7 @@ public:
   Record *InferredFrom;
 
   // The enum value assigned by CodeGenTarget::computeInstrsByEnum.
-  mutable unsigned EnumVal;
+  mutable unsigned EnumVal = 0;
 
   CodeGenInstruction(Record *R);
 


### PR DESCRIPTION
CodeGenInstruction has a new unsigned member EnumVal. It is not initialized in either the class or the constructor.