### PR TITLE
[mlir][inline] avoid inline self-recursive function

### DIFF
--- a/mlir/lib/Transforms/Inliner.cpp
+++ b/mlir/lib/Transforms/Inliner.cpp
@@ -273,10 +273,6 @@ public:
   /// Reset the nodes of this SCC with those provided.
   void reset(const std::vector<CallGraphNode *> &newNodes) { nodes = newNodes; }
 
-  bool has(CallGraphNode *node) {
-    return std::count(nodes.begin(), nodes.end(), node) > 0;
-  }
-
   /// Remove the given node from this SCC.
   void remove(CallGraphNode *node) {
     auto it = llvm::find(nodes, node);

--- a/mlir/test/Transforms/inlining-recursive-self.mlir
+++ b/mlir/test/Transforms/inlining-recursive-self.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-opt %s -inline='default-pipeline=''' | FileCheck %s
+// RUN: mlir-opt %s --mlir-disable-threading -inline='default-pipeline=''' | FileCheck %s
+
+// CHECK-LABEL: func.func @b0
+func.func @b0() {
+  // CHECK:         call @b0
+  // CHECK-NEXT:    call @b1
+  // CHECK-NEXT:    call @b0
+  // CHECK-NEXT:    call @b1
+  // CHECK-NEXT:    call @b0
+  func.call @b0() : () -> ()
+  func.call @b1() : () -> ()
+  func.call @b0() : () -> ()
+  func.call @b1() : () -> ()
+  func.call @b0() : () -> ()
+  return
+}
+func.func @b1() {
+  func.call @b1() : () -> ()
+  func.call @b1() : () -> ()
+  return
+}


### PR DESCRIPTION
We cannot get any benifit from inlining self-recursive function.
This patch want to detect this cases and ignore it.