### PR TITLE
[libc] fix typo introduced in inline_bcmp_byte_per_byte

### DIFF
--- a/libc/src/string/memory_utils/generic/byte_per_byte.h
+++ b/libc/src/string/memory_utils/generic/byte_per_byte.h
@@ -56,7 +56,7 @@ inline_bcmp_byte_per_byte(CPtr p1, CPtr p2, size_t count, size_t offset = 0) {
   LIBC_LOOP_NOUNROLL
   for (; offset < count; ++offset)
     if (p1[offset] != p2[offset])
-      return BcmpReturnType::zero();
+      return BcmpReturnType::nonzero();
   return BcmpReturnType::zero();
 }
 


### PR DESCRIPTION
My global find+replace was overzealous and broke post submit unit tests.

Link: #83345
