### PR TITLE
[GlobalISel] Dump the machine function after each legalization iteration. NFC

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
@@ -220,8 +220,14 @@ Legalizer::legalizeMachineFunction(MachineFunction &MF, const LegalizerInfo &LI,
   LegalizationArtifactCombiner ArtCombiner(MIRBuilder, MRI, LI, VT);
   bool Changed = false;
   SmallVector<MachineInstr *, 128> RetryList;
+  unsigned Iteration = 0;
   do {
-    LLVM_DEBUG(dbgs() << "=== New Iteration ===\n");
+    LLVM_DEBUG({
+      if (Iteration > 0) {
+        dbgs() << "=== New Iteration: " << Iteration << " ===\n";
+        MF.dump();
+      }
+    });
     assert(RetryList.empty() && "Expected no instructions in RetryList");
     unsigned NumArtifacts = ArtifactList.size();
     while (!InstList.empty()) {
@@ -301,6 +307,8 @@ Legalizer::legalizeMachineFunction(MachineFunction &MF, const LegalizerInfo &LI,
         InstList.insert(&MI);
       }
     }
+
+    ++Iteration;
   } while (!InstList.empty());
 
   return {Changed, /*FailedOn*/ nullptr};


### PR DESCRIPTION
I find this useful to see the current state of the machine function as legalization continues. Otherwise it is difficult to view the whole thing as individual combines/legalizations are occurring.