### PR TITLE
[LangRef][IR] Add 3-way compare intrinsics llvm.scmp/llvm.ucmp

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14544,8 +14544,8 @@ integer bit width or any vector of integer elements.
 
 ::
 
-      declare i32 @llvm.scmp.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.scmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare i2 @llvm.scmp.i2.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.scmp.i32.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""
@@ -14573,8 +14573,8 @@ integer bit width or any vector of integer elements.
 
 ::
 
-      declare i2 @llvm.ucmp.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.ucmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare i2 @llvm.ucmp.i2.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.ucmp.i32.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14556,7 +14556,7 @@ Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and
 Arguments:
 """"""""""
 
-The arguments (``%a`` and ``%b``) may be of any signed integer type or a vector with
+The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
 type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14587,7 +14587,7 @@ Arguments:
 
 The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
-type must be at least as wide as ``i2``, to uphold the three possible return values.
+type must be at least as wide as ``i2``, to hold the three possible return values.
 
 .. _int_memcpy:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14545,7 +14545,7 @@ integer bit width or any vector of integer elements.
 ::
 
       declare i2 @llvm.scmp.i2.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.scmp.i32.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare <4 x i32> @llvm.scmp.v4i32.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14531,21 +14531,21 @@ The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
 type must match the argument type.
 
-.. _int_sthreecmp:
+.. _int_scmp:
 
-'``llvm.sthreecmp.*``' Intrinsic
+'``llvm.scmp.*``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Syntax:
 """""""
 
-This is an overloaded intrinsic. You can use ``@llvm.sthreecmp`` on any
+This is an overloaded intrinsic. You can use ``@llvm.scmp`` on any
 integer bit width or any vector of integer elements.
 
 ::
 
-      declare i32 @llvm.sthreecmp.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.sthreecmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare i32 @llvm.scmp.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.scmp.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""
@@ -14560,21 +14560,21 @@ The arguments (``%a`` and ``%b``) may be of any signed integer type or a vector 
 integer element type. The argument types must match each other, and the return
 type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
 
-.. _int_uthreecmp:
+.. _int_ucmp:
 
-'``llvm.uthreecmp.*``' Intrinsic
+'``llvm.ucmp.*``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Syntax:
 """""""
 
-This is an overloaded intrinsic. You can use ``@llvm.sthreecmp`` on any
+This is an overloaded intrinsic. You can use ``@llvm.ucmp`` on any
 integer bit width or any vector of integer elements.
 
 ::
 
-      declare i2 @llvm.uthreecmp.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.uthreecmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare i2 @llvm.ucmp.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.ucmp.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14558,7 +14558,7 @@ Arguments:
 
 The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
-type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
+type must be at least as wide as ``i2``, to hold the three possible return values.
 
 .. _int_ucmp:
 
@@ -14587,7 +14587,7 @@ Arguments:
 
 The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
-type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
+type must be at least as wide as ``i2``, to uphold the three possible return values.
 
 .. _int_memcpy:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14580,7 +14580,7 @@ Overview:
 """""""""
 
 Return ``-1`` if ``%a`` is unsigned less than ``%b``, ``0`` if they are equal, and 
-``1`` if ``%a`` is greater than ``%b``. Vector intrinsics operate on a per-element basis. 
+``1`` if ``%a`` is unsigned greater than ``%b``. Vector intrinsics operate on a per-element basis. 
 
 Arguments:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14574,7 +14574,7 @@ integer bit width or any vector of integer elements.
 ::
 
       declare i2 @llvm.ucmp.i2.i32(i32 %a, i32 %b)
-      declare <4 x i32> @llvm.ucmp.i32.v4i32(<4 x i32> %a, <4 x i32> %b)
+      declare <4 x i32> @llvm.ucmp.v4i32.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 Overview:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14550,8 +14550,8 @@ integer bit width or any vector of integer elements.
 Overview:
 """""""""
 
-Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and 
-``1`` if ``%a`` is greater than ``%b``. Vector intrinsics operate on a per-element basis. 
+Return ``-1`` if ``%a`` is signed less than ``%b``, ``0`` if they are equal, and 
+``1`` if ``%a`` is signed greater than ``%b``. Vector intrinsics operate on a per-element basis. 
 
 Arguments:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14585,7 +14585,7 @@ Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and
 Arguments:
 """"""""""
 
