### PR TITLE
[benchmark] Fix dependency error for numeric_limits on release/11.x

### DIFF
--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
On `release/11.x` branch, build failed cause of `numeric_limits`, which are part of `limits` header.

```bash
ninja -C build 
ninja: Entering directory `build'
[1/3] Building CXX object utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o
FAILED: utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o 
/usr/bin/c++ -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/build/utils/benchmark/src -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src -I/usr/include/libxml2 -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/build/include -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/include -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/include -I/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/../include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -fdiagnostics-color -ffunction-sections -fdata-sections  -std=c++11  -Wall  -Wextra  -Wshadow  -pedantic  -pedantic-errors  -Wfloat-equal  -fstrict-aliasing  -fno-exceptions  -Wstrict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o -MF utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o.d -o utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o -c /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.cc
In file included from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.cc:15:
/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.h: In function ‘void AddRange(std::vector<T>*, T, T, int)’:
/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.h:17:30: error: ‘numeric_limits’ is not a member of ‘std’
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.h:17:46: error: expected primary-expression before ‘>’ token
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                              ^
/mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.h:17:49: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                                 ^~~
      |                                                 std::max
In file included from /usr/include/c++/11/algorithm:62,
                 from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/include/benchmark/benchmark.h:175,
                 from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/internal_macros.h:4,
                 from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/check.h:8,
                 from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.h:6,
                 from /mnt/EAE2CD0AE2CCDBC7/llvm-project-v11/llvm/utils/benchmark/src/benchmark_register.cc:15:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
ninja: build stopped: subcommand failed.

```

So, I add `limits` header on the `benchmark_register.h`.


I know 11.x is old and not maintained, but I think it's a big problem that it doesn't build, and I think it's a problem that I'm leaving it unattended even though it's easy to fix. Someone still need an old version of llvm, so I'm posting this PR.

Fixes #59333