### PR TITLE
[flang] fix one more compilation issue on aarch64.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -53,7 +53,7 @@ class DerivedTypeSpec;
 
 namespace lower {
 class SymMap;
-class SymbolBox;
+struct SymbolBox;
 namespace pft {
 struct Variable;
 }


### PR DESCRIPTION
I used `class` instead of `struct` for `SymbolMap`.