### PR TITLE
[ItaniumDemangle] reject A-F in FP literals

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -5540,7 +5540,7 @@ Node *AbstractManglingParser<Alloc, Derived>::parseFloatingLiteral() {
     return nullptr;
   std::string_view Data(First, N);
   for (char C : Data)
-    if (!std::isxdigit(C))
+    if (!(C >= '0' && C <= '9') && !(C >= 'a' && C <= 'f'))
       return nullptr;
   First += N;
   if (!consumeIf('E'))


### PR DESCRIPTION
Sync this change to the copy of ItaniumDemangle.h in "llvm":

https://github.com/llvm/llvm-project/pull/82864

The Itanium C++ ABI specifies that FP literals are encoded using a lowercase hexadecimal string. Previously, libc++abi allowed uppercase A-F characters but decoded them by subtracting 'a' from them, producing negative digit values. It is especially confusing to accept an 'E' digit because 'E' marks the end of the FP literal.
