### PR TITLE
[flang] Fix flang build after #83132

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/LowerHLFIRIntrinsics.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/LowerHLFIRIntrinsics.cpp
@@ -176,7 +176,14 @@ protected:
           rewriter.eraseOp(use);
       }
     }
-    rewriter.replaceAllUsesWith(op->getResults(), {base});
+    // TODO: This entire pass should be a greedy pattern rewrite or a manual
+    // IR traversal. A dialect conversion cannot be used here because
+    // `replaceAllUsesWith` is not supported. Similarly, `replaceOp` is not
+    // suitable because "op->getResult(0)" and "base" can have different types.
+    // In such a case, the dialect conversion will attempt to convert the type,
+    // but no type converter is specified in this pass. Also note that all
+    // patterns in this pass are actually rewrite patterns.
+    op->getResult(0).replaceAllUsesWith(base);
     rewriter.replaceOp(op, base);
   }
 };


### PR DESCRIPTION
This fix is a temporary workaround. `LowerHLFIRIntrinsics.cpp` should be using the greedy pattern rewriter or a manual IR traversal. All patterns in this file are rewrite patterns. The test failure was caused by `replaceAllUsesWith`, which is not supported by the dialect conversion; additional asserts were added recently to prevent incorrect API usage. These trigger now.

Alternatively, turning the patterns into conversion patterns and specifying a type converter may work.

Failing test case: `Fortran/gfortran/regression/gfortran-regression-compile-regression__inline_matmul_14_f90.test`