-The arguments (``%a`` and ``%b``) may be of any unsigned integer type or a vector with
+The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
 type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14579,7 +14579,7 @@ integer bit width or any vector of integer elements.
 Overview:
 """""""""
 
-Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and 
+Return ``-1`` if ``%a`` is unsigned less than ``%b``, ``0`` if they are equal, and 
 ``1`` if ``%a`` is greater than ``%b``. Vector intrinsics operate on a per-element basis. 
 
 Arguments:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12044,7 +12044,7 @@ pointer, or pointer vector operands.
 Arguments:
 """"""""""
 
-The '``uthreecmp``' instruction takes two signed integer operands.
+The '``uthreecmp``' instruction takes two unsigned integer operands.
 
 Semantics:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11976,98 +11976,6 @@ Example:
       <result> = icmp ule i16 -4, 5        ; yields: result=false
       <result> = icmp sge i16  4, 5        ; yields: result=false
 
-.. _i_sthreecmp:
-
-'``sthreecmp``' Instruction
-^^^^^^^^^^^^^^^^^^^^^^
-
-Syntax:
-"""""""
-
-::
-
-      <result> = sthreecmp <op1>, <op2>  ; yields i2 or <N x i2>:result
-
-Overview:
-"""""""""
-
-The '``sthreecmp``' instruction returns an integer value or a vector of
-integer values based on comparison of its two integer, integer vector,
-pointer, or pointer vector operands.
-
-Arguments:
-""""""""""
-
-The '``sthreecmp``' instruction takes two signed integer operands.
-
-Semantics:
-""""""""""
-If the operands are equal, it returns 0. If ``op1`` is less than ``op2``,
-it returns -1, and if ``op1`` is greater than ``op2``, it returns 1.
-It is also known as the '``<=>``' spaceship operator.
-
-If the operands are :ref:`pointer <t_pointer>` typed, the pointer values
-are compared as if they were integers.
-
-If the operands are integer vectors, then they are compared element by
-element. The result is an ``i2`` vector with the same number of elements
-as the values being compared. Otherwise, the result is an ``i2``.
-
-Example:
-""""""""
-
-.. code-block:: text
-
-      <result> = sthreecmp 4, 5          ; yields: result=-1
-      <result> = sthreecmp 2, 2          ; yields: result=0
-      <result> = sthreecmp -2, -1        ; yields: result=1
-
-.. _i_uthreecmp:
-
-'``uthreecmp``' Instruction
-^^^^^^^^^^^^^^^^^^^^^^
-
-Syntax:
-"""""""
-
-::
-
-      <result> = uthreecmp <op1>, <op2>  ; yields i2 or <N x i2>:result
-
-Overview:
-"""""""""
-
-The '``uthreecmp``' instruction returns an integer value or a vector of
-integer values based on comparison of its two integer, integer vector,
-pointer, or pointer vector operands.
-
-Arguments:
-""""""""""
-
-The '``uthreecmp``' instruction takes two unsigned integer operands.
-
-Semantics:
-""""""""""
-If the operands are equal, it returns 0. If ``op1`` is less than ``op2``,
-it returns -1, and if ``op1`` is greater than ``op2``, it returns 1.
-It is also known as the '``<=>``' spaceship operator.
-
-If the operands are :ref:`pointer <t_pointer>` typed, the pointer values
-are compared as if they were integers.
-
-If the operands are integer vectors, then they are compared element by
-element. The result is an ``i2`` vector with the same number of elements
-as the values being compared. Otherwise, the result is an ``i2``.
-
-Example:
-""""""""
-
-.. code-block:: text
-
-      <result> = uthreecmp 4, 5          ; yields: result=-1
-      <result> = uthreecmp 2, 2          ; yields: result=0
-      <result> = uthreecmp 9, 0          ; yields: result=1
-
 .. _i_fcmp:
 
 '``fcmp``' Instruction
