### PR TITLE
[libc++][AIX] Use input redirection instead of piping for cin tests

### DIFF
--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: Investigate
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-
 // QEMU does not detect EOF, when reading from stdin
 // "echo -n" suppresses any characters after the output and so the test hangs.
 // https://gitlab.com/qemu-project/qemu/-/issues/1963
@@ -23,7 +20,8 @@
 // istream cin;
 
 // RUN: %{build}
-// RUN: echo -n 1234 | %{exec} %t.exe
+// RUN: echo -n 1234 > %t.input
+// RUN: %{exec} %t.exe < %t.input
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: Investigate
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-
 // This test hangs on Android devices that lack shell_v2, which was added in
 // Android N (API 24).
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME && android-device-api={{2[1-3]}}
@@ -20,7 +17,8 @@
 // UNSUPPORTED: no-wide-characters
 
 // RUN: %{build}
-// RUN: echo -n 1234 | %{exec} %t.exe
+// RUN: echo -n 1234 > %t.input
+// RUN: %{exec} %t.exe < %t.input
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: Investigate
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-
 // This test hangs on Android devices that lack shell_v2, which was added in
 // Android N (API 24).
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME && android-device-api={{2[1-3]}}
@@ -20,7 +17,8 @@
 // UNSUPPORTED: no-wide-characters
 
 // RUN: %{build}
-// RUN: echo -n 1234 | %{exec} %t.exe
+// RUN: echo -n 1234 > %t.input
+// RUN: %{exec} %t.exe < %t.input
 
 #include <iostream>
 #include <cassert>


### PR DESCRIPTION
When echo is used for piping, lit uses the system echo rather than the builtin echo. The system echo on AIX doesn't support the `-n` option, which causes these tests to fail. Use input redirection, so the builtin echo can be used. 