### PR TITLE
[Clang][DebugInfo] Use CGDebugInfo::createFile in CGDebugInfo::CreateCompileUnit (#83174)

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -628,9 +628,8 @@ void CGDebugInfo::CreateCompileUnit() {
   // file was specified with an absolute path.
   if (CSKind)
     CSInfo.emplace(*CSKind, Checksum);
-  llvm::DIFile *CUFile = DBuilder.createFile(
-      remapDIPath(MainFileName), remapDIPath(getCurrentDirname()), CSInfo,
-      getSource(SM, SM.getMainFileID()));
+  llvm::DIFile *CUFile =
+      createFile(MainFileName, CSInfo, getSource(SM, SM.getMainFileID()));
 
   StringRef Sysroot, SDK;
   if (CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::LLDB) {

--- a/clang/test/CodeGen/debug-info-abspath-remap.c
+++ b/clang/test/CodeGen/debug-info-abspath-remap.c
@@ -1,0 +1,20 @@
+// RUN: mkdir -p %t/src
+// RUN: cp %s %t/src/debug-info-debug-prefix-map.c
+
+// RUN: mkdir -p %t/out
+// RUN: cd %t/out
+// RUN: %clang_cc1 -debug-info-kind=limited -triple %itanium_abi_triple \
+// RUN:   -fdebug-prefix-map="%t/=./" %t/src/debug-info-debug-prefix-map.c \
+// RUN:   -emit-llvm -o - | FileCheck %s
+
+void foo(void) {}
+
+// Compile unit filename is transformed from absolute path %t/src... to
+// a relative path ./src... But it should not be relative to directory "./out".
+
+// CHECK: = distinct !DICompileUnit({{.*}}file: ![[#CUFILE:]]
+// CHECK: ![[#CUFILE]] = !DIFile(
+// CHECK-NOT:    directory: "./out"
+// CHECK-SAME:   filename: "./src{{[^"]+}}"
+// CHECK-NOT:    directory: "./out"
+// CHECK-SAME: )


### PR DESCRIPTION
Use `CGDebugInfo::createFile` wrapper that handles file remapping and corner cases instead of directly using `DBuilder.createFile` in `CGDebugInfo::CreateCompileUnit`.

Fixes #83174