### PR TITLE
Change `image list -r` so that it actually shows the ref count and whether the image is in the shared cache.

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3376,15 +3376,19 @@ protected:
 
       case 'r': {
         size_t ref_count = 0;
+        char in_shared_cache = 'Y';
+        
         ModuleSP module_sp(module->shared_from_this());
+        if (!ModuleList::ModuleIsInCache(module))
+          in_shared_cache = 'N';
         if (module_sp) {
           // Take one away to make sure we don't count our local "module_sp"
           ref_count = module_sp.use_count() - 1;
         }
         if (width)
-          strm.Printf("{%*" PRIu64 "}", width, (uint64_t)ref_count);
+          strm.Printf("{%c %*" PRIu64 "}", in_shared_cache, width, (uint64_t)ref_count);
         else
-          strm.Printf("{%" PRIu64 "}", (uint64_t)ref_count);
+          strm.Printf("{%c %" PRIu64 "}", in_shared_cache, (uint64_t)ref_count);
       } break;
 
       case 's':

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -936,8 +936,8 @@ let Command = "target modules list" in {
     OptionalArg<"Width">, Desc<"Display the modification time with optional "
     "width of the module.">;
   def target_modules_list_ref_count : Option<"ref-count", "r">, Group<1>,
-    OptionalArg<"Width">, Desc<"Display the reference count if the module is "
-    "still in the shared module cache.">;
+    OptionalArg<"Width">, Desc<"Display whether the module is still in the "
+    "the shared module cache (Y/N), and its shared pointer use_count.">;
   def target_modules_list_pointer : Option<"pointer", "p">, Group<1>,
     OptionalArg<"None">, Desc<"Display the module pointer.">;
   def target_modules_list_global : Option<"global", "g">, Group<1>,


### PR DESCRIPTION
The help for the `-r` option to `image list` says:

       -r[<width>] ( --ref-count=[<width>] )
            Display the reference count if the module is still in the shared module cache.

but that's not what it actually does.  It unconditionally shows the use_count for all Module shared pointers, regardless of whether they are still in the shared module cache or whether they are just in the ModuleCollection and other entities are keeping them alive.  That seems like a more useful behavior, but then it is also useful to know what's in the shared cache, so I changed this to:

       -r[<width>] ( --ref-count=[<width>] )
            Display whether the module is still in the the shared module cache (Y/N), and its shared pointer use_count.

So instead of just `{5}` you will see `{Y 5}` if it is in the shared cache and `{N 5}` if not.

I didn't add tests for this because I'm not sure how much we want to fix shared cache behavior in the testsuite.