### PR TITLE
[libc++] Fix diagnostic for <stdatomic.h> before C++23

### DIFF
--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -587,6 +587,12 @@ template <class T>
 
 */
 
+#include <__config>
+
+#if _LIBCPP_STD_VER < 23 && defined(_LIBCPP_STDATOMIC_H)
+#  error <atomic> is incompatible with <stdatomic.h> before C++23. Please compile with -std=c++23.
+#endif
+
 #include <__atomic/aliases.h>
 #include <__atomic/atomic.h>
 #include <__atomic/atomic_base.h>
@@ -601,7 +607,6 @@ template <class T>
 #include <__atomic/is_always_lock_free.h>
 #include <__atomic/kill_dependency.h>
 #include <__atomic/memory_order.h>
-#include <__config>
 #include <version>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -610,10 +615,6 @@ template <class T>
 
 #ifdef _LIBCPP_HAS_NO_ATOMIC_HEADER
 #  error <atomic> is not implemented
-#endif
-
-#ifdef kill_dependency
-#  error <atomic> is incompatible with <stdatomic.h> before C++23. Please compile with -std=c++23.
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20


### PR DESCRIPTION
We normally try to issue a reasonable diagnostic when mixing <stdatomic.h> and <atomic> before C++23. However, after granularizing the <atomic> header, the check and the #error message was moved to *after* the point where mixing both causes problems. When mixing both headers, we would hence get the diagnostic burried under a pile of previous diagnostics in e.g. __atomic/kill_dependency.h.

This patch moves the check earlier to restore the intended behavior. It also switches from `#ifdef kill_dependency` to an explicit check of the inclusion of the header and the Standard version, which seems to be more reliable than checking whether a macro is defined.