@@ -14623,6 +14531,63 @@ The arguments (``%a`` and ``%b``) may be of any integer type or a vector with
 integer element type. The argument types must match each other, and the return
 type must match the argument type.
 
+.. _int_sthreecmp:
+
+'``llvm.sthreecmp.*``' Intrinsic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax:
+"""""""
+
+This is an overloaded intrinsic. You can use ``@llvm.sthreecmp`` on any
+integer bit width or any vector of integer elements.
+
+::
+
+      declare i32 @llvm.sthreecmp.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.sthreecmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+
+Overview:
+"""""""""
+
+Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and 
+``1`` if ``%a`` is greater than ``%b``. Vector intrinsics operate on a per-element basis. 
+
+Arguments:
+""""""""""
+
+The arguments (``%a`` and ``%b``) may be of any signed integer type or a vector with
+integer element type. The argument types must match each other, and the return
+type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
+
+.. _int_uthreecmp:
+
+'``llvm.uthreecmp.*``' Intrinsic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax:
+"""""""
+
+This is an overloaded intrinsic. You can use ``@llvm.sthreecmp`` on any
+integer bit width or any vector of integer elements.
+
+::
+
+      declare i2 @llvm.uthreecmp.i32(i32 %a, i32 %b)
+      declare <4 x i32> @llvm.uthreecmp.v4i32(<4 x i32> %a, <4 x i32> %b)
+
+Overview:
+"""""""""
+
+Return ``-1`` if ``%a`` is less than ``%b``, ``0`` if they are equal, and 
+``1`` if ``%a`` is greater than ``%b``. Vector intrinsics operate on a per-element basis. 
+
+Arguments:
+""""""""""
+
+The arguments (``%a`` and ``%b``) may be of any unsigned integer type or a vector with
+integer element type. The argument types must match each other, and the return
+type must be at least as wide as ``i2``, to uphold the ``-1`` return value.
 
 .. _int_memcpy:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11976,6 +11976,98 @@ Example:
       <result> = icmp ule i16 -4, 5        ; yields: result=false
       <result> = icmp sge i16  4, 5        ; yields: result=false
 
+.. _i_sthreecmp:
+
+'``sthreecmp``' Instruction
+^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax:
+"""""""
+
+::
+
+      <result> = sthreecmp <op1>, <op2>  ; yields i2 or <N x i2>:result
+
+Overview:
+"""""""""
+
+The '``sthreecmp``' instruction returns an integer value or a vector of
+integer values based on comparison of its two integer, integer vector,
+pointer, or pointer vector operands.
+
+Arguments:
+""""""""""
+
+The '``sthreecmp``' instruction takes two signed integer operands.
+
+Semantics:
+""""""""""
+If the operands are equal, it returns 0. If ``op1`` is less than ``op2``,
+it returns -1, and if ``op1`` is greater than ``op2``, it returns 1.
+It is also known as the '``<=>``' spaceship operator.
+
+If the operands are :ref:`pointer <t_pointer>` typed, the pointer values
+are compared as if they were integers.
+
+If the operands are integer vectors, then they are compared element by
+element. The result is an ``i2`` vector with the same number of elements
+as the values being compared. Otherwise, the result is an ``i2``.
+
+Example:
+""""""""
+
+.. code-block:: text
+
+      <result> = sthreecmp 4, 5          ; yields: result=-1
+      <result> = sthreecmp 2, 2          ; yields: result=0
+      <result> = sthreecmp -2, -1        ; yields: result=1
+
+.. _i_uthreecmp:
+
+'``uthreecmp``' Instruction
+^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax:
+"""""""
+
+::
+
+      <result> = uthreecmp <op1>, <op2>  ; yields i2 or <N x i2>:result
+
+Overview:
+"""""""""
+
+The '``uthreecmp``' instruction returns an integer value or a vector of
+integer values based on comparison of its two integer, integer vector,
+pointer, or pointer vector operands.
+
+Arguments:
+""""""""""
+
+The '``uthreecmp``' instruction takes two signed integer operands.
+
+Semantics:
+""""""""""
+If the operands are equal, it returns 0. If ``op1`` is less than ``op2``,
+it returns -1, and if ``op1`` is greater than ``op2``, it returns 1.
+It is also known as the '``<=>``' spaceship operator.
+
+If the operands are :ref:`pointer <t_pointer>` typed, the pointer values
+are compared as if they were integers.
+
+If the operands are integer vectors, then they are compared element by
+element. The result is an ``i2`` vector with the same number of elements
+as the values being compared. Otherwise, the result is an ``i2``.
+
+Example:
+""""""""
+
+.. code-block:: text
+
+      <result> = uthreecmp 4, 5          ; yields: result=-1
+      <result> = uthreecmp 2, 2          ; yields: result=0
+      <result> = uthreecmp 9, 0          ; yields: result=1
+
 .. _i_fcmp:
 
 '``fcmp``' Instruction

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1526,10 +1526,10 @@ def int_umax : DefaultAttrsIntrinsic<
 def int_umin : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
