### PR TITLE
[lldb] Log to system log instead of stderr from Host::SystemLog

### DIFF
--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -89,7 +89,16 @@ using namespace lldb;
 using namespace lldb_private;
 
 #if !defined(__APPLE__)
+#if !defined(_WIN32)
+#include <syslog.h>
+void Host::SystemLog(llvm::StringRef message) {
+  openlog("lldb", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
+  syslog(LOG_INFO, "%s", message.data());
+  closelog();
+}
+#else
 void Host::SystemLog(llvm::StringRef message) { llvm::errs() << message; }
+#endif
 #endif
 
 #if !defined(__APPLE__) && !defined(_WIN32)

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -92,9 +92,11 @@ using namespace lldb_private;
 #if !defined(_WIN32)
 #include <syslog.h>
 void Host::SystemLog(llvm::StringRef message) {
-  openlog("lldb", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
+  static llvm::once_flag g_openlog_once;
+  llvm::call_once(g_openlog_once, [] {
+    openlog("lldb", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
+  });
   syslog(LOG_INFO, "%s", message.data());
-  closelog();
 }
 #else
 void Host::SystemLog(llvm::StringRef message) { llvm::errs() << message; }


### PR DESCRIPTION
Currently, calls to Host::SystemLog print to stderr on all host platforms except Darwin. This severely limits its value on the command line, where we don't want to overload the user with log messages. Switch to using the syslog function on POSIX systems to send messages to the system logger instead of stdout.

On Darwin systems this sends the log message to os_log, which matches what we do today. Nevertheless I kept the current implementation that uses os_log directly as it gives us more freedom.

I'm not sure if there's an equivalent on Windows, so I kept the existing behavior of logging to stderr.