### PR TITLE
[clang][dataflow] Skip array types when handling InitListExprs.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -671,8 +671,8 @@ public:
     }
 
     if (!Type->isStructureOrClassType()) {
-      // Until array initialization is implemented, we skip arrays and don't need
-      // to care about cases where `getNumInits() > 1`.
+      // Until array initialization is implemented, we skip arrays and don't
+      // need to care about cases where `getNumInits() > 1`.
       if (!Type->isArrayType() && S->getNumInits() == 1)
         propagateValueOrStorageLocation(*S->getInit(0), *S, Env);
       return;

--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -671,9 +671,9 @@ public:
     }
 
     if (!Type->isStructureOrClassType()) {
-      // Until array initialization is implemented, we don't need to care about
-      // cases where `getNumInits() > 1`.
-      if (S->getNumInits() == 1)
+      // Until array initialization is implemented, we skip arrays and don't need
+      // to care about cases where `getNumInits() > 1`.
+      if (!Type->isArrayType() && S->getNumInits() == 1)
         propagateValueOrStorageLocation(*S->getInit(0), *S, Env);
       return;
     }

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -2367,6 +2367,21 @@ TEST(TransferTest, InitListExprAsXValue) {
       });
 }
 
+TEST(TransferTest, ArrayInitListExprOneRecordElement) {
+  // This is a crash repro.
+  std::string Code = R"cc(
+    struct S {};
+
+    void target() { S foo[] = {S()}; }
+  )cc";
+  runDataflow(
+      Code,
+      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
+         ASTContext &ASTCtx) {
+        // Just verify that it doesn't crash.
+      });
+}
+
 TEST(TransferTest, InitListExprAsUnion) {
   // This is a crash repro.
   std::string Code = R"cc(
@@ -3414,7 +3429,7 @@ TEST(TransferTest, AggregateInitializationFunctionPointer) {
     struct S {
       void (*const Field)();
     };
-    
+
     void target() {
       S s{nullptr};
     }


### PR DESCRIPTION
Crashes resulted from single-element InitListExprs for arrays with elements of a record type after #80970.