### PR TITLE
[RISCV] Support scheduling VCIX instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -1207,6 +1207,10 @@ foreach mx = SchedMxList in {
     def : ReadAdvance<!cast<SchedRead>("ReadVMergeOp_" # mx  # "_E" # sew), 0>;
 }
 
+let Latency = 100 in
+def WriteVCIX : SchedWriteRes<[SiFive7VCQ, SiFive7VA]>;
+def : InstRW<[WriteVCIX], (instregex "PseudoVC_.*")>;
+
 //===----------------------------------------------------------------------===//
 // Unsupported extensions
 defm : UnsupportedSchedZabha;


### PR DESCRIPTION
If we don't do anything, the latencies of VCIX instructions will be
all 1.

Here I just set the latency to a very large number, so the scheduler
will treat them costly.

Though I still don't know why scheduler doesn't take register pressure
into consideration.

Fixes #83391