### PR TITLE
Default to LLDB debugger tuning for shared library builds

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1061,6 +1061,17 @@ if (LLVM_USE_SPLIT_DWARF AND
   endif()
 endif()
 
+if (BUILD_SHARED_LIBS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+    ((uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG") OR
+     (uppercase_CMAKE_BUILD_TYPE STREQUAL "RELWITHDEBINFO")))
+  # When using a shared libraries build, tune the debug info output for LLDB
+  # (which enables standalone debug info) since otherwise LLDB users will not be
+  # able to print types from other shared libraries (e.g. SmallVector printing
+  # will only work inside libLLVMSupport).
+  # See https://github.com/llvm/llvm-project/issues/60994#issuecomment-1447337360
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-glldb>)
+endif()
+
 add_compile_definitions(__STDC_CONSTANT_MACROS)
 add_compile_definitions(__STDC_FORMAT_MACROS)
 add_compile_definitions(__STDC_LIMIT_MACROS)


### PR DESCRIPTION
Currently, it is not possible to sensibly debug LLVM using shared library builds with LLDB since types are not resolved across shared library boundaries. As a workaround we can enable -glldb to emit standalone debug info which ensures we get a working debugging experience at the expense of increased disk usage.

See https://github.com/llvm/llvm-project/issues/60994#issuecomment-1447337360
and the closed https://github.com/llvm/llvm-project/pull/82527.