### PR TITLE
[libc] Provide an implementation of the 'stdint.h' header

### DIFF
--- a/libc/config/baremetal/arm/headers.txt
+++ b/libc/config/baremetal/arm/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.errno
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.math
     libc.include.stdio

--- a/libc/config/baremetal/riscv/headers.txt
+++ b/libc/config/baremetal/riscv/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.errno
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.math
     libc.include.stdio

--- a/libc/config/darwin/arm/headers.txt
+++ b/libc/config/darwin/arm/headers.txt
@@ -3,6 +3,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.errno
     libc.include.fenv
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/config/darwin/x86_64/headers.txt
+++ b/libc/config/darwin/x86_64/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     # Fenv is currently disabled.
     #libc.include.fenv
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -3,6 +3,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.ctype
     libc.include.string
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -5,6 +5,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -3,6 +3,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.errno
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.math
     libc.include.stdckdint

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -7,6 +7,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -7,6 +7,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.stdint
     libc.include.inttypes
     libc.include.limits
     libc.include.math

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -85,6 +85,14 @@ add_gen_header(
 )
 
 add_gen_header(
+  stdint
+  DEF_FILE stdint.h.def
+  GEN_HDR stdint.h
+  DEPENDS
+    .llvm-libc-macros.stdint_macros
+)
+
+add_gen_header(
   limits
   DEF_FILE limits.h.def
   GEN_HDR limits.h

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -68,6 +68,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  stdint_macros
+  HDR
+    stdint-macros.h
+)
+
+add_macro_header(
   float_macros
   HDR
     float-macros.h

--- a/libc/include/llvm-libc-macros/stdint-macros.h
+++ b/libc/include/llvm-libc-macros/stdint-macros.h
@@ -1,0 +1,878 @@
+//===-- Definition of macros from stdint.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_STDINT_MACROS_H
+#define LLVM_LIBC_MACROS_STDINT_MACROS_H
+
+// These definitions are copied directly from the clang implementation located
+// at 'clang/lib/Headers/stdint.h'. We provide it here again for compatibility.
+
+/* C99 7.18.1.1 Exact-width integer types.
+ * C99 7.18.1.2 Minimum-width integer types.
+ * C99 7.18.1.3 Fastest minimum-width integer types.
+ *
+ * The standard requires that exact-width type be defined for 8-, 16-, 32-, and
+ * 64-bit types if they are implemented. Other exact width types are optional.
+ * This implementation defines an exact-width types for every integer width
+ * that is represented in the standard integer types.
+ *
+ * The standard also requires minimum-width types be defined for 8-, 16-, 32-,
+ * and 64-bit widths regardless of whether there are corresponding exact-width
+ * types.
+ *
+ * To accommodate targets that are missing types that are exactly 8, 16, 32, or
+ * 64 bits wide, this implementation takes an approach of cascading
+ * redefinitions, redefining __int_leastN_t to successively smaller exact-width
+ * types. It is therefore important that the types are defined in order of
+ * descending widths.
+ *
+ * We currently assume that the minimum-width types and the fastest
+ * minimum-width types are the same. This is allowed by the standard, but is
+ * suboptimal.
+ *
+ * In violation of the standard, some targets do not implement a type that is
+ * wide enough to represent all of the required widths (8-, 16-, 32-, 64-bit).
+ * To accommodate these targets, a required minimum-width type is only
+ * defined if there exists an exact-width type of equal or greater width.
+ */
+
+#ifdef __INT64_TYPE__
+#ifndef __int8_t_defined /* glibc sys/types.h also defines int64_t*/
+typedef __INT64_TYPE__ int64_t;
+#endif /* __int8_t_defined */
+typedef __UINT64_TYPE__ uint64_t;
+#undef __int_least64_t
+#define __int_least64_t int64_t
+#undef __uint_least64_t
+#define __uint_least64_t uint64_t
+#undef __int_least32_t
+#define __int_least32_t int64_t
+#undef __uint_least32_t
+#define __uint_least32_t uint64_t
+#undef __int_least16_t
+#define __int_least16_t int64_t
+#undef __uint_least16_t
+#define __uint_least16_t uint64_t
+#undef __int_least8_t
+#define __int_least8_t int64_t
+#undef __uint_least8_t
+#define __uint_least8_t uint64_t
+#endif /* __INT64_TYPE__ */
+
+#ifdef __int_least64_t
+typedef __int_least64_t int_least64_t;
+typedef __uint_least64_t uint_least64_t;
+typedef __int_least64_t int_fast64_t;
+typedef __uint_least64_t uint_fast64_t;
+#endif /* __int_least64_t */
+
+#ifdef __INT56_TYPE__
+typedef __INT56_TYPE__ int56_t;
+typedef __UINT56_TYPE__ uint56_t;
+typedef int56_t int_least56_t;
+typedef uint56_t uint_least56_t;
+typedef int56_t int_fast56_t;
+typedef uint56_t uint_fast56_t;
+#undef __int_least32_t
+#define __int_least32_t int56_t
+#undef __uint_least32_t
+#define __uint_least32_t uint56_t
+#undef __int_least16_t
+#define __int_least16_t int56_t
+#undef __uint_least16_t
+#define __uint_least16_t uint56_t
+#undef __int_least8_t
+#define __int_least8_t int56_t
+#undef __uint_least8_t
+#define __uint_least8_t uint56_t
+#endif /* __INT56_TYPE__ */
+
+#ifdef __INT48_TYPE__
+typedef __INT48_TYPE__ int48_t;
+typedef __UINT48_TYPE__ uint48_t;
+typedef int48_t int_least48_t;
+typedef uint48_t uint_least48_t;
+typedef int48_t int_fast48_t;
+typedef uint48_t uint_fast48_t;
+#undef __int_least32_t
+#define __int_least32_t int48_t
+#undef __uint_least32_t
+#define __uint_least32_t uint48_t
+#undef __int_least16_t
+#define __int_least16_t int48_t
+#undef __uint_least16_t
+#define __uint_least16_t uint48_t
+#undef __int_least8_t
+#define __int_least8_t int48_t
+#undef __uint_least8_t
+#define __uint_least8_t uint48_t
+#endif /* __INT48_TYPE__ */
+
+#ifdef __INT40_TYPE__
+typedef __INT40_TYPE__ int40_t;
+typedef __UINT40_TYPE__ uint40_t;
+typedef int40_t int_least40_t;
+typedef uint40_t uint_least40_t;
+typedef int40_t int_fast40_t;
+typedef uint40_t uint_fast40_t;
+#undef __int_least32_t
+#define __int_least32_t int40_t
+#undef __uint_least32_t
+#define __uint_least32_t uint40_t
+#undef __int_least16_t
+#define __int_least16_t int40_t
+#undef __uint_least16_t
+#define __uint_least16_t uint40_t
+#undef __int_least8_t
+#define __int_least8_t int40_t
+#undef __uint_least8_t
+#define __uint_least8_t uint40_t
+#endif /* __INT40_TYPE__ */
+
+#ifdef __INT32_TYPE__
+
+#ifndef __int8_t_defined /* glibc sys/types.h also defines int32_t*/
+typedef __INT32_TYPE__ int32_t;
+#endif /* __int8_t_defined */
+
+#ifndef __uint32_t_defined /* more glibc compatibility */
+#define __uint32_t_defined
+typedef __UINT32_TYPE__ uint32_t;
+#endif /* __uint32_t_defined */
+
+#undef __int_least32_t
+#define __int_least32_t int32_t
+#undef __uint_least32_t
+#define __uint_least32_t uint32_t
+#undef __int_least16_t
+#define __int_least16_t int32_t
+#undef __uint_least16_t
+#define __uint_least16_t uint32_t
+#undef __int_least8_t
+#define __int_least8_t int32_t
+#undef __uint_least8_t
+#define __uint_least8_t uint32_t
+#endif /* __INT32_TYPE__ */
+
+#ifdef __int_least32_t
+typedef __int_least32_t int_least32_t;
+typedef __uint_least32_t uint_least32_t;
+typedef __int_least32_t int_fast32_t;
+typedef __uint_least32_t uint_fast32_t;
+#endif /* __int_least32_t */
+
+#ifdef __INT24_TYPE__
+typedef __INT24_TYPE__ int24_t;
+typedef __UINT24_TYPE__ uint24_t;
+typedef int24_t int_least24_t;
+typedef uint24_t uint_least24_t;
+typedef int24_t int_fast24_t;
+typedef uint24_t uint_fast24_t;
+#undef __int_least16_t
+#define __int_least16_t int24_t
+#undef __uint_least16_t
+#define __uint_least16_t uint24_t
+#undef __int_least8_t
+#define __int_least8_t int24_t
+#undef __uint_least8_t
+#define __uint_least8_t uint24_t
+#endif /* __INT24_TYPE__ */
+
+#ifdef __INT16_TYPE__
+#ifndef __int8_t_defined /* glibc sys/types.h also defines int16_t*/
+typedef __INT16_TYPE__ int16_t;
+#endif /* __int8_t_defined */
+typedef __UINT16_TYPE__ uint16_t;
+#undef __int_least16_t
+#define __int_least16_t int16_t
+#undef __uint_least16_t
+#define __uint_least16_t uint16_t
+#undef __int_least8_t
+#define __int_least8_t int16_t
+#undef __uint_least8_t
+#define __uint_least8_t uint16_t
+#endif /* __INT16_TYPE__ */
+
+#ifdef __int_least16_t
+typedef __int_least16_t int_least16_t;
+typedef __uint_least16_t uint_least16_t;
+typedef __int_least16_t int_fast16_t;
+typedef __uint_least16_t uint_fast16_t;
+#endif /* __int_least16_t */
+
+#ifdef __INT8_TYPE__
+#ifndef __int8_t_defined /* glibc sys/types.h also defines int8_t*/
+typedef __INT8_TYPE__ int8_t;
+#endif /* __int8_t_defined */
+typedef __UINT8_TYPE__ uint8_t;
+#undef __int_least8_t
+#define __int_least8_t int8_t
+#undef __uint_least8_t
+#define __uint_least8_t uint8_t
+#endif /* __INT8_TYPE__ */
+
+#ifdef __int_least8_t
+typedef __int_least8_t int_least8_t;
+typedef __uint_least8_t uint_least8_t;
+typedef __int_least8_t int_fast8_t;
+typedef __uint_least8_t uint_fast8_t;
+#endif /* __int_least8_t */
+
+/* prevent glibc sys/types.h from defining conflicting types */
+#ifndef __int8_t_defined
+#define __int8_t_defined
+#endif /* __int8_t_defined */
+
+/* C99 7.18.1.4 Integer types capable of holding object pointers.
+ */
+#define __stdint_join3(a, b, c) a##b##c
+
+#ifndef _INTPTR_T
+#ifndef __intptr_t_defined
+typedef __INTPTR_TYPE__ intptr_t;
+#define __intptr_t_defined
+#define _INTPTR_T
+#endif
+#endif
+
+#ifndef _UINTPTR_T
+typedef __UINTPTR_TYPE__ uintptr_t;
+#define _UINTPTR_T
+#endif
+
+/* C99 7.18.1.5 Greatest-width integer types.
+ */
+typedef __INTMAX_TYPE__ intmax_t;
+typedef __UINTMAX_TYPE__ uintmax_t;
+
+/* C99 7.18.4 Macros for minimum-width integer constants.
+ *
+ * The standard requires that integer constant macros be defined for all the
+ * minimum-width types defined above. As 8-, 16-, 32-, and 64-bit minimum-width
+ * types are required, the corresponding integer constant macros are defined
+ * here. This implementation also defines minimum-width types for every other
+ * integer width that the target implements, so corresponding macros are
+ * defined below, too.
+ *
+ * These macros are defined using the same successive-shrinking approach as
+ * the type definitions above. It is likewise important that macros are defined
+ * in order of decending width.
+ *
+ * Note that C++ should not check __STDC_CONSTANT_MACROS here, contrary to the
+ * claims of the C standard (see C++ 18.3.1p2, [cstdint.syn]).
+ */
+
+#define __int_c_join(a, b) a##b
+#define __int_c(v, suffix) __int_c_join(v, suffix)
+#define __uint_c(v, suffix) __int_c_join(v##U, suffix)
+
+#ifdef __INT64_TYPE__
+#undef __int64_c_suffix
+#undef __int32_c_suffix
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT64_C_SUFFIX__
+#define __int64_c_suffix __INT64_C_SUFFIX__
+#define __int32_c_suffix __INT64_C_SUFFIX__
+#define __int16_c_suffix __INT64_C_SUFFIX__
+#define __int8_c_suffix __INT64_C_SUFFIX__
+#endif /* __INT64_C_SUFFIX__ */
+#endif /* __INT64_TYPE__ */
+
+#ifdef __int_least64_t
+#ifdef __int64_c_suffix
+#define INT64_C(v) __int_c(v, __int64_c_suffix)
+#define UINT64_C(v) __uint_c(v, __int64_c_suffix)
+#else
+#define INT64_C(v) v
+#define UINT64_C(v) v##U
+#endif /* __int64_c_suffix */
+#endif /* __int_least64_t */
+
+#ifdef __INT56_TYPE__
+#undef __int32_c_suffix
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT56_C_SUFFIX__
+#define INT56_C(v) __int_c(v, __INT56_C_SUFFIX__)
+#define UINT56_C(v) __uint_c(v, __INT56_C_SUFFIX__)
+#define __int32_c_suffix __INT56_C_SUFFIX__
+#define __int16_c_suffix __INT56_C_SUFFIX__
+#define __int8_c_suffix __INT56_C_SUFFIX__
+#else
+#define INT56_C(v) v
+#define UINT56_C(v) v##U
+#endif /* __INT56_C_SUFFIX__ */
+#endif /* __INT56_TYPE__ */
+
+#ifdef __INT48_TYPE__
+#undef __int32_c_suffix
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT48_C_SUFFIX__
+#define INT48_C(v) __int_c(v, __INT48_C_SUFFIX__)
+#define UINT48_C(v) __uint_c(v, __INT48_C_SUFFIX__)
+#define __int32_c_suffix __INT48_C_SUFFIX__
+#define __int16_c_suffix __INT48_C_SUFFIX__
+#define __int8_c_suffix __INT48_C_SUFFIX__
+#else
+#define INT48_C(v) v
+#define UINT48_C(v) v##U
+#endif /* __INT48_C_SUFFIX__ */
+#endif /* __INT48_TYPE__ */
+
+#ifdef __INT40_TYPE__
+#undef __int32_c_suffix
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT40_C_SUFFIX__
+#define INT40_C(v) __int_c(v, __INT40_C_SUFFIX__)
+#define UINT40_C(v) __uint_c(v, __INT40_C_SUFFIX__)
+#define __int32_c_suffix __INT40_C_SUFFIX__
+#define __int16_c_suffix __INT40_C_SUFFIX__
+#define __int8_c_suffix __INT40_C_SUFFIX__
+#else
+#define INT40_C(v) v
+#define UINT40_C(v) v##U
+#endif /* __INT40_C_SUFFIX__ */
+#endif /* __INT40_TYPE__ */
+
+#ifdef __INT32_TYPE__
+#undef __int32_c_suffix
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT32_C_SUFFIX__
+#define __int32_c_suffix __INT32_C_SUFFIX__
+#define __int16_c_suffix __INT32_C_SUFFIX__
+#define __int8_c_suffix __INT32_C_SUFFIX__
+#endif /* __INT32_C_SUFFIX__ */
+#endif /* __INT32_TYPE__ */
+
+#ifdef __int_least32_t
+#ifdef __int32_c_suffix
+#define INT32_C(v) __int_c(v, __int32_c_suffix)
+#define UINT32_C(v) __uint_c(v, __int32_c_suffix)
+#else
+#define INT32_C(v) v
+#define UINT32_C(v) v##U
+#endif /* __int32_c_suffix */
+#endif /* __int_least32_t */
+
+#ifdef __INT24_TYPE__
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT24_C_SUFFIX__
+#define INT24_C(v) __int_c(v, __INT24_C_SUFFIX__)
+#define UINT24_C(v) __uint_c(v, __INT24_C_SUFFIX__)
+#define __int16_c_suffix __INT24_C_SUFFIX__
+#define __int8_c_suffix __INT24_C_SUFFIX__
+#else
+#define INT24_C(v) v
+#define UINT24_C(v) v##U
+#endif /* __INT24_C_SUFFIX__ */
+#endif /* __INT24_TYPE__ */
+
+#ifdef __INT16_TYPE__
+#undef __int16_c_suffix
+#undef __int8_c_suffix
+#ifdef __INT16_C_SUFFIX__
+#define __int16_c_suffix __INT16_C_SUFFIX__
+#define __int8_c_suffix __INT16_C_SUFFIX__
+#endif /* __INT16_C_SUFFIX__ */
+#endif /* __INT16_TYPE__ */
+
+#ifdef __int_least16_t
+#ifdef __int16_c_suffix
+#define INT16_C(v) __int_c(v, __int16_c_suffix)
+#define UINT16_C(v) __uint_c(v, __int16_c_suffix)
+#else
+#define INT16_C(v) v
+#define UINT16_C(v) v##U
+#endif /* __int16_c_suffix */
+#endif /* __int_least16_t */
+
+#ifdef __INT8_TYPE__
+#undef __int8_c_suffix
+#ifdef __INT8_C_SUFFIX__
+#define __int8_c_suffix __INT8_C_SUFFIX__
+#endif /* __INT8_C_SUFFIX__ */
+#endif /* __INT8_TYPE__ */
+
+#ifdef __int_least8_t
+#ifdef __int8_c_suffix
+#define INT8_C(v) __int_c(v, __int8_c_suffix)
+#define UINT8_C(v) __uint_c(v, __int8_c_suffix)
+#else
+#define INT8_C(v) v
+#define UINT8_C(v) v##U
+#endif /* __int8_c_suffix */
+#endif /* __int_least8_t */
+
+/* C99 7.18.2.1 Limits of exact-width integer types.
+ * C99 7.18.2.2 Limits of minimum-width integer types.
+ * C99 7.18.2.3 Limits of fastest minimum-width integer types.
+ *
+ * The presence of limit macros are completely optional in C99.  This
+ * implementation defines limits for all of the types (exact- and
+ * minimum-width) that it defines above, using the limits of the minimum-width
+ * type for any types that do not have exact-width representations.
+ *
+ * As in the type definitions, this section takes an approach of
+ * successive-shrinking to determine which limits to use for the standard (8,
+ * 16, 32, 64) bit widths when they don't have exact representations. It is
+ * therefore important that the definitions be kept in order of decending
+ * widths.
+ *
+ * Note that C++ should not check __STDC_LIMIT_MACROS here, contrary to the
+ * claims of the C standard (see C++ 18.3.1p2, [cstdint.syn]).
+ */
+
+#ifdef __INT64_TYPE__
+#define INT64_MAX INT64_C(9223372036854775807)
+#define INT64_MIN (-INT64_C(9223372036854775807) - 1)
+#define UINT64_MAX UINT64_C(18446744073709551615)
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT64_WIDTH 64
+#define INT64_WIDTH UINT64_WIDTH
+
+#define __UINT_LEAST64_WIDTH UINT64_WIDTH
+#undef __UINT_LEAST32_WIDTH
+#define __UINT_LEAST32_WIDTH UINT64_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT64_WIDTH
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT64_MAX
+#endif /* __STDC_VERSION__ */
+
+#define __INT_LEAST64_MIN INT64_MIN
+#define __INT_LEAST64_MAX INT64_MAX
+#define __UINT_LEAST64_MAX UINT64_MAX
+#undef __INT_LEAST32_MIN
+#define __INT_LEAST32_MIN INT64_MIN
+#undef __INT_LEAST32_MAX
+#define __INT_LEAST32_MAX INT64_MAX
+#undef __UINT_LEAST32_MAX
+#define __UINT_LEAST32_MAX UINT64_MAX
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT64_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT64_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT64_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT64_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT64_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT64_MAX
+#endif /* __INT64_TYPE__ */
+
+#ifdef __INT_LEAST64_MIN
+#define INT_LEAST64_MIN __INT_LEAST64_MIN
+#define INT_LEAST64_MAX __INT_LEAST64_MAX
+#define UINT_LEAST64_MAX __UINT_LEAST64_MAX
+#define INT_FAST64_MIN __INT_LEAST64_MIN
+#define INT_FAST64_MAX __INT_LEAST64_MAX
+#define UINT_FAST64_MAX __UINT_LEAST64_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT_LEAST64_WIDTH __UINT_LEAST64_WIDTH
+#define INT_LEAST64_WIDTH UINT_LEAST64_WIDTH
+#define UINT_FAST64_WIDTH __UINT_LEAST64_WIDTH
+#define INT_FAST64_WIDTH UINT_FAST64_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT_LEAST64_MIN */
+
+#ifdef __INT56_TYPE__
+#define INT56_MAX INT56_C(36028797018963967)
+#define INT56_MIN (-INT56_C(36028797018963967) - 1)
+#define UINT56_MAX UINT56_C(72057594037927935)
+#define INT_LEAST56_MIN INT56_MIN
+#define INT_LEAST56_MAX INT56_MAX
+#define UINT_LEAST56_MAX UINT56_MAX
+#define INT_FAST56_MIN INT56_MIN
+#define INT_FAST56_MAX INT56_MAX
+#define UINT_FAST56_MAX UINT56_MAX
+
+#undef __INT_LEAST32_MIN
+#define __INT_LEAST32_MIN INT56_MIN
+#undef __INT_LEAST32_MAX
+#define __INT_LEAST32_MAX INT56_MAX
+#undef __UINT_LEAST32_MAX
+#define __UINT_LEAST32_MAX UINT56_MAX
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT56_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT56_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT56_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT56_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT56_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT56_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT56_WIDTH 56
+#define INT56_WIDTH UINT56_WIDTH
+#define UINT_LEAST56_WIDTH UINT56_WIDTH
+#define INT_LEAST56_WIDTH UINT_LEAST56_WIDTH
+#define UINT_FAST56_WIDTH UINT56_WIDTH
+#define INT_FAST56_WIDTH UINT_FAST56_WIDTH
+#undef __UINT_LEAST32_WIDTH
+#define __UINT_LEAST32_WIDTH UINT56_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT56_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT56_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT56_TYPE__ */
+
+#ifdef __INT48_TYPE__
+#define INT48_MAX INT48_C(140737488355327)
+#define INT48_MIN (-INT48_C(140737488355327) - 1)
+#define UINT48_MAX UINT48_C(281474976710655)
+#define INT_LEAST48_MIN INT48_MIN
+#define INT_LEAST48_MAX INT48_MAX
+#define UINT_LEAST48_MAX UINT48_MAX
+#define INT_FAST48_MIN INT48_MIN
+#define INT_FAST48_MAX INT48_MAX
+#define UINT_FAST48_MAX UINT48_MAX
+
+#undef __INT_LEAST32_MIN
+#define __INT_LEAST32_MIN INT48_MIN
+#undef __INT_LEAST32_MAX
+#define __INT_LEAST32_MAX INT48_MAX
+#undef __UINT_LEAST32_MAX
+#define __UINT_LEAST32_MAX UINT48_MAX
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT48_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT48_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT48_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT48_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT48_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT48_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT48_WIDTH 48
+#define INT48_WIDTH UINT48_WIDTH
+#define UINT_LEAST48_WIDTH UINT48_WIDTH
+#define INT_LEAST48_WIDTH UINT_LEAST48_WIDTH
+#define UINT_FAST48_WIDTH UINT48_WIDTH
+#define INT_FAST48_WIDTH UINT_FAST48_WIDTH
+#undef __UINT_LEAST32_WIDTH
+#define __UINT_LEAST32_WIDTH UINT48_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT48_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT48_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT48_TYPE__ */
+
+#ifdef __INT40_TYPE__
+#define INT40_MAX INT40_C(549755813887)
+#define INT40_MIN (-INT40_C(549755813887) - 1)
+#define UINT40_MAX UINT40_C(1099511627775)
+#define INT_LEAST40_MIN INT40_MIN
+#define INT_LEAST40_MAX INT40_MAX
+#define UINT_LEAST40_MAX UINT40_MAX
+#define INT_FAST40_MIN INT40_MIN
+#define INT_FAST40_MAX INT40_MAX
+#define UINT_FAST40_MAX UINT40_MAX
+
+#undef __INT_LEAST32_MIN
+#define __INT_LEAST32_MIN INT40_MIN
+#undef __INT_LEAST32_MAX
+#define __INT_LEAST32_MAX INT40_MAX
+#undef __UINT_LEAST32_MAX
+#define __UINT_LEAST32_MAX UINT40_MAX
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT40_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT40_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT40_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT40_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT40_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT40_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT40_WIDTH 40
+#define INT40_WIDTH UINT40_WIDTH
+#define UINT_LEAST40_WIDTH UINT40_WIDTH
+#define INT_LEAST40_WIDTH UINT_LEAST40_WIDTH
+#define UINT_FAST40_WIDTH UINT40_WIDTH
+#define INT_FAST40_WIDTH UINT_FAST40_WIDTH
+#undef __UINT_LEAST32_WIDTH
+#define __UINT_LEAST32_WIDTH UINT40_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT40_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT40_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT40_TYPE__ */
+
+#ifdef __INT32_TYPE__
+#define INT32_MAX INT32_C(2147483647)
+#define INT32_MIN (-INT32_C(2147483647) - 1)
+#define UINT32_MAX UINT32_C(4294967295)
+
+#undef __INT_LEAST32_MIN
+#define __INT_LEAST32_MIN INT32_MIN
+#undef __INT_LEAST32_MAX
+#define __INT_LEAST32_MAX INT32_MAX
+#undef __UINT_LEAST32_MAX
+#define __UINT_LEAST32_MAX UINT32_MAX
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT32_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT32_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT32_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT32_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT32_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT32_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT32_WIDTH 32
+#define INT32_WIDTH UINT32_WIDTH
+#undef __UINT_LEAST32_WIDTH
+#define __UINT_LEAST32_WIDTH UINT32_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT32_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT32_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT32_TYPE__ */
+
+#ifdef __INT_LEAST32_MIN
+#define INT_LEAST32_MIN __INT_LEAST32_MIN
+#define INT_LEAST32_MAX __INT_LEAST32_MAX
+#define UINT_LEAST32_MAX __UINT_LEAST32_MAX
+#define INT_FAST32_MIN __INT_LEAST32_MIN
+#define INT_FAST32_MAX __INT_LEAST32_MAX
+#define UINT_FAST32_MAX __UINT_LEAST32_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT_LEAST32_WIDTH __UINT_LEAST32_WIDTH
+#define INT_LEAST32_WIDTH UINT_LEAST32_WIDTH
+#define UINT_FAST32_WIDTH __UINT_LEAST32_WIDTH
+#define INT_FAST32_WIDTH UINT_FAST32_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT_LEAST32_MIN */
+
+#ifdef __INT24_TYPE__
+#define INT24_MAX INT24_C(8388607)
+#define INT24_MIN (-INT24_C(8388607) - 1)
+#define UINT24_MAX UINT24_C(16777215)
+#define INT_LEAST24_MIN INT24_MIN
+#define INT_LEAST24_MAX INT24_MAX
+#define UINT_LEAST24_MAX UINT24_MAX
+#define INT_FAST24_MIN INT24_MIN
+#define INT_FAST24_MAX INT24_MAX
+#define UINT_FAST24_MAX UINT24_MAX
+
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT24_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT24_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT24_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT24_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT24_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT24_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT24_WIDTH 24
+#define INT24_WIDTH UINT24_WIDTH
+#define UINT_LEAST24_WIDTH UINT24_WIDTH
+#define INT_LEAST24_WIDTH UINT_LEAST24_WIDTH
+#define UINT_FAST24_WIDTH UINT24_WIDTH
+#define INT_FAST24_WIDTH UINT_FAST24_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT24_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT24_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT24_TYPE__ */
+
+#ifdef __INT16_TYPE__
+#define INT16_MAX INT16_C(32767)
+#define INT16_MIN (-INT16_C(32767) - 1)
+#define UINT16_MAX UINT16_C(65535)
+
+#undef __INT_LEAST16_MIN
+#define __INT_LEAST16_MIN INT16_MIN
+#undef __INT_LEAST16_MAX
+#define __INT_LEAST16_MAX INT16_MAX
+#undef __UINT_LEAST16_MAX
+#define __UINT_LEAST16_MAX UINT16_MAX
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT16_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT16_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT16_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT16_WIDTH 16
+#define INT16_WIDTH UINT16_WIDTH
+#undef __UINT_LEAST16_WIDTH
+#define __UINT_LEAST16_WIDTH UINT16_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT16_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT16_TYPE__ */
+
+#ifdef __INT_LEAST16_MIN
+#define INT_LEAST16_MIN __INT_LEAST16_MIN
+#define INT_LEAST16_MAX __INT_LEAST16_MAX
+#define UINT_LEAST16_MAX __UINT_LEAST16_MAX
+#define INT_FAST16_MIN __INT_LEAST16_MIN
+#define INT_FAST16_MAX __INT_LEAST16_MAX
+#define UINT_FAST16_MAX __UINT_LEAST16_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT_LEAST16_WIDTH __UINT_LEAST16_WIDTH
+#define INT_LEAST16_WIDTH UINT_LEAST16_WIDTH
+#define UINT_FAST16_WIDTH __UINT_LEAST16_WIDTH
+#define INT_FAST16_WIDTH UINT_FAST16_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT_LEAST16_MIN */
+
+#ifdef __INT8_TYPE__
+#define INT8_MAX INT8_C(127)
+#define INT8_MIN (-INT8_C(127) - 1)
+#define UINT8_MAX UINT8_C(255)
+
+#undef __INT_LEAST8_MIN
+#define __INT_LEAST8_MIN INT8_MIN
+#undef __INT_LEAST8_MAX
+#define __INT_LEAST8_MAX INT8_MAX
+#undef __UINT_LEAST8_MAX
+#define __UINT_LEAST8_MAX UINT8_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT8_WIDTH 8
+#define INT8_WIDTH UINT8_WIDTH
+#undef __UINT_LEAST8_WIDTH
+#define __UINT_LEAST8_WIDTH UINT8_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT8_TYPE__ */
+
+#ifdef __INT_LEAST8_MIN
+#define INT_LEAST8_MIN __INT_LEAST8_MIN
+#define INT_LEAST8_MAX __INT_LEAST8_MAX
+#define UINT_LEAST8_MAX __UINT_LEAST8_MAX
+#define INT_FAST8_MIN __INT_LEAST8_MIN
+#define INT_FAST8_MAX __INT_LEAST8_MAX
+#define UINT_FAST8_MAX __UINT_LEAST8_MAX
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define UINT_LEAST8_WIDTH __UINT_LEAST8_WIDTH
+#define INT_LEAST8_WIDTH UINT_LEAST8_WIDTH
+#define UINT_FAST8_WIDTH __UINT_LEAST8_WIDTH
+#define INT_FAST8_WIDTH UINT_FAST8_WIDTH
+#endif /* __STDC_VERSION__ */
+#endif /* __INT_LEAST8_MIN */
+
+/* Some utility macros */
+#define __INTN_MIN(n) __stdint_join3(INT, n, _MIN)
+#define __INTN_MAX(n) __stdint_join3(INT, n, _MAX)
+#define __UINTN_MAX(n) __stdint_join3(UINT, n, _MAX)
+#define __INTN_C(n, v) __stdint_join3(INT, n, _C(v))
+#define __UINTN_C(n, v) __stdint_join3(UINT, n, _C(v))
+
+/* C99 7.18.2.4 Limits of integer types capable of holding object pointers. */
+/* C99 7.18.3 Limits of other integer types. */
+
+#define INTPTR_MIN (-__INTPTR_MAX__ - 1)
+#define INTPTR_MAX __INTPTR_MAX__
+#define UINTPTR_MAX __UINTPTR_MAX__
+#define PTRDIFF_MIN (-__PTRDIFF_MAX__ - 1)
+#define PTRDIFF_MAX __PTRDIFF_MAX__
+#define SIZE_MAX __SIZE_MAX__
+
+/* C23 7.22.2.4 Width of integer types capable of holding object pointers. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+/* NB: The C standard requires that these be the same value, but the compiler
+   exposes separate internal width macros. */
+#define INTPTR_WIDTH __INTPTR_WIDTH__
+#define UINTPTR_WIDTH __UINTPTR_WIDTH__
+#endif
+
+/* ISO9899:2011 7.20 (C11 Annex K): Define RSIZE_MAX if __STDC_WANT_LIB_EXT1__
+ * is enabled. */
+#if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ >= 1
+#define RSIZE_MAX (SIZE_MAX >> 1)
+#endif
+
+/* C99 7.18.2.5 Limits of greatest-width integer types. */
+#define INTMAX_MIN (-__INTMAX_MAX__ - 1)
+#define INTMAX_MAX __INTMAX_MAX__
+#define UINTMAX_MAX __UINTMAX_MAX__
+
+/* C23 7.22.2.5 Width of greatest-width integer types. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+/* NB: The C standard requires that these be the same value, but the compiler
+   exposes separate internal width macros. */
+#define INTMAX_WIDTH __INTMAX_WIDTH__
+#define UINTMAX_WIDTH __UINTMAX_WIDTH__
+#endif
+
+/* C99 7.18.3 Limits of other integer types. */
+#define SIG_ATOMIC_MIN __INTN_MIN(__SIG_ATOMIC_WIDTH__)
+#define SIG_ATOMIC_MAX __INTN_MAX(__SIG_ATOMIC_WIDTH__)
+#ifdef __WINT_UNSIGNED__
+#define WINT_MIN __UINTN_C(__WINT_WIDTH__, 0)
+#define WINT_MAX __UINTN_MAX(__WINT_WIDTH__)
+#else
+#define WINT_MIN __INTN_MIN(__WINT_WIDTH__)
+#define WINT_MAX __INTN_MAX(__WINT_WIDTH__)
+#endif
+
+#ifndef WCHAR_MAX
+#define WCHAR_MAX __WCHAR_MAX__
+#endif
+#ifndef WCHAR_MIN
+#if __WCHAR_MAX__ == __INTN_MAX(__WCHAR_WIDTH__)
+#define WCHAR_MIN __INTN_MIN(__WCHAR_WIDTH__)
+#else
+#define WCHAR_MIN __UINTN_C(__WCHAR_WIDTH__, 0)
+#endif
+#endif
+
+/* 7.18.4.2 Macros for greatest-width integer constants. */
+#define INTMAX_C(v) __int_c(v, __INTMAX_C_SUFFIX__)
+#define UINTMAX_C(v) __int_c(v, __UINTMAX_C_SUFFIX__)
+
+/* C23 7.22.3.x Width of other integer types. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define PTRDIFF_WIDTH __PTRDIFF_WIDTH__
+#define SIG_ATOMIC_WIDTH __SIG_ATOMIC_WIDTH__
+#define SIZE_WIDTH __SIZE_WIDTH__
+#define WCHAR_WIDTH __WCHAR_WIDTH__
+#define WINT_WIDTH __WINT_WIDTH__
+#endif
+#endif // LLVM_LIBC_MACROS_STDINT_MACROS_H

--- a/libc/include/stdint.h.def
+++ b/libc/include/stdint.h.def
@@ -1,0 +1,14 @@
+//===-- C standard library header stdint.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_STDINT_H
+#define LLVM_LIBC_STDINT_H
+
+#include <llvm-libc-macros/stdint-macros.h>
+
+#endif // LLVM_LIBC_STDINT_H

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -963,6 +963,8 @@ def StdC : StandardSpec<"stdc"> {
       ]
   >;
 
+  HeaderSpec StdInt = HeaderSpec<"StdInt.h">;
+
   HeaderSpec Limits = HeaderSpec<"limits.h">;
 
   NamedType SigAtomicT = NamedType<"sig_atomic_t">;
@@ -1268,6 +1270,7 @@ def StdC : StandardSpec<"stdc"> {
     Errno,
     Fenv,
     Float,
+    StdInt,
     Limits,
     Math,
     String,

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -998,6 +998,11 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "llvm_libc_macros_stdint_macros",
+    hdrs = ["include/llvm-libc-macros/stdint-macros.h"],
+)
+
+libc_support_library(
     name = "llvm_libc_macros_stdfix_macros",
     hdrs = ["include/llvm-libc-macros/stdfix-macros.h"],
     deps = [":llvm_libc_macros_float_macros"],


### PR DESCRIPTION
Summary:
I've noticed one problem is that the user includes `stdint.h` the
compiler will do `#include_next <stdint.h>` potentially into a
conflicting implementation on systems with multiple headers installed.
The `clang` header is standards compliant and works with `clang` and
`gcc` which are both of our targets, so I simply copied it here. This
has the effect of including `stdint.h` on clang / LLVM libc behaving the
same as `-ffreestanding`.
