### PR TITLE
[clang][Diagnostics] Add CLANG_HIGHLIGHT_COLORS= to configure syntax highlighting in diagnostics (#82945)

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -256,6 +256,17 @@ output format of the diagnostics that it generates.
    defined and ``-fcolor-diagnostics`` is passed on the command line, Clang
    will honor the command line argument.
 
+   Additionally, if enabled, Clang will semantically highlight the code
+   the diagnostics pertain to. The ``CLANG_HIGHLIGHT_COLORS`` environment
+   variable controls this behaviour:
+   if unset or set to "on", code is highlighted normally.
+   If set to "off" or "no", highlighting is disabled.
+   Otherwise, a comma-separated, `token=color` list may be given,
+   where `token`s may be ``comment``, ``literal``, or ``keyword``,
+   and `color`s may be ``{bright-,}black,red,green,yellow,blue,magenta,cyan,white``.
+   If an unknown `color` is given, it's disabled. For example, a valid spec may be
+   ``CLANG_HIGHLIGHT_COLORS=comment=blue,literal=bright-magenta,keyword=no``.
+
 .. option:: -fansi-escape-codes
 
    Controls whether ANSI escape codes are used instead of the Windows Console

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -133,6 +133,9 @@ public:
   static constexpr Colors SAVEDCOLOR = Colors::SAVEDCOLOR;
   static constexpr Colors RESET = Colors::RESET;
 
+  static std::optional<Colors>
+  parse_color(const std::string_view &name) noexcept;
+
   explicit raw_ostream(bool unbuffered = false,
                        OStreamKind K = OStreamKind::OK_OStream)
       : Kind(K), BufferMode(unbuffered ? BufferKind::Unbuffered

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstdio>
+#include <string_view>
 #include <sys/stat.h>
 
 // <fcntl.h> may provide O_BINARY.
@@ -62,6 +63,7 @@
 #endif
 
 using namespace llvm;
+using namespace std::literals;
 
 constexpr raw_ostream::Colors raw_ostream::BLACK;
 constexpr raw_ostream::Colors raw_ostream::RED;
@@ -73,6 +75,44 @@ constexpr raw_ostream::Colors raw_ostream::CYAN;
 constexpr raw_ostream::Colors raw_ostream::WHITE;
 constexpr raw_ostream::Colors raw_ostream::SAVEDCOLOR;
 constexpr raw_ostream::Colors raw_ostream::RESET;
+
+std::optional<raw_ostream::Colors>
+raw_ostream::parse_color(const std::string_view &name) noexcept {
+  if (name == "black"sv)
+    return Colors::BLACK;
+  else if (name == "red"sv)
+    return Colors::RED;
+  else if (name == "green"sv)
+    return Colors::GREEN;
+  else if (name == "yellow"sv)
+    return Colors::YELLOW;
+  else if (name == "blue"sv)
+    return Colors::BLUE;
+  else if (name == "magenta"sv)
+    return Colors::MAGENTA;
+  else if (name == "cyan"sv)
+    return Colors::CYAN;
+  else if (name == "white"sv)
+    return Colors::WHITE;
+  else if (name == "bright-black"sv)
+    return Colors::BRIGHT_BLACK;
+  else if (name == "bright-red"sv)
+    return Colors::BRIGHT_RED;
+  else if (name == "bright-green"sv)
+    return Colors::BRIGHT_GREEN;
+  else if (name == "bright-yellow"sv)
+    return Colors::BRIGHT_YELLOW;
+  else if (name == "bright-blue"sv)
+    return Colors::BRIGHT_BLUE;
+  else if (name == "bright-magenta"sv)
+    return Colors::BRIGHT_MAGENTA;
+  else if (name == "bright-cyan"sv)
+    return Colors::BRIGHT_CYAN;
+  else if (name == "bright-white"sv)
+    return Colors::BRIGHT_WHITE;
+  else
+    return std::nullopt;
+}
 
 raw_ostream::~raw_ostream() {
   // raw_ostream's subclasses should take care to flush the buffer


### PR DESCRIPTION
![](https://github.com/llvm/llvm-project/assets/6709544/5b540e17-a7aa-4188-87b7-be70cebce300)

`CLANG_HIGHLIGHT_COLORS=on` is equivalent to unset, and enables the default.

`CLANG_HIGHLIGHT_COLORS=off` (or `=no`, or anything to that effect) disables highlighting altogether.

`CLANG_HIGHLIGHT_COLORS=comment=red` highlights comments in red, and the rest as-default.

`CLANG_HIGHLIGHT_COLORS=comment=blue,literal=bright-magenta,keyword=no` highlights comments in blue, literals in bright magenta, and doesn't highlight keywords.

Also documentation because the original didn't have it.