### PR TITLE
[Transform][ObjCARC] Change the 'for(;;)' to a do-while

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -659,8 +659,7 @@ bool ObjCARCContract::run(Function &F, AAResults *A, DominatorTree *D) {
     Value *Arg = cast<CallInst>(Inst)->getArgOperand(0);
     Value *OrigArg = Arg;
 
-    // TODO: Change this to a do-while.
-    for (;;) {
+    do {
       ReplaceArgUses(Arg);
 
       // If Arg is a no-op casted pointer, strip one level of casts and iterate.
@@ -683,7 +682,7 @@ bool ObjCARCContract::run(Function &F, AAResults *A, DominatorTree *D) {
         }
         break;
       }
-    }
+    } while (true);
 
     // Replace bitcast users of Arg that are dominated by Inst.
     SmallVector<BitCastInst *, 2> BitCastUsers;


### PR DESCRIPTION
At the moment, there is a TODO item in ObjCARC just to change 'for (;;)' to a do-while. And it is the only place using 'for (;;)' in llvm. In contrary, there are many places using the do-while. It is reasonable to change the 'for(;;)' to a do-while.

This PR change the 'for(;;)' to a do-while and eliminate some discord in the code.