### PR TITLE
[llvm-config] Fix libLLVM.dylib detection

### DIFF
--- a/llvm/tools/llvm-config/llvm-config.cpp
+++ b/llvm/tools/llvm-config/llvm-config.cpp
@@ -382,13 +382,13 @@ int main(int argc, char **argv) {
   /// removed or, as in the case of CMake's `BUILD_SHARED_LIBS`, never present
   /// in the first place. This can't be done at configure/build time.
 
-  StringRef SharedExt, SharedVersionedExt, SharedDir, SharedPrefix, StaticExt,
+  StringRef SharedExt, SharedSuffix, SharedDir, SharedPrefix, StaticExt,
       StaticPrefix, StaticDir = "lib";
   std::string DirSep = "/";
   const Triple HostTriple(Triple::normalize(LLVM_HOST_TRIPLE));
   if (HostTriple.isOSWindows()) {
     SharedExt = "dll";
-    SharedVersionedExt = LLVM_DYLIB_VERSION ".dll";
+    SharedSuffix = "-" LLVM_DYLIB_VERSION ".dll";
     if (HostTriple.isOSCygMing()) {
       SharedPrefix = "lib";
       StaticExt = "a";
@@ -408,14 +408,14 @@ int main(int argc, char **argv) {
     StaticDir = ActiveLibDir;
   } else if (HostTriple.isOSDarwin()) {
     SharedExt = "dylib";
-    SharedVersionedExt = LLVM_DYLIB_VERSION ".dylib";
+    SharedSuffix = ".dylib";
     StaticExt = "a";
     StaticDir = SharedDir = ActiveLibDir;
     StaticPrefix = SharedPrefix = "lib";
   } else {
     // default to the unix values:
     SharedExt = "so";
-    SharedVersionedExt = LLVM_DYLIB_VERSION ".so";
+    SharedSuffix = "-" LLVM_DYLIB_VERSION ".so";
     StaticExt = "a";
     StaticDir = SharedDir = ActiveLibDir;
     StaticPrefix = SharedPrefix = "lib";
@@ -427,8 +427,7 @@ int main(int argc, char **argv) {
   const bool BuiltSharedLibs = !!LLVM_ENABLE_SHARED;
 
   bool DyLibExists = false;
-  const std::string DyLibName =
-      (SharedPrefix + "LLVM-" + SharedVersionedExt).str();
+  const std::string DyLibName = (SharedPrefix + "LLVM" + SharedSuffix).str();
 
   // If LLVM_LINK_DYLIB is ON, the single shared library will be returned
   // for "--libs", etc, if they exist. This behaviour can be overridden with


### PR DESCRIPTION
This fixes #39599 (which has a bit more background in https://github.com/llvm/llvm-project/issues/39599#issuecomment-1817592289).

On macOS, `libLLVM.dylib` does not include a version suffix, however `llvm-config` always expects a version suffix.

As such, before this PR `llvm-config` on macOS would never output shared linking instructions, and `llvm-config --link-shared` will always fail with `error: libLLVM-17.dylib is missing` (at least I've never observed it working).

---

Note that there is at least one change in behavior (there could be more; I'm not familiar with all the details and uses of `llvm-config`): the **default** behavior of `llvm-config` on macOS changes **if** LLVM was configured for dynamic linking:

Before: `llvm-config` couldn't find `libLLVM-<version>.dylib`, so would fall back to static linking.

Now: `llvm-config` can find `libLLVM.dylib`, so will provide shared linking instructions.

(If `--link-static` is passed explicitly, there should be no change in behavior. If `--link-shared` is passed then `llvm-config` invocations should now succeed instead of erroring out).

The old behavior could be preserved by making `llvm-config` on macOS never automatically use shared linking. Let me know if this would be desirable, and I'll update the PR.

---

I've tested this by manually running `llvm-config` with this PR applied (on macOS and with LLVM configured with `LLVM_LINK_LLVM_DYLIB=ON`), and confirmed that `llvm-config` will output shared linking instructions.

If there's a reasonable way to add an automated test for this please let me know. (The closes I found was [this test](https://github.com/llvm/llvm-project/blob/954a048d0d03d874d214cbe9ce0da456a0da35d3/llvm/test/tools/llvm-config/booleans.test#L24-L27), but that accepts output for both, static and shared linking configurations).