-def int_sthreecmp : DefaultAttrsIntrinsic<
+def int_scmp : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
-def int_uthreecmp : DefaultAttrsIntrinsic<
+def int_ucmp : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
 

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1527,10 +1527,10 @@ def int_umin : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
 def int_scmp : DefaultAttrsIntrinsic<
-    [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
+    [llvm_anyint_ty], [llvm_anyint_ty, LLVMMatchType<1>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
 def int_ucmp : DefaultAttrsIntrinsic<
-    [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
+    [llvm_anyint_ty], [llvm_anyint_ty, LLVMMatchType<1>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
 
 //===------------------------- Memory Use Markers -------------------------===//

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -2136,7 +2136,14 @@ let IntrProperties = [IntrNoMem, IntrNoSync, IntrWillReturn] in {
                                llvm_metadata_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-
+  def int_vp_sthreecmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i8_ty> ],
+                             [LLVMMatchType<0>,
+                              LLVMMatchType<0>],
+                              [IntrSpeculatable]>;
+  def int_vp_uthreecmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i8_ty>],
+                             [LLVMMatchType<0>,
+                              LLVMMatchType<0>],
+                              [IntrSpeculatable]>;
   // Reductions
   def int_vp_reduce_fadd : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                              [ LLVMVectorElementType<0>,

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1526,6 +1526,12 @@ def int_umax : DefaultAttrsIntrinsic<
 def int_umin : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
     [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
+def int_sthreecmp : DefaultAttrsIntrinsic<
+    [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
+    [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
+def int_uthreecmp : DefaultAttrsIntrinsic<
+    [llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
+    [IntrNoMem, IntrSpeculatable, IntrWillReturn]>;
 
 //===------------------------- Memory Use Markers -------------------------===//
 //
@@ -2136,14 +2142,7 @@ let IntrProperties = [IntrNoMem, IntrNoSync, IntrWillReturn] in {
                                llvm_metadata_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_sthreecmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i8_ty> ],
-                             [LLVMMatchType<0>,
-                              LLVMMatchType<0>],
-                              [IntrSpeculatable]>;
-  def int_vp_uthreecmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i8_ty>],
-                             [LLVMMatchType<0>,
-                              LLVMMatchType<0>],
-                              [IntrSpeculatable]>;
+
   // Reductions
   def int_vp_reduce_fadd : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                              [ LLVMVectorElementType<0>,

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5246,7 +5246,9 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(SrcTy->isVectorTy() == isDestTypeVector,
         "[us]cmp source and destination must both be a vector or neither", Call);
     if (isDestTypeVector) {
-      Check(SrcTy->getArrayNumElements() == DestTy->getArrayNumElements(),
+      auto srcVecLen = cast<VectorType>(SrcTy)->getElementCount();
+      auto destVecLen = cast<VectorType>(DestTy)->getElementCount();
+      Check(srcVecLen == destVecLen,
         "the return type the first arg type must have the same number of elements", Call);
     }
     break;

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5250,8 +5250,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();
-      Check(SrcVecLen == DestVecLen,
-        "return type and first arg type must have the same number of elements", Call);
+      Check(SrcVecLen == DestVecLen, "return type and first arg type must have the same number of elements", Call);
     }
     break;
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5243,12 +5243,12 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(DestTy->getScalarSizeInBits() >= 2, "result type must be at least 2 bits wide", Call);
 
     bool IsDestTypeVector = DestTy->isVectorTy();
-    Check(SrcTy->isVectorTy() == isDestTypeVector,
+    Check(SrcTy->isVectorTy() == IsDestTypeVector,
         "[us]cmp source and destination must both be a vector or neither", Call);
-    if (isDestTypeVector) {
-      auto srcVecLen = cast<VectorType>(SrcTy)->getElementCount();
-      auto destVecLen = cast<VectorType>(DestTy)->getElementCount();
-      Check(srcVecLen == destVecLen,
+    if (IsDestTypeVector) {
+      auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
+      auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();
+      Check(SrcVecLen == DestVecLen,
         "return type and first arg type must have the same number of elements", Call);
     }
     break;

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5237,7 +5237,6 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
   }
   case Intrinsic::ucmp:
   case Intrinsic::scmp: {
-
     Type *SrcTy = Call.getOperand(0)->getType();
     Type *DestTy = Call.getType();
 

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5250,7 +5250,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();
-      Check(SrcVecLen == DestVecLen, "return type and first arg type must have the same number of elements", Call);
+      Check(SrcVecLen == DestVecLen, "return type and first arg type must have the same number of " "elements", Call);
     }
     break;
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5240,11 +5240,13 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Type *SrcTy = Call.getOperand(0)->getType();
     Type *DestTy = Call.getType();
 
-    Check(DestTy->getScalarSizeInBits() >= 2, "result type must be at least 2 bits wide", Call);
+    Check(DestTy->getScalarSizeInBits() >= 2,
+          "result type must be at least 2 bits wide", Call);
 
     bool IsDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == IsDestTypeVector,
-        "[us]cmp source and destination must both be a vector or neither", Call);
+          "[us]cmp source and destination must both be a vector or neither",
+          Call);
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5250,7 +5250,10 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();
-      Check(SrcVecLen == DestVecLen, "return type and first arg type must have the same number of " "elements", Call);
+      Check(SrcVecLen == DestVecLen,
+            "return type and first arg type must have the same number of "
+            "elements",
+            Call);
     }
     break;
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5241,8 +5241,6 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Type *SrcTy = Call.getOperand(0)->getType();
     Type *DestTy = Call.getType();
 
-    Check(SrcTy->isIntOrIntVectorTy(), "[u]scmp only operates on integers", Call);
-    Check(DestTy->isIntOrIntVectorTy(), "[u]scmp only produces integers", Call);
     Check(DestTy->getScalarSizeInBits() >= 2, "DestTy must be at least 2 bits wide", Call);
 
     bool isDestTypeVector = DestTy->isVectorTy();

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5235,6 +5235,25 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     }
     break;
   }
+  case Intrinsic::ucmp:
+  case Intrinsic::scmp: {
+
+    Type *SrcTy = Call.getOperand(0)->getType();
+    Type *DestTy = Call.getType();
+
+    Check(SrcTy->isIntOrIntVectorTy(), "[u]scmp only operates on integers", Call);
+    Check(DestTy->isIntOrIntVectorTy(), "[u]scmp only produces integers", Call);
+    Check(DestTy->getScalarSizeInBits() >= 2, "DestTy must be at least 2 bits wide", Call);
+
+    auto isDestTypeVector = DestTy->isVectorTy();
+    if (isDestTypeVector) {
+      Check(SrcTy->isVectorTy() == isDestTypeVector,
+        "[u]scmp source and destination must both be a vector or neither", Call);
+      Check(SrcTy->getArrayNumElements() == DestTy->getArrayNumElements(),
+        "the return type the first arg type must have the same number of elements", Call);
+    }
+    break;
+  }
   case Intrinsic::coro_id: {
     auto *InfoArg = Call.getArgOperand(3)->stripPointerCasts();
     if (isa<ConstantPointerNull>(InfoArg))

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5240,7 +5240,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Type *SrcTy = Call.getOperand(0)->getType();
     Type *DestTy = Call.getType();
 
-    Check(DestTy->getScalarSizeInBits() >= 2, "Result type must be at least 2 bits wide", Call);
+    Check(DestTy->getScalarSizeInBits() >= 2, "result type must be at least 2 bits wide", Call);
 
     bool isDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == isDestTypeVector,
@@ -5249,7 +5249,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
       auto srcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto destVecLen = cast<VectorType>(DestTy)->getElementCount();
       Check(srcVecLen == destVecLen,
-        "the return type the first arg type must have the same number of elements", Call);
+        "return type and first arg type must have the same number of elements", Call);
     }
     break;
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5246,9 +5246,9 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(DestTy->getScalarSizeInBits() >= 2, "DestTy must be at least 2 bits wide", Call);
 
     bool isDestTypeVector = DestTy->isVectorTy();
-    if (isDestTypeVector) {
-      Check(SrcTy->isVectorTy() == isDestTypeVector,
+    Check(SrcTy->isVectorTy() == isDestTypeVector,
         "[u]scmp source and destination must both be a vector or neither", Call);
+    if (isDestTypeVector) {
       Check(SrcTy->getArrayNumElements() == DestTy->getArrayNumElements(),
         "the return type the first arg type must have the same number of elements", Call);
     }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5242,7 +5242,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
 
     Check(DestTy->getScalarSizeInBits() >= 2, "result type must be at least 2 bits wide", Call);
 
-    bool isDestTypeVector = DestTy->isVectorTy();
+    bool IsDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == isDestTypeVector,
         "[us]cmp source and destination must both be a vector or neither", Call);
     if (isDestTypeVector) {

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5241,7 +5241,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Type *SrcTy = Call.getOperand(0)->getType();
     Type *DestTy = Call.getType();
 
-    Check(DestTy->getScalarSizeInBits() >= 2, "DestTy must be at least 2 bits wide", Call);
+    Check(DestTy->getScalarSizeInBits() >= 2, "Result type must be at least 2 bits wide", Call);
 
     bool isDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == isDestTypeVector,

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5245,7 +5245,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(DestTy->isIntOrIntVectorTy(), "[u]scmp only produces integers", Call);
     Check(DestTy->getScalarSizeInBits() >= 2, "DestTy must be at least 2 bits wide", Call);
 
-    auto isDestTypeVector = DestTy->isVectorTy();
+    bool isDestTypeVector = DestTy->isVectorTy();
     if (isDestTypeVector) {
       Check(SrcTy->isVectorTy() == isDestTypeVector,
         "[u]scmp source and destination must both be a vector or neither", Call);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5245,7 +5245,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
 
     bool isDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == isDestTypeVector,
-        "[u]scmp source and destination must both be a vector or neither", Call);
+        "[us]cmp source and destination must both be a vector or neither", Call);
     if (isDestTypeVector) {
       Check(SrcTy->getArrayNumElements() == DestTy->getArrayNumElements(),
         "the return type the first arg type must have the same number of elements", Call);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5245,13 +5245,13 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
 
     bool IsDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == IsDestTypeVector,
-          "[us]cmp source and destination must both be a vector or neither",
+          "ucmp/scmp argument and result types must both be either vector or scalar types",
           Call);
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();
       auto DestVecLen = cast<VectorType>(DestTy)->getElementCount();
       Check(SrcVecLen == DestVecLen,
-            "return type and first arg type must have the same number of "
+            "return type and arguments must have the same number of "
             "elements",
             Call);
     }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5245,7 +5245,8 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
 
     bool IsDestTypeVector = DestTy->isVectorTy();
     Check(SrcTy->isVectorTy() == IsDestTypeVector,
-          "ucmp/scmp argument and result types must both be either vector or scalar types",
+          "ucmp/scmp argument and result types must both be either vector or "
+          "scalar types",
           Call);
     if (IsDestTypeVector) {
       auto SrcVecLen = cast<VectorType>(SrcTy)->getElementCount();

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -1,29 +1,26 @@
 ; RUN: not opt -S -passes=verify 2>&1 < %s | FileCheck %s
 
 
-declare void @matching_vector_lens.v4i32.v4i32(<4 x i32>, <4 x i32>)
 define void @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
-    ; CHECK-LABEL: cmp_vector_lens_match
-    ; CHECK: return type and first arg type must have the same number of elements
-    %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
-    ret void
+  ; CHECK-LABEL: cmp_vector_lens_match
+  ; CHECK: return type and first arg type must have the same number of elements
+  %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
+  ret void
 }
 
-declare void @result_len_is_at_least_2.i32.i32(i32, i32)
 define void @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
-    ; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
-    ; CHECK: result type must be at least 2 bits wide
-    %res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
-    return void
+  ; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
+  ; CHECK: result type must be at least 2 bits wide
+  %res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
+  ret void
 }
 
-declare void @both_args_are_vecs_or_neither.v4i32.i32(<4 x i32>, i32)
 define void @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
-    ; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
-    ; CHECK: [us]cmp source and destination must both be a vector or neither
-    @res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
-    ; CHECK: [us]cmp source and destination must both be a vector or neither
-    @res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
-    return void
+  ; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
+  ; CHECK: [us]cmp source and destination must both be a vector or neither
+  @res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
+  ; CHECK: [us]cmp source and destination must both be a vector or neither
+  @res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
+  ret void
 }
 

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -6,7 +6,7 @@ define void @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
     ; CHECK-LABEL: cmp_vector_lens_match
     ; CHECK: return type and first arg type must have the same number of elements
     %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
-    return void
+    ret void
 }
 
 declare void @result_len_is_at_least_2.i32.i32(i32, i32)

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -1,0 +1,23 @@
+; RUN: not opt -S -passes=verify 2>&1 < %s | FileCheck %s
+
+
+define @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
+	; CHECK-LABEL: cmp_vector_lens_match
+	; CHECK: return type and first arg type must have the same number of elements
+	%res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
+}
+
+define @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
+	; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
+	; CHECK: result type must be at least 2 bits wide
+	%res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
+}
+
+define @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
+	; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
+	; CHECK: [us]cmp source and destination must both be a vector or neither
+	@res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
+	; CHECK: [us]cmp source and destination must both be a vector or neither
+	@res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
+	; CHECK: [us]cmp source and destination must both be a vector or neither
+}

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -1,22 +1,29 @@
 ; RUN: not opt -S -passes=verify 2>&1 < %s | FileCheck %s
 
 
