### PR TITLE
[LLVM][DWARF] Make dwarf::getDebugNamesBucketCount return a pair.

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -616,20 +616,21 @@ enum AcceleratorTable {
 // Uniquify the string hashes and calculate the bucket count for the
 // DWARF v5 Accelerator Table. NOTE: This function effectively consumes the
 // 'hashes' input parameter.
-inline uint32_t getDebugNamesBucketCount(MutableArrayRef<uint32_t> hashes,
-                                         uint32_t &uniqueHashCount) {
-  uint32_t BucketCount = 0;
+inline std::pair<uint32_t, uint32_t> getDebugNamesBucketAndHashCount(
+    MutableArrayRef<uint32_t> hashes) {
+  uint32_t uniqueHashCount = 0;
+  uint32_t bucketCount = 0;
 
   sort(hashes);
   uniqueHashCount = llvm::unique(hashes) - hashes.begin();
   if (uniqueHashCount > 1024)
-    BucketCount = uniqueHashCount / 4;
+    bucketCount = uniqueHashCount / 4;
   else if (uniqueHashCount > 16)
-    BucketCount = uniqueHashCount / 2;
+    bucketCount = uniqueHashCount / 2;
   else
-    BucketCount = std::max<uint32_t>(uniqueHashCount, 1);
+    bucketCount = std::max<uint32_t>(uniqueHashCount, 1);
 
-  return BucketCount;
+  return {bucketCount, uniqueHashCount};
 }
 
 // Constants for the GNU pubnames/pubtypes extensions supporting gdb index.

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -617,19 +617,19 @@ enum AcceleratorTable {
 // DWARF v5 Accelerator Table. NOTE: This function effectively consumes the
 // 'hashes' input parameter.
 inline std::pair<uint32_t, uint32_t>
-getDebugNamesBucketAndHashCount(MutableArrayRef<uint32_t> hashes) {
-  uint32_t bucketCount = 0;
+getDebugNamesBucketAndHashCount(MutableArrayRef<uint32_t> Hashes) {
+  uint32_t BucketCount = 0;
 
-  sort(hashes);
-  uint32_t uniqueHashCount = llvm::unique(hashes) - hashes.begin();
-  if (uniqueHashCount > 1024)
-    bucketCount = uniqueHashCount / 4;
-  else if (uniqueHashCount > 16)
-    bucketCount = uniqueHashCount / 2;
+  sort(Hashes);
+  uint32_t UniqueHashCount = llvm::unique(Hashes) - Hashes.begin();
+  if (UniqueHashCount > 1024)
+    BucketCount = UniqueHashCount / 4;
+  else if (UniqueHashCount > 16)
+    BucketCount = UniqueHashCount / 2;
   else
-    bucketCount = std::max<uint32_t>(uniqueHashCount, 1);
+    BucketCount = std::max<uint32_t>(UniqueHashCount, 1);
 
-  return {bucketCount, uniqueHashCount};
+  return {BucketCount, UniqueHashCount};
 }
 
 // Constants for the GNU pubnames/pubtypes extensions supporting gdb index.

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -615,7 +615,7 @@ enum AcceleratorTable {
 
 // Uniquify the string hashes and calculate the bucket count for the
 // DWARF v5 Accelerator Table. NOTE: This function effectively consumes the
-// 'hashes' input parameter.
+// 'Hashes' input parameter.
 inline std::pair<uint32_t, uint32_t>
 getDebugNamesBucketAndHashCount(MutableArrayRef<uint32_t> Hashes) {
   uint32_t BucketCount = 0;

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -616,13 +616,12 @@ enum AcceleratorTable {
 // Uniquify the string hashes and calculate the bucket count for the
 // DWARF v5 Accelerator Table. NOTE: This function effectively consumes the
 // 'hashes' input parameter.
-inline std::pair<uint32_t, uint32_t> getDebugNamesBucketAndHashCount(
-    MutableArrayRef<uint32_t> hashes) {
-  uint32_t uniqueHashCount = 0;
+inline std::pair<uint32_t, uint32_t>
+getDebugNamesBucketAndHashCount(MutableArrayRef<uint32_t> hashes) {
   uint32_t bucketCount = 0;
 
   sort(hashes);
-  uniqueHashCount = llvm::unique(hashes) - hashes.begin();
+  uint32_t uniqueHashCount = llvm::unique(hashes) - hashes.begin();
   if (uniqueHashCount > 1024)
     bucketCount = uniqueHashCount / 4;
   else if (uniqueHashCount > 16)

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -38,9 +38,9 @@ void AccelTableBase::computeBucketCount() {
   for (const auto &E : Entries)
     Uniques.push_back(E.second.HashValue);
 
-  auto counts = llvm::dwarf::getDebugNamesBucketAndHashCount(Uniques);
-  BucketCount = counts.first;
-  UniqueHashCount = counts.second;
+  auto Counts = llvm::dwarf::getDebugNamesBucketAndHashCount(Uniques);
+  BucketCount = Counts.first;
+  UniqueHashCount = Counts.second;
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -38,7 +38,9 @@ void AccelTableBase::computeBucketCount() {
   for (const auto &E : Entries)
     Uniques.push_back(E.second.HashValue);
 
-  BucketCount = llvm::dwarf::getDebugNamesBucketCount(Uniques, UniqueHashCount);
+  auto counts = llvm::dwarf::getDebugNamesBucketAndHashCount(Uniques);
+  BucketCount = counts.first;
+  UniqueHashCount = counts.second;
 }
 
 void AccelTableBase::finalize(AsmPrinter *Asm, StringRef Prefix) {


### PR DESCRIPTION
llvm::dwarf::getDebugNamesBucketCount directly returns the bucket count, via return statement, but it also returns the hash count via a parameter. This changes the function to return them both as a std::pair, in the return statement. It also changes the name of the function to make it clear it returns both values.