### PR TITLE
[InstrProf] Change step from 64-bit to pointer-sized int

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicInst.h
+++ b/llvm/include/llvm/IR/IntrinsicInst.h
@@ -1506,6 +1506,7 @@ public:
     return isa<IntrinsicInst>(V) && classof(cast<IntrinsicInst>(V));
   }
   Value *getStep() const;
+  Value *getAtomicStep() const;
 };
 
 /// This represents the llvm.instrprof.increment.step intrinsic.

--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -288,7 +288,24 @@ Value *InstrProfIncrementInst::getStep() const {
   }
   const Module *M = getModule();
   LLVMContext &Context = M->getContext();
+  const auto &DL = M->getDataLayout();
+  Type *LargestLegalIntTy = DL.getLargestLegalIntType(Context);
+
+  if (LargestLegalIntTy) {
+    return ConstantInt::get(LargestLegalIntTy, 1);
+  }
+
   return ConstantInt::get(Type::getInt64Ty(Context), 1);
+}
+
+Value *InstrProfIncrementInst::getAtomicStep() const {
+  if (InstrProfIncrementInstStep::classof(this)) {
+    return const_cast<Value *>(getArgOperand(4));
+  }
+  const Module *M = getModule();
+  LLVMContext &Context = M->getContext();
+  const auto &DL = M->getDataLayout();
+  return ConstantInt::get(DL.getIntPtrType(Context), 1);
 }
 
 std::optional<RoundingMode> ConstrainedFPIntrinsic::getRoundingMode() const {

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -958,7 +958,7 @@ void InstrLowerer::lowerIncrement(InstrProfIncrementInst *Inc) {
   IRBuilder<> Builder(Inc);
   if (Options.Atomic || AtomicCounterUpdateAll ||
       (Inc->getIndex()->isZeroValue() && AtomicFirstCounter)) {
-    Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getStep(),
+    Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getAtomicStep(),
                             MaybeAlign(), AtomicOrdering::Monotonic);
   } else {
     Value *IncStep = Inc->getStep();


### PR DESCRIPTION
Fixed 64-bit step can lead to creating atomic instructions unsupported by the target architecture (see rust-lang/rust#112313).