-define @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
-	; CHECK-LABEL: cmp_vector_lens_match
-	; CHECK: return type and first arg type must have the same number of elements
-	%res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
+declare void @matching_vector_lens.v4i32.v4i32(<4 x i32>, <4 x i32>)
+define void @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
+    ; CHECK-LABEL: cmp_vector_lens_match
+    ; CHECK: return type and first arg type must have the same number of elements
+    %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
+    return void
 }
 
-define @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
-	; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
-	; CHECK: result type must be at least 2 bits wide
-	%res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
+declare void @result_len_is_at_least_2.i32.i32(i32, i32)
+define void @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
+    ; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
+    ; CHECK: result type must be at least 2 bits wide
+    %res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
+    return void
 }
 
-define @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
-	; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
-	; CHECK: [us]cmp source and destination must both be a vector or neither
-	@res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
-	; CHECK: [us]cmp source and destination must both be a vector or neither
-	@res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
+declare void @both_args_are_vecs_or_neither.v4i32.i32(<4 x i32>, i32)
+define void @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
+    ; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
+    ; CHECK: [us]cmp source and destination must both be a vector or neither
+    @res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
+    ; CHECK: [us]cmp source and destination must both be a vector or neither
+    @res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
+    return void
 }
+

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -19,5 +19,4 @@ define @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
 	@res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
 	; CHECK: [us]cmp source and destination must both be a vector or neither
 	@res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
