### PR TITLE
[SPIR-V] Add support for SPV_KHR_float_controls

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1143,6 +1143,8 @@ static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
   // Collect requirements for OpExecutionMode instructions.
   auto Node = M.getNamedMetadata("spirv.ExecutionMode");
   if (Node) {
+    // SPV_KHR_float_controls is not available until v1.4
+    bool RequireFloatControls = false, VerLower14 = !ST.isAtLeastSPIRVVer(14);
     for (unsigned i = 0; i < Node->getNumOperands(); i++) {
       MDNode *MDN = cast<MDNode>(Node->getOperand(i));
       const MDOperand &MDOp = MDN->getOperand(1);
@@ -1152,9 +1154,21 @@ static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
           auto EM = Const->getZExtValue();
           MAI.Reqs.getAndAddRequirements(
               SPIRV::OperandCategory::ExecutionModeOperand, EM, ST);
+          // add SPV_KHR_float_controls if the version is too low
+          switch (EM) {
+            case SPIRV::ExecutionMode::DenormPreserve:
+            case SPIRV::ExecutionMode::DenormFlushToZero:
+            case SPIRV::ExecutionMode::SignedZeroInfNanPreserve:
+            case SPIRV::ExecutionMode::RoundingModeRTE:
+            case SPIRV::ExecutionMode::RoundingModeRTZ:
+              RequireFloatControls = VerLower14;
+              break;
+          }
         }
       }
     }
+    if (RequireFloatControls && ST.canUseExtension(SPIRV::Extension::SPV_KHR_float_controls))
+      MAI.Reqs.addExtension(SPIRV::Extension::SPV_KHR_float_controls);
   }
   for (auto FI = M.begin(), E = M.end(); FI != E; ++FI) {
     const Function &F = *FI;

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1156,18 +1156,19 @@ static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
               SPIRV::OperandCategory::ExecutionModeOperand, EM, ST);
           // add SPV_KHR_float_controls if the version is too low
           switch (EM) {
-            case SPIRV::ExecutionMode::DenormPreserve:
-            case SPIRV::ExecutionMode::DenormFlushToZero:
-            case SPIRV::ExecutionMode::SignedZeroInfNanPreserve:
-            case SPIRV::ExecutionMode::RoundingModeRTE:
-            case SPIRV::ExecutionMode::RoundingModeRTZ:
-              RequireFloatControls = VerLower14;
-              break;
+          case SPIRV::ExecutionMode::DenormPreserve:
+          case SPIRV::ExecutionMode::DenormFlushToZero:
+          case SPIRV::ExecutionMode::SignedZeroInfNanPreserve:
+          case SPIRV::ExecutionMode::RoundingModeRTE:
+          case SPIRV::ExecutionMode::RoundingModeRTZ:
+            RequireFloatControls = VerLower14;
+            break;
           }
         }
       }
     }
-    if (RequireFloatControls && ST.canUseExtension(SPIRV::Extension::SPV_KHR_float_controls))
+    if (RequireFloatControls &&
+        ST.canUseExtension(SPIRV::Extension::SPV_KHR_float_controls))
       MAI.Reqs.addExtension(SPIRV::Extension::SPV_KHR_float_controls);
   }
   for (auto FI = M.begin(), E = M.end(); FI != E; ++FI) {

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -68,6 +68,11 @@ cl::list<SPIRV::Extension::Extension> Extensions(
                    "SPV_KHR_no_integer_wrap_decoration",
                    "Adds decorations to indicate that a given instruction does "
                    "not cause integer wrapping."),
+        clEnumValN(
+            SPIRV::Extension::SPV_KHR_float_controls, "SPV_KHR_float_controls",
+            "Provides new execution modes to control floating-point "
+            "computations by overriding an implementation’s default behavior "
+            "for rounding modes, denormals, signed zero, and infinities."),
         clEnumValN(SPIRV::Extension::SPV_KHR_expect_assume,
                    "SPV_KHR_expect_assume",
                    "Provides additional information to a compiler, similar to "

--- a/llvm/test/CodeGen/SPIRV/exec_mode_float_control_khr.ll
+++ b/llvm/test/CodeGen/SPIRV/exec_mode_float_control_khr.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=SPV
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s --mattr=+spirv1.3 --spirv-extensions=SPV_KHR_float_controls -o - | FileCheck %s --check-prefixes=SPVEXT
 
 define dso_local dllexport spir_kernel void @k_float_controls_0(i32 %ibuf, i32 %obuf) local_unnamed_addr {
 entry:
@@ -29,6 +30,7 @@ entry:
 !spirv.ExecutionMode = !{!15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29}
 
 ; SPV-NOT: OpExtension "SPV_KHR_float_controls"
+; SPVEXT: OpExtension "SPV_KHR_float_controls"
 
 ; SPV-DAG: OpEntryPoint {{.*}} %[[#KERNEL0:]] "k_float_controls_0"
 ; SPV-DAG: OpEntryPoint {{.*}} %[[#KERNEL1:]] "k_float_controls_1"


### PR DESCRIPTION
This PR is to add explicit support for SPV_KHR_float_controls (https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_float_controls.asciidoc). This extension is included into SPIR-V after version 1.4, but in case of lower versions it is to be included explicitly and OpExtension must be present in the module with `OpExtension "SPV_KHR_float_controls"`.

This PR fixes this issue and fixes the test case test/CodeGen/SPIRV/exec_mode_float_control_khr.ll to account for a version lower than 1.4.