### PR TITLE
[RISCV] Add getFeaturesForCPU function support

### DIFF
--- a/llvm/include/llvm/TargetParser/RISCVTargetParser.h
+++ b/llvm/include/llvm/TargetParser/RISCVTargetParser.h
@@ -25,6 +25,9 @@ namespace RISCV {
 // We use 64 bits as the known part in the scalable vector types.
 static constexpr unsigned RVVBitsPerBlock = 64;
 
+void getFeaturesForCPU(StringRef CPU,
+                       SmallVectorImpl<std::string> &EnabledFeatures,
+                       bool NeedPlus = false);
 bool parseCPU(StringRef CPU, bool IsRV64);
 bool parseTuneCPU(StringRef CPU, bool IsRV64);
 StringRef getMArchFromMcpu(StringRef CPU);

--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -14,6 +14,7 @@
 #include "llvm/TargetParser/RISCVTargetParser.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/RISCVISAInfo.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace llvm {
@@ -95,5 +96,31 @@ void fillValidTuneCPUArchList(SmallVectorImpl<StringRef> &Values, bool IsRV64) {
 #include "llvm/TargetParser/RISCVTargetParserDef.inc"
 }
 
+void getFeaturesForCPU(StringRef CPU,
+                       SmallVectorImpl<std::string> &EnabledFeatures,
+                       bool NeedPlus) {
+  StringRef MarchFromCPU = llvm::RISCV::getMArchFromMcpu(CPU);
+  if (MarchFromCPU == "")
+    return;
+
+  EnabledFeatures.clear();
+  auto RII = RISCVISAInfo::parseArchString(
+      MarchFromCPU, /* EnableExperimentalExtension */ true);
+
+  if (llvm::errorToBool(RII.takeError()))
+    return;
+
+  std::vector<std::string> FeatStrings =
+      (*RII)->toFeatures(/* AddAllExtensions */ true);
+  for (const auto &F : FeatStrings) {
+    if (F[0] == '-')
+      continue;
+
+    if (NeedPlus)
+      EnabledFeatures.push_back(F);
+    else
+      EnabledFeatures.push_back(F.substr(1, F.size() - 1));
+  }
+}
 } // namespace RISCV
 } // namespace llvm

--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -117,7 +117,7 @@ void getFeaturesForCPU(StringRef CPU,
     if (NeedPlus)
       EnabledFeatures.push_back(F);
     else
-      EnabledFeatures.push_back(F.substr(1, F.size() - 1));
+      EnabledFeatures.push_back(F.substr(1));
 }
 } // namespace RISCV
 } // namespace llvm

--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -96,6 +96,7 @@ void fillValidTuneCPUArchList(SmallVectorImpl<StringRef> &Values, bool IsRV64) {
 #include "llvm/TargetParser/RISCVTargetParserDef.inc"
 }
 
+// This function is currently used by IREE, so it's not dead code.
 void getFeaturesForCPU(StringRef CPU,
                        SmallVectorImpl<std::string> &EnabledFeatures,
                        bool NeedPlus) {
@@ -111,16 +112,12 @@ void getFeaturesForCPU(StringRef CPU,
     return;
 
   std::vector<std::string> FeatStrings =
-      (*RII)->toFeatures(/* AddAllExtensions */ true);
-  for (const auto &F : FeatStrings) {
-    if (F[0] == '-')
-      continue;
-
+      (*RII)->toFeatures(/* AddAllExtensions */ false);
+  for (const auto &F : FeatStrings)
     if (NeedPlus)
       EnabledFeatures.push_back(F);
     else
       EnabledFeatures.push_back(F.substr(1, F.size() - 1));
-  }
 }
 } // namespace RISCV
 } // namespace llvm


### PR DESCRIPTION
This function parse the cpu and return it's supported
features placed in EnabledFeatures. It is same as the
one in X86TargetParser and also is used in IREE.