-	; CHECK: [us]cmp source and destination must both be a vector or neither
 }

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -18,9 +18,9 @@ define void @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
 define void @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
   ; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
   ; CHECK: [us]cmp source and destination must both be a vector or neither
-  @res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, i32 %arg2)
+  %res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, <4 x i32> %arg1)
   ; CHECK: [us]cmp source and destination must both be a vector or neither
-  @res4 = call <4 x i32> @llvm.scmp.v4i32.i32(<4 x i32> %arg2, i32 %arg2)
+  %res4 = call <4 x i32> @llvm.scmp.v4i32.i32(i32 %arg2, i32 %arg2)
   ret void
 }
 

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -1,22 +1,18 @@
 ; RUN: not opt -S -passes=verify 2>&1 < %s | FileCheck %s
 
-
 define void @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
-  ; CHECK-LABEL: cmp_vector_lens_match
   ; CHECK: return type and first arg type must have the same number of elements
   %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
   ret void
 }
 
-define void @result_len_is_at_least_2(i32 %arg1, i32 %arg2) {
-  ; CHECK-LABEL: cmp_result_len_is_at_least_2bits_wide
+define void @result_len_is_at_least_2bits_wide(i32 %arg1, i32 %arg2) {
   ; CHECK: result type must be at least 2 bits wide
   %res2 = call i1 @llvm.scmp.i1.i32(i32 %arg1, i32 %arg2)
   ret void
 }
 
 define void @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
-  ; CHECK-LABEL: cmp_sources_and_dest_types_ranks_match
   ; CHECK: [us]cmp source and destination must both be a vector or neither
   %res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, <4 x i32> %arg1)
   ; CHECK: [us]cmp source and destination must both be a vector or neither

