### PR TITLE
[OpenMP] Fix distributed barrier hang for OMP_WAIT_POLICY=passive

### DIFF
--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -5708,9 +5708,8 @@ void __kmp_free_team(kmp_root_t *root,
           }
 #endif
           // first check if thread is sleeping
-          kmp_flag_64<> fl(&th->th.th_bar[bs_forkjoin_barrier].bb.b_go, th);
-          if (fl.is_sleeping())
-            fl.resume(__kmp_gtid_from_thread(th));
+          if (th->th.th_sleep_loc)
+            __kmp_null_resume_wrapper(th);
           KMP_CPU_PAUSE();
         }
       }

--- a/openmp/runtime/test/barrier/llvm-issue-80664.c
+++ b/openmp/runtime/test/barrier/llvm-issue-80664.c
@@ -1,8 +1,12 @@
 // RUN: %libomp-compile
-// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='linear,linear' %libomp-run
-// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='tree,tree' %libomp-run
-// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='hyper,hyper' %libomp-run
-// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='dist,dist' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive \
+// RUN:     KMP_FORKJOIN_BARRIER_PATTERN='linear,linear' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive \
+// RUN:     KMP_FORKJOIN_BARRIER_PATTERN='tree,tree' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive \
+// RUN:     KMP_FORKJOIN_BARRIER_PATTERN='hyper,hyper' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive \
+// RUN:     KMP_FORKJOIN_BARRIER_PATTERN='dist,dist' %libomp-run
 //
 // LLVM ISSUE 80664: https://github.com/llvm/llvm-project/issues/80664
 //
@@ -15,13 +19,12 @@
 
 int a = 0;
 
-void test_omp_barrier()
-{
-  #pragma omp parallel
+void test_omp_barrier() {
+#pragma omp parallel
   {
-    #pragma omp task
+#pragma omp task
     {
-      #pragma omp atomic
+#pragma omp atomic
       a++;
     }
   }

--- a/openmp/runtime/test/barrier/llvm-issue-80664.c
+++ b/openmp/runtime/test/barrier/llvm-issue-80664.c
@@ -1,0 +1,34 @@
+// RUN: %libomp-compile
+// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='linear,linear' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='tree,tree' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='hyper,hyper' %libomp-run
+// RUN: env OMP_WAIT_POLICY=passive KMP_FORKJOIN_BARRIER_PATTERN='dist,dist' %libomp-run
+//
+// LLVM ISSUE 80664: https://github.com/llvm/llvm-project/issues/80664
+//
+// Distributed barrier + OMP_WAIT_POLICY=passive hangs in library termination
+// Reason: the resume logic in __kmp_free_team() was faulty and, when checking
+// for sleep status, didn't look at correct location for distributed barrier.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int a = 0;
+
+void test_omp_barrier()
+{
+  #pragma omp parallel
+  {
+    #pragma omp task
+    {
+      #pragma omp atomic
+      a++;
+    }
+  }
+}
+
+int main() {
+  test_omp_barrier();
+  printf("a = %d\n", a);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The resume thread logic inside __kmp_free_team() is faulty. Only checking b_go for sleep status doesn't wake up distributed barrier. Change to generic check for th_sleep_loc and calling __kmp_null_resume_wrapper().

Fixes: #80664