### PR TITLE
[SCEV] Improve applyLoopGuards to support Mul

### DIFF
--- a/llvm/test/Analysis/ScalarEvolution/trip-count-minmax.ll
+++ b/llvm/test/Analysis/ScalarEvolution/trip-count-minmax.ll
@@ -61,7 +61,7 @@ define void @umin(i32 noundef %a, i32 noundef %b) {
 ; CHECK-NEXT:  Loop %for.body: backedge-taken count is (-1 + ((2 * %a) umin (4 * %b)))
 ; CHECK-NEXT:  Loop %for.body: constant max backedge-taken count is i32 2147483646
 ; CHECK-NEXT:  Loop %for.body: symbolic max backedge-taken count is (-1 + ((2 * %a) umin (4 * %b)))
-; CHECK-NEXT:  Loop %for.body: Trip multiple is 1
+; CHECK-NEXT:  Loop %for.body: Trip multiple is 2
 ;
 ; void umin(unsigned a, unsigned b) {
 ;   a *= 2;
@@ -157,7 +157,13 @@ define void @smin(i32 noundef %a, i32 noundef %b) {
 ; CHECK-NEXT:  Loop %for.body: backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
 ; CHECK-NEXT:  Loop %for.body: constant max backedge-taken count is i32 2147483646
 ; CHECK-NEXT:  Loop %for.body: symbolic max backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
+<<<<<<< HEAD
 ; CHECK-NEXT:  Loop %for.body: Trip multiple is 1
+=======
+; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
+; CHECK-NEXT:   Predicates:
+; CHECK-NEXT:  Loop %for.body: Trip multiple is 2
+>>>>>>> 9e0555c485cf ([SCEV] Improve applyLoopGuards to suppport Mul)
 ;
 ; void smin(signed a, signed b) {
 ;   a *= 2;

--- a/llvm/test/Analysis/ScalarEvolution/trip-count-minmax.ll
+++ b/llvm/test/Analysis/ScalarEvolution/trip-count-minmax.ll
@@ -157,13 +157,7 @@ define void @smin(i32 noundef %a, i32 noundef %b) {
 ; CHECK-NEXT:  Loop %for.body: backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
 ; CHECK-NEXT:  Loop %for.body: constant max backedge-taken count is i32 2147483646
 ; CHECK-NEXT:  Loop %for.body: symbolic max backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
-<<<<<<< HEAD
-; CHECK-NEXT:  Loop %for.body: Trip multiple is 1
-=======
-; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (-1 + ((2 * %a)<nsw> smin (4 * %b)<nsw>))
-; CHECK-NEXT:   Predicates:
 ; CHECK-NEXT:  Loop %for.body: Trip multiple is 2
->>>>>>> 9e0555c485cf ([SCEV] Improve applyLoopGuards to suppport Mul)
 ;
 ; void smin(signed a, signed b) {
 ;   a *= 2;

--- a/llvm/test/Analysis/ScalarEvolution/trip-multiple-guard-info.ll
+++ b/llvm/test/Analysis/ScalarEvolution/trip-multiple-guard-info.ll
@@ -574,43 +574,5 @@ exit:
   ret void
 }
 
-define void @test_trip_scevmul_multiple_5(i32 %num1, i32 %num2) {
-; CHECK-LABEL: 'test_trip_scevmul_multiple_5'
-; CHECK-NEXT:  Classifying expressions for: @test_trip_scevmul_multiple_5
-; CHECK-NEXT:    %num = mul i32 %num1, %num2
-; CHECK-NEXT:    --> (%num1 * %num2) U: full-set S: full-set
-; CHECK-NEXT:    %u = urem i32 %num, 5
-; CHECK-NEXT:    --> ((-5 * ((%num1 * %num2) /u 5)) + (%num1 * %num2)) U: full-set S: full-set
-; CHECK-NEXT:    %i.010 = phi i32 [ 0, %entry ], [ %inc, %for.body ]
-; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%for.body> U: [0,-2147483648) S: [0,-2147483648) Exits: (-1 + (%num1 * %num2)) LoopDispositions: { %for.body: Computable }
-; CHECK-NEXT:    %inc = add nuw nsw i32 %i.010, 1
-; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%for.body> U: [1,-2147483648) S: [1,-2147483648) Exits: (%num1 * %num2) LoopDispositions: { %for.body: Computable }
-; CHECK-NEXT:  Determining loop execution counts for: @test_trip_scevmul_multiple_5
-; CHECK-NEXT:  Loop %for.body: backedge-taken count is (-1 + (%num1 * %num2))
-; CHECK-NEXT:  Loop %for.body: constant max backedge-taken count is -2
-; CHECK-NEXT:  Loop %for.body: symbolic max backedge-taken count is (-1 + (%num1 * %num2))
-; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (-1 + (%num1 * %num2))
-; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:  Loop %for.body: Trip multiple is 5
-;
-entry:
-  %num = mul i32 %num1, %num2
-  %u = urem i32 %num, 5
-  %cmp = icmp eq i32 %u, 0
-  tail call void @llvm.assume(i1 %cmp)
-  %cmp.1 = icmp uge i32 %num, 5
-  tail call void @llvm.assume(i1 %cmp.1)
-  br label %for.body
-
-for.body:
-  %i.010 = phi i32 [ 0, %entry ], [ %inc, %for.body ]
-  %inc = add nuw nsw i32 %i.010, 1
-  %cmp2 = icmp ult i32 %inc, %num
-  br i1 %cmp2, label %for.body, label %exit
-
-exit:
-  ret void
-}
-
 declare void @llvm.assume(i1)
 declare void @llvm.experimental.guard(i1, ...)


### PR DESCRIPTION
Improve applyLoopGuards to preserve divisibility information of SCEVMul Expressions.
Before this patch, the code searched for a more complicated pattern, but now it simply searches for a pattern of (Expr * constant) and tries to prove that the whole SCEV divides by this constant.
For example, the SCEV ((2 * a) umin (4 * b)) is now known to divide by 2.