### PR TITLE
[libcxx] Add libcxx/include directory to LIBCXX_CONFIGURE_IDE dummy test target includes

### DIFF
--- a/libcxx/docs/BuildingLibcxx.rst
+++ b/libcxx/docs/BuildingLibcxx.rst
@@ -299,6 +299,12 @@ libc++ specific options
 
   Additional libraries libc++ is linked to which can be provided in cache.
 
+.. option:: LIBCXX_CONFIGURE_IDE:BOOL
+
+  **Default**: ``"ON"`` when ``XCODE``` or ``MSVC_IDE`` CMake variables are set.
+
+  Generate dummy CMake test targets to provide rough information to IDEs about
+  where test sources will find project headers.
 
 .. _ABI Library Specific Options:
 

--- a/libcxx/test/CMakeLists.txt
+++ b/libcxx/test/CMakeLists.txt
@@ -100,13 +100,17 @@ if (LIBCXX_CONFIGURE_IDE)
   # Create dummy targets for each of the tests in the test suite, this allows
   # IDE's such as CLion to correctly highlight the tests because it knows
   # roughly what include paths/compile flags/macro definitions are needed.
-  include_directories(support)
   file(GLOB_RECURSE LIBCXX_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/*.pass.cpp)
   file(GLOB LIBCXX_TEST_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/support/*)
   file(GLOB_RECURSE LIBCXX_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../include/*)
   add_executable(libcxx_test_objects EXCLUDE_FROM_ALL
           ${LIBCXX_TESTS} ${LIBCXX_TEST_HEADERS} ${LIBCXX_HEADERS})
   add_dependencies(libcxx_test_objects cxx)
+  target_include_directories(libcxx_test_objects
+          PRIVATE
+          support
+          ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  )
 
   split_list(LIBCXX_COMPILE_FLAGS)
   split_list(LIBCXX_LINK_FLAGS)


### PR DESCRIPTION
LIBCXX_CONFIGURE_IDE is a great little feature that makes it much easier to work with this codebase. 

This change:
- Add the libcxx/include directory as include directories to the dummy libcxx_test_objects cmake target. This allows IDEs to get a hint on how to find includes for the test sources (since the llvm-lit test sources are not part of any cmake project, this won't happen without the dummy target for IDEs that rely on cmake information entirely). Note, the headers are already listed within add_executable, but as those are supposed to be sources, CLion ignores the includes listed there (at least on modern version of CLion).
- Add LIBCXX_CONFIGURE_IDE to the docs since it's a great quality of life feature that perhaps more people would like to be aware of.

Note, CLion IDE in particular does not need the headers listed as part of add_executable, but I will be leaving them in there to not change it unnecessarily.