### PR TITLE
[ADT] Add std::string_view conversion to SmallString

### DIFF
--- a/llvm/include/llvm/ADT/SmallString.h
+++ b/llvm/include/llvm/ADT/SmallString.h
@@ -265,6 +265,11 @@ public:
   /// Implicit conversion to StringRef.
   operator StringRef() const { return str(); }
 
+  /// Implicit conversion to std::string_view
+  operator std::string_view() const {
+    return std::string_view(this->data(), this->size());
+  }
+
   explicit operator std::string() const {
     return std::string(this->data(), this->size());
   }

--- a/llvm/include/llvm/ADT/SmallString.h
+++ b/llvm/include/llvm/ADT/SmallString.h
@@ -265,7 +265,7 @@ public:
   /// Implicit conversion to StringRef.
   operator StringRef() const { return str(); }
 
-  /// Implicit conversion to std::string_view
+  /// Implicit conversion to std::string_view.
   operator std::string_view() const {
     return std::string_view(this->data(), this->size());
   }

--- a/llvm/unittests/ADT/SmallStringTest.cpp
+++ b/llvm/unittests/ADT/SmallStringTest.cpp
@@ -244,4 +244,10 @@ TEST_F(SmallStringTest, GTestPrinter) {
   EXPECT_EQ(R"("foo")", ::testing::PrintToString(ErasedSmallString));
 }
 
+TEST_F(SmallStringTest, StringView) {
+  theString = "hello from std::string_view";
+  EXPECT_EQ("hello from std::string_view",
+            static_cast<std::string_view>(theString));
+}
+
 } // namespace


### PR DESCRIPTION
This patch adds a std::string_view conversion to SmallString which we've recently found a use for downstream in a project that is using c++ standard library IO.