### PR TITLE
[flang] Produce warning instead of error when bound checking arrays

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -416,12 +416,11 @@ void ExpressionAnalyzer::CheckConstantSubscripts(ArrayRef &ref) {
           msg =
               "Subscript %jd is greater than upper bound %jd for dimension %d of array"_err_en_US;
           bound = *dimUB;
-          if (dim + 1 == arraySymbol.Rank() && IsDummy(arraySymbol) &&
-              *bound == 1) {
-            // Old-school overindexing of a dummy array isn't fatal when
-            // it's on the last dimension and the extent is 1.
-            msg->set_severity(parser::Severity::Warning);
-          }
+          // Even though this constitudes a violation of the Fortran
+          // standard, we should use a warning instead of a fatal error.
+          // This is in line with other compilers and can be turned
+          // into a fatal error using -Werror.
+          msg->set_severity(parser::Severity::Warning);
         }
         if (msg) {
           AttachDeclaration(

--- a/flang/test/Semantics/expr-errors06.f90
+++ b/flang/test/Semantics/expr-errors06.f90
@@ -7,35 +7,35 @@ subroutine subr(da)
   !ERROR: DATA statement designator 'a(0_8)' is out of range
   !ERROR: DATA statement designator 'a(11_8)' is out of range
   data a(0)/0./, a(10+1)/0./
-  !ERROR: Subscript 0 is less than lower bound 1 for dimension 1 of array
+  !WARNING: Subscript 0 is less than lower bound 1 for dimension 1 of array
   print *, a(0)
-  !ERROR: Subscript 0 is less than lower bound 1 for dimension 1 of array
+  !WARNING: Subscript 0 is less than lower bound 1 for dimension 1 of array
   print *, a(1-1)
-  !ERROR: Subscript 11 is greater than upper bound 10 for dimension 1 of array
+  !WARNING: Subscript 11 is greater than upper bound 10 for dimension 1 of array
   print *, a(11)
-  !ERROR: Subscript 11 is greater than upper bound 10 for dimension 1 of array
+  !WARNING: Subscript 11 is greater than upper bound 10 for dimension 1 of array
   print *, a(10+1)
-  !ERROR: Subscript value (0) is out of range on dimension 1 in reference to a constant array value
+  !WARNING: Subscript value (0) is out of range on dimension 1 in reference to a constant array value
   print *, n(0)
-  !ERROR: Subscript value (3) is out of range on dimension 1 in reference to a constant array value
+  !WARNING: Subscript value (3) is out of range on dimension 1 in reference to a constant array value
   print *, n(4-1)
   print *, a(1:12:3) ! ok
-  !ERROR: Subscript 13 is greater than upper bound 10 for dimension 1 of array
+  !WARNING: Subscript 13 is greater than upper bound 10 for dimension 1 of array
   print *, a(1:13:3)
   print *, a(10:-1:-3) ! ok
-  !ERROR: Subscript -2 is less than lower bound 1 for dimension 1 of array
+  !WARNING: Subscript -2 is less than lower bound 1 for dimension 1 of array
   print *, a(10:-2:-3)
   print *, a(-1:-2) ! empty section is ok
   print *, a(0:11:-1) ! empty section is ok
-  !ERROR: Subscript 0 is less than lower bound 1 for dimension 1 of array
+  !WARNING: Subscript 0 is less than lower bound 1 for dimension 1 of array
   print *, a(0:0:unknown) ! lower==upper, can ignore stride
-  !ERROR: Subscript 11 is greater than upper bound 10 for dimension 1 of array
+  !WARNING: Subscript 11 is greater than upper bound 10 for dimension 1 of array
   print *, a(11:11:unknown) ! lower==upper, can ignore stride
-  !ERROR: Subscript 0 is less than lower bound 1 for dimension 1 of array
+  !WARNING: Subscript 0 is less than lower bound 1 for dimension 1 of array
   print *, da(0,1)
-  !ERROR: Subscript 3 is greater than upper bound 2 for dimension 1 of array
+  !WARNING: Subscript 3 is greater than upper bound 2 for dimension 1 of array
   print *, da(3,1)
-  !ERROR: Subscript 0 is less than lower bound 1 for dimension 2 of array
+  !WARNING: Subscript 0 is less than lower bound 1 for dimension 2 of array
   print *, da(1,0)
   !WARNING: Subscript 2 is greater than upper bound 1 for dimension 2 of array
   print *, da(1,2)


### PR DESCRIPTION
Fixes issue #82684.

While out-of-bounds accesses are not permitted by the Fortran standard, the compiler should not produce a fatal error but emit a warning.  This is inline with other compilers and can easily be turned into an error via `-Werror`.