### PR TITLE
[PowerPC] provide CFI for ELF32 to unwind cr2, cr3, cr4

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1191,12 +1191,6 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
       if ((Reg == PPC::X2 || Reg == PPC::R2) && MustSaveTOC)
         continue;
 
-      // For SVR4, don't emit a move for the CR spill slot if we haven't
-      // spilled CRs.
-      if (isSVR4ABI && (PPC::CR2 <= Reg && Reg <= PPC::CR4)
-          && !MustSaveCR)
-        continue;
-
       // For 64-bit SVR4 when we have spilled CRs, the spill location
       // is SP+8, not a frame-relative slot.
       if (isSVR4ABI && isPPC64 && (PPC::CR2 <= Reg && Reg <= PPC::CR4)) {

--- a/llvm/test/CodeGen/PowerPC/crsave.ll
+++ b/llvm/test/CodeGen/PowerPC/crsave.ll
@@ -17,6 +17,7 @@ define i32 @test_cr2() nounwind uwtable {
 ; PPC32-NEXT:    .cfi_offset lr, 4
 ; PPC32-NEXT:    mr 31, 1
 ; PPC32-NEXT:    .cfi_def_cfa_register r31
+; PPC32-NEXT:    .cfi_offset cr2, -8
 ; PPC32-NEXT:    mfcr 12
 ; PPC32-NEXT:    stw 12, 24(31)
 ; PPC32-NEXT:    li 3, 1
@@ -227,6 +228,7 @@ define void @cloberOneNvCrField() {
 ; PPC32-NEXT:    .cfi_offset r31, -4
 ; PPC32-NEXT:    mr 31, 1
 ; PPC32-NEXT:    .cfi_def_cfa_register r31
+; PPC32-NEXT:    .cfi_offset cr2, -8
 ; PPC32-NEXT:    mfcr 12
 ; PPC32-NEXT:    stw 12, 24(31)
 ; PPC32-NEXT:    #APP
@@ -274,6 +276,9 @@ define void @cloberAllNvCrField() {
 ; PPC32-NEXT:    .cfi_offset r31, -4
 ; PPC32-NEXT:    mr 31, 1
 ; PPC32-NEXT:    .cfi_def_cfa_register r31
+; PPC32-NEXT:    .cfi_offset cr2, -8
+; PPC32-NEXT:    .cfi_offset cr3, -8
+; PPC32-NEXT:    .cfi_offset cr4, -8
 ; PPC32-NEXT:    mfcr 12
 ; PPC32-NEXT:    stw 12, 24(31)
 ; PPC32-NEXT:    #APP


### PR DESCRIPTION
Delete the code that skips the CFI for the condition register on ELF32.  The code checked !MustSaveCR, which happened only when Subtarget.is32BitELFABI(), where spillCalleeSavedRegisters is spilling cr in a different way.  The spill was missing CFI.  After deleting this code, a spill of cr2 to cr4 gets CFI in the same way as a spill of r14 to r31.

Fixes #83094