### PR TITLE
[clang-format][doc] fix documentation for clang-format

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -318,9 +318,9 @@ the configuration (without a prefix: ``Auto``).
 
   .. code-block:: c++
 
-    AlignConsecutiveMacros: AcrossEmptyLines
+    AlignConsecutiveAssignments: AcrossEmptyLines
 
-    AlignConsecutiveMacros:
+    AlignConsecutiveAssignments:
       Enabled: true
       AcrossEmptyLines: true
       AcrossComments: false
@@ -460,9 +460,9 @@ the configuration (without a prefix: ``Auto``).
 
   .. code-block:: c++
 
-    AlignConsecutiveMacros: AcrossEmptyLines
+    AlignConsecutiveBitFields: AcrossEmptyLines
 
-    AlignConsecutiveMacros:
+    AlignConsecutiveBitFields:
       Enabled: true
       AcrossEmptyLines: true
       AcrossComments: false
@@ -602,9 +602,9 @@ the configuration (without a prefix: ``Auto``).
 
   .. code-block:: c++
 
-    AlignConsecutiveMacros: AcrossEmptyLines
+    AlignConsecutiveDeclarations: AcrossEmptyLines
 
-    AlignConsecutiveMacros:
+    AlignConsecutiveDeclarations:
       Enabled: true
       AcrossEmptyLines: true
       AcrossComments: false
@@ -983,9 +983,9 @@ the configuration (without a prefix: ``Auto``).
 
   .. code-block:: c++
 
-    AlignConsecutiveMacros: AcrossEmptyLines
+    AlignConsecutiveTableGenCondOperatorColons: AcrossEmptyLines
 
-    AlignConsecutiveMacros:
+    AlignConsecutiveTableGenCondOperatorColons:
       Enabled: true
       AcrossEmptyLines: true
       AcrossComments: false
@@ -1123,9 +1123,9 @@ the configuration (without a prefix: ``Auto``).
 
   .. code-block:: c++
 
-    AlignConsecutiveMacros: AcrossEmptyLines
+    AlignConsecutiveTableGenDefinitionColons: AcrossEmptyLines
 
-    AlignConsecutiveMacros:
+    AlignConsecutiveTableGenDefinitionColons:
       Enabled: true
       AcrossEmptyLines: true
       AcrossComments: false

--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -129,6 +129,7 @@ class Option(object):
             s += indent(
                 "\n\nNested configuration flags:\n\n%s\n" % self.nested_struct, 2
             )
+            s = s.replace("[[[NAME]]]", self.name)
         return s
 
 

--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -129,7 +129,7 @@ class Option(object):
             s += indent(
                 "\n\nNested configuration flags:\n\n%s\n" % self.nested_struct, 2
             )
-            s = s.replace("[[[NAME]]]", self.name)
+            s = s.replace("<option-name>", self.name)
         return s
 
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -154,9 +154,9 @@ struct FormatStyle {
   /// For example, to align across empty lines and not across comments, either
   /// of these work.
   /// \code
-  ///   AlignConsecutiveMacros: AcrossEmptyLines
+  ///   [[[NAME]]]: AcrossEmptyLines
   ///
-  ///   AlignConsecutiveMacros:
+  ///   [[[NAME]]]:
   ///     Enabled: true
   ///     AcrossEmptyLines: true
   ///     AcrossComments: false

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -154,9 +154,9 @@ struct FormatStyle {
   /// For example, to align across empty lines and not across comments, either
   /// of these work.
   /// \code
-  ///   [[[NAME]]]: AcrossEmptyLines
+  ///   <option-name>: AcrossEmptyLines
   ///
-  ///   [[[NAME]]]:
+  ///   <option-name>:
   ///     Enabled: true
   ///     AcrossEmptyLines: true
   ///     AcrossComments: false


### PR DESCRIPTION
Fixes typo in documentation for clang-format 

Fixes #83207.