### PR TITLE
[Clang][Sema] Fix crash when MS dependent base class lookup occurs in an incomplete context

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -283,10 +283,9 @@ Bug Fixes to C++ Support
   (`#78524 <https://github.com/llvm/llvm-project/issues/78524>`_)
 - Clang no longer instantiates the exception specification of discarded candidate function
   templates when determining the primary template of an explicit specialization.
-- Fixed a crash in Microsoft compatibility mode where unqualified dependent base class lookup
-  occurs in an incomplete class.
+- Fixed a crash in Microsoft compatibility mode where unqualified dependent base class
+  lookup searches the bases of an incomplete class.
 
-in Microsoft compatibility  mode where unqualified dependent base class lookup occurs on an incomplete class.
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -283,6 +283,7 @@ Bug Fixes to C++ Support
   (`#78524 <https://github.com/llvm/llvm-project/issues/78524>`_)
 - Clang no longer instantiates the exception specification of discarded candidate function
   templates when determining the primary template of an explicit specialization.
+- Fixed a crash when MS unqualified dependent base class lookup occurs in an incomplete class.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -283,8 +283,10 @@ Bug Fixes to C++ Support
   (`#78524 <https://github.com/llvm/llvm-project/issues/78524>`_)
 - Clang no longer instantiates the exception specification of discarded candidate function
   templates when determining the primary template of an explicit specialization.
-- Fixed a crash when MS unqualified dependent base class lookup occurs in an incomplete class.
+- Fixed a crash in Microsoft compatibility mode where unqualified dependent base class lookup
+  occurs in an incomplete class.
 
+in Microsoft compatibility  mode where unqualified dependent base class lookup occurs on an incomplete class.
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2653,7 +2653,7 @@ recoverFromMSUnqualifiedLookup(Sema &S, ASTContext &Context,
     RD = ThisType->getPointeeType()->getAsCXXRecordDecl();
   else if (auto *MD = dyn_cast<CXXMethodDecl>(S.CurContext))
     RD = MD->getParent();
-  if (!RD || !RD->hasAnyDependentBases())
+  if (!RD || !RD->hasDefinition() || !RD->hasAnyDependentBases())
     return nullptr;
 
   // Diagnose this as unqualified lookup into a dependent base class.  If 'this'

--- a/clang/test/SemaTemplate/ms-lookup-template-base-classes.cpp
+++ b/clang/test/SemaTemplate/ms-lookup-template-base-classes.cpp
@@ -71,6 +71,13 @@ public:
 
 template class B<int>;
 
+template<typename T> struct C;
+
+// Test lookup with incomplete lookup context
+template<typename T>
+auto C<T>::f() -> decltype(x) { } // expected-error {{use of undeclared identifier 'x'}}
+                                  // expected-error@-1 {{out-of-line definition of 'f' from class 'C<T>' without definition}}
+
 }
 
 


### PR DESCRIPTION
When compiling the following with `-fms-compatibility`:
```cpp
template<typename T> struct C;

// Test lookup with incomplete lookup context
template<typename T>
auto C<T>::f() -> decltype(x) { }
```
An assert fails because `CXXRecordDecl::hasAnyDependentBases` is called on an incomplete class. This patch ensures we don't perform unqualified lookup into dependent base classes when the lookup context is incomplete.
