### PR TITLE
[libc] remove header guard for assert.h

### DIFF
--- a/libc/src/assert/assert.h
+++ b/libc/src/assert/assert.h
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_ASSERT_ASSERT_H
-#define LLVM_LIBC_SRC_ASSERT_ASSERT_H
-
 #include "src/assert/__assert_fail.h"
 
 // There is no header guard here since assert is intended to be capable of being
@@ -25,5 +22,3 @@
        : LIBC_NAMESPACE::__assert_fail(#e, __FILE__, __LINE__,                 \
                                        __PRETTY_FUNCTION__))
 #endif // NDEBUG
-
-#endif // LLVM_LIBC_SRC_ASSERT_ASSERT_H

--- a/libc/src/assert/assert.h
+++ b/libc/src/assert/assert.h
@@ -1,4 +1,4 @@
-// NOLINT(llvm-header-guard)
+// NOLINT(llvm-header-guard) https://github.com/llvm/llvm-project/issues/83339
 //===-- Internal header for assert ------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/src/assert/assert.h
+++ b/libc/src/assert/assert.h
@@ -1,3 +1,4 @@
+// NOLINT(llvm-header-guard)
 //===-- Internal header for assert ------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
It's meant to be included multiple times! Maybe use a NOLINT rule to suppress
clang-tidy's llvm-header-guard lint warning.