--- a/llvm/test/Verifier/intrinsic-cmp.ll
+++ b/llvm/test/Verifier/intrinsic-cmp.ll
@@ -1,7 +1,7 @@
 ; RUN: not opt -S -passes=verify 2>&1 < %s | FileCheck %s
 
 define void @matching_vector_lens(<4 x i32> %arg1, <4 x i32> %arg2) {
-  ; CHECK: return type and first arg type must have the same number of elements
+  ; CHECK: return type and arguments must have the same number of elements
   %res = call <8 x i32> @llvm.scmp.v8i32.v4i32(<4 x i32> %arg1, <4 x i32> %arg2)
   ret void
 }
@@ -13,9 +13,9 @@ define void @result_len_is_at_least_2bits_wide(i32 %arg1, i32 %arg2) {
 }
 
 define void @both_args_are_vecs_or_neither(<4 x i32> %arg1, i32 %arg2) {
-  ; CHECK: [us]cmp source and destination must both be a vector or neither
+  ; CHECK: ucmp/scmp argument and result types must both be either vector or scalar types
   %res3 = call i2 @llvm.scmp.i2.v4i32(<4 x i32> %arg1, <4 x i32> %arg1)
-  ; CHECK: [us]cmp source and destination must both be a vector or neither
+  ; CHECK: ucmp/scmp argument and result types must both be either vector or scalar types
   %res4 = call <4 x i32> @llvm.scmp.v4i32.i32(i32 %arg2, i32 %arg2)
   ret void
 }

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -891,8 +891,6 @@ TEST(ValueTracking, propagatesPoison) {
       {true, "call i32 @llvm.smin.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umax.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umin.i32(i32 %x, i32 %y)", 0},
-      {true, "call i32 @llvm.sthreecmp.i32(i32 %x, i32 %y)", 0},
-      {true, "call i32 @llvm.uthreecmp.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.bitreverse.i32(i32 %x)", 0},
       {true, "call i32 @llvm.bswap.i32(i32 %x)", 0},
       {false, "call i32 @llvm.fshl.i32(i32 %x, i32 %y, i32 %shamt)", 0},

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -891,6 +891,8 @@ TEST(ValueTracking, propagatesPoison) {
       {true, "call i32 @llvm.smin.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umax.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umin.i32(i32 %x, i32 %y)", 0},
+      {true, "call i32 @llvm.sthreecmp.i32(i32 %x, i32 %y)", 0},
+      {true, "call i32 @llvm.uthreecmp.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.bitreverse.i32(i32 %x)", 0},
       {true, "call i32 @llvm.bswap.i32(i32 %x)", 0},
       {false, "call i32 @llvm.fshl.i32(i32 %x, i32 %y, i32 %shamt)", 0},


### PR DESCRIPTION
This PR adds the `[us]cmp` intrinsics to the LangRef, `Intrinsics.td` and some tests to the IRVerifier.

RFC: https://discourse.llvm.org/t/rfc-add-3-way-comparison-intrinsics/76685