### PR TITLE
[libc++][modules] Fixes naming inconsistency.

### DIFF
--- a/libcxx/modules/modules.json.in
+++ b/libcxx/modules/modules.json.in
@@ -5,7 +5,7 @@
     {
       "logical-name": "std",
       "source-path": "@LIBCXX_MODULE_RELATIVE_PATH@/std.cppm",
-      "is-standard-library": true,
+      "is-std-library": true,
       "local-arguments": {
         "system-include-directories": [
           "@LIBCXX_MODULE_RELATIVE_PATH@"


### PR DESCRIPTION
The modules used is-standard-library and is-std-library. The latter is the name used in the SG15 proposal,

Fixes: https://github.com/llvm/llvm-project/issues/82879