### PR TITLE
[OpenCL] Fix BIenqueue_kernel fallthrough

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -5640,7 +5640,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         EmitLifetimeEnd(TmpSize, TmpPtr);
       return Call;
     }
-    [[fallthrough]];
+    llvm_unreachable("Unexpected enqueue_kernel signature");
   }
   // OpenCL v2.0 s6.13.17.6 - Kernel query functions need bitcast of block
   // parameter.


### PR DESCRIPTION
Handling of the `BIenqueue_kernel` builtin must not fallthrough to the `BIget_kernel_work_group_size` builtin, as these builtins have no common functionality.