### PR TITLE
[lldb] Add SBProcess methods for get/set/use address masks

### DIFF
--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -437,12 +437,12 @@ public:
   /// before reading from memory.
   ///
   /// \param[in] type
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     eAddressMaskTypeAny is often a suitable value when code and
   ///     data masks are the same on a given target.
   ///
   /// \param[in] addr_range
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     This will default to eAddressMaskRangeLow which is the
   ///     only set of masks used normally.
   ///
@@ -457,7 +457,7 @@ public:
   /// before reading from memory.
   ///
   /// \param[in] type
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     eAddressMaskTypeAll is often a suitable value when the
   ///     same mask is being set for both code and data.
   ///
@@ -466,7 +466,7 @@ public:
   ///     should be set to 1 in the mask.
   ///
   /// \param[in] addr_range
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     This will default to eAddressMaskRangeLow which is the
   ///     only set of masks used normally.
   void SetAddressMask(
@@ -475,13 +475,14 @@ public:
 
   /// Set the number of bits used for addressing in this Process.
   ///
-  /// In some environments, the number of bits that are used for addressing
-  /// is the natural representation instead of a mask, but lldb
-  /// internally represents this as a mask.  This method calculates
-  /// the addressing mask that lldb uses that number of addressable bits.
+  /// On Darwin and similar systems, the addressable bits are expressed
+  /// as the number of low order bits that are relevant to addressing,
+  /// instead of a more general address mask.
+  /// This method calculates the correct mask value for a given number
+  /// of low order addressable bits.
   ///
   /// \param[in] type
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     eAddressMaskTypeAll is often a suitable value when the
   ///     same mask is being set for both code and data.
   ///
@@ -492,7 +493,7 @@ public:
   ///     metadata like pointer authentication, Type Byte Ignore, etc.
   ///
   /// \param[in] addr_range
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     This will default to eAddressMaskRangeLow which is the
   ///     only set of masks used normally.
   void
@@ -510,7 +511,7 @@ public:
   ///     The address that should be cleared of non-addressable bits.
   ///
   /// \param[in] type
-  ///     See \ref Mask Address Methods descripton of this argument.
+  ///     See \ref Mask Address Methods description of this argument.
   ///     eAddressMaskTypeAny is the default value, correct when it
   ///     is unknown if the address is a code or data address.
   lldb::addr_t

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -426,7 +426,7 @@ public:
   /// which is an AddressMaskRange enum value.
   /// Needing to specify the address range is highly unusual, and the
   /// default argument can be used in nearly all circumstances.
-  /// On some architectures like AArch64, it is possible to have
+  /// On some architectures (e.g., AArch64), it is possible to have
   /// different page table setups for low and high memory, so different
   /// numbers of bits relevant to addressing. It is possible to have
   /// a program running in one half of memory and accessing the other
@@ -488,8 +488,8 @@ public:
   ///
   /// \param[in] num_bits
   ///     Number of bits that are used for addressing.
-  ///     A value of 42 indicates that the low 42 bits are relevant for
-  ///     addressing, and that higher order bits may be used for various
+  ///     For example, a value of 42 indicates that the low 42 bits are relevant for
+  ///     addressing, and that higher-order bits may be used for various
   ///     metadata like pointer authentication, Type Byte Ignore, etc.
   ///
   /// \param[in] addr_range

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -416,10 +416,11 @@ public:
   /// There can be different address masks for code addresses and
   /// data addresses, this argument can select which to get/set,
   /// or to use when clearing non-addressable bits from an address.
-  /// On AArch32 code with arm+thumb code, where instructions start
-  /// on even addresses, the 0th bit may be used to indicate that
-  /// a function is thumb code.  On such a target, the eAddressMaskTypeCode
-  /// may clear the 0th bit from an address to get the actual address.
+  /// This choice of mask can be important for example on AArch32 systems. Where
+  /// instructions where instructions start on even addresses, the 0th bit may
+  /// be used to indicate that a function is thumb code.  On such a target, the
+  /// eAddressMaskTypeCode may clear the 0th bit from an address to get the
+  /// actual address Whereas eAddressMaskTypeData would not.
   ///
   /// \a addr_range
   /// Many of the methods in this group take an \a addr_range argument
@@ -500,7 +501,7 @@ public:
   SetAddressableBits(AddressMaskType type, uint32_t num_bits,
                      AddressMaskRange addr_range = lldb::eAddressMaskRangeLow);
 
-  /// Clear the non-addressable bits of an \a addr value and return a
+  /// Clear the non-address bits of an \a addr value and return a
   /// virtual address in memory.
   ///
   /// Bits that are not used in addressing may be used for other purposes;
@@ -508,7 +509,7 @@ public:
   /// of armv7 code addresses to indicate arm/thumb are common examples.
   ///
   /// \param[in] addr
-  ///     The address that should be cleared of non-addressable bits.
+  ///     The address that should be cleared of non-address bits.
   ///
   /// \param[in] type
   ///     See \ref Mask Address Methods description of this argument.

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -416,11 +416,11 @@ public:
   /// There can be different address masks for code addresses and
   /// data addresses, this argument can select which to get/set,
   /// or to use when clearing non-addressable bits from an address.
-  /// This choice of mask can be important for example on AArch32 systems. Where
-  /// instructions where instructions start on even addresses, the 0th bit may
-  /// be used to indicate that a function is thumb code.  On such a target, the
-  /// eAddressMaskTypeCode may clear the 0th bit from an address to get the
-  /// actual address Whereas eAddressMaskTypeData would not.
+  /// This choice of mask can be important for example on AArch32
+  /// systems. Where instructions where instructions start on even addresses,
+  /// the 0th bit may be used to indicate that a function is thumb code.  On
+  /// such a target, the eAddressMaskTypeCode may clear the 0th bit from an
+  /// address to get the actual address Whereas eAddressMaskTypeData would not.
   ///
   /// \a addr_range
   /// Many of the methods in this group take an \a addr_range argument
@@ -489,9 +489,10 @@ public:
   ///
   /// \param[in] num_bits
   ///     Number of bits that are used for addressing.
-  ///     For example, a value of 42 indicates that the low 42 bits are relevant for
-  ///     addressing, and that higher-order bits may be used for various
-  ///     metadata like pointer authentication, Type Byte Ignore, etc.
+  ///     For example, a value of 42 indicates that the low 42 bits
+  ///     are relevant for addressing, and that higher-order bits may
+  ///     be used for various metadata like pointer authentication,
+  ///     Type Byte Ignore, etc.
   ///
   /// \param[in] addr_range
   ///     See \ref Mask Address Methods description of this argument.

--- a/lldb/include/lldb/Utility/AddressableBits.h
+++ b/lldb/include/lldb/Utility/AddressableBits.h
@@ -10,6 +10,7 @@
 #define LLDB_UTILITY_ADDRESSABLEBITS_H
 
 #include "lldb/lldb-forward.h"
+#include "lldb/lldb-public.h"
 
 namespace lldb_private {
 
@@ -32,6 +33,8 @@ public:
   void SetLowmemAddressableBits(uint32_t lowmem_addressing_bits);
 
   void SetHighmemAddressableBits(uint32_t highmem_addressing_bits);
+
+  static lldb::addr_t AddressableBitToMask(uint32_t addressable_bits);
 
   void SetProcessMasks(lldb_private::Process &process);
 

--- a/lldb/include/lldb/lldb-defines.h
+++ b/lldb/include/lldb/lldb-defines.h
@@ -128,7 +128,9 @@
 #endif
 
 /// Address Mask
-#define LLDB_INVALID_ADDRESS_MASK 0
+/// Bits not used for addressing are set to 1 in the mask;
+/// all mask bits set is an invalid value.
+#define LLDB_INVALID_ADDRESS_MASK UINT64_MAX
 
 // ignore GCC function attributes
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/lldb/include/lldb/lldb-defines.h
+++ b/lldb/include/lldb/lldb-defines.h
@@ -127,6 +127,9 @@
 #define MAX_PATH 260
 #endif
 
+/// Address Mask
+#define LLDB_INVALID_ADDRESS_MASK 0
+
 // ignore GCC function attributes
 #if defined(_MSC_VER) && !defined(__clang__)
 #define __attribute__(X)

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1323,6 +1323,20 @@ enum SymbolDownload {
   eSymbolDownloadForeground = 2,
 };
 
+enum AddressMaskType {
+  eAddressMaskTypeCode = 0,
+  eAddressMaskTypeData,
+  eAddressMaskTypeAny,
+  eAddressMaskTypeAll = eAddressMaskTypeAny
+};
+
+enum AddressMaskRange {
+  eAddressMaskRangeLow = 0,
+  eAddressMaskRangeHigh,
+  eAddressMaskRangeAny,
+  eAddressMaskRangeAll = eAddressMaskRangeAny,
+};
+
 } // namespace lldb
 
 #endif // LLDB_LLDB_ENUMERATIONS_H

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1323,6 +1323,7 @@ enum SymbolDownload {
   eSymbolDownloadForeground = 2,
 };
 
+/// Used in the SBProcess AddressMask/FixAddress methods.
 enum AddressMaskType {
   eAddressMaskTypeCode = 0,
   eAddressMaskTypeData,
@@ -1330,6 +1331,7 @@ enum AddressMaskType {
   eAddressMaskTypeAll = eAddressMaskTypeAny
 };
 
+/// Used in the SBProcess AddressMask/FixAddress methods.
 enum AddressMaskRange {
   eAddressMaskRangeLow = 0,
   eAddressMaskRangeHigh,

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1255,6 +1255,95 @@ lldb::SBFileSpec SBProcess::GetCoreFile() {
   return SBFileSpec(core_file);
 }
 
+addr_t SBProcess::GetAddressMask(AddressMaskType type,
+                                 AddressMaskRange addr_range) {
+  LLDB_INSTRUMENT_VA(this, type, addr_range);
+  addr_t default_mask = 0;
+  if (ProcessSP process_sp = GetSP()) {
+    switch (type) {
+    case eAddressMaskTypeCode:
+      if (addr_range == eAddressMaskRangeHigh)
+        return process_sp->GetHighmemCodeAddressMask();
+      else
+        return process_sp->GetCodeAddressMask();
+    case eAddressMaskTypeData:
+      if (addr_range == eAddressMaskRangeHigh)
+        return process_sp->GetHighmemDataAddressMask();
+      else
+        return process_sp->GetDataAddressMask();
+    case eAddressMaskTypeAny:
+      if (addr_range == eAddressMaskRangeHigh)
+        return process_sp->GetHighmemDataAddressMask();
+      else
+        return process_sp->GetDataAddressMask();
+    }
+  }
+  return default_mask;
+}
+
+void SBProcess::SetAddressMask(AddressMaskType type, addr_t mask,
+                               AddressMaskRange addr_range) {
+  LLDB_INSTRUMENT_VA(this, type, mask, addr_range);
+  if (ProcessSP process_sp = GetSP()) {
+    switch (type) {
+    case eAddressMaskTypeCode:
+      if (addr_range == eAddressMaskRangeAll) {
+        process_sp->SetCodeAddressMask(mask);
+        process_sp->SetHighmemCodeAddressMask(mask);
+      } else if (addr_range == eAddressMaskRangeHigh) {
+        process_sp->SetHighmemCodeAddressMask(mask);
+      } else {
+        process_sp->SetCodeAddressMask(mask);
+      }
+      break;
+    case eAddressMaskTypeData:
+      if (addr_range == eAddressMaskRangeAll) {
+        process_sp->SetDataAddressMask(mask);
+        process_sp->SetHighmemDataAddressMask(mask);
+      } else if (addr_range == eAddressMaskRangeHigh) {
+        process_sp->SetHighmemDataAddressMask(mask);
+      } else {
+        process_sp->SetDataAddressMask(mask);
+      }
+      break;
+    case eAddressMaskTypeAll:
+      if (addr_range == eAddressMaskRangeAll) {
+        process_sp->SetCodeAddressMask(mask);
+        process_sp->SetDataAddressMask(mask);
+        process_sp->SetHighmemCodeAddressMask(mask);
+        process_sp->SetHighmemDataAddressMask(mask);
+      } else if (addr_range == eAddressMaskRangeHigh) {
+        process_sp->SetHighmemCodeAddressMask(mask);
+        process_sp->SetHighmemDataAddressMask(mask);
+      } else {
+        process_sp->SetCodeAddressMask(mask);
+        process_sp->SetDataAddressMask(mask);
+      }
+      break;
+    }
+  }
+}
+
+void SBProcess::SetAddressableBits(AddressMaskType type, uint32_t num_bits,
+                                   AddressMaskRange addr_range) {
+  LLDB_INSTRUMENT_VA(this, type, num_bits, addr_range);
+  SetAddressMask(type, AddressableBits::AddressableBitToMask(num_bits),
+                 addr_range);
+}
+
+addr_t SBProcess::FixAddress(addr_t addr, AddressMaskType type) {
+  LLDB_INSTRUMENT_VA(this, addr, type);
+  if (ProcessSP process_sp = GetSP()) {
+    if (type == eAddressMaskTypeAny)
+      return process_sp->FixAnyAddress(addr);
+    else if (type == eAddressMaskTypeData)
+      return process_sp->FixDataAddress(addr);
+    else if (type == eAddressMaskTypeCode)
+      return process_sp->FixCodeAddress(addr);
+  }
+  return addr;
+}
+
 lldb::addr_t SBProcess::AllocateMemory(size_t size, uint32_t permissions,
                                        lldb::SBError &sb_error) {
   LLDB_INSTRUMENT_VA(this, size, permissions, sb_error);

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1258,7 +1258,7 @@ lldb::SBFileSpec SBProcess::GetCoreFile() {
 addr_t SBProcess::GetAddressMask(AddressMaskType type,
                                  AddressMaskRange addr_range) {
   LLDB_INSTRUMENT_VA(this, type, addr_range);
-  addr_t default_mask = 0;
+
   if (ProcessSP process_sp = GetSP()) {
     switch (type) {
     case eAddressMaskTypeCode:
@@ -1278,12 +1278,13 @@ addr_t SBProcess::GetAddressMask(AddressMaskType type,
         return process_sp->GetDataAddressMask();
     }
   }
-  return default_mask;
+  return LLDB_INVALID_ADDRESS_MASK;
 }
 
 void SBProcess::SetAddressMask(AddressMaskType type, addr_t mask,
                                AddressMaskRange addr_range) {
   LLDB_INSTRUMENT_VA(this, type, mask, addr_range);
+
   if (ProcessSP process_sp = GetSP()) {
     switch (type) {
     case eAddressMaskTypeCode:
@@ -1327,12 +1328,14 @@ void SBProcess::SetAddressMask(AddressMaskType type, addr_t mask,
 void SBProcess::SetAddressableBits(AddressMaskType type, uint32_t num_bits,
                                    AddressMaskRange addr_range) {
   LLDB_INSTRUMENT_VA(this, type, num_bits, addr_range);
+
   SetAddressMask(type, AddressableBits::AddressableBitToMask(num_bits),
                  addr_range);
 }
 
 addr_t SBProcess::FixAddress(addr_t addr, AddressMaskType type) {
   LLDB_INSTRUMENT_VA(this, addr, type);
+
   if (ProcessSP process_sp = GetSP()) {
     if (type == eAddressMaskTypeAny)
       return process_sp->FixAnyAddress(addr);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5682,21 +5682,22 @@ void Process::Flush() {
 
 lldb::addr_t Process::GetCodeAddressMask() {
   if (uint32_t num_bits_setting = GetVirtualAddressableBits())
-    return ~((1ULL << num_bits_setting) - 1);
+    return AddressableBits::AddressableBitToMask(num_bits_setting);
 
   return m_code_address_mask;
 }
 
 lldb::addr_t Process::GetDataAddressMask() {
   if (uint32_t num_bits_setting = GetVirtualAddressableBits())
-    return ~((1ULL << num_bits_setting) - 1);
+    return AddressableBits::AddressableBitToMask(num_bits_setting);
 
   return m_data_address_mask;
 }
 
 lldb::addr_t Process::GetHighmemCodeAddressMask() {
   if (uint32_t num_bits_setting = GetHighmemVirtualAddressableBits())
-    return ~((1ULL << num_bits_setting) - 1);
+    return AddressableBits::AddressableBitToMask(num_bits_setting);
+
   if (m_highmem_code_address_mask)
     return m_highmem_code_address_mask;
   return GetCodeAddressMask();
@@ -5704,7 +5705,8 @@ lldb::addr_t Process::GetHighmemCodeAddressMask() {
 
 lldb::addr_t Process::GetHighmemDataAddressMask() {
   if (uint32_t num_bits_setting = GetHighmemVirtualAddressableBits())
-    return ~((1ULL << num_bits_setting) - 1);
+    return AddressableBits::AddressableBitToMask(num_bits_setting);
+
   if (m_highmem_data_address_mask)
     return m_highmem_data_address_mask;
   return GetDataAddressMask();

--- a/lldb/source/Utility/AddressableBits.cpp
+++ b/lldb/source/Utility/AddressableBits.cpp
@@ -33,18 +33,26 @@ void AddressableBits::SetHighmemAddressableBits(
   m_high_memory_addr_bits = highmem_addressing_bits;
 }
 
+addr_t AddressableBits::AddressableBitToMask(uint32_t addressable_bits) {
+  assert(addressable_bits <= sizeof(addr_t) * 8);
+  if (addressable_bits == 64)
+    return 0; // all bits used for addressing
+  else
+    return ~((1ULL << addressable_bits) - 1);
+}
+
 void AddressableBits::SetProcessMasks(Process &process) {
   if (m_low_memory_addr_bits == 0 && m_high_memory_addr_bits == 0)
     return;
 
   if (m_low_memory_addr_bits != 0) {
-    addr_t low_addr_mask = ~((1ULL << m_low_memory_addr_bits) - 1);
+    addr_t low_addr_mask = AddressableBitToMask(m_low_memory_addr_bits);
     process.SetCodeAddressMask(low_addr_mask);
     process.SetDataAddressMask(low_addr_mask);
   }
 
   if (m_high_memory_addr_bits != 0) {
-    addr_t hi_addr_mask = ~((1ULL << m_high_memory_addr_bits) - 1);
+    addr_t hi_addr_mask = AddressableBitToMask(m_high_memory_addr_bits);
     process.SetHighmemCodeAddressMask(hi_addr_mask);
     process.SetHighmemDataAddressMask(hi_addr_mask);
   }

--- a/lldb/test/API/python_api/process/address-masks/Makefile
+++ b/lldb/test/API/python_api/process/address-masks/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
+++ b/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
@@ -1,0 +1,64 @@
+"""Test Python APIs for setting, getting, and using address masks."""
+
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class AddressMasksTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_address_masks(self):
+        self.build()
+        (target, process, t, bp) = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.c")
+        )
+
+        process.SetAddressableBits(lldb.eAddressMaskTypeAll, 42)
+        self.assertEqual(0x0000029500003F94, process.FixAddress(0x00265E9500003F94))
+
+        # ~((1ULL<<42)-1) == 0xfffffc0000000000
+        process.SetAddressMask(lldb.eAddressMaskTypeAll, 0xFFFFFC0000000000)
+        self.assertEqual(0x0000029500003F94, process.FixAddress(0x00265E9500003F94))
+
+        # Check that all bits can pass through unmodified
+        process.SetAddressableBits(lldb.eAddressMaskTypeAll, 64)
+        self.assertEqual(0x00265E9500003F94, process.FixAddress(0x00265E9500003F94))
+
+        process.SetAddressableBits(
+            lldb.eAddressMaskTypeAll, 42, lldb.eAddressMaskRangeLow
+        )
+        process.SetAddressableBits(
+            lldb.eAddressMaskTypeAll, 15, lldb.eAddressMaskRangeHigh
+        )
+        self.assertEqual(0x000002950001F694, process.FixAddress(0x00265E950001F694))
+        self.assertEqual(0xFFFFFFFFFFFFF694, process.FixAddress(0xFFA65E950000F694))
+
+        process.SetAddressableBits(
+            lldb.eAddressMaskTypeAll, 42, lldb.eAddressMaskRangeAll
+        )
+        self.assertEqual(0x000002950001F694, process.FixAddress(0x00265E950001F694))
+        self.assertEqual(0xFFFFFE950000F694, process.FixAddress(0xFFA65E950000F694))
+
+        process.SetAddressMask(lldb.eAddressMaskTypeCode, 0xFFFFFC0000000003)
+        self.assertEqual(0x000002950001F697, process.FixAddress(0x00265E950001F697))
+        self.assertEqual(0xFFFFFE950000F697, process.FixAddress(0xFFA65E950000F697))
+        self.assertEqual(
+            0x000002950001F697,
+            process.FixAddress(0x00265E950001F697, lldb.eAddressMaskTypeData),
+        )
+        self.assertEqual(
+            0x000002950001F694,
+            process.FixAddress(0x00265E950001F697, lldb.eAddressMaskTypeCode),
+        )
+
+        # The user can override whatever settings the Process thinks should be used.
+        process.SetAddressableBits(
+            lldb.eAddressMaskTypeAll, 42, lldb.eAddressMaskRangeAll
+        )
+        self.runCmd("settings set target.process.virtual-addressable-bits 15")
+        self.runCmd("settings set target.process.highmem-virtual-addressable-bits 15")
+        self.assertEqual(0x0000000000007694, process.FixAddress(0x00265E950001F694))
+        self.assertEqual(0xFFFFFFFFFFFFF694, process.FixAddress(0xFFA65E950000F694))

--- a/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
+++ b/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
@@ -42,6 +42,13 @@ class AddressMasksTestCase(TestBase):
         self.assertEqual(0x000002950001F694, process.FixAddress(0x00265E950001F694))
         self.assertEqual(0xFFFFFE950000F694, process.FixAddress(0xFFA65E950000F694))
 
+        # Set a eAddressMaskTypeCode which has the low 3 bits marked as non-address
+        # bits, confirm that they're cleared by FixAddress.
+        process.SetAddressableBits(
+            lldb.eAddressMaskTypeAll, 42, lldb.eAddressMaskRangeAll
+        )
+        mask = process.GetAddressMask(lldb.eAddressMaskTypeAny)
+        process.SetAddressMask(lldb.eAddressMaskTypeCode, mask | 0x3)
         process.SetAddressMask(lldb.eAddressMaskTypeCode, 0xFFFFFC0000000003)
         self.assertEqual(0x000002950001F697, process.FixAddress(0x00265E950001F697))
         self.assertEqual(0xFFFFFE950000F697, process.FixAddress(0xFFA65E950000F697))
@@ -62,3 +69,6 @@ class AddressMasksTestCase(TestBase):
         self.runCmd("settings set target.process.highmem-virtual-addressable-bits 15")
         self.assertEqual(0x0000000000007694, process.FixAddress(0x00265E950001F694))
         self.assertEqual(0xFFFFFFFFFFFFF694, process.FixAddress(0xFFA65E950000F694))
+        self.runCmd("settings set target.process.virtual-addressable-bits 0")
+        self.runCmd("settings set target.process.highmem-virtual-addressable-bits 0")
+        self.assertEqual(0x000002950001F694, process.FixAddress(0x00265E950001F694))

--- a/lldb/test/API/python_api/process/address-masks/main.c
+++ b/lldb/test/API/python_api/process/address-masks/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(int argc, char const *argv[]) {
+  puts("Hello address masking world"); // break here
+}


### PR DESCRIPTION
I'm reviving a patch from phabracator, https://reviews.llvm.org/D155905 which was approved but I wasn't thrilled with all the API I was adding to SBProcess for all of the address mask types / memory regions. In this update, I added enums to control type address mask type (code, data, any) and address space specifiers (low, high, all) with defaulted arguments for the most common case.

This patch is also fixing a bug in the "addressable bits to address mask" calculation I added in AddressableBits::SetProcessMasks. If lldb were told that 64 bits are valid for addressing, this method would overflow the calculation and set an invalid mask.  Added tests to check this specific bug while I was adding these APIs.

rdar://123530562